### PR TITLE
add check for null track drawable

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				Control.SetOnCheckedChangeListener(null);
 
-				_defaultTrackDrawable.Dispose();
+				_defaultTrackDrawable?.Dispose();
 				_defaultTrackDrawable = null;
 			}
 


### PR DESCRIPTION
### Description of Change ###

Copy over nullable check when disposing of track to non appcompat

### Issues Resolved ### 
- fixes #5970


### Platforms Affected ### 
- Android

