### PR TITLE
[UWP] Fixed resetting the background color of the frame

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
@@ -64,15 +64,8 @@ namespace Xamarin.Forms.Platform.UWP
 			Color backgroundColor = Element.BackgroundColor;
 			if (Control != null)
 			{
-				if (!backgroundColor.IsDefault)
-				{
-					Control.Background = backgroundColor.ToBrush();
-				}
-				else
-				{
-					Control.ClearValue(BackgroundProperty);
-				}
-			}			
+				Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
+			}
 		}
 
 		void PackChild()


### PR DESCRIPTION
### Description of Change ###

Fixed resetting the background color of the frame

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Before
![image](https://user-images.githubusercontent.com/27482193/59046660-0f4c4880-888b-11e9-94bf-f5497bc53837.png)

After
![image](https://user-images.githubusercontent.com/27482193/59046857-6d792b80-888b-11e9-81ae-95200de46b5d.png)

### Testing Procedure ###

- run `Dynamic ViewGallery`
- select any control
- set any color and reset it (switch off)
- application should't crash & color should be reseted

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
