### PR TITLE
[Android] Remove call to update Image on button during measure

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6260.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6260.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6260, "[Android] infinite layout loop",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Button)]
+#endif
+	public class Issue6260 : TestContentPage
+	{
+		const string text = "If this number keeps increasing test has failed: ";
+		static string success = text + "0";
+
+		protected override void Init()
+		{
+			int measurecount = 0;
+
+			var button = new Button()
+			{
+				Text = "Click me",
+				BackgroundColor = Color.Green,
+				
+			};
+
+			var label = new Label()
+			{
+				Text = success
+			};
+
+			this.Appearing += (_, __) =>
+			{
+				button.ImageSource = "coffee.png";
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					button.MeasureInvalidated += (___, ____) =>
+					{
+						measurecount++;
+						label.Text = text + measurecount.ToString();
+					};
+				});
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "Welcome to Xamarin.Forms!",
+						HorizontalOptions = LayoutOptions.Center,
+						VerticalOptions = LayoutOptions.CenterAndExpand
+					},
+					new Entry(),
+					button,
+					label
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void ButtonImageInfiniteLayout()
+		{
+			RunningApp.WaitForElement(success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6260.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4992.xaml.cs">

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -180,12 +180,6 @@ namespace Xamarin.Forms.Material.Android
 			base.OnLayout(changed, left, top, right, bottom);
 		}
 
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			_buttonLayoutManager?.Update();
-			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-		}
-
 		void UpdateFont()
 		{
 			if (_disposed || Element == null)
@@ -334,7 +328,6 @@ namespace Xamarin.Forms.Material.Android
 
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			_buttonLayoutManager?.Update();
 			Measure(widthConstraint, heightConstraint);
 			return new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), new Size());
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -52,11 +52,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void AView.IOnAttachStateChangeListener.OnViewDetachedFromWindow(AView detachedView) =>
 			_buttonLayoutManager?.OnViewDetachedFromWindow(detachedView);
 
-		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
-		{
-			return base.GetDesiredSize(widthConstraint, heightConstraint);
-		}
-
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
 		{
 			_buttonLayoutManager?.OnLayout(changed, l, t, r, b);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -241,12 +241,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			base.OnLayout(changed, l, t, r, b);
 		}
 
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			_buttonLayoutManager?.Update();
-			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-		}
-
 		void SetTracker(VisualElementTracker tracker)
 		{
 			_tracker = tracker;


### PR DESCRIPTION
### Description of Change ###
The invalidate measure call when used with fastrenderers was causing a ping pong effect when loading images

- image loaded
- invalidate measure
- image.updateimage
- image loaded
- invalidate measure
- image.updateimage

### Issues Resolved ### 
- fixes #6260 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- UI test included
- any additional testing you want to do with button and setting the image and nulling it and just trying to break the layout would be helpful.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
