### PR TITLE
[macOS] fix layout problems after the parent height change

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4854.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4854.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq.Expressions;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4854, "[macOS] Visual glitch when exiting the full screen with ScrollViewer", PlatformAffected.macOS)]
+	public class Issue4854 : TestContentPage
+	{
+
+		protected override void Init()
+		{
+			var gMain = new Grid { BackgroundColor = Color.LightBlue };
+			gMain.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+			gMain.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+			var label = new Label
+			{
+				Text = "Enter full screen and exit and see the artifacts on the screen.",
+				FontSize = 14
+			};
+			var sl = new StackLayout { HorizontalOptions = LayoutOptions.Center, WidthRequest = 300, Padding = new Thickness(15) };
+			sl.Children.Add(label);
+			gMain.Children.Add(sl);
+
+			var button = new Button { Text = "Test", BackgroundColor = Color.Gray, HorizontalOptions = LayoutOptions.Center };
+			var g = new Grid { BackgroundColor = Color.LightGray, Padding = new Thickness(20) };
+			g.Children.Add(button);
+			Grid.SetRow(g, 1);
+			gMain.Children.Add(g);
+
+			Content = new ScrollView { Content = gMain, BackgroundColor = Color.LightGreen };
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5890.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5890.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Linq.Expressions;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5890, "[macOS] Control with VerticalOption=Start is sticked to bottom", PlatformAffected.macOS)]
+	public class Issue5890 : TestContentPage
+	{
+		
+		protected override void Init()
+		{
+			var sp = new StackLayout {VerticalOptions = LayoutOptions.Start};
+			sp.Children.Add(new Button
+			{
+				Text = "Change the height of the window. This button should be sticked to the top."
+			});
+			Content = sp;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -918,6 +918,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4356.cs">
       <DependentUpon>Issue4356.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5890.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4854.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -43,6 +43,17 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty HeightProperty = HeightPropertyKey.BindableProperty;
 
+		public static readonly BindableProperty ParentHeightProperty = BindableProperty.Create("ParentHeight", typeof(double), typeof(VisualElement), default(double));
+
+		double ParentHeight
+		{
+			get { return (double)GetValue(ParentHeightProperty); }
+			set { SetValue(ParentHeightProperty, value); }
+		}
+
+		static bool IsMacOsPlatform = Device.RuntimePlatform == Device.macOS;
+
+
 		public static readonly BindableProperty RotationProperty = BindableProperty.Create("Rotation", typeof(double), typeof(VisualElement), default(double));
 
 		public static readonly BindableProperty RotationXProperty = BindableProperty.Create("RotationX", typeof(double), typeof(VisualElement), default(double));
@@ -300,11 +311,15 @@ namespace Xamarin.Forms
 			private set
 			{
 				if (value.X == X && value.Y == Y && value.Height == Height && value.Width == Width)
+				{
+					if (IsMacOsPlatform) ParentHeight = (Parent as VisualElement)?.Height ?? 0;
 					return;
+				}
 				BatchBegin();
 				X = value.X;
 				Y = value.Y;
 				SetSize(value.Width, value.Height);
+				if (IsMacOsPlatform) ParentHeight = (Parent as VisualElement)?.Height ?? 0;
 				BatchCommit();
 			}
 		}

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -43,15 +43,14 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty HeightProperty = HeightPropertyKey.BindableProperty;
 
-		public static readonly BindableProperty ParentHeightProperty = BindableProperty.Create("ParentHeight", typeof(double), typeof(VisualElement), default(double));
+		// Due to a different coordinate system in macOS, "ParentHeightForMacOS" is required to be passed to VisualElementTracker
+		static readonly BindableProperty ParentHeightForMacOSProperty = BindableProperty.Create("ParentHeightForMacOS", typeof(double), typeof(VisualElement), default(double));
 
-		double ParentHeight
+		double ParentHeightForMacOS
 		{
-			get { return (double)GetValue(ParentHeightProperty); }
-			set { SetValue(ParentHeightProperty, value); }
+			get { return (double)GetValue(ParentHeightForMacOSProperty); }
+			set { SetValue(ParentHeightForMacOSProperty, value); }
 		}
-
-		static bool IsMacOsPlatform = Device.RuntimePlatform == Device.macOS;
 
 
 		public static readonly BindableProperty RotationProperty = BindableProperty.Create("Rotation", typeof(double), typeof(VisualElement), default(double));
@@ -312,14 +311,18 @@ namespace Xamarin.Forms
 			{
 				if (value.X == X && value.Y == Y && value.Height == Height && value.Width == Width)
 				{
-					if (IsMacOsPlatform) ParentHeight = (Parent as VisualElement)?.Height ?? 0;
+					// Due to a different coordinate system in macOS, "ParentHeightForMacOS' is required to be passed to VisualElementTracker
+					if (Device.RuntimePlatform == Device.macOS)
+						ParentHeightForMacOS = (Parent as VisualElement)?.Height ?? 0;
 					return;
 				}
 				BatchBegin();
 				X = value.X;
 				Y = value.Y;
 				SetSize(value.Width, value.Height);
-				if (IsMacOsPlatform) ParentHeight = (Parent as VisualElement)?.Height ?? 0;
+				// Due to a different coordinate system in macOS, "ParentHeightForMacOS" is required to be passed to VisualElementTracker
+				if (Device.RuntimePlatform == Device.macOS)
+					ParentHeightForMacOS = (Parent as VisualElement)?.Height ?? 0;
 				BatchCommit();
 			}
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -255,7 +255,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (ContentView == null || ScrollView == null || ScrollView.Content == null)
 				return false;
 
-			if (Math.Abs(ScrollView.ScrollY) < 0.001 && Math.Abs(ScrollView.ScrollX) < 0.001 && ScrollView.Content.Height > ScrollView.Height)
+			if (Math.Abs(ScrollView.ScrollY) < 0.001 && Math.Abs(ScrollView.ScrollX) < 0.001 && ScrollView.Content.Height >= ScrollView.Height)
 			{
 				ContentView.ScrollToPoint(new CoreGraphics.CGPoint(0, 0));
 				return true;
@@ -270,12 +270,17 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (ScrollView == null)
 				return;
 
-			if (ScrollView.ContentSize.Height >= ScrollView.Height)
+			var height = ScrollView.Height;
+			var contentHeightOverflow = ScrollView.ContentSize.Height - height;
+			if (contentHeightOverflow >= 0)
 			{
-				CoreGraphics.CGPoint location = ContentView.DocumentVisibleRect().Location;
+				if (height >= 0)
+				{
+					var location = ContentView.DocumentVisibleRect().Location;
 
-				if (location.Y > -1 && ScrollView.Height >= 0)
-					ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, ScrollView.ContentSize.Height - ScrollView.Height - location.Y));
+					if (location.Y > -1)
+						ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, contentHeightOverflow - location.Y));
+				}
 			}
 			else
 				ResetNativeNonScroll();

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -86,7 +86,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (TrackFrame && (e.PropertyName == VisualElement.XProperty.PropertyName ||
 							   e.PropertyName == VisualElement.YProperty.PropertyName ||
 							   e.PropertyName == VisualElement.WidthProperty.PropertyName ||
-							   e.PropertyName == VisualElement.HeightProperty.PropertyName))
+							   e.PropertyName == VisualElement.HeightProperty.PropertyName ||
+							   e.PropertyName == VisualElement.ParentHeightProperty.PropertyName))
 			{
 				UpdateNativeControl();
 			}

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -87,7 +87,8 @@ namespace Xamarin.Forms.Platform.MacOS
 							   e.PropertyName == VisualElement.YProperty.PropertyName ||
 							   e.PropertyName == VisualElement.WidthProperty.PropertyName ||
 							   e.PropertyName == VisualElement.HeightProperty.PropertyName ||
-							   e.PropertyName == VisualElement.ParentHeightProperty.PropertyName))
+							   // Due to a different coordinate system in macOS, "ParentHeightForMacOS" is required to be passed from VisualElement
+							   e.PropertyName == "ParentHeightForMacOS"))
 			{
 				UpdateNativeControl();
 			}


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->
The coordinate system in macOS is different than in Xamarin.Forms - the point (X=0, Y=0) is located in the left bottom corner. This fix resolves the problem of moving up the child control when the height of the parent is changed, but size and location of the child is the same. It was necessary to add new properties described below to be able to monitor parent height change.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5890 
- fixes #4854

### API Changes ###

Added in Xamarin.Forms.VisualElement (as private):
 - static readonly BindableProperty ParentHeightPropertyForMacOS { get; }
 - double ParentHeightForMacOS { get; set; }


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- macOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Child controls should not move as described in the resolved issues.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Manual tests included in Xamarin.Forms.Controls.Issues:
- Issue4854
- Issue5890

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
