### PR TITLE
Testing a theory about an unreliable memory leak test

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Helpers/GarbageCollectionHelper.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Helpers/GarbageCollectionHelper.cs
@@ -10,7 +10,9 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			GC.Collect();
 			GC.WaitForPendingFinalizers();
+
 			GC.Collect();
+			GC.WaitForPendingFinalizers();
 		}
 	}
 }


### PR DESCRIPTION
The Issue5555 test is failing about 75% of the time on Android; testing the theory that this is a timing issue because the second Collect call isn't being waited on.