### PR TITLE
Make CollectionView SelectedItem and SelectedItems binding function correctly

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBoundMultiSelection.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBoundMultiSelection.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 47803, "CollectionView: Multi Selection Binding", PlatformAffected.All)]
+	public class CollectionViewBoundMultiSelection : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			PushAsync(new GalleryPages.CollectionViewGalleries.SelectionGalleries.MultipleBoundSelection());
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void ItemsFromViewModelShouldBeSelected()
+		{
+			// Initially Items 1 and 2 should be selected (from the view model)
+			RunningApp.WaitForElement("Selected: Item 1, Item 2");
+
+			// Tapping Item 3 should select it and updating the binding
+			RunningApp.Tap("Item 3");	
+			RunningApp.WaitForElement("Selected: Item 1, Item 2, Item 3");
+
+			// Test clearing the selection from the view model and updating it
+			RunningApp.Tap("ClearAndAdd");	
+			RunningApp.WaitForElement("Selected: Item 1, Item 2");
+
+			// Test removing an item from the selection
+			RunningApp.Tap("Item 2");
+			RunningApp.WaitForElement("Selected: Item 1");
+
+			// Test setting a new selection list in the view mdoel 
+			RunningApp.Tap("Reset");	
+			RunningApp.WaitForElement("Selected: Item 1, Item 2");
+
+			RunningApp.Tap("Item 0");
+			
+			// Test setting the selection directly with CollectionView.SelectedItems 
+			RunningApp.Tap("DirectUpdate");	
+			RunningApp.WaitForElement("Selected: Item 0, Item 3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBoundSingleSelection.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBoundSingleSelection.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 4539134, "CollectionView: Single Selection Binding", PlatformAffected.All)]
+	public class CollectionViewBoundSingleSelection : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			PushAsync(new GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection());
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void SelectionShouldUpdateBinding()
+		{
+			// Initially Item 2 should be selected (from the view model)
+			RunningApp.WaitForElement("Selected: Item: 2");
+
+			// Tapping Item 3 should select it and updating the binding
+			RunningApp.Tap("Item 3");	
+			RunningApp.WaitForElement("Selected: Item: 3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundSingleSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4992.xaml.cs">
       <DependentUpon>Issue4992.xaml</DependentUpon>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundMultiSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundSingleSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4992.xaml.cs">

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
+{
+	internal class BoundSelectionModel : INotifyPropertyChanged
+	{
+		private CollectionViewGalleryTestItem _selectedItem;
+		private ObservableCollection<CollectionViewGalleryTestItem> _items;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public BoundSelectionModel()
+		{
+			Items = new ObservableCollection<CollectionViewGalleryTestItem>();
+
+			for (int n = 0; n < 4; n++)
+			{
+				Items.Add(new CollectionViewGalleryTestItem(DateTime.Now.AddDays(n), $"Item {n}", "coffee.png", n));
+			}
+
+			SelectedItem = Items[2];
+		}
+
+		void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		public CollectionViewGalleryTestItem SelectedItem
+		{
+			get => _selectedItem;
+			set
+			{
+				_selectedItem = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ObservableCollection<CollectionViewGalleryTestItem> Items
+		{
+			get => _items;
+			set { _items = value; OnPropertyChanged(); }
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
@@ -10,6 +9,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 	{
 		private CollectionViewGalleryTestItem _selectedItem;
 		private ObservableCollection<CollectionViewGalleryTestItem> _items;
+		private ObservableCollection<object> _selectedItems;
 
 		public event PropertyChangedEventHandler PropertyChanged;
 
@@ -23,6 +23,16 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 			}
 
 			SelectedItem = Items[2];
+
+			SelectedItems = new ObservableCollection<object>()
+			{
+				Items[1], Items[2]
+			};
+		}
+
+		private void SelectedItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			OnPropertyChanged(nameof(SelectedItemsText));
 		}
 
 		void OnPropertyChanged([CallerMemberName] string propertyName = null)
@@ -40,10 +50,31 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 			}
 		}
 
+		public ObservableCollection<object> SelectedItems
+		{
+			get => _selectedItems;
+			set
+			{
+				if (_selectedItems != null)
+				{
+					_selectedItems.CollectionChanged -= SelectedItemsCollectionChanged;
+				}
+
+				_selectedItems = value;
+
+				_selectedItems.CollectionChanged += SelectedItemsCollectionChanged;
+
+				OnPropertyChanged();
+				OnPropertyChanged(nameof(SelectedItemsText));
+			}
+		}
+
 		public ObservableCollection<CollectionViewGalleryTestItem> Items
 		{
 			get => _items;
 			set { _items = value; OnPropertyChanged(); }
 		}
+
+		public string SelectedItemsText => SelectedItems.ToCommaSeparatedList();
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/BoundSelectionModel.cs
@@ -2,9 +2,11 @@
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
 {
+	[Preserve(AllMembers = true)]
 	internal class BoundSelectionModel : INotifyPropertyChanged
 	{
 		private CollectionViewGalleryTestItem _selectedItem;

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml
@@ -5,17 +5,22 @@
     <ContentPage.Content>
         <StackLayout Spacing="5">
 
-            <Label Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
+            <Label Text="The selected items in the CollectionView should always match the 'Selected' Label below. If it does not, this test has failed."
                 VerticalOptions="CenterAndExpand" 
                 HorizontalOptions="CenterAndExpand" />
 
-            <Label Text="{Binding SelectedItemsText, StringFormat='{}Selected: {0}'}"
+            <Label Text="{Binding SelectedItemsText, StringFormat='{}Selected: {0}'}" FontAttributes="Bold"
                 VerticalOptions="CenterAndExpand" 
                 HorizontalOptions="CenterAndExpand" />
 
-            <Button AutomationId="Reset" Text="Reset Selection to Items 1 and 2" Clicked="ResetClicked" />
+            <Button AutomationId="ClearAndAdd" Text="Clear VM selection and add Items 1 and 2" Clicked="ClearAndAdd" />
 
-            <CollectionView ItemsSource="{Binding Items}" SelectionMode="Multiple" SelectedItems="{Binding SelectedItems}">
+            <Button AutomationId="Reset" Text="Set VM selection to new list" Clicked="ResetClicked" />
+
+            <Button AutomationId="DirectUpdate" Text="Clear CV selection and add Items 0 and 3" Clicked="DirectUpdateClicked" />
+
+            <CollectionView x:Name="CollectionView" ItemsSource="{Binding Items}" 
+                            SelectionMode="Multiple" SelectedItems="{Binding SelectedItems}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <StackLayout>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.MultipleBoundSelection">
+    <ContentPage.Content>
+        <StackLayout Spacing="5">
+
+            <Label Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+
+            <Label Text="{Binding SelectedItemsText, StringFormat='{}Selected: {0}'}"
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+
+            <Button AutomationId="Reset" Text="Reset Selection to Items 1 and 2" Clicked="ResetClicked" />
+
+            <CollectionView ItemsSource="{Binding Items}" SelectionMode="Multiple" SelectedItems="{Binding SelectedItems}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Image Source="{Binding Image}" HeightRequest="50" />
+                            <Label Text="{Binding Caption}"></Label>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml
@@ -1,31 +1,29 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.MultipleBoundSelection">
     <ContentPage.Content>
-        <StackLayout Spacing="5">
+        <StackLayout Spacing="2">
 
             <Label Text="The selected items in the CollectionView should always match the 'Selected' Label below. If it does not, this test has failed."
-                VerticalOptions="CenterAndExpand" 
-                HorizontalOptions="CenterAndExpand" />
+                FontSize="10" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
 
             <Label Text="{Binding SelectedItemsText, StringFormat='{}Selected: {0}'}" FontAttributes="Bold"
-                VerticalOptions="CenterAndExpand" 
-                HorizontalOptions="CenterAndExpand" />
+                FontSize="10" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
 
-            <Button AutomationId="ClearAndAdd" Text="Clear VM selection and add Items 1 and 2" Clicked="ClearAndAdd" />
+            <Button AutomationId="ClearAndAdd" HeightRequest="35" FontSize="10" Text="Clear VM selection and add Items 1 and 2" Clicked="ClearAndAdd" />
 
-            <Button AutomationId="Reset" Text="Set VM selection to new list" Clicked="ResetClicked" />
+            <Button AutomationId="Reset" HeightRequest="35" FontSize="10" Text="Set VM selection to new list" Clicked="ResetClicked" />
 
-            <Button AutomationId="DirectUpdate" Text="Clear CV selection and add Items 0 and 3" Clicked="DirectUpdateClicked" />
+            <Button AutomationId="DirectUpdate" HeightRequest="35" FontSize="10" Text="Clear CV selection and add Items 0 and 3" Clicked="DirectUpdateClicked" />
 
             <CollectionView x:Name="CollectionView" ItemsSource="{Binding Items}" 
                             SelectionMode="Multiple" SelectedItems="{Binding SelectedItems}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <StackLayout>
-                            <Image Source="{Binding Image}" HeightRequest="50" />
-                            <Label Text="{Binding Caption}"></Label>
+                            <Image Source="{Binding Image}" HeightRequest="30" />
+                            <Label FontSize="10" Text="{Binding Caption}"></Label>
                         </StackLayout>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class MultipleBoundSelection : ContentPage
+	{
+		BoundSelectionModel _vm;
+
+		public MultipleBoundSelection()
+		{
+			InitializeComponent();
+			_vm = new BoundSelectionModel();
+			BindingContext = _vm;
+		}
+
+		private void ResetClicked(object sender, EventArgs e)
+		{
+			_vm.SelectedItems.Clear();
+			_vm.SelectedItems.Add(_vm.Items[1]);
+			_vm.SelectedItems.Add(_vm.Items[2]);
+
+			//_vm.SelectedItems = new ObservableCollection<CollectionViewGalleryTestItem>
+			//{
+			//	_vm.Items[1],
+			//	_vm.Items[2]
+			//};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/MultipleBoundSelection.xaml.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using Xamarin.Forms.Xaml;
 
@@ -12,22 +11,32 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 
 		public MultipleBoundSelection()
 		{
-			InitializeComponent();
 			_vm = new BoundSelectionModel();
 			BindingContext = _vm;
+			InitializeComponent();
 		}
 
-		private void ResetClicked(object sender, EventArgs e)
+		private void ClearAndAdd(object sender, EventArgs e)
 		{
 			_vm.SelectedItems.Clear();
 			_vm.SelectedItems.Add(_vm.Items[1]);
 			_vm.SelectedItems.Add(_vm.Items[2]);
+		}
 
-			//_vm.SelectedItems = new ObservableCollection<CollectionViewGalleryTestItem>
-			//{
-			//	_vm.Items[1],
-			//	_vm.Items[2]
-			//};
+		private void ResetClicked(object sender, EventArgs e)
+		{
+			_vm.SelectedItems = new ObservableCollection<object>
+			{
+				_vm.Items[1],
+				_vm.Items[2]
+			};
+		}
+
+		private void DirectUpdateClicked(object sender, EventArgs e)
+		{
+			CollectionView.SelectedItems.Clear();
+			CollectionView.SelectedItems.Add(_vm.Items[0]);
+			CollectionView.SelectedItems.Add(_vm.Items[3]);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
@@ -24,6 +24,8 @@
 							new PreselectedItemsGallery(), Navigation),
 						GalleryBuilder.NavButton("Single Selection, Bound", () =>
 							new SingleBoundSelection(), Navigation),
+						GalleryBuilder.NavButton("Multiple Selection, Bound", () =>
+							new MultipleBoundSelection(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
@@ -22,6 +22,8 @@
 							new PreselectedItemGallery(), Navigation),
 						GalleryBuilder.NavButton("Preselected Items", () =>
 							new PreselectedItemsGallery(), Navigation),
+						GalleryBuilder.NavButton("Single Selection, Bound", () =>
+							new SingleBoundSelection(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionHelpers.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionHelpers.cs
@@ -1,0 +1,19 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
+{
+	internal static class SelectionHelpers
+	{
+		public static string ToCommaSeparatedList(this IEnumerable<object> items)
+		{
+			if (items == null)
+			{
+				return string.Empty;
+			}
+
+			return items.Aggregate(string.Empty,
+				(s, o) => s + (s.Length == 0 ? "" : ", ") + ((CollectionViewGalleryTestItem)o).Caption);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionHelpers.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionHelpers.cs
@@ -12,8 +12,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 				return string.Empty;
 			}
 
-			return items.Aggregate(string.Empty,
-				(s, o) => s + (s.Length == 0 ? "" : ", ") + ((CollectionViewGalleryTestItem)o).Caption);
+			return string.Join(", ", items.Cast<CollectionViewGalleryTestItem>().Select(i => i.Caption));
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionModeGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionModeGallery.xaml.cs
@@ -35,8 +35,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 
 		void UpdateSelectionInfo(IEnumerable<object> currentSelectedItems, IEnumerable<object> previousSelectedItems)
 		{
-			var previous = ToList(previousSelectedItems);
-			var current = ToList(currentSelectedItems);
+			var previous = previousSelectedItems.ToCommaSeparatedList();
+			var current = currentSelectedItems.ToCommaSeparatedList();
 
 			if (string.IsNullOrEmpty(previous))
 			{
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 
 			if(CollectionView.SelectionMode == SelectionMode.Multiple)
 			{
-				current = ToList(CollectionView?.SelectedItems);
+				current = CollectionView?.SelectedItems.ToCommaSeparatedList();
 			}
 			else if (CollectionView.SelectionMode == SelectionMode.Single)
 			{
@@ -66,17 +66,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 			}
 
 			SelectedItemsCommand.Text = $"Selection (command): {current}";
-		}
-
-		static string ToList(IEnumerable<object> items)
-		{
-			if (items == null)
-			{
-				return string.Empty;
-			}
-
-			return items.Aggregate(string.Empty, 
-				(s, o) => s + (s.Length == 0 ? "" : ", ") + ((CollectionViewGalleryTestItem)o).Caption);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
+    <ContentPage.Content>
+        <StackLayout Spacing="5">
+
+            <Label Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+
+            <Label Text="{Binding SelectedItem, StringFormat='{}Selected: {0}'}"
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+
+            <Button AutomationId="Reset" Text="Reset Selection to Item 0" Clicked="ResetClicked" />
+
+            <CollectionView ItemsSource="{Binding Items}" SelectionMode="Single" SelectedItem="{Binding SelectedItem}">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Image Source="{Binding Image}" HeightRequest="50" />
+                            <Label Text="{Binding Caption}"></Label>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
@@ -14,6 +14,8 @@
                 HorizontalOptions="CenterAndExpand" />
 
             <Button AutomationId="Reset" Text="Reset Selection to Item 0" Clicked="ResetClicked" />
+            
+            <Button AutomationId="Clear" Text="Clear Selection" Clicked="ClearClicked" />
 
             <CollectionView ItemsSource="{Binding Items}" SelectionMode="Single" SelectedItem="{Binding SelectedItem}">
                 <CollectionView.ItemTemplate>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class SingleBoundSelection : ContentPage
+	{
+		BoundSelectionModel _vm;
+
+		public SingleBoundSelection()
+		{
+			InitializeComponent();
+			_vm = new BoundSelectionModel();
+			BindingContext = _vm;
+		}
+
+		private void ResetClicked(object sender, EventArgs e)
+		{
+			_vm.SelectedItem = _vm.Items[0];
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml.cs
@@ -19,5 +19,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 		{
 			_vm.SelectedItem = _vm.Items[0];
 		}
+
+		private void ClearClicked(object sender, EventArgs e)
+		{
+			_vm.SelectedItem = null;
+		}
 	}
 }

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -60,6 +60,9 @@
     <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\EmptyViewGalleries\EmptyViewSwapGallery.xaml">
 	<Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\SelectionGalleries\MultipleBoundSelection.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\SelectionGalleries\PreselectedItemsGallery.xaml">
        <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core/Items/SelectableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/SelectableItemsView.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty SelectedItemProperty =
 			BindableProperty.Create(nameof(SelectedItem), typeof(object), typeof(SelectableItemsView), default(object),
+				defaultBindingMode: BindingMode.TwoWay,
 				propertyChanged: SelectedItemPropertyChanged);
 
 		static readonly BindablePropertyKey SelectedItemsPropertyKey =

--- a/Xamarin.Forms.Core/Items/SelectableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/SelectableItemsView.cs
@@ -15,10 +15,12 @@ namespace Xamarin.Forms
 				defaultBindingMode: BindingMode.TwoWay,
 				propertyChanged: SelectedItemPropertyChanged);
 
-		static readonly BindablePropertyKey SelectedItemsPropertyKey =
-			BindableProperty.CreateReadOnly(nameof(SelectedItems), typeof(IList<object>), typeof(SelectableItemsView), null);
-
-		public static readonly BindableProperty SelectedItemsProperty = SelectedItemsPropertyKey.BindableProperty;
+		public static readonly BindableProperty SelectedItemsProperty =
+			BindableProperty.Create(nameof(SelectedItems), typeof(IList<object>), typeof(SelectableItemsView), null,
+				defaultBindingMode: BindingMode.OneWay,
+				propertyChanged: SelectedItemsPropertyChanged,
+				coerceValue: CoerceSelectedItems,
+				defaultValueCreator: DefaultValueCreator);
 
 		public static readonly BindableProperty SelectionChangedCommandProperty =
 			BindableProperty.Create(nameof(SelectionChangedCommand), typeof(ICommand), typeof(SelectableItemsView));
@@ -27,10 +29,10 @@ namespace Xamarin.Forms
 			BindableProperty.Create(nameof(SelectionChangedCommandParameter), typeof(object),
 				typeof(SelectableItemsView));
 
+		static readonly IList<object> s_empty = new List<object>(0);
+
 		public SelectableItemsView()
 		{
-			var selectionList = new SelectionList(this);
-			SetValue(SelectedItemsPropertyKey, selectionList);
 		}
 
 		public object SelectedItem
@@ -42,6 +44,7 @@ namespace Xamarin.Forms
 		public IList<object> SelectedItems
 		{
 			get => (IList<object>)GetValue(SelectedItemsProperty);
+			set => SetValue(SelectedItemsProperty, new SelectionList(this, value));
 		}
 
 		public ICommand SelectionChangedCommand
@@ -68,9 +71,39 @@ namespace Xamarin.Forms
 		{
 		}
 
+		static object CoerceSelectedItems(BindableObject bindable, object value)
+		{
+			if (value == null)
+			{
+				return new SelectionList((SelectableItemsView)bindable);
+			}
+
+			if (!(value is SelectionList))
+			{
+				return new SelectionList((SelectableItemsView)bindable, value as IList<object>);
+			}
+
+			return value;
+		}
+
+		static object DefaultValueCreator(BindableObject bindable)
+		{
+			return new SelectionList((SelectableItemsView)bindable);
+		}
+
+		static void SelectedItemsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			var selectableItemsView = (SelectableItemsView)bindable;
+			var oldSelection = oldValue == null ? s_empty : (IList<object>)oldValue;
+			var newSelection = newValue == null ? s_empty : (IList<object>)newValue;
+
+			selectableItemsView.SelectedItemsPropertyChanged(oldSelection, newSelection);
+		}
+
 		internal void SelectedItemsPropertyChanged(IList<object> oldSelection, IList<object> newSelection)
 		{
 			SelectionPropertyChanged(this, new SelectionChangedEventArgs(oldSelection, newSelection));
+			
 			OnPropertyChanged(SelectedItemsProperty.PropertyName);
 		}
 

--- a/Xamarin.Forms.Core/Items/SelectableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/SelectableItemsView.cs
@@ -78,12 +78,12 @@ namespace Xamarin.Forms
 				return new SelectionList((SelectableItemsView)bindable);
 			}
 
-			if (!(value is SelectionList))
+			if(value is SelectionList)
 			{
-				return new SelectionList((SelectableItemsView)bindable, value as IList<object>);
+				return value;
 			}
 
-			return value;
+			return new SelectionList((SelectableItemsView)bindable, value as IList<object>);
 		}
 
 		static object DefaultValueCreator(BindableObject bindable)
@@ -94,8 +94,8 @@ namespace Xamarin.Forms
 		static void SelectedItemsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var selectableItemsView = (SelectableItemsView)bindable;
-			var oldSelection = oldValue == null ? s_empty : (IList<object>)oldValue;
-			var newSelection = newValue == null ? s_empty : (IList<object>)newValue;
+			var oldSelection = (IList<object>)oldValue ?? s_empty;
+			var newSelection = (IList<object>)newValue ?? s_empty;
 
 			selectableItemsView.SelectedItemsPropertyChanged(oldSelection, newSelection);
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/SelectableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/SelectableItemsViewController.cs
@@ -34,6 +34,17 @@ namespace Xamarin.Forms.Platform.iOS
 			CollectionView.SelectItem(index, true, UICollectionViewScrollPosition.None);
 		}
 
+		// Called by Forms to clear the native selection
+		internal void ClearSelection()
+		{
+			var selectedItemIndexes = CollectionView.GetIndexPathsForSelectedItems();
+
+			foreach (var index in selectedItemIndexes)
+			{
+				CollectionView.DeselectItem(index, true);
+			}
+		}
+
 		void FormsSelectItem(NSIndexPath indexPath)
 		{
 			var mode = SelectableItemsView.SelectionMode;
@@ -86,6 +97,11 @@ namespace Xamarin.Forms.Platform.iOS
 					if (selectedItem != null)
 					{
 						SelectItem(selectedItem);
+					}
+					else
+					{
+						// SelectedItem has been set to null; if an item is selected, we need to de-select it
+						ClearSelection();
 					}
 				
 					return;


### PR DESCRIPTION
### Description of Change ###

These changes make the `SelectedItem` property two-way bindable so that binding to the `SelectedItem` property works as expected. 

These changes also update the `SelectedItems` property to be bindable from a viewmodel in an intuitive way.

Also adds automated tests for single and multiple selection binding.

### Issues Resolved ### 

- fixes #6158 
- fixes #5832 

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
