### PR TITLE
Added option to display icons instead of text in context actions for iOS

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/GalleryPages/ContextActionDisplayTest.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/GalleryPages/ContextActionDisplayTest.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls
+{
+	public class ContextActionDisplayTest : ContentPage
+	{
+		public ContextActionDisplayTest()
+		{
+			var template = new DataTemplate(() =>
+			{
+				var cell = new TextCell();
+				cell.SetBinding(TextCell.TextProperty, ".");
+				cell.Height = 200;
+
+				var textContext = new MenuItem { Text = "Text", IconImageSource = new FileImageSource { File = "about.png" }, IsDestructive = true };
+				var iconContext = new MenuItem { Text = "Icon", IconImageSource = new FileImageSource { File = "about.png" } };
+				iconContext.On<iOS>().SetContextActionDisplay(ContextActionDisplay.Icon);
+
+				cell.ContextActions.Add(textContext);
+				cell.ContextActions.Add(iconContext);
+
+				return cell;
+			});
+
+			var data = new List<string>();
+			for (var i = 0; i < 10; i++)
+				data.Add($"{i+1:D3}");
+
+			var list = new ListView();
+			list.ItemTemplate = template;
+			list.ItemsSource = data;
+
+			Content = list;
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/PlatformSpecificCoreGalleryFactory.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/PlatformSpecificCoreGalleryFactory.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 
 		public IEnumerable<(Func<Page> Create, string Title)> GetPages()
 		{
+			yield return (() => new ContextActionDisplayTest(), "Context Action Display Test");
 #if HAVE_OPENTK
 			yield return (() => new AdvancedOpenGLGallery(), "Advanced OpenGL Gallery - Legacy");
 #else

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\xamarin.forms.controls\gallerypages\openglgalleries\AdvancedOpenGLGallery.cs">
       <Link>GalleryPages\AdvancedOpenGLGallery.cs</Link>
     </Compile>
+    <Compile Include="GalleryPages\ContextActionDisplayTest.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -4,7 +4,7 @@ using System.Windows.Input;
 
 namespace Xamarin.Forms
 {
-	public class MenuItem : BaseMenuItem, IMenuItemController
+	public class MenuItem : BaseMenuItem, IMenuItemController, IElementConfiguration<MenuItem>
 	{
 		public static readonly BindableProperty AcceleratorProperty = BindableProperty.CreateAttached(nameof(Accelerator), typeof(Accelerator), typeof(MenuItem), null);
 
@@ -27,6 +27,8 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty IsEnabledProperty = IsEnabledPropertyKey.BindableProperty;
 
 		public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(MenuItem), null);
+
+		readonly Lazy<PlatformConfigurationRegistry<MenuItem>> _platformConfigurationRegistry;
 
 		public static Accelerator GetAccelerator(BindableObject bindable) => (Accelerator)bindable.GetValue(AcceleratorProperty);
 
@@ -88,6 +90,11 @@ namespace Xamarin.Forms
 
 		protected virtual void OnClicked() => Clicked?.Invoke(this, EventArgs.Empty);
 
+		public MenuItem()
+		{
+			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<MenuItem>>(() => new PlatformConfigurationRegistry<MenuItem>(this));
+		}
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		void IMenuItemController.Activate()
 		{
@@ -126,6 +133,11 @@ namespace Xamarin.Forms
 				return;
 
 			IsEnabledCore = Command.CanExecute(CommandParameter);
+		}
+
+		public IPlatformElementConfiguration<T, MenuItem> On<T>() where T : IConfigPlatform
+		{
+			return _platformConfigurationRegistry.Value.On<T>();
 		}
 	}
 }

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/MenuItem.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/MenuItem.cs
@@ -1,0 +1,35 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.MenuItem;
+
+	public static class MenuItem
+	{
+		public static readonly BindableProperty ContextActionDisplayProperty = BindableProperty.Create(nameof(ContextActionDisplay), typeof(ContextActionDisplay), typeof(MenuItem), ContextActionDisplay.Text);
+
+		public static ContextActionDisplay GetContextActionDisplay(BindableObject element)
+			=> (ContextActionDisplay)element.GetValue(ContextActionDisplayProperty);
+
+		public static void SetContextActionDisplay(BindableObject element, ContextActionDisplay value)
+			=> element.SetValue(ContextActionDisplayProperty, value);
+
+		public static ContextActionDisplay DefaultContextActionCellDisplay(this IPlatformElementConfiguration<iOS, FormsElement> config)
+			=> GetContextActionDisplay(config.Element);
+
+		public static ContextActionDisplay GetContextActionDisplay(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetContextActionDisplay(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetContextActionDisplay(this IPlatformElementConfiguration<iOS, FormsElement> config, ContextActionDisplay value)
+		{
+			SetContextActionDisplay(config.Element, value);
+			return config;
+		}
+	}
+
+	public enum ContextActionDisplay
+	{
+		Text, 
+		Icon
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS.Resources;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using PointF = CoreGraphics.CGPoint;
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
@@ -418,8 +419,23 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				button.SetBackgroundImage(DestructiveBackground, UIControlState.Normal);
 
-			button.SetTitle(item.Text, UIControlState.Normal);
-			button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
+			var displayType = item.OnThisPlatform().GetContextActionDisplay();
+			if (displayType == ContextActionDisplay.Icon)
+			{
+				var handler = Internals.Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(item.IconImageSource);
+				if (handler != null)
+				{
+					var image = handler.LoadImageAsync(item.IconImageSource).GetAwaiter().GetResult();
+					button.ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
+					button.SetImage(image, UIControlState.Normal);
+					button.ImageEdgeInsets = new UIEdgeInsets(5, 15, 5, 15);
+				}
+			}
+			else
+			{
+				button.SetTitle(item.Text, UIControlState.Normal);
+				button.TitleEdgeInsets = new UIEdgeInsets(0, 15, 0, 15);
+			}
 
 			button.Enabled = item.IsEnabled;
 
@@ -559,7 +575,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				var button = GetButton(item);
 				button.Tag = i;
-				var buttonWidth = button.TitleLabel.SizeThatFits(new SizeF(width, height)).Width + 30;
+				var buttonWidth = (nfloat)Math.Max(button.ImageView.SizeThatFits(new SizeF(width, height)).Width, button.TitleLabel.SizeThatFits(new SizeF(width, height)).Width) + 30;
 				if (buttonWidth > largestWidth)
 					largestWidth = buttonWidth;
 


### PR DESCRIPTION
### Description of Change ###

/!\ This is the same PR as https://github.com/xamarin/Xamarin.Forms/pull/6382 just implemented in a more dynamic way but in this case the More ContextAction could not changed by the app developer (because it is never an icon) and it requires more changes to Xamarin.Forms (MenuItem additional interface) - I would prefer https://github.com/xamarin/Xamarin.Forms/pull/6382 as 2nd thoughts  /!\

I've added a enum to choose if ContextActions within a ListView should be displayed as Icon or Text. This can be activated for each individual MenuItem. 

### Issues Resolved ### 

None

### API Changes ###

Added:
 - IElementConfiguration<MenuItem> to MenuItem
- Added On<iOS>().SetContextActionDisplay(ContextActionDisplay.Icon) for MenuItem

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None with default settings. When ContextActionDisplay.Icon is set for MenuItem they will appear as Icon instead of text in iOS. 

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added "Context Action Display Test" to Control Gallery which includes one Icon ContextAction and one Text based. 

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard

### Additional noted ###

Maybe this option should be moved to the ViewCell instead. This would prevent a base class to change (in this case MenuItem which now has an additional interface) and the More-Action could also change to an Icon (maybe the UITabBarSystemItem.More?) but it will remove some freedom which should be displayed as Icon and which one should not (at least if there is any reason for this to happen?). 

/!\ This is the same PR as https://github.com/xamarin/Xamarin.Forms/pull/6382 just implemented in a more dynamic way but in this case the More ContextAction could not changed by the app developer (because it is never an icon) and it requires more changes to Xamarin.Forms (MenuItem additional interface) - I would prefer https://github.com/xamarin/Xamarin.Forms/pull/6382 as 2nd thoughts  /!\
