### PR TITLE
retain local variable of page so not collected

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.Platform.iOS
 		VisualElementPackager _packager;
 		VisualElementTracker _tracker;
 
+		// storing this into a local variable causes it to not get collected. Do not delete this please		
+		PageContainer _pageContainer;
 		internal PageContainer Container => NativeView as PageContainer;
 
 		Page Page => Element as Page;
@@ -121,9 +123,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void LoadView()
 		{
-			View = new PageContainer(this);
-		}
+			if (_pageContainer == null)
+				_pageContainer = new PageContainer(this);
 
+			View = _pageContainer;
+		}
 		public override void ViewWillLayoutSubviews()
 		{
 			base.ViewWillLayoutSubviews();
@@ -262,6 +266,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				Element = null;
 				Container?.Dispose();
+				_pageContainer = null;
 				_disposed = true;
 			}
 


### PR DESCRIPTION
### Description of Change ###
If you don't store the page container to a local variable then scenarios can happen where it gets collected. The main area we were seeing this issue was when using the previewer on the About page of the MDP template
