### PR TITLE
item template attached, fix icon propagations

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -155,6 +155,12 @@
     <AndroidResource Include="Resources\drawable\icon_search.png" />
     <AndroidResource Include="Resources\drawable\icon_bookmark.png" />
     <AndroidResource Include="Resources\drawable\button_add.png" />
+    <AndroidResource Include="Resources\drawable\gamesflyout.png" />
+    <AndroidResource Include="Resources\drawable\filmflyout.png" />
+    <AndroidResource Include="Resources\drawable\headphoneflyout.png" />
+    <AndroidResource Include="Resources\drawable\newspaperflyout.png" />
+    <AndroidResource Include="Resources\drawable\booksflyout.png" />
+    <AndroidResource Include="Resources\drawable\homeflyout.png" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\Icon.png" />

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -1,117 +1,117 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <localTest:TestShell xmlns="http://xamarin.com/schemas/2014/forms"
-            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            xmlns:local="clr-namespace:Xamarin.Forms.Controls.XamStore"
-            xmlns:localTest="clr-namespace:Xamarin.Forms.Controls"
-            x:Class="Xamarin.Forms.Controls.XamStore.StoreShell">
-    <Shell.Resources>
-        <Style x:Key="BaseStyle" TargetType="Element">
-            <Setter Property="Shell.BackgroundColor" Value="#455A64" />
-            <Setter Property="Shell.ForegroundColor" Value="White" />
-            <Setter Property="Shell.TitleColor" Value="White" />
-            <Setter Property="Shell.DisabledColor" Value="#B4FFFFFF" />
-            <Setter Property="Shell.UnselectedColor" Value="#95FFFFFF" />
-        </Style>
-        <Style TargetType="ShellItem" BasedOn="{StaticResource BaseStyle}" />
-        <Style x:Key="GreenShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-            <Setter Property="Shell.BackgroundColor" Value="#689F39" />
-        </Style>
-        <Style x:Key="MusicShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-            <Setter Property="Shell.BackgroundColor" Value="#EF6C00" />
-        </Style>
-        <Style x:Key="MoviesShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-            <Setter Property="Shell.BackgroundColor" Value="#ED3B3B" />
-        </Style>
-        <Style x:Key="BooksShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-            <Setter Property="Shell.BackgroundColor" Value="#039BE6" />
-        </Style>
-        <Style x:Key="NewsShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-            <Setter Property="Shell.BackgroundColor" Value="#546DFE" />
-        </Style>
-        <DataTemplate x:Key="MenuItemTemplate">
-            <ContentView>
-                <Button Visual="Material" ImageSource="{Binding FlyoutIcon}" Text="{Binding Text}"  />
-            </ContentView>
-        </DataTemplate>
-        <DataTemplate x:Key="ShellItemTemplate">
-            <ContentView BackgroundColor="LightBlue">
-                <StackLayout Orientation="Horizontal">
-                    <Image Source="{Binding FlyoutIcon}"/>
-                    <Label Text="{Binding Title}" />
-                </StackLayout>
-            </ContentView>
-        </DataTemplate>
-    </Shell.Resources>
+			xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			xmlns:local="clr-namespace:Xamarin.Forms.Controls.XamStore"
+			xmlns:localTest="clr-namespace:Xamarin.Forms.Controls"
+			x:Class="Xamarin.Forms.Controls.XamStore.StoreShell">
+	<Shell.Resources>
+		<Style x:Key="BaseStyle" TargetType="Element">
+			<Setter Property="Shell.BackgroundColor" Value="#455A64" />
+			<Setter Property="Shell.ForegroundColor" Value="White" />
+			<Setter Property="Shell.TitleColor" Value="White" />
+			<Setter Property="Shell.DisabledColor" Value="#B4FFFFFF" />
+			<Setter Property="Shell.UnselectedColor" Value="#95FFFFFF" />
+		</Style>
+		<Style TargetType="ShellItem" BasedOn="{StaticResource BaseStyle}" />
+		<Style x:Key="GreenShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+			<Setter Property="Shell.BackgroundColor" Value="#689F39" />
+		</Style>
+		<Style x:Key="MusicShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+			<Setter Property="Shell.BackgroundColor" Value="#EF6C00" />
+		</Style>
+		<Style x:Key="MoviesShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+			<Setter Property="Shell.BackgroundColor" Value="#ED3B3B" />
+		</Style>
+		<Style x:Key="BooksShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+			<Setter Property="Shell.BackgroundColor" Value="#039BE6" />
+		</Style>
+		<Style x:Key="NewsShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+			<Setter Property="Shell.BackgroundColor" Value="#546DFE" />
+		</Style>
+		<DataTemplate x:Key="MenuItemTemplate">
+			<ContentView>
+				<Button Visual="Material" ImageSource="{Binding FlyoutIcon}" Text="{Binding Text}"  />
+			</ContentView>
+		</DataTemplate>
+		<DataTemplate x:Key="ShellItemTemplate">
+			<ContentView BackgroundColor="LightBlue">
+				<StackLayout Orientation="Horizontal">
+					<Image Source="{Binding FlyoutIcon}"/>
+					<Label Text="{Binding Title}" />
+				</StackLayout>
+			</ContentView>
+		</DataTemplate>
+	</Shell.Resources>
 
-    <Shell.FlyoutHeader>
-        <local:FlyoutHeader />
-    </Shell.FlyoutHeader>
-    
-    <ShellContent Title="Search" Route="search" ContentTemplate="{DataTemplate local:SearchHandlerPage}" />
-    <ShellSection FlyoutDisplayOptions="AsMultipleItems" Route="apps" Title="My apps &amp; games" Icon="grid.png" Style="{StaticResource GreenShell}">
-        <ShellContent Route="updates" Title="Updates" ContentTemplate="{DataTemplate local:UpdatesPage}" />
-        <ShellContent Route="installed" Title="Installed" ContentTemplate="{DataTemplate local:InstalledPage}" />
-        <ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
-    </ShellSection>
+	<Shell.FlyoutHeader>
+		<local:FlyoutHeader />
+	</Shell.FlyoutHeader>
+	
+	<ShellContent Title="Search" Route="search" ContentTemplate="{DataTemplate local:SearchHandlerPage}" />
+	<ShellSection FlyoutDisplayOptions="AsMultipleItems" Route="apps" Title="My apps &amp; games" Icon="grid.png" Style="{StaticResource GreenShell}">
+		<ShellContent Route="updates" Title="Updates" ContentTemplate="{DataTemplate local:UpdatesPage}" />
+		<ShellContent Route="installed" Title="Installed" ContentTemplate="{DataTemplate local:InstalledPage}" />
+		<ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
+	</ShellSection>
 
-    <ShellContent Route="notifications" Style="{StaticResource BaseStyle}" Title="My notifications" FlyoutIcon="homeflyout.png" Icon="bell.png" ContentTemplate="{DataTemplate local:NotificationsPage}" />
+	<ShellContent Route="notifications" Style="{StaticResource BaseStyle}" Title="My notifications" FlyoutIcon="homeflyout.png" Icon="bell.png" ContentTemplate="{DataTemplate local:NotificationsPage}" />
 
-    <ShellContent Route="subs" Title="Subscriptions" Icon="loop.png" ContentTemplate="{DataTemplate local:SubscriptionsPage}" />
+	<ShellContent Route="subs" Title="Subscriptions" Icon="loop.png" ContentTemplate="{DataTemplate local:SubscriptionsPage}" />
 
-    <ShellItem Route="xamtube" Title="XamTube">
-        <ShellContent Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
-        <ShellSection Route="activity" Title="Activity" Icon="grid.png" Style="{StaticResource GreenShell}">
-            <ShellContent Route="shared" Title="Shared" ContentTemplate="{DataTemplate local:UpdatesPage}" />
-            <ShellContent Route="Notifications" Title="Notifications" ContentTemplate="{DataTemplate local:LibraryPage}" />
-        </ShellSection>
-        <ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
-    </ShellItem>
+	<ShellItem Route="xamtube" Title="XamTube">
+		<ShellContent Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
+		<ShellSection Route="activity" Title="Activity" Icon="grid.png" Style="{StaticResource GreenShell}">
+			<ShellContent Route="shared" Title="Shared" ContentTemplate="{DataTemplate local:UpdatesPage}" />
+			<ShellContent Route="Notifications" Title="Notifications" ContentTemplate="{DataTemplate local:LibraryPage}" />
+		</ShellSection>
+		<ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
+	</ShellItem>
 
-    <ShellItem Route="store" x:Name="_storeItem" FlyoutDisplayOptions="AsMultipleItems">
-        <ShellContent Shell.ItemTemplate="{StaticResource ShellItemTemplate}" Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
-        <ShellContent Route="list" Title="List"  Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:DemoShellPage}" />
-        <ShellContent Route="games" Style="{StaticResource GreenShell}" Title="Games" Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:GamesPage}" />
-        <ShellContent Route="movies" Style="{StaticResource MoviesShell}" Title="Movies &amp; TV" 
-                      Icon="film.png" FlyoutIcon="filmflyout.png" ContentTemplate="{DataTemplate local:MoviesPage}">
-            <ShellContent.MenuItems>
-                <MenuItem Icon="film.png" Text="Open Movies App" />
-            </ShellContent.MenuItems>
-        </ShellContent>
-        <ShellContent Route="books" Style="{StaticResource BooksShell}" Title="Books" 
-                      Icon="books.png" FlyoutIcon="booksflyout.png" ContentTemplate="{DataTemplate local:BooksPage}">
-            <ShellContent.MenuItems>
-                <MenuItem Icon="books.png" Text="Open Reader" />
-            </ShellContent.MenuItems>
-        </ShellContent>
-        <ShellContent Route="music" Style="{StaticResource MusicShell}" Title="Music" 
-                      Icon="headphone.png" FlyoutIcon="headphoneflyout.png" ContentTemplate="{DataTemplate local:MusicPage}">
-            <ShellContent.MenuItems>
-                <MenuItem Icon="headphone.png" Text="Open Music App" />
-            </ShellContent.MenuItems>
-        </ShellContent>
-        <ShellContent Route="news" Style="{StaticResource NewsShell}" Title="Newsstand" 
-                      Icon="newspaper.png" FlyoutIcon="newspaperflyout.png" ContentTemplate="{DataTemplate local:NewsPage}">
-            <ShellContent.MenuItems>
-                <MenuItem Icon="newspaper.png" Text="Open News App" />
-            </ShellContent.MenuItems>
-        </ShellContent>
-    </ShellItem>
+	<ShellItem Route="store" x:Name="_storeItem" FlyoutDisplayOptions="AsMultipleItems">
+		<ShellContent Shell.ItemTemplate="{StaticResource ShellItemTemplate}" Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
+		<ShellContent Route="list" Title="List"  Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:DemoShellPage}" />
+		<ShellContent Route="games" Style="{StaticResource GreenShell}" Title="Games" Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:GamesPage}" />
+		<ShellContent Route="movies" Style="{StaticResource MoviesShell}" Title="Movies &amp; TV" 
+					  Icon="film.png" FlyoutIcon="filmflyout.png" ContentTemplate="{DataTemplate local:MoviesPage}">
+			<ShellContent.MenuItems>
+				<MenuItem Icon="film.png" Text="Open Movies App" />
+			</ShellContent.MenuItems>
+		</ShellContent>
+		<ShellContent Route="books" Style="{StaticResource BooksShell}" Title="Books" 
+					  Icon="books.png" FlyoutIcon="booksflyout.png" ContentTemplate="{DataTemplate local:BooksPage}">
+			<ShellContent.MenuItems>
+				<MenuItem Icon="books.png" Text="Open Reader" />
+			</ShellContent.MenuItems>
+		</ShellContent>
+		<ShellContent Route="music" Style="{StaticResource MusicShell}" Title="Music" 
+					  Icon="headphone.png" FlyoutIcon="headphoneflyout.png" ContentTemplate="{DataTemplate local:MusicPage}">
+			<ShellContent.MenuItems>
+				<MenuItem Icon="headphone.png" Text="Open Music App" />
+			</ShellContent.MenuItems>
+		</ShellContent>
+		<ShellContent Route="news" Style="{StaticResource NewsShell}" Title="Newsstand" 
+					  Icon="newspaper.png" FlyoutIcon="newspaperflyout.png" ContentTemplate="{DataTemplate local:NewsPage}">
+			<ShellContent.MenuItems>
+				<MenuItem Icon="newspaper.png" Text="Open News App" />
+			</ShellContent.MenuItems>
+		</ShellContent>
+	</ShellItem>
 
-    <ShellContent Route="account" Title="Account" Icon="person.png" ContentTemplate="{DataTemplate local:AccountsPage}" />
+	<ShellContent Route="account" Title="Account" Icon="person.png" ContentTemplate="{DataTemplate local:AccountsPage}" />
 
-    <MenuItem Text="Redeem" Icon="card.png" />
+	<MenuItem Text="Redeem" Icon="card.png" />
 
-    <ShellContent Route="wishlist" Title="Wishlist" Icon="star.png" ContentTemplate="{DataTemplate local:WishlistPage}" />
-    
-    <MenuItem Shell.MenuItemTemplate="{StaticResource MenuItemTemplate}" Text="Xam Protect" Icon="jet.png" />
+	<ShellContent Route="wishlist" Title="Wishlist" Icon="star.png" ContentTemplate="{DataTemplate local:WishlistPage}" />
+	
+	<MenuItem Shell.MenuItemTemplate="{StaticResource MenuItemTemplate}" Text="Xam Protect" Icon="jet.png" />
 
-    <ShellContent Route="settings" Title="Settings" Icon="gear.png" ContentTemplate="{DataTemplate local:SettingsPage}" />
+	<ShellContent Route="settings" Title="Settings" Icon="gear.png" ContentTemplate="{DataTemplate local:SettingsPage}" />
 
 	<ShellItem Route="propagation" Title="Propagation">
-        <ShellContent Shell.NavBarIsVisible="false" Route="home" Style="{StaticResource GreenShell}" Title="No Nav" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
-        <ShellSection Shell.TabBarIsVisible="false" Route="activity" Title="No Tab" Icon="grid.png" Style="{StaticResource GreenShell}">
-            <ShellContent Route="sharednotab" Title="No Tabs" ContentTemplate="{DataTemplate local:UpdatesPage}" />
-            <ShellContent Route="Notificationstabs" Shell.TabBarIsVisible="true" Title="Yes Tabs" ContentTemplate="{DataTemplate local:LibraryPage}" />
-        </ShellSection>
-    </ShellItem>
+		<ShellContent Shell.NavBarIsVisible="false" Route="home" Style="{StaticResource GreenShell}" Title="No Nav" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
+		<ShellSection Shell.TabBarIsVisible="false" Route="activity" Title="No Tab" Icon="grid.png" Style="{StaticResource GreenShell}">
+			<ShellContent Route="sharednotab" Title="No Tabs" ContentTemplate="{DataTemplate local:UpdatesPage}" />
+			<ShellContent Route="Notificationstabs" Shell.TabBarIsVisible="true" Title="Yes Tabs" ContentTemplate="{DataTemplate local:LibraryPage}" />
+		</ShellSection>
+	</ShellItem>
 </localTest:TestShell>

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -1,102 +1,117 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <localTest:TestShell xmlns="http://xamarin.com/schemas/2014/forms"
-			xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-			xmlns:local="clr-namespace:Xamarin.Forms.Controls.XamStore"
-			xmlns:localTest="clr-namespace:Xamarin.Forms.Controls"
-			x:Class="Xamarin.Forms.Controls.XamStore.StoreShell">
-	<Shell.Resources>
-		<Style x:Key="BaseStyle" TargetType="Element">
-			<Setter Property="Shell.BackgroundColor" Value="#455A64" />
-			<Setter Property="Shell.ForegroundColor" Value="White" />
-			<Setter Property="Shell.TitleColor" Value="White" />
-			<Setter Property="Shell.DisabledColor" Value="#B4FFFFFF" />
-			<Setter Property="Shell.UnselectedColor" Value="#95FFFFFF" />
-		</Style>
-		<Style TargetType="ShellItem" BasedOn="{StaticResource BaseStyle}" />
-		<Style x:Key="GreenShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-			<Setter Property="Shell.BackgroundColor" Value="#689F39" />
-		</Style>
-		<Style x:Key="MusicShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-			<Setter Property="Shell.BackgroundColor" Value="#EF6C00" />
-		</Style>
-		<Style x:Key="MoviesShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-			<Setter Property="Shell.BackgroundColor" Value="#ED3B3B" />
-		</Style>
-		<Style x:Key="BooksShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-			<Setter Property="Shell.BackgroundColor" Value="#039BE6" />
-		</Style>
-		<Style x:Key="NewsShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
-			<Setter Property="Shell.BackgroundColor" Value="#546DFE" />
-		</Style>
+            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+            xmlns:local="clr-namespace:Xamarin.Forms.Controls.XamStore"
+            xmlns:localTest="clr-namespace:Xamarin.Forms.Controls"
+            x:Class="Xamarin.Forms.Controls.XamStore.StoreShell">
+    <Shell.Resources>
+        <Style x:Key="BaseStyle" TargetType="Element">
+            <Setter Property="Shell.BackgroundColor" Value="#455A64" />
+            <Setter Property="Shell.ForegroundColor" Value="White" />
+            <Setter Property="Shell.TitleColor" Value="White" />
+            <Setter Property="Shell.DisabledColor" Value="#B4FFFFFF" />
+            <Setter Property="Shell.UnselectedColor" Value="#95FFFFFF" />
+        </Style>
+        <Style TargetType="ShellItem" BasedOn="{StaticResource BaseStyle}" />
+        <Style x:Key="GreenShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+            <Setter Property="Shell.BackgroundColor" Value="#689F39" />
+        </Style>
+        <Style x:Key="MusicShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+            <Setter Property="Shell.BackgroundColor" Value="#EF6C00" />
+        </Style>
+        <Style x:Key="MoviesShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+            <Setter Property="Shell.BackgroundColor" Value="#ED3B3B" />
+        </Style>
+        <Style x:Key="BooksShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+            <Setter Property="Shell.BackgroundColor" Value="#039BE6" />
+        </Style>
+        <Style x:Key="NewsShell" TargetType="Element" BasedOn="{StaticResource BaseStyle}">
+            <Setter Property="Shell.BackgroundColor" Value="#546DFE" />
+        </Style>
         <DataTemplate x:Key="MenuItemTemplate">
             <ContentView>
-                <Button Visual="Material" ImageSource="{Binding Icon}" Text="{Binding Text}"  />
+                <Button Visual="Material" ImageSource="{Binding FlyoutIcon}" Text="{Binding Text}"  />
             </ContentView>
         </DataTemplate>
-	</Shell.Resources>
+        <DataTemplate x:Key="ShellItemTemplate">
+            <ContentView BackgroundColor="LightBlue">
+                <StackLayout Orientation="Horizontal">
+                    <Image Source="{Binding FlyoutIcon}"/>
+                    <Label Text="{Binding Title}" />
+                </StackLayout>
+            </ContentView>
+        </DataTemplate>
+    </Shell.Resources>
 
-	<Shell.FlyoutHeader>
-		<local:FlyoutHeader />
-	</Shell.FlyoutHeader>
+    <Shell.FlyoutHeader>
+        <local:FlyoutHeader />
+    </Shell.FlyoutHeader>
     
     <ShellContent Title="Search" Route="search" ContentTemplate="{DataTemplate local:SearchHandlerPage}" />
-	<ShellSection FlyoutDisplayOptions="AsMultipleItems" Route="apps" Title="My apps &amp; games" Icon="grid.png" Style="{StaticResource GreenShell}">
-		<ShellContent Route="updates" Title="Updates" ContentTemplate="{DataTemplate local:UpdatesPage}" />
-		<ShellContent Route="installed" Title="Installed" ContentTemplate="{DataTemplate local:InstalledPage}" />
-		<ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
-	</ShellSection>
+    <ShellSection FlyoutDisplayOptions="AsMultipleItems" Route="apps" Title="My apps &amp; games" Icon="grid.png" Style="{StaticResource GreenShell}">
+        <ShellContent Route="updates" Title="Updates" ContentTemplate="{DataTemplate local:UpdatesPage}" />
+        <ShellContent Route="installed" Title="Installed" ContentTemplate="{DataTemplate local:InstalledPage}" />
+        <ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
+    </ShellSection>
 
-	<ShellContent Route="notifications" Style="{StaticResource BaseStyle}" Title="My notifications" Icon="bell.png" ContentTemplate="{DataTemplate local:NotificationsPage}" />
+    <ShellContent Route="notifications" Style="{StaticResource BaseStyle}" Title="My notifications" FlyoutIcon="homeflyout.png" Icon="bell.png" ContentTemplate="{DataTemplate local:NotificationsPage}" />
 
-	<ShellContent Route="subs" Title="Subscriptions" Icon="loop.png" ContentTemplate="{DataTemplate local:SubscriptionsPage}" />
+    <ShellContent Route="subs" Title="Subscriptions" Icon="loop.png" ContentTemplate="{DataTemplate local:SubscriptionsPage}" />
 
-	<ShellItem Route="xamtube" Title="XamTube">
-		<ShellContent Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
-		<ShellSection Route="activity" Title="Activity" Icon="grid.png" Style="{StaticResource GreenShell}">
-			<ShellContent Route="shared" Title="Shared" ContentTemplate="{DataTemplate local:UpdatesPage}" />
-			<ShellContent Route="Notifications" Title="Notifications" ContentTemplate="{DataTemplate local:LibraryPage}" />
-		</ShellSection>
-		<ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
-	</ShellItem>
+    <ShellItem Route="xamtube" Title="XamTube">
+        <ShellContent Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
+        <ShellSection Route="activity" Title="Activity" Icon="grid.png" Style="{StaticResource GreenShell}">
+            <ShellContent Route="shared" Title="Shared" ContentTemplate="{DataTemplate local:UpdatesPage}" />
+            <ShellContent Route="Notifications" Title="Notifications" ContentTemplate="{DataTemplate local:LibraryPage}" />
+        </ShellSection>
+        <ShellContent Route="library" Title="Library" ContentTemplate="{DataTemplate local:LibraryPage}" />
+    </ShellItem>
 
-	<ShellItem Route="store" x:Name="_storeItem" FlyoutDisplayOptions="AsMultipleItems">
-		<ShellContent Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
+    <ShellItem Route="store" x:Name="_storeItem" FlyoutDisplayOptions="AsMultipleItems">
+        <ShellContent Shell.ItemTemplate="{StaticResource ShellItemTemplate}" Route="home" Style="{StaticResource GreenShell}" Title="Home" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
         <ShellContent Route="list" Title="List"  Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:DemoShellPage}" />
-		<ShellContent Route="games" Style="{StaticResource GreenShell}" Title="Games" Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:GamesPage}" />
-		<ShellContent Route="movies" Style="{StaticResource MoviesShell}" Title="Movies &amp; TV" 
-					  Icon="film.png" FlyoutIcon="filmflyout.png" ContentTemplate="{DataTemplate local:MoviesPage}">
-			<ShellContent.MenuItems>
-				<MenuItem Icon="film.png" Text="Open Movies App" />
-			</ShellContent.MenuItems>
-		</ShellContent>
-		<ShellContent Route="books" Style="{StaticResource BooksShell}" Title="Books" 
-					  Icon="books.png" FlyoutIcon="booksflyout.png" ContentTemplate="{DataTemplate local:BooksPage}">
-			<ShellContent.MenuItems>
-				<MenuItem Icon="books.png" Text="Open Reader" />
-			</ShellContent.MenuItems>
-		</ShellContent>
-		<ShellContent Route="music" Style="{StaticResource MusicShell}" Title="Music" 
-					  Icon="headphone.png" FlyoutIcon="headphoneflyout.png" ContentTemplate="{DataTemplate local:MusicPage}">
-			<ShellContent.MenuItems>
-				<MenuItem Icon="headphone.png" Text="Open Music App" />
-			</ShellContent.MenuItems>
-		</ShellContent>
-		<ShellContent Route="news" Style="{StaticResource NewsShell}" Title="Newsstand" 
-					  Icon="newspaper.png" FlyoutIcon="newspaperflyout.png" ContentTemplate="{DataTemplate local:NewsPage}">
-			<ShellContent.MenuItems>
-				<MenuItem Icon="newspaper.png" Text="Open News App" />
-			</ShellContent.MenuItems>
-		</ShellContent>
-	</ShellItem>
+        <ShellContent Route="games" Style="{StaticResource GreenShell}" Title="Games" Icon="games.png" FlyoutIcon="gamesflyout.png" ContentTemplate="{DataTemplate local:GamesPage}" />
+        <ShellContent Route="movies" Style="{StaticResource MoviesShell}" Title="Movies &amp; TV" 
+                      Icon="film.png" FlyoutIcon="filmflyout.png" ContentTemplate="{DataTemplate local:MoviesPage}">
+            <ShellContent.MenuItems>
+                <MenuItem Icon="film.png" Text="Open Movies App" />
+            </ShellContent.MenuItems>
+        </ShellContent>
+        <ShellContent Route="books" Style="{StaticResource BooksShell}" Title="Books" 
+                      Icon="books.png" FlyoutIcon="booksflyout.png" ContentTemplate="{DataTemplate local:BooksPage}">
+            <ShellContent.MenuItems>
+                <MenuItem Icon="books.png" Text="Open Reader" />
+            </ShellContent.MenuItems>
+        </ShellContent>
+        <ShellContent Route="music" Style="{StaticResource MusicShell}" Title="Music" 
+                      Icon="headphone.png" FlyoutIcon="headphoneflyout.png" ContentTemplate="{DataTemplate local:MusicPage}">
+            <ShellContent.MenuItems>
+                <MenuItem Icon="headphone.png" Text="Open Music App" />
+            </ShellContent.MenuItems>
+        </ShellContent>
+        <ShellContent Route="news" Style="{StaticResource NewsShell}" Title="Newsstand" 
+                      Icon="newspaper.png" FlyoutIcon="newspaperflyout.png" ContentTemplate="{DataTemplate local:NewsPage}">
+            <ShellContent.MenuItems>
+                <MenuItem Icon="newspaper.png" Text="Open News App" />
+            </ShellContent.MenuItems>
+        </ShellContent>
+    </ShellItem>
 
-	<ShellContent Route="account" Title="Account" Icon="person.png" ContentTemplate="{DataTemplate local:AccountsPage}" />
+    <ShellContent Route="account" Title="Account" Icon="person.png" ContentTemplate="{DataTemplate local:AccountsPage}" />
 
-	<MenuItem Text="Redeem" Icon="card.png" />
+    <MenuItem Text="Redeem" Icon="card.png" />
 
-	<ShellContent Route="wishlist" Title="Wishlist" Icon="star.png" ContentTemplate="{DataTemplate local:WishlistPage}" />
-	
-	<MenuItem Shell.MenuItemTemplate="{StaticResource MenuItemTemplate}" Text="Xam Protect" Icon="jet.png" />
+    <ShellContent Route="wishlist" Title="Wishlist" Icon="star.png" ContentTemplate="{DataTemplate local:WishlistPage}" />
+    
+    <MenuItem Shell.MenuItemTemplate="{StaticResource MenuItemTemplate}" Text="Xam Protect" Icon="jet.png" />
 
-	<ShellContent Route="settings" Title="Settings" Icon="gear.png" ContentTemplate="{DataTemplate local:SettingsPage}" />
+    <ShellContent Route="settings" Title="Settings" Icon="gear.png" ContentTemplate="{DataTemplate local:SettingsPage}" />
 
+	<ShellItem Route="propagation" Title="Propagation">
+        <ShellContent Shell.NavBarIsVisible="false" Route="home" Style="{StaticResource GreenShell}" Title="No Nav" Icon="home.png" FlyoutIcon="homeflyout.png" ContentTemplate="{DataTemplate local:HomePage}" />
+        <ShellSection Shell.TabBarIsVisible="false" Route="activity" Title="No Tab" Icon="grid.png" Style="{StaticResource GreenShell}">
+            <ShellContent Route="sharednotab" Title="No Tabs" ContentTemplate="{DataTemplate local:UpdatesPage}" />
+            <ShellContent Route="Notificationstabs" Shell.TabBarIsVisible="true" Title="Yes Tabs" ContentTemplate="{DataTemplate local:LibraryPage}" />
+        </ShellSection>
+    </ShellItem>
 </localTest:TestShell>

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Controls.XamStore
 		public StoreShell() 
 		{
 			InitializeComponent();
+			CurrentItem = _storeItem;
 		}
 
 		protected override void Init()
@@ -45,7 +46,6 @@ namespace Xamarin.Forms.Controls.XamStore
 
 			FlyoutIcon.SetAutomationPropertiesHelpText("This as Shell FlyoutIcon");
 			FlyoutIcon.SetAutomationPropertiesName("SHELLMAINFLYOUTICON");
-			CurrentItem = _storeItem;
 			Routing.RegisterRoute("demo", typeof(DemoShellPage));
 			Routing.RegisterRoute("demo/demo", typeof(DemoShellPage));
 		}

--- a/Xamarin.Forms.Core/Internals/PropertyPropagationExtensions.cs
+++ b/Xamarin.Forms.Core/Internals/PropertyPropagationExtensions.cs
@@ -15,6 +15,12 @@ namespace Xamarin.Forms.Internals
 			if (propertyName == null || propertyName == VisualElement.VisualProperty.PropertyName)
 				Element.SetVisualfromParent(element);
 
+			if (propertyName == null || propertyName == Shell.NavBarIsVisibleProperty.PropertyName)
+				BaseShellItem.PropagateFromParent(Shell.NavBarIsVisibleProperty, element);
+
+			if (propertyName == null || propertyName == Shell.TabBarIsVisibleProperty.PropertyName)
+				BaseShellItem.PropagateFromParent(Shell.TabBarIsVisibleProperty, element);
+
 			foreach (var child in children)
 			{
 				if (child is IPropertyPropagationController view)

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms
 		{
 			return source.StartsWith(ImplicitPrefix, StringComparison.Ordinal);
 		}
-		internal static bool IsImplicit(Element source)
+		internal static bool IsImplicit(BindableObject source)
 		{
 			return IsImplicit(GetRoute(source));
 		}
@@ -71,7 +71,7 @@ namespace Xamarin.Forms
 			return result;
 		}
 
-		public static string GetRoute(Element obj)
+		public static string GetRoute(BindableObject obj)
 		{
 			return (string)obj.GetValue(RouteProperty);
 		}

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Runtime.CompilerServices;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
@@ -131,6 +132,39 @@ namespace Xamarin.Forms
 
 			var shellItem = (BaseShellItem)bindable;
 			shellItem.FlyoutIcon = (ImageSource)newValue;
+		}
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+			if (Parent != null)
+			{
+				if (propertyName == Shell.ItemTemplateProperty.PropertyName || propertyName == nameof(Parent))
+					Propagate(Shell.ItemTemplateProperty, this, Parent, true);
+			}
+		}
+
+		internal static void PropagateFromParent(BindableProperty property, Element me)
+		{
+			if (me == null || me.Parent == null)
+				return;
+
+			Propagate(property, me.Parent, me, false);
+		}
+
+		internal static void Propagate(BindableProperty property, BindableObject from, BindableObject to, bool onlyToImplicit)
+		{
+			if (from == null || to == null)
+				return;
+
+			if (onlyToImplicit && Routing.IsImplicit(from))
+				return;
+
+			if (to is Shell)
+				return;
+
+			if (from.IsSet(property) && !to.IsSet(property))
+				to.SetValue(property, from.GetValue(property));
 		}
 
 		void IPropertyPropagationController.PropagatePropertyChanged(string propertyName)

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms
 
 			SetBinding(TitleProperty, new Binding("Text", BindingMode.OneWay, source: menuItem));
 			SetBinding(IconProperty, new Binding("Icon", BindingMode.OneWay, source: menuItem));
+			SetBinding(FlyoutIconProperty, new Binding("Icon", BindingMode.OneWay, source: menuItem));
+
 			Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
 			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;
 		}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -54,6 +54,12 @@ namespace Xamarin.Forms
 		public static DataTemplate GetMenuItemTemplate(BindableObject obj) => (DataTemplate)obj.GetValue(MenuItemTemplateProperty);
 		public static void SetMenuItemTemplate(BindableObject obj, DataTemplate menuItemTemplate) => obj.SetValue(MenuItemTemplateProperty, menuItemTemplate);
 
+		public static readonly BindableProperty ItemTemplateProperty =
+			BindableProperty.CreateAttached(nameof(ItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
+
+		public static DataTemplate GetItemTemplate(BindableObject obj) => (DataTemplate)obj.GetValue(ItemTemplateProperty);
+		public static void SetItemTemplate(BindableObject obj, DataTemplate itemTemplate) => obj.SetValue(ItemTemplateProperty, itemTemplate);
+
 		public static BackButtonBehavior GetBackButtonBehavior(BindableObject obj) => (BackButtonBehavior)obj.GetValue(BackButtonBehaviorProperty);
 		public static void SetBackButtonBehavior(BindableObject obj, BackButtonBehavior behavior) => obj.SetValue(BackButtonBehaviorProperty, behavior);
 
@@ -555,9 +561,6 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty ItemsProperty = ItemsPropertyKey.BindableProperty;
 
-		public static readonly BindableProperty ItemTemplateProperty =
-			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime);
-
 		public static readonly BindableProperty FlyoutIconProperty =
 			BindableProperty.Create(nameof(FlyoutIcon), typeof(ImageSource), typeof(Shell), null);
 
@@ -630,8 +633,8 @@ namespace Xamarin.Forms
 
 		public DataTemplate ItemTemplate
 		{
-			get => (DataTemplate)GetValue(ItemTemplateProperty);
-			set => SetValue(ItemTemplateProperty, value);
+			get => GetItemTemplate(this);
+			set => SetItemTemplate(this, value);
 		}
 
 		public DataTemplate MenuItemTemplate

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -109,8 +109,9 @@ namespace Xamarin.Forms
 			shellContent.Route = Routing.GenerateImplicitRoute(pageRoute);
 
 			shellContent.Content = page;
-			shellContent.SetBinding(TitleProperty, new Binding("Title", BindingMode.OneWay, source: page));
-			shellContent.SetBinding(IconProperty, new Binding("Icon", BindingMode.OneWay, source: page));
+			shellContent.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: page));
+			shellContent.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: page));
+			shellContent.SetBinding(FlyoutIconProperty, new Binding(nameof(FlyoutIcon), BindingMode.OneWay, source: page));
 
 			return shellContent;
 		}

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -135,6 +136,8 @@ namespace Xamarin.Forms
 			result.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(FlyoutDisplayOptionsProperty, new Binding(nameof(FlyoutDisplayOptions), BindingMode.OneTime, source: shellSection));
+			result.SetBinding(FlyoutIconProperty, new Binding(nameof(FlyoutIcon), BindingMode.OneWay, source: shellSection));
+			
 			return result;
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -197,8 +198,11 @@ namespace Xamarin.Forms
 			shellSection.Route = Routing.GenerateImplicitRoute(contentRoute);
 
 			shellSection.Items.Add(shellContent);
-			shellSection.SetBinding(TitleProperty, new Binding("Title", BindingMode.OneWay, source: shellContent));
-			shellSection.SetBinding(IconProperty, new Binding("Icon", BindingMode.OneWay, source: shellContent));
+
+			shellSection.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: shellContent));
+			shellSection.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: shellContent));
+			shellSection.SetBinding(FlyoutIconProperty, new Binding(nameof(FlyoutIcon), BindingMode.OneWay, source: shellContent));
+
 			return shellSection;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -47,11 +47,15 @@ namespace Xamarin.Forms.Platform.Android
 		public override int GetItemViewType(int position)
 		{
 			var item = _listItems[position];
-			var dataTemplate = Shell.ItemTemplate ?? DefaultItemTemplate;
+			DataTemplate dataTemplate = null;
 			if (item.Element is IMenuItemController)
 			{
 				dataTemplate = Shell.GetMenuItemTemplate(item.Element) ?? Shell.MenuItemTemplate ?? DefaultMenuItemTemplate;
 			}
+			else
+			{
+				dataTemplate = Shell.GetItemTemplate(item.Element) ?? Shell.ItemTemplate ?? DefaultItemTemplate;
+			}	
 
 			var template = dataTemplate.SelectDataTemplate(item.Element, Shell);
 			var id = ((IDataTemplateController)template).Id;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				template = _context.Shell.ItemTemplate ?? DefaultItemTemplate;
+				template = Shell.GetItemTemplate(context) ?? _context.Shell.ItemTemplate ?? DefaultItemTemplate;
 			}
 
 			var cellId = ((IDataTemplateController)template.SelectDataTemplate(context, _context.Shell)).IdString;


### PR DESCRIPTION
### Description of Change ###

- add propagation for navbarvisible and tabbarvisible to propagate down children
- changed Shell.ItemTemplate to be an attached property so it can be attached to any Shell<thing>
- fixed implicit Shell<thing> creations to properly bind additional properties (like flyouticon)

### Issues Resolved ### 
- partially fixes #5940

### API Changes ###

Changed:
 - Shell.ItemTemplate to be an attached property

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- I added another flyout item to store shell where you can see these properties set at different hierarchies

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard