### PR TITLE
[UWP] fixes hangs ListView when using Narrator

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -768,9 +768,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected override AutomationPeer OnCreateAutomationPeer()
 		{
-			return List == null
-				? new FrameworkElementAutomationPeer(this)
-				: new ListViewAutomationPeer(List);
+			if (List == null)
+				return new FrameworkElementAutomationPeer(this);
+
+			var automationPeer = new ListViewAutomationPeer(List);
+			// skip this renderer from automationPeer tree to avoid infinity loop
+			automationPeer.SetParent(new FrameworkElementAutomationPeer(Parent as FrameworkElement));
+			return automationPeer;
 		}
 
 	}


### PR DESCRIPTION
### Description of Change ###

FIxes automation implementation for `ListViewRenderer`

### Issues Resolved ### 

- fixes #5340

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Testing Procedure ###

- run UItest B60699
- launch Narrator
- select any item in ListView
- app should't hang

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
