### PR TITLE
[iOS] Fix missing partial columns in horizontal grid layout

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6077.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6077.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6077, "CollectionView (iOS) using horizontal grid does not display last column of uneven item count", PlatformAffected.iOS)]
+	public class Issue6077 : TestNavigationPage
+	{
+		public class MainViewModel : INotifyPropertyChanged
+		{
+			readonly IList<ItemModel> _items;
+			public ObservableCollection<ItemModel> Items { get; private set; }
+
+			public MainViewModel()
+			{
+				_items = new List<ItemModel>();
+				CreateItemsCollection();
+			}
+
+			void CreateItemsCollection()
+			{
+				_items.Add(new ItemModel
+				{
+					Title = "Item 1",
+				});
+				_items.Add(new ItemModel
+				{
+					Title = "Item 2",
+				});
+				_items.Add(new ItemModel
+				{
+					Title = "Item 3",
+				});
+
+				_items.Add(new ItemModel
+				{
+					Title = "Item 4",
+				});
+			
+				Items = new ObservableCollection<ItemModel>(_items);
+			}
+
+			protected bool SetProperty<T>(ref T backingStore, T value,
+				[CallerMemberName]string propertyName = "",
+				Action onChanged = null)
+			{
+				if (EqualityComparer<T>.Default.Equals(backingStore, value))
+					return false;
+
+				backingStore = value;
+				onChanged?.Invoke();
+				OnPropertyChanged(propertyName);
+				return true;
+			}
+
+			#region INotifyPropertyChanged
+			public event PropertyChangedEventHandler PropertyChanged;
+			protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+			{
+				var changed = PropertyChanged;
+				if (changed == null)
+					return;
+
+				changed.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+			#endregion
+		}
+
+		public class ItemModel
+		{
+			string _title;
+			public string Title
+			{
+				get { return _title; }
+				set { _title = value; }
+			}
+		}
+
+		ContentPage CreateRoot()
+		{
+			var page = new ContentPage { Title = "Issue6077" };
+
+			var cv = new CollectionView();
+
+			var itemsLayout = new GridItemsLayout(3, ItemsLayoutOrientation.Horizontal);
+
+			cv.ItemsLayout = itemsLayout;
+
+			var template = new DataTemplate(() => {
+				var grid = new Grid { };
+
+				grid.RowDefinitions = new RowDefinitionCollection { new RowDefinition { Height = new GridLength(100) } };
+				grid.ColumnDefinitions = new ColumnDefinitionCollection { new ColumnDefinition { Width = new GridLength(100) } };
+
+				var label = new Label { };
+
+				label.SetBinding(Label.TextProperty, new Binding("Title"));
+
+				var content = new ContentView { Content = label };
+
+				grid.Children.Add(content);
+
+				return grid;
+			});
+
+			cv.ItemTemplate = template;
+			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Items"));
+			page.Content = cv;
+			BindingContext = new MainViewModel();
+
+			return page;
+		}
+
+		protected override void Init()
+		{
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			PushAsync(CreateRoot());
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6077.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6077.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 6077, "CollectionView (iOS) using horizontal grid does not display last column of uneven item count", PlatformAffected.iOS)]
 	public class Issue6077 : TestNavigationPage
 	{
+		[Preserve(AllMembers = true)]
 		public class MainViewModel : INotifyPropertyChanged
 		{
 			readonly IList<ItemModel> _items;
@@ -73,6 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 			#endregion
 		}
 
+		[Preserve(AllMembers = true)]
 		public class ItemModel
 		{
 			public string Title { get; set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -964,6 +964,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5132.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5888.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6334.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6077.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
@@ -49,21 +49,24 @@ namespace Xamarin.Forms.Core.UITests
 		//	"ScrollToItemCode,HorizontalList", "ScrollToItemCode,VerticalList", "ScrollToItemCode,HorizontalGrid", "ScrollToItemCode,VerticalGrid",
 		//  }, 19, 3)]
 		//[TestCase("Snap Points", new string[] { "SnapPointsCode,HorizontalList", "SnapPointsCode,VerticalList", "SnapPointsCode,HorizontalGrid", "SnapPointsCode,VerticalGrid" }, 19, 2)]
-		[TestCase("Observable Collection", new string[] { "Add/RemoveItemsList", "Add/RemoveItemsGrid" }, 19, 6)]
-		[TestCase("Default Text", new string[] { "VerticalListCode", "HorizontalListCode", "VerticalGridCode", "HorizontalGridCode" }, 101, 11)]
-		[TestCase("DataTemplate", new string[] { "VerticalListCode", "HorizontalListCode", "VerticalGridCode", "HorizontalGridCode" }, 19, 6)]
-		public void VisitAndUpdateItemsSource(string collectionTestName, string[] subGalleries, int firstItem, int lastItem)
+		[TestCase("Observable Collection", "Add/RemoveItemsList", 19, 6)]
+		[TestCase("Observable Collection", "Add/RemoveItemsGrid", 19, 6)]
+
+		[TestCase("Default Text", "VerticalListCode", 101, 11)]
+		[TestCase("Default Text", "HorizontalListCode", 101, 11)]
+		[TestCase("Default Text", "VerticalGridCode", 101, 11)]
+		[TestCase("Default Text", "HorizontalGridCode", 101, 11)]
+
+		[TestCase("DataTemplate", "VerticalListCode", 19, 6)]
+		[TestCase("DataTemplate", "HorizontalListCode", 19, 6)]
+		[TestCase("DataTemplate", "VerticalGridCode", 19, 6)]
+		[TestCase("DataTemplate", "HorizontalGridCode", 19, 6)]
+		public void VisitAndUpdateItemsSource(string collectionTestName, string subGallery, int firstItem, int lastItem)
 		{
 			VisitInitialGallery(collectionTestName);
 
-			foreach (var gallery in subGalleries)
-			{
-				if (gallery == "FilterItems")
-					continue;
-
-				VisitSubGallery(gallery, !gallery.Contains("Horizontal"), $"Item: {firstItem}", $"Item: {lastItem}", lastItem - 1, true, false);
-				App.NavigateBack();
-			}
+			VisitSubGallery(subGallery, !subGallery.Contains("Horizontal"), $"Item: {firstItem}", $"Item: {lastItem}", lastItem - 1, true, false);
+			App.NavigateBack();
 		}
 
 		//[TestCase("ScrollTo", new string[] {

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -139,6 +139,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var itemCount = CollectionView.NumberOfItemsInSection(section);
 
+			if (itemCount < _itemsLayout.Span)
+			{
+				// If there is just one partial column, no problem; UICollectionViewFlowLayout gets it right
+			}
+
 			if (itemCount % _itemsLayout.Span == 0)
 			{
 				// All of the columns are full; the bug only occurs when we have a partial column

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using CoreGraphics;
 using Foundation;
 using UIKit;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -1,7 +1,6 @@
-﻿using System;
-using System.ComponentModel;
-using System.Diagnostics;
+﻿using System.ComponentModel;
 using CoreGraphics;
+using Foundation;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -43,7 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			ConstrainedDimension = (availableSpace - spacing) / _itemsLayout.Span;
 
-			// TODO hartez 2018/09/12 14:52:24 We need to truncate the decimal part of ConstrainedDimension
+			// We need to truncate the decimal part of ConstrainedDimension
 			// or we occasionally run into situations where the rows/columns don't fit	
 			// But this can run into situations where we have an extra gap because we're cutting off too much
 			// and we have a small gap; need to determine where the cut-off is that leads to layout dropping a whole row/column
@@ -57,6 +56,96 @@ namespace Xamarin.Forms.Platform.iOS
 
 			ConstrainedDimension = (int)ConstrainedDimension;
 			DetermineCellSize();
+		}
+
+		/* `CollectionViewContentSize` and `LayoutAttributesForElementsInRect` are overridden here to work around what 
+		 * appears to be a bug in the UICollectionViewFlowLayout implementation: for horizontally scrolling grid
+		 * layouts with auto-sized cells, trailing items which don't fill out a column are never displayed. 
+		 * For example, with a span of 3 and either 4 or 5 items, the resulting layout looks like
+		 *
+		 * 		Item1 
+		 * 		Item2
+		 * 		Item3
+		 * 
+		 * But with 6 items, it looks like
+		 * 
+		 * 		Item1 Item4
+		 * 		Item2 Item5
+		 * 		Item3 Item6
+		 * 
+		 * IOW, if there are not enough items to fill out the last column, the last column is ignored.
+		 * 
+		 * These overrides detect and correct that situation.	 
+		 */
+
+		public override CGSize CollectionViewContentSize
+		{
+			get
+			{
+				if (!NeedsPartialColumnAdjustment())
+				{
+					return base.CollectionViewContentSize;
+				}
+
+				var contentSize = base.CollectionViewContentSize;
+
+				// Add space for the missing column at the end
+				var correctedSize = new CGSize(contentSize.Width + EstimatedItemSize.Width, contentSize.Height);
+
+				return correctedSize;
+			}
+		}
+
+		public override UICollectionViewLayoutAttributes[] LayoutAttributesForElementsInRect(CGRect rect)
+		{
+			if (!NeedsPartialColumnAdjustment())
+			{ 
+				return base.LayoutAttributesForElementsInRect(rect);
+			}
+
+			// When we implement Groups, we'll have to iterate over all of them to adjust and this will
+			// be a lot more complicated. But until then, we only have to worry about section 0
+			int section = 0;
+
+			var fullColumns = base.LayoutAttributesForElementsInRect(rect);
+
+			var itemCount = CollectionView.NumberOfItemsInSection(section);
+			var missingCellCount = itemCount % _itemsLayout.Span;
+
+			UICollectionViewLayoutAttributes[] allCells = new UICollectionViewLayoutAttributes[fullColumns.Length + missingCellCount];
+			fullColumns.CopyTo(allCells, 0);
+
+			for (int n = fullColumns.Length; n < allCells.Length; n++)
+			{
+				allCells[n] = LayoutAttributesForItem(NSIndexPath.FromItemSection(n, section));
+			}
+
+			return allCells;
+		}
+
+		bool NeedsPartialColumnAdjustment(int section = 0)
+		{
+			if (ScrollDirection == UICollectionViewScrollDirection.Vertical)
+			{
+				// The bug only occurs with Horizontal scrolling
+				return false; 
+			}
+
+			if (EstimatedItemSize.IsEmpty)
+			{
+				// The bug only occurs when using Autolayout; with a set ItemSize, we don't have to worry about it
+				return false;
+			}
+
+			var itemCount = CollectionView.NumberOfItemsInSection(section);
+
+			if (itemCount % _itemsLayout.Span == 0)
+			{
+				// All of the columns are full; the bug only occurs when we have a partial column
+				return false;
+			}
+
+			return true;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -142,6 +142,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (itemCount < _itemsLayout.Span)
 			{
 				// If there is just one partial column, no problem; UICollectionViewFlowLayout gets it right
+				return false;
 			}
 
 			if (itemCount % _itemsLayout.Span == 0)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -110,6 +110,12 @@ namespace Xamarin.Forms.Platform.iOS
 			var fullColumns = base.LayoutAttributesForElementsInRect(rect);
 
 			var itemCount = CollectionView.NumberOfItemsInSection(section);
+
+			if (fullColumns.Length == itemCount)
+			{
+				return fullColumns;
+			}
+
 			var missingCellCount = itemCount % _itemsLayout.Span;
 
 			UICollectionViewLayoutAttributes[] allCells = new UICollectionViewLayoutAttributes[fullColumns.Length + missingCellCount];

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -27,6 +27,15 @@ namespace Xamarin.Forms.Platform.iOS
 				: UICollectionViewScrollDirection.Vertical;
 
 			Initialize(scrollDirection);
+
+			if (Forms.IsiOS11OrNewer)
+			{
+				// `ContentInset` is actually the default value, but I'm leaving this here as a note to
+				// future maintainers; it's likely that someone will want a Platform Specific to change this behavior
+				// (Setting it to `SafeArea` lets you do the thing where the header/footer of your UICollectionView
+				// fills the screen width in landscape while your items are automatically shifted to avoid the notch)
+				SectionInsetReference = UICollectionViewFlowLayoutSectionInsetReference.ContentInset;
+			}
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -85,6 +85,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UpdateLayout();
 			ItemsViewController = CreateController(newElement, _layout);
+			 
+			if (Forms.IsiOS11OrNewer)
+			{
+				// We set this property to keep iOS from trying to be helpful about insetting all the 
+				// CollectionView content when we're in landscape mode (to avoid the notch)
+				// The SetUseSafeArea Platform Specific is already taking care of this for us 
+				// That said, at some point it's possible folks will want a PS for controlling this behavior
+				ItemsViewController.CollectionView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
+			}
+
 			SetNativeControl(ItemsViewController.View);
 			ItemsViewController.CollectionView.BackgroundColor = UIColor.Clear;
 			ItemsViewController.UpdateEmptyView();


### PR DESCRIPTION
### Description of Change ###

These changes work around a UICollectionViewFlowLayout issue where horizontally-scrolling grid layouts do not display the last column if it is only partial. 

These changes also fix an issue where the CollectionView does not respect the Page's safe area settings on iOS 11+ (which had a side-effect of incorrectly laying out columns in landscape mode).

### Issues Resolved ### 

- fixes #6077

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Issue 6077 in Control Gallery (automated).

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Boxes checked