### PR TITLE
[iOS] Fix NRE SearchHandler iOS10

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (result != null)
 					return result;
 
-				for (var i = 0; i < descendantView.Subviews.Length; i++)
+				for (var i = 0; i < descendantView.Subviews?.Length; i++)
 					queue.Enqueue(descendantView.Subviews[i]);
 			}
 


### PR DESCRIPTION
### Description of Change ###

Running Shell on iOS10 with get a NRE when trying to get the UIButtons of UISearchBar.

### Issues Resolved ### 



### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
