### PR TITLE
Props and targets

### DIFF
--- a/EmbeddingTestBeds/Embedding.XF/Directory.Build.props
+++ b/EmbeddingTestBeds/Embedding.XF/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\..\.nuspec\Xamarin.Forms.props" />
+  <Import Project="..\..\Directory.Build.props" />
+</Project> 

--- a/EmbeddingTestBeds/Embedding.XF/Directory.Build.targets
+++ b/EmbeddingTestBeds/Embedding.XF/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
+  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+</Project>

--- a/EmbeddingTestBeds/Embedding.XF/Embedding.XF.csproj
+++ b/EmbeddingTestBeds/Embedding.XF/Embedding.XF.csproj
@@ -4,34 +4,9 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="AlertsAndActionSheets.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="WebViewExample.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Page3.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Hello.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="Page4.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="OpenUri.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
+ <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj" />
     <ProjectReference Include="..\..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj" />
     <ProjectReference Include="..\..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj" />
   </ItemGroup>
-  
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
- 
 </Project> 

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -291,6 +291,4 @@
     <PackageReference Include="Xamarin.Android.Support.Vector.Drawable" Version="28.0.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 </Project>

--- a/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
+++ b/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
@@ -164,15 +164,4 @@
     <VisualStudioVersion>14.0</VisualStudioVersion>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Microsoft\WindowsXaml\v$(VisualStudioVersion)\Microsoft.Windows.UI.Xaml.CSharp.targets" />
-    
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
-  
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/PagesGallery/PagesGallery.iOS/PagesGallery.iOS.csproj
+++ b/PagesGallery/PagesGallery.iOS/PagesGallery.iOS.csproj
@@ -145,6 +145,4 @@
     <PackageReference Include="Xamarin.iOS.MaterialComponents" Version="72.2.0.1" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 </Project>

--- a/PagesGallery/PagesGallery/Directory.Build.props
+++ b/PagesGallery/PagesGallery/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\..\.nuspec\Xamarin.Forms.props" />
+  <Import Project="..\..\Directory.Build.props" />
+</Project> 

--- a/PagesGallery/PagesGallery/Directory.Build.targets
+++ b/PagesGallery/PagesGallery/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
+  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+</Project>

--- a/PagesGallery/PagesGallery/PagesGallery.csproj
+++ b/PagesGallery/PagesGallery/PagesGallery.csproj
@@ -3,30 +3,10 @@
     <TargetFramework>netstandard2.0</TargetFramework>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="App.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="EventsPage.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="SpeakersPage.xaml">
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-      <SubType>Designer</SubType>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
+ <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj" />
     <ProjectReference Include="..\..\Xamarin.Forms.Pages\Xamarin.Forms.Pages.csproj" />
     <ProjectReference Include="..\..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj" />
     <ProjectReference Include="..\..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj" />
   </ItemGroup>
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 </Project>

--- a/Xamarin.Forms.Controls/Directory.Build.props
+++ b/Xamarin.Forms.Controls/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\.nuspec\Xamarin.Forms.props" />
+  <Import Project="..\Directory.Build.props" />
+</Project> 

--- a/Xamarin.Forms.Controls/Directory.Build.targets
+++ b/Xamarin.Forms.Controls/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
+  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+</Project>

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -5,8 +5,6 @@
   <PropertyGroup>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
-  <Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.props" />
-	<Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.targets" />
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>TRACE;DEBUG;PERF;APP</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
@@ -30,8 +28,6 @@
     <ProjectReference Include="..\Xamarin.Forms.Maps\Xamarin.Forms.Maps.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj" />
   </ItemGroup>
-  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 
   <ItemGroup>
     <EmbeddedResource Include="BuildNumber.txt" />

--- a/Xamarin.Forms.Sandbox/Directory.Build.props
+++ b/Xamarin.Forms.Sandbox/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\.nuspec\Xamarin.Forms.props" />
+  <Import Project="..\Directory.Build.props" />
+</Project> 

--- a/Xamarin.Forms.Sandbox/Directory.Build.targets
+++ b/Xamarin.Forms.Sandbox/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
+  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+</Project>

--- a/Xamarin.Forms.Sandbox/Xamarin.Forms.Sandbox.csproj
+++ b/Xamarin.Forms.Sandbox/Xamarin.Forms.Sandbox.csproj
@@ -6,8 +6,6 @@
   <PropertyGroup>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
-  <Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.props" />
-  <Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.targets" />
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
     <DebugType>pdbonly</DebugType>
@@ -22,7 +20,4 @@
     <ProjectReference Include="..\Xamarin.Forms.Maps\Xamarin.Forms.Maps.csproj" />
     <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj" />
   </ItemGroup>
-
-  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 </Project>

--- a/Xamarin.Forms.Xaml.UnitTests/Directory.Build.props
+++ b/Xamarin.Forms.Xaml.UnitTests/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\.nuspec\Xamarin.Forms.props" />
+  <Import Project="..\Directory.Build.props" />
+</Project> 

--- a/Xamarin.Forms.Xaml.UnitTests/Directory.Build.targets
+++ b/Xamarin.Forms.Xaml.UnitTests/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project>
+  <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
+  <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+</Project>

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/_Directory.Build.props
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/_Directory.Build.props
@@ -1,0 +1,4 @@
+﻿<Project>
+  <Import Project="..\..\..\..\..\..\.nuspec\Xamarin.Forms.props" />
+  <Import Project="..\..\..\..\..\..\Directory.Build.props" />
+</Project> 

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/_Directory.Build.targets
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/_Directory.Build.targets
@@ -1,0 +1,4 @@
+﻿<Project>
+  <Import Project="..\..\..\..\..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
+  <Import Project="..\..\..\..\..\..\.nuspec\Xamarin.Forms.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
+</Project>

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -3,12 +3,6 @@
     <TargetFramework>net47</TargetFramework>
     <RootNamespace>Xamarin.Forms.Xaml.UnitTests</RootNamespace>
     <AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
-  </PropertyGroup>
-	
-  <Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.props" />
-  <Import Project="..\.nuspec\Xamarin.Forms.DefaultItems.targets" />
-	
-  <PropertyGroup>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0672;0219;0414</NoWarn>
   </PropertyGroup>
@@ -18,12 +12,6 @@
     <ErrorReport>prompt</ErrorReport>
     <DebugType>full</DebugType>
     <DebugSymbols>true</DebugSymbols>
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-  </PropertyGroup>
-
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
   </PropertyGroup>
 
   <ItemGroup>
@@ -42,6 +30,4 @@
       <Link>BaseTestFixture.cs</Link>
     </Compile>
   </ItemGroup>
-  <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' == 'true' AND Exists('$(__XFBuildTasksLocation)Xamarin.Forms.Build.Tasks.dll')" />
-  <Import Project="..\.nuspec\Xamarin.Forms.Debug.targets" Condition="'$(BuildingInsideVisualStudio)' != 'true'" />
 </Project>


### PR DESCRIPTION
### Description of Change ###

Change internal project and tests so they use Directory.Build.props and targets, so the order of execution is as close as what the user experience with NuGet.

