### PR TITLE
fix tizen obsolete errors

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/ToolbarItemButton.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/ToolbarItemButton.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				UpdateIsEnabled();
 			}
-			else if (e.PropertyName == ToolbarItem.IconProperty.PropertyName)
+			else if (e.PropertyName == ToolbarItem.IconImageSourceProperty.PropertyName)
 			{
 				UpdateIcon();
 			}

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellRenderer.cs
@@ -156,9 +156,9 @@ namespace Xamarin.Forms.Platform.Tizen
 					else if (flyoutGroup[j] is MenuItem menuItem)
 					{
 						title = menuItem.Text;
-						if (menuItem.Icon != null)
+						if (menuItem.IconImageSource is FileImageSource source)
 						{
-							icon = menuItem.Icon.File;
+							icon = source.File;
 						}
 					}
 

--- a/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
+++ b/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
@@ -6,7 +6,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
     <WarningsAsErrors>NU1605</WarningsAsErrors>
   </PropertyGroup>
 


### PR DESCRIPTION
### Description of Change ###

Tizen didn't have treat warnings as errors set for debug builds (only for release builds) so these errors weren't caught