### PR TITLE
MacOS: Allow third party libs to display animated images correctly

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
@@ -83,7 +83,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			await ImageElementManager.SetImage(this, Element, oldElement).ConfigureAwait(false);
 		}
 
-		void IImageVisualElementRenderer.SetImage(NSImage image) => Control.Image = image;
+		void IImageVisualElementRenderer.SetImage(NSImage image)
+		{
+			Control.Image = image;
+			Control.Animates = image != null && image.Representations().Length > 1;
+		}
 
 		bool IImageVisualElementRenderer.IsDisposed => _isDisposed;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
@@ -115,11 +115,17 @@ namespace Xamarin.Forms.Platform.MacOS
 			var imageController = imageElement as IImageController;
 
 			var source = imageElement.Source;
-		
+#if __MOBILE__
 			if (Control.Image?.Images != null && Control.Image.Images.Length > 1)
 			{
 				renderer.SetImage(null);
 			} 
+#else
+			if (Control.Image != null && Control.Image.Representations().Length > 1)
+			{
+				renderer.SetImage(null);
+			}
+#endif
 			else if (oldElement != null)
 			{
 				var oldSource = oldElement.Source;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
@@ -116,13 +116,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var source = imageElement.Source;
 		
-#if __MOBILE__
 			if (Control.Image?.Images != null && Control.Image.Images.Length > 1)
 			{
 				renderer.SetImage(null);
-			} else
-#endif
-			if (oldElement != null)
+			} 
+			else if (oldElement != null)
 			{
 				var oldSource = oldElement.Source;
 				if (Equals(oldSource, source))


### PR DESCRIPTION
### Description of Change ###

Similar to iOS fix: https://github.com/xamarin/Xamarin.Forms/pull/6153
Same sample applies: https://github.com/daniel-luberda/XF-PR6153

Background: Third party libs can now be used with `Image` view (after registering `IImageSourceHandler`)

This change won't affect standard image loading. It'll allow third party libs like FFImageLoading to display animated images correctly.

### API Changes ###

None

### Platforms Affected ### 

- MacOS