### PR TITLE
Added tap position to the Tapped event of the TapGestureRecognizer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38978.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla38978.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Label label = new Label { Text = "Click the image to resize", VerticalOptions = LayoutOptions.Center };
 
 				var tapGestureRecognizer = new TapGestureRecognizer ();
-				tapGestureRecognizer.Tapped += (object sender, EventArgs e) => {
+				tapGestureRecognizer.Tapped += (object sender, TappedEventArgs e) => {
 					if (_image.HeightRequest < 250) {
 						_image.HeightRequest = _image.Height + 100;
 						ForceUpdateSize ();

--- a/Xamarin.Forms.Controls/ControlGalleryPages/TapGestureTestPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/TapGestureTestPage.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Controls
 				RowDefinitions = new RowDefinitionCollection { new RowDefinition {Height = GridLength.Auto},new RowDefinition {Height = GridLength.Auto}, new RowDefinition {Height = GridLength.Star} }
 			};
 
-			var picker = new Picker { ItemsSource = new List<int> { 1, 2 } };
+			var picker = new Picker { ItemsSource = new List<int> { 1, 2 }, Title = "Number of taps" };
 			grid.AddChild(picker, 0, 0);
 
 			outputLabel = new Label { Text = "Nothing tapped yet!", LineBreakMode = LineBreakMode.WordWrap, HorizontalTextAlignment = TextAlignment.Center };

--- a/Xamarin.Forms.Controls/ControlGalleryPages/TapGestureTestPage.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/TapGestureTestPage.cs
@@ -1,0 +1,56 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Forms.Controls
+{
+	public class TapGestureTestPage : ContentPage
+	{
+		readonly Label outputLabel;
+
+		public TapGestureTestPage()
+		{
+			var grid = new Grid
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection { new ColumnDefinition { Width = GridLength.Star }, new ColumnDefinition { Width = GridLength.Star } },
+				RowDefinitions = new RowDefinitionCollection { new RowDefinition {Height = GridLength.Auto},new RowDefinition {Height = GridLength.Auto}, new RowDefinition {Height = GridLength.Star} }
+			};
+
+			var picker = new Picker { ItemsSource = new List<int> { 1, 2 } };
+			grid.AddChild(picker, 0, 0);
+
+			outputLabel = new Label { Text = "Nothing tapped yet!", LineBreakMode = LineBreakMode.WordWrap, HorizontalTextAlignment = TextAlignment.Center };
+			grid.AddChild(outputLabel, 0, 1, 2);
+
+			var box = new BoxView { BackgroundColor = Color.Gray };
+			grid.AddChild(box, 0, 2, 2);
+
+			var button = new Button { Text = "Set", Command = new Command(() => UpdateGesture(picker, box)) };
+			grid.AddChild(button, 1, 0);
+			
+			Content = grid;
+
+			picker.SelectedItem = 1;
+			button.Command.Execute(null);
+		}
+
+		void UpdateGesture(Picker settings, BoxView box)
+		{
+			if (settings.SelectedItem is int count)
+			{
+				var gestureRecognizer = new TapGestureRecognizer { NumberOfTapsRequired = count };
+				gestureRecognizer.Tapped += OnTapped;
+
+				foreach (var recognizer in box.GestureRecognizers.Where(r => r is TapGestureRecognizer).Cast<TapGestureRecognizer>())
+					recognizer.Tapped -= OnTapped;
+
+				box.GestureRecognizers.Clear();
+				box.GestureRecognizers.Add(gestureRecognizer);
+			}
+		}
+
+		void OnTapped(object sender, TappedEventArgs args)
+		{
+			outputLabel.Text = $"Tapped at {args.Position}";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -306,6 +306,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new SwipeGestureGalleryPage(), "Swipe gesture Gallery"),
 				new GalleryPageFactory(() => new PinchGestureTestPage(), "Pinch gesture Gallery"),
 				new GalleryPageFactory(() => new ClickGestureGalleryPage(), "Click gesture Gallery"),
+				new GalleryPageFactory(() => new TapGestureTestPage(), "Tap gesture Gallery"),
 				new GalleryPageFactory(() => new AutomationIdGallery(), "AutomationID Gallery"),
 				new GalleryPageFactory(() => new LayoutPerformanceGallery(), "Layout Perf Gallery"),
 				new GalleryPageFactory(() => new ListViewSelectionColor(), "ListView SelectionColor Gallery"),

--- a/Xamarin.Forms.Core.UnitTests/NativeBindingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/NativeBindingTests.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		public void FireBazChanged()
 		{
-			BazChanged?.Invoke(this, new TappedEventArgs(null));
+			BazChanged?.Invoke(this, new TappedEventArgs(null, new Point()));
 		}
 
 		public event EventHandler<TappedEventArgs> BazChanged;

--- a/Xamarin.Forms.Core/TapGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/TapGestureRecognizer.cs
@@ -34,18 +34,17 @@ namespace Xamarin.Forms
 			set { SetValue(NumberOfTapsRequiredProperty, value); }
 		}
 
-		public event EventHandler Tapped;
+		public event TappedEventHandler Tapped;
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SendTapped(View sender)
+		public void SendTapped(View sender, Point position)
 		{
 			ICommand cmd = Command;
 			if (cmd != null && cmd.CanExecute(CommandParameter))
 				cmd.Execute(CommandParameter);
 
-			EventHandler handler = Tapped;
-			if (handler != null)
-				handler(sender, new TappedEventArgs(CommandParameter));
+			var handler = Tapped;
+			handler?.Invoke(sender, new TappedEventArgs(CommandParameter, position));
 
 #pragma warning disable 0618 // retain until TappedCallback removed
 			Action<View, object> callback = TappedCallback;

--- a/Xamarin.Forms.Core/TapGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/TapGestureRecognizer.cs
@@ -43,8 +43,7 @@ namespace Xamarin.Forms
 			if (cmd != null && cmd.CanExecute(CommandParameter))
 				cmd.Execute(CommandParameter);
 
-			var handler = Tapped;
-			handler?.Invoke(sender, new TappedEventArgs(CommandParameter, position));
+			Tapped?.Invoke(sender, new TappedEventArgs(CommandParameter, position));
 
 #pragma warning disable 0618 // retain until TappedCallback removed
 			Action<View, object> callback = TappedCallback;

--- a/Xamarin.Forms.Core/TappedEventArgs.cs
+++ b/Xamarin.Forms.Core/TappedEventArgs.cs
@@ -4,11 +4,13 @@ namespace Xamarin.Forms
 {
 	public class TappedEventArgs : EventArgs
 	{
-		public TappedEventArgs(object parameter)
+		public TappedEventArgs(object parameter, Point position)
 		{
 			Parameter = parameter;
+			Position = position;
 		}
 
-		public object Parameter { get; private set; }
+		public object Parameter { get; }
+		public Point Position { get; }
 	}
 }

--- a/Xamarin.Forms.Core/TappedEventArgs.cs
+++ b/Xamarin.Forms.Core/TappedEventArgs.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Forms
 {
 	public class TappedEventArgs : EventArgs
 	{
-		public TappedEventArgs(object parameter, Point position)
+		public TappedEventArgs(object parameter, Point position = new Point())
 		{
 			Parameter = parameter;
 			Position = position;

--- a/Xamarin.Forms.Core/TappedEventHandler.cs
+++ b/Xamarin.Forms.Core/TappedEventHandler.cs
@@ -1,0 +1,4 @@
+namespace Xamarin.Forms
+{
+	public delegate void TappedEventHandler(object sender, TappedEventArgs args);
+}

--- a/Xamarin.Forms.Platform.Android/GestureManager.cs
+++ b/Xamarin.Forms.Platform.Android/GestureManager.cs
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Platform.Android
 					return view.GetChildElements(Point.Zero) ?? new List<GestureElement>();
 
 				return new List<GestureElement>();
-			}),
+			}, context.FromPixels),
 				new PanGestureHandler(() => View, context.FromPixels),
 			    	new SwipeGestureHandler(() => View, context.FromPixels));
 

--- a/Xamarin.Forms.Platform.Android/TapGestureHandler.cs
+++ b/Xamarin.Forms.Platform.Android/TapGestureHandler.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(recognizer => recognizer.NumberOfTapsRequired == count))
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, point);
 					captured = true;
 				}
 
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Platform.Android
 			IEnumerable<TapGestureRecognizer> gestureRecognizers = TapGestureRecognizers(count);
 			foreach (var gestureRecognizer in gestureRecognizers)
 			{
-				gestureRecognizer.SendTapped(view);
+				gestureRecognizer.SendTapped(view, point);
 				captured = true;
 			}
 

--- a/Xamarin.Forms.Platform.Android/TapGestureHandler.cs
+++ b/Xamarin.Forms.Platform.Android/TapGestureHandler.cs
@@ -7,8 +7,11 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal class TapGestureHandler
 	{
-		public TapGestureHandler(Func<View> getView, Func<IList<GestureElement>> getChildElements)
+		readonly Func<double, double> _pixelTranslation;
+
+		public TapGestureHandler(Func<View> getView, Func<IList<GestureElement>> getChildElements, Func<double, double> pixelTranslation)
 		{
+			_pixelTranslation = pixelTranslation;
 			GetView = getView;
 			GetChildElements = getChildElements;
 		}
@@ -35,11 +38,12 @@ namespace Xamarin.Forms.Platform.Android
 			var captured = false;
 
 			var children = view.GetChildElements(point);
+			var translatedPoint = new Point(_pixelTranslation(point.X), _pixelTranslation(point.Y));
 
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(recognizer => recognizer.NumberOfTapsRequired == count))
 				{
-					recognizer.SendTapped(view, point);
+					recognizer.SendTapped(view, translatedPoint);
 					captured = true;
 				}
 
@@ -49,7 +53,7 @@ namespace Xamarin.Forms.Platform.Android
 			IEnumerable<TapGestureRecognizer> gestureRecognizers = TapGestureRecognizers(count);
 			foreach (var gestureRecognizer in gestureRecognizers)
 			{
-				gestureRecognizer.SendTapped(view, point);
+				gestureRecognizer.SendTapped(view, translatedPoint);
 				captured = true;
 			}
 

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -326,7 +326,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2))
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, new Point(tapPosition.X, tapPosition.Y));
 					e.Handled = true;
 				}
 
@@ -336,7 +336,7 @@ namespace Xamarin.Forms.Platform.UWP
 			IEnumerable<TapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2);
 			foreach (TapGestureRecognizer recognizer in doubleTapGestures)
 			{
-				recognizer.SendTapped(view);
+				recognizer.SendTapped(view, new Point(tapPosition.X, tapPosition.Y));
 				e.Handled = true;
 			}
 		}
@@ -421,7 +421,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (children != null)
 				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1))
 				{
-					recognizer.SendTapped(view);
+					recognizer.SendTapped(view, new Point(tapPosition.X, tapPosition.Y));
 					e.Handled = true;
 				}
 
@@ -431,7 +431,7 @@ namespace Xamarin.Forms.Platform.UWP
 			IEnumerable<TapGestureRecognizer> tapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1);
 			foreach (var recognizer in tapGestures)
 			{
-				recognizer.SendTapped(view);
+				recognizer.SendTapped(view, new Point(tapPosition.X, tapPosition.Y));
 				e.Handled = true;
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -199,8 +199,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)sender.NumberOfTapsRequired).Count() > 0)
 					return;
 
+				var position = sender.LocationInView(null);
 				if (weakRecognizer.Target is TapGestureRecognizer tapGestureRecognizer && view != null)
-					tapGestureRecognizer.SendTapped(view);
+					tapGestureRecognizer.SendTapped(view, new Point(position.X, position.Y));
 			});
 		}
 
@@ -218,10 +219,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				if(recognizers == null)
 					return;
 
+				var position = sender.LocationInView(null);
 				var tapGestureRecognizer = ((ChildGestureRecognizer)weakRecognizer.Target).GestureRecognizer as TapGestureRecognizer;
 				foreach (var item in recognizers)
 					if (item == tapGestureRecognizer && view != null)
-						tapGestureRecognizer.SendTapped(view);
+						tapGestureRecognizer.SendTapped(view, new Point(position.X, position.Y));
 			});
 		}
 #endif


### PR DESCRIPTION
### Description of Change ###

Added tap position to the Tapped Event of the TapGestureRecognizer.

### Issues Resolved ### 

- fixed #5347

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - TappedEventHandler(object sender, TappedEventArgs args)
 - Point Position { get; } to Point Position { get; }

Changed:
 - EventHandler Tapped =>TappedEventHandler Tapped
 - void SendTapped(View sender) => void SendTapped(View sender, Point position)
  
### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

No visual changes but the currently registered Tapped events may break because of the parameter change. This can easily fixed by replacing the `EventArgs` parameter in registered Tapped-Events to the `TappedEventArgs`. 

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added `TapGestureTestPage` to `ControlGalleryPages` for testing

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
