### PR TITLE
[UWP] Fixes default button padding

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -55,7 +55,8 @@ namespace Xamarin.Forms.Platform.UWP
 				if (Element.IsSet(Button.CornerRadiusProperty) && Element.CornerRadius != (int)Button.CornerRadiusProperty.DefaultValue)
 					UpdateBorderRadius();
 
-				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
+				// By default Button loads width padding 8, 4, 8 ,4
+				if (Element.IsSet(Button.PaddingProperty))
 					UpdatePadding();
 
 				UpdateFont();

--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -112,7 +112,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (Element.IsSet(ImageButton.CornerRadiusProperty) && Element.CornerRadius != (int)ImageButton.CornerRadiusProperty.DefaultValue)
 					UpdateBorderRadius();
-				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
+
+				// By default Button loads width padding 8, 4, 8 ,4
+				if (Element.IsSet(Button.PaddingProperty))
 					UpdatePadding();
 
 				await TryUpdateSource().ConfigureAwait(false);


### PR DESCRIPTION
### Description of Change ###

By default button loading with no empty padding. Therefore empty padding must be set to the native control.

### Issues Resolved ### 

- fixes #6450

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Before
![image](https://user-images.githubusercontent.com/27482193/59118105-083f3c00-8958-11e9-906a-245193376199.png)

After
![image](https://user-images.githubusercontent.com/27482193/59118004-cf06cc00-8957-11e9-9af0-4802c6fd497e.png)


### Testing Procedure ###

- run Button Layout Gallery
- check button padding

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
