### PR TITLE
[iOS] adds a flag to ios if user needs to disable accessibility sizing for named font sizes

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -54,27 +54,27 @@
 		}
 		#endregion
 
-		#region DisableAccessibilityScalingForNamedFontSizes
-		public static readonly BindableProperty DisableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("DisableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), false);
+		#region EnableAccessibilityScalingForNamedFontSizes
+		public static readonly BindableProperty EnableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("EnableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), true);
 
-		public static bool GetDisableAccessibilityScalingForNamedFontSizes(BindableObject element)
+		public static bool GetEnableAccessibilityScalingForNamedFontSizes(BindableObject element)
 		{
-			return (bool)element.GetValue(DisableAccessibilityScalingForNamedFontSizesProperty);
+			return (bool)element.GetValue(EnableAccessibilityScalingForNamedFontSizesProperty);
 		}
 
-		public static void SetDisableAccessibilityScalingForNamedFontSizes(BindableObject element, bool value)
+		public static void SetEnableAccessibilityScalingForNamedFontSizes(BindableObject element, bool value)
 		{
-			element.SetValue(DisableAccessibilityScalingForNamedFontSizesProperty, value);
+			element.SetValue(EnableAccessibilityScalingForNamedFontSizesProperty, value);
 		}
 
-		public static bool GetDisableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		public static bool GetEnableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config)
 		{
-			return GetDisableAccessibilityScalingForNamedFontSizes(config.Element);
+			return GetEnableAccessibilityScalingForNamedFontSizes(config.Element);
 		}
 
-		public static IPlatformElementConfiguration<iOS, FormsElement> SetDisableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetEnableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
 		{
-			SetDisableAccessibilityScalingForNamedFontSizes(config.Element, value);
+			SetEnableAccessibilityScalingForNamedFontSizes(config.Element, value);
 			return config;
 		}
 		#endregion

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/Application.cs
@@ -53,5 +53,30 @@
 			return config;
 		}
 		#endregion
+
+		#region DisableAccessibilityScalingForNamedFontSizes
+		public static readonly BindableProperty DisableAccessibilityScalingForNamedFontSizesProperty = BindableProperty.Create("DisableAccessibilityScalingForNamedFontSizes", typeof(bool), typeof(Application), false);
+
+		public static bool GetDisableAccessibilityScalingForNamedFontSizes(BindableObject element)
+		{
+			return (bool)element.GetValue(DisableAccessibilityScalingForNamedFontSizesProperty);
+		}
+
+		public static void SetDisableAccessibilityScalingForNamedFontSizes(BindableObject element, bool value)
+		{
+			element.SetValue(DisableAccessibilityScalingForNamedFontSizesProperty, value);
+		}
+
+		public static bool GetDisableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetDisableAccessibilityScalingForNamedFontSizes(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetDisableAccessibilityScalingForNamedFontSizes(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetDisableAccessibilityScalingForNamedFontSizes(config.Element, value);
+			return config;
+		}
+		#endregion
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Flags.cs
+++ b/Xamarin.Forms.Platform.iOS/Flags.cs
@@ -2,6 +2,5 @@
 {
 	internal static class Flags
 	{
-		internal const string DisableAccessibilityScalingForNamedFontSizes = "DisableAccessibilityScalingForNamedFontSizes";
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Flags.cs
+++ b/Xamarin.Forms.Platform.iOS/Flags.cs
@@ -2,5 +2,6 @@
 {
 	internal static class Flags
 	{
+		internal const string DisableAccessibilityScalingForNamedFontSizes = "DisableAccessibilityScalingForNamedFontSizes";
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -160,9 +160,12 @@ namespace Xamarin.Forms
 			public IOSPlatformServices()
 			{
 #if __MOBILE__
-				//The standard accisibility size for a font is 18, we can get a
-				//close aproximation to the new Size by multiplying by this scale factor
-				_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
+				//The standard accessibility size for a font is 18, we can get a
+				//close approximation to the new Size by multiplying by this scale factor
+				if (!Forms.Flags.Contains(global::Xamarin.Forms.Flags.DisableAccessibilityScalingForNamedFontSizes))
+				{
+					_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
+				}
 #endif
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -161,6 +161,8 @@ namespace Xamarin.Forms
 			public IOSPlatformServices()
 			{
 #if __MOBILE__
+				// We make these up anyway, so new sizes didn't really change
+				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
 				_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
 #endif
 			}
@@ -206,8 +208,6 @@ namespace Xamarin.Forms
 				}
 #endif
 
-				// We make these up anyway, so new sizes didn't really change
-				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
 				switch (size)
 				{
 					//We multiply the fonts by the scale factor, and cast to an int, to make them whole numbers.

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -13,6 +13,8 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Foundation;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 #if __MOBILE__
 using UIKit;
 using Xamarin.Forms.Platform.iOS;
@@ -155,18 +157,10 @@ namespace Xamarin.Forms
 
 		class IOSPlatformServices : IPlatformServices
 		{
-
 			readonly double _fontScalingFactor = 1;
 			public IOSPlatformServices()
 			{
-#if __MOBILE__
-				//The standard accessibility size for a font is 18, we can get a
-				//close approximation to the new Size by multiplying by this scale factor
-				if (!Forms.Flags.Contains(global::Xamarin.Forms.Flags.DisableAccessibilityScalingForNamedFontSizes))
-				{
-					_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
-				}
-#endif
+				_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
 			}
 
 			static readonly MD5CryptoServiceProvider s_checksum = new MD5CryptoServiceProvider();
@@ -200,21 +194,31 @@ namespace Xamarin.Forms
 
 			public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 			{
+
+				var scalingFactor = _fontScalingFactor;
+
+#if __MOBILE__
+				if (Application.Current?.On<iOS>().GetDisableAccessibilityScalingForNamedFontSizes() == true)
+				{
+					scalingFactor = 1;
+				}
+#endif
+
 				// We make these up anyway, so new sizes didn't really change
 				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
 				switch (size)
 				{
 					//We multiply the fonts by the scale factor, and cast to an int, to make them whole numbers.
 					case NamedSize.Default:
-						return (int)((typeof(Button).IsAssignableFrom(targetElementType) ? 15 : 17) * _fontScalingFactor);
+						return (int)((typeof(Button).IsAssignableFrom(targetElementType) ? 15 : 17) * scalingFactor);
 					case NamedSize.Micro:
-						return (int)(12 * _fontScalingFactor);
+						return (int)(12 * scalingFactor);
 					case NamedSize.Small:
-						return (int)(14 * _fontScalingFactor);
+						return (int)(14 * scalingFactor);
 					case NamedSize.Medium:
-						return (int)(17 * _fontScalingFactor);
+						return (int)(17 * scalingFactor);
 					case NamedSize.Large:
-						return (int)(22 * _fontScalingFactor);
+						return (int)(22 * scalingFactor);
 #if __IOS__
 					case NamedSize.Body:
 						return (double)UIFont.PreferredBody.PointSize;

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -13,17 +13,17 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Foundation;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
 #if __MOBILE__
 using UIKit;
 using Xamarin.Forms.Platform.iOS;
 using TNativeView = UIKit.UIView;
-using Xamarin.Forms.PlatformConfiguration;
-using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 #else
 using AppKit;
 using Xamarin.Forms.Platform.MacOS;
 using TNativeView = AppKit.NSView;
-
 #endif
 
 namespace Xamarin.Forms
@@ -202,12 +202,10 @@ namespace Xamarin.Forms
 				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
 				var scalingFactor = _fontScalingFactor;
 
-#if __MOBILE__
-				if (Application.Current?.On<iOS>().GetDisableAccessibilityScalingForNamedFontSizes() == true)
+				if (Application.Current?.On<iOS>().GetEnableAccessibilityScalingForNamedFontSizes() == false)
 				{
 					scalingFactor = 1;
 				}
-#endif
 
 				switch (size)
 				{

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -161,8 +161,8 @@ namespace Xamarin.Forms
 			public IOSPlatformServices()
 			{
 #if __MOBILE__
-				// We make these up anyway, so new sizes didn't really change
-				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
+				//The standard accisibility size for a font is 18, we can get a
+				//close aproximation to the new Size by multiplying by this scale factor
 				_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
 #endif
 			}
@@ -198,7 +198,8 @@ namespace Xamarin.Forms
 
 			public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 			{
-
+				// We make these up anyway, so new sizes didn't really change
+				// iOS docs say default button font size is 15, default label font size is 17 so we use those as the defaults.
 				var scalingFactor = _fontScalingFactor;
 
 #if __MOBILE__

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -13,12 +13,12 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Foundation;
-using Xamarin.Forms.PlatformConfiguration;
-using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 #if __MOBILE__
 using UIKit;
 using Xamarin.Forms.Platform.iOS;
 using TNativeView = UIKit.UIView;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 #else
 using AppKit;
 using Xamarin.Forms.Platform.MacOS;
@@ -160,7 +160,9 @@ namespace Xamarin.Forms
 			readonly double _fontScalingFactor = 1;
 			public IOSPlatformServices()
 			{
+#if __MOBILE__
 				_fontScalingFactor = (double)UIFont.PreferredBody.PointSize / 18f;
+#endif
 			}
 
 			static readonly MD5CryptoServiceProvider s_checksum = new MD5CryptoServiceProvider();


### PR DESCRIPTION
### Description of Change ###
https://github.com/xamarin/Xamarin.Forms/pull/5985

Changed the default behavior of named fontsizes for iOS to make it more in line with how Android and UWP work. This technically is a breaking change but we see it as an acceptable breaking change. That being said we still want to give users the ability to opt out of it if need be.

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- Create a page where font sizes are being set through named values (or just make one)
- Go to accessibility settings on the iDevice, set large text on, and make the text really large
- run the app
- now set this flag
```C#

	    Forms.SetFlags("DisableAccessibilityScalingForNamedFontSizes");
            global::Xamarin.Forms.Forms.Init();
```
- Rerun the app and the font should now be smaller because it's no longer scaled

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
