### PR TITLE
[Shell] propagate css to logical child element

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -478,5 +478,26 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.SetValue(Shell.FlyoutHeaderProperty, new ContentView());
 			Assert.AreEqual(null, flyoutView.BindingContext);
 		}
+
+
+
+		[Test]
+		public async Task TitleViewLogicalChild()
+		{
+			Shell shell = new Shell();
+			ContentPage page = new ContentPage();
+			shell.Items.Add(CreateShellItem(page));
+			page.BindingContext = new { Text = "Binding" };
+
+			// setup title view
+			StackLayout layout = new StackLayout() { BackgroundColor = Color.White };
+			Label label = new Label();
+			label.SetBinding(Label.TextProperty, "Text");
+			layout.Children.Add(label);
+			Shell.SetTitleView(page, layout);
+
+
+			Assert.True(page.JustTheLogicalChildren.Contains(layout));
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -518,10 +518,10 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.FlyoutHeader = null;
 			shell.FlyoutHeader = layout;
 
-			Assert.True(shell.LogicalChildren.Contains(layout));
+			Assert.True(shell.ChildrenNotDrawnByThisElement.Contains(layout));
 			shell.FlyoutHeader = null;
 
-			Assert.False(shell.LogicalChildren.Contains(layout));
+			Assert.False(shell.ChildrenNotDrawnByThisElement.Contains(layout));
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -497,7 +497,31 @@ namespace Xamarin.Forms.Core.UnitTests
 			Shell.SetTitleView(page, layout);
 
 
-			Assert.True(page.JustTheLogicalChildren.Contains(layout));
+			Assert.True(page.ChildrenNotDrawnByThisElement.Contains(layout));
+		}
+
+
+		[Test]
+		public async Task FlyoutHeaderLogicalChild()
+		{
+			Shell shell = new Shell();
+			ContentPage page = new ContentPage();
+			shell.Items.Add(CreateShellItem(page));
+
+			// setup title view
+			StackLayout layout = new StackLayout() { BackgroundColor = Color.White };
+			Label label = new Label();
+			label.SetBinding(Label.TextProperty, "Text");
+			layout.Children.Add(label);
+
+
+			shell.FlyoutHeader = null;
+			shell.FlyoutHeader = layout;
+
+			Assert.True(shell.LogicalChildren.Contains(layout));
+			shell.FlyoutHeader = null;
+
+			Assert.False(shell.LogicalChildren.Contains(layout));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -121,7 +121,20 @@ namespace Xamarin.Forms
 		}
 
 		internal virtual ReadOnlyCollection<Element> LogicalChildrenInternal => EmptyChildren;
-		internal virtual IEnumerable<Element> ActuallyLogicalChildrenInternal => EmptyChildren;
+		internal IEnumerable<Element> ActuallyLogicalChildren
+		{
+			get
+			{
+				foreach (var child in LogicalChildrenInternal)
+					yield return child;
+
+				foreach (var child in JustTheLogicalChildren)
+					yield return child;
+			}
+		}
+
+		internal virtual IEnumerable<Element> JustTheLogicalChildren => EmptyChildren;
+
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ReadOnlyCollection<Element> LogicalChildren => LogicalChildrenInternal;
@@ -338,10 +351,11 @@ namespace Xamarin.Forms
 		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
 			base.OnPropertyChanged(propertyName);
-
-			IPropertyPropagationController titleView = Shell.GetTitleView(this) ?? NavigationPage.GetTitleView(this);
-			if(titleView != null)
-				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { titleView });
+			foreach(var logicalChildren in JustTheLogicalChildren)
+			{
+				if(logicalChildren is IPropertyPropagationController controller)
+					PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { logicalChildren });
+			}
 
 			if (_effects == null || _effects.Count == 0)
 				return;

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -121,6 +121,7 @@ namespace Xamarin.Forms
 		}
 
 		internal virtual ReadOnlyCollection<Element> LogicalChildrenInternal => EmptyChildren;
+		internal virtual IEnumerable<Element> ActuallyLogicalChildrenInternal => EmptyChildren;
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ReadOnlyCollection<Element> LogicalChildren => LogicalChildrenInternal;

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -121,19 +121,19 @@ namespace Xamarin.Forms
 		}
 
 		internal virtual ReadOnlyCollection<Element> LogicalChildrenInternal => EmptyChildren;
-		internal IEnumerable<Element> ActuallyLogicalChildren
+		internal IEnumerable<Element> AllChildren
 		{
 			get
 			{
 				foreach (var child in LogicalChildrenInternal)
 					yield return child;
 
-				foreach (var child in JustTheLogicalChildren)
+				foreach (var child in ChildrenNotDrawnByThisElement)
 					yield return child;
 			}
 		}
 
-		internal virtual IEnumerable<Element> JustTheLogicalChildren => EmptyChildren;
+		internal virtual IEnumerable<Element> ChildrenNotDrawnByThisElement => EmptyChildren;
 
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -351,7 +351,7 @@ namespace Xamarin.Forms
 		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
 		{
 			base.OnPropertyChanged(propertyName);
-			foreach(var logicalChildren in JustTheLogicalChildren)
+			foreach(var logicalChildren in ChildrenNotDrawnByThisElement)
 			{
 				if(logicalChildren is IPropertyPropagationController controller)
 					PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { logicalChildren });

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -144,6 +144,26 @@ namespace Xamarin.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
+		internal override IEnumerable<Element> ActuallyLogicalChildrenInternal
+		{
+			get
+			{
+				foreach (var child in InternalChildren)
+					yield return child;
+
+				var titleviewPart1TheShell = Shell.GetTitleView(this);
+				var titleViewPart2TheNavBar = NavigationPage.GetTitleView(this);
+				var searchHandler = Shell.GetSearchHandler(this);
+
+				if (titleviewPart1TheShell != null)
+					yield return titleviewPart1TheShell;
+
+				if (titleViewPart2TheNavBar != null)
+					yield return titleViewPart2TheNavBar;
+
+			}
+		}
+
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => 
 			_logicalChildren ?? (_logicalChildren = new ReadOnlyCollection<Element>(InternalChildren));
 

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -144,16 +144,12 @@ namespace Xamarin.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
-		internal override IEnumerable<Element> ActuallyLogicalChildrenInternal
+		internal override IEnumerable<Element> JustTheLogicalChildren
 		{
 			get
 			{
-				foreach (var child in InternalChildren)
-					yield return child;
-
 				var titleviewPart1TheShell = Shell.GetTitleView(this);
 				var titleViewPart2TheNavBar = NavigationPage.GetTitleView(this);
-				var searchHandler = Shell.GetSearchHandler(this);
 
 				if (titleviewPart1TheShell != null)
 					yield return titleviewPart1TheShell;

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
 
-		internal override IEnumerable<Element> JustTheLogicalChildren
+		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement
 		{
 			get
 			{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -572,6 +573,8 @@ namespace Xamarin.Forms
 		bool _accumulateNavigatedEvents;
 		View _flyoutHeaderView;
 		bool _checkExperimentalFlag = true;
+		IList<Element> _logicalChildren = new List<Element>();
+		ReadOnlyCollection<Element> _logicalChildrenReadOnly;
 
 		public Shell() : this(true)
 		{
@@ -788,8 +791,11 @@ namespace Xamarin.Forms
 			return false;
 		}
 
+		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
+
 		protected override void OnChildAdded(Element child)
 		{
+			_logicalChildren.Add(child);
 			base.OnChildAdded(child);
 
 			if (child is ShellItem shellItem && CurrentItem == null && !(child is MenuShellItem))
@@ -800,6 +806,7 @@ namespace Xamarin.Forms
 
 		protected override void OnChildRemoved(Element child)
 		{
+			_logicalChildren.Add(child);
 			base.OnChildRemoved(child);
 
 			if (child == CurrentItem && Items.Count > 0)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -806,7 +806,7 @@ namespace Xamarin.Forms
 
 		protected override void OnChildRemoved(Element child)
 		{
-			_logicalChildren.Add(child);
+			_logicalChildren.Remove(child);
 			base.OnChildRemoved(child);
 
 			if (child == CurrentItem && Items.Count > 0)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -423,7 +422,7 @@ namespace Xamarin.Forms
 			{
 				await CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate);
 			}
-			
+
 			//if (Routing.CompareWithRegisteredRoutes(shellItemRoute))
 			//{
 			//	var shellItem = ShellItem.GetShellItemFromRouteName(shellItemRoute);
@@ -573,8 +572,6 @@ namespace Xamarin.Forms
 		bool _accumulateNavigatedEvents;
 		View _flyoutHeaderView;
 		bool _checkExperimentalFlag = true;
-		IList<Element> _logicalChildren = new List<Element>();
-		ReadOnlyCollection<Element> _logicalChildrenReadOnly;
 
 		public Shell() : this(true)
 		{
@@ -791,11 +788,8 @@ namespace Xamarin.Forms
 			return false;
 		}
 
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
-
 		protected override void OnChildAdded(Element child)
 		{
-			_logicalChildren.Add(child);
 			base.OnChildAdded(child);
 
 			if (child is ShellItem shellItem && CurrentItem == null && !(child is MenuShellItem))
@@ -806,7 +800,6 @@ namespace Xamarin.Forms
 
 		protected override void OnChildRemoved(Element child)
 		{
-			_logicalChildren.Remove(child);
 			base.OnChildRemoved(child);
 
 			if (child == CurrentItem && Items.Count > 0)
@@ -814,6 +807,16 @@ namespace Xamarin.Forms
 				((IShellController)this).OnFlyoutItemSelected(Items[0]);
 			}
 		}
+
+		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement
+		{
+			get
+			{
+				if (FlyoutHeaderView != null)
+					yield return FlyoutHeaderView;
+			}
+		}
+
 
 		protected virtual void OnNavigated(ShellNavigatedEventArgs args)
 		{
@@ -1089,7 +1092,7 @@ namespace Xamarin.Forms
 		{
 			readonly Shell _shell;
 
-			NavigationProxy SectionProxy => _shell.CurrentItem.CurrentItem.NavigationProxy;			
+			NavigationProxy SectionProxy => _shell.CurrentItem.CurrentItem.NavigationProxy;
 
 			public NavigationImpl(Shell shell) => _shell = shell;
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -291,11 +291,11 @@ namespace Xamarin.Forms
 				if (currentItem.Page != null)
 					DisplayedPage = currentItem.Page;
 			}
-
 		}
 
 		protected override void OnChildAdded(Element child)
 		{
+			_logicalChildren.Add(child);
 			base.OnChildAdded(child);
 			if (CurrentItem == null && Items.Contains(child))
 				SetValueFromRenderer(CurrentItemProperty, child);
@@ -305,6 +305,9 @@ namespace Xamarin.Forms
 
 		protected override void OnChildRemoved(Element child)
 		{
+			if (!_logicalChildren.Remove(child))
+				return;
+
 			base.OnChildRemoved(child);
 			if (CurrentItem == child)
 			{
@@ -346,7 +349,7 @@ namespace Xamarin.Forms
 				return;
 
 			_navStack.Insert(index, page);
-			AddPage(page);
+			OnChildAdded(page);
 			SendAppearanceChanged();
 
 			var args = new NavigationRequestedEventArgs(page, before, false)
@@ -457,7 +460,7 @@ namespace Xamarin.Forms
 			};
 
 			_navStack.Add(page);
-			AddPage(page);
+			OnChildAdded(page);
 			SendAppearanceChanged();
 			_navigationRequested?.Invoke(this, args);
 
@@ -515,12 +518,6 @@ namespace Xamarin.Forms
 			shellSection.UpdateDisplayedPage();
 		}
 
-		void AddPage(Page page)
-		{
-			_logicalChildren.Add(page);
-			OnChildAdded(page);
-		}
-
 		void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.NewItems != null)
@@ -540,8 +537,7 @@ namespace Xamarin.Forms
 
 		void RemovePage(Page page)
 		{
-			if (_logicalChildren.Remove(page))
-				OnChildRemoved(page);
+			OnChildRemoved(page);
 		}
 
 		void SendAppearanceChanged() => ((IShellController)Parent?.Parent)?.AppearanceChanged(this, false);

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -291,11 +291,11 @@ namespace Xamarin.Forms
 				if (currentItem.Page != null)
 					DisplayedPage = currentItem.Page;
 			}
+
 		}
 
 		protected override void OnChildAdded(Element child)
 		{
-			_logicalChildren.Add(child);
 			base.OnChildAdded(child);
 			if (CurrentItem == null && Items.Contains(child))
 				SetValueFromRenderer(CurrentItemProperty, child);
@@ -305,9 +305,6 @@ namespace Xamarin.Forms
 
 		protected override void OnChildRemoved(Element child)
 		{
-			if (!_logicalChildren.Remove(child))
-				return;
-
 			base.OnChildRemoved(child);
 			if (CurrentItem == child)
 			{
@@ -326,6 +323,8 @@ namespace Xamarin.Forms
 
 			UpdateDisplayedPage();
 		}
+
+		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement => Items;
 
 		protected virtual void OnInsertPageBefore(Page page, Page before)
 		{
@@ -349,7 +348,7 @@ namespace Xamarin.Forms
 				return;
 
 			_navStack.Insert(index, page);
-			OnChildAdded(page);
+			AddPage(page);
 			SendAppearanceChanged();
 
 			var args = new NavigationRequestedEventArgs(page, before, false)
@@ -460,7 +459,7 @@ namespace Xamarin.Forms
 			};
 
 			_navStack.Add(page);
-			OnChildAdded(page);
+			AddPage(page);
 			SendAppearanceChanged();
 			_navigationRequested?.Invoke(this, args);
 
@@ -518,6 +517,12 @@ namespace Xamarin.Forms
 			shellSection.UpdateDisplayedPage();
 		}
 
+		void AddPage(Page page)
+		{
+			_logicalChildren.Add(page);
+			OnChildAdded(page);
+		}
+
 		void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.NewItems != null)
@@ -537,7 +542,8 @@ namespace Xamarin.Forms
 
 		void RemovePage(Page page)
 		{
-			OnChildRemoved(page);
+			if (_logicalChildren.Remove(page))
+				OnChildRemoved(page);
 		}
 
 		void SendAppearanceChanged() => ((IShellController)Parent?.Parent)?.AppearanceChanged(this, false);

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.StyleSheets
 			foreach (var child in styleable.LogicalChildrenInternal)
 				((IStyle)this).Apply(child);
 
-			foreach (var child in styleable.ActuallyLogicalChildrenInternal)
+			foreach (var child in styleable.ActuallyLogicalChildren)
 				((IStyle)this).Apply(child);
 		}
 

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -97,9 +97,6 @@ namespace Xamarin.Forms.StyleSheets
 		void Apply(Element styleable)
 		{
 			ApplyCore(styleable);
-			foreach (var child in styleable.LogicalChildrenInternal)
-				((IStyle)this).Apply(child);
-
 			foreach (var child in styleable.ActuallyLogicalChildren)
 				((IStyle)this).Apply(child);
 		}

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -99,6 +99,9 @@ namespace Xamarin.Forms.StyleSheets
 			ApplyCore(styleable);
 			foreach (var child in styleable.LogicalChildrenInternal)
 				((IStyle)this).Apply(child);
+
+			foreach (var child in styleable.ActuallyLogicalChildrenInternal)
+				((IStyle)this).Apply(child);
 		}
 
 		void ApplyCore(Element styleable)

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -97,7 +97,7 @@ namespace Xamarin.Forms.StyleSheets
 		void Apply(Element styleable)
 		{
 			ApplyCore(styleable);
-			foreach (var child in styleable.ActuallyLogicalChildren)
+			foreach (var child in styleable.AllChildren)
 				((IStyle)this).Apply(child);
 		}
 

--- a/Xamarin.Forms.Sandbox/App.StartHere.cs
+++ b/Xamarin.Forms.Sandbox/App.StartHere.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Reflection;
 using System.Text;
+using Xamarin.Forms.StyleSheets;
 
 namespace Xamarin.Forms.Sandbox
 {
@@ -9,9 +11,17 @@ namespace Xamarin.Forms.Sandbox
 		// This code is called from the App Constructor so just initialize the main page of the application here
 		void InitializeMainPage()
 		{
-			//MainPage = CreateStackLayoutPage(new[] { new Button() { Text = "text" } });
+
+
+			this.Resources.Add(StyleSheet.FromAssemblyResource(
+				IntrospectionExtensions.GetTypeInfo(typeof(App)).Assembly,
+				"Xamarin.Forms.Sandbox.Styles.css"));
+
+			//MainPage = CreateStackLayoutPage(new[] { new Button() {  Text = "text" } });
 			//MainPage.Visual = VisualMarker.Material;
-			MainPage = new MainPage();
+			MainPage = new ShellPage();
+
+		//	MainPage = new NavigationPage(new MainPage());
 		}
 	}
 }

--- a/Xamarin.Forms.Sandbox/MainPage.xaml
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml
@@ -1,12 +1,16 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Sandbox.MainPage"
              xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
              ios:Page.UseSafeArea="true">
-    <ContentPage.Content>
-        <StackLayout>
+
+    <NavigationPage.TitleView>
+        <Grid>
             <Button Text="I am a Button"  />
-        </StackLayout>
-    </ContentPage.Content>
+        </Grid>
+    </NavigationPage.TitleView>
+    <StackLayout>
+        <Button Text="I am a Button"  />
+    </StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Sandbox/MainPage.xaml.cs
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Sandbox
 {
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class MainPage : ContentPage
-	{
+    {
 		public MainPage()
 		{
 			InitializeComponent();

--- a/Xamarin.Forms.Sandbox/ShellPage.xaml
+++ b/Xamarin.Forms.Sandbox/ShellPage.xaml
@@ -1,9 +1,25 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Shell xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.Forms.Sandbox.ShellPage">
+             x:Class="Xamarin.Forms.Sandbox.ShellPage"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true">
 
-    <ShellContent Title="test">
-        <ContentPage></ContentPage>
+    <Shell.FlyoutHeader>
+        <StackLayout>
+            <Button Text="I am a Button"  />
+        </StackLayout>
+    </Shell.FlyoutHeader>
+    <ShellContent>
+        <ContentPage>
+            <Shell.TitleView>
+                <StackLayout>
+                    <Button Text="I am a Button"  />
+                </StackLayout>
+            </Shell.TitleView>
+            <StackLayout>
+                <Button Text="I am a Button"  />
+            </StackLayout>
+        </ContentPage>
     </ShellContent>
 </Shell>

--- a/Xamarin.Forms.Sandbox/Styles.css
+++ b/Xamarin.Forms.Sandbox/Styles.css
@@ -1,0 +1,4 @@
+﻿button {
+    background-color:green;
+    color:#FFFFFF
+}


### PR DESCRIPTION
### Description of Change ###
AFAICT you can't add to a logical child structure on page and have it only act in a logical non visual fashion. This creates a structure ActuallyLogicalChildren that's a combination of pages that are real children (visual) and ones that are only logically bound to the page through bindable properties.

At some point we could expose this property which would easily allow people to do the same in custom controls

This also made the code in Element simpler and more consolidated for propagating visual and RTL properties

In reality I think we should make LogicalChildren work in such a way that there's a differentiation between LogicalChildren and Children but this works for now and I don't think it's unacceptably crazy

### Issues Resolved ### 
- fixes #4683
- fixes #5956

### API Changes ###

n/a

### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
Apply a style sheet at the app.xaml level and make sure it gets applied to
- content inside the shell
- titleviews
- search bar header

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
