### PR TITLE
[iOS] Fix Bounds for PageContainer 

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -15,7 +15,7 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: Dependency(typeof(CacheService))]
 [assembly: ExportRenderer(typeof(DisposePage), typeof(DisposePageRenderer))]
 [assembly: ExportRenderer(typeof(DisposeLabel), typeof(DisposeLabelRenderer))]
-[assembly: ExportEffect(typeof(BorderEffect), "BorderEffect")]
+[assembly: ExportEffect(typeof(BorderEffect), nameof(BorderEffect))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 	public class BorderEffect : PlatformEffect

--- a/Xamarin.Forms.ControlGallery.iOS/CustomEffects/GradientEffect.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomEffects/GradientEffect.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.ComponentModel;
+using CoreAnimation;
+using CoreGraphics;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportEffect(typeof(GradientEffect), Issue6334.EffectName)]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class GradientEffect : PlatformEffect
+	{
+		protected override void OnAttached()
+		{
+			InsertGradient();
+		}
+
+		CAGradientLayer layer;
+		void InsertGradient()
+		{
+			System.Diagnostics.Debug.WriteLine("InsertGradient : " + Container.Bounds);
+			var page = Element as ContentPage;
+			var childLabel = page?.Content as Label;
+			if (childLabel != null && Container.Bounds.Width == 0)
+			{
+				return;
+			}
+
+			if (layer == null)
+			{
+
+				childLabel.Text = Issue6334.Success;
+
+				var eColor = page.BackgroundColor.ToCGColor();
+				var sColor = page.BackgroundColor.AddLuminosity(0.5).ToCGColor();
+				layer = new CAGradientLayer
+				{
+					Frame = Container.Bounds,
+					Colors = new CGColor[] { sColor, eColor }
+				};
+				Container.Layer.InsertSublayer(layer, 0);
+			}
+		}
+
+		protected override void OnElementPropertyChanged(PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(args);
+			if (args.PropertyName == Page.WidthProperty.PropertyName ||
+				args.PropertyName == Page.HeightProperty.PropertyName)
+			{
+				layer.Frame = Container.Bounds;
+				// or (Element as VisualElement).Bounds.ToRectangleF();
+			}
+		}
+
+		protected override void OnDetached()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\xamarin.forms.controls\gallerypages\openglgalleries\AdvancedOpenGLGallery.cs">
       <Link>GalleryPages\AdvancedOpenGLGallery.cs</Link>
     </Compile>
+    <Compile Include="CustomEffects\GradientEffect.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">
@@ -397,6 +398,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\Fonts\" />
+    <Folder Include="CustomEffects\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6334.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6334.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue6334Test() 
 		{
-			RunningApp.WaitForElement (q => q.Marked (AutomationId));
+			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
 			RunningApp.WaitForElement(q => q.Marked(Success));
 			RunningApp.Screenshot ("I see the gradient");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6334.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6334.cs
@@ -1,0 +1,47 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6334, "iOS effect no longer works after upgrading to XF 4.0 since UIView.Bounds has no size", PlatformAffected.iOS)]
+	public class Issue6334 : TestContentPage
+	{
+		public const string EffectName = "GradientEffect";
+		public const string Success = "Success";
+		public const string Fail = "Fail";
+		
+		protected override void Init()
+		{
+			BackgroundColor = Color.Blue;
+			var effect = Effect.Resolve($"{Issues.Effects.ResolutionGroupName}.{EffectName}");
+
+			Effects.Add(effect);
+
+			Content = new Label
+			{
+				AutomationId = "IssuePageLabel",
+				Text = Fail
+			};
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void Issue6334Test() 
+		{
+			RunningApp.WaitForElement (q => q.Marked (AutomationId));
+			RunningApp.WaitForElement(q => q.Marked(Success));
+			RunningApp.Screenshot ("I see the gradient");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -934,6 +934,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5951.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5132.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5888.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6334.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1199,7 +1200,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6130.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public PageContainer(IAccessibilityElementsController parent)
 		{
+			AutoresizingMask = UIViewAutoresizing.FlexibleWidth | UIViewAutoresizing.FlexibleHeight;
 			_parent = parent;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -123,8 +123,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void LoadView()
 		{
+			//by default use the MainScreen Bounds so Effects can access the Container size
 			if (_pageContainer == null)
-				_pageContainer = new PageContainer(this);
+				_pageContainer = new PageContainer(this) { Frame = UIScreen.MainScreen.Bounds};
 
 			View = _pageContainer;
 		}


### PR DESCRIPTION
### Description of Change ###

We introduced a wrapper PageContainer and doing so we override the default LoadView of our PageRenderer ViewController. 

The default method provided a UIView with a Frame and Bounds, while our PageContainer doesn't provide one when it's created. Since our effects are attached when we set the elements for reuse on renderers when the user access the Bounds of the container there are not set ,while in previous versions there were (even if wrong ) .
Since these are related with size even previous versions should be using not the attach only but also the OnElementPropertyChanged or other methods to update there frame if the size changes. 


After some testing seems that the default size that was provided was the UIScreen even if inside a NavigationPage, this also is not very important as the Frame will be updated later on chain ViewWillLayoutSubviews.
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6334
- fixes #6372

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Should visit Issue 6334 and see a gradient and Success message.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard