### PR TITLE
[iOS] Add missing null check to `SelectableItemsViewRenderer.SetupNewElement`.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FlagTestHelpers.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FlagTestHelpers.cs
@@ -1,0 +1,17 @@
+﻿using System.Collections.Generic;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	internal static class FlagTestHelpers
+	{
+		public static void SetTestFlag(string flag)
+		{
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { flag });
+		}
+
+		public static void SetCollectionViewTestFlag()
+		{
+			SetTestFlag("CollectionView_Experimental");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+			FlagTestHelpers.SetCollectionViewTestFlag();
 
 			PushAsync(new GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewSwapGallery());
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5949, "CollectionView cannot access a disposed object.",
+		PlatformAffected.iOS)]
+	public class Issue5949 : TestContentPage
+	{
+		protected override void Init()
+		{
+			FlagTestHelpers.SetCollectionViewTestFlag();
+			Appearing += Issue5949Appearing;
+		}
+
+		private void Issue5949Appearing(object sender, EventArgs e)
+		{
+			Application.Current.MainPage = new Issue5949_1();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949.cs
@@ -34,5 +34,19 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Application.Current.MainPage = new Issue5949_1();
 		}
+
+#if UITEST
+		[Test]
+		public void DoNotAccessDisposedCollectionView()
+		{
+			RunningApp.WaitForElement("Login");
+			RunningApp.Tap("Login");	
+			
+			RunningApp.WaitForElement(Issue5949_2.BackButton);
+			RunningApp.Tap(Issue5949_2.BackButton);
+		
+			RunningApp.WaitForElement("Login");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<MasterDetailPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue5949_1"
+             Title="Issue 5949">
+    <MasterDetailPage.Master>
+        <ContentPage Title="Issue 5949">
+            <Label Text="Detail"></Label>
+        </ContentPage>
+    </MasterDetailPage.Master>
+
+    <MasterDetailPage.Detail>
+        <NavigationPage>
+            <x:Arguments>
+                <local:Issue5949_2 />
+            </x:Arguments>
+        </NavigationPage>
+    </MasterDetailPage.Detail>
+</MasterDetailPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml.cs
@@ -16,7 +16,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue5949_1()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml.cs
@@ -10,7 +10,9 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
 	[Preserve(AllMembers = true)]
 	public partial class Issue5949_1 : MasterDetailPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_1.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Preserve(AllMembers = true)]
+	public partial class Issue5949_1 : MasterDetailPage
+	{
+		public Issue5949_1()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml
@@ -4,6 +4,7 @@
              x:Class="Xamarin.Forms.Controls.Issues.Issue5949_2"
              Title="Issue 5949">
     <StackLayout>
+        <Label Text="Tap the 'Login' toolbar item. On the next page, tap the 'Back' button. If the application crashes, this test has failed." />
         <CollectionView 
                 ItemsSource="{Binding Items}"
                 VerticalOptions="FillAndExpand" >

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue5949_2"
+             Title="Issue 5949">
+    <ContentPage.ToolbarItems>
+        <ToolbarItem Text="Login" Order="Primary" Priority="1" Clicked="ToolbarItem_Clicked"></ToolbarItem>
+    </ContentPage.ToolbarItems>
+    <StackLayout>
+        <CollectionView 
+                ItemsSource="{Binding Items}"
+                VerticalOptions="FillAndExpand" >
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Label Text="{Binding}"></Label>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</ContentPage>
+    

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml
@@ -3,9 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Controls.Issues.Issue5949_2"
              Title="Issue 5949">
-    <ContentPage.ToolbarItems>
-        <ToolbarItem Text="Login" Order="Primary" Priority="1" Clicked="ToolbarItem_Clicked"></ToolbarItem>
-    </ContentPage.ToolbarItems>
     <StackLayout>
         <CollectionView 
                 ItemsSource="{Binding Items}"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	[Preserve(AllMembers = true)]
+	public partial class Issue5949_2 : ContentPage
+	{
+		const string BackButton = "5949GoBack";
+
+		public Issue5949_2()
+		{
+#if APP
+			InitializeComponent();
+			BindingContext = new _5949ViewModel();
+#endif
+		}
+
+		[Preserve(AllMembers = true)]
+		class _5949ViewModel
+		{
+			public _5949ViewModel()
+			{
+				Items = new List<string>
+				{
+					"one", "two", "three"
+				};
+			}
+
+			public List<string> Items { get; set; }
+		}
+
+		void ToolbarItem_Clicked(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(LoginPage());
+		}
+
+		ContentPage LoginPage()
+		{
+			var page = new ContentPage
+			{
+				Title = "Issue 5949"
+			};
+
+			var button = new Button { Text = "Back", AutomationId = BackButton };
+
+			button.Clicked += ButtonClicked;
+
+			page.Content = button;
+
+			return page;
+		}
+
+		private void ButtonClicked(object sender, EventArgs e)
+		{
+			Application.Current.MainPage = new Issue5949_1();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml.cs
@@ -9,12 +9,14 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public partial class Issue5949_2 : ContentPage
 	{
-		const string BackButton = "5949GoBack";
+		public const string BackButton = "5949GoBack";
+		public const string ToolBarItem = "Login";
 
 		public Issue5949_2()
 		{
 #if APP
 			InitializeComponent();
+			ToolbarItems.Add(new ToolbarItem(ToolBarItem, null, () => Navigation.PushAsync(LoginPage())));
 			BindingContext = new _5949ViewModel();
 #endif
 		}
@@ -31,11 +33,6 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 
 			public List<string> Items { get; set; }
-		}
-
-		void ToolbarItem_Clicked(object sender, EventArgs e)
-		{
-			Navigation.PushAsync(LoginPage());
 		}
 
 		ContentPage LoginPage()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949_2.xaml.cs
@@ -5,7 +5,9 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
 	[Preserve(AllMembers = true)]
 	public partial class Issue5949_2 : ContentPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FlagTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4915.xaml.cs">
       <SubType>Code</SubType>
@@ -458,6 +459,15 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue5535.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5949.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5949_1.xaml.cs">
+      <DependentUpon>Issue5949_1.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5949_2.xaml.cs">
+      <DependentUpon>Issue5949_2.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />
@@ -1174,6 +1184,18 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4915.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5949_1.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5949_2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/SelectableItemsViewRenderer.cs
@@ -36,6 +36,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			base.SetUpNewElement(newElement);
 
+			if (newElement == null)
+			{
+				return;
+			}
+
 			SelectableItemsViewController.UpdateSelectionMode();
 			SelectableItemsViewController.UpdateNativeSelection();
 		}


### PR DESCRIPTION
### Description of Change ###

Missing null check in `SelectableItemsViewRenderer.SetupNewElement` causes an unhandled exception when the CollectionView's renderer is disposed. This change adds the null check and an automated test.

### Issues Resolved ### 

- fixes #5949 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Navigate to the test for Issue 5949 and follow the instructions.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
