### PR TITLE
Fix for layouts in a cell to expand on resize (WPF) Issue #5682

### DIFF
--- a/Xamarin.Forms.Platform.WPF/CellControl.cs
+++ b/Xamarin.Forms.Platform.WPF/CellControl.cs
@@ -93,11 +93,11 @@ namespace Xamarin.Forms.Platform.WPF
 				{
 					foreach (var child in vc.LogicalChildren)
 					{
-						if (child is Grid childGrid)
+						if (child is Layout<View> layout)
 						{
-							if (childGrid.HorizontalOptions.Expands)
+							if (layout.HorizontalOptions.Expands)
 							{
-								childGrid.Layout(new Rectangle(childGrid.X, childGrid.Y, sizeInfo.NewSize.Width, sizeInfo.NewSize.Height));
+								layout.Layout(new Rectangle(layout.X, layout.Y, sizeInfo.NewSize.Width, sizeInfo.NewSize.Height));
 							}
 						}
 					}

--- a/Xamarin.Forms.Platform.WPF/CellControl.cs
+++ b/Xamarin.Forms.Platform.WPF/CellControl.cs
@@ -96,7 +96,10 @@ namespace Xamarin.Forms.Platform.WPF
 					{
 						if (child is Grid childGrid)
 						{
-							childGrid.Layout(new Rectangle(childGrid.X, childGrid.Y, sizeInfo.NewSize.Width, sizeInfo.NewSize.Height));
+							if (childGrid.HorizontalOptions.Expands)
+							{
+								childGrid.Layout(new Rectangle(childGrid.X, childGrid.Y, sizeInfo.NewSize.Width, sizeInfo.NewSize.Height));
+							}
 						}
 					}
 				}

--- a/Xamarin.Forms.Platform.WPF/CellControl.cs
+++ b/Xamarin.Forms.Platform.WPF/CellControl.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
-using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;

--- a/Xamarin.Forms.Platform.WPF/CellControl.cs
+++ b/Xamarin.Forms.Platform.WPF/CellControl.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -71,18 +72,36 @@ namespace Xamarin.Forms.Platform.WPF
 			if (newCell != null)
 			{
 				((ICellController)newCell).SendAppearing();
-				
+
 				if (oldCell == null || oldCell.GetType() != newCell.GetType())
 					ContentTemplate = GetTemplate(newCell);
 
 				Content = newCell;
-				
+
 				SetupContextMenu();
 
 				newCell.PropertyChanged += _propertyChangedHandler;
 			}
 			else
 				Content = null;
+		}
+
+		protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+		{
+			if (Content is ViewCell vc)
+			{
+				if (vc.LogicalChildren != null && vc.LogicalChildren.Any())
+				{
+					foreach (var child in vc.LogicalChildren)
+					{
+						if (child is Grid childGrid)
+						{
+							childGrid.Layout(new Rectangle(childGrid.X, childGrid.Y, sizeInfo.NewSize.Width, sizeInfo.NewSize.Height));
+						}
+					}
+				}
+			}
+			base.OnRenderSizeChanged(sizeInfo);
 		}
 
 		void SetupContextMenu()

--- a/Xamarin.Forms.Platform.WPF/CellControl.cs
+++ b/Xamarin.Forms.Platform.WPF/CellControl.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Forms.Platform.WPF
 				{
 					foreach (var child in vc.LogicalChildren)
 					{
-						if (child is Layout<View> layout)
+						if (child is Layout layout)
 						{
 							if (layout.HorizontalOptions.Expands)
 							{


### PR DESCRIPTION
### Description of Change ###
The child layouts where not receiving any notification to re-layout.  This fix calls layout on the children view items.

### Issues Resolved ### 
Grid will now auto expand within a ViewCell

### PR Checklist ###
- [] Has automated tests (Visual Tested)
- [x] Rebased on top of the target branch at time of PR (Not needed)
- [x] Changes adhere to coding standard
