### PR TITLE
[Shell] Allow to set background image for flyout item.

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -261,6 +261,28 @@ namespace Xamarin.Forms.Controls.XamStore
 			}, 0, 17);
 			grid.Children.Add(headerWidth, 1, 17);
 
+			grid.Children.Add(MakeButton("bg image",
+				() => Shell.Current.FlyoutBackgroundImage = ImageSource.FromFile("photo.jpg")),
+			0, 18);
+			grid.Children.Add(MakeButton("bg color",
+				() => Shell.Current.FlyoutBackgroundColor = Color.DarkGreen),
+			1, 18);
+			grid.Children.Add(MakeButton("bg aFit",
+				() => Shell.Current.FlyoutBackgroundImageAspect = Aspect.AspectFit),
+			2, 18);
+			grid.Children.Add(MakeButton("bg aFill",
+				() => Shell.Current.FlyoutBackgroundImageAspect = Aspect.AspectFill),
+			0, 19);
+			grid.Children.Add(MakeButton("bg Fill",
+				() => Shell.Current.FlyoutBackgroundImageAspect = Aspect.Fill),
+			1, 19);
+			grid.Children.Add(MakeButton("clear bg",
+				() => {
+					Shell.Current.ClearValue(Shell.FlyoutBackgroundColorProperty);
+					Shell.Current.ClearValue(Shell.FlyoutBackgroundImageProperty);
+				}),
+			2, 19);
+
 			Content = new ScrollView { Content = grid };
 
 			//var listView = new ListView();

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -542,6 +542,12 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty CurrentStateProperty = CurrentStatePropertyKey.BindableProperty;
 
+		public static readonly BindableProperty FlyoutBackgroundImageProperty =
+			BindableProperty.Create(nameof(FlyoutBackgroundImage), typeof(ImageSource), typeof(Shell), default(ImageSource), BindingMode.OneTime);
+
+		public static readonly BindableProperty FlyoutBackgroundImageAspectProperty =
+			BindableProperty.Create(nameof(FlyoutBackgroundImageAspect), typeof(Aspect), typeof(Shell), default(Aspect), BindingMode.OneTime);
+
 		public static readonly BindableProperty FlyoutBackgroundColorProperty =
 			BindableProperty.Create(nameof(FlyoutBackgroundColor), typeof(Color), typeof(Shell), Color.Default, BindingMode.OneTime);
 
@@ -592,6 +598,19 @@ namespace Xamarin.Forms
 		}
 
 		public ShellNavigationState CurrentState => (ShellNavigationState)GetValue(CurrentStateProperty);
+
+		[TypeConverter(typeof(ImageSourceConverter))]
+		public ImageSource FlyoutBackgroundImage
+		{
+			get => (ImageSource)GetValue(FlyoutBackgroundImageProperty);
+			set => SetValue(FlyoutBackgroundImageProperty, value);
+		}
+
+		public Aspect FlyoutBackgroundImageAspect
+		{
+			get => (Aspect)GetValue(FlyoutBackgroundImageAspectProperty);
+			set => SetValue(FlyoutBackgroundImageAspectProperty, value);
+		}
 
 		public Color FlyoutBackgroundColor
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -109,25 +109,28 @@ namespace Xamarin.Forms.Platform.Android
 
         protected virtual void OnShellPropertyChanged(object sender, PropertyChangedEventArgs e)
         {
-            if (e.PropertyName == Shell.FlyoutHeaderBehaviorProperty.PropertyName)
-                UpdateFlyoutHeaderBehavior();
-            else if (e.IsOneOf(
-				Shell.FlyoutBackgroundColorProperty, 
-				Shell.FlyoutBackgroundImageProperty, 
+			if (e.PropertyName == Shell.FlyoutHeaderBehaviorProperty.PropertyName)
+				UpdateFlyoutHeaderBehavior();
+			else if (e.IsOneOf(
+				Shell.FlyoutBackgroundColorProperty,
+				Shell.FlyoutBackgroundImageProperty,
 				Shell.FlyoutBackgroundImageAspectProperty))
-                UpdateFlyoutBackground();
+				UpdateFlyoutBackground();
         }
 
-		protected virtual async void UpdateFlyoutBackground()
+		protected virtual void UpdateFlyoutBackground()
 		{
-			// color
 			var color = _shellContext.Shell.FlyoutBackgroundColor;
 			if (_defaultBackgroundColor == null)
 				_defaultBackgroundColor = _rootView.Background;
 
 			_rootView.Background = color.IsDefault ? _defaultBackgroundColor : new ColorDrawable(color.ToAndroid());
 
-			// image
+			UpdateFlyoutBgImageAsync();
+		}
+
+		async void UpdateFlyoutBgImageAsync()
+		{
 			var imageSource = _shellContext.Shell.FlyoutBackgroundImage;
 			if (imageSource == null || !_shellContext.Shell.IsSet(Shell.FlyoutBackgroundImageProperty))
 			{
@@ -135,7 +138,6 @@ namespace Xamarin.Forms.Platform.Android
 					_rootView.RemoveView(_bgImage);
 				return;
 			}
-
 			using (var drawable = await _shellContext.AndroidContext.GetFormsDrawableAsync(imageSource) as BitmapDrawable)
 			{
 				if (_rootView.IsDisposed())
@@ -147,10 +149,6 @@ namespace Xamarin.Forms.Platform.Android
 						_rootView.RemoveView(_bgImage);
 					return;
 				}
-
-				var bitmapSize = new Size(drawable.Bitmap.Width, drawable.Bitmap.Height);
-				var boundingSize = new Size(_rootView.Width, _rootView.Height - _headerView.Height);
-				var size = bitmapSize;
 
 				_bgImage.SetImageDrawable(drawable);
 
@@ -173,7 +171,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-        protected virtual void UpdateFlyoutHeaderBehavior()
+		protected virtual void UpdateFlyoutHeaderBehavior()
         {
             switch (_shellContext.Shell.FlyoutHeaderBehavior)
             {

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public class ShellFlyoutContentRenderer : UIViewController, IShellFlyoutContentRenderer
 	{
 		UIVisualEffectView _blurView;
+		UIImageView _bgImage;
 		readonly IShellContext _shellContext;
 		UIContainerView _headerView;
 		ShellTableViewController _tableViewController;
@@ -31,12 +32,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void HandleShellPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Shell.FlyoutBackgroundColorProperty.PropertyName)
-				UpdateBackgroundColor();
+			if (e.IsOneOf(
+				Shell.FlyoutBackgroundColorProperty, 
+				Shell.FlyoutBackgroundImageProperty,
+				Shell.FlyoutBackgroundImageAspectProperty))
+				UpdateBackground();
 		}
 
-		protected virtual void UpdateBackgroundColor()
+		protected virtual async void UpdateBackground()
 		{
+			// color
 			var color = _shellContext.Shell.FlyoutBackgroundColor;
 			View.BackgroundColor = color.ToUIColor(Color.White);
 
@@ -49,6 +54,46 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_blurView.Superview != null)
 					_blurView.RemoveFromSuperview();
 			}
+
+			// image
+			var imageSource = _shellContext.Shell.FlyoutBackgroundImage;
+			if (imageSource == null || !_shellContext.Shell.IsSet(Shell.FlyoutBackgroundImageProperty))
+			{
+				_bgImage.RemoveFromSuperview();
+				_bgImage.Image?.Dispose();
+				_bgImage.Image = null;
+				return;
+			}
+
+			using (var nativeImage = await imageSource.GetNativeImageAsync())
+			{
+				if (View == null)
+					return;
+
+				if (nativeImage == null)
+				{
+					_bgImage?.RemoveFromSuperview();
+					return;
+				}
+
+				_bgImage.Image = nativeImage;
+				switch (_shellContext.Shell.FlyoutBackgroundImageAspect)
+				{
+					default:
+					case Aspect.AspectFit:
+						_bgImage.ContentMode = UIViewContentMode.ScaleAspectFit;
+						break;
+					case Aspect.AspectFill:
+						_bgImage.ContentMode = UIViewContentMode.ScaleAspectFill;
+						break;
+					case Aspect.Fill:
+						_bgImage.ContentMode = UIViewContentMode.ScaleToFill;
+						break;
+				}
+
+				if (_bgImage.Superview != View)
+					View.InsertSubview(_bgImage, 0);
+			}
 		}
 
 		public UIViewController ViewController => this;
@@ -59,6 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_tableViewController.LayoutParallax();
 			_blurView.Frame = View.Bounds;
+			_bgImage.Frame = View.Bounds;
 		}
 
 		public override void ViewDidLoad()
@@ -75,8 +121,14 @@ namespace Xamarin.Forms.Platform.iOS
 			var effect = UIBlurEffect.FromStyle(UIBlurEffectStyle.Regular);
 			_blurView = new UIVisualEffectView(effect);
 			_blurView.Frame = View.Bounds;
+			_bgImage = new UIImageView
+			{
+				Frame = View.Bounds,
+				ContentMode = UIViewContentMode.ScaleAspectFit,
+				ClipsToBounds = true
+			};
 
-			UpdateBackgroundColor();
+			UpdateBackground();
 		}
 
 		public override void ViewWillAppear(bool animated)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -39,9 +39,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateBackground();
 		}
 
-		protected virtual async void UpdateBackground()
+		protected virtual void UpdateBackground()
 		{
-			// color
 			var color = _shellContext.Shell.FlyoutBackgroundColor;
 			View.BackgroundColor = color.ToUIColor(Color.White);
 
@@ -55,6 +54,11 @@ namespace Xamarin.Forms.Platform.iOS
 					_blurView.RemoveFromSuperview();
 			}
 
+			UpdateFlyoutBgImageAsync();
+		}
+
+		async void UpdateFlyoutBgImageAsync()
+		{
 			// image
 			var imageSource = _shellContext.Shell.FlyoutBackgroundImage;
 			if (imageSource == null || !_shellContext.Shell.IsSet(Shell.FlyoutBackgroundImageProperty))


### PR DESCRIPTION
### Description of Change ###

Allow to set background image for flyout.
The current implementation gives choice how the image will be placed. 

### Issues Resolved ### 

- fixes #4410

### API Changes ###

Added:
 - ImageSource Shell.FlyoutBackgroundImage { get; set; } //Bindable Property
 - Aspect Shell.FlyoutBackgroundImageAspect  { get; set; } //Bindable Property

### Platforms Affected ### 

- iOS
- Android

### After Screencasts ### 

Android http://recordit.co/pny7X2hPfk
iOS http://recordit.co/M8u34dMCE7

### Testing Procedure ###

- switch to shell control panel
- click on `bg image`

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
