### PR TITLE
additional proguard rules for shell

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -161,7 +161,7 @@
     </PrepareForBuildDependsOn>
   </PropertyGroup>
   
-  <Target Name="IncludeProguardForAndroid">
+  <Target Name="IncludeProguardForAndroid" Condition="'$(XFDisableDefaultProguardConfiguration)' != 'True'">
     <ItemGroup>
       <ProguardConfiguration Include="$(MSBuildThisFileDirectory)MonoAndroid10\proguard.cfg" />
     </ItemGroup>

--- a/.nuspec/proguard.cfg
+++ b/.nuspec/proguard.cfg
@@ -1,2 +1,4 @@
 -keep class android.support.v7.widget.FitWindowsFrameLayout { *; }
 -dontwarn android.support.v7.widget.FitWindowsFrameLayout
+-keep class android.support.design.** { *; }
+-keep class android.support.multidex.MultiDexApplication { *; }

--- a/Xamarin.Forms.Sandbox.Android/proguard.cfg
+++ b/Xamarin.Forms.Sandbox.Android/proguard.cfg
@@ -1,2 +1,4 @@
 -keep class android.support.v7.widget.FitWindowsFrameLayout { *; }
 -dontwarn android.support.v7.widget.FitWindowsFrameLayout
+-keep class android.support.design.** { *; }
+-keep class android.support.multidex.MultiDexApplication { *; }


### PR DESCRIPTION
### Description of Change ###
Shell needs some additional help to work with proguard.

I also added a keep for multidex which will be fixed in an upcoming VS release but I figured we might as well just include it for now to remove friction

Also added a property to disable default proguard rules if users want more fine grained control

```xml
<Target Name="IncludeProguardForAndroid" Condition="'$(XFDisableDefaultProguardConfiguration)' != 'True'">
    <ItemGroup>
      <ProguardConfiguration Include="$(MSBuildThisFileDirectory)MonoAndroid10\proguard.cfg" />
    </ItemGroup>
  </Target>
```
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5799 

### Platforms Affected ### 
- Android

### Testing Procedure ###
install the nuget for this PR into a XF project using shell.  On that project enable multidex, proguard, and set the linker to full. At this point the project should run without any errors

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
