### PR TITLE
[Android] _shellContext.Shell.FlyoutIcon was null, crashing AutomationProperties.GetHelpText...

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -292,14 +292,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void UpdateToolbarIconAccessibilityText(Toolbar toolbar, Shell shell)
 		{
-			// TODO shellIconTextDescription isn't even used!!
-
-			//string helpText = null;
-			//if (_shellContext.Shell.FlyoutIcon != null)
-			//	helpText = AutomationProperties.GetHelpText(_shellContext.Shell.FlyoutIcon);
-
-			//var shellIconTextDescription = shell.FlyoutIcon?.AutomationId ?? helpText ?? shell.AutomationId;
-
 			//if AutomationId was specified the user wants to use UITests and interact with FlyoutIcon
 			if (!string.IsNullOrEmpty(shell.FlyoutIcon?.AutomationId))
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -292,7 +292,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void UpdateToolbarIconAccessibilityText(Toolbar toolbar, Shell shell)
 		{
-			var shellIconTextDescription = shell.FlyoutIcon?.AutomationId ?? AutomationProperties.GetHelpText(_shellContext.Shell.FlyoutIcon) ?? shell.AutomationId;
+			// TODO shellIconTextDescription isn't even used!!
+
+			//string helpText = null;
+			//if (_shellContext.Shell.FlyoutIcon != null)
+			//	helpText = AutomationProperties.GetHelpText(_shellContext.Shell.FlyoutIcon);
+
+			//var shellIconTextDescription = shell.FlyoutIcon?.AutomationId ?? helpText ?? shell.AutomationId;
 
 			//if AutomationId was specified the user wants to use UITests and interact with FlyoutIcon
 			if (!string.IsNullOrEmpty(shell.FlyoutIcon?.AutomationId))


### PR DESCRIPTION
### Description of Change ###

...but more concerning is that the `shellIconTextDescription` isn't used at all. Is it leftover code, or is this a mistake? paging @PureWeen @rmarinho 

### Issues Resolved ### 
n/a

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run G4684. If it doesn't crash, success!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
