### PR TITLE
[Android] Fixed applying effects to Frames

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3548.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3548.cs
@@ -11,7 +11,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 3548, "Cannot attach effect to Frame", PlatformAffected.iOS, NavigationBehavior.PushAsync)]
+	[Issue(IssueTracker.Github, 3548, "Cannot attach effect to Frame", PlatformAffected.Android)]
 	public class Issue3548 : TestContentPage
 	{
 		private const string SuccessMessage = "EFFECT IS ATTACHED!";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3548.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3548.cs
@@ -3,17 +3,23 @@ using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Controls.Effects;
 using System.Threading.Tasks;
 
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 3548, "Cannot attach effect to Frame", PlatformAffected.Android, NavigationBehavior.PushAsync)]
-	public class Issue3548 : ContentPage
+	[Issue(IssueTracker.Github, 3548, "Cannot attach effect to Frame", PlatformAffected.iOS, NavigationBehavior.PushAsync)]
+	public class Issue3548 : TestContentPage
 	{
+		private const string SuccessMessage = "EFFECT IS ATTACHED!";
+
 		private Frame _statusFrame;
 		private AttachedStateEffect _effect;
 
-		public Issue3548()
+		protected override void Init()
 		{
 			var statusLabel = new Label
 			{
@@ -37,7 +43,7 @@ namespace Xamarin.Forms.Controls.Issues
 			_effect.StateChanged += (sender, e) =>
 			{
 				statusLabel.Text = _effect.State == AttachedStateEffect.AttachedState.Attached
-					? "EFFECT IS ATTACHED!"
+					? SuccessMessage
 					: "EFFECT IS DEATTACHED";
 
 				_statusFrame.BackgroundColor = Color.LightGreen;
@@ -52,10 +58,9 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 		}
 
-		protected override async void OnAppearing()
+		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			await Task.Delay(500);
 			_statusFrame.Effects.Add(_effect);
 		}
 
@@ -64,6 +69,14 @@ namespace Xamarin.Forms.Controls.Issues
 			base.OnDisappearing();
 			_statusFrame.Effects.Remove(_effect);
 		}
+
+#if UITEST
+		[Test]
+		public void CheckIsEffectAttached()
+		{
+			RunningApp.WaitForElement(q => q.Marked(SuccessMessage));
+		}
+#endif
 	}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3548.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3548.cs
@@ -1,0 +1,69 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Controls.Effects;
+using System.Threading.Tasks;
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3548, "Cannot attach effect to Frame", PlatformAffected.Android, NavigationBehavior.PushAsync)]
+	public class Issue3548 : ContentPage
+	{
+		private Frame _statusFrame;
+		private AttachedStateEffect _effect;
+
+		public Issue3548()
+		{
+			var statusLabel = new Label
+			{
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				FontSize = 40,
+				Text = "EFFECT IS NOT ATTACHED"
+			};
+
+			_effect = new AttachedStateEffect();
+
+			_statusFrame = new Frame
+			{
+				BackgroundColor = Color.Red,
+				Padding = 15,
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				Content = statusLabel
+			};
+
+			_effect.StateChanged += (sender, e) =>
+			{
+				statusLabel.Text = _effect.State == AttachedStateEffect.AttachedState.Attached
+					? "EFFECT IS ATTACHED!"
+					: "EFFECT IS DEATTACHED";
+
+				_statusFrame.BackgroundColor = Color.LightGreen;
+			};
+
+			Content = new StackLayout
+			{
+				Padding = 50,
+				Children = {
+					_statusFrame
+				}
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+			await Task.Delay(500);
+			_statusFrame.Effects.Add(_effect);
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			_statusFrame.Effects.Remove(_effect);
+		}
+	}
+}
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -970,6 +970,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6334.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6368.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6077.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3548.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -11,7 +11,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
-	public class FrameRenderer : CardView, IVisualElementRenderer, IEffectControlProvider, IViewRenderer, ITabStop
+	public class FrameRenderer : CardView, IVisualElementRenderer, IViewRenderer, ITabStop
 	{
 		float _defaultElevation = -1f;
 		float _defaultCornerRadius = -1f;
@@ -23,9 +23,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		VisualElementPackager _visualElementPackager;
 		VisualElementTracker _visualElementTracker;
+		VisualElementRenderer _visualElementRenderer;
 
-		readonly GestureManager _gestureManager;
-		readonly EffectControlProvider _effectControlProvider;
 		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
@@ -33,16 +32,14 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		public FrameRenderer(Context context) : base(context)
 		{
-			_gestureManager = new GestureManager(this);
-			_effectControlProvider = new EffectControlProvider(this);
+			_visualElementRenderer = new VisualElementRenderer(this);
 		}
 
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use FrameRenderer(Context) instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public FrameRenderer() : base(Forms.Context)
 		{
-			_gestureManager = new GestureManager(this);
-			_effectControlProvider = new EffectControlProvider(this);
+			_visualElementRenderer = new VisualElementRenderer(this);
 		}
 
 		protected CardView Control => this;
@@ -104,11 +101,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			tracker?.UpdateLayout();
 		}
 
-		void IEffectControlProvider.RegisterEffect(Effect effect)
-		{
-			_effectControlProvider.RegisterEffect(effect);
-		}
-
 		void IViewRenderer.MeasureExactly()
 		{
 			ViewRenderer.MeasureExactly(this, Element, Context);
@@ -123,8 +115,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			if (disposing)
 			{
-				_gestureManager?.Dispose();
-
 				if (_visualElementTracker != null)
 				{
 					_visualElementTracker.Dispose();
@@ -142,7 +132,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 					_backgroundDrawable.Dispose();
 					_backgroundDrawable = null;
 				}
-				
+
+				_visualElementRenderer?.Dispose();
+				_visualElementRenderer = null;
+
 				int count = ChildCount;
 				for (var i = 0; i < count; i++)
 				{
@@ -215,7 +208,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		public override bool OnTouchEvent(MotionEvent e)
 		{
-			if (_gestureManager.OnTouchEvent(e) || base.OnTouchEvent(e))
+			if (_visualElementRenderer.OnTouchEvent(e) || base.OnTouchEvent(e))
 			{
 				return true;
 			}


### PR DESCRIPTION
### Description of Change ###

Added *VisualElementRenderer* field as observer of Android Frame renderer (combination of gesture / effects listeners) instead of separate listeners (the same approach with Label's fast renderer.

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/3548

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

It's possible to adjust effects to frames

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Described in original issue ticket. Please check: https://github.com/xamarin/Xamarin.Forms/issues/3548
