### PR TITLE
[Android] Pass correct measurement values to item content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
@@ -28,36 +28,39 @@ namespace Xamarin.Forms.Controls.Issues
 			PushAsync(CreateRoot());
 		}
 
-		private Page CreateRoot()
+		Frame CreateFrame()
+		{
+			var frame = new Frame() { CornerRadius = 10, BackgroundColor = Color.SeaGreen };
+
+			var flexLayout = new FlexLayout()
+			{
+				Direction = FlexDirection.Row,
+				JustifyContent = FlexJustify.SpaceBetween,
+				AlignItems = FlexAlignItems.Stretch
+			};
+
+			var label1 = new Label { Text = "First Label", AutomationId = Target, HeightRequest = 100 };
+			var label2 = new Label { Text = "Second Label" };
+
+			flexLayout.Children.Add(label1);
+			flexLayout.Children.Add(label2);
+
+			frame.Content = flexLayout;
+
+			return frame;
+		}
+
+		Page CreateRoot()
 		{
 			var page = new ContentPage() { Title = "Issue5765" };
 
 			var cv = new CollectionView();
 
 			cv.ItemTemplate = new DataTemplate(() => {
-
-				var frame = new Frame() { CornerRadius = 10 };
-
-				var flexLayout = new FlexLayout()
-				{
-					Direction = FlexDirection.Row,
-					JustifyContent = FlexJustify.SpaceBetween,
-					AlignItems = FlexAlignItems.Stretch
-				};
-
-				var label1 = new Label { Text = "First Label", AutomationId = Target };
-				var label2 = new Label { Text = "Second Label" };
-
-				flexLayout.Children.Add(label1);
-				flexLayout.Children.Add(label2);
-
-				frame.Content = flexLayout;
-
-				return frame;
-
+				return CreateFrame();	
 			});
 
-			cv.ItemsSource = new List<string> { "one", "two" };
+			cv.ItemsSource = new List<string> { "one", "two", "three" };
 
 			page.Content = cv;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void LabelsInFramesShouldBeVisible()
+		public void FlexLayoutsInFramesShouldSizeCorrectly()
 		{
 			// If the first label is visible at all, then this has succeeded
 			RunningApp.WaitForElement(Target);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5765, "[Frame, CollectionView, Android]The Label.Text is invisible on Android if DataTemplate have frame as layout",
+		PlatformAffected.Android)]
+	class Issue5765 : TestNavigationPage
+	{
+		const string Target = "FirstLabel";
+
+		protected override void Init()
+		{
+			FlagTestHelpers.SetCollectionViewTestFlag();
+
+			PushAsync(CreateRoot());
+		}
+
+		private Page CreateRoot()
+		{
+			var page = new ContentPage() { Title = "Issue5765" };
+
+			var cv = new CollectionView();
+
+			cv.ItemTemplate = new DataTemplate(() => {
+
+				var frame = new Frame() { CornerRadius = 10 };
+
+				var flexLayout = new FlexLayout()
+				{
+					Direction = FlexDirection.Row,
+					JustifyContent = FlexJustify.SpaceBetween,
+					AlignItems = FlexAlignItems.Stretch
+				};
+
+				var label1 = new Label { Text = "First Label", AutomationId = Target };
+				var label2 = new Label { Text = "Second Label" };
+
+				flexLayout.Children.Add(label1);
+				flexLayout.Children.Add(label2);
+
+				frame.Content = flexLayout;
+
+				return frame;
+
+			});
+
+			cv.ItemsSource = new List<string> { "one", "two" };
+
+			page.Content = cv;
+
+			return page;
+		}
+
+#if UITEST
+		[Test]
+		public void LabelsInFramesShouldBeVisible()
+		{
+			// If the first label is visible at all, then this has succeeded
+			RunningApp.WaitForElement(Target);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -20,7 +20,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundMultiSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundSingleSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5765.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4992.xaml.cs">
       <DependentUpon>Issue4992.xaml</DependentUpon>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,6 +19,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundMultiSelection.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundSingleSelection.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5765.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4992.xaml.cs">
       <DependentUpon>Issue4992.xaml</DependentUpon>
@@ -483,7 +485,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue5949_2.xaml.cs">
-      <DependentUpon>Issue5949_2.xaml</DependentUpon>      
+      <DependentUpon>Issue5949_2.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue5793.cs" />

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
@@ -66,6 +66,16 @@ namespace Xamarin.Forms.Platform.Android
 			var width = Context.FromPixels(pixelWidth);
 			var height = Context.FromPixels(pixelHeight);
 
+			if (height == 0 && MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified)
+			{
+				height = double.PositiveInfinity;
+			}
+
+			if (width == 0 && MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified)
+			{
+				width = double.PositiveInfinity;
+			}
+
 			SizeRequest measure = Content.Element.Measure(width, height, MeasureFlags.IncludeMargins);
 
 			// When we implement ItemSizingStrategy.MeasureFirstItem for Android, these next two clauses will need to

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
@@ -29,12 +29,12 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				Content.Element.MeasureInvalidated -= ElementMeasureInvalidated;
 			}
-			
-			if(Content?.View != null)
+
+			if (Content?.View != null)
 			{
 				RemoveView(Content.View);
 			}
-			
+
 			Content = null;
 		}
 
@@ -63,18 +63,13 @@ namespace Xamarin.Forms.Platform.Android
 			int pixelWidth = MeasureSpec.GetSize(widthMeasureSpec);
 			int pixelHeight = MeasureSpec.GetSize(heightMeasureSpec);
 
-			var width = Context.FromPixels(pixelWidth);
-			var height = Context.FromPixels(pixelHeight);
+			var width = MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified
+				? double.PositiveInfinity
+				: Context.FromPixels(pixelWidth);
 
-			if (height == 0 && MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified)
-			{
-				height = double.PositiveInfinity;
-			}
-
-			if (width == 0 && MeasureSpec.GetMode(widthMeasureSpec) == MeasureSpecMode.Unspecified)
-			{
-				width = double.PositiveInfinity;
-			}
+			var height = MeasureSpec.GetMode(heightMeasureSpec) == MeasureSpecMode.Unspecified
+				? double.PositiveInfinity
+				: Context.FromPixels(pixelHeight);
 
 			SizeRequest measure = Content.Element.Measure(width, height, MeasureFlags.IncludeMargins);
 


### PR DESCRIPTION
### Description of Change ###

ItemContentView was not respecting MeasureSpecMode.Unspecified in the unconstrained direction, which caused FlexLayouts to always get a size of zero in that direction. These changes allow FlexLayout to measure correctly.

### Issues Resolved ### 

- fixes #5765
- fixes #5782

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Xs placed between square brackets
