### PR TITLE
[iOS] remove SetPaddingInsets api and just have it pad content and flyout by default

### DIFF
--- a/Xamarin.Forms.Controls/ShellContentTest.xaml
+++ b/Xamarin.Forms.Controls/ShellContentTest.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 			 Title="Welcome"
 			 Routing.Route="shellcontent"
-			 Shell.SetPaddingInsets="true"
 			 Shell.TabBarIsVisible="false"
              x:Class="Xamarin.Forms.Controls.ShellContentTest">
 	<Page.ToolbarItems>

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -58,7 +58,7 @@
 
 	<ShellItem Route="store" x:Name="_storeItem" FlyoutDisplayOptions="AsMultipleItems">
 		<ShellContent Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
-        <ShellContent Route="list" Title="List"  Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:DemoShellPage}" Shell.SetPaddingInsets="true" />
+        <ShellContent Route="list" Title="List"  Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:DemoShellPage}" />
 		<ShellContent Route="games" Style="{StaticResource GreenShell}" Title="Games" Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:GamesPage}" />
 		<ShellContent Route="movies" Style="{StaticResource MoviesShell}" Title="Movies &amp; TV" 
 					  Icon="film.png" FlyoutIcon="filmflyout.png" ContentTemplate="{DataTemplate local:MoviesPage}">

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -47,9 +47,6 @@ namespace Xamarin.Forms
 				SetInheritedBindingContext(newHandler, bindable.BindingContext);
 		}
 
-		public static readonly BindableProperty SetPaddingInsetsProperty =
-			BindableProperty.CreateAttached("SetPaddingInsets", typeof(bool), typeof(Shell), false);
-
 		public static readonly BindableProperty TabBarIsVisibleProperty =
 			BindableProperty.CreateAttached("TabBarIsVisible", typeof(bool), typeof(Shell), true);
 
@@ -67,9 +64,6 @@ namespace Xamarin.Forms
 
 		public static SearchHandler GetSearchHandler(BindableObject obj) => (SearchHandler)obj.GetValue(SearchHandlerProperty);
 		public static void SetSearchHandler(BindableObject obj, SearchHandler handler) => obj.SetValue(SearchHandlerProperty, handler);
-
-		public static bool GetSetPaddingInsets(BindableObject obj) => (bool)obj.GetValue(SetPaddingInsetsProperty);
-		public static void SetSetPaddingInsets(BindableObject obj, bool value) => obj.SetValue(SetPaddingInsetsProperty, value);
 
 		public static bool GetTabBarIsVisible(BindableObject obj) => (bool)obj.GetValue(TabBarIsVisibleProperty);
 		public static void SetTabBarIsVisible(BindableObject obj, bool value) => obj.SetValue(TabBarIsVisibleProperty, value);

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -220,6 +220,25 @@ namespace Xamarin.Forms.Platform.iOS
 			base.OnBindingContextChanged();
 		}
 
+		internal static UIEdgeInsets SafeAreaInsetsForWindow
+		{
+			get
+			{
+				UIEdgeInsets safeAreaInsets;
+
+				if (!Forms.IsiOS11OrNewer)
+					safeAreaInsets = new UIEdgeInsets(UIApplication.SharedApplication.StatusBarFrame.Size.Height, 0, 0, 0);
+				else if (UIApplication.SharedApplication.KeyWindow != null)
+					safeAreaInsets = UIApplication.SharedApplication.KeyWindow.SafeAreaInsets;
+				else if (UIApplication.SharedApplication.Windows.Length > 0)
+					safeAreaInsets = UIApplication.SharedApplication.Windows[0].SafeAreaInsets;
+				else
+					safeAreaInsets = UIEdgeInsets.Zero;
+
+				return safeAreaInsets;
+			}
+		}
+
 		internal void DidAppear()
 		{
 			_animateModals = false;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -339,32 +339,24 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateShellInsetPadding()
 		{
-			if (Element == null)
+			if (!(Element?.Parent is ShellContent))
 				return;
 
-			var setInsets = Shell.GetSetPaddingInsets(Element);
+			nfloat topPadding = 0;
+			nfloat bottomPadding = 0;
 
-			if (!setInsets && Element.Parent != null)
-				setInsets = Shell.GetSetPaddingInsets(Element.Parent);
-
-			if (setInsets)
+			if (Forms.IsiOS11OrNewer)
 			{
-				nfloat topPadding = 0;
-				nfloat bottomPadding = 0;
-
-				if (Forms.IsiOS11OrNewer)
-				{
-					topPadding = View.SafeAreaInsets.Top;
-					bottomPadding = View.SafeAreaInsets.Bottom;
-				}
-				else
-				{
-					topPadding = TopLayoutGuide.Length;
-					bottomPadding = BottomLayoutGuide.Length;
-				}
-
-				(Element as Page).Padding = new Thickness(0, topPadding, 0, bottomPadding);
+				topPadding = View.SafeAreaInsets.Top;
+				bottomPadding = View.SafeAreaInsets.Bottom;
 			}
+			else
+			{
+				topPadding = TopLayoutGuide.Length;
+				bottomPadding = BottomLayoutGuide.Length;
+			}
+
+			(Element as Page).Padding = new Thickness(0, topPadding, 0, bottomPadding);
 		}
 
 		void UpdateStatusBarPrefersHidden()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -301,7 +301,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			get
 			{
-				var animation = ((Page)Element).OnThisPlatform().PreferredStatusBarUpdateAnimation();
+				var animation = Page.OnThisPlatform().PreferredStatusBarUpdateAnimation();
 				switch (animation)
 				{
 					case (PageUIStatusBarAnimation.Fade):
@@ -356,7 +356,7 @@ namespace Xamarin.Forms.Platform.iOS
 				bottomPadding = BottomLayoutGuide.Length;
 			}
 
-			(Element as Page).Padding = new Thickness(0, topPadding, 0, bottomPadding);
+			Page.Padding = new Thickness(0, topPadding, 0, bottomPadding);
 		}
 
 		void UpdateStatusBarPrefersHidden()
@@ -364,7 +364,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element == null)
 				return;
 
-			var animation = ((Page)Element).OnThisPlatform().PreferredStatusBarUpdateAnimation();
+			var animation = Page.OnThisPlatform().PreferredStatusBarUpdateAnimation();
 			if (animation == PageUIStatusBarAnimation.Fade || animation == PageUIStatusBarAnimation.Slide)
 				UIView.Animate(0.25, () => SetNeedsStatusBarAppearanceUpdate());
 			else
@@ -384,7 +384,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override bool PrefersStatusBarHidden()
 		{
-			var mode = ((Page)Element).OnThisPlatform().PrefersStatusBarHidden();
+			var mode = Page.OnThisPlatform().PrefersStatusBarHidden();
 			switch (mode)
 			{
 				case (StatusBarHiddenMode.True):
@@ -418,8 +418,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateTitle()
 		{
-			if (!string.IsNullOrWhiteSpace(((Page)Element).Title))
-				NavigationItem.Title = ((Page)Element).Title;
+			if (!string.IsNullOrWhiteSpace(Page.Title))
+				NavigationItem.Title = Page.Title;
 		}
 
 		IEnumerable<UIView> ViewAndSuperviewsOfView(UIView view)
@@ -439,6 +439,6 @@ namespace Xamarin.Forms.Platform.iOS
 			SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 
-		public override bool PrefersHomeIndicatorAutoHidden => ((Page)Element).OnThisPlatform().PrefersHomeIndicatorAutoHidden();
+		public override bool PrefersHomeIndicatorAutoHidden => Page.OnThisPlatform().PrefersHomeIndicatorAutoHidden();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_headerView.Frame = new CGRect(0, _headerOffset + SafeAreaOffset, parent.Frame.Width, _headerSize);
 
-				if (_headerOffset < 0)
+				if (_headerOffset < 0 && _headerSize + _headerOffset >= 0)
 				{
 					CAShapeLayer shapeLayer = new CAShapeLayer();
 					CGRect rect = new CGRect(0, _headerOffset * -1, parent.Frame.Width, _headerSize + _headerOffset);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -103,25 +103,6 @@ namespace Xamarin.Forms.Platform.iOS
 			LayoutParallax();
 		}
 
-		float SafeAreaOffset
-		{
-			get
-			{
-				if (!Forms.IsiOS11OrNewer)
-				{
-
-					return (float)UIApplication.SharedApplication.StatusBarFrame.Size.Height;
-
-				}
-
-				if (UIApplication.SharedApplication.KeyWindow != null)
-					return (float)UIApplication.SharedApplication.KeyWindow.SafeAreaInsets.Top;
-
-				if (UIApplication.SharedApplication.Windows.Length > 0)
-					return (float)UIApplication.SharedApplication.Windows[0].SafeAreaInsets.Top;
-
-				return 0;
-			}
-		}
+		float SafeAreaOffset => (float)Platform.SafeAreaInsetsForWindow.Top;
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -1,4 +1,5 @@
-﻿using CoreGraphics;
+﻿using CoreAnimation;
+using CoreGraphics;
 using System;
 using UIKit;
 
@@ -40,10 +41,20 @@ namespace Xamarin.Forms.Platform.iOS
 		public void LayoutParallax()
 		{
 			var parent = TableView.Superview;
-
-			TableView.Frame = parent.Bounds;
+			TableView.Frame = parent.Bounds.Inset(0, SafeAreaOffset);
 			if (_headerView != null)
-				_headerView.Frame = new CGRect(0, _headerOffset, parent.Frame.Width, _headerSize);
+			{
+				_headerView.Frame = new CGRect(0, _headerOffset + SafeAreaOffset, parent.Frame.Width, _headerSize);
+
+				if (_headerOffset < 0)
+				{
+					CAShapeLayer shapeLayer = new CAShapeLayer();
+					CGRect rect = new CGRect(0, _headerOffset * -1, parent.Frame.Width, _headerSize + _headerOffset);
+					var path = CGPath.FromRect(rect);
+					shapeLayer.Path = path;
+					_headerView.Layer.Mask = shapeLayer;
+				}
+			}
 		}
 
 		public override void ViewDidLoad()
@@ -53,18 +64,18 @@ namespace Xamarin.Forms.Platform.iOS
 			TableView.SeparatorStyle = UITableViewCellSeparatorStyle.None;
 			if (Forms.IsiOS11OrNewer)
 				TableView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
-			TableView.ContentInset = new UIEdgeInsets((nfloat)_headerMax, 0, 0, 0);
+			TableView.ContentInset = new UIEdgeInsets((nfloat)_headerMax + SafeAreaOffset, 0, 0, 0);
 			TableView.Source = _source;
 		}
 
 		protected override void Dispose(bool disposing)
 		{
-			if(disposing)
+			if (disposing)
 			{
 				if ((_context?.Shell as IShellController) != null)
 					((IShellController)_context.Shell).StructureChanged -= OnStructureChanged;
 			}
-			
+
 			base.Dispose(disposing);
 		}
 
@@ -81,7 +92,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				case FlyoutHeaderBehavior.Scroll:
 					_headerSize = _headerMax;
-					_headerOffset = Math.Min (0, -(_headerMax + e.ContentOffset.Y));
+					_headerOffset = Math.Min(0, -(_headerMax + e.ContentOffset.Y));
 					break;
 
 				case FlyoutHeaderBehavior.CollapseOnScroll:
@@ -90,6 +101,27 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			LayoutParallax();
+		}
+
+		float SafeAreaOffset
+		{
+			get
+			{
+				if (!Forms.IsiOS11OrNewer)
+				{
+
+					return (float)UIApplication.SharedApplication.StatusBarFrame.Size.Height;
+
+				}
+
+				if (UIApplication.SharedApplication.KeyWindow != null)
+					return (float)UIApplication.SharedApplication.KeyWindow.SafeAreaInsets.Top;
+
+				if (UIApplication.SharedApplication.Windows.Length > 0)
+					return (float)UIApplication.SharedApplication.Windows[0].SafeAreaInsets.Top;
+
+				return 0;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
- Remove Shell.SetPaddingInsets api for now as it's not really serving it's correct purpose
- Fixed iOS so that it just pads the Flyout and page renderer the same on iOS and android which means you don't have to set SafeArea anymore
- Also fixes ios10 to pad the page area content

### Issues Resolved ### 
- fixes #5971

### API Changes ###

 Removed:
 - Shell.SetPaddingInsets 
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
- Flyout now offsets from notch or status bar on ios10
- when the header scrolls with the list it doesn't show up behind the clock anymore


Before / After

![image](https://user-images.githubusercontent.com/5375137/56679151-9d74c280-6681-11e9-927a-2de0f5d5863c.png)

When scrolling I added a mask so it doesn't overlap the status bar

![image](https://user-images.githubusercontent.com/5375137/56679273-e593e500-6681-11e9-95dd-a064a18f1691.png)

iOS 10
![image](https://user-images.githubusercontent.com/5375137/56679411-3e637d80-6682-11e9-9d90-073af39577a6.png)

![image](https://user-images.githubusercontent.com/5375137/56679441-4f13f380-6682-11e9-979f-57382fb7c129.png)


### Testing Procedure ###
- 4684 should pass on ios10

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
