### PR TITLE
Added new named Font Sizes, iOS Named fonts now all AutoScale based on Accessibility Options

### DIFF
--- a/Xamarin.Forms.Core/FontSizeConverter.cs
+++ b/Xamarin.Forms.Core/FontSizeConverter.cs
@@ -34,6 +34,16 @@ namespace Xamarin.Forms
 					namedSize = NamedSize.Medium;
 				else if (value.Equals(nameof(NamedSize.Large), sc))
 					namedSize = NamedSize.Large;
+				else if (value.Equals(nameof(NamedSize.Body), sc))
+					namedSize = NamedSize.Body;
+				else if (value.Equals(nameof(NamedSize.Caption), sc))
+					namedSize = NamedSize.Caption;
+				else if (value.Equals(nameof(NamedSize.Header), sc))
+					namedSize = NamedSize.Header;
+				else if (value.Equals(nameof(NamedSize.Subtitle), sc))
+					namedSize = NamedSize.Subtitle;
+				else if (value.Equals(nameof(NamedSize.Title), sc))
+					namedSize = NamedSize.Title;
 				else if (Enum.TryParse(value, ignoreCase, out NamedSize ns))
 					namedSize = ns;
 
@@ -62,6 +72,16 @@ namespace Xamarin.Forms
 					return Device.GetNamedSize(NamedSize.Medium, typeof(Label), false);
 				if (value.Equals(nameof(NamedSize.Large), StringComparison.Ordinal))
 					return Device.GetNamedSize(NamedSize.Large, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Body), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Body, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Caption), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Caption, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Header), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Header, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Subtitle), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Subtitle, typeof(Label), false);
+				if (value.Equals(nameof(NamedSize.Title), StringComparison.Ordinal))
+					return Device.GetNamedSize(NamedSize.Title, typeof(Label), false);
 				if (Enum.TryParse(value, out NamedSize namedSize))
 					return Device.GetNamedSize(namedSize, typeof(Label), false);
 			}

--- a/Xamarin.Forms.Core/NamedSize.cs
+++ b/Xamarin.Forms.Core/NamedSize.cs
@@ -6,6 +6,11 @@ namespace Xamarin.Forms
 		Micro = 1,
 		Small = 2,
 		Medium = 3,
-		Large = 4
+		Large = 4,
+		Body = 5,
+		Header = 6,
+		Title = 7,
+		Subtitle = 8,
+		Caption = 9
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -493,6 +493,16 @@ namespace Xamarin.Forms
 							return 14;
 						case NamedSize.Large:
 							return 18;
+						case NamedSize.Body:
+							return 16;
+						case NamedSize.Caption:
+							return 12;
+						case NamedSize.Header:
+							return 96;
+						case NamedSize.Subtitle:
+							return 16;
+						case NamedSize.Title:
+							return 24;
 						default:
 							throw new ArgumentOutOfRangeException("size");
 					}

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -49,13 +49,23 @@ namespace Xamarin.Forms.Platform.UWP
 				case NamedSize.Default:
 					return (double)WApplication.Current.Resources["ControlContentThemeFontSize"];
 				case NamedSize.Micro:
-					return 18.667 - 3;
+					return 15.667;
 				case NamedSize.Small:
 					return 18.667;
 				case NamedSize.Medium:
 					return 22.667;
 				case NamedSize.Large:
 					return 32;
+				case NamedSize.Body:
+					return 14;
+				case NamedSize.Caption:
+					return 12;
+				case NamedSize.Header:
+					return 46;
+				case NamedSize.Subtitle:
+					return 20;
+				case NamedSize.Title:
+					return 24;
 				default:
 					throw new ArgumentOutOfRangeException("size");
 			}

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -163,11 +163,13 @@ namespace Xamarin.Forms
 				_notification = UIDevice.Notifications.ObserveOrientationDidChange((sender, args) => CurrentOrientation = UIDevice.CurrentDevice.Orientation.ToDeviceOrientation());
 				_scalingFactor = UIScreen.MainScreen.Scale;
 				_scaledScreenSize = new Size(UIScreen.MainScreen.Bounds.Width, UIScreen.MainScreen.Bounds.Height);
+				
 #else
 				_scalingFactor = NSScreen.MainScreen.BackingScaleFactor;
 				_scaledScreenSize = new Size(NSScreen.MainScreen.Frame.Width, NSScreen.MainScreen.Frame.Height);
 #endif
 				PixelScreenSize = new Size(_scaledScreenSize.Width * _scalingFactor, _scaledScreenSize.Height * _scalingFactor);
+				
 			}
 
 			public override Size PixelScreenSize { get; }
@@ -187,6 +189,17 @@ namespace Xamarin.Forms
 
 		class IOSPlatformServices : IPlatformServices
 		{
+
+			readonly double _fontScalingFactor = 1;
+			public IOSPlatformServices()
+			{
+#if __MOBILE__
+				//The standard accisibility size for a font is 18, we can get a 
+				//close aproximation to the new Size by multiplying by this scale factor
+				_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
+#endif
+			}
+
 			static readonly MD5CryptoServiceProvider s_checksum = new MD5CryptoServiceProvider();
 
 			public void BeginInvokeOnMainThread(Action action)
@@ -222,16 +235,41 @@ namespace Xamarin.Forms
 				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
 				switch (size)
 				{
+					//We multiply the fonts by the scale factor, and cast to an int, to make them whole numbers.
 					case NamedSize.Default:
-						return typeof(Button).IsAssignableFrom(targetElementType) ? 15 : 17;
+						return (int)((typeof(Button).IsAssignableFrom(targetElementType) ? 15 : 17) * _fontScalingFactor);
 					case NamedSize.Micro:
-						return 12;
+						return (int)(12 * _fontScalingFactor);
 					case NamedSize.Small:
-						return 14;
+						return (int)(14 * _fontScalingFactor);
 					case NamedSize.Medium:
-						return 17;
+						return (int)(17 * _fontScalingFactor);
 					case NamedSize.Large:
-						return 22;
+						return (int)(22 * _fontScalingFactor);
+#if __IOS__
+					case NamedSize.Body:
+						return (double)UIFont.PreferredBody.PointSize;
+					case NamedSize.Caption:
+						return (double)UIFont.PreferredCaption1.PointSize;
+					case NamedSize.Header:
+						return (double)UIFont.PreferredHeadline.PointSize;
+					case NamedSize.Subtitle:
+						return (double)UIFont.PreferredTitle2.PointSize;
+					case NamedSize.Title:
+						return (double)UIFont.PreferredTitle1.PointSize;
+#else
+					case NamedSize.Body:
+						return 23;
+					case NamedSize.Caption:
+						return 18;
+					case NamedSize.Header:
+						return 23;
+					case NamedSize.Subtitle:
+						return 28;
+					case NamedSize.Title:
+						return 34;
+
+#endif
 					default:
 						throw new ArgumentOutOfRangeException("size");
 				}


### PR DESCRIPTION
We now use the iOS Prefered Font Scaling stuff so fonts are magical

### Description of Change ###

Added new Named Fonts

fixes #5474

### API Changes ###
Added:
NamedSize Sizes
		Large = 4,
		Body = 5,
		Header = 6,
		Title = 7,
		Subtitle = 8,
		Caption = 9

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
iOS Font named font sizes now Scale just like Android does.

### Testing Procedure ###
Use a named font,
Set the Large Font Size  option in iOS, Accessibility options.

### PR Checklist ###
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
