### PR TITLE
fixes BindableLayout DataTemplate - XamlC #5486

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -472,7 +472,7 @@ namespace Xamarin.Forms.Build.Tasks
 					var property = previousPartTypeRef.GetProperty(pd => pd.Name == p && pd.GetMethod != null && pd.GetMethod.IsPublic, out var propDeclTypeRef)
 					                                  ?? throw new XamlParseException($"Binding: Property '{p}' not found on '{previousPartTypeRef}'", lineInfo);
 					properties.Add((property, propDeclTypeRef, null));
-					previousPartTypeRef = property.PropertyType;
+					previousPartTypeRef = property.PropertyType.ResolveGenericParameters(propDeclTypeRef);
 				}
 				if (indexArg != null) {
 					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module, ("mscorlib", "System.Reflection", "DefaultMemberAttribute"));

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Build.Tasks
 				return properties.Single();
 			if (typeDef.IsInterface) {
 				foreach (var face in typeDef.Interfaces) {
-					var p = face.InterfaceType.GetProperty(predicate, out var interfaceDeclaringTypeRef);
+					var p = face.InterfaceType.ResolveGenericParameters(typeRef).GetProperty(predicate, out var interfaceDeclaringTypeRef);
 					if (p != null) {
 						declaringTypeRef = interfaceDeclaringTypeRef;
 						return p;
@@ -404,7 +404,7 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			return self.ElementType.MakeGenericInstanceType(args.ToArray());
 		}
-
+		
 		static Dictionary<TypeReference, TypeDefinition> resolves = new Dictionary<TypeReference, TypeDefinition>();
 		public static TypeDefinition ResolveCached(this TypeReference typeReference)
 		{

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -404,7 +404,7 @@ namespace Xamarin.Forms.Build.Tasks
 			}
 			return self.ElementType.MakeGenericInstanceType(args.ToArray());
 		}
-		
+
 		static Dictionary<TypeReference, TypeDefinition> resolves = new Dictionary<TypeReference, TypeDefinition>();
 		public static TypeDefinition ResolveCached(this TypeReference typeReference)
 		{

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5486.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5486.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5486"
+		x:DataType="local:IGh5486VM">
+    <Label x:Name="label" Text="{Binding Data.Label}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5486.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5486.xaml.cs
@@ -1,0 +1,76 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh5486VM : IGh5486VM
+	{
+		public Gh5486VM()
+		{
+			this.Data = new Tag5486()
+			{
+				Label = "test",
+			};
+		}
+
+		public ITag5486 Data { get; set; }
+	}
+
+	public class Tag5486 : ITag5486
+	{
+		public string Label { get; set; }
+	}
+
+	public interface ITag5486
+	{
+		string Label { get; set; }
+	}
+
+	public interface IGh5486VM : IGh5486VMBase<ITag5486>
+	{
+	}
+
+	public interface IGh5486VMBase<T>
+	{
+		T Data { get; }
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Gh5486 : ContentPage
+	{
+		public Gh5486()
+		{
+			InitializeComponent();
+		}
+
+		public Gh5486(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void GenericBaseInterfaceResolution(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh5486)));
+				var layout = new Gh5486(useCompiledXaml) { BindingContext = new Gh5486VM() };
+				Assert.That(layout.label.Text, Is.EqualTo("test"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5651.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5651.xaml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+		xmlns="http://xamarin.com/schemas/2014/forms"
+		xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+		xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+		x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5651"
+		x:DataType="local:IViewModel5651">
+    <Label x:Name="label" Text="{Binding SelectedItem}" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5651.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5651.xaml.cs
@@ -1,0 +1,63 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh5651VM : IViewModel5651
+	{
+		public Gh5651VM()
+		{
+			this.SelectedItem = "test";
+		}
+
+		public string SelectedItem { get; set; }
+	}
+
+	public interface IViewModel5651 : IEditViewModel5651<string>{}
+
+	public interface IEditViewModel5651<T> : IBaseViewModel5651<T>{}
+
+	public interface IBaseViewModel5651<T>
+	{
+		T SelectedItem { get; set; }
+	}
+
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Gh5651 : ContentPage
+	{
+		public Gh5651()
+		{
+			InitializeComponent();
+		}
+
+		public Gh5651(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				Device.PlatformServices = null;
+			}
+
+			[TestCase(true), TestCase(false)]
+			public void GenericBaseInterfaceResolution(bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh5651)));
+				var layout = new Gh5651(useCompiledXaml) { BindingContext = new Gh5651VM() };
+				Assert.That(layout.label.Text, Is.EqualTo("test"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

This pull request fixes both issues, I have added Unit tests for both issues because there where two fixes necessary

<!-- Describe your changes here. -->

Issue https://github.com/xamarin/Xamarin.Forms/issues/5486 fixed by this
previousPartTypeRef = property.PropertyType.ResolveGenericParameters(propDeclTypeRef);

Generic parameter where not resolved on propertyType

Issue https://github.com/xamarin/Xamarin.Forms/issues/5651 fixed by this
var p = face.InterfaceType.ResolveGenericParameters(typeRef).GetProperty(predicate, out var interfaceDeclaringTypeRef);

Generic Parameters where not resolved on interface

### Issues Resolved ### 
- fixes #5651
- fixes #5486

### API Changes ###
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
Compiled Bindings work now better for Generic Interfaces, enabeling more cases

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Run Unit Tests

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
