### PR TITLE
[Build]Update version so it matches what we have now

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
 - name: SolutionFile
   value: Xamarin.Forms.sln
 - name: BuildVersion
-  value: $[counter('$(Build.SourceBranchName)_counter', 1)]
+  value: $[counter('$(Build.SourceBranchName)_counter', 3000000)]
 - name: MONO_VERSION
   value: 5_18_1
 - name: XCODE_VERSION


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

Bump the default counter of the buildnumber so it matches what we have on old build definition that uses the BuildID, we can remove this later when we branch from master. 
This will allow us to start ship stable builds to nightly.

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
