### PR TITLE
Implement CollectionView.ItemsUpdatingScrollMode for Android/iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsUpdatingScrollMode.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsUpdatingScrollMode.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 8888888, "CollectionView ItemsUpdatingScrollMode", PlatformAffected.All)]
+	public class CollectionViewItemsUpdatingScrollMode : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			PushAsync(new GalleryPages.CollectionViewGalleries.ScrollModeGalleries.ScrollModeTestGallery());
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void KeepItemsInView()
+		{
+			RunningApp.WaitForElement("ScrollToMiddle");
+			RunningApp.Tap("ScrollToMiddle");	
+			RunningApp.WaitForElement("Vegetables.jpg, 10");
+			RunningApp.Tap("AddItemAbove");	
+			RunningApp.WaitForNoElement("photo.jpg, 9");
+		}
+
+		[Test]
+		public void KeepScrollOffset()
+		{
+			RunningApp.WaitForElement("KeepItemsInView");
+			RunningApp.Tap("KeepItemsInView");
+			RunningApp.Tap("KeepScrollOffset");
+
+			RunningApp.WaitForElement("ScrollToMiddle");
+			RunningApp.Tap("ScrollToMiddle");	
+			RunningApp.WaitForElement("Vegetables.jpg, 10");
+			RunningApp.Tap("AddItemAbove");	
+			RunningApp.WaitForElement("photo.jpg, 9");
+		}
+
+		[Test]
+		public void KeepLastItemInView()
+		{
+			RunningApp.WaitForElement("KeepItemsInView");
+			RunningApp.Tap("KeepItemsInView");
+			RunningApp.Tap("KeepLastItemInView");
+
+			RunningApp.WaitForElement("ScrollToMiddle");
+			RunningApp.Tap("ScrollToMiddle");	
+			RunningApp.WaitForElement("Vegetables.jpg, 10");
+			RunningApp.Tap("AddItemToEnd");	
+			RunningApp.WaitForElement("Added item");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsUpdatingScrollMode.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsUpdatingScrollMode.cs
@@ -42,8 +42,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void KeepScrollOffset()
 		{
-			RunningApp.WaitForElement("KeepItemsInView");
-			RunningApp.Tap("KeepItemsInView");
+			RunningApp.WaitForElement("SelectScrollMode");
+			RunningApp.Tap("SelectScrollMode");
 			RunningApp.Tap("KeepScrollOffset");
 
 			RunningApp.WaitForElement("ScrollToMiddle");
@@ -56,8 +56,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void KeepLastItemInView()
 		{
-			RunningApp.WaitForElement("KeepItemsInView");
-			RunningApp.Tap("KeepItemsInView");
+			RunningApp.WaitForElement("SelectScrollMode");
+			RunningApp.Tap("SelectScrollMode");
 			RunningApp.Tap("KeepLastItemInView");
 
 			RunningApp.WaitForElement("ScrollToMiddle");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundMultiSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundSingleSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5765.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4992.xaml.cs">
       <DependentUpon>Issue4992.xaml</DependentUpon>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -2,6 +2,7 @@
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ItemSizeGalleries;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SpacingGalleries;
+using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollModeGalleries;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
@@ -25,6 +26,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					GalleryBuilder.NavButton("Propagation Galleries", () => new PropagationGallery(), Navigation),
 					GalleryBuilder.NavButton("Item Size Galleries", () => new ItemsSizeGallery(), Navigation),
 					GalleryBuilder.NavButton("Spacing Galleries", () => new ItemsSpacingGallery(), Navigation),
+					GalleryBuilder.NavButton("Scroll Mode Galleries", () => new ScrollModeGallery(), Navigation),
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EnumSelector.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EnumSelector.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 		
 		readonly Picker _picker;
 
-		public EnumSelector(Func<T> getValue, Action<T> setValue)
+		public EnumSelector(Func<T> getValue, Action<T> setValue, string automationId = "")
 		{
 			_setValue = setValue;
 
@@ -26,7 +26,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			{
 				WidthRequest = 200,
 				ItemsSource = source,
-				SelectedItem = getValue().ToString()
+				SelectedItem = getValue().ToString(),
+				AutomationId = automationId
 			};
 
 			_picker.SelectedIndexChanged += PickerOnSelectedIndexChanged;

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeGallery.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollModeGalleries
+{
+	internal class ScrollModeGallery : ContentPage
+	{
+		public ScrollModeGallery()
+		{
+			var descriptionLabel =
+					new Label { Text = "Scroll Mode Galleries", Margin = new Thickness(2, 2, 2, 2) };
+
+			Title = "Scroll Mode Galleries";
+
+			Content = new ScrollView
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						descriptionLabel,
+						GalleryBuilder.NavButton("Keep Items in View", () =>
+							new ScrollModeTestGallery(), Navigation),
+						GalleryBuilder.NavButton("Keep Scroll Offset", () =>
+							new ScrollModeTestGallery(), Navigation),
+						GalleryBuilder.NavButton("Keep Last Item In View", () =>
+							new ScrollModeTestGallery(), Navigation),
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeGallery.cs
@@ -20,12 +20,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 					Children =
 					{
 						descriptionLabel,
-						GalleryBuilder.NavButton("Keep Items in View", () =>
-							new ScrollModeTestGallery(), Navigation),
-						GalleryBuilder.NavButton("Keep Scroll Offset", () =>
-							new ScrollModeTestGallery(), Navigation),
-						GalleryBuilder.NavButton("Keep Last Item In View", () =>
-							new ScrollModeTestGallery(), Navigation),
+						GalleryBuilder.NavButton("Scroll Modes Testing", () =>
+							new ScrollModeTestGallery(), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml
@@ -13,14 +13,17 @@
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
 
-            <Button x:Name="ScrollToMiddle" Text="Scroll To Middle" Grid.Row="1" HeightRequest="50" Clicked="ScrollToMiddle_Clicked" />
-            <Button x:Name="AddItemAbove" Text="Add Item Above" Grid.Row="2" HeightRequest="50" Clicked="AddItemAbove_Clicked" />
-            <Button x:Name="AddItemBelow" Text="Add Item Below" Grid.Row="3" HeightRequest="50" Clicked="AddItemBelow_Clicked" />
-            <Button x:Name="AddItemToEnd" Text="Add Item To End" Grid.Row="4" HeightRequest="50" Clicked="AddItemToEnd_Clicked" />
+            <Button x:Name="ScrollToMiddle" FontSize="10" AutomationId="ScrollToMiddle" Text="Scroll To Middle" 
+                    Grid.Row="1" HeightRequest="40" Clicked="ScrollToMiddle_Clicked" />
+            <Button x:Name="AddItemAbove" FontSize="10" AutomationId="AddItemAbove" Text="Add Item Above" Grid.Row="2" 
+                    HeightRequest="40" Clicked="AddItemAbove_Clicked" />
+            <Button x:Name="AddItemBelow" FontSize="10" AutomationId="AddItemBelow" Text="Add Item Below" Grid.Row="3"
+                    HeightRequest="40" Clicked="AddItemBelow_Clicked" />
+            <Button x:Name="AddItemToEnd" FontSize="10" AutomationId="AddItemToEnd" Text="Add Item To End" Grid.Row="4"
+                    HeightRequest="40" Clicked="AddItemToEnd_Clicked" />
 
-            <CollectionView x:Name="CollectionView" Grid.Row="5">
-                
-            </CollectionView>
+            <CollectionView x:Name="CollectionView" Grid.Row="5" />
+
         </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollModeGalleries.ScrollModeTestGallery">
+    <ContentPage.Content>
+        <Grid x:Name="Grid">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+
+            <Button x:Name="ScrollToMiddle" Text="Scroll To Middle" Grid.Row="1" HeightRequest="50" Clicked="ScrollToMiddle_Clicked" />
+            <Button x:Name="AddItemAbove" Text="Add Item Above" Grid.Row="2" HeightRequest="50" Clicked="AddItemAbove_Clicked" />
+            <Button x:Name="AddItemBelow" Text="Add Item Below" Grid.Row="3" HeightRequest="50" Clicked="AddItemBelow_Clicked" />
+            <Button x:Name="AddItemToEnd" Text="Add Item To End" Grid.Row="4" HeightRequest="50" Clicked="AddItemToEnd_Clicked" />
+
+            <CollectionView x:Name="CollectionView" Grid.Row="5">
+                
+            </CollectionView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 			InitializeComponent();
 
 			var scrollModeSelector = new EnumSelector<ItemsUpdatingScrollMode>(() => CollectionView.ItemsUpdatingScrollMode,
-			mode => CollectionView.ItemsUpdatingScrollMode = mode);
+			mode => CollectionView.ItemsUpdatingScrollMode = mode, "SelectScrollMode");
 
 			Grid.Children.Add(scrollModeSelector);
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class ScrollModeTestGallery : ContentPage
 	{
-		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(200);
+		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(20);
 
 		public ScrollModeTestGallery()
 		{
@@ -29,17 +29,29 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 
 		private void ScrollToMiddle_Clicked(object sender, EventArgs e)
 		{
-			CollectionView.ScrollTo(_demoFilteredItemSource.Items.Count / 2, animate: false);
+			CollectionView.ScrollTo(_demoFilteredItemSource.Items.Count / 2, position: ScrollToPosition.Start, animate: false);
 		}
 
 		private void AddItemAbove_Clicked(object sender, EventArgs e)
 		{
+			var index = (_demoFilteredItemSource.Items.Count / 2) - 1;
 
+			_demoFilteredItemSource.Items.Insert(index,
+				new CollectionViewGalleryTestItem(DateTime.Now,
+				"Inserted item",
+				"coffee.png",
+				index));
 		}
 
 		private void AddItemBelow_Clicked(object sender, EventArgs e)
 		{
+			var index = (_demoFilteredItemSource.Items.Count / 2) + 2;
 
+			_demoFilteredItemSource.Items.Insert(index,
+				new CollectionViewGalleryTestItem(DateTime.Now,
+				"Inserted item",
+				"coffee.png",
+				index));
 		}
 
 		private void AddItemToEnd_Clicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollModeGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class ScrollModeTestGallery : ContentPage
+	{
+		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(200);
+
+		public ScrollModeTestGallery()
+		{
+			InitializeComponent();
+
+			CollectionView.ItemTemplate = ExampleTemplates.PhotoTemplate();
+			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+		}
+
+		private void ScrollToMiddle_Clicked(object sender, EventArgs e)
+		{
+			
+		}
+
+		private void AddItemAbove_Clicked(object sender, EventArgs e)
+		{
+
+		}
+
+		private void AddItemBelow_Clicked(object sender, EventArgs e)
+		{
+
+		}
+
+		private void AddItemToEnd_Clicked(object sender, EventArgs e)
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -18,13 +18,18 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 		{
 			InitializeComponent();
 
+			var scrollModeSelector = new EnumSelector<ItemsUpdatingScrollMode>(() => CollectionView.ItemsUpdatingScrollMode,
+			mode => CollectionView.ItemsUpdatingScrollMode = mode);
+
+			Grid.Children.Add(scrollModeSelector);
+
 			CollectionView.ItemTemplate = ExampleTemplates.PhotoTemplate();
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
 		}
 
 		private void ScrollToMiddle_Clicked(object sender, EventArgs e)
 		{
-			
+			CollectionView.ScrollTo(_demoFilteredItemSource.Items.Count / 2, animate: false);
 		}
 
 		private void AddItemAbove_Clicked(object sender, EventArgs e)
@@ -39,7 +44,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 
 		private void AddItemToEnd_Clicked(object sender, EventArgs e)
 		{
-
+			_demoFilteredItemSource.Items.Add(
+				new CollectionViewGalleryTestItem(DateTime.Now, 
+				"Added item", 
+				"coffee.png", 
+				_demoFilteredItemSource.Items.Count));
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollModeGalleries/ScrollModeTestGallery.xaml.cs
@@ -27,12 +27,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
 		}
 
-		private void ScrollToMiddle_Clicked(object sender, EventArgs e)
+		void ScrollToMiddle_Clicked(object sender, EventArgs e)
 		{
 			CollectionView.ScrollTo(_demoFilteredItemSource.Items.Count / 2, position: ScrollToPosition.Start, animate: false);
 		}
 
-		private void AddItemAbove_Clicked(object sender, EventArgs e)
+		void AddItemAbove_Clicked(object sender, EventArgs e)
 		{
 			var index = (_demoFilteredItemSource.Items.Count / 2) - 1;
 
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 				index));
 		}
 
-		private void AddItemBelow_Clicked(object sender, EventArgs e)
+		void AddItemBelow_Clicked(object sender, EventArgs e)
 		{
 			var index = (_demoFilteredItemSource.Items.Count / 2) + 2;
 
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollMode
 				index));
 		}
 
-		private void AddItemToEnd_Clicked(object sender, EventArgs e)
+		void AddItemToEnd_Clicked(object sender, EventArgs e)
 		{
 			_demoFilteredItemSource.Items.Add(
 				new CollectionViewGalleryTestItem(DateTime.Now, 

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -41,6 +41,10 @@
     <Compile Update="GalleryPages\CollectionViewGalleries\EmptyViewGalleries\EmptyViewLoadSimulateGallery.xaml.cs">
       <DependentUpon>EmptyViewLoadSimulateGallery.xaml</DependentUpon>
       </Compile>
+    <Compile Update="GalleryPages\CollectionViewGalleries\ScrollModeGalleries\ScrollModeTestGallery.xaml.cs">
+	  <DependentUpon>ScrollModeTestGallery.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Update="GalleryPages\CollectionViewGalleries\SelectionGalleries\PreselectedItemsGallery.xaml.cs">
       <DependentUpon>PreselectedItemsGallery.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Core/Items/ItemsUpdatingScrollMode.cs
+++ b/Xamarin.Forms.Core/Items/ItemsUpdatingScrollMode.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms
 {
 	public enum ItemsUpdatingScrollMode
 	{
-		KeepItemsInView,
+		KeepItemsInView = 0,
 		KeepScrollOffset,
 		KeepLastItemInView
 	}

--- a/Xamarin.Forms.Core/Items/ItemsUpdatingScrollMode.cs
+++ b/Xamarin.Forms.Core/Items/ItemsUpdatingScrollMode.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms
+{
+	public enum ItemsUpdatingScrollMode
+	{
+		KeepItemsInView,
+		KeepScrollOffset,
+		KeepLastItemInView
+	}
+}

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -67,13 +67,6 @@ namespace Xamarin.Forms
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
 #endif
 
-		// TODO hartez 2018/08/29 17:35:10 Should ItemsView be abstract? With ItemsLayout as an interface?
-		// Trying to come up with a reasonable way to restrict CarouselView to ListItemsLayout(LinearLayout) 
-		// ((because setting Carousel to grid is ... weird? And by default it just won't do anything.))
-		// And allow CollectionView to use a broader set of Layout options
-		// So the Bindable property only exists at the CarouselView/CollectionView (i.e., concrete class) level
-		// but some version of IItemsLayout is still here?
-
 		public static readonly BindableProperty ItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView), 
 				ListItemsLayout.Vertical);
@@ -100,6 +93,16 @@ namespace Xamarin.Forms
 		{
 			get => (ItemSizingStrategy)GetValue(ItemSizingStrategyProperty);
 			set => SetValue(ItemSizingStrategyProperty, value);
+		}
+
+		public static readonly BindableProperty ItemsUpdatingScrollModeProperty =
+			BindableProperty.Create(nameof(ItemsUpdatingScrollMode), typeof(ItemsUpdatingScrollMode), typeof(ItemsView),
+				default(ItemsUpdatingScrollMode));
+
+		public ItemsUpdatingScrollMode ItemsUpdatingScrollMode
+		{
+			get => (ItemsUpdatingScrollMode)GetValue(ItemsUpdatingScrollModeProperty);
+			set => SetValue(ItemsUpdatingScrollModeProperty, value);
 		}
 
 		public void ScrollTo(int index, int groupIndex = -1,

--- a/Xamarin.Forms.Platform.Android/CollectionView/DataChangeObserver.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/DataChangeObserver.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			Observing = false;
 		}
-
+		 
 		public override void OnChanged()
 		{
 			base.OnChanged();

--- a/Xamarin.Forms.Platform.Android/CollectionView/DataChangeObserver.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/DataChangeObserver.cs
@@ -1,5 +1,6 @@
 using System;
 using Android.Support.V7.Widget;
+using static Android.Support.V7.Widget.RecyclerView;
 using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
@@ -7,10 +8,32 @@ namespace Xamarin.Forms.Platform.Android
 	internal class DataChangeObserver : RecyclerView.AdapterDataObserver
 	{
 		readonly Action _onDataChange;
+		public bool Observing { get; private set; }
 
 		public DataChangeObserver(Action onDataChange) : base()
 		{
 			_onDataChange = onDataChange;
+		}
+
+		public void Start(Adapter adapter)
+		{
+			if (Observing)
+			{
+				return;
+			}
+
+			adapter.RegisterAdapterDataObserver(this);
+			Observing = true;
+		}
+
+		public void Stop(Adapter adapter)
+		{
+			if (Observing && adapter != null)
+			{
+				adapter.UnregisterAdapterDataObserver(this);
+			}
+
+			Observing = false;
 		}
 
 		public override void OnChanged()

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -458,27 +458,20 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void UpdateItemsUpatingScrollMode()
 		{
-			// TODO ezhart ItemsUpdatingScrollMode
-
-			// Change the dataChangeViewObserver to be ON if ItemsUpdateScrollMode is KeepLastItemInView (may need it for scroll offset, too, later)
-			// So it's on if there's an emptyview or if KeepLastItemInView mode is on (_watchingForEmpty will probably change its name)
-			// When there's a data change, always scroll to the end.
-
 			if (ItemsViewAdapter == null || ItemsView == null)
 			{
 				return;
 			}
 
-			if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepLastItemInView)
+			if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepItemsInView)
 			{
-				_itemsUpdateScrollObserver.Start(ItemsViewAdapter);
+				// Keeping the current items in view is the default, so we don't need to watch for data changes
+				_itemsUpdateScrollObserver.Stop(ItemsViewAdapter);
 			}
 			else
 			{
-				_itemsUpdateScrollObserver.Stop(ItemsViewAdapter);
+				_itemsUpdateScrollObserver.Start(ItemsViewAdapter);
 			}
-
-			AdjustScrollForItemUpdate();
 		}
 
 		protected virtual void ReconcileFlowDirectionAndLayout()
@@ -579,7 +572,16 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal void AdjustScrollForItemUpdate()
 		{
-			System.Diagnostics.Debug.WriteLine($">>>>> AdjustScrollForItemUpdate");
+			if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepLastItemInView)
+			{
+				ScrollTo(new ScrollToRequestEventArgs(ItemsViewAdapter.ItemCount, 0,
+					Xamarin.Forms.ScrollToPosition.MakeVisible, true));
+			}
+			else if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepScrollOffset)
+			{
+				// TODO ezhart Implement this
+
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -27,15 +27,18 @@ namespace Xamarin.Forms.Platform.Android
 
 		IItemsLayout _layout;
 		SnapManager _snapManager;
-		ScrollHelper _scrollHelper;
 
 		EmptyViewAdapter _emptyViewAdapter;
 		readonly DataChangeObserver _emptyCollectionObserver;
 		readonly DataChangeObserver _itemsUpdateScrollObserver;
-
+		ScrollHelper _scrollHelper;
 		RecyclerView.ItemDecoration _itemDecoration;
 
-		public ItemsViewRenderer(Context context) : base(context)
+		ScrollHelper ScrollHelper => _scrollHelper = _scrollHelper ?? new ScrollHelper(this);
+
+		// RecyclerView doesn't provide a way to add scrollbars from code; you have to do it from a layout or style
+		// So we're providing a collectionViewStyle with scrollbars pre-added here
+		public ItemsViewRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.collectionViewStyle))
 		{
 			CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewRenderer));
 
@@ -44,9 +47,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			_emptyCollectionObserver = new DataChangeObserver(UpdateEmptyViewVisibility);
 			_itemsUpdateScrollObserver = new DataChangeObserver(AdjustScrollForItemUpdate);
-		}
 
-		ScrollHelper ScrollHelper => _scrollHelper ?? (_scrollHelper = new ScrollHelper(this));
+			// By default, we're going to leave the scroll bars off for now (this is the default for RecyclerView)
+			// At some point, we'll be supporting turning these on/off (maybe controlling fading) on all the platforms,
+			// and then we can move this into the appropriate property handlers
+			// See https://github.com/xamarin/Xamarin.Forms/issues/6053
+			VerticalScrollBarEnabled = false;
+			HorizontalScrollBarEnabled = false;
+		}
 
 		// TODO hartez 2018/10/24 19:27:12 Region all the interface implementations	
 
@@ -579,8 +587,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else if (ItemsView.ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepScrollOffset)
 			{
-				// TODO ezhart Implement this
-
+				ScrollHelper.UndoNextScrollAdjustment();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -226,7 +226,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else if (changedProperty.Is(ItemsView.ItemsUpdatingScrollModeProperty))
 			{
-				UpdateItemsUpatingScrollMode();
+				UpdateItemsUpdatingScrollMode();
 			}
 		}
 
@@ -243,7 +243,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateAdapter();
 
 			// Set up any properties which require observing data changes in the adapter
-			UpdateItemsUpatingScrollMode();
+			UpdateItemsUpdatingScrollMode();
 			UpdateEmptyView();
 		}
 
@@ -464,7 +464,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateEmptyViewVisibility();
 		}
 
-		protected virtual void UpdateItemsUpatingScrollMode()
+		protected virtual void UpdateItemsUpdatingScrollMode()
 		{
 			if (ItemsViewAdapter == null || ItemsView == null)
 			{

--- a/Xamarin.Forms.Platform.Android/CollectionView/ScrollHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ScrollHelper.cs
@@ -4,7 +4,7 @@ using Android.Support.V7.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class ScrollHelper
+	internal class ScrollHelper : RecyclerView.OnScrollListener
 	{
 		readonly RecyclerView _recyclerView;
 		Action _pendingScrollAdjustment;
@@ -29,7 +29,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (!_maintainingScrollOffsets)
 			{
 				_maintainingScrollOffsets = true;
-				_recyclerView.ScrollChange += ScrollChange;
+				//_recyclerView.ScrollChange += ScrollChange;
+				_recyclerView.AddOnScrollListener(this);
 			}
 
 			_undoNextScrollAdjustment = true;
@@ -194,7 +195,7 @@ namespace Xamarin.Forms.Platform.Android
 			_recyclerView.ScrollBy(offset, 0);
 		}
 
-		void ScrollChange(object sender, global::Android.Views.View.ScrollChangeEventArgs args)
+		void TrackOffsets()
 		{
 			var newXOffset = _recyclerView.ComputeHorizontalScrollOffset();
 			var newYOffset = _recyclerView.ComputeVerticalScrollOffset();
@@ -217,6 +218,12 @@ namespace Xamarin.Forms.Platform.Android
 				_lastDeltaX = 0;
 				_lastDeltaY = 0;
 			}
+		}
+
+		public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
+		{
+			base.OnScrolled(recyclerView, dx, dy);
+			TrackOffsets();
 		}
 
 	}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ScrollHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ScrollHelper.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 			_recyclerView = recyclerView;
 		}
 
-		// Used by the renderer to maintain scoll offset when using ItemsUpdatingScrollMode KeepScrollOffset
+		// Used by the renderer to maintain scroll offset when using ItemsUpdatingScrollMode KeepScrollOffset
 		public void UndoNextScrollAdjustment()
 		{
 			// Don't start tracking the scroll offsets until we really need to

--- a/Xamarin.Forms.Platform.Android/CollectionView/ScrollHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ScrollHelper.cs
@@ -9,9 +9,33 @@ namespace Xamarin.Forms.Platform.Android
 		readonly RecyclerView _recyclerView;
 		Action _pendingScrollAdjustment;
 
+		bool _undoNextScrollAdjustment;
+		bool _maintainingScrollOffsets;
+
+		int _lastScrollX;
+		int _lastScrollY;
+		int _lastDeltaX;
+		int _lastDeltaY;
+
 		public ScrollHelper(RecyclerView recyclerView)
 		{
 			_recyclerView = recyclerView;
+		}
+
+		// Used by the renderer to maintain scoll offset when using ItemsUpdatingScrollMode KeepScrollOffset
+		public void UndoNextScrollAdjustment()
+		{
+			// Don't start tracking the scroll offsets until we really need to
+			if (!_maintainingScrollOffsets)
+			{
+				_maintainingScrollOffsets = true;
+				_recyclerView.ScrollChange += ScrollChange;
+			}
+
+			_undoNextScrollAdjustment = true;
+
+			_lastScrollX = _recyclerView.ComputeHorizontalScrollOffset();
+			_lastScrollY = _recyclerView.ComputeVerticalScrollOffset();
 		}
 
 		public void AdjustScroll()
@@ -169,5 +193,31 @@ namespace Xamarin.Forms.Platform.Android
 
 			_recyclerView.ScrollBy(offset, 0);
 		}
+
+		void ScrollChange(object sender, global::Android.Views.View.ScrollChangeEventArgs args)
+		{
+			var newXOffset = _recyclerView.ComputeHorizontalScrollOffset();
+			var newYOffset = _recyclerView.ComputeVerticalScrollOffset();
+
+			_lastDeltaX = Math.Max(newXOffset - _lastScrollX, 0);
+			_lastDeltaY = Math.Max(newYOffset - _lastScrollY, 0);
+
+			_lastScrollX = newXOffset;
+			_lastScrollY = newYOffset;
+
+			if (_undoNextScrollAdjustment)
+			{
+				// This last scroll adjustment happened because a new item was added and it caused the scroll
+				// offset to shift; since the ItemsUpdatingScrollMode is set to KeepScrollOffset; we need to undo 
+				// that shift and stay where we were before the item was added
+
+				_undoNextScrollAdjustment = false;
+				_recyclerView.ScrollBy(-_lastDeltaX, -_lastDeltaY);
+
+				_lastDeltaX = 0;
+				_lastDeltaY = 0;
+			}
+		}
+
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<resources xmlns:android="http://schemas.android.com/apk/res/android"
+		xmlns:app="http://schemas.android.com/apk/res-auto">
+  <!--<attr name="collectionViewStyle" format="reference"/>-->
+  <style name="collectionViewStyle" android:id="@+id/collectionViewStyle">
+    <item name="android:scrollbars">vertical|horizontal</item>
+  </style>
+</resources>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -375,6 +375,11 @@
       <Properties>CreateAllAndroidTargets=false;Configuration=$(Configuration);Platform=$(Platform);AndroidTargetFrameworkVersion=v8.1</Properties>
     </ProjectToBuild>
   </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\values\styles.xml">
+      <Generator>MSBuild:UpdateGeneratedFiles</Generator>
+    </AndroidResource>
+  </ItemGroup>
   <Target Name="BeforeBuild" Condition=" '$(CreateAllAndroidTargets)' == 'true' ">
     <!--  create 8.1 binaries-->
     <MSBuild Targets="Restore" Projects="@(ProjectToBuild)">

--- a/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathExtensions.cs
@@ -1,0 +1,42 @@
+﻿using Foundation;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal static class IndexPathExtensions
+	{
+		public static bool IsLessThanOrEqualToPath(this NSIndexPath path, NSIndexPath otherPath)
+		{
+			if (path.Section < otherPath.Section)
+			{
+				return true;
+			}
+
+			if (path.Section == otherPath.Section)
+			{
+				return path.Item <= otherPath.Item;
+			}
+
+			return false;
+		}
+
+		public static NSIndexPath FindFirst(this NSIndexPath[] paths)
+		{
+			NSIndexPath firstPath = null;
+			foreach (var path in paths)
+			{
+				if (firstPath == null)
+				{
+					firstPath = path;
+					continue;
+				}
+
+				if (path.IsLessThanOrEqualToPath(firstPath))
+				{
+					firstPath = path;
+				}
+			}
+
+			return firstPath;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly ItemsView _itemsView;
 		ItemsViewLayout _layout;
 		bool _initialConstraintsSet;
-		bool _safeForReload;
 		bool _wasEmpty;
 		bool _currentBackgroundIsEmptyView;
 		bool _disposed;
@@ -29,10 +28,6 @@ namespace Xamarin.Forms.Platform.iOS
 			_itemsView = itemsView;
 			_itemsSource = ItemsSourceFactory.Create(_itemsView.ItemsSource, CollectionView);
 			
-			// If we already have data, the UICollectionView will have items and we'll be safe to call
-			// ReloadData if the ItemsSource changes in the future (see UpdateItemsSource for more).
-			_safeForReload = _itemsSource?.Count > 0;
-
 			UpdateLayout(layout);
 		}
 
@@ -135,57 +130,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public virtual void UpdateItemsSource()
 		{
-			if (_safeForReload)
-			{
-				UpdateItemsSourceAndReload();
-			}
-			else
-			{
-				// Okay, thus far this UICollectionView has never had any items in it. At this point, if
-				// we set the ItemsSource and try to call ReloadData(), it'll crash. AFAICT this is a bug, but
-				// until it's fixed (or we can figure out another way to go from empty -> having items), we'll
-				// have to use this crazy workaround
-				EmptyCollectionViewReloadWorkaround();
-			}
-		}
-
-		void UpdateItemsSourceAndReload()
-		{
 			_itemsSource = ItemsSourceFactory.Create(_itemsView.ItemsSource, CollectionView);
 			CollectionView.ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
-		}
-
-		void EmptyCollectionViewReloadWorkaround()
-		{
-			var enumerator = _itemsView.ItemsSource.GetEnumerator();
-
-			if (!enumerator.MoveNext())
-			{
-				// The source we're updating to is empty, so we can just update as normal; it won't crash
-				UpdateItemsSourceAndReload();
-			}
-			else
-			{
-				// Grab the first item from the new ItemsSource and create a usable source for the UICollectionView
-				// from that
-				var firstItem = new List<object> { enumerator.Current };
-				_itemsSource = ItemsSourceFactory.Create(firstItem, CollectionView);
-
-				// Insert that item into the UICollectionView
-				// TODO ezhart When we implement grouping, this will need to be the index of the first actual item
-				// Which might not be zero,zero if we have empty groups
-				var indexesToInsert = new NSIndexPath[1] { NSIndexPath.Create(0, 0) };
-
-				UIView.PerformWithoutAnimation(() =>
-				{
-					CollectionView.InsertItems(indexesToInsert);
-				});
-
-				// Okay, from now on we can just call ReloadData and things will work fine
-				_safeForReload = true;
-				UpdateItemsSource();
-			}
 		}
 
 		protected virtual void UpdateDefaultCell(DefaultCell cell, NSIndexPath indexPath)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _wasEmpty;
 		bool _currentBackgroundIsEmptyView;
 		bool _disposed;
+		bool _safeForReload;
 
 		UIView _backgroundUIView;
 		UIView _emptyUIView;
@@ -27,7 +28,18 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_itemsView = itemsView;
 			_itemsSource = ItemsSourceFactory.Create(_itemsView.ItemsSource, CollectionView);
-			
+
+			if (Forms.IsiOS12OrNewer)
+			{
+				_safeForReload = true;
+			}
+			else
+			{
+				// If we already have data, the UICollectionView will have items and we'll be safe to call	
+				// ReloadData if the ItemsSource changes in the future (see UpdateItemsSource for more).	
+				_safeForReload = _itemsSource?.Count > 0;
+			}
+
 			UpdateLayout(layout);
 		}
 
@@ -130,9 +142,59 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public virtual void UpdateItemsSource()
 		{
-			_itemsSource = ItemsSourceFactory.Create(_itemsView.ItemsSource, CollectionView);
-			CollectionView.ReloadData();
-			CollectionView.CollectionViewLayout.InvalidateLayout();
+			if (_safeForReload)
+			{
+				UpdateItemsSourceAndReload();
+			}
+			else
+			{
+				// Okay, thus far this UICollectionView has never had any items in it. At this point, if	
+				// we set the ItemsSource and try to call ReloadData(), it'll crash. AFAICT this is a bug, but	
+				// until it's fixed (or we can figure out another way to go from empty -> having items), we'll	
+				// have to use this crazy workaround	
+				EmptyCollectionViewReloadWorkaround();
+			}
+		}
+
+		void UpdateItemsSourceAndReload()
+		{
+			{
+				_itemsSource = ItemsSourceFactory.Create(_itemsView.ItemsSource, CollectionView);
+				CollectionView.ReloadData();
+				CollectionView.CollectionViewLayout.InvalidateLayout();
+			}
+		}
+
+		void EmptyCollectionViewReloadWorkaround()
+		{
+			var enumerator = _itemsView.ItemsSource.GetEnumerator();
+
+			if (!enumerator.MoveNext())
+			{
+				// The source we're updating to is empty, so we can just update as normal; it won't crash	
+				UpdateItemsSourceAndReload();
+			}
+			else
+			{
+				// Grab the first item from the new ItemsSource and create a usable source for the UICollectionView	
+				// from that	
+				var firstItem = new List<object> { enumerator.Current };
+				_itemsSource = ItemsSourceFactory.Create(firstItem, CollectionView);
+
+				// Insert that item into the UICollectionView	
+				// TODO ezhart When we implement grouping, this will need to be the index of the first actual item	
+				// Which might not be zero,zero if we have empty groups	
+				var indexesToInsert = new NSIndexPath[1] { NSIndexPath.Create(0, 0) };
+
+				UIView.PerformWithoutAnimation(() =>
+				{
+					CollectionView.InsertItems(indexesToInsert);
+				});
+
+				// Okay, from now on we can just call ReloadData and things will work fine	
+				_safeForReload = true;
+				UpdateItemsSource();
+			}
 		}
 
 		protected virtual void UpdateDefaultCell(DefaultCell cell, NSIndexPath indexPath)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -462,6 +462,12 @@ namespace Xamarin.Forms.Platform.iOS
 			// Find the first visible item
 			var firstPath = collectionView.IndexPathsForVisibleItems.FindFirst();
 
+			if (firstPath == null)
+			{
+				// No visible items to shift
+				return false;
+			}
+
 			// Determine whether any of the new items will be "before" the first visible item
 			foreach (var item in updateItems)
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -469,6 +469,11 @@ namespace Xamarin.Forms.Platform.iOS
 					|| item.UpdateAction == UICollectionUpdateAction.Insert
 					|| item.UpdateAction == UICollectionUpdateAction.Move)
 				{
+					if (item.IndexPathAfterUpdate == null)
+					{
+						continue;
+					}
+
 					if (item.IndexPathAfterUpdate.IsLessThanOrEqualToPath(firstPath))
 					{
 						// If any of these items will end up "before" the first visible item, then the items will shift

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Foundation;
 using UIKit;
 
@@ -46,6 +47,10 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (changedProperty.Is(ItemsView.ItemSizingStrategyProperty))
 			{
 				UpdateItemSizingStrategy();
+			}
+			else if (changedProperty.Is(ItemsView.ItemsUpdatingScrollModeProperty))
+			{
+				UpdateItemsUpdatingScrollMode();
 			}
 		}
 
@@ -98,6 +103,7 @@ namespace Xamarin.Forms.Platform.iOS
 			SetNativeControl(ItemsViewController.View);
 			ItemsViewController.CollectionView.BackgroundColor = UIColor.Clear;
 			ItemsViewController.UpdateEmptyView();
+			UpdateItemsUpdatingScrollMode();
 
 			// Listen for ScrollTo requests
 			newElement.ScrollToRequested += ScrollToRequested;
@@ -127,6 +133,11 @@ namespace Xamarin.Forms.Platform.iOS
 				// we'll just have to swap out the whole UICollectionViewLayout
 				UpdateLayout();
 			}
+		}
+
+		protected virtual void UpdateItemsUpdatingScrollMode()
+		{
+			_layout.ItemsUpdatingScrollMode = Element.ItemsUpdatingScrollMode;
 		}
 
 		protected virtual ItemsViewController CreateController(ItemsView newElement, ItemsViewLayout layout)

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS9OrNewer;
 		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
+		static bool? s_isiOS12OrNewer;
 #endif
 
 #if __MOBILE__
@@ -67,6 +68,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS11OrNewer.HasValue)
 					s_isiOS11OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
 				return s_isiOS11OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS12OrNewer
+		{
+			get
+			{
+				if (!s_isiOS12OrNewer.HasValue)
+					s_isiOS12OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(12, 0);
+				return s_isiOS12OrNewer.Value;
 			}
 		}
 #endif

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -112,6 +112,7 @@
     <Compile Include="CollectionView\CollectionViewRenderer.cs" />
     <Compile Include="CollectionView\EmptySource.cs" />
     <Compile Include="CollectionView\IItemsViewSource.cs" />
+    <Compile Include="CollectionView\IndexPathExtensions.cs" />
     <Compile Include="CollectionView\ItemsSourceFactory.cs" />
     <Compile Include="CollectionView\ItemsViewCell.cs" />
     <Compile Include="CollectionView\DefaultCell.cs" />


### PR DESCRIPTION
### Description of Change ###

Add `ItemsUpdatingScrollMode` to the CollectionView control. Includes implementations for Android and iOS, plus automated tests for the feature.

### Issues Resolved ### 

- implements part of #3172

### API Changes ###

Added:
```
public enum ItemsUpdatingScrollMode
{
	KeepItemsInView,
	KeepScrollOffset,
	KeepLastItemInView
}
```
`BindableProperty ItemsView.ItemsUpdatingScrollMode`

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated tests in CollectionViewItemsUpdatingScrollMode.cs

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] I've submitted so many of these I check all the boxes without thinking now