### PR TITLE
[Bug] ListView HasUnevenRows was not working in iOS 10

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5888.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5888.cs
@@ -1,0 +1,26 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5888, "[Bug] ListView HasUnevenRows is not working in iOS 10", PlatformAffected.iOS)]
+	public class Issue5888 : TestContentPage 
+	{
+		protected override void Init()
+		{
+
+			var stack2 = new StackLayout
+			{
+				Children = { new Label { Text = "Hi" }, new Label { Text = "Bye" }, new Label { Text = "Open" } }
+			};
+			var listview = new ListView
+			{
+				HasUnevenRows = true,
+				ItemTemplate = new DataTemplate(() => new ViewCell { View = stack2 }),
+				ItemsSource = new string[] { "mono", "monodroid" }
+			};
+			Content = new StackLayout { Children = { listview } };
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -892,6 +892,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4356.cs">
       <DependentUpon>Issue4356.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5888.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -711,7 +711,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (_tableViewController != null)
 				_tableViewController.UpdateRefreshControlColor(color == Color.Default ? null : color.ToUIColor());
-    }
+		}
 
 		void UpdateVerticalScrollBarVisibility()
 		{
@@ -817,11 +817,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			protected override void UpdateEstimatedRowHeight(UITableView tableView)
 			{
-				var estimatedRowheight  = GetEstimatedRowHeight(tableView);
+				var estimatedRowHeight = GetEstimatedRowHeight(tableView);
 				//if we are providing 0 we are disabling EstimatedRowHeight,
 				//this works fine on newer versions, but iOS10 it will cause a crash so we leave the default value
-				if (estimatedRowheight == 0 && Forms.IsiOS11OrNewer)
-					tableView.EstimatedRowHeight = estimatedRowheight;
+				if (estimatedRowHeight > 0 || (estimatedRowHeight == 0 && Forms.IsiOS11OrNewer))
+					tableView.EstimatedRowHeight = estimatedRowHeight;
 			}
 
 			internal Cell GetPrototypicalCell(NSIndexPath indexPath)
@@ -1247,7 +1247,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UpdateShortNameListener();
 
-				if(List.OnThisPlatform().RowAnimationsEnabled())
+				if (List.OnThisPlatform().RowAnimationsEnabled())
 					_uiTableView.ReloadData();
 				else
 					PerformWithoutAnimation(() => { _uiTableView.ReloadData(); });
@@ -1551,7 +1551,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewWillAppear(bool animated)
 		{
 			(TableView?.Source as ListViewRenderer.ListViewDataSource)?.Cleanup();
-			if (!_list.IsRefreshing || !_refresh.Refreshing) return;
+			if (!_list.IsRefreshing || !_refresh.Refreshing)
+				return;
 
 			// Restart the refreshing to get the animation to trigger
 			UpdateIsRefreshing(false);


### PR DESCRIPTION
### Description of Change ###

#4365 made EstimateRowHeight better for iOS11+, but it inadvertently broke HasUnevenRows on iOS10. This resolves the issue. Thanks @melimion for tracking down the code change!

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5888

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

1. Run G5888.
2. If the rows are not overlapping, success!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
