### PR TITLE
[Housekeeping] Fixed Xaml Binding StringFormat intellisense errors

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGallery.xaml
@@ -33,13 +33,13 @@
             
             <DataTemplate x:Key="EmptyTemplate">
                 <StackLayout>
-                    <Label Text="{Binding ., StringFormat='({0}) does not match any day of the week.'}"></Label>
+                    <Label Text="{Binding ., StringFormat='{}({0}) does not match any day of the week.'}"></Label>
                 </StackLayout>
             </DataTemplate>
 
             <DataTemplate x:Key="SymbolsTemplate">
                 <StackLayout BackgroundColor="Red">
-                    <Label Text="{Binding ., StringFormat='({0}) _definitely_ does not match any day of the week.'}"></Label>
+                    <Label Text="{Binding ., StringFormat='{}({0}) _definitely_ does not match any day of the week.'}"></Label>
                 </StackLayout>
             </DataTemplate>
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewTemplateGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewTemplateGallery.xaml
@@ -20,7 +20,7 @@
 						<StackLayout> 
 							<Label FontAttributes="Bold" FontSize="18" Margin="10,25,10,10"
 									HorizontalOptions="Fill" HorizontalTextAlignment="Center" 
-									Text="{Binding Filter, StringFormat='Your filter term of {0} did not match any records'}"></Label>
+									Text="{Binding Filter, StringFormat='{}Your filter term of {0} did not match any records'}"></Label>
 						</StackLayout>
 					</DataTemplate>
 				</CollectionView.EmptyViewTemplate>


### PR DESCRIPTION
### Description of Change ###

Fixed compile erros of Controls gallery on VS for Mac 2019

More info about workaround: https://developercommunity.visualstudio.com/content/problem/252490/error-in-xamarin-stringformat-intellisense.html

### Before/After Screenshots ### 

Before:
![image](https://user-images.githubusercontent.com/10124814/58919155-bcad4800-8735-11e9-9679-4571f80dc049.png)

After:
![image](https://user-images.githubusercontent.com/10124814/58919118-9d161f80-8735-11e9-9e53-b2f80bea3c0d.png)


### Testing Procedure ###

Try to compile controls gallery on VS for mac 2019

![image](https://user-images.githubusercontent.com/10124814/58919171-c931a080-8735-11e9-96b6-1c3af2b91451.png)


