### PR TITLE
[Android] VisualElementRenderer and ElevationHelper should be public

### DIFF
--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -2,7 +2,7 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal static class ElevationHelper
+	public static class ElevationHelper
 	{
 		internal static void SetElevation(global::Android.Views.View view, VisualElement element)
 		{

--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public static class ElevationHelper
 	{
-		internal static void SetElevation(global::Android.Views.View view, VisualElement element)
+		public static void SetElevation(global::Android.Views.View view, VisualElement element)
 		{
 			if (view == null || element == null || !Forms.IsLollipopOrNewer)
 			{

--- a/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
@@ -7,7 +7,7 @@ using AView = Android.Views.View;
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
 	// TODO hartez 2017/03/03 14:11:17 It's weird that this class is called VisualElementRenderer but it doesn't implement that interface. The name should probably be different.
-	internal sealed class VisualElementRenderer : IDisposable, IEffectControlProvider, ITabStop
+	public sealed class VisualElementRenderer : IDisposable, IEffectControlProvider, ITabStop
 	{
 		bool _disposed;
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
@@ -6,7 +6,6 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	// TODO hartez 2017/03/03 14:11:17 It's weird that this class is called VisualElementRenderer but it doesn't implement that interface. The name should probably be different.
 	public sealed class VisualElementRenderer : IDisposable, IEffectControlProvider, ITabStop
 	{
 		bool _disposed;


### PR DESCRIPTION
### Description of Change ###

VisualElementRenderer and ElevationHelper should be public. It's needed for custom fast renderer implementations. Currently, libs like FFImageLoading use reflection to use those classes.

@samhouts Related to this: https://github.com/xamarin/Xamarin.Forms/pull/5926#issuecomment-489590844

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard