### PR TITLE
Add EventToCommandBehavior

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BehaviorTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/BehaviorTest.cs
@@ -14,7 +14,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			base.OnAttachedTo (bindable);
 			attached = true;
 			AttachCount++;
-			AssociatedObject = bindable;
 		}
 
 		protected override void OnDetachingFrom (BindableObject bindable)
@@ -22,10 +21,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			AttachCount--;
 			detached = true;
 			base.OnDetachingFrom (bindable);
-			AssociatedObject = null;
 		}
-
-		public BindableObject AssociatedObject {get;set;}
 	}
 
 	[TestFixture]

--- a/Xamarin.Forms.Core.UnitTests/EventToCommandBehaviorTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/EventToCommandBehaviorTests.cs
@@ -13,6 +13,11 @@ namespace Xamarin.Forms.Core.UnitTests
 	{
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
+			if(value is ElementEventArgs args)
+			{
+				value = args.Element;
+			}
+
 			if(value is Button btn)
 			{
 				return btn.Text;
@@ -66,6 +71,27 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.NotNull(element);
 			Assert.AreSame(button, element);
+		}
+
+		[Test]
+		public void InvokesCommandWithParameterUsingConverter()
+		{
+			var sl = new StackLayout();
+			var button = new Button { Text = "Some Text" };
+			string buttonText = null;
+			var behavior = new EventToCommandBehavior
+			{
+				Command = new Command<string>(t => buttonText = t),
+				EventName = "ChildAdded",
+				EventArgsConverter = new MockButtonTextConverter()
+			};
+
+			sl.Behaviors.Add(behavior);
+
+			sl.Children.Add(button);
+
+			Assert.NotNull(buttonText);
+			Assert.AreEqual(button.Text, buttonText);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/EventToCommandBehaviorTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/EventToCommandBehaviorTests.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms.Core.Interactivity;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	class MockButtonTextConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			if(value is Button btn)
+			{
+				return btn.Text;
+			}
+
+			return value;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
+		}
+	}
+
+	[TestFixture]
+	public class EventToCommandBehaviorTests : BaseTestFixture
+	{
+		[Test]
+		public void InvokesCommandWithNoParameter()
+		{
+			var button = new Button();
+			bool wasClicked = false;
+			var behavior = new EventToCommandBehavior
+			{
+				Command = new Command(() => wasClicked = true),
+				EventName = "Clicked"
+			};
+
+			button.Behaviors.Add(behavior);
+			button.SendClicked();
+
+			Assert.True(wasClicked);
+		}
+
+		[Test]
+		public void InvokesCommandWithParameterFromEventArgsPath()
+		{
+			var sl = new StackLayout();
+			var button = new Button();
+			Element element = null;
+			var behavior = new EventToCommandBehavior
+			{
+				Command = new Command<Element>(e => element = e),
+				EventName = "ChildAdded",
+				EventArgsParameterPath = "Element"
+			};
+
+			sl.Behaviors.Add(behavior);
+
+			sl.Children.Add(button);
+
+			Assert.NotNull(element);
+			Assert.AreSame(button, element);
+		}
+
+		[Test]
+		public void InvokesCommandWithParameterFromEventArgsPathUsingConverter()
+		{
+			var sl = new StackLayout();
+			var button = new Button { Text = "Some Text" };
+			string buttonText = null;
+			var behavior = new EventToCommandBehavior
+			{
+				Command = new Command<string>(t => buttonText = t),
+				EventName = "ChildAdded",
+				EventArgsParameterPath = "Element",
+				EventArgsConverter = new MockButtonTextConverter()
+			};
+
+			sl.Behaviors.Add(behavior);
+
+			sl.Children.Add(button);
+
+			Assert.NotNull(buttonText);
+			Assert.AreEqual(button.Text, buttonText);
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -74,6 +74,7 @@
     <Compile Include="CommandTests.cs" />
     <Compile Include="DependencyResolutionTests.cs" />
     <Compile Include="EffectiveFlowDirectionExtensions.cs" />
+    <Compile Include="EventToCommandBehaviorTests.cs" />
     <Compile Include="ShellTestBase.cs" />
     <Compile Include="ShellUriHandlerTests.cs" />
     <Compile Include="VisualTests.cs" />

--- a/Xamarin.Forms.Core/Interactivity/Behavior.cs
+++ b/Xamarin.Forms.Core/Interactivity/Behavior.cs
@@ -39,9 +39,20 @@ namespace Xamarin.Forms
 		{
 		}
 
+		public T AssociatedObject { get; private set; }
+
 		protected override void OnAttachedTo(BindableObject bindable)
 		{
 			base.OnAttachedTo(bindable);
+			AssociatedObject = (T)bindable;
+
+			if(AssociatedObject.BindingContext != null)
+			{
+				BindingContext = AssociatedObject.BindingContext;
+			}
+
+			AssociatedObject.BindingContextChanged += OnBindingContextChanged;
+
 			OnAttachedTo((T)bindable);
 		}
 
@@ -52,11 +63,18 @@ namespace Xamarin.Forms
 		protected override void OnDetachingFrom(BindableObject bindable)
 		{
 			OnDetachingFrom((T)bindable);
+			AssociatedObject.BindingContextChanged -= OnBindingContextChanged;
+			AssociatedObject = null;
 			base.OnDetachingFrom(bindable);
 		}
 
 		protected virtual void OnDetachingFrom(T bindable)
 		{
+		}
+
+		void OnBindingContextChanged(object sender, EventArgs e)
+		{
+			BindingContext = AssociatedObject.BindingContext;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Interactivity/EventToCommandBehavior.cs
+++ b/Xamarin.Forms.Core/Interactivity/EventToCommandBehavior.cs
@@ -1,0 +1,160 @@
+﻿using System;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Windows.Input;
+
+namespace Xamarin.Forms.Core.Interactivity
+{
+	public class EventToCommandBehavior : Behavior
+	{
+		public static readonly BindableProperty EventNameProperty =
+			BindableProperty.Create(nameof(EventName), typeof(string), typeof(EventToCommandBehavior));
+
+		public static readonly BindableProperty CommandProperty =
+			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(EventToCommandBehavior));
+
+		public static readonly BindableProperty CommandParameterProperty =
+			BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(EventToCommandBehavior));
+
+		public static readonly BindableProperty EventArgsConverterProperty =
+			BindableProperty.Create(nameof(EventArgsConverter), typeof(IValueConverter), typeof(EventToCommandBehavior));
+
+		public static readonly BindableProperty EventArgsConverterParameterProperty =
+			BindableProperty.Create(nameof(EventArgsConverterParameter), typeof(object), typeof(EventToCommandBehavior));
+
+		public static readonly BindableProperty EventArgsParameterPathProperty =
+			BindableProperty.Create(
+				nameof(EventArgsParameterPath),
+				typeof(string),
+				typeof(EventToCommandBehavior));
+
+		protected EventInfo _eventInfo;
+		protected Delegate _handler;
+
+		public string EventArgsParameterPath
+		{
+			get { return (string)GetValue(EventArgsParameterPathProperty); }
+			set { SetValue(EventArgsParameterPathProperty, value); }
+		}
+
+		public string EventName
+		{
+			get { return (string)GetValue(EventNameProperty); }
+			set { SetValue(EventNameProperty, value); }
+		}
+
+		public ICommand Command
+		{
+			get { return (ICommand)GetValue(CommandProperty); }
+			set { SetValue(CommandProperty, value); }
+		}
+
+		public object CommandParameter
+		{
+			get { return GetValue(CommandParameterProperty); }
+			set { SetValue(CommandParameterProperty, value); }
+		}
+
+		public IValueConverter EventArgsConverter
+		{
+			get { return (IValueConverter)GetValue(EventArgsConverterProperty); }
+			set { SetValue(EventArgsConverterProperty, value); }
+		}
+
+		public object EventArgsConverterParameter
+		{
+			get { return GetValue(EventArgsConverterParameterProperty); }
+			set { SetValue(EventArgsConverterParameterProperty, value); }
+		}
+
+		protected override void OnAttachedTo(BindableObject bindable)
+		{
+			base.OnAttachedTo(bindable);
+
+			_eventInfo = bindable
+				.GetType()
+				.GetRuntimeEvent(EventName);
+			if (_eventInfo == null)
+			{
+				throw new ArgumentException(
+					$"No matching event '{EventName}' on attached type '{bindable.GetType().Name}'");
+			}
+
+			AddEventHandler(_eventInfo, bindable, OnEventRaised);
+		}
+
+		protected override void OnDetachingFrom(BindableObject bindable)
+		{
+			if (_handler != null)
+			{
+				_eventInfo.RemoveEventHandler(bindable, _handler);
+			}
+			_handler = null;
+			_eventInfo = null;
+			base.OnDetachingFrom(bindable);
+		}
+
+		private void AddEventHandler(EventInfo eventInfo, object item, Action<object, EventArgs> action)
+		{
+			var eventParameters = eventInfo.EventHandlerType
+				.GetRuntimeMethods().First(m => m.Name == "Invoke")
+				.GetParameters()
+				.Select(p => Expression.Parameter(p.ParameterType))
+				.ToArray();
+
+			var actionInvoke = action.GetType()
+				.GetRuntimeMethods().First(m => m.Name == "Invoke");
+
+			_handler = Expression.Lambda(
+				eventInfo.EventHandlerType,
+				Expression.Call(Expression.Constant(action), actionInvoke, eventParameters[0], eventParameters[1]),
+				eventParameters)
+				.Compile();
+
+			eventInfo.AddEventHandler(item, _handler);
+		}
+
+		protected virtual void OnEventRaised(object sender, EventArgs eventArgs)
+		{
+			if (Command == null)
+			{
+				return;
+			}
+
+			var parameter = CommandParameter;
+
+			if (parameter == null && !string.IsNullOrEmpty(EventArgsParameterPath))
+			{
+				//Walk the ParameterPath for nested properties.
+				var propertyPathParts = EventArgsParameterPath.Split('.');
+				object propertyValue = eventArgs;
+				foreach (var propertyPathPart in propertyPathParts)
+				{
+					var propInfo = propertyValue.GetType().GetRuntimeProperty(propertyPathPart);
+					if (propInfo == null)
+						throw new MissingMemberException($"Unable to find {EventArgsParameterPath}");
+
+					propertyValue = propInfo.GetValue(propertyValue);
+					if (propertyValue == null)
+					{
+						break;
+					}
+				}
+				parameter = propertyValue;
+			}
+
+			if (parameter == null && eventArgs != null && eventArgs != EventArgs.Empty && EventArgsConverter != null)
+			{
+				parameter = EventArgsConverter.Convert(eventArgs, typeof(object), EventArgsConverterParameter,
+					CultureInfo.CurrentUICulture);
+			}
+
+			if (Command.CanExecute(parameter))
+			{
+				Command.Execute(parameter);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Interactivity/EventToCommandBehavior.cs
+++ b/Xamarin.Forms.Core/Interactivity/EventToCommandBehavior.cs
@@ -145,7 +145,7 @@ namespace Xamarin.Forms.Core.Interactivity
 				parameter = propertyValue;
 			}
 
-			if (parameter == null && eventArgs != null && eventArgs != EventArgs.Empty && EventArgsConverter != null)
+			if(EventArgsConverter != null && (parameter != null || eventArgs != EventArgs.Empty))
 			{
 				parameter = EventArgsConverter.Convert(eventArgs, typeof(object), EventArgsConverterParameter,
 					CultureInfo.CurrentUICulture);

--- a/Xamarin.Forms.Core/Interactivity/EventToCommandBehavior.cs
+++ b/Xamarin.Forms.Core/Interactivity/EventToCommandBehavior.cs
@@ -96,7 +96,7 @@ namespace Xamarin.Forms.Core.Interactivity
 			base.OnDetachingFrom(bindable);
 		}
 
-		private void AddEventHandler(EventInfo eventInfo, object item, Action<object, EventArgs> action)
+		void AddEventHandler(EventInfo eventInfo, object item, Action<object, EventArgs> action)
 		{
 			var eventParameters = eventInfo.EventHandlerType
 				.GetRuntimeMethods().First(m => m.Name == "Invoke")


### PR DESCRIPTION
### Description of Change ###

This closes #5685 from @davidortinau for an EventToCommandBehavior. This makes two changes

1) Adds the AssociatedObject in Behavior{T} which is the major missing piece of Behavior and even shown in numerous samples and docs.
2) Adds the EventToCommandBehavior from Prism which provides support for invoking a command based on a Path Name of a property in the EventArgs and/or using a IValueConverter to convert the EventArgs/Property 

### API Changes ###

Added:
 - T Behavior<T>.AssociatedObject { get; } 
 - EventToCommandBehavior
 
### Platforms Affected ### 

- Core

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

n/a

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
