### PR TITLE
[Tests]Update to Xamarin.UITest 3.0 and NUnit 3.0

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -349,7 +349,7 @@
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.Insights" Version="1.12.3" />
     <PackageReference Include="Xamarin.iOS.MaterialComponents" Version="72.2.0.1" />
-    <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.21.7" />
+    <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.21.8" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35736.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla35736.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST && __IOS__
 		[Test]
 		[Category(UITestCategories.ManualReview)]
-		[Ignore]
+		[Ignore("Fails sometimes")]
 		public void Bugzilla35736Test() 
 		{
 			RunningApp.WaitForElement(q => q.Marked("Bugzilla35736Editor"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -236,9 +236,7 @@ namespace Xamarin.Forms.Controls
 
 		public void SwipeRight()
 		{
-#pragma warning disable 618
-			_app.SwipeRight();
-#pragma warning restore 618
+			SwipeLeftToRight();
 		}
 
 		public void SwipeLeftToRight(double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)
@@ -253,9 +251,7 @@ namespace Xamarin.Forms.Controls
 
 		public void SwipeLeft()
 		{
-#pragma warning disable 618
-			_app.SwipeLeft();
-#pragma warning restore 618
+			SwipeRightToLeft();
 		}
 
 		public void SwipeRightToLeft(double swipePercentage = 0.67, int swipeSpeed = 500, bool withInertia = true)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -696,7 +696,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[SetUpFixture]
 	public class IssuesSetup
 	{
-		[SetUp]
+		[OneTimeSetUp]
 		public void RunBeforeAnyTests()
 		{
 			AppSetup.RunningApp = AppSetup.Setup(null);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1247,7 +1247,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5801.xaml">
       <SubType>Designer</SubType>

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -51,7 +51,7 @@
       <Version>2.1.1</Version>
     </PackageReference>
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="2.2.7" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseViewContainerRemoteAndroid.cs" />

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -46,12 +46,12 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="NUnitTestAdapter">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.13.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseViewContainerRemoteAndroid.cs" />
@@ -87,7 +87,7 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="_CopyXamarinUITestFiles" AfterTargets="Build">
     <ItemGroup>
-      <_XamarinUITestFiles Include="$(NuGetPackageRoot)Xamarin.UITest\%(Version)\**" Condition="@(PackageReference -> '%(Identity)') == 'Xamarin.UITest'" InProject="False" />
+      <_XamarinUITestFiles Include="$(NuGetPackageRoot)Xamarin.UITest\%(Version)\**" Condition="@(PackageReference -&gt; '%(Identity)') == 'Xamarin.UITest'" InProject="False" />
     </ItemGroup>
     <Copy SourceFiles="@(_XamarinUITestFiles)" DestinationFolder="$(SolutionDir)packages\Xamarin.UITest.AnyVersion\%(RecursiveDir)" ContinueOnError="true" Retries="0" />
   </Target>

--- a/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		public static AppRect ScreenBounds { get; set; }
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		protected virtual void FixtureTeardown()
 		{
 		}
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Core.UITests
 		[SetUp]
 		protected virtual void TestSetup()
 		{
-			EnsureMemory();
+			//EnsureMemory();
 		}
 
 		[TearDown]
@@ -55,9 +55,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		protected abstract void NavigateToGallery();
 
-#pragma warning disable 618
-		[TestFixtureSetUp]
-#pragma warning restore 618
+		[OneTimeSetUp]
 		protected virtual void FixtureSetup()
 		{
 			ResetApp();
@@ -111,7 +109,6 @@ namespace Xamarin.Forms.Core.UITests
 		}
 	}
 }
-
 #if UITEST
 
 namespace Xamarin.Forms.Core.UITests
@@ -121,7 +118,7 @@ namespace Xamarin.Forms.Core.UITests
 	[SetUpFixture]
 	public class CoreUITestsSetup
 	{
-		[SetUp]
+		[OneTimeSetUp]
 		public void RunBeforeAnyTests()
 		{
 			LaunchApp();

--- a/Xamarin.Forms.Core.UnitTests/AnimationTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AnimationTests.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Core.UnitTests
 	{
 		[Test]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=51424
-		public async void AnimationRepeats()
+		public async Task AnimationRepeats()
 		{
 			var box = new BoxView();
 			Assume.That(box.Rotation, Is.EqualTo(0d));

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -1588,7 +1588,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => bindable.SetBinding (MockBindable.TextProperty, new Binding ("Text2")), Throws.Nothing);
 			Assert.That (bindable.Text, Is.EqualTo (MockBindable.TextProperty.DefaultValue));
 			Assert.That (log.Messages.Count, Is.EqualTo (1), "An error was not logged");
-			Assert.That (log.Messages[0], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[0], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"Text2",
 				"Xamarin.Forms.Core.UnitTests.BindingUnitTests+DifferentViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",
@@ -1607,7 +1607,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (bindable.Text, Is.EqualTo ("Foo"));
 
 			Assert.That (log.Messages.Count, Is.Not.GreaterThan (1), "Too many errors were logged");
-			Assert.That (log.Messages[0], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[0], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"Text",
 				"Xamarin.Forms.Core.UnitTests.BindingUnitTests+EmptyViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",
@@ -1621,7 +1621,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => bindable.SetBinding (MockBindable.TextProperty, new Binding ("Text")), Throws.Nothing);
 
 			Assert.That (log.Messages.Count, Is.EqualTo (1), "An error was not logged");
-			Assert.That (log.Messages[0], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[0], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"Text",
 				"Xamarin.Forms.Core.UnitTests.BindingUnitTests+DifferentViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",
@@ -1637,7 +1637,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => bindable.SetBinding (MockBindable.TextProperty, new Binding ("PrivateSetter")), Throws.Nothing);
 
 			Assert.That (log.Messages.Count, Is.EqualTo (1), "An error was not logged");
-			Assert.That (log.Messages[0], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[0], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"PrivateSetter",
 				"Xamarin.Forms.Core.UnitTests.BindingUnitTests+DifferentViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",
@@ -1646,7 +1646,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => bindable.SetValueCore (MockBindable.TextProperty, "foo"), Throws.Nothing);
 
 			Assert.That (log.Messages.Count, Is.EqualTo (2), "An error was not logged");
-			Assert.That (log.Messages[1], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[1], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"PrivateSetter",
 				"Xamarin.Forms.Core.UnitTests.BindingUnitTests+DifferentViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",
@@ -1660,7 +1660,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => bindable.SetBinding (MockBindable.TextProperty, new Binding ("MissingProperty")), Throws.Nothing);
 
 			Assert.That (log.Messages.Count, Is.EqualTo (1), "An error was not logged");
-			Assert.That (log.Messages[0], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[0], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"MissingProperty",
 				"Xamarin.Forms.Core.UnitTests.MockViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",
@@ -1688,7 +1688,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => bindable.SetBinding (MockBindable.TextProperty, new Binding ("Model.MissingProperty")), Throws.Nothing);
 
 			Assert.That (log.Messages.Count, Is.EqualTo (1), "An error was not logged");
-			Assert.That (log.Messages[0], Is.StringContaining (String.Format (BindingExpression.PropertyNotFoundErrorMessage,
+			Assert.That (log.Messages[0], Does.Contain(String.Format (BindingExpression.PropertyNotFoundErrorMessage,
 				"MissingProperty",
 				"Xamarin.Forms.Core.UnitTests.BindingBaseUnitTests+ComplexMockViewModel",
 				"Xamarin.Forms.Core.UnitTests.MockBindable",

--- a/Xamarin.Forms.Core.UnitTests/CellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CellTests.cs
@@ -1,5 +1,6 @@
 using NUnit.Framework;
 using System;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -153,7 +154,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void ForceUpdateSizeCallsAreRateLimited()
+		public async Task ForceUpdateSizeCallsAreRateLimited()
 		{
 			var lv = new ListView { HasUnevenRows = true };
 			var cell = new ViewCell { Parent = lv };
@@ -172,7 +173,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void ForceUpdateSizeWillNotBeCalledIfParentIsNotAListViewWithUnevenRows ()
+		public async Task ForceUpdateSizeWillNotBeCalledIfParentIsNotAListViewWithUnevenRows ()
 		{
 			var lv = new ListView { HasUnevenRows = false };
 			var cell = new ViewCell { Parent = lv };

--- a/Xamarin.Forms.Core.UnitTests/GeocoderUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GeocoderUnitTests.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Core.UnitTests
 	public class GeocoderUnitTests : BaseTestFixture
 	{
 		[Test]
-		public async void AddressesForPosition ()
+		public async Task AddressesForPosition ()
 		{
 			Geocoder.GetAddressesForPositionFuncAsync = GetAddressesForPositionFuncAsync;
 			var geocoder = new Geocoder ();
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void PositionsForAddress () {
+		public async Task PositionsForAddress () {
 			Geocoder.GetPositionsForAddressAsyncFunc = GetPositionsForAddressAsyncFunc	;
 			var geocoder = new Geocoder ();
 			var result = await geocoder.GetPositionsForAddressAsync ("quux");

--- a/Xamarin.Forms.Core.UnitTests/MotionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MotionTests.cs
@@ -61,14 +61,14 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class MotionTests : BaseTestFixture
 	{
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void Init ()
 		{
 			Device.PlatformServices = new MockPlatformServices ();
 			Ticker.Default = new BlockingTicker ();
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void End ()
 		{
 			Device.PlatformServices = null;
@@ -154,14 +154,14 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class TickerSystemEnabledTests
 	{
-		[TestFixtureSetUp]
+		[OneTimeSetUp]
 		public void Init ()
 		{
 			Device.PlatformServices = new MockPlatformServices ();
 			Ticker.Default = new AsyncTicker(); 
 		}
 
-		[TestFixtureTearDown]
+		[OneTimeTearDown]
 		public void End ()
 		{
 			Device.PlatformServices = null;

--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -441,7 +441,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void HandlesPopToRoot ()
+		public async Task HandlesPopToRoot ()
 		{
 			var root = new ContentPage { Title = "Root" };
 			var navPage = new NavigationPage (root);
@@ -489,7 +489,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void NavigatesBackWhenBackButtonPressed ()
+		public async Task NavigatesBackWhenBackButtonPressed ()
 		{
 			var root = new ContentPage { Title = "Root" };
 			var navPage = new NavigationPage (root);
@@ -503,7 +503,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void DoesNotNavigatesBackWhenBackButtonPressedIfHandled ()
+		public async Task DoesNotNavigatesBackWhenBackButtonPressedIfHandled ()
 		{
 			var root = new BackButtonPage { Title = "Root" };
 			var second = new BackButtonPage () {Handle = true};
@@ -562,7 +562,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async void TestRemovePage()
+		public async Task TestRemovePage()
 		{
 			var root = new ContentPage { Title = "Root" };
 			var newPage = new ContentPage();

--- a/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ResourceDictionaryTests.cs
@@ -261,7 +261,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var rd = new ResourceDictionary();
 			rd.Add("foo", "bar");
 			var ex = Assert.Throws<KeyNotFoundException>(() => { var foo = rd ["test_invalid_key"]; });
-			Assert.That(ex.Message, Is.StringContaining("test_invalid_key"));
+			Assert.That(ex.Message, Does.Contain("test_invalid_key"));
 		}
 
 		class MyRD : ResourceDictionary

--- a/Xamarin.Forms.Core.UnitTests/StyleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleTests.cs
@@ -411,7 +411,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		[Test]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=31207
-		public async void StyleDontHoldStrongReferences ()
+		public async Task StyleDontHoldStrongReferences ()
 		{
 			var style = new Style (typeof(Label));
 			var label = new Label ();

--- a/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
@@ -1490,7 +1490,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		[Ignore]
+		[Ignore("SpeedTestApply")]
 		public void SpeedTestApply()
 		{
 			
@@ -1560,7 +1560,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		[Ignore]
+		[Ignore("SpeedTestSetBC")]
 		public void SpeedTestSetBC()
 		{
 			var property = BindableProperty.Create("Foo", typeof(string), typeof(MockBindable));

--- a/Xamarin.Forms.Core.UnitTests/UriImageSourceTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/UriImageSourceTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		[Ignore]
+		[Ignore("LoadImageFromStream")]
 		public void LoadImageFromStream ()
 		{
 			var loader = new UriImageSource { 
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		[Ignore]
+		[Ignore("SecondCallLoadFromCache")]
 		public void SecondCallLoadFromCache ()
 		{
 			var loader = new UriImageSource { 
@@ -80,7 +80,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		[Ignore]
+		[Ignore("DoNotKeepFailedRetrieveInCache")]
 		public void DoNotKeepFailedRetrieveInCache ()
 		{
 			var loader = new UriImageSource { 
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		[Ignore]
+		[Ignore("ConcurrentCallsOnSameUriAreQueued")]
 		public void ConcurrentCallsOnSameUriAreQueued ()
 		{
 			var loader = new UriImageSource { 

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -45,8 +45,10 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="NUnitTestAdapter" Version="2.1.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.13.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
@@ -242,8 +244,8 @@
   </ItemGroup>
   <Target Name="_CopyNUnitTestAdapterFiles" AfterTargets="Build">
     <ItemGroup>
-      <_NUnitTestAdapterFiles Include="$(NuGetPackageRoot)NUnitTestAdapter\%(Version)\**" Condition="@(PackageReference -> '%(Identity)') == 'NUnitTestAdapter'" InProject="False" />
+      <_NUnitTestAdapterFiles Include="$(NuGetPackageRoot)NUnit3TestAdapter\%(Version)\build\net35\**" Condition="@(PackageReference -> '%(Identity)') == 'NUnit3TestAdapter'" InProject="False" />
     </ItemGroup>
-    <Copy SourceFiles="@(_NUnitTestAdapterFiles)" DestinationFolder="$(SolutionDir)packages\NUnitTestAdapter.AnyVersion\%(RecursiveDir)" ContinueOnError="true" Retries="0" />
+    <Copy SourceFiles="@(_NUnitTestAdapterFiles)" DestinationFolder="$(SolutionDir)packages\NUnitTestAdapter.AnyVersion\tools\%(RecursiveDir)" ContinueOnError="true" Retries="0" />
   </Target>
 </Project>

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -56,7 +56,7 @@
     <PackageReference Include="Selenium.Support" Version="3.14.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="2.2.7" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="WindowsTestBase.cs" />

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -49,14 +49,14 @@
     <PackageReference Include="Castle.Core" Version="4.3.1" />
     <PackageReference Include="DotNetSeleniumExtras.PageObjects" Version="3.11.0" />
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="NUnitTestAdapter">
-      <Version>2.1.1</Version>
-    </PackageReference>
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Selenium.Support" Version="3.14.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.13.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="WindowsTestBase.cs" />

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NUnit" Version="2.6.4" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="2.2.7" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseViewContainerRemoteiOS.cs" />

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -46,7 +46,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
   </ItemGroup>

--- a/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
+++ b/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
@@ -48,7 +48,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="ServiceStack.Client" Version="4.5.12" />
     <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
     <PackageReference Include="ServiceStack.Text" Version="4.5.12" />

--- a/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
+++ b/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
     <PackageReference Include="ServiceStack.Text" Version="4.5.12" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="2.2.7" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.0" />
     <PackageReference Include="Xamarin.UITest.Desktop" Version="0.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Pages.UnitTests/Xamarin.Forms.Pages.UnitTests.csproj
+++ b/Xamarin.Forms.Pages.UnitTests/Xamarin.Forms.Pages.UnitTests.csproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
@@ -42,8 +42,10 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
-    <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="NUnitTestAdapter" Version="2.1.1" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="NUnit3TestAdapter">
+      <Version>3.13.0</Version>
+    </PackageReference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core.UnitTests\MockPlatformServices.cs">
@@ -77,8 +79,8 @@
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Target Name="_CopyNUnitTestAdapterFiles" AfterTargets="Build">
     <ItemGroup>
-      <_NUnitTestAdapterFiles Include="$(NuGetPackageRoot)NUnitTestAdapter\%(Version)\**" Condition="@(PackageReference -> '%(Identity)') == 'NUnitTestAdapter'" InProject="False" />
+      <_NUnitTestAdapterFiles Include="$(NuGetPackageRoot)NUnit3TestAdapter\%(Version)\build\net35\**" Condition="@(PackageReference -&gt; '%(Identity)') == 'NUnit3TestAdapter'" InProject="False" />
     </ItemGroup>
-    <Copy SourceFiles="@(_NUnitTestAdapterFiles)" DestinationFolder="$(SolutionDir)packages\NUnitTestAdapter.AnyVersion\%(RecursiveDir)" ContinueOnError="true" Retries="0" />
+    <Copy SourceFiles="@(_NUnitTestAdapterFiles)" DestinationFolder="$(SolutionDir)packages\NUnitTestAdapter.AnyVersion\tools\%(RecursiveDir)" ContinueOnError="true" Retries="0" />
   </Target>
 </Project>

--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -167,7 +167,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(page.Content.BackgroundColor, Is.EqualTo(Color.Red));
 		}
 
-		[Test][Ignore]
+		[Test][Ignore(nameof(ImplicitStyleAppliedToMissingType))]
 		public void ImplicitStyleAppliedToMissingType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.That(myButton.BackgroundColor, Is.Not.EqualTo(Color.Red));
 		}
 
-		[Test][Ignore]
+		[Test][Ignore(nameof(StyleTargetingMissingTypeNotAppliedToFallbackType))]
 		public void StyleTargetingMissingTypeNotAppliedToFallbackType()
 		{
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(Button);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/GH2691.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/GH2691.xaml.cs
@@ -113,16 +113,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					"Release";
 #endif
 
+				var dir = Path.GetFullPath(
+						Path.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll"));
 				var xamlg = new XamlGTask()
 				{
 					BuildEngine = new DummyBuildEngine(),
 					AssemblyName = "test",
 					Language = "C#",
 					XamlFiles = new[] { item },
-					OutputFiles = new [] { new TaskItem(xamlOutputFile) },
-					References = Path.GetFullPath(
-						Path.Combine(
-							Directory.GetCurrentDirectory(), "Xamarin.Forms.Controls.dll"))
+					OutputFiles = new[] { new TaskItem(xamlOutputFile) },
+					References = dir
 				};
 
 				var generator = new XamlGenerator(item, xamlg.Language, xamlg.AssemblyName, xamlOutputFile, xamlg.References, null);

--- a/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/LoaderTests.cs
@@ -795,8 +795,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			var bindingType = XamlParser.GetElementType(new XmlType("http://xamarin.com/schemas/2014/forms", "Binding", null), null, null, out var ex);
 			Assert.That(ex, Is.Null);
 			Assert.That(bindingType, Is.EqualTo(typeof(BindingExtension)));
-
-			var bindingTypeRef = new XmlType("http://xamarin.com/schemas/2014/forms", "Binding", null).GetTypeReference(ModuleDefinition.CreateModule("foo", ModuleKind.Dll), null);
+			var module = ModuleDefinition.CreateModule("foo", new ModuleParameters()
+			{
+				AssemblyResolver = new MockAssemblyResolver(),
+				Kind = ModuleKind.Dll,
+			});
+			var bindingTypeRef = new XmlType("http://xamarin.com/schemas/2014/forms", "Binding", null).GetTypeReference(module, null);
 			Assert.That(bindingType.FullName, Is.EqualTo("Xamarin.Forms.Xaml.BindingExtension"));
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -488,15 +488,15 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			AssertExists (Path.Combine (intermediateDirectory, "XamlC.stamp"));
 		}
 
-		[Test, ExpectedException (typeof(AssertionException))]
-		public void InvalidXml ([Values (false, true)] bool sdkStyle)
+		[Test]
+		public void InvalidXml([Values(false, true)] bool sdkStyle)
 		{
-			var project = NewProject (sdkStyle);
-			project.Add (AddFile ("MainPage.xaml", "EmbeddedResource", "notxmlatall"));
-			var projectFile = Path.Combine (tempDirectory, "test.csproj");
-			project.Save (projectFile);
-			RestoreIfNeeded (projectFile, sdkStyle);
-			Build (projectFile);
+			var project = NewProject(sdkStyle);
+			project.Add(AddFile("MainPage.xaml", "EmbeddedResource", "notxmlatall"));
+			var projectFile = Path.Combine(tempDirectory, "test.csproj");
+			project.Save(projectFile);
+			RestoreIfNeeded(projectFile, sdkStyle);
+			Assert.Throws<AssertionException>(() => Build(projectFile));
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml.UnitTests/MockAssemblyResolver.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MockAssemblyResolver.cs
@@ -1,0 +1,20 @@
+﻿using Mono.Cecil;
+using NUnit.Framework;
+using System.IO;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class MockAssemblyResolver : BaseAssemblyResolver
+	{
+		public override AssemblyDefinition Resolve(AssemblyNameReference name)
+		{
+			AssemblyDefinition assembly;
+			var localPath = Path.GetFullPath(Path.Combine(TestContext.CurrentContext.TestDirectory, $"{name.Name}.dll"));
+			if (File.Exists(localPath))
+				assembly = AssemblyDefinition.ReadAssembly(localPath);
+			else
+				assembly = base.Resolve(name);
+			return assembly;
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Speed/SimpleContentPage.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Speed/SimpleContentPage.xaml.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			}
 
 			[Test]
-			[Ignore]
+			[Ignore(nameof(XamlCIs20TimesFasterThanXaml))]
 			public void XamlCIs20TimesFasterThanXaml ()
 			{
 				var swXamlC = new Stopwatch ();
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			}
 
 			[Test]
-			[Ignore]
+			[Ignore(nameof(XamlCIsNotMuchSlowerThanCode))]
 			public void XamlCIsNotMuchSlowerThanCode ()
 			{
 				var swXamlC = new Stopwatch ();

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -19,8 +19,9 @@
     <ProjectReference Include="..\Xamarin.Forms.Build.Tasks\Xamarin.Forms.Build.Tasks.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.31" />
+    <PackageReference Include="NUnit" Version="3.12.0" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.2" />
+    <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core.UnitTests\MockPlatformServices.cs">

--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -4,7 +4,7 @@
     <RootNamespace>Xamarin.Forms.Xaml.UnitTests</RootNamespace>
     <AssemblyName>Xamarin.Forms.Xaml.UnitTests</AssemblyName>
     <WarningLevel>4</WarningLevel>
-    <NoWarn>0672;0219;0414</NoWarn>
+    <NoWarn>0672;0219;0414;CS0436</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/FieldReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/FieldReferenceExtensionsTests.cs
@@ -6,6 +6,7 @@ using Mono.Cecil;
 using Xamarin.Forms.Build.Tasks;
 
 using NUnit.Framework;
+using Xamarin.Forms.Xaml.UnitTests;
 
 namespace Xamarin.Forms.XamlcUnitTests
 {
@@ -31,7 +32,11 @@ namespace Xamarin.Forms.XamlcUnitTests
 		[SetUp]
 		public void SetUp ()
 		{
-			module = ModuleDefinition.CreateModule ("foo", ModuleKind.Dll);
+			module = ModuleDefinition.CreateModule("foo", new ModuleParameters()
+			{
+				AssemblyResolver = new MockAssemblyResolver(),
+				Kind = ModuleKind.Dll,
+			});
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodDefinitionExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodDefinitionExtensionsTests.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms.Build.Tasks;
 
 using NUnit.Framework;
 using System.Collections.Generic;
+using Xamarin.Forms.Xaml.UnitTests;
 
 namespace Xamarin.Forms.XamlcUnitTests
 {
@@ -33,7 +34,11 @@ namespace Xamarin.Forms.XamlcUnitTests
 		[SetUp]
 		public void SetUp()
 		{
-			module = ModuleDefinition.CreateModule("foo", ModuleKind.Dll);
+			module = ModuleDefinition.CreateModule("foo", new ModuleParameters()
+			{
+				AssemblyResolver = new MockAssemblyResolver(),
+				Kind = ModuleKind.Dll,
+			});
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/MethodReferenceExtensionsTests.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Linq;
 
 using Mono.Cecil;
@@ -7,6 +6,7 @@ using Xamarin.Forms.Build.Tasks;
 
 using NUnit.Framework;
 using System.Collections.Generic;
+using Xamarin.Forms.Xaml.UnitTests;
 
 namespace Xamarin.Forms.XamlcUnitTests
 {
@@ -23,9 +23,13 @@ namespace Xamarin.Forms.XamlcUnitTests
 		}
 
 		[SetUp]
-		public void SetUp ()
+		public void SetUp()
 		{
-			module = ModuleDefinition.CreateModule ("foo", ModuleKind.Dll);
+			module = ModuleDefinition.CreateModule("foo", new ModuleParameters()
+			{
+				AssemblyResolver = new MockAssemblyResolver(),
+				Kind = ModuleKind.Dll,
+			});
 		}
 
 		[Test]

--- a/Xamarin.Forms.Xaml.UnitTests/XamlParseExceptionConstraint.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlParseExceptionConstraint.cs
@@ -2,7 +2,7 @@ using System;
 using NUnit.Framework.Constraints;
 
 namespace Xamarin.Forms.Xaml.UnitTests
-{	
+{
 	public class XamlParseExceptionConstraint : ExceptionTypeConstraint
 	{
 		bool haslineinfo;
@@ -10,13 +10,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		int lineposition;
 		Func<string, bool> messagePredicate;
 
-		XamlParseExceptionConstraint (bool haslineinfo) : base (typeof (XamlParseException))
+		XamlParseExceptionConstraint(bool haslineinfo) : base(typeof(XamlParseException))
 		{
 			this.haslineinfo = haslineinfo;
-			DisplayName = "xamlparse";
 		}
 
-		public XamlParseExceptionConstraint () : this (false)
+		public override string DisplayName => "xamlparse";
+
+		public XamlParseExceptionConstraint() : this(false)
 		{
 		}
 
@@ -27,9 +28,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			this.messagePredicate = messagePredicate;
 		}
 
-		public override bool Matches (object actual)
+		protected override bool Matches (object actual)
 		{
-			this.actual = actual;
 			if (!base.Matches (actual))
 				return false;
 			var xmlInfo = ((XamlParseException)actual).XmlInfo;
@@ -43,25 +43,30 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			return xmlInfo.LineNumber == linenumber && xmlInfo.LinePosition == lineposition;
 		}
 
-		public override void WriteDescriptionTo (MessageWriter writer)
+		public override string Description
 		{
-			base.WriteDescriptionTo (writer);
-			if (haslineinfo)
-				writer.Write (string.Format (" line {0}, position {1}", linenumber, lineposition));
-		}
-
-		public override void WriteActualValueTo (MessageWriter writer)
-		{
-			var ex = actual as XamlParseException;
-			writer.WriteActualValue ((actual == null) ? null : actual.GetType ());
-			if (ex != null) {
-				if (ex.XmlInfo != null && ex.XmlInfo.HasLineInfo ())
-					writer.Write (" line {0}, position {1}", ex.XmlInfo.LineNumber, ex.XmlInfo.LinePosition);
-				else 
-					writer.Write (" no line info");
-				writer.WriteLine (" ({0})", ex.Message);
-				writer.Write (ex.StackTrace);
+			get
+			{
+				if (haslineinfo)
+				{
+					return string.Format($"{base.Description} line {linenumber}, position {lineposition}");
+				}
+				return base.Description;
 			}
 		}
+
+		//public override void WriteActualValueTo (MessageWriter writer)
+		//{
+		//	var ex = actual as XamlParseException;
+		//	writer.WriteActualValue ((actual == null) ? null : actual.GetType ());
+		//	if (ex != null) {
+		//		if (ex.XmlInfo != null && ex.XmlInfo.HasLineInfo ())
+		//			writer.Write (" line {0}, position {1}", ex.XmlInfo.LineNumber, ex.XmlInfo.LinePosition);
+		//		else 
+		//			writer.Write (" no line info");
+		//		writer.WriteLine (" ({0})", ex.Message);
+		//		writer.Write (ex.StackTrace);
+		//	}
+		//}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

- Update Xamarin.UITest 3.0 so we can test iOS and Xcode 10.2
- Move to NUNit 3.0

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5982

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
