### PR TITLE
[Android] Retrieve PackageName from the correct Platform instance

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -23,11 +23,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		bool _navAnimationInProgress;
 		NavigationModel _navModel = new NavigationModel();
 		Page _pendingRootChange = null;
+		internal static string PackageName { get; private set; }
+		internal static string GetPackageName() => PackageName ?? Android.Platform.PackageName;
 
 		public Platform(Context context)
 		{
 			_context = context;
-
+			PackageName = context?.PackageName;
 			_renderer = new PlatformRenderer(context, this);
 
 			FormsAppCompatActivity.BackPressed += HandleBackPressed;

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 
 		internal static string PackageName { get; private set; }
+		internal static string GetPackageName() => PackageName ?? AppCompat.Platform.PackageName;
+
 		internal const string CloseContextActionsSignalName = "Xamarin.CloseContextActions";
 
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),

--- a/Xamarin.Forms.Platform.Android/Renderers/FileImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FileImageSourceHandler.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (File.Exists (file))
 				bitmap = !DecodeSynchronously ? (await BitmapFactory.DecodeFileAsync (file).ConfigureAwait (false)) : BitmapFactory.DecodeFile (file);
 			else
-				bitmap = !DecodeSynchronously ? (await context.Resources.GetBitmapAsync (file).ConfigureAwait (false)) : context.Resources.GetBitmap (file);
+				bitmap = !DecodeSynchronously ? (await context.Resources.GetBitmapAsync (file, context).ConfigureAwait (false)) : context.Resources.GetBitmap (file, context);
 
 			if (bitmap == null)
 			{

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -379,7 +379,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (packageName != null)
 			{
 				id = resource.GetIdentifier(name, defType, packageName);
-			
+
 				if (id > 0)
 					return id;
 			}

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -254,9 +254,19 @@ namespace Xamarin.Forms.Platform.Android
 			return BitmapFactory.DecodeResource(resource, IdFromTitle(name, DrawableClass, _drawableDefType, resource));
 		}
 
+		public static Bitmap GetBitmap(this Resources resource, string name, Context context)
+		{
+			return BitmapFactory.DecodeResource(resource, IdFromTitle(name, DrawableClass, _drawableDefType, resource, context.PackageName));
+		}
+
 		public static Task<Bitmap> GetBitmapAsync(this Resources resource, string name)
 		{
 			return BitmapFactory.DecodeResourceAsync(resource, IdFromTitle(name, DrawableClass, _drawableDefType, resource));
+		}
+
+		public static Task<Bitmap> GetBitmapAsync(this Resources resource, string name, Context context)
+		{
+			return BitmapFactory.DecodeResourceAsync(resource, IdFromTitle(name, DrawableClass, _drawableDefType, resource, context.PackageName));
 		}
 
 		[Obsolete("GetDrawable(this Resources, string) is obsolete as of version 2.5. "
@@ -310,9 +320,19 @@ namespace Xamarin.Forms.Platform.Android
 			return IdFromTitle(name, LayoutClass);
 		}
 
+		public static int GetLayout(this Context context, string name)
+		{
+			return IdFromTitle(name, LayoutClass, "layout", context);
+		}
+
 		public static int GetStyleByName(string name)
 		{
 			return IdFromTitle(name, StyleClass);
+		}
+
+		public static int GetStyle(this Context context, string name)
+		{
+			return IdFromTitle(name, StyleClass, "style", context);
 		}
 
 		public static void Init(Assembly masterAssembly)
@@ -335,7 +355,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		static int IdFromTitle(string title, Type resourceType, string defType, Resources resource)
 		{
-			return IdFromTitle(title, resourceType, defType, resource, Platform.PackageName);
+			return IdFromTitle(title, resourceType, defType, resource, AppCompat.Platform.GetPackageName());
 		}
 
 		static int IdFromTitle(string title, Type resourceType, string defType, Context context)
@@ -359,7 +379,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (packageName != null)
 			{
 				id = resource.GetIdentifier(name, defType, packageName);
-
+			
 				if (id > 0)
 					return id;
 			}


### PR DESCRIPTION
### Description of Change ###

- PackageName was being retrieved from the non appcompat version of platform so it needed to be updated to use appcompat
- Changed the call to retrieve the bitmap for the fileimagehandler so that it passes in the Android Context

### Issues Resolved ### 

- fixes #6327 


### Platforms Affected ### 
- Android


### Testing Procedure ###
This one is really weird to test. Your best option for testing is to pull down the repo on the included issues and test there.  The only way to recreate this issues is to:
- create an android library
- move the entire resource library from the head project to the library
- If the head project has even a single resource or drawable in it then the issue can't be recreated. 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
