### PR TITLE
[UWP] fixes ListView displays null values black

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26233.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26233.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var listview = new ListView ();
 			listview.ItemTemplate = new DataTemplate (typeof (ItemTemplate));
-			listview.ItemsSource = new string[] { "item1", "item2", "item3", "item4", "item5" };
+			listview.ItemsSource = new string[] { "item1", "item2", "item3", "item4", "item5", null, null };
 			var btnBack = new Button { Text = "back", Command = new Command (() => Navigation.PopAsync ()) };
 			listview.ItemSelected += (s, e) => Navigation.PushAsync (new ContentPage { Content = btnBack });
 			var btnPush = new Button {

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -40,6 +40,16 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected WListView List { get; private set; }
 
+		protected class ListViewTransparent : WListView
+		{
+			public ListViewTransparent() : base() { }
+
+			// Container is not created when the item is null. 
+			// To prevent this, base container preparationan receives an empty object.
+			protected override void PrepareContainerForItemOverride(DependencyObject element, object item)
+				=> base.PrepareContainerForItemOverride(element, item ?? new object());
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<ListView> e)
 		{
 			base.OnElementChanged(e);
@@ -59,7 +69,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (List == null)
 				{
-					List = new WListView
+					List = new ListViewTransparent
 					{
 						IsSynchronizedWithCurrentItem = false,
 						ItemTemplate = (Windows.UI.Xaml.DataTemplate)WApp.Current.Resources["CellTemplate"],


### PR DESCRIPTION
### Description of Change ###

Preparation container for item receives an empty object instead `null`. This allows to create an empty container with transparency.

### Issues Resolved ### 

- fixes #6154
- fixes #6233

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before
![image](https://user-images.githubusercontent.com/27482193/57866763-8a7c8a80-7808-11e9-8341-d20753ab97e6.png)

After
![Screenshot_2](https://user-images.githubusercontent.com/27482193/57866359-e692df00-7807-11e9-9aab-1a487456e40a.png)

### Testing Procedure ###

- run UItest 26233

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
