### PR TITLE
[WPF] restored missed assembly attribute

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
@@ -4,6 +4,8 @@ using System.Windows;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.WPF;
 
+[assembly: ThemeInfo(ResourceDictionaryLocation.None, ResourceDictionaryLocation.SourceAssembly)]
+
 [assembly: ExportRenderer(typeof(Layout), typeof(LayoutRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]
 [assembly: ExportRenderer(typeof(Button), typeof(ButtonRenderer))]


### PR DESCRIPTION
### Description of Change ###

Restored missed the Assembly attribute `ThemeInfo`

### Issues Resolved ### 

- fixes #6399

### API Changes ###
 
 None

### Platforms Affected ### 

- WPF

### Before/After Screenshots ### 

Before
![image](https://user-images.githubusercontent.com/27482193/58960193-549b4800-87af-11e9-9edf-d718e24c38c0.png)

After
![image](https://user-images.githubusercontent.com/27482193/58960160-3d5c5a80-87af-11e9-82e0-fd4c0e04059d.png)

### Testing Procedure ###

- run ControlGalley

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
