### PR TITLE
Correctly constrain cell width on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalTemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalTemplatedCell.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var measure = VisualElementRenderer.Element.Measure(double.PositiveInfinity, 
 				ConstrainedDimension, MeasureFlags.IncludeMargins);
 
-			return new CGSize(measure.Request.Height, ConstrainedDimension);
+			return new CGSize(measure.Request.Width, ConstrainedDimension);
 		}
 
 		public override void ConstrainTo(CGSize constraint)


### PR DESCRIPTION
### Description of Change ###

Horizontal templated cell is constraining its width to the measured height instead of width. This change corrects that issue.

### Issues Resolved ### 

- fixes #6168

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
