### PR TITLE
[Android] Image load fixes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml
@@ -3,17 +3,22 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Controls.Issues.Issue4915ContentPage"
              xmlns:local="clr-namespace:Xamarin.Forms.Controls"
-            BackgroundImage="{Binding Image}"
-            Icon="{Binding Image}">
+             BackgroundImage="{Binding Image}"
+             Icon="{Binding Image}">
     <ContentPage.ToolbarItems>
         <ToolbarItem Name="MenuItem1" Order="Primary" Icon="{Binding Image}" Text="Item 1" Priority="0" />
+        <ToolbarItem Name="MenuItem1" Order="Primary" IconImageSource="{Binding ImageUrl}" Text="Item 1" Priority="0" />
     </ContentPage.ToolbarItems>
     <ContentPage.Content>
-        <StackLayout>
-            <Button Image="{Binding Image}"></Button>
-            <Slider ThumbImage="{Binding Image}"></Slider>
-            <Label Text="Verify that Button.Image, MenuItem.Icon, Page.BackgroundImage, Page.Icon, Slider.ThumbImage all have coffee cups"></Label>
-            <Label Text="Nothing Crashed"></Label>
-        </StackLayout>
+        <ScrollView>
+            <StackLayout>
+                <Label Text="Nothing Crashed"></Label>
+                <Label Text="Verify that Button.Image, MenuItem.Icon, Page.BackgroundImage, Page.Icon, Slider.ThumbImage all have coffee cups"></Label>
+                <Button Image="{Binding Image}"></Button>
+                <Slider ThumbImage="{Binding Image}"></Slider>
+                <Button ImageSource="{Binding ImageUrl}"></Button>
+                <Slider ThumbImageSource="{Binding ImageUrl}"></Slider>          
+            </StackLayout>
+        </ScrollView>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml
@@ -14,9 +14,9 @@
             <StackLayout>
                 <Label Text="Nothing Crashed"></Label>
                 <Label Text="Verify that Button.Image, MenuItem.Icon, Page.BackgroundImage, Page.Icon, Slider.ThumbImage all have coffee cups"></Label>
-                <Button Image="{Binding Image}"></Button>
+                <Button Image="{Binding Image}" Clicked="ButtonClicked"></Button>
                 <Slider ThumbImage="{Binding Image}"></Slider>
-                <Button ImageSource="{Binding ImageUrl}"></Button>
+                <Button ImageSource="{Binding ImageUrl}" Clicked="ButtonClicked"></Button>
                 <Slider ThumbImageSource="{Binding ImageUrl}"></Slider>          
             </StackLayout>
         </ScrollView>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -27,8 +27,17 @@ namespace Xamarin.Forms.Controls.Issues
 #pragma warning restore CS0618 // Type or member is obsolete
 			navPage.BindingContext = new Issue4915ContentPage.ViewModel();
 
+
+			var urlNavPage = new NavigationPage(new Issue4915ContentPage()) { Title = "nav page 1" };
+			urlNavPage.SetBinding(Page.IconImageSourceProperty, "ImageUrl");
+			urlNavPage.BindingContext = new Issue4915ContentPage.ViewModel();
+
+
 			Children.Add(navPage);
+			Children.Add(urlNavPage);
 			Children.Add(new Issue4915ContentPage() { Title = "page 2" });
+
+
 		}
 
 #if UITEST
@@ -57,6 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public class ViewModel
 		{
 			public string Image { get; set; } = "coffee.png";
+			public string ImageUrl { get; set; } = "https://raw.githubusercontent.com/xamarin/Xamarin.Forms/f27f5a3650f37894d4a1ac925d6fab4dc7350087/Xamarin.Forms.ControlGallery.iOS/oasis.jpg";
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -62,6 +62,28 @@ namespace Xamarin.Forms.Controls.Issues
 
 		}
 
+		private void ButtonClicked(object sender, EventArgs e)
+		{
+			ViewModel vm = null;
+			if ((BindingContext as ViewModel).Image != "oasis.png")
+			{
+				vm = new ViewModel()
+				{
+					Image = "oasis.png",
+					ImageUrl = "https://raw.githubusercontent.com/xamarin/Xamarin.Forms/78385f9fc1fc56dc88bd98e73bf9c8f2f2d0a90a/Xamarin.Forms.ControlGallery.iOS/Resources/jet.png"
+				};
+
+			}
+			else
+			{
+				vm = new ViewModel();
+			}
+
+			BindingContext = vm;
+			Parent.BindingContext = vm;
+			Parent.Parent.BindingContext = vm;
+		}
+
 		[Preserve(AllMembers = true)]
 		public class ViewModel
 		{

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -54,7 +54,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			_buttonLayoutManager?.Update();
 			return base.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	public class ButtonRenderer : ViewRenderer<Button, AppCompatButton>,
 		AView.IOnAttachStateChangeListener, AView.IOnClickListener, AView.IOnTouchListener,
-		IBorderVisualElementRenderer, IButtonLayoutRenderer
+		IBorderVisualElementRenderer, IButtonLayoutRenderer, IDisposedState
 	{
 		BorderBackgroundManager _backgroundTracker;
 		TextColorSwitcher _textColorSwitcher;
@@ -202,5 +202,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		}
 
 		AppCompatButton IButtonLayoutRenderer.View => Control;
+		bool IDisposedState.IsDisposed => _isDisposed;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -22,7 +22,8 @@ namespace Xamarin.Forms.Platform.Android
 		AView.IOnFocusChangeListener,
 		AView.IOnClickListener,
 		AView.IOnTouchListener,
-		ILayoutChanges
+		ILayoutChanges,
+		IDisposedState
 	{
 		bool _inputTransparent;
 		bool _disposed;
@@ -41,7 +42,8 @@ namespace Xamarin.Forms.Platform.Android
 		VisualElement IVisualElementRenderer.Element => Element;
 		AView IVisualElementRenderer.View => this;
 		ViewGroup IVisualElementRenderer.ViewGroup => null;
-		VisualElementTracker IVisualElementRenderer.Tracker => _tracker;
+		VisualElementTracker IVisualElementRenderer.Tracker => _tracker;		
+		bool IDisposedState.IsDisposed => _disposed;
 
 		public ImageButton Element
 		{

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -276,8 +276,20 @@ namespace Xamarin.Forms.Platform.Android
 			else
 				view.CompoundDrawablePadding = (int)Context.ToPixels(layout.Spacing);
 
+			Drawable existingImage = null;
+			var images = TextViewCompat.GetCompoundDrawablesRelative(view);
+			for (int i = 0; i < images.Length; i++)
+				if(images[i] != null)
+				{
+					existingImage = images[i];
+					break;
+				}
+
 			_renderer.ApplyDrawableAsync(Button.ImageSourceProperty, Context, image =>
 			{
+				if (image == existingImage)
+					return;
+
 				switch (layout.Position)
 				{
 					case Button.ButtonContentLayout.ImagePosition.Top:
@@ -294,11 +306,8 @@ namespace Xamarin.Forms.Platform.Android
 						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, image, null, null, null);
 						break;
 				}
-
-				// Invalidating here causes a crazy amount of increased measure invalidations
-				// when I tested with Issue4484 it caused about 800 calls to invalidate measure vs the 8 without this
-				// I'm pretty sure it gets into a layout / invalidation loop where these are invalidating mid layout				
-				//_element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
+		
+				_element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
 			});
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			AppCompatButton view = View;
-			if (view == null || view.Layout == null)
+			if (view == null)
 				return;
 
 			Drawable drawable = null;

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _preserveInitialPadding;
 		bool _borderAdjustsPadding;
 		bool _maintainLegacyMeasurements;
+		bool _hasLayoutOccurred;
 
 		public ButtonLayoutManager(IButtonLayoutRenderer renderer)
 			: this(renderer, false, false, false, true)
@@ -141,6 +142,8 @@ namespace Xamarin.Forms.Platform.Android
 					}
 				}
 			}
+
+			_hasLayoutOccurred = true;
 		}
 
 		public void OnViewAttachedToWindow(AView attachedView)
@@ -306,8 +309,12 @@ namespace Xamarin.Forms.Platform.Android
 						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, image, null, null, null);
 						break;
 				}
-		
-				_element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
+
+				// I'm not thrilled about the BeginInvokeOnMainThread
+				// but without it the button won't resize based on the image dimensions if the image has changed
+				// you can see this using Issue4915
+				if (_hasLayoutOccurred)
+					Device.BeginInvokeOnMainThread(() => _element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged));
 			});
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -310,11 +310,8 @@ namespace Xamarin.Forms.Platform.Android
 						break;
 				}
 
-				// I'm not thrilled about the BeginInvokeOnMainThread
-				// but without it the button won't resize based on the image dimensions if the image has changed
-				// you can see this using Issue4915
 				if (_hasLayoutOccurred)
-					Device.BeginInvokeOnMainThread(() => _element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged));
+					_element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
 			});
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -53,6 +53,10 @@ namespace Xamarin.Forms.Platform.Android
 						}
 					}
 				}
+				else if (!Forms.IsLollipopOrNewer)
+				{
+					imageView.SetImageDrawable(null);
+				}
 			}
 			finally
 			{

--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -53,9 +53,9 @@ namespace Xamarin.Forms.Platform.Android
 						}
 					}
 				}
-				else if (!Forms.IsLollipopOrNewer)
+				else
 				{
-					imageView.SetImageDrawable(null);
+					imageView.SetImageBitmap(null);
 				}
 			}
 			finally

--- a/Xamarin.Forms.Platform.Android/IDisposedState.cs
+++ b/Xamarin.Forms.Platform.Android/IDisposedState.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal interface IDisposedState : IDisposable
+	{
+		bool IsDisposed { get; }
+	}
+}

--- a/Xamarin.Forms.Platform.Android/ImageCache.cs
+++ b/Xamarin.Forms.Platform.Android/ImageCache.cs
@@ -1,4 +1,5 @@
 ﻿using System.Threading.Tasks;
+using Java.Lang;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -12,6 +13,25 @@ namespace Xamarin.Forms.Platform.Android
 		const string _cachePlaceHolder = "PLEASEHOLD";
 
 		global::Android.Util.LruCache _lruCache;
+		public class FormsLruCache : global::Android.Util.LruCache
+		{
+			public FormsLruCache(int maxSize) : base(maxSize)
+			{
+			}
+
+			protected override int SizeOf(Object key, Object value)
+			{
+				if (value != null && value is global::Android.Graphics.Bitmap bitmap)
+					return bitmap.ByteCount;
+
+				return base.SizeOf(key, value);
+			}
+
+			protected override Object Create(Object key)
+			{
+				return base.Create(key);
+			}
+		}
 
 		static int GetCacheSize()
 		{
@@ -27,7 +47,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public ImageCache() : base()
 		{
-			_lruCache = new global::Android.Util.LruCache(GetCacheSize());
+			_lruCache = new FormsLruCache(GetCacheSize());
 		}
 
 		public async void Put(string key, Java.Lang.Object cacheObject)

--- a/Xamarin.Forms.Platform.Android/ImageCache.cs
+++ b/Xamarin.Forms.Platform.Android/ImageCache.cs
@@ -117,10 +117,10 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				// https://developer.android.com/topic/performance/graphics/cache-bitmap
 				int cacheSize = 4 * 1024 * 1024;
-				if (Java.Lang.Runtime.GetRuntime()?.MaxMemory() != null)
+				var maxMemory = Java.Lang.Runtime.GetRuntime()?.MaxMemory();
+				if (maxMemory != null)
 				{
-					var maxMemory = (int)(Java.Lang.Runtime.GetRuntime().MaxMemory() / 1024);
-					cacheSize = maxMemory / 8;
+					cacheSize = (int)(maxMemory.Value / 8);
 				}
 				return cacheSize;
 			}

--- a/Xamarin.Forms.Platform.Android/ImageCache.cs
+++ b/Xamarin.Forms.Platform.Android/ImageCache.cs
@@ -1,0 +1,108 @@
+﻿using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	/// <summary>
+	/// I setup the access to all the cache elements to be async because
+	/// if I didn't then it was locking up the GC and freezing the entire app
+	/// </summary>
+	class ImageCache
+	{
+
+		const string _cachePlaceHolder = "PLEASEHOLD";
+
+		global::Android.Util.LruCache _lruCache;
+
+		static int GetCacheSize()
+		{
+			// https://developer.android.com/topic/performance/graphics/cache-bitmap
+			int cacheSize = 4 * 1024 * 1024;
+			if (Java.Lang.Runtime.GetRuntime()?.MaxMemory() != null)
+			{
+				var maxMemory = (int)(Java.Lang.Runtime.GetRuntime().MaxMemory() / 1024);
+				cacheSize = maxMemory / 8;
+			}
+			return cacheSize;
+		}
+
+		public ImageCache() : base()
+		{
+			_lruCache = new global::Android.Util.LruCache(GetCacheSize());
+		}
+
+		public async void Put(string key, Java.Lang.Object cacheObject)
+		{
+			await Task.Run(() =>
+			{
+				try
+				{
+					_lruCache.Put(key, cacheObject);
+				}
+				catch
+				{
+					//just in case
+				}
+
+
+			}).ConfigureAwait(false);
+		}
+
+		public async void PutLoadingKey(string key)
+		{
+			await Task.Run(() =>
+			{
+				try
+				{
+					_lruCache.Put(key, _cachePlaceHolder);
+				}
+				catch
+				{
+					//just in case
+				}
+
+			}).ConfigureAwait(false);
+		}
+
+		public Task<Java.Lang.Object> GetAsync(string cacheKey)
+		{
+			return Task.Run(async () =>
+			{
+				try
+				{
+					var innerCacheObject = _lruCache.Get(cacheKey);
+
+					// this only really gets hit during load when there are a lot of requests for the same image
+					while (innerCacheObject?.ToString() == _cachePlaceHolder)
+					{
+						await Task.Delay(100).ConfigureAwait(false);
+						innerCacheObject = _lruCache.Get(cacheKey);
+					}
+
+					return innerCacheObject;
+				}
+				catch
+				{
+					//just in case
+				}
+
+				return null;
+			});
+		}
+
+		public async void Remove(string key)
+		{
+			await Task.Run(() =>
+			{
+				try
+				{
+					_lruCache.Remove(key);
+				}
+				catch
+				{
+					//just in case
+				}
+
+			}).ConfigureAwait(false);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/ImageCache.cs
+++ b/Xamarin.Forms.Platform.Android/ImageCache.cs
@@ -20,19 +20,9 @@ namespace Xamarin.Forms.Platform.Android
 			_lruCache = new FormsLruCache();			
 		}
 
-		async void Put(string key, TimeSpan cacheValidity, global::Android.Graphics.Bitmap cacheObject)
+		void Put(string key, TimeSpan cacheValidity, global::Android.Graphics.Bitmap cacheObject)
 		{
-			await Task.Run(() =>
-			{
-				try
-				{
-					_lruCache.Put(key, new CacheEntry() { TimeToLive = DateTimeOffset.Now.Add(cacheValidity), Data = cacheObject });
-				}
-				catch
-				{
-					//just in case
-				}
-			});
+			_lruCache.Put(key, new CacheEntry() { TimeToLive = DateTimeOffset.Now.Add(cacheValidity), Data = cacheObject });
 		}
 
 		public Task<Java.Lang.Object> GetAsync(string cacheKey, TimeSpan cacheValidity, Func<Task<Java.Lang.Object>> createMethod)

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -194,10 +194,7 @@ namespace Xamarin.Forms.Platform.Android
 					// Keep track of the image height so we can use it in OnLayout
 					_imageHeight = image?.IntrinsicHeight ?? -1;
 
-					// Invalidating here causes a crazy amount of increased measure invalidations
-					// when I tested with Issue4484 it caused about 800 calls to invalidate measure vs the 8 without this
-					// I'm pretty sure it gets into a layout / invalidation loop where these are invalidating mid layout				
-					//Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
+					Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
 				});
 				return;
 			}
@@ -225,10 +222,7 @@ namespace Xamarin.Forms.Platform.Android
 						break;
 				}
 
-				// Invalidating here causes a crazy amount of increased measure invalidations
-				// when I tested with Issue4484 it caused about 800 calls to invalidate measure vs the 8 without this
-				// I'm pretty sure it gets into a layout / invalidation loop where these are invalidating mid layout				
-				//Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
+				Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
 			});
 		}
 

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -155,10 +155,10 @@ namespace Xamarin.Forms.Platform.Android
 
 					// Todo improve for other sources
 					// volley the requests better up front so that if the same request comes in it isn't requeued
-					if (initialSource is UriImageSource uri)
+					if (initialSource is UriImageSource uri && uri.CachingEnabled)
 					{
 						cacheKey = Device.PlatformServices.GetMD5Hash(uri.Uri.ToString());
-						var cacheObject = await GetCache().GetAsync(cacheKey, async () =>
+						var cacheObject = await GetCache().GetAsync(cacheKey, uri.CacheValidity, async () =>
 						{
 							var drawable = await context.GetFormsDrawableAsync(initialSource, cancellationToken);
 							return drawable;

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -18,22 +18,9 @@ namespace Xamarin.Forms.Platform.Android
 	public static class ResourceManager
 	{
 		const string _drawableDefType = "drawable";
-		static ImageCache _lruCache = null;
-		static object _lruCacheHandle = new object();
 
-		static ImageCache GetCache()
-		{
-			if (_lruCache != null)
-				return _lruCache;
-
-			lock(_lruCacheHandle)
-			{
-				if (_lruCache == null)
-					_lruCache = new ImageCache();
-			}
-
-			return _lruCache;
-		}
+		readonly static Lazy<ImageCache> _lruCache = new Lazy<ImageCache>(() => new ImageCache());
+		static ImageCache GetCache() => _lruCache.Value;
 
 
 		public static Type DrawableClass { get; set; }

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -11,7 +11,7 @@ using Android.Support.V4.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public abstract class VisualElementRenderer<TElement> : FormsViewGroup, IVisualElementRenderer, 
+	public abstract class VisualElementRenderer<TElement> : FormsViewGroup, IVisualElementRenderer, IDisposedState,
 		IEffectControlProvider where TElement : VisualElement
 	{
 		readonly List<EventHandler<VisualElementChangedEventArgs>> _elementChangedHandlers = new List<EventHandler<VisualElementChangedEventArgs>>();
@@ -265,10 +265,14 @@ namespace Xamarin.Forms.Platform.Android
 		/// </summary>
 		protected virtual bool ManageNativeControlLifetime => true;
 
+		bool CheckFlagsForDisposed() => (_flags & VisualElementRendererFlags.Disposed) != 0;
+		bool IDisposedState.IsDisposed => CheckFlagsForDisposed();
+
 		protected override void Dispose(bool disposing)
 		{
-			if ((_flags & VisualElementRendererFlags.Disposed) != 0)
+			if (CheckFlagsForDisposed())
 				return;
+
 			_flags |= VisualElementRendererFlags.Disposed;
 
 			if (disposing)

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -143,6 +143,7 @@
     <Compile Include="GetDesiredSizeDelegate.cs" />
     <Compile Include="IBorderVisualElementRenderer.cs" />
     <Compile Include="IDeviceInfoProvider.cs" />
+    <Compile Include="IDisposedState.cs" />
     <Compile Include="ILayoutChanges.cs" />
     <Compile Include="IScrollView.cs" />
     <Compile Include="ITabStop.cs" />

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -145,6 +145,7 @@
     <Compile Include="IDeviceInfoProvider.cs" />
     <Compile Include="IDisposedState.cs" />
     <Compile Include="ILayoutChanges.cs" />
+    <Compile Include="ImageCache.cs" />
     <Compile Include="IScrollView.cs" />
     <Compile Include="ITabStop.cs" />
     <Compile Include="IPickerRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###
The bulk of this code is to make it so the layout and loading of images doesn't thrash the system as much
- I added a basic lrucache for images loaded from url (Added Peppers and Matt on here to validate my effort)
- I made the button invalidate the measure only after it's been laid out otherwise you get all these repetitive invalidations on initial load
- API 19 doesn't look to clear the image out when it's set to translucent so for < Lollipop I just set the drawable to null

### Issues Resolved ### 

- fixes #6061
- fixes #6010 

### Platforms Affected ### 
- Android

### Testing Procedure ###
Test all the image loading on android you can
Issue4915 does a lot of different image loading against different types

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
