### PR TITLE
InvalidateLayout after reload to avoid iOS 10 crash

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 					break;
 				case NotifyCollectionChangedAction.Reset:
 					_collectionView.ReloadData();
+					_collectionView.CollectionViewLayout.InvalidateLayout();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();


### PR DESCRIPTION
### Description of Change ###

Unlike other versions of iOS, 10 needs a explicit call to `invalidateLayout` after reloading items or it will crash if the number of items in the data source has changed.

### Issues Resolved ### 

- fixes UI test 5793 failing on iOS 10

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run UI test 5793 on iOS 10

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Splines reticulated