### PR TITLE
[iOS] add DesignerFlyoutRenderer when running as previewer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1183,7 +1183,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4992.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -263,7 +263,8 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		class DesignerFlyoutRenderer : IShellFlyoutRenderer
+		// this won't work on the previewer if it's private
+		internal class DesignerFlyoutRenderer : IShellFlyoutRenderer
 		{
 			readonly UIViewController _parent;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -119,6 +119,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual IShellFlyoutRenderer CreateFlyoutRenderer()
 		{
+			// HACK
 			if(UIApplication.SharedApplication?.Delegate?.GetType()?.FullName == "XamarinFormsPreviewer.iOS.AppDelegate")
 			{
 				return new DesignerFlyoutRenderer(this);
@@ -262,7 +263,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		public class DesignerFlyoutRenderer : IShellFlyoutRenderer
+		class DesignerFlyoutRenderer : IShellFlyoutRenderer
 		{
 			readonly UIViewController _parent;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public UIView NativeView => FlyoutRenderer.View;
 		public Shell Shell => (Shell)Element;
 		public UIViewController ViewController => FlyoutRenderer.ViewController;
-		
+
 		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint) => new SizeRequest(new Size(100, 100));
 
 		public void RegisterEffect(Effect effect)
@@ -119,10 +119,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual IShellFlyoutRenderer CreateFlyoutRenderer()
 		{
+			if(UIApplication.SharedApplication?.Delegate?.GetType()?.FullName == "XamarinFormsPreviewer.iOS.AppDelegate")
+			{
+				return new DesignerFlyoutRenderer(this);
+			}
+
 			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 			{
 				return new TabletShellFlyoutRenderer();
 			}
+
 			return new ShellFlyoutRenderer()
 			{
 				FlyoutTransition = new SlideFlyoutTransition()
@@ -253,6 +259,27 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (_currentShellItemRenderer == null)
 			{
 				OnCurrentItemChanged();
+			}
+		}
+
+		public class DesignerFlyoutRenderer : IShellFlyoutRenderer
+		{
+			readonly UIViewController _parent;
+
+			public DesignerFlyoutRenderer(UIViewController parent)
+			{
+				_parent = parent;
+			}
+			public UIViewController ViewController => _parent;
+
+			public UIView View => _parent.View;
+
+			public void AttachFlyout(IShellContext context, UIViewController content)
+			{
+			}
+
+			public void Dispose()
+			{
 			}
 		}
 	}

--- a/Xamarin.Forms.Sandbox.Android/Properties/AndroidManifest.xml
+++ b/Xamarin.Forms.Sandbox.Android/Properties/AndroidManifest.xml
@@ -2,6 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="com.companyname.Xamarin.Forms.Sandbox" android:installLocation="auto">
 	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 	<application android:label="Forms Sandbox">
-    <uses-library android:name="org.apache.http.legacy" android:required="false" />
-  </application>
+		<uses-library android:name="org.apache.http.legacy" android:required="false" />
+	</application>
 </manifest>


### PR DESCRIPTION
### Description of Change ###
Makes shell not crash on ios previewer

### Testing Procedure ###
- run a normal shell app to a device and make sure that still works
- install the nuget from this PR and make sure designer doesn't crash

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
