### PR TITLE
fix up shell menu items, fix templates, fix bindings

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -31,6 +31,11 @@
 		<Style x:Key="NewsShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
 			<Setter Property="Shell.ShellBackgroundColor" Value="#546DFE" />
 		</Style>
+        <DataTemplate x:Key="MenuItemTemplate">
+            <ContentView>
+                <Button Visual="Material" ImageSource="{Binding Icon}" Text="{Binding Text}"  />
+            </ContentView>
+        </DataTemplate>
 	</Shell.Resources>
 
 	<Shell.FlyoutHeader>
@@ -92,13 +97,8 @@
 
 	<ShellContent Route="wishlist" Title="Wishlist" Icon="star.png" ContentTemplate="{DataTemplate local:WishlistPage}" />
 	
-	<MenuItem Text="Xam Protect" Icon="jet.png" />
+	<MenuItem Shell.MenuItemTemplate="{StaticResource MenuItemTemplate}" Text="Xam Protect" Icon="jet.png" />
 
 	<ShellContent Route="settings" Title="Settings" Icon="gear.png" ContentTemplate="{DataTemplate local:SettingsPage}" />
 
-	<Shell.MenuItems>
-		<MenuItem Text="Help &amp; feedback" />
-		<MenuItem Text="Parent Guide" />
-		<MenuItem Text="About Xam Store" />
-	</Shell.MenuItems>
 </localTest:TestShell>

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			var shell = new Shell();
 
 			Assert.IsEmpty(shell.Items);
-			Assert.IsEmpty(shell.MenuItems);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -477,5 +477,31 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.SetValue(Shell.FlyoutHeaderProperty, new ContentView());
 			Assert.AreEqual(null, flyoutView.BindingContext);
 		}
+
+
+
+		[Test]
+		public void MenuItemBindingContext()
+		{
+			Shell shell = new Shell();
+			ContentPage page = new ContentPage();
+			shell.Items.Add(CreateShellItem(page));
+			shell.BindingContext = new { Text = "Binding" };
+
+
+			object bindingContext = new object();
+
+			var menuItem = new MenuItem();
+			shell.Items.Add(new MenuShellItem(menuItem));
+
+			shell.BindingContext = bindingContext;
+
+			var menuItem2 = new MenuItem();
+			shell.Items.Add(new MenuShellItem(menuItem2));
+
+
+			Assert.AreEqual(bindingContext, menuItem.BindingContext);
+			Assert.AreEqual(bindingContext, menuItem2.BindingContext);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -20,8 +20,8 @@ namespace Xamarin.Forms
 		{
 			if (e.PropertyName == Shell.MenuItemTemplateProperty.PropertyName)
 				Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
-			else if (e.PropertyName == "Title")
-				OnPropertyChanged("Text");
+			else if (e.PropertyName == TitleProperty.PropertyName)
+				OnPropertyChanged(MenuItem.TextProperty.PropertyName);
 		}
 
 		public MenuItem MenuItem { get; }
@@ -37,7 +37,7 @@ namespace Xamarin.Forms
 		protected override void OnBindingContextChanged()
 		{
 			base.OnBindingContextChanged();
-			MenuItem.BindingContext = BindingContext;
+			SetInheritedBindingContext(MenuItem, BindingContext);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -33,5 +33,11 @@ namespace Xamarin.Forms
 		{
 			(MenuItem as IMenuItemController).Activate();
 		}
+
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+			MenuItem.BindingContext = BindingContext;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -1,6 +1,8 @@
-﻿namespace Xamarin.Forms
+﻿using System.Runtime.CompilerServices;
+
+namespace Xamarin.Forms
 {
-	public class MenuShellItem : ShellItem
+	internal class MenuShellItem : ShellItem, IMenuItemController
 	{
 		internal MenuShellItem(MenuItem menuItem)
 		{
@@ -8,8 +10,28 @@
 
 			SetBinding(TitleProperty, new Binding("Text", BindingMode.OneWay, source: menuItem));
 			SetBinding(IconProperty, new Binding("Icon", BindingMode.OneWay, source: menuItem));
+			Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
+			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;
+		}
+
+		public string Text => Title;
+
+		void OnMenuItemPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == Shell.MenuItemTemplateProperty.PropertyName)
+				Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
+			else if (e.PropertyName == "Title")
+				OnPropertyChanged("Text");
 		}
 
 		public MenuItem MenuItem { get; }
+		bool IMenuItemController.IsEnabled { get => MenuItem.IsEnabled; set => MenuItem.IsEnabled = value; }
+
+		string IMenuItemController.IsEnabledPropertyName => MenuItem.IsEnabledProperty.PropertyName;
+
+		void IMenuItemController.Activate()
+		{
+			(MenuItem as IMenuItemController).Activate();
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -53,6 +53,12 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty TitleViewProperty =
 			BindableProperty.CreateAttached("TitleView", typeof(View), typeof(Shell), null, propertyChanged: OnTitleViewChanged);
 
+		public static readonly BindableProperty MenuItemTemplateProperty =
+			BindableProperty.CreateAttached(nameof(MenuItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
+
+		public static DataTemplate GetMenuItemTemplate(BindableObject obj) => (DataTemplate)obj.GetValue(MenuItemTemplateProperty);
+		public static void SetMenuItemTemplate(BindableObject obj, DataTemplate menuItemTemplate) => obj.SetValue(MenuItemTemplateProperty, menuItemTemplate);
+
 		public static BackButtonBehavior GetBackButtonBehavior(BindableObject obj) => (BackButtonBehavior)obj.GetValue(BackButtonBehaviorProperty);
 		public static void SetBackButtonBehavior(BindableObject obj, BackButtonBehavior behavior) => obj.SetValue(BackButtonBehaviorProperty, behavior);
 
@@ -174,9 +180,6 @@ namespace Xamarin.Forms
 
 		static readonly BindablePropertyKey ItemsPropertyKey = BindableProperty.CreateReadOnly(nameof(Items), typeof(ShellItemCollection), typeof(Shell), null,
 				defaultValueCreator: bo => new ShellItemCollection { Inner = new ElementCollection<ShellItem>(((Shell)bo).InternalChildren) });
-
-		static readonly BindablePropertyKey MenuItemsPropertyKey =
-			BindableProperty.CreateReadOnly(nameof(MenuItems), typeof(MenuItemCollection), typeof(Shell), null, defaultValueCreator: bo => new MenuItemCollection());
 
 		List<(IAppearanceObserver Observer, Element Pivot)> _appearanceObservers = new List<(IAppearanceObserver Observer, Element Pivot)>();
 		List<IFlyoutBehaviorObserver> _flyoutBehaviorObservers = new List<IFlyoutBehaviorObserver>();
@@ -560,11 +563,6 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
 
-		public static readonly BindableProperty MenuItemsProperty = MenuItemsPropertyKey.BindableProperty;
-
-		public static readonly BindableProperty MenuItemTemplateProperty =
-			BindableProperty.Create(nameof(MenuItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
-
 		public static readonly BindableProperty FlyoutIconProperty =
 			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(Shell), null);
 
@@ -658,12 +656,10 @@ namespace Xamarin.Forms
 			set => SetValue(ItemTemplateProperty, value);
 		}
 
-		public MenuItemCollection MenuItems => (MenuItemCollection)GetValue(MenuItemsProperty);
-
 		public DataTemplate MenuItemTemplate
 		{
-			get => (DataTemplate)GetValue(MenuItemTemplateProperty);
-			set => SetValue(MenuItemTemplateProperty, value);
+			get => GetMenuItemTemplate(this);
+			set => SetMenuItemTemplate(this, value);
 		}
 
 		public string Route
@@ -765,8 +761,6 @@ namespace Xamarin.Forms
 			}
 
 			IncrementGroup();
-
-			currentGroup.AddRange(MenuItems);
 
 			return result;
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -48,9 +48,9 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var item = _listItems[position];
 			var dataTemplate = Shell.ItemTemplate ?? DefaultItemTemplate;
-			if (item.Element is MenuItem)
+			if (item.Element is IMenuItemController)
 			{
-				dataTemplate = Shell.MenuItemTemplate ?? DefaultMenuItemTemplate;
+				dataTemplate = Shell.GetMenuItemTemplate(item.Element) ?? Shell.MenuItemTemplate ?? DefaultMenuItemTemplate;
 			}
 
 			var template = dataTemplate.SelectDataTemplate(item.Element, Shell);
@@ -140,6 +140,7 @@ namespace Xamarin.Forms.Platform.Android
 			var template = _templateMap[viewType];
 
 			var content = (View)template.CreateContent();
+			content.Parent = _shellContext.Shell;
 
 			var linearLayout = new LinearLayoutWithFocus(parent.Context)
 			{
@@ -158,7 +159,7 @@ namespace Xamarin.Forms.Platform.Android
 			container.LayoutParameters = new LP(LP.MatchParent, LP.WrapContent);
 			linearLayout.AddView(container);
 
-			return new ElementViewHolder(content, linearLayout, bar, _selectedCallback); ;
+			return new ElementViewHolder(content, linearLayout, bar, _selectedCallback);
 		}
 
 		protected virtual List<AdapterListItem> GenerateItemList()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -52,9 +52,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var context = Groups[section][row];
 
 			DataTemplate template = null;
-			if (context is MenuItem)
+			if (context is IMenuItemController)
 			{
-				template = _context.Shell.MenuItemTemplate ?? DefaultMenuItemTemplate;
+				template = Shell.GetMenuItemTemplate(context) ?? _context.Shell.MenuItemTemplate ?? DefaultMenuItemTemplate;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

- deleted Shell.MenuItems from the top level Shell class because it serves no purpose. Just add the menuitem to the root
- changed MenuItemTemplate to an attached property so you can attach different templates to menu items
- Fixed Text so that it'll propagate correctly when MenuItem is wrapped as MenuShellItem
- Fixed shell level menu item template so it applies correctly
- set parent of created template to shell like it does on iOS

### Issues Resolved ### 
- fixes #4399
- fixes #5707

### API Changes ###

 Removed:
 - made MenuShellItem Internal
 
 
### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Testing Procedure ###
Updated shell with a custom menu item template you can see on ios and android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
