### PR TITLE
[Android] Fixes work IsClippedToBounds on (Fast Renderer) Frame

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3150, "IsClippedToBounds on (Fast Renderer) Frame not working", PlatformAffected.Android)]
+
+	class Issue3150 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Frame
+					{
+						BackgroundColor = Color.Blue,
+						HorizontalOptions = LayoutOptions.CenterAndExpand,
+						VerticalOptions = LayoutOptions.CenterAndExpand,
+						IsClippedToBounds = false,
+						Content = new BoxView
+						{
+							BackgroundColor = Color.Yellow,
+							TranslationX = 50
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = new StackLayout
 			{
 				Children = {
+					new Label { Text = "If the yellow box extends past the end of the blue box, the test has passed" },
 					new Frame
 					{
 						BackgroundColor = Color.Blue,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
@@ -10,22 +10,37 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			const string buttonText = "Toggle IsClippedToBounds: ";
+			var frame = new Frame
+			{
+				BackgroundColor = Color.Blue,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				IsClippedToBounds = false,
+				Content = new BoxView
+				{
+					BackgroundColor = Color.Yellow,
+					TranslationX = 50
+				}
+			};
+
+			Button button = null;
+			button = new Button()
+			{
+				Text = $"{buttonText}{frame.IsClippedToBounds}",
+				Command = new Command(() =>
+				{
+					frame.IsClippedToBounds = !frame.IsClippedToBounds;
+					button.Text = $"{buttonText}{frame.IsClippedToBounds}";
+				})
+			};
+
 			Content = new StackLayout
 			{
 				Children = {
 					new Label { Text = "If the yellow box extends past the end of the blue box, the test has passed" },
-					new Frame
-					{
-						BackgroundColor = Color.Blue,
-						HorizontalOptions = LayoutOptions.CenterAndExpand,
-						VerticalOptions = LayoutOptions.CenterAndExpand,
-						IsClippedToBounds = false,
-						Content = new BoxView
-						{
-							BackgroundColor = Color.Yellow,
-							TranslationX = 50
-						}
-					}
+					frame,
+					button
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3150.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6260.cs" />

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -191,6 +191,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateBackgroundColor();
 				UpdateCornerRadius();
 				UpdateBorderColor();
+				UpdateClippedToBounds();
 
 				ElevationHelper.SetElevation(this, e.NewElement);
 			}
@@ -234,6 +235,14 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateCornerRadius();
 			else if (e.PropertyName == Frame.BorderColorProperty.PropertyName)
 				UpdateBorderColor();
+			else if (e.Is(Xamarin.Forms.Layout.IsClippedToBoundsProperty))
+				UpdateClippedToBounds();
+		}
+
+		void UpdateClippedToBounds()
+		{
+			if (!_disposed)
+				ClipToOutline = Element.IsClippedToBounds;
 		}
 
 		void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -241,7 +241,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		void UpdateClippedToBounds()
 		{
-			if (!_disposed)
+			if (!_disposed && Forms.IsLollipopOrNewer)
 				ClipToOutline = Element.IsClippedToBounds;
 		}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -239,11 +239,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateClippedToBounds();
 		}
 
-		void UpdateClippedToBounds()
-		{
-			if (!_disposed && Forms.IsLollipopOrNewer)
-				ClipToOutline = Element.IsClippedToBounds;
-		}
+		void UpdateClippedToBounds() => this.SetClipToOutline(Element.IsClippedToBounds);
 
 		void UpdateBackgroundColor()
 		{

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -77,5 +77,21 @@ namespace Xamarin.Forms.Platform.Android
 				view.Id = Platform.GenerateViewId();
 			}
 		}
+
+		public static bool GetClipToOutline(this AView view)
+		{
+			if (view.IsDisposed() || !Forms.IsLollipopOrNewer)
+				return false;
+
+			return view.ClipToOutline;
+		}
+
+		public static void SetClipToOutline(this AView view, bool value)
+		{
+			if (view.IsDisposed() || !Forms.IsLollipopOrNewer)
+				return;
+
+			view.ClipToOutline = value;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

### Issues Resolved ### 

- fixes #3150
- fixes #6447 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Before/After Screenshots ### 

Before
![image](https://user-images.githubusercontent.com/27482193/58642690-84a59f80-8306-11e9-8d1c-edea35489a5e.png)

After
![image](https://user-images.githubusercontent.com/27482193/58642414-f7fae180-8305-11e9-9910-d8e6c27179c2.png)

### Testing Procedure ###

- run UItest 3150
- yellow square should't be clipped

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
