### PR TITLE
[XamlC] Correctly load addresses of values in more compiled binding paths

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -488,6 +488,49 @@ namespace Xamarin.Forms.Build.Tasks
 			return properties;
 		}
 
+		static IEnumerable<Instruction> DigProperties(IEnumerable<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> properties, Dictionary<TypeReference, VariableDefinition> locs, Func<Instruction> fallback, IXmlLineInfo lineInfo, ModuleDefinition module)
+		{
+			var first = true;
+
+			foreach (var (property, propDeclTypeRef, indexArg) in properties) {
+				if (!first && propDeclTypeRef.IsValueType) {
+					var importedPropDeclTypeRef = module.ImportReference(propDeclTypeRef);
+
+					if (!locs.TryGetValue(importedPropDeclTypeRef, out var loc)) {
+						loc = new VariableDefinition(importedPropDeclTypeRef);
+						locs[importedPropDeclTypeRef] = loc;
+					}
+
+					yield return Create(Stloc, loc);
+					yield return Create(Ldloca, loc);
+				}
+
+				if (fallback != null && !propDeclTypeRef.IsValueType) {
+					yield return Create(Dup);
+					yield return Create(Brfalse, fallback());
+				}
+
+				if (indexArg != null) {
+					var indexType = property.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(propDeclTypeRef);
+					if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.String))
+						yield return Create(Ldstr, indexArg);
+					else if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.Int32) && int.TryParse(indexArg, out int index))
+						yield return Create(Ldc_I4, index);
+					else
+						throw new XamlParseException($"Binding: {indexArg} could not be parsed as an index for a {property.Name}", lineInfo);
+				}
+
+				var getMethod = module.ImportReference((module.ImportReference(property.GetMethod)).ResolveGenericParameters(propDeclTypeRef, module));
+
+				if (property.GetMethod.IsVirtual)
+					yield return Create(Callvirt, getMethod);
+				else
+					yield return Create(Call, getMethod);
+
+				first = false;
+			}
+		}
+
 		static IEnumerable<Instruction> CompiledBindingGetGetter(TypeReference tSourceRef, TypeReference tPropertyRef, IList<(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg)> properties, ElementNode node, ILContext context)
 		{
 //				.method private static hidebysig default valuetype[mscorlib] System.ValueTuple`2<string, bool> '<Main>m__0' (class ViewModel A_0)  cil managed
@@ -538,70 +581,33 @@ namespace Xamarin.Forms.Build.Tasks
 				else
 					il.Emit(Ldarg_0);
 
-				for (int i = 0; i < properties.Count; i++) {
-					(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg) = properties[i];
-					if (i > 0 && propDeclTypeRef.IsValueType) {
-						var importedPropDeclTypeRef = module.ImportReference(propDeclTypeRef);
+				Instruction pop = null;
+				il.Append(DigProperties(properties, locs, () => {
+					if (pop == null)
+						pop = Create(Pop);
 
-						if (!locs.TryGetValue(importedPropDeclTypeRef, out var loc)) {
-							loc = new VariableDefinition(importedPropDeclTypeRef);
-							getter.Body.Variables.Add(loc);
-							locs[importedPropDeclTypeRef] = loc;
-						}
+					return pop;
+				}, node as IXmlLineInfo, module));
 
-						il.Emit(Stloc, loc);
-						il.Emit(Ldloca, loc);
-					}
+				foreach (var loc in locs.Values)
+					getter.Body.Variables.Add(loc);
 
-					if (!propDeclTypeRef.IsValueType) { //if part of the path is null, return (default(T), false)
-						var nop = Create(Nop);
-						il.Emit(Dup);
-						il.Emit(Ldnull);
-						il.Emit(Ceq);
-						il.Emit(Brfalse, nop);
-						il.Emit(Pop);
-						if (tPropertyRef.IsValueType) {
-							var importedTPropertyRef = module.ImportReference(tPropertyRef);
-
-							if (!locs.TryGetValue(importedTPropertyRef, out var defaultValueVarDef)) {
-								defaultValueVarDef = new VariableDefinition(tPropertyRef);
-								getter.Body.Variables.Add(defaultValueVarDef);
-								locs[importedTPropertyRef] = defaultValueVarDef;
-							}
-
-							il.Emit(Ldloca_S, defaultValueVarDef);
-							il.Emit(Initobj, tPropertyRef);
-							il.Emit(Ldloc, defaultValueVarDef);
-						}
-						else
-							il.Emit(Ldnull);
-						il.Emit(Ldc_I4_0); //false
-
-						il.Emit(Newobj, tupleCtorRef);
-						il.Emit(Ret);
-						il.Append(nop);
-					}
-
-					if (indexArg != null) {
-						var indexType = property.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(propDeclTypeRef);
-						if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.String))
-							il.Emit(Ldstr, indexArg);
-						else if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.Int32) && int.TryParse(indexArg, out int index))
-							il.Emit(Ldc_I4, index);
-						else
-							throw new XamlParseException($"Binding: {indexArg} could not be parsed as an index for a {property.Name}", node as IXmlLineInfo);
-					}
-
-					var getMethod = module.ImportReference((module.ImportReference(property.GetMethod)).ResolveGenericParameters(propDeclTypeRef, module));
-
-					if (property.GetMethod.IsVirtual)
-						il.Emit(Callvirt, getMethod);
-					else
-						il.Emit(Call, getMethod);
-				}
 				il.Emit(Ldc_I4_1); //true
 				il.Emit(Newobj, tupleCtorRef);
 				il.Emit(Ret);
+
+				if (pop != null) {
+					if (!locs.TryGetValue(tupleRef, out var defaultValueVarDef)) {
+						defaultValueVarDef = new VariableDefinition(tupleRef);
+						getter.Body.Variables.Add(defaultValueVarDef);
+					}
+
+					il.Append(pop);
+					il.Emit(Ldloca_S, defaultValueVarDef);
+					il.Emit(Initobj, tupleRef);
+					il.Emit(Ldloc, defaultValueVarDef);
+					il.Emit(Ret);
+				}
 			}
 			context.Body.Method.DeclaringType.Methods.Add(getter);
 
@@ -658,29 +664,25 @@ namespace Xamarin.Forms.Build.Tasks
 				il.Emit(Ldarga_S, (byte)0);
 			else
 				il.Emit(Ldarg_0);
-			for (int i = 0; i < properties.Count - 1; i++) {
-				(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg) = properties[i];
-				if (indexArg != null) {
-					var indexType = property.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(propDeclTypeRef);
-					if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.String))
-						il.Emit(Ldstr, indexArg);
-					else if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.Int32)) {
-						if (!int.TryParse(indexArg, out var index))
-							throw new XamlParseException($"Binding: {indexArg} could not be parsed as an index for a {property.Name}", node as IXmlLineInfo);
-						il.Emit(Ldc_I4, index);
-					}
-				}
+			var locs = new Dictionary<TypeReference, VariableDefinition>();
+			il.Append(DigProperties(properties.Take(properties.Count - 1), locs, null, node as IXmlLineInfo, module));
 
-				var getMethod = module.ImportReference(property.GetMethod);
-				getMethod = module.ImportReference(getMethod.ResolveGenericParameters(propDeclTypeRef, module));
-
-				if (property.GetMethod.IsVirtual)
-					il.Emit(Callvirt, getMethod);
-				else
-					il.Emit(Call, getMethod);
-			}
+			foreach (var loc in locs.Values)
+				setter.Body.Variables.Add(loc);
 
 			(PropertyDefinition lastProperty, TypeReference lastPropDeclTypeRef, string lastIndexArg) = properties.Last();
+			if (lastPropDeclTypeRef.IsValueType) {
+				var importedPropDeclTypeRef = module.ImportReference(lastPropDeclTypeRef);
+
+				if (!locs.TryGetValue(importedPropDeclTypeRef, out var loc)) {
+					loc = new VariableDefinition(importedPropDeclTypeRef);
+					setter.Body.Variables.Add(loc);
+				}
+
+				il.Emit(Stloc, loc);
+				il.Emit(Ldloca, loc);
+			}
+
 			if (lastIndexArg != null) {
 				var indexType = lastProperty.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(lastPropDeclTypeRef);
 				if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.String))
@@ -765,30 +767,11 @@ namespace Xamarin.Forms.Build.Tasks
 					il.Emit(Ldarga_S, (byte)0);
 				else
 					il.Emit(Ldarg_0);
-				var lastGetterTypeRef = tSourceRef;
-				for (int j = 0; j < i; j++) {
-					(PropertyDefinition property, TypeReference propDeclTypeRef, string indexArg) = properties[j];
-					if (indexArg != null) {
-						var indexType = property.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(propDeclTypeRef);
-						if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.String))
-							il.Emit(Ldstr, indexArg);
-						else if (TypeRefComparer.Default.Equals(indexType, module.TypeSystem.Int32)) {
-							if (!int.TryParse(indexArg, out var index))
-								throw new XamlParseException($"Binding: {indexArg} could not be parsed as an index for a {property.Name}", node as IXmlLineInfo);
-							il.Emit(Ldc_I4, index);
-						}
-					}
-
-					var getMethod = module.ImportReference(property.GetMethod);
-					getMethod = module.ImportReference(getMethod.ResolveGenericParameters(propDeclTypeRef, module));
-
-					if (property.GetMethod.IsVirtual)
-						il.Emit(Callvirt, getMethod);
-					else
-						il.Emit(Call, getMethod);
-
-					lastGetterTypeRef = property.PropertyType;
-				}
+				var lastGetterTypeRef = properties[i - 1].property.PropertyType;
+				var locs = new Dictionary<TypeReference, VariableDefinition>();
+				il.Append(DigProperties(properties.Take(i), locs, null, node as IXmlLineInfo, module));
+				foreach (var loc in locs.Values)
+					partGetter.Body.Variables.Add(loc);
 				if (lastGetterTypeRef.IsValueType)
 					il.Emit(Box, module.ImportReference(lastGetterTypeRef));
 

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
@@ -18,7 +18,8 @@
 			<Entry Text="{Binding Text, Mode=TwoWay}" x:Name="entry0"/>
             <Label Text="{Binding .}" x:Name="label7" x:DataType="sys:Int32"/>
             <Label Text="{Binding Text, Mode=OneTime}" x:Name="label8" />
-			<Label Text="{Binding StructModel.Text}" x:Name="label9" />
+			<Label Text="{Binding StructModel.Text, Mode=TwoWay}" x:Name="label9" />
+			<Label Text="{Binding StructModel.Model.Text, Mode=TwoWay}" x:Name="label10" />
 		</StackLayout>
 		<Label Text="{Binding Text}" x:Name="labelWithUncompiledBinding" />
 	</StackLayout>

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -50,7 +50,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 						Text = "Text1"
 					},
 					StructModel = new MockStructViewModel {
-						Text = "Text9"
+						Model = new MockViewModel {
+							Text = "Text9"
+						}
 					}
 				};
 				vm.Model [3] = "TextIndex";
@@ -74,6 +76,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.That(layout.label5.Text, Is.EqualTo("42"));
 				Assert.That(layout.label6.Text, Is.EqualTo("text6"));
 				Assert.AreEqual("Text9", layout.label9.Text);
+				Assert.AreEqual("Text9", layout.label10.Text);
+				layout.label9.Text = "Text from label9";
+				Assert.AreEqual("Text from label9", vm.StructModel.Text);
+				layout.label10.Text = "Text from label10";
+				Assert.AreEqual("Text from label10", vm.StructModel.Model.Text);
 
 				//testing selfPath
 				layout.label4.BindingContext = "Self";
@@ -100,7 +107,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 	struct MockStructViewModel
 	{
-		public string Text { get; set; }
+		public string Text {
+			get { return Model.Text; }
+			set { Model.Text = value; }
+		}
 		public int I { get; set; }
 		public MockViewModel Model { get; set; }
 	}


### PR DESCRIPTION
### Description of Change ###

This is a follow-up of commit 12f5b702ef4c8bcbd343b6272555ba9f01b36438.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
Run automated tests.

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
