### PR TITLE
fix infinite loops and remove public apis

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		}
 
-		protected Uri CreateUri(string uri) => new Uri(uri, UriKind.RelativeOrAbsolute);
+		protected Uri CreateUri(string uri) => ShellUriHandler.CreateUri(uri);
 
 		protected ShellSection MakeSimpleShellSection(string route, string contentRoute)
 		{

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -161,13 +161,13 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await shell.GoToAsync("app:///s/two/tab21/");
 
-			await shell.GoToAsync("/tab22");
+			await shell.GoToAsync("/tab22", false, true);
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab22/content/"));
 
-			await shell.GoToAsync("tab21");
+			await shell.GoToAsync("tab21", false, true);
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab21/content/"));
 
-			await shell.GoToAsync("/tab23");
+			await shell.GoToAsync("/tab23", false, true);
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab23/content/"));
 
 			/*

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -94,11 +94,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.Items.Add(one);
 			shell.Items.Add(two);
 
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/one/tabone/content/"));
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/one/tabone/content"));
 
 			shell.GoToAsync(new ShellNavigationState("app:///s/two/tabfour/"));
 
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tabfour/content/"));
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tabfour/content"));
 		}
 
 		[Test]
@@ -162,13 +162,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			await shell.GoToAsync("app:///s/two/tab21/");
 
 			await shell.GoToAsync("/tab22", false, true);
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab22/content/"));
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab22/content"));
 
 			await shell.GoToAsync("tab21", false, true);
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab21/content/"));
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab21/content"));
 
 			await shell.GoToAsync("/tab23", false, true);
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab23/content/"));
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("app:///s/two/tab23/content"));
 
 			/*
 			 * removing support for .. notation for now

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -17,6 +17,23 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task RouteWithGlobalPageRoute()
+		{
+
+			var shell = new Shell() { RouteScheme = "app", Route= "xaminals", RouteHost = "thehost" };
+			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
+			var item2 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "cats");
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			Routing.RegisterRoute("catdetails", typeof(ContentPage));
+			await shell.GoToAsync("//cats/catdetails?name=3");
+
+			Assert.AreEqual("app://thehost/xaminals/animals/domestic/cats/catdetails", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
 		public async Task LocationRemovesImplicit()
 		{
 

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -34,6 +34,20 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task AbsoluteRoutingToPage()
+		{
+
+			var shell = new Shell() { RouteScheme = "app", Route = "xaminals", RouteHost = "thehost" };
+			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
+			shell.Items.Add(item1);
+
+			Routing.RegisterRoute("catdetails", typeof(ContentPage));
+
+			Assert.That(async () => await shell.GoToAsync($"//catdetails"), Throws.Exception);
+		}
+
+
+		[Test]
 		public async Task LocationRemovesImplicit()
 		{
 
@@ -51,7 +65,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var shell = new Shell() { RouteScheme = "app", Route = "shellroute" };
 			Routing.RegisterRoute("/seg1/seg2/seg3", typeof(object));
-			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("app://seg1/seg2/seg3"));
+			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("/seg1/seg2/seg3"));
 
 			Assert.AreEqual("app:///shellroute/seg1/seg2/seg3", request.Request.FullUri.ToString());
 		}

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -325,7 +325,8 @@ namespace Xamarin.Forms.Core.UnitTests
 				CreateUri("app://shellroute/path"),
 				CreateUri("app:/shellroute/path"),
 				CreateUri("app://host/shellroute/path"),
-				CreateUri("app:/host/shellroute/path")
+				CreateUri("app:/host/shellroute/path"),
+				CreateUri("app:/host/shellroute\\path")
 			};
 
 

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -17,13 +17,26 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task GlobalRegisterAbsoluteMatching()
+		public async Task LocationRemovesImplicit()
+		{
+
+			var shell = new Shell() { RouteScheme = "app" };
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
+
+			shell.Items.Add(item1);
+
+			Assert.AreEqual("app:///rootlevelcontent1", shell.CurrentState.Location.ToString());
+		}
+
+
+		[Test]
+		public async Task GlobalRegisterAbsoluteMatching()	
 		{
 			var shell = new Shell() { RouteScheme = "app", Route = "shellroute" };
 			Routing.RegisterRoute("/seg1/seg2/seg3", typeof(object));
 			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("app://seg1/seg2/seg3"));
 
-			Assert.AreEqual("/seg1/seg2/seg3", request.Request.ShortUri.ToString());
+			Assert.AreEqual("app:///shellroute/seg1/seg2/seg3", request.Request.FullUri.ToString());
 		}
 
 		[Test]
@@ -140,7 +153,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.Items.Add(item1);
 
 			await shell.GoToAsync("//rootlevelcontent1");
-			var location = shell.CurrentState.Location;
+			var location = shell.CurrentState.FullLocation;
 			await shell.GoToAsync("edit", false, true);
 
 			Assert.AreEqual(editShellContent, shell.CurrentItem.CurrentItem.CurrentItem);
@@ -228,7 +241,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual(
 				"app://xamarin.com/xaminals/animals/domestic/cats/catdetails",
-				shell.CurrentState.Location.ToString()
+				shell.CurrentState.FullLocation.ToString()
 				);
 		}
 

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.Items.Add(item1);
 			shell.Items.Add(item2);
 			await shell.GoToAsync("//item1/section1/rootlevelcontent1");
-			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("section1/edit"));
+			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("section1/edit"), true);
 
 			Assert.AreEqual(1, request.Request.GlobalRoutes.Count);
 			Assert.AreEqual("item1/section1/edit", request.Request.GlobalRoutes.First());
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.Items.Add(item1);
 
 			await shell.GoToAsync("//rootlevelcontent1");
-			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("edit"));
+			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("edit"), true);
 
 			Assert.AreEqual("section1/edit", request.Request.GlobalRoutes.First());
 		}
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await shell.GoToAsync("//rootlevelcontent1");
 			var location = shell.CurrentState.Location;
-			await shell.GoToAsync("edit");
+			await shell.GoToAsync("edit", false, true);
 
 			Assert.AreEqual(editShellContent, shell.CurrentItem.CurrentItem.CurrentItem);
 		}
@@ -209,6 +209,50 @@ namespace Xamarin.Forms.Core.UnitTests
 			builders = ShellUriHandler.GenerateRoutePaths(shell, CreateUri("//item2/rootlevelcontent")).Select(x => x.PathNoImplicit).ToArray();
 			Assert.AreEqual(1, builders.Length);
 			Assert.IsTrue(builders.Contains("//item2/rootlevelcontent"));
+		}
+
+
+		[Test]
+		public async Task AbsoluteNavigationToRelativeWithGlobal()
+		{
+			var shell = new Shell() { RouteScheme = "app", RouteHost = "xamarin.com", Route = "xaminals" };
+
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "dogs");
+			var item2 = CreateShellItem(asImplicit: true, shellSectionRoute: "domestic", shellContentRoute: "cats", shellItemRoute: "animals");
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			Routing.RegisterRoute("catdetails", typeof(ContentPage));
+			await shell.GoToAsync($"app://xamarin.com/xaminals/animals/domestic/cats/catdetails?name=domestic");
+
+			Assert.AreEqual(
+				"app://xamarin.com/xaminals/animals/domestic/cats/catdetails",
+				shell.CurrentState.Location.ToString()
+				);
+		}
+
+		[Test]
+		public async Task RelativeNavigationWithRoute()
+		{
+			var shell = new Shell() { RouteScheme = "app", RouteHost = "xamarin.com", Route = "xaminals" };
+
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "dogs");
+			var item2 = CreateShellItem(asImplicit: true, shellSectionRoute: "domestic", shellContentRoute: "cats", shellItemRoute: "animals");
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			Routing.RegisterRoute("catdetails", typeof(ContentPage));
+			Assert.That(async () => await shell.GoToAsync($"cats/catdetails?name=domestic"), Throws.Exception);
+
+			// once relative routing with a stack is fixed then we can remove the above exception check and add below back in
+			// await shell.GoToAsync($"cats/catdetails?name=domestic")
+			//Assert.AreEqual(
+			//	"app://xamarin.com/xaminals/animals/domestic/cats/catdetails",
+			//	shell.CurrentState.Location.ToString()
+			//	);
+
 		}
 
 

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -87,8 +87,10 @@ namespace Xamarin.Forms
 
 		internal static Uri RemoveImplicit(Uri uri)
 		{
+			uri = ShellUriHandler.FormatUri(uri);
+
 			if (!uri.IsAbsoluteUri)
-				return ShellUriHandler.FormatUri(uri);
+				return uri;
 
 			string[] parts = uri.OriginalString.TrimEnd(_pathSeparator[0]).Split(_pathSeparator[0]);
 

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -84,6 +84,21 @@ namespace Xamarin.Forms
 			return $"{source}/";
 		}
 
+		internal static Uri RemoveImplicit(Uri uri)
+		{
+			if (!uri.IsAbsoluteUri)
+				return uri;
+
+			string[] parts = uri.ToString().TrimEnd('/').Split('/');
+
+			List<string> toKeep = new List<string>();
+			for (int i = 0; i < parts.Length; i++)
+				if (!IsImplicit(parts[i]))
+					toKeep.Add(parts[i]);
+
+			return new Uri(string.Join("/", toKeep));
+		}
+
 		public static string FormatRoute(List<string> segments)
 		{
 			var route = FormatRoute(String.Join("/", segments));

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms
 			return bindable.GetType().Name + ++s_routeCount;
 		}
 
-		public static string[] GetRouteKeys()
+		internal static string[] GetRouteKeys()
 		{
 			string[] keys = new string[s_routes.Count];
 			s_routes.Keys.CopyTo(keys, 0);

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms
 		static Dictionary<string, RouteFactory> s_routes = new Dictionary<string, RouteFactory>();
 
 		internal const string ImplicitPrefix = "IMPL_";
+		const string _pathSeparator = "/";
 
 		internal static string GenerateImplicitRoute(string source)
 		{
@@ -87,21 +88,21 @@ namespace Xamarin.Forms
 		internal static Uri RemoveImplicit(Uri uri)
 		{
 			if (!uri.IsAbsoluteUri)
-				return uri;
+				return ShellUriHandler.FormatUri(uri);
 
-			string[] parts = uri.ToString().TrimEnd('/').Split('/');
+			string[] parts = uri.OriginalString.TrimEnd(_pathSeparator[0]).Split(_pathSeparator[0]);
 
 			List<string> toKeep = new List<string>();
 			for (int i = 0; i < parts.Length; i++)
 				if (!IsImplicit(parts[i]))
 					toKeep.Add(parts[i]);
 
-			return new Uri(string.Join("/", toKeep));
+			return new Uri(string.Join(_pathSeparator, toKeep));
 		}
 
 		public static string FormatRoute(List<string> segments)
 		{
-			var route = FormatRoute(String.Join("/", segments));
+			var route = FormatRoute(String.Join(_pathSeparator, segments));
 			return route;
 		}
 
@@ -143,7 +144,7 @@ namespace Xamarin.Forms
 		static void ValidateRoute(string route)
 		{
 			if (string.IsNullOrWhiteSpace(route))
-				throw new ArgumentNullException("Route cannot be an empty string");
+				throw new ArgumentNullException(nameof(route), "Route cannot be an empty string");
 
 			var uri = new Uri(route, UriKind.RelativeOrAbsolute);
 

--- a/Xamarin.Forms.Core/Shell/IShellItemController.cs
+++ b/Xamarin.Forms.Core/Shell/IShellItemController.cs
@@ -6,8 +6,6 @@ namespace Xamarin.Forms
 {
 	public interface IShellItemController : IElementController
 	{
-		Task GoToPart(NavigationRequest navigationRequest, Dictionary<string, string> queryData);
-
 		bool ProposeSection(ShellSection shellSection, bool setValue = true);
 	}
 }

--- a/Xamarin.Forms.Core/Shell/IShellSectionController.cs
+++ b/Xamarin.Forms.Core/Shell/IShellSectionController.cs
@@ -15,8 +15,6 @@ namespace Xamarin.Forms
 
 		void AddDisplayedPageObserver(object observer, Action<Page> callback);
 
-		Task GoToPart(NavigationRequest request, Dictionary<string, string> queryData);
-
 		bool RemoveContentInsetObserver(IShellContentInsetObserver observer);
 
 		bool RemoveDisplayedPageObserver(object observer);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -383,7 +383,12 @@ namespace Xamarin.Forms
 			return routes;
 		}
 
-		public async Task GoToAsync(ShellNavigationState state, bool animate = true)
+		public Task GoToAsync(ShellNavigationState state, bool animate = true)
+		{
+			return GoToAsync(state, animate, false);
+		}
+
+		internal async Task GoToAsync(ShellNavigationState state, bool animate, bool enableRelativeShellRoutes)
 		{
 			// FIXME: This should not be none, we need to compute the delta and set flags correctly
 			var accept = ProposeNavigation(ShellNavigationSource.Unknown, state, true);
@@ -392,7 +397,7 @@ namespace Xamarin.Forms
 
 			_accumulateNavigatedEvents = true;
 
-			var navigationRequest = ShellUriHandler.GetNavigationRequest(this, state.Location);
+			var navigationRequest = ShellUriHandler.GetNavigationRequest(this, state.Location, enableRelativeShellRoutes);
 			var uri = navigationRequest.Request.FullUri;
 			var queryString = navigationRequest.Query;
 			var queryData = ParseQueryString(queryString);
@@ -426,7 +431,7 @@ namespace Xamarin.Forms
 				parts.RemoveAt(0);
 
 				if (parts.Count > 0)
-					await ((IShellItemController)shellItem).GoToPart(navigationRequest, queryData);
+					await shellItem.GoToPart(navigationRequest, queryData);
 			}
 			else
 			{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -370,12 +370,10 @@ namespace Xamarin.Forms
 						var content = section.Items[k];
 
 						string longUri = $"{RouteScheme}://{RouteHost}/{Routing.GetRoute(this)}/{Routing.GetRoute(item)}/{Routing.GetRoute(section)}/{Routing.GetRoute(content)}";
-						string shortUri = $"{RouteScheme}://{RouteHost}/{Routing.GetRoutePathIfNotImplicit(this)}{Routing.GetRoutePathIfNotImplicit(item)}{Routing.GetRoutePathIfNotImplicit(section)}{Routing.GetRoutePathIfNotImplicit(content)}";
 
 						longUri = longUri.TrimEnd('/');
-						shortUri = shortUri.TrimEnd('/');
 
-						routes.Add(new RequestDefinition(longUri, shortUri, item, section, content, new List<string>()));
+						routes.Add(new RequestDefinition(longUri, item, section, content, new List<string>()));
 					}
 				}
 			}
@@ -397,7 +395,7 @@ namespace Xamarin.Forms
 
 			_accumulateNavigatedEvents = true;
 
-			var navigationRequest = ShellUriHandler.GetNavigationRequest(this, state.Location, enableRelativeShellRoutes);
+			var navigationRequest = ShellUriHandler.GetNavigationRequest(this, state.FullLocation, enableRelativeShellRoutes);
 			var uri = navigationRequest.Request.FullUri;
 			var queryString = navigationRequest.Query;
 			var queryData = ParseQueryString(queryString);
@@ -514,29 +512,20 @@ namespace Xamarin.Forms
 			if (shellItem != null)
 			{
 				var shellItemRoute = shellItem.Route;
-				//if (!shellItemRoute.StartsWith(Routing.ImplicitPrefix, StringComparison.Ordinal))
-				{
-					stateBuilder.Append(shellItemRoute);
-					stateBuilder.Append("/");
-				}
+				stateBuilder.Append(shellItemRoute);
+				stateBuilder.Append("/");
 
 				if (shellSection != null)
 				{
 					var shellSectionRoute = shellSection.Route;
-					//if (!shellSectionRoute.StartsWith(Routing.ImplicitPrefix, StringComparison.Ordinal))
-					{
-						stateBuilder.Append(shellSectionRoute);
-						stateBuilder.Append("/");
-					}
+					stateBuilder.Append(shellSectionRoute);
+					stateBuilder.Append("/");
 
 					if (shellContent != null)
 					{
 						var shellContentRoute = shellContent.Route;
-						//if (!shellContentRoute.StartsWith(Routing.ImplicitPrefix, StringComparison.Ordinal))
-						{
-							stateBuilder.Append(shellContentRoute);
-							stateBuilder.Append("/");
-						}
+						stateBuilder.Append(shellContentRoute);
+						stateBuilder.Append("/");
 					}
 
 					if (!stackAtRoot)

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms
 
 		#region IShellItemController
 
-		Task IShellItemController.GoToPart(NavigationRequest request, Dictionary<string, string> queryData)
+		internal Task GoToPart(NavigationRequest request, Dictionary<string, string> queryData)
 		{
 			var shellSection = request.Request.Section;
 
@@ -39,7 +39,7 @@ namespace Xamarin.Forms
 			if (CurrentItem != shellSection)
 				SetValueFromRenderer(CurrentItemProperty, shellSection);
 
-			return ((IShellSectionController)shellSection).GoToPart(request, queryData);
+			return shellSection.GoToPart(request, queryData);
 		}
 
 		bool IShellItemController.ProposeSection(ShellSection shellSection, bool setValue)

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms
 	[DebuggerDisplay("Location = {Location}")]
 	public class ShellNavigationState
 	{
-		private Uri _fullLocation;
+		Uri _fullLocation;
 
 		internal Uri FullLocation
 		{

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -7,11 +7,27 @@ namespace Xamarin.Forms
 	[DebuggerDisplay("Location = {Location}")]
 	public class ShellNavigationState
 	{
-		public Uri Location { get; set; }
+		private Uri _fullLocation;
+
+		internal Uri FullLocation
+		{
+			get => _fullLocation;
+			set
+			{
+				_fullLocation = value;
+				Location = Routing.RemoveImplicit(value);
+			}
+		}
+
+		public Uri Location
+		{
+			get;
+			private set;
+		}
 
 		public ShellNavigationState() { }
-		public ShellNavigationState(string location) => Location = new Uri(location, UriKind.RelativeOrAbsolute);
-		public ShellNavigationState(Uri location) => Location = location;
+		public ShellNavigationState(string location) => FullLocation = new Uri(location, UriKind.RelativeOrAbsolute);
+		public ShellNavigationState(Uri location) => FullLocation = location;
 		public static implicit operator ShellNavigationState(Uri uri) => new ShellNavigationState(uri);
 		public static implicit operator ShellNavigationState(string value) => new ShellNavigationState(value);
 	}

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -26,7 +26,12 @@ namespace Xamarin.Forms
 		}
 
 		public ShellNavigationState() { }
-		public ShellNavigationState(string location) => FullLocation = new Uri(location, UriKind.RelativeOrAbsolute);
+		public ShellNavigationState(string location)
+		{
+			FullLocation = ShellUriHandler.CreateUri(location);
+
+		}
+
 		public ShellNavigationState(Uri location) => FullLocation = location;
 		public static implicit operator ShellNavigationState(Uri uri) => new ShellNavigationState(uri);
 		public static implicit operator ShellNavigationState(string value) => new ShellNavigationState(value);

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Forms
 			callback(DisplayedPage);
 		}
 
-		Task IShellSectionController.GoToPart(NavigationRequest request, Dictionary<string, string> queryData)
+		internal Task GoToPart(NavigationRequest request, Dictionary<string, string> queryData)
 		{
 			ShellContent shellContent = request.Request.Content;
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms
 			var routeKeys = Routing.GetRouteKeys();
 			for (int i = 0; i < routeKeys.Length; i++)
 			{
-				if(routeKeys[i] == originalRequest.OriginalString)
+				if (routeKeys[i] == originalRequest.OriginalString)
 				{
 					var builder = new RouteRequestBuilder(routeKeys[i], routeKeys[i], null, new string[] { routeKeys[i] });
 					return new List<RouteRequestBuilder> { builder };

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -86,7 +86,6 @@ namespace Xamarin.Forms
 			RequestDefinition definition =
 				new RequestDefinition(
 					ConvertToStandardFormat(shell, new Uri(theWinningRoute.PathFull, UriKind.RelativeOrAbsolute)),
-					new Uri(theWinningRoute.PathNoImplicit, UriKind.RelativeOrAbsolute),
 					theWinningRoute.Item,
 					theWinningRoute.Section,
 					theWinningRoute.Content,
@@ -751,25 +750,23 @@ namespace Xamarin.Forms
 
 
 	[DebuggerDisplay("Full = {FullUri}, Short = {ShortUri}")]
-	public class RequestDefinition
+	internal class RequestDefinition
 	{
-		public RequestDefinition(Uri fullUri, Uri shortUri, ShellItem item, ShellSection section, ShellContent content, List<string> globalRoutes)
+		public RequestDefinition(Uri fullUri, ShellItem item, ShellSection section, ShellContent content, List<string> globalRoutes)
 		{
 			FullUri = fullUri;
-			ShortUri = shortUri;
 			Item = item;
 			Section = section;
 			Content = content;
 			GlobalRoutes = globalRoutes;
 		}
 
-		public RequestDefinition(string fullUri, string shortUri, ShellItem item, ShellSection section, ShellContent content, List<string> globalRoutes) :
-			this(new Uri(fullUri, UriKind.Absolute), new Uri(shortUri, UriKind.Absolute), item, section, content, globalRoutes)
+		public RequestDefinition(string fullUri, ShellItem item, ShellSection section, ShellContent content, List<string> globalRoutes) :
+			this(new Uri(fullUri, UriKind.Absolute), item, section, content, globalRoutes)
 		{
 		}
 
 		public Uri FullUri { get; }
-		public Uri ShortUri { get; }
 		public ShellItem Item { get; }
 		public ShellSection Section { get; }
 		public ShellContent Content { get; }

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms
 
 		internal static string FormatUri(string path)
 		{
-			return path.Replace("\\", _pathSeparator);
+			return path.Replace(_pathSeparators[1], _pathSeparator[0]);
 		}
 
 		internal static Uri CreateUri(string path)
@@ -530,7 +530,7 @@ namespace Xamarin.Forms
 			for (var i = 0; i < keys.Length; i++)
 			{
 				var key = FormatUri(keys[i]);
-				if (key.StartsWith("/", StringComparison.Ordinal) && !(node is Shell))
+				if (key.StartsWith(_pathSeparator, StringComparison.Ordinal) && !(node is Shell))
 					continue;
 
 				var segments = key.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -205,7 +205,7 @@ namespace Xamarin.Forms
 					{
 						// currently relative routes to shell routes isn't supported as we aren't creating navigation stacks
 						// So right now we will just throw an exception so that once this is implemented
-						// GotoAsync doesn't start acting inconsistely and all of a suddent starts creating routes
+						// GotoAsync doesn't start acting inconsistently and all of a suddent starts creating routes
 						if (!enableRelativeShellRoutes && pureGlobalRoutesMatch[0].SegmentsMatched.Count > 0)
 						{
 							throw new Exception($"Relative routing to shell elements is currently not supported. Try prefixing your uri with ///: ///{originalRequest}");

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms
 		internal static Uri FormatUri(Uri path)
 		{
 			if (path.IsAbsoluteUri)
-				return path;
+				return new Uri(FormatUri(path.OriginalString), UriKind.Absolute);
 
 			return new Uri(FormatUri(path.OriginalString), UriKind.Relative);
 		}

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -9,9 +9,10 @@ namespace Xamarin.Forms
 
 	internal class ShellUriHandler
 	{
-		static readonly char[] _pathSeparator = { '/', '\\' };
+		static readonly char[] _pathSeparators = { '/', '\\' };
+		const string _pathSeparator = "/";
 
-		static Uri FormatUri(Uri path)
+		internal static Uri FormatUri(Uri path)
 		{
 			if (path.IsAbsoluteUri)
 				return path;
@@ -21,7 +22,7 @@ namespace Xamarin.Forms
 
 		internal static string FormatUri(string path)
 		{
-			return path.Replace("\\", "/");
+			return path.Replace("\\", _pathSeparator);
 		}
 
 		internal static Uri CreateUri(string path)
@@ -31,14 +32,11 @@ namespace Xamarin.Forms
 			// on iOS if the uri starts with // it'll instantiate as absolute with
 			// file: as the default scheme where as android just crashes
 			// so this checks if it starts with / and just forces relative
-			if (path.StartsWith("/", StringComparison.Ordinal))
+			if (path.StartsWith(_pathSeparator, StringComparison.Ordinal))
 				return new Uri(path, UriKind.Relative);
 
-			Uri result;
-			if (Uri.TryCreate(path, UriKind.Absolute, out result))
-			{
+			if (Uri.TryCreate(path, UriKind.Absolute, out Uri result))
 				return result;
-			}
 
 			return new Uri(path, UriKind.Relative);
 		}
@@ -52,7 +50,7 @@ namespace Xamarin.Forms
 			else
 				pathAndQuery = request.OriginalString;
 
-			var segments = new List<string>(pathAndQuery.Split(_pathSeparator, StringSplitOptions.RemoveEmptyEntries));
+			var segments = new List<string>(pathAndQuery.Split(_pathSeparators, StringSplitOptions.RemoveEmptyEntries));
 
 
 			if (segments[0] != shell.RouteHost)
@@ -61,7 +59,7 @@ namespace Xamarin.Forms
 			if (segments[1] != shell.Route)
 				segments.Insert(1, shell.Route);
 
-			var path = String.Join("/", segments.ToArray());
+			var path = String.Join(_pathSeparator, segments.ToArray());
 			string uri = $"{shell.RouteScheme}://{path}";
 
 			return new Uri(uri);
@@ -140,10 +138,10 @@ namespace Xamarin.Forms
 
 			bool relativeMatch = false;
 			if (!originalRequest.IsAbsoluteUri &&
-				!originalRequest.OriginalString.StartsWith("/", StringComparison.Ordinal))
+				!originalRequest.OriginalString.StartsWith(_pathSeparator, StringComparison.Ordinal))
 				relativeMatch = true;
 
-			var segments = localPath.Split(_pathSeparator, StringSplitOptions.RemoveEmptyEntries);
+			var segments = localPath.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
 			if (!relativeMatch)
 			{
@@ -383,7 +381,7 @@ namespace Xamarin.Forms
 				if (Content != null && !Routing.IsImplicit(Content))
 					paths.Add(Content.Route);
 
-				string uri = String.Join("/", paths);
+				string uri = String.Join(_pathSeparator, paths);
 				return new Uri($"{Shell.RouteScheme}://{uri}");
 			}
 
@@ -530,7 +528,7 @@ namespace Xamarin.Forms
 				if (key.StartsWith("/", StringComparison.Ordinal) && !(node is Shell))
 					continue;
 
-				var segments = key.Split(_pathSeparator, StringSplitOptions.RemoveEmptyEntries);
+				var segments = key.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
 				if (segments[0] == route)
 				{
@@ -553,7 +551,7 @@ namespace Xamarin.Forms
 			{
 				get
 				{
-					var segments = _path.Split(_pathSeparator, StringSplitOptions.RemoveEmptyEntries).ToList().Skip(1).ToList();
+					var segments = _path.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToList().Skip(1).ToList();
 
 					if (segments.Count == 0)
 						return new object[0];
@@ -568,7 +566,7 @@ namespace Xamarin.Forms
 			{
 				get
 				{
-					var segments = _path.Split(_pathSeparator, StringSplitOptions.RemoveEmptyEntries);
+					var segments = _path.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
 
 					if (segments.Length == 0)
 						return string.Empty;
@@ -581,7 +579,7 @@ namespace Xamarin.Forms
 			{
 				get
 				{
-					var segments = _path.Split(_pathSeparator, StringSplitOptions.RemoveEmptyEntries).ToList().Skip(1).ToList();
+					var segments = _path.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries).ToList().Skip(1).ToList();
 
 					if (segments.Count == 0)
 						return true;
@@ -711,7 +709,7 @@ namespace Xamarin.Forms
 				if (nextMatch >= _allSegments.Length)
 					return null;
 
-				return Routing.FormatRoute(String.Join("/", _allSegments.Skip(nextMatch)));
+				return Routing.FormatRoute(String.Join(_uriSeparator, _allSegments.Skip(nextMatch)));
 			}
 		}
 		public string[] RemainingSegments
@@ -728,7 +726,7 @@ namespace Xamarin.Forms
 
 		string MakeUriString(List<string> segments)
 		{
-			if (segments[0].StartsWith("/", StringComparison.Ordinal) || segments[0].StartsWith("\\", StringComparison.Ordinal))
+			if (segments[0].StartsWith(_uriSeparator, StringComparison.Ordinal) || segments[0].StartsWith("\\", StringComparison.Ordinal))
 				return String.Join(_uriSeparator, segments);
 
 			return $"//{String.Join(_uriSeparator, segments)}";

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -156,7 +156,7 @@ namespace Xamarin.Forms
 					var uri = ConvertToStandardFormat(shell, CreateUri(route));
 					if (uri.Equals(request))
 					{
-						throw new Exception($"Global routes currently cannot be the only page on the stack so absolute routing to global routes is not supported. For now just navigate to: {originalRequest.OriginalString.Replace("//","")}");
+						throw new Exception($"Global routes currently cannot be the only page on the stack, so absolute routing to global routes is not supported. For now, just navigate to: {originalRequest.OriginalString.Replace("//","")}");
 						//var builder = new RouteRequestBuilder(route, route, null, segments);
 						//return new List<RouteRequestBuilder> { builder };
 					}

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -121,14 +121,19 @@ namespace Xamarin.Forms
 
 		internal static List<RouteRequestBuilder> GenerateRoutePaths(Shell shell, Uri request, Uri originalRequest, bool enableRelativeShellRoutes)
 		{
-			request = FormatUri(request);
-			originalRequest = FormatUri(originalRequest);
-
 			var routeKeys = Routing.GetRouteKeys();
 			for (int i = 0; i < routeKeys.Length; i++)
 			{
+				if(routeKeys[i] == originalRequest.OriginalString)
+				{
+					var builder = new RouteRequestBuilder(routeKeys[i], routeKeys[i], null, new string[] { routeKeys[i] });
+					return new List<RouteRequestBuilder> { builder };
+				}
 				routeKeys[i] = FormatUri(routeKeys[i]);
 			}
+
+			request = FormatUri(request);
+			originalRequest = FormatUri(originalRequest);
 
 			List<RouteRequestBuilder> possibleRoutePaths = new List<RouteRequestBuilder>();
 			if (!request.IsAbsoluteUri)
@@ -138,7 +143,7 @@ namespace Xamarin.Forms
 
 			bool relativeMatch = false;
 			if (!originalRequest.IsAbsoluteUri &&
-				!originalRequest.OriginalString.StartsWith(_pathSeparator, StringComparison.Ordinal))
+				!originalRequest.OriginalString.StartsWith("//", StringComparison.Ordinal))
 				relativeMatch = true;
 
 			var segments = localPath.Split(_pathSeparator.ToCharArray(), StringSplitOptions.RemoveEmptyEntries);
@@ -149,11 +154,11 @@ namespace Xamarin.Forms
 				{
 					var route = routeKeys[i];
 					var uri = ConvertToStandardFormat(shell, CreateUri(route));
-					// Todo is this supported?
 					if (uri.Equals(request))
 					{
-						var builder = new RouteRequestBuilder(route, route, null, segments);
-						return new List<RouteRequestBuilder> { builder };
+						throw new Exception($"Global routes currently cannot be the only page on the stack so absolute routing to global routes is not supported. For now just navigate to: {originalRequest.OriginalString.Replace("//","")}");
+						//var builder = new RouteRequestBuilder(route, route, null, segments);
+						//return new List<RouteRequestBuilder> { builder };
 					}
 				}
 			}
@@ -212,7 +217,7 @@ namespace Xamarin.Forms
 					currentLocation.Pop();
 				}
 
-				string searchPath = String.Join("/", segments);
+				string searchPath = String.Join(_pathSeparator, segments);
 
 				if (routeKeys.Contains(searchPath))
 				{


### PR DESCRIPTION
### Description of Change ###

- removed GoToPart from the IShellController code parts because there isn't any platform code that uses them so it's not useful at this point
- added an exception if someone tries to do a relative route to a shell section as this behavior hasn't been implemented yet so I don't want the behavior to change once we make it so relative routes push to a stack. I also added an internal overload to turn this on for unit tests so unit tests can continue unhindered with validating behavior
- I fixed  the logic when you use an absolute route to navigation via <routename> / <page>. It was causing an  infinite loop
- removed getroutekeys and a few additional classes added in pre9 that will become exposed later down the road


### API Changes ###
 Removed:
 - Routing.GetRouteKeys
- class NavigationRequest
- GotoPart from the IShellController classes as the platforms don't use these methods so they don't need to be apart of the controllers

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- there are unit tests

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
