### PR TITLE
Properly guard against statusbar usage

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -339,46 +339,52 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			_bounds = new Rectangle(0, 0, _page.ActualWidth, _page.ActualHeight);
 
-			StatusBar statusBar = MobileStatusBar;
-			if (statusBar != null)
-			{
-				bool landscape = Device.Info.CurrentOrientation.IsLandscape();
-				bool titleBar = CoreApplication.GetCurrentView().TitleBar.IsVisible;
-				double offset = landscape ? statusBar.OccludedRect.Width : statusBar.OccludedRect.Height;
-
-				_bounds = new Rectangle(0, 0, _page.ActualWidth - (landscape ? offset : 0), _page.ActualHeight - (landscape ? 0 : offset));
-
-				// Even if the MainPage is a ContentPage not inside of a NavigationPage, the calculated bounds
-				// assume the TitleBar is there even if it isn't visible. When UpdatePageSizes is called,
-				// _container.ActualWidth is correct because it's aware that the TitleBar isn't there, but the
-				// bounds aren't, and things can subsequently run under the StatusBar.
-				if (!titleBar)
+            if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+            {
+				StatusBar statusBar = MobileStatusBar;
+				if (statusBar != null)
 				{
-					_bounds.Width -= (_bounds.Width - _container.ActualWidth);
+					bool landscape = Device.Info.CurrentOrientation.IsLandscape();
+					bool titleBar = CoreApplication.GetCurrentView().TitleBar.IsVisible;
+					double offset = landscape ? statusBar.OccludedRect.Width : statusBar.OccludedRect.Height;
+
+					_bounds = new Rectangle(0, 0, _page.ActualWidth - (landscape ? offset : 0), _page.ActualHeight - (landscape ? 0 : offset));
+
+					// Even if the MainPage is a ContentPage not inside of a NavigationPage, the calculated bounds
+					// assume the TitleBar is there even if it isn't visible. When UpdatePageSizes is called,
+					// _container.ActualWidth is correct because it's aware that the TitleBar isn't there, but the
+					// bounds aren't, and things can subsequently run under the StatusBar.
+					if (!titleBar)
+					{
+						_bounds.Width -= (_bounds.Width - _container.ActualWidth);
+					}
 				}
 			}
 		}
 
 		void InitializeStatusBar()
 		{
-			StatusBar statusBar = MobileStatusBar;
-			if (statusBar != null)
-			{
-				statusBar.Showing += (sender, args) => UpdateBounds();
-				statusBar.Hiding += (sender, args) => UpdateBounds();
-
-				// UWP 14393 Bug: If RequestedTheme is Light (which it is by default), then the 
-				// status bar uses White Foreground with White Background. 
-				// UWP 10586 Bug: If RequestedTheme is Light (which it is by default), then the 
-				// status bar uses Black Foreground with Black Background. 
-				// Since the Light theme should have a Black on White status bar, we will set it explicitly. 
-				// This can be overriden by setting the status bar colors in App.xaml.cs OnLaunched.
-
-				if (statusBar.BackgroundColor == null && statusBar.ForegroundColor == null && Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Light)
+            if (ApiInformation.IsTypePresent("Windows.UI.ViewManagement.StatusBar"))
+            {
+				StatusBar statusBar = MobileStatusBar;
+				if (statusBar != null)
 				{
-					statusBar.BackgroundColor = Colors.White;
-					statusBar.ForegroundColor = Colors.Black;
-					statusBar.BackgroundOpacity = 1;
+					statusBar.Showing += (sender, args) => UpdateBounds();
+					statusBar.Hiding += (sender, args) => UpdateBounds();
+
+					// UWP 14393 Bug: If RequestedTheme is Light (which it is by default), then the 
+					// status bar uses White Foreground with White Background. 
+					// UWP 10586 Bug: If RequestedTheme is Light (which it is by default), then the 
+					// status bar uses Black Foreground with Black Background. 
+					// Since the Light theme should have a Black on White status bar, we will set it explicitly. 
+					// This can be overriden by setting the status bar colors in App.xaml.cs OnLaunched.
+
+					if (statusBar.BackgroundColor == null && statusBar.ForegroundColor == null && Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Light)
+					{
+						statusBar.BackgroundColor = Colors.White;
+						statusBar.ForegroundColor = Colors.Black;
+						statusBar.BackgroundOpacity = 1;
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

If you add the `Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer` nuget package, you'll find the analyzer points out these locations as not correctly guarded against usage.

### Issues Resolved ### 
Potential to hit a type that isn't present.

### API Changes ###
None

 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Add the `Microsoft.Toolkit.Uwp.PlatformSpecificAnalyzer` nuget package.

You'll still see the analyzer points out the MobileStatusBar property to not be guarded. There's not really away around that except to disable the warning using `#pragma warning disable UWP001 // Platform-specific`. I didn't want to add that though, unless the nuget package gets permanently added to the project, and any usage of the property will get called out by the analyzer, so it would be safe to disable here.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
