### PR TITLE
Virtualize Lifecycle Events

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -285,28 +285,28 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SendResume()
+		public virtual void SendResume()
 		{
 			s_current = this;
 			OnResume();
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SendSleep()
+		public virtual void SendSleep()
 		{
 			OnSleep();
 			SavePropertiesAsFireAndForget();
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public Task SendSleepAsync()
+		public virtual Task SendSleepAsync()
 		{
 			OnSleep();
 			return SavePropertiesAsync();
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SendStart()
+		public virtual void SendStart()
 		{
 			OnStart();
 		}


### PR DESCRIPTION
### Description of Change ###

Virtualizes lifecycle events to allow 3rd party frameworks like Prism to allow custom logic for Startup/Resume/Sleep without requiring downstream developers to know to call base.On{Event}().

### Issues Resolved ### 

- fixes #6159

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

- Application Lifecycle (Start/Resume/Sleep) Event invokers are now virtual so that 3rd parties with custom base Applications can inject additional logic without downstream users needing to know to call `base.On{Event}()`

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

n/a

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
