### PR TITLE
[GTK] Add Alpha support to Frame background

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/CustomFrame.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/CustomFrame.cs
@@ -6,10 +6,10 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 {
 	public class CustomFrame : Gtk.Frame
 	{
-		private Gdk.Color _defaultBorderColor;
-		private Gdk.Color _defaultBackgroundColor;
-		private Gdk.Color? _borderColor;
-		private Gdk.Color? _backgroundColor;
+		private Color _defaultBorderColor;
+		private Color _defaultBackgroundColor;
+		private Color? _borderColor;
+		private Color? _backgroundColor;
 
 		private uint _borderWidth;
 		private bool _hasShadow;
@@ -23,11 +23,11 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			_borderWidth = 0;
 			_hasShadow = false;
 			_shadowWidth = 2;
-			_defaultBackgroundColor = Style.Backgrounds[(int)StateType.Normal];
-			_defaultBorderColor = Style.BaseColors[(int)StateType.Active];
+			_defaultBackgroundColor = Style.Backgrounds[(int)StateType.Normal].ToXFColor();
+			_defaultBorderColor = Style.BaseColors[(int)StateType.Active].ToXFColor();
 		}
 
-		public void SetBackgroundColor(Gdk.Color? color)
+		public void SetBackgroundColor(Color? color)
 		{
 			_backgroundColor = color;
 			QueueDraw();
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			QueueDraw();
 		}
 
-		public void SetBorderColor(Gdk.Color? color)
+		public void SetBorderColor(Color? color)
 		{
 			_borderColor = color;
 			QueueDraw();
@@ -77,15 +77,13 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
 		protected override bool OnExposeEvent(EventExpose evnt)
 		{
-			double colorMaxValue = 65535;
-
 			using (var cr = CairoHelper.Create(GdkWindow))
 			{
-				//Draw Shadow
+				// Draw Shadow
 				if (_hasShadow)
 				{
-					var color = Color.Black.ToGtkColor();
-					cr.SetSourceRGBA(color.Red / colorMaxValue, color.Green / colorMaxValue, color.Blue / colorMaxValue, 1.0);
+					var color = Color.Black;
+					cr.SetSourceRGBA(color.R, color.G, color.B, color.A);
 					cr.Rectangle(Allocation.Left + _shadowWidth, Allocation.Top + _shadowWidth, Allocation.Width + _shadowWidth, Allocation.Height + _shadowWidth);
 					cr.Fill();
 				}
@@ -94,7 +92,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 				if (_backgroundColor.HasValue)
 				{
 					var color = _backgroundColor.Value;
-					cr.SetSourceRGBA(color.Red / colorMaxValue, color.Green / colorMaxValue, color.Blue / colorMaxValue, 1.0);
+					cr.SetSourceRGBA(color.R, color.G, color.B, color.A);
 					cr.Rectangle(Allocation.Left, Allocation.Top, Allocation.Width, Allocation.Height);
 					cr.FillPreserve();
 				}
@@ -104,7 +102,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 				{
 					cr.LineWidth = _borderWidth;
 					var color = _borderColor.Value;
-					cr.SetSourceRGB(color.Red / colorMaxValue, color.Green / colorMaxValue, color.Blue / colorMaxValue);
+					cr.SetSourceRGBA(color.R, color.G, color.B, color.A);
 					cr.Rectangle(Allocation.Left, Allocation.Top, Allocation.Width, Allocation.Height);
 					cr.StrokePreserve();
 				}

--- a/Xamarin.Forms.Platform.GTK/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.GTK/Extensions/ColorExtensions.cs
@@ -11,6 +11,11 @@
 			return gtkColor;
 		}
 
+		internal static Xamarin.Forms.Color ToXFColor(this Gdk.Color color, double opacity = 255)
+		{
+			return new Color(color.Red, color.Green, color.Blue, opacity);
+		}
+
 		internal static string ToRgbaColor(this Color color)
 		{
 			int red = (int)(color.R * 255);

--- a/Xamarin.Forms.Platform.GTK/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/FrameRenderer.cs
@@ -51,11 +51,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				Control.ResetBorderColor();
 			else
 				Control.SetBorderColor(Element.BorderColor);
-
-			if (Element.HasShadow)
-				Control.SetShadow();
-			else
-				Control.ResetShadow();
 		}
 
 		private void PackChild()

--- a/Xamarin.Forms.Platform.GTK/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/FrameRenderer.cs
@@ -7,8 +7,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
 		{
-			base.OnElementChanged(e);
-
 			if (e.NewElement != null)
 			{
 				if (Control == null)
@@ -24,6 +22,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				PackChild();
 				SetupLayer();
 			}
+
+			base.OnElementChanged(e);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -45,12 +45,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			if (Element.BackgroundColor == Color.Default)
 				Control.ResetBackgroundColor();
 			else
-				Control.SetBackgroundColor(Element.BackgroundColor.ToGtkColor());
+				Control.SetBackgroundColor(Element.BackgroundColor);
 
 			if (Element.BorderColor == Color.Default)
 				Control.ResetBorderColor();
 			else
-				Control.SetBorderColor(Element.BorderColor.ToGtkColor());
+				Control.SetBorderColor(Element.BorderColor);
 
 			if (Element.HasShadow)
 				Control.SetShadow();


### PR DESCRIPTION
### Description of Change ###

- Use Xamarin.Forms.Color instead of Gdk.Color for alpha support.
- Add an extension method from Gdk.Color to XF.Color.
- Call `base.OnElementChanged` at the end of the method in `FrameRenderer.cs`
- Remove set Shadow.

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/4700

### API Changes ###

 None

### Platforms Affected ### 

- GTK

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Having a transparent Frame becomes possible.

### Testing Procedure ###

Just a basic content page with this 
```
<Frame x:Name="frame1" BackgroundColor="Blue" BorderColor="Red">
   <Frame x:Name="frame2" BackgroundColor="Transparent" BorderColor="Transparent"/>
</Frame>
```
Should be enough to see the problem.

Local repro here: https://github.com/mfkl/Gtk-Frame-Background-Bug
Start `Gtk-Frame-Background-Bug\Gtk-Frame-Background-Bug.csproj`

Repro with fix in Xamarin.Forms repo: https://github.com/mfkl/Xamarin.Forms/tree/local-repro

Without https://github.com/xamarin/Xamarin.Forms/commit/41052bcd28f8139c2b9c61f341616e4f15b04d8b, the repro with the 2 frames positioned on top of each other (one blue, one transparent) shows a black frame. It comes from this code
```
// Draw Shadow
if (_hasShadow)
{
    var color = Color.Black;
    cr.SetSourceRGBA(color.R, color.G, color.B, color.A);
    cr.Rectangle(Allocation.Left + _shadowWidth, Allocation.Top + _shadowWidth, Allocation.Width + _shadowWidth, Allocation.Height + _shadowWidth);
    cr.Fill();
}
```
As when not run, the frames display fine. 
Also https://github.com/xamarin/Xamarin.Forms/blob/42b61a87228eb4686a9bce6c1a687a6c9ef34572/Xamarin.Forms.Platform.GTK/Controls/CustomFrame.cs#L20 this would probably need changing to allow shadow support, which I guess should be taken care of in a separate PR. Hence my commit removing the call to `Control.SetShadow();` which seemed systematic.

Let me know what you think.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
