### PR TITLE
fix global routes to push onto stack correctly

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -61,6 +61,26 @@ namespace Xamarin.Forms.Core.UnitTests
 
 
 		[Test]
+		public async Task GlobalNavigateTwice()
+		{
+
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
+
+			shell.Items.Add(item1);
+			Routing.RegisterRoute("cat", typeof(ContentPage));
+			Routing.RegisterRoute("details", typeof(ContentPage));
+
+			await shell.GoToAsync("cat");
+			await shell.GoToAsync("details");
+
+			Assert.AreEqual("app:///rootlevelcontent1/cat/details", shell.CurrentState.Location.ToString());
+			await shell.GoToAsync("//rootlevelcontent1/details");
+			Assert.AreEqual("app:///rootlevelcontent1/details", shell.CurrentState.Location.ToString());
+		}
+
+
+		[Test]
 		public async Task GlobalRegisterAbsoluteMatching()	
 		{
 			var shell = new Shell() { RouteScheme = "app", Route = "shellroute" };

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -426,7 +426,7 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				await CurrentItem.CurrentItem.GoToAsync(navigationRequest.Request.GlobalRoutes, queryData, animate);
+				await CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate);
 			}
 			
 			//if (Routing.CompareWithRegisteredRoutes(shellItemRoute))

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -75,13 +75,12 @@ namespace Xamarin.Forms
 			if (shellContent == null)
 				return Task.FromResult(true);
 
-			
-			if(request.Request.GlobalRoutes.Count > 0)
+			if (request.Request.GlobalRoutes.Count > 0)
 			{
 				// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
 				Device.BeginInvokeOnMainThread(async () =>
 				{
-					await GoToAsync(request.Request.GlobalRoutes, queryData, false);
+					await GoToAsync(request, queryData, false);
 				});
 			}
 
@@ -226,8 +225,9 @@ namespace Xamarin.Forms
 			return (ShellSection)(ShellContent)page;
 		}
 
-		public virtual async Task GoToAsync(List<string> routes, IDictionary<string, string> queryData, bool animate)
+		internal async Task GoToAsync(NavigationRequest request, IDictionary<string, string> queryData, bool animate)
 		{
+			List<string> routes = request.Request.GlobalRoutes;
 			if (routes == null || routes.Count == 0)
 			{
 				await Navigation.PopToRootAsync(animate);
@@ -248,9 +248,12 @@ namespace Xamarin.Forms
 						continue;
 					}
 
-					while (_navStack.Count > i + 1)
+					if (request.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
 					{
-						await OnPopAsync(false);
+						while (_navStack.Count > i + 1)
+						{
+							await OnPopAsync(false);
+						}
 					}
 				}
 


### PR DESCRIPTION
### Description of Change ###
Pages on shell sections were always just being pushed off. This change correctly interprets the URI request and then pushes or replaces accordingly

### Issues Resolved ### 
- fixes #6016 

### API Changes ###
 Removed:
 - Made ShellSection.GoToAsync internal for now. Converted away from public virtual. This will be replaced later with handlers
 

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
There is a unit test but you can try doing this
gotoasync("page")
gotoasync("page")

and make sure it creates a stack of two pages

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

