### PR TITLE
4.0 ABI Fixes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Title = "Test";
 			BackgroundColor = Color.Pink;
 			Content = new Label { Text = "Hello", AutomationId ="lblHello" };
-			NavigationPage.SetTitleIcon(this, "bank.png");
+			NavigationPage.SetTitleIconImageSource(this, "bank.png");
 		}
 
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4138.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4138.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
         {
             ContentPage contentPage = new ContentPage();
 
-            NavigationPage.SetTitleIcon(contentPage, "coffee.png");
+            NavigationPage.SetTitleIconImageSource(contentPage, "coffee.png");
 
             PushAsync(contentPage);
         }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -28,13 +28,19 @@ namespace Xamarin.Forms.Controls.Issues
 			navPage.BindingContext = new Issue4915ContentPage.ViewModel();
 
 
-			var urlNavPage = new NavigationPage(new Issue4915ContentPage()) { Title = "nav page 1" };
+			var urlNavPage = new NavigationPage(new Issue4915ContentPage()) { Title = "nav page 2" };
 			urlNavPage.SetBinding(Page.IconImageSourceProperty, "ImageUrl");
 			urlNavPage.BindingContext = new Issue4915ContentPage.ViewModel();
 
+			var titleIconPage = new Issue4915ContentPage();
+			var justSetOnNavPage = new NavigationPage(titleIconPage) { Title = "nav page 3" };
+#pragma warning disable CS0618 // Type or member is obsolete
+			NavigationPage.SetTitleIcon(titleIconPage, "coffee.png");
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			Children.Add(navPage);
 			Children.Add(urlNavPage);
+			Children.Add(justSetOnNavPage);
 			Children.Add(new Issue4915ContentPage() { Title = "page 2" });
 
 

--- a/Xamarin.Forms.Controls/GalleryPages/ImageSourcesGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ImageSourcesGallery.cs
@@ -112,7 +112,7 @@ namespace Xamarin.Forms.Controls
 						Spacing = 10,
 						Children =
 						{
-							CreateImageSourcePicker("Change Title Icon", getter => NavigationPage.SetTitleIcon(this, getter())),
+							CreateImageSourcePicker("Change Title Icon", getter => NavigationPage.SetTitleIconImageSource(this, getter())),
 							new Button
 							{
 								Text = "Page & Toolbar",

--- a/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/NavigationBarGallery.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Controls
 
 			ToolbarItems.Add(new ToolbarItem { Text = "Save" });
 
-			NavigationPage.SetTitleIcon(this, "coffee.png");
+			NavigationPage.SetTitleIconImageSource(this, "coffee.png");
 
 			SearchBar searchBar = new SearchBar { HeightRequest = 44, WidthRequest = 100 };
 
@@ -111,14 +111,14 @@ namespace Xamarin.Forms.Controls
 							Text = "Toggle TitleIcon",
 							Command = new Command (() => {
 
-								var titleIcon = NavigationPage.GetTitleIcon(this);
+								var titleIcon = NavigationPage.GetTitleIconImageSource(this);
 
 								if (titleIcon == null)
 									titleIcon = "coffee.png";
 								else
 									titleIcon = null;
 
-								NavigationPage.SetTitleIcon(this, titleIcon);
+								NavigationPage.SetTitleIconImageSource(this, titleIcon);
 							})
 						},
 						new Button {

--- a/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/TitleView.xaml.cs
@@ -185,12 +185,12 @@ namespace Xamarin.Forms.Controls.GalleryPages
 
 		static void toggleTitleIcon(Page page)
 		{
-			var titleIcon = NavigationPage.GetTitleIcon(page);
+			var titleIcon = NavigationPage.GetTitleIconImageSource(page);
 
 			if (titleIcon == null)
-				NavigationPage.SetTitleIcon(page, "coffee.png");
+				NavigationPage.SetTitleIconImageSource(page, "coffee.png");
 			else
-				NavigationPage.SetTitleIcon(page, null);
+				NavigationPage.SetTitleIconImageSource(page, null);
 		}
 
 		void masterDetailsPageIcon_Clicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms
 
 		[Obsolete("Image is obsolete as of 4.0.0. Please use ImageSource instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public ImageSource Image
+		public FileImageSource Image
 		{
 			get { return GetValue(ImageProperty) as FileImageSource; }
 			set { SetValue(ImageProperty, value); }

--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -26,7 +26,11 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty BarTextColorProperty = BarElement.BarTextColorProperty;
 
-		public static readonly BindableProperty TitleIconProperty = BindableProperty.CreateAttached("TitleIcon", typeof(ImageSource), typeof(NavigationPage), default(ImageSource));
+		public static readonly BindableProperty TitleIconImageSourceProperty = BindableProperty.CreateAttached("TitleIconImageSource", typeof(ImageSource), typeof(NavigationPage), default(ImageSource));
+
+		[Obsolete("TitleIconProperty is obsolete as of 4.0.0. Please use TitleIconImageSourceProperty instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static readonly BindableProperty TitleIconProperty = TitleIconImageSourceProperty;
 
 		public static readonly BindableProperty TitleViewProperty = BindableProperty.CreateAttached("TitleView", typeof(View), typeof(NavigationPage), null, propertyChanging: TitleViewPropertyChanging);
 
@@ -138,9 +142,16 @@ namespace Xamarin.Forms
 			return (bool)page.GetValue(HasNavigationBarProperty);
 		}
 
-		public static ImageSource GetTitleIcon(BindableObject bindable)
+		[Obsolete("GetTitleIcon is obsolete as of 4.0.0. Please use GetTitleIconImageSource instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static FileImageSource GetTitleIcon(BindableObject bindable)
 		{
-			return (ImageSource)bindable.GetValue(TitleIconProperty);
+			return bindable.GetValue(TitleIconImageSourceProperty) as FileImageSource;
+		}
+
+		public static ImageSource GetTitleIconImageSource(BindableObject bindable)
+		{
+			return (ImageSource)bindable.GetValue(TitleIconImageSourceProperty);
 		}
 
 		public static View GetTitleView(BindableObject bindable)
@@ -250,9 +261,16 @@ namespace Xamarin.Forms
 			page.SetValue(HasNavigationBarProperty, value);
 		}
 
-		public static void SetTitleIcon(BindableObject bindable, ImageSource value)
+		[Obsolete("SetTitleIcon is obsolete as of 4.0.0. Please use SetTitleIconImageSource instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetTitleIcon(BindableObject bindable, FileImageSource value)
 		{
-			bindable.SetValue(TitleIconProperty, value);
+			bindable.SetValue(TitleIconImageSourceProperty, value);
+		}
+
+		public static void SetTitleIconImageSource(BindableObject bindable, ImageSource value)
+		{
+			bindable.SetValue(TitleIconImageSourceProperty, value);
 		}
 
 		public static void SetTitleView(BindableObject bindable, View value)

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms
 
 		[Obsolete("BackgroundImage is obsolete as of 4.0.0. Please use BackgroundImageSource instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public FileImageSource BackgroundImage
+		public string BackgroundImage
 		{
 			get { return GetValue(BackgroundImageProperty) as FileImageSource; }
 			set { SetValue(BackgroundImageProperty, value); }

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -529,7 +529,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.HasBackButtonProperty.PropertyName)
 				UpdateToolbar();
-			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName ||
+			else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName ||
 					 e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 				UpdateToolbar();
 		}
@@ -1011,7 +1011,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateTitleIcon()
 		{
 			Page currentPage = Element.CurrentPage;
-			ImageSource source = NavigationPage.GetTitleIcon(currentPage);
+			ImageSource source = NavigationPage.GetTitleIconImageSource(currentPage);
 
 			if (source == null || source.IsEmpty)
 			{
@@ -1032,7 +1032,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				_imageSource = source;
 				_titleIconView.SetImageResource(global::Android.Resource.Color.Transparent);
-				_ = this.ApplyDrawableAsync(currentPage, NavigationPage.TitleIconProperty, Context, drawable =>
+				_ = this.ApplyDrawableAsync(currentPage, NavigationPage.TitleIconImageSourceProperty, Context, drawable =>
 				{
 					_titleIconView.SetImageDrawable(drawable);
 				});

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -18,6 +18,7 @@ using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
 using AView = Android.Views.View;
 using AMenu = Android.Views.Menu;
 using AColor = Android.Graphics.Color;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -535,10 +536,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				else
 				{
 					TabLayout.Tab tab = _tabLayout.GetTabAt(index);
-					_ = this.ApplyDrawableAsync(page, Page.IconImageSourceProperty, Context, icon =>
-					{
-						SetTabIcon(tab, icon);
-					});
+					SetTabIconImageSource(page, tab);
 				}
 			}
 		}
@@ -681,17 +679,40 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			{
 				Page child = Element.Children[i];
 				TabLayout.Tab tab = tabs.GetTabAt(i);
-				_ = this.ApplyDrawableAsync(child, Page.IconImageSourceProperty, Context, icon =>
-				{
-					SetTabIcon(tab, icon);
-				});
+				SetTabIconImageSource(child, tab);
 			}
 		}
 
-		void SetTabIcon(TabLayout.Tab tab, Drawable icon)
+		[Obsolete("GetIconDrawable is obsolete as of 4.0.0. Please override SetTabIconImageSource instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		protected virtual Drawable GetIconDrawable(FileImageSource icon) =>
+			Context.GetDrawable(icon as FileImageSource);
+
+
+		[Obsolete("SetTabIcon is obsolete as of 4.0.0. Please use SetTabIconImageSource instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		protected virtual void SetTabIcon(TabLayout.Tab tab, FileImageSource icon)
+		{
+		}
+
+
+		protected virtual void SetTabIconImageSource(TabLayout.Tab tab, Drawable icon)
 		{
 			tab.SetIcon(icon);
 			SetIconColorFilter(tab);
+		}
+
+		void SetTabIconImageSource(Page page, TabLayout.Tab tab)
+		{
+			_ = this.ApplyDrawableAsync(page, Page.IconImageSourceProperty, Context, icon =>
+			{
+				SetTabIconImageSource(tab, icon);
+
+#pragma warning disable CS0618 // Type or member is obsolete
+				SetTabIcon(tab, page.Icon as FileImageSource);
+#pragma warning restore CS0618 // Type or member is obsolete
+
+			});
 		}
 
 		void UpdateBarBackgroundColor()

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1077,12 +1077,12 @@ namespace Xamarin.Forms.Platform.Android
 			if (ShouldShowActionBarTitleArea())
 			{
 				actionBar.Title = view.Title;
-				_ = _context.ApplyDrawableAsync(view, NavigationPage.TitleIconProperty, icon =>
+				_ = _context.ApplyDrawableAsync(view, NavigationPage.TitleIconImageSourceProperty, icon =>
 				{
 					if (icon != null)
 						actionBar.SetLogo(icon);
 				});
-				var titleIcon = NavigationPage.GetTitleIcon(view);
+				var titleIcon = NavigationPage.GetTitleIconImageSource(view);
 				useLogo = titleIcon != null && titleIcon.IsEmpty;
 				showHome = true;
 				showTitle = true;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TabbedPageRenderer.cs
@@ -204,7 +204,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (icon != null)
 				{
-					var image = GetTabViewItemIcon(icon);
+					var image = GetTabViewItemIconImageSource(icon);
 					if (image != null)
 						tvi.Image = image;
 				}
@@ -212,7 +212,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			return tvi;
 		}
 
-		protected virtual NSImage GetTabViewItemIcon(NSImage image)
+		protected virtual NSImage GetTabViewItemIcon(string imageName) => GetTabViewItemIconImageSource(NSImage.ImageNamed(imageName));
+
+		protected virtual NSImage GetTabViewItemIconImageSource(NSImage image)
 		{
 			if (image == null)
 				return null;

--- a/Xamarin.Forms.Platform.UAP/FormsSlider.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsSlider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Media.Imaging;
@@ -10,10 +11,14 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		internal Thumb Thumb { get; set; }
 		internal Thumb ImageThumb { get; set; }
-
-		public static readonly DependencyProperty ThumbImageProperty = 
-			DependencyProperty.Register(nameof(ThumbImage), typeof(WImageSource), 
+			   
+		public static readonly DependencyProperty ThumbImageSourceProperty = 
+			DependencyProperty.Register(nameof(ThumbImageSource), typeof(WImageSource), 
 			typeof(FormsSlider), new PropertyMetadata(null, PropertyChangedCallback));
+
+		[Obsolete("ThumbImageProperty is obsolete as of 4.0.0. Please use ThumbImageSourceProperty instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static readonly DependencyProperty ThumbImageProperty = ThumbImageSourceProperty;
 
 		static void PropertyChangedCallback(DependencyObject dependencyObject,
 			DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
@@ -29,7 +34,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 
-			if (slider.ThumbImage != null)
+			if (slider.ThumbImageSource != null)
 			{
 				slider.Thumb.Visibility = Visibility.Collapsed;
 				slider.ImageThumb.Visibility = Visibility.Visible;
@@ -41,10 +46,18 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		public WImageSource ThumbImage
+		public WImageSource ThumbImageSource
 		{
-			get { return (WImageSource)GetValue(ThumbImageProperty); }
-			set { SetValue(ThumbImageProperty, value); }
+			get { return (WImageSource)GetValue(ThumbImageSourceProperty); }
+			set { SetValue(ThumbImageSourceProperty, value); }
+		}
+
+		[Obsolete("ThumbImage is obsolete as of 4.0.0. Please use ThumbImageSource instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public BitmapImage ThumbImage
+		{
+			get { return GetValue(ThumbImageSourceProperty) as BitmapImage; }
+			set { SetValue(ThumbImageSourceProperty, value); }
 		}
 
 		internal event EventHandler Ready;

--- a/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailPageRenderer.cs
@@ -269,7 +269,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateDetailTitle();
-			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName)
 				UpdateDetailTitleIcon();
 			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 				UpdateDetailTitleView();
@@ -343,7 +343,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_detail == null)
 				return;
 
-			Control.DetailTitleIcon = await NavigationPage.GetTitleIcon(GetCurrentPage()).ToWindowsImageSourceAsync();
+			Control.DetailTitleIcon = await NavigationPage.GetTitleIconImageSource(GetCurrentPage()).ToWindowsImageSourceAsync();
 			Control.InvalidateMeasure();
 		}
 

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -344,7 +344,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateTitleVisible();
 			else if (e.PropertyName == Page.TitleProperty.PropertyName)
 				UpdateTitleOnParents();
-			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName)
 				UpdateTitleIcon();
 			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 				UpdateTitleView();
@@ -368,7 +368,7 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateToolbarPlacement();
 			else if (e.PropertyName == ToolbarDynamicOverflowEnabledProperty.PropertyName)
 				UpdateToolbarDynamicOverflowEnabled();
-			else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName)
 				UpdateTitleIcon();
 			else if (e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 				UpdateTitleView();
@@ -539,7 +539,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_currentPage == null)
 				return;
 
-			ImageSource source = NavigationPage.GetTitleIcon(_currentPage);
+			ImageSource source = NavigationPage.GetTitleIconImageSource(_currentPage);
 
 			_titleIcon = await source.ToWindowsImageSourceAsync();
 

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -410,7 +410,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				var button = new AppBarButton();
 				button.SetBinding(AppBarButton.LabelProperty, "Text");
-				button.SetBinding(AppBarButton.IconProperty, "Icon", _imageSourceIconElementConverter);
+				button.SetBinding(AppBarButton.IconProperty, "IconImageSource", _imageSourceIconElementConverter);
 				button.Command = new MenuItemCommand(item);
 				button.DataContext = item;
 				button.SetValue(NativeAutomationProperties.AutomationIdProperty, item.AutomationId);

--- a/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SliderRenderer.cs
@@ -176,11 +176,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (thumbImage == null)
 			{
-				Control.ThumbImage = null;
+				Control.ThumbImageSource = null;
 				return;
 			}
 
-			Control.ThumbImage = await thumbImage.ToWindowsImageSourceAsync();
+			Control.ThumbImageSource = await thumbImage.ToWindowsImageSourceAsync();
 		}
 
 		protected override void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.UAP/SliderStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/SliderStyle.xaml
@@ -197,7 +197,7 @@
 										Background="{ThemeResource SystemControlForegroundAccentBrush}"
 										Style="{StaticResource SliderThumbImageStyle}"
 										DataContext="{TemplateBinding Value}"
-										Tag="{Binding ThumbImage, RelativeSource={RelativeSource TemplatedParent}}"
+										Tag="{Binding ThumbImageSource, RelativeSource={RelativeSource TemplatedParent}}"
 										Height="24"
 										Width="24"
 										Grid.Row="0"

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -7,7 +7,7 @@
 			<Setter.Value>
 				<DataTemplate>
 					<StackPanel Orientation="Vertical" Name="TabbedPageHeaderStackPanel">
-                        <Image Name="TabbedPageHeaderImage" DataContext="{Binding IconImageSource, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" Margin="0,12,0,0"/>
+						<Image Name="TabbedPageHeaderImage" DataContext="{Binding IconImageSource, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" Margin="0,12,0,0"/>
 						<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}"/>
 					</StackPanel>
 				</DataTemplate>

--- a/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageStyle.xaml
@@ -7,7 +7,7 @@
 			<Setter.Value>
 				<DataTemplate>
 					<StackPanel Orientation="Vertical" Name="TabbedPageHeaderStackPanel">
-						<Image Name="TabbedPageHeaderImage" DataContext="{Binding Icon, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" Margin="0,12,0,0"/>
+                        <Image Name="TabbedPageHeaderImage" DataContext="{Binding IconImageSource, Converter={StaticResource ImageConverter}}" Source="{Binding Value}" Width="16" Height="16" Visibility="Collapsed" Margin="0,12,0,0"/>
 						<TextBlock Name="TabbedPageHeaderTextBlock" Text="{Binding Title}" Style="{ThemeResource BodyTextBlockStyle}"/>
 					</StackPanel>
 				</DataTemplate>

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -32,6 +32,17 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
+#if __MOBILE__
+		public static UIColor FromPatternImageFromBundle(string bgImage)
+		{
+			var image = UIImage.FromBundle(bgImage);
+			if (image == null)
+				return UIColor.White;
+
+			return UIColor.FromPatternImage(image);
+		}
+#endif
+
 		public static Color ToColor(this UIColor color)
 		{
 			nfloat red;

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1037,7 +1037,7 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdatePrefersStatusBarHidden();
 				else if (e.PropertyName == LargeTitleDisplayProperty.PropertyName)
 					UpdateLargeTitles();
-				else if (e.PropertyName == NavigationPage.TitleIconProperty.PropertyName ||
+				else if (e.PropertyName == NavigationPage.TitleIconImageSourceProperty.PropertyName ||
 					 e.PropertyName == NavigationPage.TitleViewProperty.PropertyName)
 					UpdateTitleArea(Child);
 			}
@@ -1066,7 +1066,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 
-			public bool NeedsTitleViewContainer(Page page) => NavigationPage.GetTitleIcon(page) != null || NavigationPage.GetTitleView(page) != null;
+			public bool NeedsTitleViewContainer(Page page) => NavigationPage.GetTitleIconImageSource(page) != null || NavigationPage.GetTitleView(page) != null;
 
 			internal void UpdateBackButtonTitle(Page page) => UpdateBackButtonTitle(page.Title, NavigationPage.GetBackButtonTitle(page));
 
@@ -1087,7 +1087,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (page == null)
 					return;
 
-				ImageSource titleIcon = NavigationPage.GetTitleIcon(page);
+				ImageSource titleIcon = NavigationPage.GetTitleIconImageSource(page);
 				View titleView = NavigationPage.GetTitleView(page);
 				bool needContainer = titleView != null || titleIcon != null;
 


### PR DESCRIPTION
### Description of Change ###

With #4915 we are wanting to keep all the original types the same so as to limit/remove any ABI breaks. This change snuck in 

### Issues Resolved ### 
- fixes #6123

### API Changes ###
 
### Namespace Xamarin.Forms

#### Type Changed: Xamarin.Forms.Button

Modified properties:

```diff
-public ImageSource Image { get; set; }
+public FileImageSource Image { get; set; }
```


#### Type Changed: Xamarin.Forms.NavigationPage

Removed methods:

```csharp
public static ImageSource GetTitleIcon (BindableObject bindable);
public static void SetTitleIcon (BindableObject bindable, ImageSource value);
```


#### Type Changed: Xamarin.Forms.Page

Modified properties:

```diff
-public FileImageSource BackgroundImage { get; set; }
+public string BackgroundImage { get; set; }
```

### Namespace Xamarin.Forms.Platform.Android.AppCompat

#### Type Changed: Xamarin.Forms.Platform.Android.AppCompat.TabbedPageRenderer

Added methods:

```csharp

[Obsolete ("GetIconDrawable is obsolete as of 4.0.0. Please override SetTabIconImageSource instead.")]
protected virtual Android.Graphics.Drawables.Drawable GetIconDrawable (Xamarin.Forms.FileImageSource icon);

[Obsolete ("SetTabIcon is obsolete as of 4.0.0. Please use SetTabIconImageSource instead.")]
protected virtual void SetTabIcon (Android.Support.Design.Widget.TabLayout.Tab tab, Xamarin.Forms.FileImageSource icon);
protected virtual void SetTabIconImageSource (Android.Support.Design.Widget.TabLayout.Tab tab, Android.Graphics.Drawables.Drawable icon);
```


### Namespace Xamarin.Forms.Platform.iOS

#### Type Changed: Xamarin.Forms.Platform.iOS.ColorExtensions

Added method:

```csharp
public static UIKit.UIColor FromPatternImageFromBundle (string bgImage);
```


### Namespace Xamarin.Forms.Platform.MacOS

#### Type Changed: Xamarin.Forms.Platform.MacOS.TabbedPageRenderer

Removed method:

```csharp
protected virtual AppKit.NSImage GetTabViewItemIcon (AppKit.NSImage image);
```

Added methods:

```csharp
protected virtual AppKit.NSImage GetTabViewItemIcon (string imageName);
protected virtual AppKit.NSImage GetTabViewItemIconImageSource (AppKit.NSImage image);
```



### Namespace Xamarin.Forms.Platform.UWP

#### Type Changed: Xamarin.Forms.Platform.UWP.FormsSlider

Obsoleted fields:

```diff
 [Obsolete ("ThumbImageProperty is obsolete as of 4.0.0. Please use ThumbImageSourceProperty instead.")]

 public static Windows.UI.Xaml.DependencyProperty ThumbImageProperty;
```

Added field:

```csharp
public static Windows.UI.Xaml.DependencyProperty ThumbImageSourceProperty;
```

Obsoleted properties:

```diff
 [Obsolete ("ThumbImage is obsolete as of 4.0.0. Please use ThumbImageSource instead.")]

 public Windows.UI.Xaml.Media.Imaging.BitmapImage ThumbImage { get; set; }
```

Modified properties:

```diff
-public Windows.UI.Xaml.Media.ImageSource ThumbImage { get; set; }
+public Windows.UI.Xaml.Media.Imaging.BitmapImage ThumbImage { get; set; }
```

Added property:

```csharp
public Windows.UI.Xaml.Media.ImageSource ThumbImageSource { get; set; }
  ```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
  

### Testing Procedure ###
There's a UI test that vets everything loads but another thing to check would be a quick look back at the PR for #4915 just to make sure nothing else was missed

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
