### PR TITLE
[UWP] Fixes IndexOutOfRangeException on TabbedPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6323.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6323.cs
@@ -1,0 +1,35 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6323, "TabbedPage Page not watching icon changes", PlatformAffected.UWP)]
+	public class Issue6323 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Device.StartTimer(TimeSpan.FromSeconds(2), () =>
+			{
+				Children.Add(new ContentPage
+				{
+					Content = new Label { Text = "Success" }
+				});
+				return false;
+			});
+		}
+
+#if UITEST && __WINDOWS__
+		[Test]
+		public void Issue6323Test()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6323.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6323.cs
@@ -14,11 +14,13 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			SelectedTabColor = Color.Purple;
 			Device.StartTimer(TimeSpan.FromSeconds(2), () =>
 			{
 				Children.Add(new ContentPage
 				{
-					Content = new Label { Text = "Success" }
+					Content = new Label { Text = "Success" },
+					Title = "I'm a title"
 				});
 				return false;
 			});

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -518,6 +518,9 @@ namespace Xamarin.Forms.Controls
 		protected abstract void Init();
 	}
 
+#if UITEST
+	[Category(UITestCategories.TabbedPage)]
+#endif
 	public abstract class TestTabbedPage : TabbedPage
 	{
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -857,6 +857,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41038.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla38284.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39486.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6323.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue55555.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla41029.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39908.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -48,5 +48,6 @@
 		public const string Visual = "Visual";
 		public const string AppLinks = "AppLinks";
 		public const string Shell = "Shell";
+		public const string TabbedPage = "TabbedPage";
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -287,6 +287,7 @@ namespace Xamarin.Forms.Platform.UWP
 					// Need to make sure any new items have the correct fore/background colors
 					ApplyBarBackgroundColor(true);
 					ApplyBarTextColor(true);
+					UpdateSelectedTabColors();
 					break;
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -556,16 +556,14 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			// Retrieve all tab header textblocks
 			var allTabHeaderTextBlocks = Control.GetDescendantsByName<WTextBlock>(TabBarHeaderTextBlockName).ToArray();
+			if (allTabHeaderTextBlocks.Length != Control.Items.Count)
+				return;
 
 			// Loop through all pages in the Pivot control
 			foreach (Page page in Control.Items)
 			{
-				var pageIndex = Control.Items.IndexOf(page);
-				if (allTabHeaderTextBlocks.Length <= pageIndex)
-					continue;
-
 				// Fetch just the textblock for the current page
-				var tabBarTextBlock = allTabHeaderTextBlocks[pageIndex];
+				var tabBarTextBlock = allTabHeaderTextBlocks[Control.Items.IndexOf(page)];
 
 				// Apply selected or unselected style to the current textblock
 				if (page == Element.CurrentPage)

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -559,8 +559,12 @@ namespace Xamarin.Forms.Platform.UWP
 			// Loop through all pages in the Pivot control
 			foreach (Page page in Control.Items)
 			{
+				var pageIndex = Control.Items.IndexOf(page);
+				if (allTabHeaderTextBlocks.Length <= pageIndex)
+					continue;
+
 				// Fetch just the textblock for the current page
-				var tabBarTextBlock = allTabHeaderTextBlocks[Control.Items.IndexOf(page)];
+				var tabBarTextBlock = allTabHeaderTextBlocks[pageIndex];
 
 				// Apply selected or unselected style to the current textblock
 				if (page == Element.CurrentPage)


### PR DESCRIPTION
### Description of Change ###

Fixes IndexOutOfRangeException when adding page after rendering the `TabbedPage`

### Issues Resolved ### 

- fixes #6323

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Testing Procedure ###

- UITest 6323

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
