### PR TITLE
remove safe area from inset

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnHeaderSizeChanged(object sender, EventArgs e)
 		{
 			_headerSize = HeaderMax;
-			TableView.ContentInset = new UIEdgeInsets((nfloat)HeaderMax + SafeAreaOffset, 0, 0, 0);
+			TableView.ContentInset = new UIEdgeInsets((nfloat)HeaderMax, 0, 0, 0);
 			LayoutParallax();
 		}
 
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.iOS
 			TableView.SeparatorStyle = UITableViewCellSeparatorStyle.None;
 			if (Forms.IsiOS11OrNewer)
 				TableView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
-			TableView.ContentInset = new UIEdgeInsets((nfloat)HeaderMax + SafeAreaOffset, 0, 0, 0);
+			TableView.ContentInset = new UIEdgeInsets((nfloat)HeaderMax, 0, 0, 0);
 			TableView.Source = _source;
 		}
 


### PR DESCRIPTION
### Description of Change ###

The Frame on the tableview already accounted for SafeArea so it was causing too much spacing especially if no header view is present

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
The Tableview should line up against the safe area better

*BEFORE*
![image](https://user-images.githubusercontent.com/5375137/57562355-c4501b80-7346-11e9-85ae-862d75c7b170.png)

*AFTER*
![image](https://user-images.githubusercontent.com/5375137/57562383-09744d80-7347-11e9-9423-1a1eb7eca266.png)


### Testing Procedure ###
- test without a header view
- test the various scroll options with header view

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
