### PR TITLE
[iOS] Protect against SetNativeControl when no Element is present

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/CustomRenderer.cs
@@ -14,7 +14,10 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		{
 			base.OnElementChanged(e);
 
-			//this Pattern is wrong
+			//
+			// --- Important --- //
+			//
+			// This is a WRONG Pattern!
 			//Pattern taken from: https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/custom-renderer/view
 			if (this.Control == null)
 			{

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/CustomRenderer.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Platform.iOS;
+using static Xamarin.Forms.Controls.Issues.Issue6368;
+
+[assembly: ExportRenderer(typeof(CustomView), typeof(CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class CustomRenderer : ViewRenderer<CustomView, UIView>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<CustomView> e)
+		{
+			base.OnElementChanged(e);
+
+			//this Pattern is wrong
+			//Pattern taken from: https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/custom-renderer/view
+			if (this.Control == null)
+			{
+				// Instantiate the native control and assign it to the Control property with
+				// the SetNativeControl method
+				UIView myView = new UIView();
+				this.SetNativeControl(myView);
+			}
+
+			if (e.OldElement != null)
+			{
+				// Unsubscribe from event handlers and cleanup any resources
+			}
+
+			if (e.NewElement != null)
+			{
+				// Configure the control and subscribe to event handlers
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/RoundedLabelRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/RoundedLabelRenderer.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS.CustomRenderers;
+using Xamarin.Forms.Platform.iOS;
+using static Xamarin.Forms.Controls.Issues.Issue6368;
+
+[assembly: ExportRenderer(typeof(RoundedLabel), typeof(RoundedLabelRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS.CustomRenderers
+{
+	public class RoundedLabelRenderer : LabelRenderer
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			if (Control == null)
+			{
+				SetNativeControl(new TagUiLabel());
+			}
+			base.OnElementChanged(e);
+			if (e.NewElement != null)
+			{
+				this.Layer.CornerRadius = 10;
+				this.Layer.BorderColor = ColorExtensions.ToCGColor(ColorExtensions.ToColor(UIColor.FromRGB(3, 169, 244)));
+				this.Layer.BackgroundColor = ColorExtensions.ToCGColor(Color.GhostWhite);
+				this.Layer.BorderWidth = 1;
+			}
+		}
+	}
+
+	class TagUiLabel : UILabel
+	{
+
+		private UIEdgeInsets EdgeInsets = new UIEdgeInsets(10, 5, 10, 5);
+		private UIEdgeInsets InverseEdgeInsets = new UIEdgeInsets(-10, -5, -10, -5);
+
+		public override CoreGraphics.CGRect TextRectForBounds(CoreGraphics.CGRect bounds, nint numberOfLines)
+		{
+			var textRect = base.TextRectForBounds(EdgeInsets.InsetRect(bounds), numberOfLines);
+			return InverseEdgeInsets.InsetRect(textRect);
+		}
+		public override void DrawText(CoreGraphics.CGRect rect)
+		{
+			base.DrawText(EdgeInsets.InsetRect(rect));
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/RoundedLabelRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/RoundedLabelRenderer.cs
@@ -29,18 +29,17 @@ namespace Xamarin.Forms.ControlGallery.iOS.CustomRenderers
 
 	class TagUiLabel : UILabel
 	{
-
-		private UIEdgeInsets EdgeInsets = new UIEdgeInsets(10, 5, 10, 5);
-		private UIEdgeInsets InverseEdgeInsets = new UIEdgeInsets(-10, -5, -10, -5);
+		UIEdgeInsets _edgeInsets = new UIEdgeInsets(10, 5, 10, 5);
+		UIEdgeInsets _inverseEdgeInsets = new UIEdgeInsets(-10, -5, -10, -5);
 
 		public override CoreGraphics.CGRect TextRectForBounds(CoreGraphics.CGRect bounds, nint numberOfLines)
 		{
-			var textRect = base.TextRectForBounds(EdgeInsets.InsetRect(bounds), numberOfLines);
-			return InverseEdgeInsets.InsetRect(textRect);
+			var textRect = base.TextRectForBounds(_edgeInsets.InsetRect(bounds), numberOfLines);
+			return _inverseEdgeInsets.InsetRect(textRect);
 		}
 		public override void DrawText(CoreGraphics.CGRect rect)
 		{
-			base.DrawText(EdgeInsets.InsetRect(rect));
+			base.DrawText(_edgeInsets.InsetRect(rect));
 		}
 	}
 }

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -117,6 +117,8 @@
     <Compile Include="CustomRenderers.cs" />
     <Compile Include="CustomRendererBugzila38731.cs" />
     <Compile Include="CustomApplication.cs" />
+    <Compile Include="CustomRenderers\CustomRenderer.cs" />
+    <Compile Include="CustomRenderers\RoundedLabelRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">
@@ -386,6 +388,7 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\Fonts\" />
+    <Folder Include="CustomRenderers\" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6368.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6368.cs
@@ -1,0 +1,67 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+#if UITEST
+	[Category(UITestCategories.CustomRenderers)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6368, "[CustomRenderer]Crash when navigating back from page with custom renderer control", PlatformAffected.iOS)]
+	public class Issue6368 : TestNavigationPage 
+	{
+		public class CustomView : View
+		{
+		}
+
+		public class RoundedLabel : Label
+		{
+		}
+
+		protected override void Init()
+		{
+			var rootPage = new ContentPage();
+			var button = new Button()
+			{
+				AutomationId = "btnGo",
+				Text = "Click me",
+				Command = new Command(() => PushAsync(new ContentPage()
+				{
+					Content = GetContent()
+				}))
+			};
+			var content = GetContent();
+			content.Children.Add(button);
+			rootPage.Content = content;
+			PushAsync(rootPage);
+		}
+
+		static StackLayout GetContent()
+		{
+			var content2 = new StackLayout();
+			content2.Children.Add(new RoundedLabel { Text = "Go to next Page" });
+			content2.Children.Add(new RoundedLabel { Text = "then navigate back" });
+			content2.Children.Add(new RoundedLabel { Text = "If test doesn't crash it passed" });
+			content2.Children.Add(new CustomView());
+			return content2;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue6368Test() 
+		{
+			RunningApp.WaitForElement (q => q.Marked ("btnGo"));
+			RunningApp.Tap(q => q.Marked("btnGo"));
+			RunningApp.WaitForElement(q => q.Marked("Go to next Page"));
+			RunningApp.NavigateBack();
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6368.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6368.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var button = new Button()
 			{
 				AutomationId = "btnGo",
-				Text = "Click me",
+				Text = "Click me to go to the next page",
 				Command = new Command(() => PushAsync(new ContentPage()
 				{
 					Content = GetContent()
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Controls.Issues
 			return content2;
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Issue6368Test() 
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -893,6 +893,7 @@
       <DependentUpon>Issue4356.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue5888.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6368.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -47,5 +47,7 @@
 		public const string Performance = "Performance";
 		public const string Visual = "Visual";
 		public const string AppLinks = "AppLinks";
+		public const string Shell = "Shell";
+		public const string CustomRenderers = "CustomRenderers";
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		event EventHandler _controlChanging;
 		event EventHandler _controlChanged;
 
-
+		bool IsElementOrControlEmpty => Element == null || Control == null;
 
 		protected virtual TNativeView CreateNativeControl()
 		{
@@ -188,7 +188,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void SetBackgroundColor(Color color)
 		{
-			if (Control == null)
+			if (IsElementOrControlEmpty)
 				return;
 #if __MOBILE__
 			if (color == Color.Default)
@@ -217,8 +217,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 			Control = uiview;
 
-			if (Element.BackgroundColor != Color.Default)
-				SetBackgroundColor(Element.BackgroundColor);
+			UpdateBackgroundColor();
 
 			UpdateIsEnabled();
 
@@ -236,9 +235,18 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 #endif
 
+		void UpdateBackgroundColor()
+		{
+			if (IsElementOrControlEmpty)
+				return;
+
+			if (Element.BackgroundColor != Color.Default)
+				SetBackgroundColor(Element.BackgroundColor);
+		}
+
 		void UpdateIsEnabled()
 		{
-			if (Element == null || Control == null)
+			if (IsElementOrControlEmpty)
 				return;
 
 			var uiControl = Control as NativeControl;
@@ -249,6 +257,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateFlowDirection()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			Control.UpdateFlowDirection(Element);
 		}
 


### PR DESCRIPTION
### Description of Change ###

By introducing some fixes in how we dispose the children renderers of pages renderes we started passing `Null`on SetElement so we can do some cleanup and detaching effects for example.
`SetNativeControl` is expected to be called when we have Element, for example a NewElement, but since we now pass Null and users don't take that in account in there code they end up creating a new NativeControl when we are disposing. 

Our users are using this [pattern](https://docs.microsoft.com/en-us/xamarin/xamarin-forms/app-fundamentals/custom-renderer/view) that is wrong:
```
protected override void OnElementChanged (ElementChangedEventArgs<NativeListView> e)
{
  base.OnElementChanged (e);

  if (Control == null) {
    // Instantiate the native control and assign it to the Control property with
    // the SetNativeControl method
  }

  if (e.OldElement != null) {
    // Unsubscribe from event handlers and cleanup any resources
  }

  if (e.NewElement != null) {
    // Configure the control and subscribe to event handlers
  }
}
```

While they should be using something like this:
```
protected override void OnElementChanged (ElementChangedEventArgs<NativeListView> e)
{
  base.OnElementChanged (e);

  if (e.OldElement != null) {
    // Unsubscribe from event handlers and cleanup any resources
  }

  if (e.NewElement != null) {
      if (Control == null) {
       // Instantiate the native control and assign it to the Control property with
      // the SetNativeControl method
     }
  }
}
```
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6368
- fixes #6328 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Should not crash when disposing 

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
