### PR TITLE
[Android] Fix context actions icon so that it loads

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6258.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6258.cs
@@ -38,8 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 					cells.ContextActions.Add(new MenuItem()
 					{
 						IconImageSource = "coffee.png",
-						AutomationId = "coffee.png",
-						//Text = "Menuitem Text"
+						AutomationId = "coffee.png"
 					});
 
 					cells.View = new StackLayout()
@@ -48,7 +47,7 @@ namespace Xamarin.Forms.Controls.Issues
 						{
 							new Label()
 							{
-								Text = "test",
+								Text = "Trigger context action on this row and you should see a coffee cup. Test only relevation on Android",
 								AutomationId = "ListViewItem"
 							}
 						}
@@ -59,7 +58,7 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 		}
 
-#if UITEST
+#if UITEST && __ANDROID__
 		[Test]
 		public void ContextActionsIconImageSource()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6258.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6258.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6258, "[Android] ContextActions icon not working",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue6258 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			var page = new ContentPage();
+
+			PushAsync(page);
+
+			page.Content = new ListView()
+			{
+				ItemsSource = new [] {"1"},
+				ItemTemplate = new DataTemplate(() =>
+				{
+					ViewCell cells = new ViewCell();
+
+					cells.ContextActions.Add(new MenuItem()
+					{
+						IconImageSource = "coffee.png",
+						AutomationId = "coffee.png",
+						//Text = "Menuitem Text"
+					});
+
+					cells.View = new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "test",
+								AutomationId = "ListViewItem"
+							}
+						}
+					};
+
+					return cells;
+				})
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void ContextActionsIconImageSource()
+		{
+			RunningApp.WaitForElement("ListViewItem");
+			RunningApp.ActivateContextMenu("ListViewItem");
+			RunningApp.WaitForElement("coffee.png");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6458.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6458.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6458, "[Android] Fix load TitleIcon on non app compact", PlatformAffected.Android)]
+	public class Issue6458 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			NavigationPage.SetTitleIconImageSource(this, new FileImageSource { File = "bank.png" });
+			Content = new Label
+			{
+				AutomationId = "IssuePageLabel",
+				Text = "Make sure you run this on Non AppCompact Activity"
+			};
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Issue6458Test()
+		{
+			RunningApp.WaitForElement(q => q.Marked("IssuePageLabel"));
+			RunningApp.Screenshot("You should see the bank icon on the ActionBar");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6458.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6458.cs
@@ -9,16 +9,17 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-#if UITEST
-	[Category(UITestCategories.ManualReview)]
-#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 6458, "[Android] Fix load TitleIcon on non app compact", PlatformAffected.Android)]
 	public class Issue6458 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
 		protected override void Init()
 		{
-			NavigationPage.SetTitleIconImageSource(this, new FileImageSource { File = "bank.png" });
+			NavigationPage.SetTitleIconImageSource(this, 
+				new FileImageSource {
+					File = "bank.png",
+					AutomationId = "banktitleicon"
+				});
 			Content = new Label
 			{
 				AutomationId = "IssuePageLabel",
@@ -30,8 +31,13 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue6458Test()
 		{
-			RunningApp.WaitForElement(q => q.Marked("IssuePageLabel"));
-			RunningApp.Screenshot("You should see the bank icon on the ActionBar");
+			RunningApp.WaitForElement("IssuePageLabel");
+			var element = RunningApp.WaitForElement("banktitleicon");
+
+			Assert.AreEqual(1, element.Length, "banktitleicon not found");
+
+			Assert.Greater(element[0].Rect.Height, 10);
+			Assert.Greater(element[0].Rect.Width, 10);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6258.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3150.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6258.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3150.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6262.cs" />

--- a/Xamarin.Forms.Controls/ControlGalleryPages/AutomationPropertiesGallery.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/AutomationPropertiesGallery.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Controls
 					labeledByInstructions = $"The following Entry should read aloud \"EditBox {EntryPlaceholder} for {EntryHelpText}.\", plus native instructions on how to use an Entry element. This text comes from the Entry placeholder and text of the Label.";
 					imageInstructions = $"The following Image should read aloud \"{ImageName}. {ImageHelpText}\". You should be able to tap the image and hear an alert box.";
 					boxInstructions = $"The following Box should read aloud \"{BoxName}. {BoxHelpText}\". You should be able to tap the box and hear an alert box.";
-					toolbarInstructions = $"The Toolbar should have a coffee cup icon. Activating the coffee cup should read aloud \"{toolbarItemName}\". The Toolbar should also show the text \"{toolbarItem2Text}\". Activating this item should read aloud \"{toolbarItem2Text}\".";
+					toolbarInstructions = $"The Toolbar should have a coffee cup icon. Activating the coffee cup should read aloud \"{toolbarItemName}\". The Toolbar should also show the text \"{toolbarItem2Text}\". Activating this item should read aloud \"{toolbarItem2Text}. {toolbarItemHint2}\".";
 					break;
 				case Device.UWP:
 					screenReader = "Narrator";

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Core.UITests
 			var btn2 = App.Query(c => c.Marked(btn4Id))[0];
 			Assert.False(btn2.Enabled, "Toolbar Item  should be disable");
 #else
-			var btn1 = App.Query(c => c.Marked(btn1Id))[0];
+			var btn1 = App.WaitForElement(c => c.Marked(btn1Id))[0];
 			ShouldShowMenu();
 			//var btn2 = App.Query (c => c.Marked (btn4Id)) [0];
 			//TODO: how to check Enable for the textview

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -11,11 +11,11 @@ namespace Xamarin.Forms.Core.UITests
 	[Category(UITestCategories.UwpIgnore)]
 	internal class ToolbarItemTests : BaseTestFixture
 	{
-		string btn1Id = "tb1";
-		string btn2Id = "tb2";
-		string btn4Id = "tb4";
+		string btn1Id = "toolbaritem_primary";
+		string btn2Id = "toolbaritem_primary2";
+		string btn4Id = "toolbaritem_secondary2";
 #if !__MACOS__
-		string btn3Id = "tb3";
+		string btn3Id = "toolbaritem_secondary";
 #endif 
 
 #if __ANDROID__
@@ -45,15 +45,6 @@ namespace Xamarin.Forms.Core.UITests
 		protected override void NavigateToGallery()
 		{
 			App.NavigateToGallery(GalleryQueries.ToolbarItemGallery);
-#if __IOS__
-			btn1Id = "menuIcon";
-			btn4Id = "tb4";
-			if (AppSetup.iOSVersion  >= 9)
-			{
-				btn1Id = "toolbaritem_primary";
-				btn4Id = "toolbaritem_secondary2";
-			}
-#endif
 		}
 
 		[Test]
@@ -75,9 +66,7 @@ namespace Xamarin.Forms.Core.UITests
 		public void ToolbarButtonsCommand()
 		{
 			ShouldShowMenu();
-#if __ANDROID__
-			//App.Query (c => c.Marked (btn4Id))[0];
-#else
+
 			App.WaitForElement(btn4Id);
 			App.Tap(c => c.Marked(btn4Id));
 			App.WaitForNoElement(c => c.Text("button 4 new text"));
@@ -86,13 +75,18 @@ namespace Xamarin.Forms.Core.UITests
 #else
 			App.Tap(c => c.Marked(btn3Id));
 #endif
+#if __ANDROID__
+			ShouldShowMenu();
+#endif
 			App.Tap(c => c.Marked(btn4Id));
 			App.WaitForElement(c => c.Text("button 4 new text"));
 #if __MACOS__
 			App.Tap(c => c.Button().Index(6));
 #else
-			App.Tap(c => c.Marked(btn3Id));
+#if __ANDROID__
+			ShouldShowMenu();
 #endif
+			App.Tap(c => c.Marked(btn3Id));
 #endif
 		}
 

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -20,25 +20,27 @@ namespace Xamarin.Forms.Core.UITests
 #endif 
 
 #if __ANDROID__
-		static bool isSecondaryMenuOpen = false;
+		bool isSecondaryMenuOpen()
+		{
+			Thread.Sleep(1000);
+			var items = App.Query(btn4Id);
+			return items.Length > 0;
+		}
 #endif
-		static void ShouldShowMenu()
+		void ShouldShowMenu()
 		{
 #if __ANDROID__
-			isSecondaryMenuOpen = true;
 			//show secondary menu
 			App.WaitForElement(c => c.Class("OverflowMenuButton"));
 			App.Tap(c => c.Class("OverflowMenuButton"));
 #endif
 		}
 
-		static void ShouldHideMenu()
+		void ShouldHideMenu()
 		{
 #if __ANDROID__
-			if (isSecondaryMenuOpen)
+			if (isSecondaryMenuOpen())
 			{
-				isSecondaryMenuOpen = false;
-
 				// slight pause in case menu hasn't quite closed
 				Thread.Sleep(500);
 				App.Back();
@@ -91,9 +93,6 @@ namespace Xamarin.Forms.Core.UITests
 			ShouldShowMenu();
 #endif
 			App.Tap(c => c.Marked(btn3Id));
-#if __ANDROID__
-			isSecondaryMenuOpen = false;
-#endif
 #endif
 		}
 
@@ -159,6 +158,13 @@ namespace Xamarin.Forms.Core.UITests
 #endif
 		}
 
+
+		protected override void TestTearDown()
+		{
+			base.TestTearDown();
+			ResetApp();
+			NavigateToGallery();
+		}
 	}
 }
 

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -1,4 +1,5 @@
-﻿using NUnit.Framework;
+﻿using System.Threading;
+using NUnit.Framework;
 using Xamarin.Forms.Controls;
 using Xamarin.Forms.CustomAttributes;
 
@@ -37,6 +38,9 @@ namespace Xamarin.Forms.Core.UITests
 			if (isSecondaryMenuOpen)
 			{
 				isSecondaryMenuOpen = false;
+
+				// slight pause in case menu hasn't quite closed
+				Thread.Sleep(500);
 				App.Back();
 			}
 #endif
@@ -87,6 +91,9 @@ namespace Xamarin.Forms.Core.UITests
 			ShouldShowMenu();
 #endif
 			App.Tap(c => c.Marked(btn3Id));
+#if __ANDROID__
+			isSecondaryMenuOpen = false;
+#endif
 #endif
 		}
 

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -44,6 +44,7 @@ namespace Xamarin.Forms.Core.UITests
 			}
 			else
 			{
+				app.DismissKeyboard();
 				app.Tap(q => q.Raw(goToTestButtonQuery));
 			}
 

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -34,17 +34,16 @@ namespace Xamarin.Forms.Core.UITests
 
 			app.WaitForElement("SearchBar");
 			app.EnterText(q => q.Raw("* marked:'SearchBar'"), text);
+			app.DismissKeyboard();
 
-			if(!String.IsNullOrWhiteSpace(visual))
+			if (!String.IsNullOrWhiteSpace(visual))
 			{
-				app.DismissKeyboard();
 				app.ActivateContextMenu($"{text}AutomationId");
 				app.Tap("Select Visual");
 				app.Tap("Material");
 			}
 			else
 			{
-				app.DismissKeyboard();
 				app.Tap(q => q.Raw(goToTestButtonQuery));
 			}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -1035,6 +1035,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_ = this.ApplyDrawableAsync(currentPage, NavigationPage.TitleIconImageSourceProperty, Context, drawable =>
 				{
 					_titleIconView.SetImageDrawable(drawable);
+					FastRenderers.AutomationPropertiesProvider.SetAutomationIdAndContentDescription(_titleIconView, source);
 				});
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -898,7 +898,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					IMenuItem menuItem = menu.Add(item.Text);
 					menuItem.SetEnabled(controller.IsEnabled);
-					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));
+					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));					
 					menuItem.SetTitleOrContentDescription(item);
 				}
 				else
@@ -1035,7 +1035,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_ = this.ApplyDrawableAsync(currentPage, NavigationPage.TitleIconImageSourceProperty, Context, drawable =>
 				{
 					_titleIconView.SetImageDrawable(drawable);
-					FastRenderers.AutomationPropertiesProvider.SetAutomationIdAndContentDescription(_titleIconView, source);
+					FastRenderers.AutomationPropertiesProvider.AccessibilitySettingsChanged(_titleIconView, source);
 				});
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -200,7 +200,6 @@ namespace Xamarin.Forms.Platform.Android
 					if (iconDrawable != null && !_isDisposed && !_actionModeNeedsUpdates)
 					{
 						item.SetIcon(iconDrawable);
-						string value = FastRenderers.AutomationPropertiesProvider.ConcatenateNameAndHelpText(action);
 						item.SetTitleOrContentDescription(action);
 					}
 				});

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				_ = _context.ApplyDrawableAsync(action, MenuItem.IconImageSourceProperty, iconDrawable =>
 				{
-					if (iconDrawable != null && !_isDisposed && !_actionModeNeedsUpdates)
+					if (iconDrawable != null && !_isDisposed && !this.IsDisposed() && !_actionModeNeedsUpdates)
 					{
 						item.SetIcon(iconDrawable);
 						item.SetTitleOrContentDescription(action);

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _actionModeNeedsUpdates;
 		AView _contextView;
 		global::Android.Support.V7.View.ActionMode _supportActionMode;
+		bool _isDisposed = false;
 
 		protected CellAdapter(Context context)
 		{
@@ -196,8 +197,12 @@ namespace Xamarin.Forms.Platform.Android
 
 				_ = _context.ApplyDrawableAsync(action, MenuItem.IconImageSourceProperty, iconDrawable =>
 				{
-					if (iconDrawable != null)
+					if (iconDrawable != null && !_isDisposed && !_actionModeNeedsUpdates)
+					{
 						item.SetIcon(iconDrawable);
+						string value = FastRenderers.AutomationPropertiesProvider.ConcatenateNameAndHelpText(action);
+						item.SetTitleOrContentDescription(action);
+					}
 				});
 
 				action.PropertyChanged += changed;
@@ -333,6 +338,13 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			return false;
+		}
+
+
+		protected override void Dispose(bool disposing)
+		{
+			_isDisposed = true;
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -10,6 +10,7 @@ using AView = Android.Views.View;
 using AListView = Android.Widget.ListView;
 using Android.Graphics.Drawables;
 using Android.Support.V7.App;
+using AActionMode = global::Android.Support.V7.View.ActionMode;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -22,8 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool _actionModeNeedsUpdates;
 		AView _contextView;
-		global::Android.Support.V7.View.ActionMode _supportActionMode;
-		bool _isDisposed = false;
+		AActionMode _supportActionMode;
 
 		protected CellAdapter(Context context)
 		{
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				_ = _context.ApplyDrawableAsync(action, MenuItem.IconImageSourceProperty, iconDrawable =>
 				{
-					if (iconDrawable != null && !_isDisposed && !this.IsDisposed() && !_actionModeNeedsUpdates)
+					if (iconDrawable != null && !this.IsDisposed() && !_actionModeNeedsUpdates)
 					{
 						item.SetIcon(iconDrawable);
 						item.SetTitleOrContentDescription(action);
@@ -337,13 +337,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			return false;
-		}
-
-
-		protected override void Dispose(bool disposing)
-		{
-			_isDisposed = true;
-			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
@@ -102,20 +102,26 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static void SetTitleOrContentDescription(this IMenuItem Control, ToolbarItem Element)
 		{
+			SetTitleOrContentDescription(Control, (MenuItem)Element);
+		}
+
+		public static void SetTitleOrContentDescription(this IMenuItem Control, MenuItem Element)
+		{
 			if (Element == null)
 				return;
-
-			// TODO: Android API 26+ will let us set the ContentDescription
-			// Until then, we will set the Title, but only if there is no Text.
-			// Thus, a ToolbarItem on Android can have one or the other, and Text
-			// will take precedence (since it will be visible on the screen).
-			if (!string.IsNullOrWhiteSpace(Element.Text))
-				return;
-
+			
 			var elemValue = ConcatenateNameAndHint(Element);
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
-				Control.SetTitle(elemValue);
+				global::Android.Support.V4.View.MenuItemCompat.SetContentDescription(Control, elemValue);
+			else
+			{
+				string value = Element.AutomationId;
+				if (!string.IsNullOrEmpty(value))
+				{
+					global::Android.Support.V4.View.MenuItemCompat.SetContentDescription(Control, value);
+				}
+			}
 
 			return;
 		}

--- a/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Android.Views;
+using AMenuItemCompat = global::Android.Support.V4.View.MenuItemCompat;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -112,16 +113,11 @@ namespace Xamarin.Forms.Platform.Android
 			
 			var elemValue = ConcatenateNameAndHint(Element);
 
+			if (string.IsNullOrWhiteSpace(elemValue))
+				elemValue = Element.AutomationId;
+
 			if (!string.IsNullOrWhiteSpace(elemValue))
-				global::Android.Support.V4.View.MenuItemCompat.SetContentDescription(Control, elemValue);
-			else
-			{
-				string value = Element.AutomationId;
-				if (!string.IsNullOrEmpty(value))
-				{
-					global::Android.Support.V4.View.MenuItemCompat.SetContentDescription(Control, value);
-				}
-			}
+				AMenuItemCompat.SetContentDescription(Control, elemValue);
 
 			return;
 		}

--- a/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
@@ -119,7 +119,6 @@ namespace Xamarin.Forms.Platform.Android
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				AMenuItemCompat.SetContentDescription(Control, elemValue);
 
-			return;
 		}
 
 		static string ConcatenateNameAndHint(Element Element)

--- a/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/AccessibilityExtensions.cs
@@ -115,6 +115,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (string.IsNullOrWhiteSpace(elemValue))
 				elemValue = Element.AutomationId;
+			else if (!String.IsNullOrEmpty(Element.Text))
+				elemValue = String.Join(". ", Element.Text, elemValue);
 
 			if (!string.IsNullOrWhiteSpace(elemValue))
 				AMenuItemCompat.SetContentDescription(Control, elemValue);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -29,7 +29,16 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			resourceIdClose = context.Resources.GetIdentifier($"{automationIdParent}{s_defaultDrawerIdCloseSuffix}", "string", context.ApplicationInfo.PackageName);
 		}
 
-		internal static void SetAutomationId(AView control, VisualElement element, string value = null)
+
+		internal static void SetAutomationIdAndContentDescription(AView control, Element element)
+		{
+			string defaultHint = null;
+			string defaultDescription = null;
+			SetAutomationId(control, element);
+			SetContentDescription(control, element, ref defaultHint, ref defaultDescription);
+		}
+
+		internal static void SetAutomationId(AView control, Element element, string value = null)
 		{
 			if (element == null || control == null)
 			{

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -46,17 +46,23 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		internal static void SetBasicContentDescription(
 			AView control,
-			BindableObject element,
+			BindableObject bindableObject,
 			ref string defaultContentDescription)
 		{
-			if (element == null || control == null)
+			if (bindableObject == null || control == null)
 				return;
 
 			if (defaultContentDescription == null)
 				defaultContentDescription = control.ContentDescription;
 
-			string value = ConcatenateNameAndHelpText(element);
-			control.ContentDescription = !string.IsNullOrWhiteSpace(value) ? value : defaultContentDescription;
+			string value = ConcatenateNameAndHelpText(bindableObject);
+
+			var contentDescription = !string.IsNullOrWhiteSpace(value) ? value : defaultContentDescription;
+
+			if (String.IsNullOrWhiteSpace(contentDescription) && bindableObject is Element element)
+				contentDescription = element.AutomationId;
+
+			control.ContentDescription = contentDescription;
 		}
 
 		internal static void SetContentDescription(

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -29,15 +29,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			resourceIdClose = context.Resources.GetIdentifier($"{automationIdParent}{s_defaultDrawerIdCloseSuffix}", "string", context.ApplicationInfo.PackageName);
 		}
 
-
-		internal static void SetAutomationIdAndContentDescription(AView control, Element element)
-		{
-			string defaultHint = null;
-			string defaultDescription = null;
-			SetAutomationId(control, element);
-			SetContentDescription(control, element, ref defaultHint, ref defaultDescription);
-		}
-
 		internal static void SetAutomationId(AView control, Element element, string value = null)
 		{
 			if (element == null || control == null)
@@ -80,7 +71,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			SetBasicContentDescription(control, element, ref defaultContentDescription);
 		}
 
-		internal static void SetFocusable(AView control, VisualElement element, ref bool? defaultFocusable)
+		internal static void SetFocusable(AView control, Element element, ref bool? defaultFocusable)
 		{
 			if (element == null || control == null)
 			{
@@ -96,7 +87,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				(bool)((bool?)element.GetValue(AutomationProperties.IsInAccessibleTreeProperty) ?? defaultFocusable);
 		}
 
-		internal static void SetLabeledBy(AView control, VisualElement element)
+		internal static void SetLabeledBy(AView control, Element element)
 		{
 			if (element == null || control == null)
 				return;
@@ -199,6 +190,27 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		bool SetHint()
 			=> SetHint(Control, Element, ref _defaultHint);
 
+		void SetLabeledBy()
+			=> SetLabeledBy(Control, Element);
+
+		internal static void AccessibilitySettingsChanged(AView control, Element element, ref string _defaultHint, ref string _defaultContentDescription, ref bool? _defaultFocusable)
+		{
+			SetHint(control, element, ref _defaultHint);
+			SetAutomationId(control, element);
+			SetContentDescription(control, element, ref _defaultContentDescription, ref _defaultHint);
+			SetFocusable(control, element, ref _defaultFocusable);
+			SetLabeledBy(control, element);
+		}
+
+		internal static void AccessibilitySettingsChanged(AView control, Element element)
+		{
+			string _defaultHint = String.Empty;
+			string _defaultContentDescription = String.Empty;
+			bool? _defaultFocusable = null;
+			AccessibilitySettingsChanged(control, element, ref _defaultHint, ref _defaultContentDescription, ref _defaultFocusable);
+		}
+
+
 		internal static string ConcatenateNameAndHelpText(BindableObject Element)
 		{
 			var name = (string)Element.GetValue(AutomationProperties.NameProperty);
@@ -212,9 +224,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			return $"{name}. {helpText}";
 		}
 
-		void SetLabeledBy()
-			=> SetLabeledBy(Control, Element);
-
 		void OnElementChanged(object sender, VisualElementChangedEventArgs e)
 		{
 			if (e.OldElement != null)
@@ -227,11 +236,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 			}
 
-			SetHint();
-			SetAutomationId();
-			SetContentDescription();
-			SetFocusable();
-			SetLabeledBy();
+			AccessibilitySettingsChanged(Control, Element, ref _defaultHint, ref _defaultContentDescription, ref _defaultFocusable);
 		}
 
 		void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1085,7 +1085,7 @@ namespace Xamarin.Forms.Platform.Android
 						actionBar.SetLogo(icon);
 				});
 				var titleIcon = NavigationPage.GetTitleIconImageSource(view);
-				useLogo = titleIcon != null && titleIcon.IsEmpty;
+				useLogo = titleIcon != null && !titleIcon.IsEmpty;
 				showHome = true;
 				showTitle = true;
 			}

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -133,7 +133,6 @@ namespace Xamarin.Forms.Platform.Android
 												Action<bool> onLoading = null,
 												CancellationToken cancellationToken = default(CancellationToken))
 		{
-			_ = renderer ?? throw new ArgumentNullException(nameof(renderer));
 			_ = context ?? throw new ArgumentNullException(nameof(context));
 			_ = imageSourceProperty ?? throw new ArgumentNullException(nameof(imageSourceProperty));
 			_ = onSet ?? throw new ArgumentNullException(nameof(onSet));
@@ -141,7 +140,7 @@ namespace Xamarin.Forms.Platform.Android
 			// TODO: it might be good to make sure the renderer has not been disposed
 
 			// make sure things are good before we start
-			var element = bindable ?? renderer.Element;
+			var element = bindable ?? renderer?.Element;
 
 			if (element == null)
 				return;
@@ -174,10 +173,10 @@ namespace Xamarin.Forms.Platform.Android
 							return;
 
 						// we are back, so update the working element
-						element = bindable ?? renderer.Element;
+						element = bindable ?? renderer?.Element;
 
 						// makse sure things are good now that we are back
-						if (element == null || renderer.View == null)
+						if (element == null || renderer?.View == null)
 							return;
 
 						// only set if we are still on the same image
@@ -196,10 +195,10 @@ namespace Xamarin.Forms.Platform.Android
 								return;
 
 							// we are back, so update the working element
-							element = bindable ?? renderer.Element;
+							element = bindable ?? renderer?.Element;
 
 							// makse sure things are good now that we are back
-							if (element == null || renderer.View == null)
+							if (element == null || (renderer != null && renderer.View == null))
 								return;
 
 							// only set if we are still on the same image

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -176,7 +176,7 @@ namespace Xamarin.Forms.Platform.Android
 						element = bindable ?? renderer?.Element;
 
 						// makse sure things are good now that we are back
-						if (element == null || renderer?.View == null)
+						if (element == null || (renderer != null && renderer.View == null))
 							return;
 
 						// only set if we are still on the same image

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -194,14 +194,7 @@ namespace Xamarin.Forms.Platform.Android
 
 						using (var drawable = await context.GetFormsDrawableAsync(initialSource, cancellationToken))
 						{
-							if (renderer is IDisposedState disposed && disposed.IsDisposed)
-								return;
-
-							// we are back, so update the working element
-							element = bindable ?? renderer?.Element;
-
-							// makse sure things are good now that we are back
-							if (element == null || (renderer != null && renderer.View == null))
+							if (!renderer.IsDrawableSourceValid(bindable, out element))
 								return;
 
 							// only set if we are still on the same image

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -108,10 +108,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		static bool IsDrawableSourceValid(this IVisualElementRenderer renderer, BindableObject bindable, out BindableObject element)
 		{
-			if (renderer == null)
-				element = bindable;
-			else if((renderer is IDisposedState disposed && disposed.IsDisposed) || renderer.View == null)
+			if ((renderer is IDisposedState disposed && disposed.IsDisposed) || (renderer != null && renderer.View == null))
 				element = null;
+			else if (bindable != null)
+				element = bindable;
 			else
 				element = renderer.Element;
 
@@ -185,7 +185,7 @@ namespace Xamarin.Forms.Platform.Android
 						// only set if we are still on the same image
 						if (element.GetValue(imageSourceProperty) == initialSource)
 						{
-							using(returnValue)
+							using (returnValue)
 								onSet(returnValue);
 						}
 					}


### PR DESCRIPTION
### Description of Change ###
- Images loaded from icons don't have a renderer to work from so needed to update the image loading code to work if no renderer is specified
- Fixed menuitem/toolbaritem to correctly set Automation Id using appcompat 

### Breaking changes ###
On Android the AutomationId for Toolbaritems will now set the ContentDescription which makes the UI tests fall more inline with iOS. 

### Issues Resolved ### 
- fixes #6258 


### Platforms Affected ### 
- Android


### Testing Procedure ###
Run the included UI Test

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
