### PR TITLE
Check for correct API version

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			if (Forms.IsLollipopOrNewer)
+			if (Forms.IsMarshmallowOrNewer)
 			{
 				// We're looking for the foreground ripple effect, which is not available on older APIs
 				_selectableItemDrawable = GetSelectableItemDrawable();


### PR DESCRIPTION
### Description of Change ###

The check for being able to set the Ripple effect on the selection is looking at the wrong API level. While RippleDrawable was added in 21 (Lollipop), the `setForeground` method wasn't added until 23 (Marshmallow).

Automated tests missed it because we test 19 and then skip to 25, this is an issue specifically on 21 & 22.

### Issues Resolved ### 

- fixes #5693 (for real this time)

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

On a Lollipop device, Control Gallery -> Selection Galleries -> Selection Mode, Select "Single" and select an item.

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
