### PR TITLE
Add separate MarkerClick and InfoWindowClick events for Pins

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29017.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla29017.cs
@@ -31,9 +31,10 @@ namespace Xamarin.Forms.Controls.Issues
 					new Button {
 						Text = "Add pins",
 						Command = new Command (() => {
-
 							foreach (var pin in map.Pins) {
+#pragma warning disable CS0618
 								pin.Clicked -= PinClicked;
+#pragma warning restore CS0618
 							}
 
 							map.Pins.Clear ();
@@ -54,8 +55,9 @@ namespace Xamarin.Forms.Controls.Issues
 									Type = PinType.Place,
 									Position = new Position (map.VisibleRegion.Center.Latitude + lat, map.VisibleRegion.Center.Longitude + lng)
 								};
-
+#pragma warning disable CS0618
 								pin.Clicked += PinClicked;
+#pragma warning restore CS0618
 								map.Pins.Add (pin);
 							}
 						})

--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml
@@ -10,6 +10,7 @@
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
@@ -17,11 +18,16 @@
                    Placeholder="Search Address"
                    SearchButtonPressed="SearchForAddress" />
 
-        <Label x:Name="LastPinClickLabel"
-               Grid.Row="2" />
-        <Label x:Name="LastMapClickLabel"
-               Grid.Row="3" />
-        <ScrollView Grid.Row="4">
+        <Label
+            x:Name="LastMarkerClickLabel"
+            Grid.Row="2" />
+        <Label
+            x:Name="LastInfoWindowClickLabel"
+            Grid.Row="3" />
+        <Label
+            x:Name="LastMapClickLabel"
+            Grid.Row="4" />
+        <ScrollView Grid.Row="5">
             <StackLayout>
                 <Button Clicked="MapTypeClicked"
                         Text="Map Type" />

--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
@@ -23,7 +23,9 @@ namespace Xamarin.Forms.Controls
 			InitializeComponent();
 
 			Map = MakeMap();
+#pragma warning disable CS0618
 			Map.Pins.ForEach(pin => pin.Clicked += PinClicked);
+#pragma warning restore CS0618
 			Map.MapClicked += MapClicked;
 
 			((Grid)Content).Children.Add(Map, 0, 1);

--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
@@ -23,9 +23,11 @@ namespace Xamarin.Forms.Controls
 			InitializeComponent();
 
 			Map = MakeMap();
-#pragma warning disable CS0618
-			Map.Pins.ForEach(pin => pin.Clicked += PinClicked);
-#pragma warning restore CS0618
+			Map.Pins.ForEach(pin =>
+			{
+				pin.MarkerClicked += MarkerClicked;
+				pin.InfoWindowClicked += InfoWindowClicked;
+			});
 			Map.MapClicked += MapClicked;
 
 			((Grid)Content).Children.Add(Map, 0, 1);
@@ -65,9 +67,15 @@ namespace Xamarin.Forms.Controls
 			};
 		}
 
-		void PinClicked(object sender, EventArgs e)
+		void MarkerClicked(object sender, PinClickedEventArgs e)
 		{
-			LastPinClickLabel.Text = $"Last Pin Clicked: {((Pin)sender).Label}";
+			LastMarkerClickLabel.Text = $"Last Marker Clicked: {((Pin)sender).Label}";
+		}
+
+		void InfoWindowClicked(object sender, PinClickedEventArgs e)
+		{
+			LastInfoWindowClickLabel.Text = $"Last Info Window Clicked: {((Pin)sender).Label}";
+			e.HideInfoWindow = true;
 		}
 
 		async void SearchForAddress(object sender, EventArgs e)

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -305,20 +305,37 @@ namespace Xamarin.Forms.Maps.Android
 		void OnMarkerClick(object sender, GoogleMap.MarkerClickEventArgs e)
 		{
 			var pin = GetPinForMarker(e.Marker);
-			bool handled = pin?.SendMarkerClick() ?? false;
+
+			if (pin == null)
+			{
+				return;
+			}
+
+			// Setting e.Handled = true will prevent the info window from being presented
+			// SendMarkerClick() returns the value of PinClickedEventArgs.HideInfoWindow
+			bool handled = pin.SendMarkerClick();
 			e.Handled = handled;
 		}
 
 		void OnInfoWindowClick(object sender, GoogleMap.InfoWindowClickEventArgs e)
 		{
-			var pin = GetPinForMarker(e.Marker);
+			var marker = e.Marker;
+			var pin = GetPinForMarker(marker);
 
-			if (pin != null)
+			if (pin == null)
 			{
+				return;
+			}
+
 #pragma warning disable CS0612
-				pin.SendTap();
+			pin.SendTap();
 #pragma warning restore CS0612
-				pin.SendInfoWindowClicked();
+
+			// SendInfoWindowClick() returns the value of PinClickedEventArgs.HideInfoWindow
+			bool hideInfoWindow = pin.SendInfoWindowClick();
+			if (hideInfoWindow)
+			{
+				marker.HideInfoWindow();
 			}
 		}
 

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -287,7 +287,19 @@ namespace Xamarin.Forms.Maps.Android
 
 		protected Pin GetPinForMarker(Marker marker)
 		{
-			return Map?.Pins.FirstOrDefault(p => (string)p.MarkerId == marker.Id);
+			Pin targetPin = null;
+
+			for (int i = 0; i < Map.Pins.Count; i++)
+			{
+				var pin = Map.Pins[i];
+				if ((string)pin.MarkerId == marker.Id)
+				{
+					targetPin = pin;
+					break;
+				}
+			}
+
+			return targetPin;
 		}
 
 		void OnMarkerClick(object sender, GoogleMap.MarkerClickEventArgs e)

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -303,7 +303,9 @@ namespace Xamarin.Forms.Maps.Android
 
 			if (pin != null)
 			{
+#pragma warning disable CS0612
 				pin.SendTap();
+#pragma warning restore CS0612
 				pin.SendInfoWindowClicked();
 			}
 		}

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -327,9 +327,9 @@ namespace Xamarin.Forms.Maps.Android
 				return;
 			}
 
-#pragma warning disable CS0612
+#pragma warning disable CS0618
 			pin.SendTap();
-#pragma warning restore CS0612
+#pragma warning restore CS0618
 
 			// SendInfoWindowClick() returns the value of PinClickedEventArgs.HideInfoWindow
 			bool hideInfoWindow = pin.SendInfoWindowClick();

--- a/Xamarin.Forms.Maps.GTK/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.GTK/MapRenderer.cs
@@ -418,8 +418,10 @@ namespace Xamarin.Forms.Maps.GTK
                 if(pin.Position.Latitude == marker.Position.Lat &&
                     pin.Position.Longitude == marker.Position.Lng)
                 {
-                    pin.SendTap();
-                    break;
+#pragma warning disable CS0618
+	                pin.SendTap();
+#pragma warning restore CS0618
+					break;
                 }
             }
         }

--- a/Xamarin.Forms.Maps.Tizen/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Tizen/MapRenderer.cs
@@ -207,7 +207,9 @@ namespace Xamarin.Forms.Maps.Tizen
 				pin.MarkerId = nativePin;
 				nativePin.Clicked += (s, e) =>
 				{
+#pragma warning disable CS0618
 					pin.SendTap();
+#pragma warning restore CS0618
 				};
 				Control.Add(nativePin);
 				_pins.Add(pin);

--- a/Xamarin.Forms.Maps.UWP/PushPin.cs
+++ b/Xamarin.Forms.Maps.UWP/PushPin.cs
@@ -46,9 +46,9 @@ namespace Xamarin.Forms.Maps.UWP
 
 		void PushPinTapped(object sender, TappedRoutedEventArgs e)
 		{
-#pragma warning disable CS0612
+#pragma warning disable CS0618
 			_pin.SendTap();
-#pragma warning restore CS0612
+#pragma warning restore CS0618
 			_pin.SendMarkerClick();
 		}
 

--- a/Xamarin.Forms.Maps.UWP/PushPin.cs
+++ b/Xamarin.Forms.Maps.UWP/PushPin.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Forms.Maps.UWP
 		void PushPinTapped(object sender, TappedRoutedEventArgs e)
 		{
 			_pin.SendTap();
+			_pin.SendMarkerClick();
 		}
 
 		void UpdateLocation()

--- a/Xamarin.Forms.Maps.UWP/PushPin.cs
+++ b/Xamarin.Forms.Maps.UWP/PushPin.cs
@@ -46,7 +46,9 @@ namespace Xamarin.Forms.Maps.UWP
 
 		void PushPinTapped(object sender, TappedRoutedEventArgs e)
 		{
+#pragma warning disable CS0612
 			_pin.SendTap();
+#pragma warning restore CS0612
 			_pin.SendMarkerClick();
 		}
 

--- a/Xamarin.Forms.Maps.WPF/FormsPushPin.cs
+++ b/Xamarin.Forms.Maps.WPF/FormsPushPin.cs
@@ -36,7 +36,9 @@ namespace Xamarin.Forms.Maps.WPF
 
 		void FormsPushPin_MouseDown(object sender, MouseButtonEventArgs e)
 		{
+#pragma warning disable CS0618
 			Pin.SendTap();
+#pragma warning restore CS0618
 		}
 
 		void PinPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -284,7 +284,13 @@ namespace Xamarin.Forms.Maps.MacOS
 
 			if (pin != null)
 			{
-				pin.SendMarkerClick();
+				// SendMarkerClick() returns the value of PinClickedEventArgs.HideInfoWindow
+				// Hide the info window by deselecting the annotation
+				bool deselect = pin.SendMarkerClick();
+				if (deselect)
+				{
+					((MKMapView)Control).DeselectAnnotation(annotation, false);
+				}
 			}
 		}
 		
@@ -305,7 +311,14 @@ namespace Xamarin.Forms.Maps.MacOS
 #pragma warning disable CS0612
 			targetPin.SendTap();
 #pragma warning restore CS0612
-			targetPin.SendInfoWindowClicked();
+
+			// SendInfoWindowedClick() returns the value of PinClickedEventArgs.HideInfoWindow
+			// Hide the info window by deselecting the annotation
+			bool deselect = targetPin.SendInfoWindowClick();
+			if (deselect)
+			{
+				((MKMapView)Control).DeselectAnnotation(annotation, true);
+			}
 		}
 
 #if __MOBILE__

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -304,9 +304,9 @@ namespace Xamarin.Forms.Maps.MacOS
 			if (_lastTouchedView is MKAnnotationView)
 				return;
 
-#pragma warning disable CS0612
+#pragma warning disable CS0618
 			targetPin.SendTap();
-#pragma warning restore CS0612
+#pragma warning restore CS0618
 
 			// SendInfoWindowClick() returns the value of PinClickedEventArgs.HideInfoWindow
 			// Hide the info window by deselecting the annotation

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using System.Linq;
 using CoreLocation;
 using MapKit;
 using ObjCRuntime;
@@ -71,6 +72,7 @@ namespace Xamarin.Forms.Maps.MacOS
 				}
 
 				var mkMapView = (MKMapView)Control;
+				mkMapView.DidSelectAnnotationView -= MkMapViewOnAnnotationViewSelected;
 				mkMapView.RegionChanged -= MkMapViewOnRegionChanged;
 				mkMapView.GetViewForAnnotation = null;
 				if (mkMapView.Delegate != null)
@@ -145,6 +147,7 @@ namespace Xamarin.Forms.Maps.MacOS
 					SetNativeControl(mapView);
 
 					mapView.GetViewForAnnotation = GetViewForAnnotation;
+					mapView.DidSelectAnnotationView += MkMapViewOnAnnotationViewSelected;
 					mapView.RegionChanged += MkMapViewOnRegionChanged;
 #if __MOBILE__
 					mapView.AddGestureRecognizer(_mapClickedGestureRecognizer = new UITapGestureRecognizer(OnMapClicked));
@@ -256,6 +259,17 @@ namespace Xamarin.Forms.Maps.MacOS
 			mapPin.AddGestureRecognizer(recognizer);
 		}
 
+		void MkMapViewOnAnnotationViewSelected(object sender, MKAnnotationViewEventArgs e)
+		{
+			var annotation = e.View.Annotation;
+			var pin = ((Map)Element).Pins.FirstOrDefault(p => p.MarkerId == annotation);
+
+			if (pin != null)
+			{
+				pin.SendMarkerClick();
+			}
+		}
+
 #if __MOBILE__
 		void OnClick(object annotationObject, UITapGestureRecognizer recognizer)
 #else
@@ -289,6 +303,7 @@ namespace Xamarin.Forms.Maps.MacOS
 				return;
 
 			targetPin.SendTap();
+			targetPin.SendInfoWindowClicked();
 		}
 
 #if __MOBILE__

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -302,7 +302,9 @@ namespace Xamarin.Forms.Maps.MacOS
 			if (_lastTouchedView is MKAnnotationView)
 				return;
 
+#pragma warning disable CS0612
 			targetPin.SendTap();
+#pragma warning restore CS0612
 			targetPin.SendInfoWindowClicked();
 		}
 

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -1,15 +1,11 @@
-﻿using System;
-using System.Collections;
-using System.Collections.Generic;
+﻿using System.Collections;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Linq;
 using CoreLocation;
 using MapKit;
 using ObjCRuntime;
 using RectangleF = CoreGraphics.CGRect;
-using Foundation;
 
 #if __MOBILE__
 using UIKit;
@@ -312,7 +308,7 @@ namespace Xamarin.Forms.Maps.MacOS
 			targetPin.SendTap();
 #pragma warning restore CS0612
 
-			// SendInfoWindowedClick() returns the value of PinClickedEventArgs.HideInfoWindow
+			// SendInfoWindowClick() returns the value of PinClickedEventArgs.HideInfoWindow
 			// Hide the info window by deselecting the annotation
 			bool deselect = targetPin.SendInfoWindowClick();
 			if (deselect)

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Maps
 			}
 		}
 
-		[Obsolete("This event is obsolete as of 4.2.0. Please use MarkerClicked and/or InfoWindowClicked instead.")]
+		[Obsolete("This event is obsolete as of 4.3.0. Please use MarkerClicked and/or InfoWindowClicked instead.")]
 		public event EventHandler Clicked;
 
 		public event EventHandler<PinClickedEventArgs> MarkerClicked;
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Maps
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[Obsolete("This method is obsolete as of 4.2.0.")]
+		[Obsolete("This method is obsolete as of 4.3.0.")]
 		public bool SendTap()
 		{
 			EventHandler handler = Clicked;

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Maps
 			}
 		}
 
-		[Obsolete("This event is obsolete. Please use MarkerClicked and/or InfoWindowClicked instead.")]
+		[Obsolete("This event is obsolete as of 4.1.0. Please use MarkerClicked and/or InfoWindowClicked instead.")]
 		public event EventHandler Clicked;
 
 		public event EventHandler<PinClickedEventArgs> MarkerClicked;
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Maps
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[Obsolete]
+		[Obsolete("This method is obsolete as of 4.1.0.")]
 		public bool SendTap()
 		{
 			EventHandler handler = Clicked;

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -68,9 +68,9 @@ namespace Xamarin.Forms.Maps
 		[Obsolete("This event is obsolete. Please use MarkerClicked and/or InfoWindowClicked instead.")]
 		public event EventHandler Clicked;
 
-		public event EventHandler MarkerClicked;
+		public event EventHandler<PinClickedEventArgs> MarkerClicked;
 
-		public event EventHandler InfoWindowClicked;
+		public event EventHandler<PinClickedEventArgs> InfoWindowClicked;
 
 		public override bool Equals(object obj)
 		{
@@ -120,29 +120,17 @@ namespace Xamarin.Forms.Maps
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public bool SendMarkerClick()
 		{
-			var handler = MarkerClicked;
-
-			if (handler == null)
-			{
-				return false;
-			}
-
-			handler(this, EventArgs.Empty);
-			return true;
+			var args = new PinClickedEventArgs();
+			MarkerClicked?.Invoke(this, args);
+			return args.HideInfoWindow;
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public bool SendInfoWindowClicked()
+		public bool SendInfoWindowClick()
 		{
-			var handler = InfoWindowClicked;
-
-			if (handler == null)
-			{
-				return false;
-			}
-			
-			handler(this, EventArgs.Empty);
-			return true;
+			var args = new PinClickedEventArgs();
+			InfoWindowClicked?.Invoke(this, args);
+			return args.HideInfoWindow;
 		}
 
 		bool Equals(Pin other)

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Forms.Maps
 			}
 		}
 
+		[Obsolete("This event is obsolete. Please use MarkerClicked and/or InfoWindowClicked instead.")]
 		public event EventHandler Clicked;
 
 		public event EventHandler MarkerClicked;
@@ -105,6 +106,7 @@ namespace Xamarin.Forms.Maps
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete]
 		public bool SendTap()
 		{
 			EventHandler handler = Clicked;

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -67,6 +67,10 @@ namespace Xamarin.Forms.Maps
 
 		public event EventHandler Clicked;
 
+		public event EventHandler MarkerClicked;
+
+		public event EventHandler InfoWindowClicked;
+
 		public override bool Equals(object obj)
 		{
 			if (ReferenceEquals(null, obj))
@@ -107,6 +111,34 @@ namespace Xamarin.Forms.Maps
 			if (handler == null)
 				return false;
 
+			handler(this, EventArgs.Empty);
+			return true;
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool SendMarkerClick()
+		{
+			var handler = MarkerClicked;
+
+			if (handler == null)
+			{
+				return false;
+			}
+
+			handler(this, EventArgs.Empty);
+			return true;
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool SendInfoWindowClicked()
+		{
+			var handler = InfoWindowClicked;
+
+			if (handler == null)
+			{
+				return false;
+			}
+			
 			handler(this, EventArgs.Empty);
 			return true;
 		}

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Maps
 			}
 		}
 
-		[Obsolete("This event is obsolete as of 4.1.0. Please use MarkerClicked and/or InfoWindowClicked instead.")]
+		[Obsolete("This event is obsolete as of 4.2.0. Please use MarkerClicked and/or InfoWindowClicked instead.")]
 		public event EventHandler Clicked;
 
 		public event EventHandler<PinClickedEventArgs> MarkerClicked;
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Maps
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		[Obsolete("This method is obsolete as of 4.1.0.")]
+		[Obsolete("This method is obsolete as of 4.2.0.")]
 		public bool SendTap()
 		{
 			EventHandler handler = Clicked;

--- a/Xamarin.Forms.Maps/PinClickedEventArgs.cs
+++ b/Xamarin.Forms.Maps/PinClickedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.Maps
+{
+	public class PinClickedEventArgs : EventArgs
+	{
+		public bool HideInfoWindow { get; set; }
+
+		public PinClickedEventArgs()
+		{
+			HideInfoWindow = false;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Replace the `Pin.Clicked` event which has caused much confusion about when it is actually fired with two separate events, `MarkerClicked` and `InfoWindowClicked`.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2509 
- fixes #3131
- fixes #5490

### API Changes ###

Added:
 - `public class PinClickedEventArgs`
 - Pin
   - `public event EventHandler<PinClickedEventArgs> MarkerClicked;`
   - `public event EventHandler<PinClickedEventArgs> InfoWindowClicked;`
   - `public bool SendMarkerClick()`
   - `public bool SendInfoWindowClick()`
 - Android MapRenderer
   - `protected Pin GetPinForMarker(Marker marker)`
   - `void OnMarkerClick(object sender, GoogleMap.MarkerClickEventArgs e)`
 - iOS MapRenderer
   - `protected Pin GetPinForAnnotation(IMKAnnotation annotation)`
   - `void MkMapViewOnAnnotationViewSelected(object sender, MKAnnotationViewEventArgs e)`

Changed:
 - Android MapRenderer
   - `void MapOnMarkerClick(object sender, GoogleMap.InfoWindowClickEventArgs eventArgs)` --> `void OnInfoWindowClick(object sender, GoogleMap.InfoWindowClickEventArgs e)`
 - iOS MapRenderer
   - `void OnClick(object annotationObject, UITapGestureRecognizer recognizer)` --> `void OnCalloutClicked(IMKAnnotation annotation)`
 - MacOS MapRenderer
   - `void OnClick(object annotationObject, NSClickGestureRecognizer recognizer)` --> `void OnCalloutClicked(IMKAnnotation annotation)`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
- `Pin.Clicked` and `Pin.SendTap()` marked as obsolete.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Go to the "Map Gallery - Legacy" page in the Control Gallery. Clicking a pin will update the Last Marker Clicked label and present the info window. Clicking the info window will update the Last Info Window Clicked label and dismiss the info window.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
