### PR TITLE
[Tizen] Support new Named Font Sizes for Tizen

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -67,7 +67,22 @@ namespace Xamarin.Forms.Platform.Tizen
 					pt = Device.Idiom == TargetIdiom.TV ? 28 : (Device.Idiom == TargetIdiom.Watch ? 32 : 25);
 					break;
 				case NamedSize.Large:
-					pt = Device.Idiom == TargetIdiom.TV ? 84 : (Device.Idiom == TargetIdiom.Watch ? 36 : 31);
+					pt = Device.Idiom == TargetIdiom.TV ? 32 : (Device.Idiom == TargetIdiom.Watch ? 36 : 31);
+					break;
+				case NamedSize.Body:
+					pt = Device.Idiom == TargetIdiom.TV ? 30 : (Device.Idiom == TargetIdiom.Watch ? 32 : 28);
+					break;
+				case NamedSize.Caption:
+					pt = Device.Idiom == TargetIdiom.TV ? 26 : (Device.Idiom == TargetIdiom.Watch ? 24 : 22);
+					break;
+				case NamedSize.Header:
+					pt = Device.Idiom == TargetIdiom.TV ? 84 : (Device.Idiom == TargetIdiom.Watch ? 36 : 138);
+					break;
+				case NamedSize.Subtitle:
+					pt = Device.Idiom == TargetIdiom.TV ? 30 : (Device.Idiom == TargetIdiom.Watch ? 30 : 28);
+					break;
+				case NamedSize.Title:
+					pt = Device.Idiom == TargetIdiom.TV ? 42 : (Device.Idiom == TargetIdiom.Watch ? 36 : 40);
 					break;
 				default:
 					throw new ArgumentOutOfRangeException(nameof(size));


### PR DESCRIPTION
### Description of Change ###
This PR is to support new Named Font Sizes (Body, Caption, Header, Subtitle, Title) which are newly added from #5985 for Tizen. So, now Tizen's named font sizes for each `TargetIdiom` (Phone, TV, Watch) are as follows,

NamedSize  | Phone | TV | Watch 
---| ---| ---|---
**Micro** | 19 pt | 24 pt | 24 pt
**Small** | 22 pt| 26 pt | 30 pt
**Medium / Default** | 25 pt | 28 pt | 32 pt
**Large** | 31 pt | 32 pt | 36 pt
**Body** | 28 pt | 30 pt | 32 pt
**Caption** | 22 pt | 26 pt | 24 pt
**Header**| 138 pt | 84 pt | 36 pt
**Subtitle** | 28 pt | 30 pt | 30 pt
**Title** | 40 pt | 42 pt | 36 pt


### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
The font size of `NamedSize.Large` on `TargetIdiom.TV` has been changed from 84pt to 32pt. If you want to use the existing font size (84pt), please use `NamedSize.Header` instead.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Use a named font,

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
