### PR TITLE
[Android] rollback IButtonLayoutRenderer  to match 3.6

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -361,6 +361,14 @@ namespace Xamarin.Forms.Material.Android
 
 		// IButtonLayoutRenderer
 		AppCompatButton IButtonLayoutRenderer.View => this;
+
+		Button IButtonLayoutRenderer.Element => this.Element;
+
+		event EventHandler<VisualElementChangedEventArgs> IButtonLayoutRenderer.ElementChanged
+		{
+			add => ((IVisualElementRenderer)this).ElementChanged += value;
+			remove => ((IVisualElementRenderer)this).ElementChanged -= value;
+		}
 	}
 }
 #endif

--- a/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ButtonRenderer.cs
@@ -201,6 +201,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			remove => ((IVisualElementRenderer)this).ElementChanged -= value;
 		}
 
+		event EventHandler<VisualElementChangedEventArgs> IButtonLayoutRenderer.ElementChanged
+		{
+			add => ((IVisualElementRenderer)this).ElementChanged += value;
+			remove => ((IVisualElementRenderer)this).ElementChanged -= value;
+		}
+
 		AppCompatButton IButtonLayoutRenderer.View => Control;
 		bool IDisposedState.IsDisposed => _isDisposed;
 	}

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -288,31 +288,34 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 				}
 
-			_renderer.ApplyDrawableAsync(Button.ImageSourceProperty, Context, image =>
+			if (_renderer is IVisualElementRenderer visualElementRenderer)
 			{
-				if (image == existingImage)
-					return;
-
-				switch (layout.Position)
+				visualElementRenderer.ApplyDrawableAsync(Button.ImageSourceProperty, Context, image =>
 				{
-					case Button.ButtonContentLayout.ImagePosition.Top:
-						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, image, null, null);
-						break;
-					case Button.ButtonContentLayout.ImagePosition.Right:
-						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, null, image, null);
-						break;
-					case Button.ButtonContentLayout.ImagePosition.Bottom:
-						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, null, null, image);
-						break;
-					default:
+					if (image == existingImage)
+						return;
+
+					switch (layout.Position)
+					{
+						case Button.ButtonContentLayout.ImagePosition.Top:
+							TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, image, null, null);
+							break;
+						case Button.ButtonContentLayout.ImagePosition.Right:
+							TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, null, image, null);
+							break;
+						case Button.ButtonContentLayout.ImagePosition.Bottom:
+							TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, null, null, image);
+							break;
+						default:
 						// Defaults to image on the left
 						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, image, null, null, null);
-						break;
-				}
+							break;
+					}
 
-				if (_hasLayoutOccurred)
-					_element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
-			});
+					if (_hasLayoutOccurred)
+						_element?.InvalidateMeasureNonVirtual(InvalidationTrigger.MeasureChanged);
+				});
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -351,5 +351,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		}
 
 		AppCompatButton IButtonLayoutRenderer.View => this;
+
+		Button IButtonLayoutRenderer.Element => this.Element;
 	}
 }

--- a/Xamarin.Forms.Platform.Android/IButtonLayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/IButtonLayoutRenderer.cs
@@ -1,9 +1,12 @@
-﻿using Android.Support.V7.Widget;
+﻿using System;
+using Android.Support.V7.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public interface IButtonLayoutRenderer : IVisualElementRenderer
+	public interface IButtonLayoutRenderer
 	{
-		new AppCompatButton View { get; }
+		AppCompatButton View { get; }		
+		Button Element { get; }
+		event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This returns IButtonLayoutRenderer  to how it was defined in 3.6 so that it doesn't introduce ABI breaks for 4.0 

### Platforms Affected ### 
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
