### PR TITLE
[Tizen] Add TFM identifier and version explicitly for vs2019 16.1

### DIFF
--- a/EmbeddingTestBeds/Embedding.Tizen/Embedding.Tizen.csproj
+++ b/EmbeddingTestBeds/Embedding.Tizen/Embedding.Tizen.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/PagesGallery/PagesGallery.Tizen/PagesGallery.Tizen.csproj
+++ b/PagesGallery/PagesGallery.Tizen/PagesGallery.Tizen.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
 

--- a/Stubs/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen (Forwarders).csproj
@@ -2,6 +2,8 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <AssemblyName>Xamarin.Forms.Platform</AssemblyName>
     <DefineConstants>TIZEN4_0</DefineConstants>
     <OutputType>Library</OutputType>

--- a/Xamarin.Forms.ControlGallery.Tizen/Xamarin.Forms.ControlGallery.Tizen.csproj
+++ b/Xamarin.Forms.ControlGallery.Tizen/Xamarin.Forms.ControlGallery.Tizen.csproj
@@ -3,6 +3,8 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Xamarin.Forms.Maps.Tizen/Xamarin.Forms.Maps.Tizen.csproj
+++ b/Xamarin.Forms.Maps.Tizen/Xamarin.Forms.Maps.Tizen.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Xamarin.Forms.Material.Tizen/Xamarin.Forms.Material.Tizen.csproj
+++ b/Xamarin.Forms.Material.Tizen/Xamarin.Forms.Material.Tizen.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <RootNamespace>Xamarin.Forms.Material.Tizen</RootNamespace>
     <AssemblyName>Xamarin.Forms.Material</AssemblyName>

--- a/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
+++ b/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
@@ -4,6 +4,8 @@
   </PropertyGroup>
   <PropertyGroup>
     <TargetFramework>tizen40</TargetFramework>
+    <TargetFrameworkIdentifier>Tizen</TargetFrameworkIdentifier>
+    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###
Specify the `<TargetFramworkIdentifier>` and `<TargetFrameworkVersion>` to all tizen projects (`*.csproj`) explicitly. This is for resolving the issue occurred in vs2019 `16.1`.

### Issues Resolved ### 
Since VS2019 16.1 version, visual studio ran into an unexpected problem with Tizen projects as shown below. 
![vs2019_error](https://user-images.githubusercontent.com/1029134/58339258-24d17380-7e84-11e9-8e9d-ace7a5cb3131.png)

### API Changes ###
None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None


### Testing Procedure ###
Just open the solution (`Xamarin.Forms.sln`) on VS2019 `16.1`. It is OK if you can't see any error messages of tizen projects.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
