### PR TITLE
[iOS] Shell _headerView can apparently be null

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -20,10 +20,11 @@ namespace Xamarin.Forms.Platform.iOS
 			_headerView = headerView;
 			_source = new ShellTableViewSource(context, onElementSelected);
 			_source.ScrolledEvent += OnScrolled;
-			_headerView.HeaderSizeChanged += OnHeaderSizeChanged;
+			if (_headerView != null)
+				_headerView.HeaderSizeChanged += OnHeaderSizeChanged;
 			((IShellController)_context.Shell).StructureChanged += OnStructureChanged;
 		}
-		
+
 		void OnHeaderSizeChanged(object sender, EventArgs e)
 		{
 			_headerSize = HeaderMax;
@@ -63,7 +64,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidLoad()
 		{
 			base.ViewDidLoad();
-			_headerView.MeasureIfNeeded();
+			_headerView?.MeasureIfNeeded();
 
 			TableView.SeparatorStyle = UITableViewCellSeparatorStyle.None;
 			if (Forms.IsiOS11OrNewer)
@@ -79,10 +80,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if ((_context?.Shell as IShellController) != null)
 					((IShellController)_context.Shell).StructureChanged -= OnStructureChanged;
 
-				if(_source != null)
+				if (_source != null)
 					_source.ScrolledEvent -= OnScrolled;
 
-				if(_headerView != null)
+				if (_headerView != null)
 					_headerView.HeaderSizeChanged -= OnHeaderSizeChanged;
 			}
 
@@ -115,6 +116,6 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		float SafeAreaOffset => (float)Platform.SafeAreaInsetsForWindow.Top;
-		double HeaderMax => _headerView.MeasuredHeight;
+		double HeaderMax => _headerView?.MeasuredHeight ?? 0;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

UI Test 5132 was crashing because the FlyoutHeader was null on loading.

### Issues Resolved ### 

 n/a

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run G5132. If it doesn't crash, success!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
