### PR TITLE
stack the elevation of elements

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2653.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 // https://github.com/xamarin/Xamarin.Forms/issues/2989
-#if UITEST && !__ANDROID__
+#if UITEST
 		[Test]
 		public void ZIndexWhenInsertingChildren()
 		{

--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -21,5 +21,28 @@ namespace Xamarin.Forms.Platform.Android
 
 			view.Elevation = elevation.Value;
 		}
+
+		internal static float? GetElevation(global::Android.Views.View view)
+		{
+			if (view == null || !Forms.IsLollipopOrNewer)
+			{
+				return null;
+			}
+
+			return view.Elevation;
+		}
+
+		internal static float? GetElevation(VisualElement element)
+		{
+			if (element == null || !Forms.IsLollipopOrNewer)
+			{
+				return null;
+			}
+
+			var iec = element as IElementConfiguration<VisualElement>;
+			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
+
+			return elevation;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -144,6 +144,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 		void EnsureChildOrder()
 		{
+			float elevationToSet = 0;
 			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
 			{
 				Element child = ElementController.LogicalChildren[i];
@@ -152,7 +153,21 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					IVisualElementRenderer r = Platform.GetRenderer(element);
 					if (r != null)
+					{
 						(_renderer.View as ViewGroup)?.BringChildToFront(r.View);
+
+						if (Forms.IsLollipopOrNewer)
+						{
+							var elevation = ElevationHelper.GetElevation(r.View) ?? 0;
+							var elementElevation = ElevationHelper.GetElevation(element);
+
+							if (elevation > elevationToSet)
+								elevationToSet = elevation;
+
+							if(elementElevation == null)
+								r.View.Elevation = elevationToSet;
+						}
+					}
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -5,7 +5,6 @@ using Android.Content;
 using Xamarin.Forms.Internals;
 using Android.Views;
 using AView = Android.Views.View;
-using System.Linq;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -154,8 +153,6 @@ namespace Xamarin.Forms.Platform.Android
 					IVisualElementRenderer r = Platform.GetRenderer(element);
 					if (r != null)
 					{
-						(_renderer.View as ViewGroup)?.BringChildToFront(r.View);
-
 						if (Forms.IsLollipopOrNewer)
 						{
 							var elevation = ElevationHelper.GetElevation(r.View) ?? 0;
@@ -169,6 +166,8 @@ namespace Xamarin.Forms.Platform.Android
 								r.View.Elevation = elevationToSet;
 							}
 						}
+
+						(_renderer.View as ViewGroup)?.BringChildToFront(r.View);
 					}
 				}
 			}
@@ -180,7 +179,31 @@ namespace Xamarin.Forms.Platform.Android
 			if (view != null)
 				AddChild(view);
 
-			if (ElementController.LogicalChildren.LastOrDefault() != view)
+			int itemCount = ElementController.LogicalChildren.Count;
+			if (itemCount <= 1)
+				return;
+
+
+			Element lastChild = ElementController.LogicalChildren[itemCount - 1];
+
+			if(lastChild != view)
+			{
+				EnsureChildOrder();
+				return;
+			}
+
+			Element previousChild = ElementController.LogicalChildren[itemCount - 2];
+
+			IVisualElementRenderer lastRenderer = null;
+			IVisualElementRenderer previousRenderer = null;
+
+			if (lastChild is VisualElement last)
+				lastRenderer = Platform.GetRenderer(last);
+
+			if (previousChild is VisualElement previous)
+				previousRenderer = Platform.GetRenderer(previous);
+
+			if (lastRenderer?.View?.Elevation < previousRenderer?.View?.Elevation)
 				EnsureChildOrder();
 		}
 

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -192,6 +192,9 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
+			if (!Forms.IsLollipopOrNewer)
+				return;
+
 			Element previousChild = ElementController.LogicalChildren[itemCount - 2];
 
 			IVisualElementRenderer lastRenderer = null;
@@ -203,7 +206,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (previousChild is VisualElement previous)
 				previousRenderer = Platform.GetRenderer(previous);
 
-			if (lastRenderer?.View?.Elevation < previousRenderer?.View?.Elevation)
+			if (ElevationHelper.GetElevation(lastRenderer?.View) < ElevationHelper.GetElevation(previousRenderer?.View))
 				EnsureChildOrder();
 		}
 

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -161,11 +161,13 @@ namespace Xamarin.Forms.Platform.Android
 							var elevation = ElevationHelper.GetElevation(r.View) ?? 0;
 							var elementElevation = ElevationHelper.GetElevation(element);
 
-							if (elevation > elevationToSet)
-								elevationToSet = elevation;
+							if (elementElevation == null)
+							{
+								if (elevation > elevationToSet)
+									elevationToSet = elevation;
 
-							if(elementElevation == null)
 								r.View.Elevation = elevationToSet;
+							}
 						}
 					}
 				}


### PR DESCRIPTION
### Description of Change ###
If you have an elevation set on a control then that is going to trump a call to BringToFront. With the fastrenderers we unwrapped Button from ViewGroup so now it has a default elevation set. This means that even if you call BringToFront on an element that overlaps button the button will still be visually higher because it has a default elevation. 

This PR attempts to correlate the visual hierarchy to the elevation values set for controls. If a user sets an elevation themselves then that elevation is honored

### Issues Resolved ### 
- fixes #2989
- fixes #3543


### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
Controls stacked with buttons will now get their elevation set to the same values as button


### Testing Procedure ###
This PR enables UI Tests that were previously disabled

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
