### PR TITLE
add delay to UI Test 2951

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml
@@ -43,6 +43,9 @@
 		</ResourceDictionary>
 	</controls:TestContentPage.Resources>
 	<controls:TestContentPage.Content>
-		<ListView ItemTemplate="{StaticResource TheItemTemplate}" ItemsSource="{Binding Items}" RowHeight="74" />
-	</controls:TestContentPage.Content>
+        <StackLayout>
+            <Label x:Name="lblReady"></Label>
+		    <ListView x:Name="listView" ItemAppearing="ListView_ItemAppearing" ItemTemplate="{StaticResource TheItemTemplate}" ItemsSource="{Binding Items}" RowHeight="74" />
+	    </StackLayout>
+    </controls:TestContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -5,6 +5,7 @@ using Xamarin.Forms.CustomAttributes;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 #if UITEST
 using Xamarin.UITest.Queries;
@@ -23,9 +24,20 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue2951 ()
 		{
-			#if APP
+#if APP
 			InitializeComponent ();
-			#endif
+#endif
+		}
+
+		async void ListView_ItemAppearing(object sender, ItemVisibilityEventArgs e)
+		{
+			if(e.ItemIndex == 2)
+			{
+				await Task.Delay(10);
+#if APP
+				lblReady.Text = "Ready";
+#endif
+			}
 		}
 
 		protected override void Init ()
@@ -93,11 +105,12 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			}
 		}
-	
-		#if UITEST
+
+#if UITEST
 		[Test]
 		public void Issue2951Test ()
 		{
+			RunningApp.WaitForElement("Ready");
 			var bt = RunningApp.WaitForElement (c => c.Marked ("btnChangeStatus"));
 			var buttons = RunningApp.Query (c => c.Marked ("btnChangeStatus"));
 			Assert.That (buttons.Length, Is.EqualTo (3));
@@ -114,7 +127,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 	
-		#endif
+#endif
 	}
 }
 


### PR DESCRIPTION
### Description of Change ###

Issue2951 occasionally fails UI Tests most likely because the read of the three buttons happens before they actually render. This adds some code that lets the UI Test wait for a prompt that they've finished rendering


### Testing Instructions ###
Run and rerun the API 28 LR / FR a couple times before merging to see if this test fails at all

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
