### PR TITLE
Implement ItemSizingStrategy.MeasureFirstItem on Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
@@ -1,11 +1,15 @@
+using System;
 using Android.Content;
 using Android.Views;
+using ASize = Android.Util.Size;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	internal class ItemContentView : ViewGroup
 	{
 		protected IVisualElementRenderer Content;
+		ASize _size;
+		Action<ASize> _reportMeasure;
 
 		public ItemContentView(Context context) : base(context)
 		{
@@ -13,6 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal void RealizeContent(View view)
 		{
+			
 			Content = CreateRenderer(view, Context);
 			AddView(Content.View);
 			Content.Element.MeasureInvalidated += ElementMeasureInvalidated;
@@ -36,6 +41,13 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			Content = null;
+			_size = null;
+		}
+
+		internal void HandleItemSizingStrategy(Action<ASize> reportMeasure, ASize size)
+		{
+			_reportMeasure = reportMeasure;
+			_size = size;
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)
@@ -60,6 +72,13 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
+			if (_size != null)
+			{
+				// If we're using ItemSizingStrategy.MeasureFirstItem and now we have a set size, use that
+				SetMeasuredDimension(_size.Width, _size.Height);
+				return;
+			}
+
 			int pixelWidth = MeasureSpec.GetSize(widthMeasureSpec);
 			int pixelHeight = MeasureSpec.GetSize(heightMeasureSpec);
 
@@ -73,9 +92,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			SizeRequest measure = Content.Element.Measure(width, height, MeasureFlags.IncludeMargins);
 
-			// When we implement ItemSizingStrategy.MeasureFirstItem for Android, these next two clauses will need to
-			// be updated to use the static width/height
-
 			if (pixelWidth == 0)
 			{
 				pixelWidth = (int)Context.ToPixels(measure.Request.Width);
@@ -85,6 +101,9 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				pixelHeight = (int)Context.ToPixels(measure.Request.Height);
 			}
+
+			_reportMeasure?.Invoke(new ASize(pixelWidth, pixelHeight));
+			_reportMeasure = null; // Make sure we only report back the measure once
 
 			SetMeasuredDimension(pixelWidth, pixelHeight);
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -2,9 +2,9 @@ using System;
 using Android.Content;
 using Android.Support.V7.Widget;
 using Android.Widget;
-using AView = Android.Views.View;
 using Object = Java.Lang.Object;
 using ViewGroup = Android.Views.ViewGroup;
+using ASize = Android.Util.Size;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Platform.Android
 		readonly Func<View, Context, ItemContentView> _createItemContentView;
 		internal readonly IItemsViewSource ItemsSource;
 		bool _disposed;
+		ASize _size;
 
 		internal ItemsViewAdapter(ItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
@@ -50,9 +51,22 @@ namespace Xamarin.Forms.Platform.Android
 					textViewHolder.TextView.Text = ItemsSource[position].ToString();
 					break;
 				case TemplatedItemViewHolder templatedItemViewHolder:
-					templatedItemViewHolder.Bind(ItemsSource[position], ItemsView);
+					if (ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem)
+					{
+						templatedItemViewHolder.Bind(ItemsSource[position], ItemsView, SetStaticSize, _size);
+					}
+					else
+					{
+						templatedItemViewHolder.Bind(ItemsSource[position], ItemsView);
+					}
+
 					break;
 			}
+		}
+
+		void SetStaticSize(ASize size)
+		{
+			_size = size;
 		}
 
 		public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
@@ -65,8 +79,19 @@ namespace Xamarin.Forms.Platform.Android
 				return new TextViewHolder(view);
 			}
 
-			var itemContentView = new ItemContentView(parent.Context);
+			var itemContentView = CreateItemContentView(parent.Context);
 			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate);
+		}
+
+		ItemContentView CreateItemContentView(Context context)
+		{
+			if(ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureAllItems
+				|| _size == null)
+			{
+				return new ItemContentView(context);
+			}
+
+			return new ItemContentView(context);
 		}
 
 		public override int ItemCount => ItemsSource.Count;

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -79,19 +79,8 @@ namespace Xamarin.Forms.Platform.Android
 				return new TextViewHolder(view);
 			}
 
-			var itemContentView = CreateItemContentView(parent.Context);
+			var itemContentView = new ItemContentView(context);
 			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate);
-		}
-
-		ItemContentView CreateItemContentView(Context context)
-		{
-			if(ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureAllItems
-				|| _size == null)
-			{
-				return new ItemContentView(context);
-			}
-
-			return new ItemContentView(context);
 		}
 
 		public override int ItemCount => ItemsSource.Count;

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -205,6 +205,10 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateEmptyView();
 			}
+			else if (changedProperty.Is(ItemsView.ItemSizingStrategyProperty))
+			{
+				UpdateAdapter();
+			}
 		}
 
 		protected virtual void UpdateItemsSource()

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -1,5 +1,6 @@
 using System;
 using Xamarin.Forms.Internals;
+using ASize = Android.Util.Size;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -37,7 +38,8 @@ namespace Xamarin.Forms.Platform.Android
 			itemsView.RemoveLogicalChild(View);
 		}
 
-		public void Bind(object itemBindingContext, ItemsView itemsView)
+		public void Bind(object itemBindingContext, ItemsView itemsView, 
+			Action<ASize> reportMeasure = null, ASize size = null)
 		{
 			var template = _template.SelectDataTemplate(itemBindingContext, itemsView);
 
@@ -48,6 +50,8 @@ namespace Xamarin.Forms.Platform.Android
 				_itemContentView.RealizeContent(View);
 				_selectedTemplate = template;
 			}
+
+			_itemContentView.HandleItemSizingStrategy(reportMeasure, size); 
 
 			// Set the binding context before we add it as a child of the ItemsView; otherwise, it will
 			// inherit the ItemsView's binding context


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

- implements part of #3172

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery, navigate to CollectionView Gallery ->Item Size Galleries ->ItemSizing Strategy

The initial selection is MeasureFirstItem; all of the items should have the same size. If you switch to MeasureAllItems, the items will have varying sizes.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
