### PR TITLE
[Android] set dialog to null when dismissed

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -168,6 +168,8 @@ namespace Xamarin.Forms.Platform.Android
 			_dialog.DismissEvent += (sender, args) =>
 			{
 				ElementController?.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
+				_dialog?.Dispose();
+				_dialog = null;
 			};
 			_dialog.Show();
 		}


### PR DESCRIPTION
### Description of Change ###

Dialog needs to be set to null when it's dismissed so that it can live again

### Issues Resolved ### 
- fixes #5945
### Platforms Affected ### 

- Android

### Testing Procedure ###
Comment out the registering of the appcompat renderer for the picker and then test some pickers

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
