### PR TITLE
return from designer earlier

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -38,48 +38,18 @@ namespace Xamarin.Forms.Platform.Android
         protected virtual void LoadView(IShellContext shellContext)
         {
             var context = shellContext.AndroidContext;
-            var coordinator = (ViewGroup)LayoutInflater.FromContext(context).Inflate(Resource.Layout.FlyoutContent, null);
+
+			// Android designer can't load fragments or resources from layouts
+			if (context.IsDesignerContext())
+				return;
+
+            var coordinator = LayoutInflater.FromContext(context).Inflate(Resource.Layout.FlyoutContent, null);
 			var recycler = coordinator.FindViewById<RecyclerView>(Resource.Id.flyoutcontent_recycler);
-			var appBar = coordinator.FindViewById<ViewGroup>(Resource.Id.flyoutcontent_appbar);
+			var appBar = coordinator.FindViewById<AppBarLayout>(Resource.Id.flyoutcontent_appbar);
 
 			_rootView = coordinator;
 
-			if((recycler == null || appBar == null) && !context.IsDesignerContext())
-			{
-				if (recycler == null)
-					throw new ArgumentNullException("flyoutcontent_recycler", "Unable to find layout for flyoutcontent_recycler");
-
-				// PREVIEWER HACK for some reason previewer pulls this out as a FrameLayout and ignores the internal resources
-				if (appBar == null)
-					throw new ArgumentNullException("flyoutcontent_appbar", "Unable to find layout for flyoutcontent_recycler");
-
-			}
-
-
-			try
-			{
-				// PREVIEWER HACK for some reason previewer can't find the resources for the recycler or the appBar
-				if (recycler == null)
-					recycler = (RecyclerView)coordinator.GetChildAt(1);
-				if (appBar == null)
-					appBar = (AppBarLayout)coordinator.GetChildAt(0);
-			}
-			catch
-			{
-				// PReviewer hack.
-				// appcompat and non appcompat initialize this whole thing differently so the above are for appcompat the below are for non
-			}
-
-			// PREVIEWER HACK for some reason previewer can't find the resources for the recycler or the appBar
-			if (recycler == null)
-				recycler = coordinator.FindViewById<RecyclerView>(context.Resources.GetIdentifier("flyoutcontent_recycler", "id", context.PackageName));
-
-			// PREVIEWER HACK for some reason previewer pulls this out as a FrameLayout and ignores the internal resources
-			if (appBar == null)
-				appBar = coordinator.FindViewById<ViewGroup>(context.Resources.GetIdentifier("flyoutcontent_appbar", "id", context.PackageName));
-
-
-			(appBar as AppBarLayout)?.AddOnOffsetChangedListener(this);
+			appBar.AddOnOffsetChangedListener(this);
 
             int actionBarHeight = (int)context.ToPixels(56);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Android
 			// Android designer can't load fragments or resources from layouts
 			if (context.IsDesignerContext())
 			{
-				_rootView = new CoordinatorLayout(context);
+				_rootView = new FrameLayout(context);
 				return;
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -41,9 +41,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			// Android designer can't load fragments or resources from layouts
 			if (context.IsDesignerContext())
+			{
+				_rootView = new CoordinatorLayout(context);
 				return;
+			}
 
-            var coordinator = LayoutInflater.FromContext(context).Inflate(Resource.Layout.FlyoutContent, null);
+			var coordinator = LayoutInflater.FromContext(context).Inflate(Resource.Layout.FlyoutContent, null);
 			var recycler = coordinator.FindViewById<RecyclerView>(Resource.Id.flyoutcontent_recycler);
 			var appBar = coordinator.FindViewById<AppBarLayout>(Resource.Id.flyoutcontent_appbar);
 

--- a/Xamarin.Forms.Sandbox/Xamarin.Forms.Sandbox.csproj
+++ b/Xamarin.Forms.Sandbox/Xamarin.Forms.Sandbox.csproj
@@ -13,12 +13,6 @@
     <DebugType>pdbonly</DebugType>
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-
-  <ItemGroup>
-    <None Include="ShellPage.xaml">
-      <Generator>MSBuild:Compile</Generator>
-    </None>
-  </ItemGroup>
   
   <ItemGroup>
     <!-- A reference to the entire .NET Framework is automatically included -->


### PR DESCRIPTION
### Description of Change ###

This PR stops trying so hard to make parts work with the designer and just exits early. Knowing what resources will and won't be available at designer runtime is just too inconsistent
