### PR TITLE
[ios] Shell inset,  general SafeArea fixes for shell and non shell embedded pages, entry scrolling fixes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
@@ -101,10 +101,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement($"{_safeAreaText}{false}");
 			element = RunningApp.WaitForElement(_paddingLabel).First();
 
-			if (usesSafeAreaInsets)
-				Assert.AreEqual(element.ReadText(), "0, 0, 0, 0");
-			else
-				Assert.AreEqual(element.ReadText(), "25, 25, 25, 25");
+			Assert.AreEqual(element.ReadText(), "25, 25, 25, 25");
 
 			// enable Safe Area insets
 			RunningApp.Tap(_safeAreaAutomationId);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml
@@ -16,7 +16,7 @@
                 <Label Text="Verify that Button.Image, MenuItem.Icon, Page.BackgroundImage, Page.Icon, Slider.ThumbImage all have coffee cups"></Label>
                 <Button Image="{Binding Image}" Clicked="ButtonClicked"></Button>
                 <Slider ThumbImage="{Binding Image}"></Slider>
-                <Button ImageSource="{Binding ImageUrl}" Clicked="ButtonClicked"></Button>
+                <Button AutomationId="Image1" ImageSource="{Binding ImageUrl}" Clicked="ButtonClicked"></Button>
                 <Slider ThumbImageSource="{Binding ImageUrl}"></Slider>          
             </StackLayout>
         </ScrollView>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -11,6 +11,7 @@ using Xamarin.Forms.Xaml;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
@@ -51,6 +52,19 @@ namespace Xamarin.Forms.Controls.Issues
 		public void LegacyImageSourceProperties()
 		{
 			RunningApp.WaitForElement("Nothing Crashed");
+			RunningApp.RetryUntilPresent(
+				() =>
+				{
+					var result = RunningApp.WaitForElement("Image1");
+
+					if (result[0].Rect.Height > 50)
+						return result;
+
+					return null;
+				}, 10, 2000);
+
+			// ensure url images have loaded
+			System.Threading.Thread.Sleep(2000);
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5132.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5132.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Ignore("Shell test is only supported on Android and iOS")]
 #endif 
 		[Test]
-		public void Issue5132Test()
+		public void ShellFlyoutAndHamburgerAutomationProperties()
 		{
 			RunningApp.WaitForElement(q => q.Marked(_idIconElement));
 			TapInFlyout(_titleElement, _idIconElement);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5239.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5239.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5239, "[iOS] Top Padding not working on iOS when it is set alone",
+		PlatformAffected.iOS, navigationBehavior: NavigationBehavior.SetApplicationRoot)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Page)]
+#endif
+	public class Issue5239 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Padding = new Thickness(0, 20, 0, 0);
+			Label label = new Label { Text = "I should be 20 pixels from the top", AutomationId = "Hello" };
+			Content = label;
+		}
+
+
+#if UITEST && __IOS__
+		[Test]
+		public void PaddingEqualToSafeAreaWorks()
+		{
+			var somePadding = RunningApp.WaitForElement("Hello");
+			Assert.AreEqual(20f, somePadding[0].Rect.Y);
+
+
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -25,6 +25,10 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class ShellInsets : TestShell
 	{
+		const string EntryTest = "EntryTest";
+		const string EntryToClick = "EntryToClick";
+		const string EntrySuccess = "EntrySuccess";
+
 		protected override void Init()
 		{
 			SetupLandingPage();
@@ -43,7 +47,8 @@ namespace Xamarin.Forms.Controls.Issues
 					new Button()
 					{
 						Text = "Entry Inset",
-						Command = new Command(() => EntryInset())
+						Command = new Command(() => EntryInset()),
+						AutomationId = EntryTest
 					},
 					new StackLayout()
 					{
@@ -141,7 +146,7 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					Children =
 						{
-							new Label(){ VerticalOptions= LayoutOptions.FillAndExpand, Text = "Click the entry and it should scroll up and stay visible. Click off entry and this label should still be visible"},
+							new Label(){ AutomationId = EntrySuccess, VerticalOptions= LayoutOptions.FillAndExpand, Text = "Click the entry and it should scroll up and stay visible. Click off entry and this label should still be visible"},
 							new Button(){ Text = "Top Tab", Command = new Command(() => AddTopTab("top"))},
 							new Button(){ Text = "Bottom Tab", Command = new Command(() => AddBottomTab("bottom"))},
 							new Button(){ Text = "Change Navbar Visible", Command = new Command(() => Shell.SetNavBarIsVisible(view.Parent, !(Shell.GetNavBarIsVisible(view.Parent))))},
@@ -152,6 +157,9 @@ namespace Xamarin.Forms.Controls.Issues
 							},
 							new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )},
 							new Entry()
+							{
+								AutomationId = EntryToClick
+							}
 						}
 				}
 			};
@@ -160,10 +168,16 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
-		public void UpdatingSourceOfDisposedListViewDoesNotCrash()
+		public void EntryScrollTest()
 		{
+			RunningApp.Tap(EntryTest);
+			RunningApp.Tap(EntryToClick);
+			RunningApp.WaitForNoElement(EntrySuccess);
+			RunningApp.TapCoordinates(0, 0);
+			RunningApp.WaitForElement(EntrySuccess);
+
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Inset Test",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellInsets : TestShell
+	{
+		protected override void Init()
+		{
+			SetupLandingPage();
+		}
+
+		void SetupLandingPage()
+		{
+			var page = CreateContentPage();
+			CheckBox cbox = new CheckBox();
+			Entry entryPadding = new Entry() { WidthRequest = 150 };
+
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Button()
+					{
+						Text = "Entry Inset",
+						Command = new Command(() => EntryInset())
+					},
+					new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							cbox,
+							new Button()
+							{
+								Text = "Safe Area",
+								Command = new Command(() => SafeArea(cbox.IsChecked))
+							}
+						},
+						HorizontalOptions = LayoutOptions.Center
+					},
+					new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							entryPadding,
+							new Button()
+							{
+								Text = "Padding",
+								Command = new Command(() => PaddingPage(entryPadding.Text))
+							}
+						},
+						HorizontalOptions = LayoutOptions.Center
+					}
+				}
+			};
+
+			CurrentItem = Items.Last();
+			if (Items.Count > 1)
+				Items.RemoveAt(0);
+		}
+
+		void PaddingPage(string text)
+		{
+			var page = CreateContentPage();
+
+			int padding = 0;
+			if (Int32.TryParse(text, out padding))
+				page.Padding = padding;
+
+			page.On<iOS>().SetUseSafeArea(false);
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label(){ Text = "Top Label", HeightRequest = 200},
+					new Label() { Text = $"Padding: {text}"},
+					new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )}
+				}
+			};
+
+			CurrentItem = Items.Last();
+			Items.RemoveAt(0);
+		}
+
+		void SafeArea(bool value)
+		{
+			var page = CreateContentPage();
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label(){ Text = "Top Label", HeightRequest = 200},
+					new Label(){Text = value ? "You should see two labels" : "You should see one label"},
+					new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )}
+				}
+			};
+
+			page.On<iOS>().SetUseSafeArea(value);
+			CurrentItem = Items.Last();
+			Items.RemoveAt(0);
+		}
+
+		void EntryInset()
+		{
+			var page = CreateContentPage();
+			page.Title = "Main";
+			page.Content = CreateEntryInsetView();
+
+			CurrentItem = Items.Last();
+			Items.RemoveAt(0);
+		}
+
+		View CreateEntryInsetView()
+		{
+			ScrollView view = null;
+			view = new ScrollView()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+						{
+							new Label(){ VerticalOptions= LayoutOptions.FillAndExpand, Text = "Click the entry and it should scroll up and stay visible. Click off entry and this label should still be visible"},
+							new Button(){ Text = "Top Tab", Command = new Command(() => AddTopTab("top"))},
+							new Button(){ Text = "Bottom Tab", Command = new Command(() => AddBottomTab("bottom"))},
+							new Button(){ Text = "Change Navbar Visible", Command = new Command(() => Shell.SetNavBarIsVisible(view.Parent, !(Shell.GetNavBarIsVisible(view.Parent))))},
+							new Button()
+							{
+								Text = "Push On Page",
+								Command = new Command(() => Navigation.PushAsync(new ContentPage(){ Content = CreateEntryInsetView() }))
+							},
+							new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )},
+							new Entry()
+						}
+				}
+			};
+
+			return view;
+		}
+
+
+#if UITEST
+		[Test]
+		public void UpdatingSourceOfDisposedListViewDoesNotCrash()
+		{
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -50,6 +50,11 @@ namespace Xamarin.Forms.Controls.Issues
 						Command = new Command(() => EntryInset()),
 						AutomationId = EntryTest
 					},
+					new Button()
+					{
+						Text = "List View Scroll Test",
+						Command = new Command(() => ListViewPage())
+					},
 					new StackLayout()
 					{
 						Orientation = StackOrientation.Horizontal,
@@ -84,6 +89,38 @@ namespace Xamarin.Forms.Controls.Issues
 			CurrentItem = Items.Last();
 			if (Items.Count > 1)
 				Items.RemoveAt(0);
+		}
+
+		void ListViewPage()
+		{
+			var page = CreateContentPage();
+
+			page.Content = new ListView(ListViewCachingStrategy.RecycleElement)
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					ViewCell cell = new ViewCell();
+					var label = new Label() { Text = " I am a label" }; ;
+					label.SetBinding(Label.TextProperty, ".");
+					cell.View =
+					new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							label,
+							new Entry(),
+							new Button() { Text = "Reset", Command = new Command(() => SetupLandingPage()) }
+						}
+					};
+
+					return cell;
+				}),
+				ItemsSource = Enumerable.Range(0, 1000)
+			};
+
+			CurrentItem = Items.Last();
+			Items.RemoveAt(0);
 		}
 
 		void PaddingPage(string text)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class ShellInsets : TestShell
 	{
-		const string EntryTest = "EntryTest";
+		const string EntryTest = nameof(EntryTest);
 		const string EntryToClick = "EntryToClick";
 		const string EntryToClick2 = "EntryToClick2";
 		const string EntrySuccess = "EntrySuccess";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -27,7 +27,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		const string EntryTest = "EntryTest";
 		const string EntryToClick = "EntryToClick";
+		const string EntryToClick2 = "EntryToClick2";
 		const string EntrySuccess = "EntrySuccess";
+		const string ResetKeyboard = "Hide Keyboard";
 		const string Reset = "Reset";
 
 		const string ToggleSafeArea = "ToggleSafeArea";
@@ -260,7 +262,7 @@ namespace Xamarin.Forms.Controls.Issues
 							new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )},
 							new Button()
 							{
-								Text = "Click Me"
+								Text = ResetKeyboard
 
 							},
 							new Entry()
@@ -269,11 +271,15 @@ namespace Xamarin.Forms.Controls.Issues
 							},
 							new Button()
 							{
-								Text = "Click Me"
+								Text = ResetKeyboard
 
 							},
 							new Button(){ Text = "Top Tab", Command = new Command(() => AddTopTab("top"))},
 							new Button(){ Text = "Bottom Tab", Command = new Command(() => AddBottomTab("bottom"))},
+							new Entry()
+							{
+								AutomationId = EntryToClick2
+							},
 						}
 				}
 			};
@@ -288,8 +294,17 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.Tap(EntryTest);
 			RunningApp.Tap(EntryToClick);
+
+			// if the device has too much height then try clicking the second entry
+			// to trigger keyboard movement
+			if (RunningApp.Query(EntrySuccess).Length != 0)
+			{
+				RunningApp.Tap(ResetKeyboard);
+				RunningApp.Tap(EntryToClick2);
+			}
+
 			RunningApp.WaitForNoElement(EntrySuccess);
-			RunningApp.Tap("Click Me");
+			RunningApp.Tap(ResetKeyboard);
 			RunningApp.WaitForElement(EntrySuccess);
 
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -294,13 +294,16 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.Tap(EntryTest);
 			RunningApp.Tap(EntryToClick);
+			RunningApp.EnterText(EntryToClick, "keyboard");
 
 			// if the device has too much height then try clicking the second entry
 			// to trigger keyboard movement
 			if (RunningApp.Query(EntrySuccess).Length != 0)
 			{
 				RunningApp.Tap(ResetKeyboard);
+				RunningApp.DismissKeyboard();
 				RunningApp.Tap(EntryToClick2);
+				RunningApp.EnterText(EntryToClick2, "keyboard");
 			}
 
 			RunningApp.WaitForNoElement(EntrySuccess);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -294,6 +294,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void EntryScrollTest()
 		{
 			RunningApp.Tap(EntryTest);
+			var originalPosition = RunningApp.WaitForElement(EntrySuccess)[0].Rect;
 			RunningApp.Tap(EntryToClick);
 			RunningApp.EnterText(EntryToClick, "keyboard");
 
@@ -308,17 +309,25 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 
 			var entry = RunningApp.Query(EntrySuccess);
+
+			// ios10 on appcenter for some reason still returns this entry
+			// even though it's hidden so this is a fall back test just to ensure
+			// that the entry has scrolled up
 			if(entry.Length > 0 && entry[0].Rect.Y > 0)
 			{
 				Thread.Sleep(2000);
 				entry = RunningApp.Query(EntrySuccess);
 
 				if (entry.Length > 0)
-					Assert.Less(entry[0].Rect.Y, 0);
+					Assert.Less(entry[0].Rect.Y, originalPosition.Y);
 			}
 
 			RunningApp.Tap(ResetKeyboard);
-			RunningApp.WaitForElement(EntrySuccess);
+			var finalPosition = RunningApp.WaitForElement(EntrySuccess)[0].Rect;
+
+			// verify that label has returned to about the same spot
+			var diff = Math.Abs(originalPosition.Y - finalPosition.Y);
+			Assert.LessOrEqual(diff, 2);
 
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -132,13 +132,13 @@ namespace Xamarin.Forms.Controls.Issues
 								new Label() { Text = "This page should have no safe area padding at the top" },
 								new Button() { Text = "Reset", Command = new Command(() => SetupLandingPage()) }
 							},
-							BackgroundColor = Color.Yellow,
+							BackgroundColor = Color.White,
 
 						}
 					}
 				};
 
-			page.BackgroundColor = Color.Green;
+			page.BackgroundColor = Color.Yellow;
 
 			page.Appearing += (_, __) =>
 			{
@@ -180,6 +180,7 @@ namespace Xamarin.Forms.Controls.Issues
 				}),
 				ItemsSource = Enumerable.Range(0, 1000).Select(x => $"Item{x}").ToArray()
 			};
+			page.BackgroundColor = Color.Yellow;
 
 			CurrentItem = Items.Last();
 			Items.RemoveAt(0);
@@ -203,6 +204,7 @@ namespace Xamarin.Forms.Controls.Issues
 					new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )}
 				}
 			};
+			page.BackgroundColor = Color.Yellow;
 
 			CurrentItem = Items.Last();
 			Items.RemoveAt(0);
@@ -221,6 +223,7 @@ namespace Xamarin.Forms.Controls.Issues
 					new Button(){ Text = "Reset", Command = new Command(() => SetupLandingPage() )}
 				}
 			};
+			page.BackgroundColor = Color.Yellow;
 
 			page.On<iOS>().SetUseSafeArea(value);
 			CurrentItem = Items.Last();
@@ -232,6 +235,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var page = CreateContentPage();
 			page.Title = "Main";
 			page.Content = CreateEntryInsetView();
+			page.BackgroundColor = Color.Yellow;
 
 			CurrentItem = Items.Last();
 			Items.RemoveAt(0);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -211,6 +211,11 @@ namespace Xamarin.Forms.Controls.Issues
 								Command = new Command(() => Navigation.PushAsync(new ContentPage(){ Content = CreateEntryInsetView() }))
 							},
 							new Button(){Text = "Reset", Command = new Command(() => SetupLandingPage() )},
+							new Button()
+							{
+								Text = "Click Me"
+
+							},
 							new Entry()
 							{
 								AutomationId = EntryToClick

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -202,8 +202,6 @@ namespace Xamarin.Forms.Controls.Issues
 					Children =
 						{
 							new Label(){ AutomationId = EntrySuccess, VerticalOptions= LayoutOptions.FillAndExpand, Text = "Click the entry and it should scroll up and stay visible. Click off entry and this label should still be visible"},
-							new Button(){ Text = "Top Tab", Command = new Command(() => AddTopTab("top"))},
-							new Button(){ Text = "Bottom Tab", Command = new Command(() => AddBottomTab("bottom"))},
 							new Button(){ Text = "Change Navbar Visible", Command = new Command(() => Shell.SetNavBarIsVisible(view.Parent, !(Shell.GetNavBarIsVisible(view.Parent))))},
 							new Button()
 							{
@@ -224,7 +222,9 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								Text = "Click Me"
 
-							}
+							},
+							new Button(){ Text = "Top Tab", Command = new Command(() => AddTopTab("top"))},
+							new Button(){ Text = "Bottom Tab", Command = new Command(() => AddBottomTab("bottom"))},
 						}
 				}
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms.Internals;
 using System.Linq;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
 
 
 #if UITEST
@@ -306,7 +307,16 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.EnterText(EntryToClick2, "keyboard");
 			}
 
-			RunningApp.WaitForNoElement(EntrySuccess);
+			var entry = RunningApp.Query(EntrySuccess);
+			if(entry.Length > 0 && entry[0].Rect.Y > 0)
+			{
+				Thread.Sleep(2000);
+				entry = RunningApp.Query(EntrySuccess);
+
+				if (entry.Length > 0)
+					Assert.Less(entry[0].Rect.Y, 0);
+			}
+
 			RunningApp.Tap(ResetKeyboard);
 			RunningApp.WaitForElement(EntrySuccess);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -584,6 +584,35 @@ namespace Xamarin.Forms.Controls
 #endif
 		}
 
+		public ContentPage AddTopTab(string title)
+		{
+			ContentPage page = new ContentPage();
+			Items[0].Items[0].Items.Add(new ShellContent()
+			{
+				Title = title,
+				Content = page
+			});
+			return page;
+		}
+
+		public ContentPage AddBottomTab(string title)
+		{
+
+			ContentPage page = new ContentPage();
+			Items[0].Items.Add(new ShellSection()
+			{
+				Items =
+				{
+					new ShellContent()
+					{
+						Content = page,
+						Title = title
+					}
+				}
+			});
+			return page;
+		}
+
 		public ContentPage CreateContentPage()
 		{
 			ContentPage page = new ContentPage();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGrouping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5412.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Helpers\GarbageCollectionHelper.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1231,7 +1231,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5801.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)A11yTabIndex.xaml">
       <SubType>Designer</SubType>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -981,6 +981,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6077.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5239.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -51,5 +51,6 @@
 		public const string Shell = "Shell";
 		public const string TabbedPage = "TabbedPage";
 		public const string CustomRenderers = "CustomRenderers";
+		public const string Page = "Page";
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Core.UITests
 			var results = func();
 
 			int counter = 0;
-			while (results.Length == 0 && counter < retryCount)
+			while ((results == null || results.Length == 0) && counter < retryCount)
 			{
 				Thread.Sleep(delayInMs);
 				results = func();

--- a/Xamarin.Forms.Platform.iOS/Renderers/KeyboardInsetTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/KeyboardInsetTracker.cs
@@ -10,16 +10,24 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly Func<UIWindow> _fetchWindow;
 		readonly Action<PointF> _setContentOffset;
 		readonly Action<UIEdgeInsets> _setInsetAction;
-		readonly UIView _targetView;
+		readonly UIScrollView _targetView;
 		bool _disposed;
-
+		UIEdgeInsets _currentInset;
 		RectangleF _lastKeyboardRect;
+		ShellScrollViewTracker _shellScrollViewTracker;
 
-		public KeyboardInsetTracker(UIView targetView, Func<UIWindow> fetchWindow, Action<UIEdgeInsets> setInsetAction) : this(targetView, fetchWindow, setInsetAction, null)
+
+		public KeyboardInsetTracker(UIScrollView targetView, Func<UIWindow> fetchWindow, Action<UIEdgeInsets> setInsetAction) 
+			: this(targetView, fetchWindow, setInsetAction, null)
 		{
 		}
 
-		public KeyboardInsetTracker(UIView targetView, Func<UIWindow> fetchWindow, Action<UIEdgeInsets> setInsetAction, Action<PointF> setContentOffset)
+		public KeyboardInsetTracker(UIScrollView targetView, Func<UIWindow> fetchWindow, Action<UIEdgeInsets> setInsetAction, Action<PointF> setContentOffset)
+			 : this(targetView, fetchWindow, setInsetAction, setContentOffset, null)
+		{
+		}
+
+		public KeyboardInsetTracker(UIScrollView targetView, Func<UIWindow> fetchWindow, Action<UIEdgeInsets> setInsetAction, Action<PointF> setContentOffset, IVisualElementRenderer renderer)
 		{
 			_setContentOffset = setContentOffset;
 			_targetView = targetView;
@@ -27,16 +35,22 @@ namespace Xamarin.Forms.Platform.iOS
 			_setInsetAction = setInsetAction;
 			KeyboardObserver.KeyboardWillShow += OnKeyboardShown;
 			KeyboardObserver.KeyboardWillHide += OnKeyboardHidden;
+			if (renderer != null)
+				_shellScrollViewTracker = new ShellScrollViewTracker(renderer);
 		}
 
 		public void Dispose()
 		{
 			if (_disposed)
 				return;
+
 			_disposed = true;
 
 			KeyboardObserver.KeyboardWillShow -= OnKeyboardShown;
 			KeyboardObserver.KeyboardWillHide -= OnKeyboardHidden;
+
+			_shellScrollViewTracker.Dispose();
+			_shellScrollViewTracker = null;
 		}
 
 		//This method allows us to update the insets if the Frame changes
@@ -68,6 +82,7 @@ namespace Xamarin.Forms.Platform.iOS
 			//let's see how much does it cover our target view
 			var overlay = RectangleF.Intersect(rect, _targetView.Frame);
 
+			_currentInset = _targetView.ContentInset;
 			_setInsetAction(new UIEdgeInsets(0, 0, overlay.Height, 0));
 
 			if (field is UITextView && _setContentOffset != null)
@@ -81,9 +96,13 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		public void OnLayoutSubviews() => _shellScrollViewTracker?.OnLayoutSubviews();
+
 		void OnKeyboardHidden(object sender, UIKeyboardEventArgs args)
 		{
-			_setInsetAction(new UIEdgeInsets(0, 0, 0, 0));
+			if(_shellScrollViewTracker == null || !_shellScrollViewTracker.Reset())
+				_setInsetAction(new UIEdgeInsets(0,0,0,0));
+
 			_lastKeyboardRect = RectangleF.Empty;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/KeyboardInsetTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/KeyboardInsetTracker.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Platform.iOS
 			KeyboardObserver.KeyboardWillShow -= OnKeyboardShown;
 			KeyboardObserver.KeyboardWillHide -= OnKeyboardHidden;
 
-			_shellScrollViewTracker.Dispose();
+			_shellScrollViewTracker?.Dispose();
 			_shellScrollViewTracker = null;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void LayoutSubviews()
 		{
+			_insetTracker?.OnLayoutSubviews();
 			base.LayoutSubviews();
 
 			double height = Bounds.Height;
@@ -224,7 +225,7 @@ namespace Xamarin.Forms.Platform.iOS
 						var offset = Control.ContentOffset;
 						offset.Y += point.Y;
 						Control.SetContentOffset(offset, true);
-					});
+					}, this);
 				}
 
 				var listView = e.NewElement;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			//by default use the MainScreen Bounds so Effects can access the Container size
 			if (_pageContainer == null)
-				_pageContainer = new PageContainer(this) { Frame = UIScreen.MainScreen.Bounds};
+				_pageContainer = new PageContainer(this) { Frame = UIScreen.MainScreen.Bounds };
 
 			View = _pageContainer;
 		}
@@ -169,7 +169,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.Parent is BaseShellItem)
 				Element.Layout(View.Bounds.ToRectangle());
 
-			if(_safeAreasSet || !Forms.IsiOS11OrNewer)
+			if (_safeAreasSet || !Forms.IsiOS11OrNewer)
 				UpdateUseSafeArea();
 		}
 
@@ -179,7 +179,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateUseSafeArea();
 			base.ViewSafeAreaInsetsDidChange();
 		}
-		
+
 		public UIViewController ViewController => _disposed ? null : this;
 
 		public override void ViewDidAppear(bool animated)
@@ -191,7 +191,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_appeared = true;
 			UpdateStatusBarPrefersHidden();
-			if(Forms.IsiOS11OrNewer)
+			if (Forms.IsiOS11OrNewer)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			if (Element.Parent is CarouselPage)
@@ -326,7 +326,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateUseSafeArea();
 			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.Page.PrefersHomeIndicatorAutoHiddenProperty.PropertyName)
 				UpdateHomeIndicatorAutoHidden();
-			else if(e.PropertyName == Page.PaddingProperty.PropertyName)
+			else if (e.PropertyName == Page.PaddingProperty.PropertyName)
 			{
 				if (ShouldUseSafeArea() && Page.Padding != SafeAreaInsets)
 					_userOverriddenSafeArea = true;
@@ -374,7 +374,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (_userOverriddenSafeArea)
 				return;
-						
+
 			if (!IsPartOfShell && !Forms.IsiOS11OrNewer)
 				return;
 
@@ -399,7 +399,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Page.On<PlatformConfiguration.iOS>().SetSafeAreaInsets(safeareaPadding);
 			}
 			else if (IsPartOfShell)
-			{	
+			{
 				safeareaPadding = new Thickness(0, TopLayoutGuide.Length + tabThickness, 0, BottomLayoutGuide.Length);
 				Page.On<PlatformConfiguration.iOS>().SetSafeAreaInsets(safeareaPadding);
 			}
@@ -413,7 +413,7 @@ namespace Xamarin.Forms.Platform.iOS
 					usingSafeArea = true;
 			}
 
-			if(!usingSafeArea && isSafeAreaSet && Page.Padding == safeareaPadding)
+			if (!usingSafeArea && isSafeAreaSet && Page.Padding == safeareaPadding)
 			{
 				Page.SetValueFromRenderer(Page.PaddingProperty, _userPadding);
 			}
@@ -421,13 +421,33 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!usingSafeArea)
 				return;
 
-			if (View != null && View.Subviews.Length > 0 && View.Subviews[0] is UIScrollView && IsPartOfShell)
+			if (SafeAreaInsets == Page.Padding)
 				return;
 
+			// this is determining if there is a UIScrollView control occupying the whole screen
+			if (IsPartOfShell && !isSafeAreaSet)
+			{
+				var subViewSearch = View;
+				for (int i = 0; i < 2 && subViewSearch != null; i++)
+				{
+					if (subViewSearch?.Subviews.Length > 0)
+					{
+						if (subViewSearch.Subviews[0] is UIScrollView)
+							return;
+
+						subViewSearch = subViewSearch.Subviews[0];
+					}
+					else
+					{
+						subViewSearch = null;
+					}
+				}
+			}
 			
 			Page.SetValueFromRenderer(Page.PaddingProperty, SafeAreaInsets);
 		}
 
+		
 		void UpdateStatusBarPrefersHidden()
 		{
 			if (Element == null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -374,7 +374,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (_userOverriddenSafeArea)
 				return;
-
+						
 			if (!IsPartOfShell && !Forms.IsiOS11OrNewer)
 				return;
 
@@ -408,7 +408,10 @@ namespace Xamarin.Forms.Platform.iOS
 			bool isSafeAreaSet = Element.IsSet(PageSpecific.UseSafeAreaProperty);
 
 			if (IsPartOfShell && !isSafeAreaSet)
-				usingSafeArea = true;
+			{
+				if (Shell.GetNavBarIsVisible(Element) || _tabThickness != default(Thickness))
+					usingSafeArea = true;
+			}
 
 			if(!usingSafeArea && isSafeAreaSet && Page.Padding == safeareaPadding)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -169,7 +169,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.Parent is BaseShellItem)
 				Element.Layout(View.Bounds.ToRectangle());
 
-			if(_safeAreasSet)
+			if(_safeAreasSet || !Forms.IsiOS11OrNewer)
 				UpdateUseSafeArea();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -115,28 +115,27 @@ namespace Xamarin.Forms.Platform.iOS
 					SetAutomationId(element.AutomationId);
 
 				element.SendViewInitialized(NativeView);
+
+				var parent = Element.Parent;
+
+				while (!Application.IsApplicationOrNull(parent))
+				{
+					if (parent is ShellContent)
+						_isInItems = true;
+
+					if (parent is ShellSection shellSection)
+					{
+						_shellSection = shellSection;
+						((IShellSectionController)_shellSection).AddContentInsetObserver(this);
+
+						break;
+					}
+
+					parent = parent.Parent;
+				}
 			}
 
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
-
-			var parent = Element.Parent;
-
-			while (!Application.IsApplicationOrNull(parent))
-			{
-				if (parent is ShellContent)
-					_isInItems = true;
-
-				if (parent is ShellSection shellSection)
-				{
-					_shellSection = shellSection;
-					((IShellSectionController)_shellSection).AddContentInsetObserver(this);
-
-					break;
-				}
-
-				parent = parent.Parent;
-			}
-
 		}
 
 		public void SetElementSize(Size size)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -375,6 +375,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_userOverriddenSafeArea)
 				return;
 
+			if (!IsPartOfShell && !Forms.IsiOS11OrNewer)
+				return;
+
 			var tabThickness = _tabThickness;
 			if (!_isInItems)
 				tabThickness = 0;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -529,7 +529,7 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		double _tabThickness;
-		private bool _isInItems;
+		bool _isInItems;
 
 		void IShellContentInsetObserver.OnInsetChanged(Thickness inset, double tabThickness)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -23,12 +23,10 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _checkedForRtlScroll = false;
 		bool _previousLTR = true;
 
-		ShellScrollViewTracker _shellScrollTracker;
-
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
 			ScrollAnimationEnded += HandleScrollAnimationEnded;
-			Scrolled += HandleScrolled;
+			Scrolled += HandleScrolled;			
 		}
 
 		ScrollView ScrollView
@@ -76,12 +74,17 @@ namespace Xamarin.Forms.Platform.iOS
 					_events = new EventTracker(this);
 					_events.LoadEvents(this);
 
-					_insetTracker = new KeyboardInsetTracker(this, () => Window, insets => ContentInset = ScrollIndicatorInsets = insets, point =>
+
+					_insetTracker = new KeyboardInsetTracker(this, () => Window, insets =>
+					{
+						ContentInset = ScrollIndicatorInsets = insets;
+					}, 
+					point =>
 					{
 						var offset = ContentOffset;
 						offset.Y += point.Y;
 						SetContentOffset(offset, true);
-					});
+					}, this);
 				}
 
 				UpdateDelaysContentTouches();
@@ -90,8 +93,6 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateIsEnabled();
 				UpdateVerticalScrollBarVisibility();
 				UpdateHorizontalScrollBarVisibility();
-
-				_shellScrollTracker = new ShellScrollViewTracker(this);
 
 				OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
@@ -119,8 +120,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void LayoutSubviews()
 		{
-			_shellScrollTracker?.OnLayoutSubviews();
-
+			_insetTracker?.OnLayoutSubviews();
 			base.LayoutSubviews();
 
 			if(Superview != null)
@@ -172,9 +172,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 				Element?.ClearValue(Platform.RendererProperty);
 				SetElement(null);
-
-				_shellScrollTracker.Dispose();
-				_shellScrollTracker = null;
 
 				_packager.Dispose();
 				_packager = null;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
 			ScrollAnimationEnded += HandleScrollAnimationEnded;
-			Scrolled += HandleScrolled;			
+			Scrolled += HandleScrolled;
 		}
 
 		ScrollView ScrollView

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -144,6 +144,11 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void OnRendererSet()
 		{
 			NavigationItem = ViewController.NavigationItem;
+
+			if (!Forms.IsiOS11OrNewer)
+			{
+				ViewController.AutomaticallyAdjustsScrollViewInsets = false;
+			}
 		}
 
 		protected virtual void UpdateTitleView()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -146,7 +146,11 @@ namespace Xamarin.Forms.Platform.iOS
 			NavigationItem = ViewController.NavigationItem;
 			if (!Forms.IsiOS11OrNewer)
 			{
-				ViewController.AutomaticallyAdjustsScrollViewInsets = false;
+				var View = ViewController.View;
+				if (!Forms.IsiOS11OrNewer && View != null && View.Subviews.Length > 0 && View.Subviews[0] is UIScrollView)
+					ViewController.AutomaticallyAdjustsScrollViewInsets = true;
+				else
+					ViewController.AutomaticallyAdjustsScrollViewInsets = false;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -144,14 +144,6 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void OnRendererSet()
 		{
 			NavigationItem = ViewController.NavigationItem;
-			if (!Forms.IsiOS11OrNewer)
-			{
-				var View = ViewController.View;
-				if (!Forms.IsiOS11OrNewer && View != null && View.Subviews.Length > 0 && View.Subviews[0] is UIScrollView)
-					ViewController.AutomaticallyAdjustsScrollViewInsets = true;
-				else
-					ViewController.AutomaticallyAdjustsScrollViewInsets = false;
-			}
 		}
 
 		protected virtual void UpdateTitleView()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -87,9 +87,19 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_lastInset == 0 && _tabThickness == 0)
 				return false;
 
-			UpdateContentInset(_lastInset, _tabThickness);
+			if (!Forms.IsiOS11OrNewer)
+			{
+				UpdateContentInset(_lastInset, _tabThickness);
+				return true;
+			}
 
-			return true;
+			if (_shellSection.Items.Count > 1 && _isInItems)
+			{
+				UpdateContentInset(_lastInset, _tabThickness);
+				return true;
+			}
+
+			return false;
 		}
 
 		void UpdateContentInset(Thickness inset, double tabThickness)
@@ -113,16 +123,16 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				if ((_shellSection.Items.Count > 1 && _isInItems))
-				{
-					var top = (float)(inset.Top) + (float)tabThickness;
+				var top = (float)(inset.Top);
 
-					var delta = _scrollView.ContentInset.Top - top;
-					_scrollView.ContentInset = new UIEdgeInsets(top, (float)inset.Left, (float)inset.Bottom, (float)inset.Right);
+				if(_isInItems)
+					top += (float)tabThickness;
 
-					var currentOffset = _scrollView.ContentOffset;
-					_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta);
-				}
+				var delta = _scrollView.ContentInset.Top - top;
+				_scrollView.ContentInset = new UIEdgeInsets(top, (float)inset.Left, (float)inset.Bottom, (float)inset.Right);
+
+				var currentOffset = _scrollView.ContentOffset;
+				_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta - inset.Bottom);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -71,7 +71,8 @@ namespace Xamarin.Forms.Platform.iOS
 				var newBounds = _scrollView.AdjustedContentInset.InsetRect(_scrollView.Bounds).ToRectangle();
 				newBounds.X = 0;
 				newBounds.Y = 0;
-				((ScrollView)_renderer.Element).LayoutAreaOverride = newBounds;
+				if(_renderer.Element is ScrollView scrollView)
+					scrollView.LayoutAreaOverride = newBounds;
 			}
 		}
 
@@ -132,7 +133,8 @@ namespace Xamarin.Forms.Platform.iOS
 			// If we can't bounce in that case you may not be able to expose the handler.
 			// Also the hiding behavior only depends on scroll on iOS 11. In 10 and below
 			// the search goes in the TitleView so there is nothing to collapse/expand.
-			if (!Forms.IsiOS11OrNewer || ((ScrollView)_renderer.Element).Orientation == ScrollOrientation.Horizontal)
+			if (!Forms.IsiOS11OrNewer || 
+				(_renderer.Element is ScrollView scrollView && scrollView.Orientation == ScrollOrientation.Horizontal))
 				return;
 
 			var parent = _renderer.Element.Parent;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			while (!Application.IsApplicationOrNull(parent))
 			{
-				if (parent is ScrollView || parent is ListView || parent is TableView)
+				if (parent is ScrollView || parent is ListView || parent is TableView || parent is CollectionView)
 					break;
 				parent = parent.Parent;
 
@@ -68,8 +68,26 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		Thickness _lastInset;
+		double _tabThickness;
+
+		public bool Reset()
+		{
+			if (!_isInShell)
+				return false;
+
+			if (_lastInset == 0 && _tabThickness == 0)
+				return false;
+
+			UpdateContentInset(_lastInset, _tabThickness);
+
+			return true;
+		}
+
 		void UpdateContentInset(Thickness inset, double tabThickness)
 		{
+			_lastInset = inset;
+			_tabThickness = tabThickness;
 			if (Forms.IsiOS11OrNewer)
 			{
 				if (_shellSection.Items.Count > 1 && _isInItems)
@@ -87,16 +105,16 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				var top = (float)(inset.Top);
+				if ((_shellSection.Items.Count > 1 && _isInItems))
+				{
+					var top = (float)(inset.Top) + (float)tabThickness;
 
-				if (_shellSection.Items.Count > 1 && _isInItems)
-					top += (float)tabThickness;
+					var delta = _scrollView.ContentInset.Top - top;
+					_scrollView.ContentInset = new UIEdgeInsets(top, (float)inset.Left, (float)inset.Bottom, (float)inset.Right);
 
-				var delta = _scrollView.ContentInset.Top - top;
-				_scrollView.ContentInset = new UIEdgeInsets(top, (float)inset.Left, (float)inset.Bottom, (float)inset.Right);
-
-				var currentOffset = _scrollView.ContentOffset;
-				_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta);
+					var currentOffset = _scrollView.ContentOffset;
+					_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -25,7 +25,14 @@ namespace Xamarin.Forms.Platform.iOS
 		public ShellScrollViewTracker(IVisualElementRenderer renderer)
 		{
 			_renderer = renderer;
-			_scrollView = (UIScrollView)_renderer.NativeView;
+
+			if (_renderer.NativeView is UIScrollView scrollView)
+				_scrollView = scrollView;
+			else if (_renderer.NativeView.Subviews.Length > 0 && _renderer.NativeView.Subviews[0] is UIScrollView nestedScrollView)
+				_scrollView = nestedScrollView;
+
+			if (_scrollView == null)
+				return;
 
 			var parent = _renderer.Element.Parent;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellScrollViewTracker.cs
@@ -113,10 +113,15 @@ namespace Xamarin.Forms.Platform.iOS
 					var top = (float)tabThickness;
 
 					var delta = _scrollView.ContentInset.Top - top;
-					_scrollView.ContentInset = new UIEdgeInsets(top, 0, 0, 0);
+					var newInset = new UIEdgeInsets(top, 0, 0, 0);
 
-					var currentOffset = _scrollView.ContentOffset;
-					_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta);
+					if (newInset != _scrollView.ContentInset)
+					{
+						_scrollView.ContentInset = newInset;
+
+						var currentOffset = _scrollView.ContentOffset;
+						_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta);
+					}
 				}
 
 				_scrollView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Always;
@@ -125,14 +130,19 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var top = (float)(inset.Top);
 
-				if(_isInItems)
+				if (_isInItems)
 					top += (float)tabThickness;
 
 				var delta = _scrollView.ContentInset.Top - top;
-				_scrollView.ContentInset = new UIEdgeInsets(top, (float)inset.Left, (float)inset.Bottom, (float)inset.Right);
+				var newInset = new UIEdgeInsets(top, (float)inset.Left, (float)inset.Bottom, (float)inset.Right);
 
-				var currentOffset = _scrollView.ContentOffset;
-				_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta - inset.Bottom);
+				if (newInset != _scrollView.ContentInset)
+				{
+					_scrollView.ContentInset = newInset;
+
+					var currentOffset = _scrollView.ContentOffset;
+					_scrollView.ContentOffset = new PointF(currentOffset.X, currentOffset.Y + delta - inset.Bottom);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -137,21 +137,7 @@ namespace Xamarin.Forms.Platform.iOS
 				ShellContent item = ShellSection.Items[i];
 				var page = ((IShellContentController)item).GetOrCreateContent();
 				var renderer = Platform.CreateRenderer(page);
-				Platform.SetRenderer(page, renderer);
-
-				if (!Forms.IsiOS11OrNewer)
-				{
-					var childView = renderer.ViewController?.View;
-					if (childView != null && childView.Subviews.Length > 0 && childView.Subviews[0] is UIScrollView)
-					{
-						renderer.ViewController.AutomaticallyAdjustsScrollViewInsets = true;
-					}
-					else
-					{
-						renderer.ViewController.AutomaticallyAdjustsScrollViewInsets = false;
-					}
-				}
-
+				Platform.SetRenderer(page, renderer);				 
 				AddChildViewController(renderer.ViewController);
 
 				if (item == currentItem)
@@ -267,16 +253,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void LayoutHeader()
 		{
-			if (_header == null)
-				return;
-
-			CGRect frame;
-			if (Forms.IsiOS11OrNewer)
-				frame = new CGRect(View.Bounds.X, View.SafeAreaInsets.Top, View.Bounds.Width, HeaderHeight);
-			else
-				frame = new CGRect(View.Bounds.X, TopLayoutGuide.Length, View.Bounds.Width, HeaderHeight);
-			_blurView.Frame = frame;
-			_header.View.Frame = frame;
+			int tabThickness = 0;
+			if (_header != null)
+			{
+				tabThickness = HeaderHeight;
+				CGRect frame;
+				if (Forms.IsiOS11OrNewer)
+					frame = new CGRect(View.Bounds.X, View.SafeAreaInsets.Top, View.Bounds.Width, HeaderHeight);
+				else
+					frame = new CGRect(View.Bounds.X, TopLayoutGuide.Length, View.Bounds.Width, HeaderHeight);
+				_blurView.Frame = frame;
+				_header.View.Frame = frame;
+			}
 
 			nfloat left;
 			nfloat top;
@@ -297,7 +285,7 @@ namespace Xamarin.Forms.Platform.iOS
 				bottom = BottomLayoutGuide.Length;
 			}
 
-			((IShellSectionController)ShellSection).SendInsetChanged(new Thickness(left, top, right, bottom), HeaderHeight);
+			((IShellSectionController)ShellSection).SendInsetChanged(new Thickness(left, top, right, bottom), tabThickness);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -257,11 +257,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_header != null)
 			{
 				tabThickness = HeaderHeight;
-				CGRect frame;
-				if (Forms.IsiOS11OrNewer)
-					frame = new CGRect(View.Bounds.X, View.SafeAreaInsets.Top, View.Bounds.Width, HeaderHeight);
-				else
-					frame = new CGRect(View.Bounds.X, TopLayoutGuide.Length, View.Bounds.Width, HeaderHeight);
+				var headerTop = Forms.IsiOS11OrNewer ? View.SafeAreaInsets.Top : TopLayoutGuide.Length;
+				CGRect frame = new CGRect(View.Bounds.X, headerTop, View.Bounds.Width, HeaderHeight);
 				_blurView.Frame = frame;
 				_header.View.Frame = frame;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -137,7 +137,7 @@ namespace Xamarin.Forms.Platform.iOS
 				ShellContent item = ShellSection.Items[i];
 				var page = ((IShellContentController)item).GetOrCreateContent();
 				var renderer = Platform.CreateRenderer(page);
-				Platform.SetRenderer(page, renderer);				 
+				Platform.SetRenderer(page, renderer);
 				AddChildViewController(renderer.ViewController);
 
 				if (item == currentItem)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -26,6 +26,9 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _isAnimating;
 		Dictionary<ShellContent, IVisualElementRenderer> _renderers = new Dictionary<ShellContent, IVisualElementRenderer>();
 		IShellPageRendererTracker _tracker;
+		bool _didLayoutSubviews;
+		int _lastTabThickness = Int32.MinValue;
+		Thickness _lastInset;
 
 		ShellSection ShellSection { get; set; }
 
@@ -37,6 +40,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLayoutSubviews()
 		{
+			_didLayoutSubviews = true;
 			base.ViewDidLayoutSubviews();
 
 			_containerArea.Frame = View.Bounds;
@@ -282,7 +286,17 @@ namespace Xamarin.Forms.Platform.iOS
 				bottom = BottomLayoutGuide.Length;
 			}
 
-			((IShellSectionController)ShellSection).SendInsetChanged(new Thickness(left, top, right, bottom), tabThickness);
+
+			if (_didLayoutSubviews)
+			{
+				var newInset = new Thickness(left, top, right, bottom);
+				if (newInset != _lastTabThickness || tabThickness != _lastTabThickness)
+				{
+					_lastTabThickness = tabThickness;
+					_lastInset = new Thickness(left, top, right, bottom);
+					((IShellSectionController)ShellSection).SendInsetChanged(_lastInset, _lastTabThickness);
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -139,6 +139,19 @@ namespace Xamarin.Forms.Platform.iOS
 				var renderer = Platform.CreateRenderer(page);
 				Platform.SetRenderer(page, renderer);
 
+				var childView = renderer.ViewController.View;
+				if (!Forms.IsiOS11OrNewer)
+				{
+					if(childView != null && childView.Subviews.Length > 0 && childView.Subviews[0] is UIScrollView)
+					{
+						renderer.ViewController.AutomaticallyAdjustsScrollViewInsets = true;
+					}
+					else
+					{
+						renderer.ViewController.AutomaticallyAdjustsScrollViewInsets = false;
+					}
+				}
+
 				AddChildViewController(renderer.ViewController);
 
 				if (item == currentItem)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -139,10 +139,10 @@ namespace Xamarin.Forms.Platform.iOS
 				var renderer = Platform.CreateRenderer(page);
 				Platform.SetRenderer(page, renderer);
 
-				var childView = renderer.ViewController.View;
 				if (!Forms.IsiOS11OrNewer)
 				{
-					if(childView != null && childView.Subviews.Length > 0 && childView.Subviews[0] is UIScrollView)
+					var childView = renderer.ViewController?.View;
+					if (childView != null && childView.Subviews.Length > 0 && childView.Subviews[0] is UIScrollView)
 					{
 						renderer.ViewController.AutomaticallyAdjustsScrollViewInsets = true;
 					}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void LayoutSubviews()
 		{
+			_insetTracker?.OnLayoutSubviews();
 			base.LayoutSubviews();
 
 			if (_previousFrame != Frame)
@@ -81,7 +82,7 @@ namespace Xamarin.Forms.Platform.iOS
 						var offset = Control.ContentOffset;
 						offset.Y += point.Y;
 						Control.SetContentOffset(offset, true);
-					});
+					}, this);
 				}
 
 				SetSource();

--- a/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
+++ b/Xamarin.Forms.Sandbox.Android/Xamarin.Forms.Sandbox.Android.csproj
@@ -30,7 +30,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <AndroidDexTool Condition=" '$(MSBuildAssemblyVersion)' != '15.0'">d8</AndroidDexTool>
-    <AndroidEnableMultiDex Condition=" '$(MSBuildAssemblyVersion)' == '15.0'">true</AndroidEnableMultiDex>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
### Description of Change ###

- Fix iOS so the content pads correctly for: pages with top tabs, all pages not just scroll views
- Fixed the keyboard focus auto scroll so that when you click off the entry it'll scroll back correctly
- fixed safe area so that if you turn it off content will set to 0,0 (this also applies to page with top tabs)
- fixed safe area padding to include top tabs size as well
- consolidated all the safe area setting logic to a single method so it's easy to follow the logic of why we set it when

### Issues Resolved ### 
- fixes #5239
- fixes #6424
- fixes #6499

### Platforms Affected ### 
- iOS

### Breaking ###

- prior to this PR if the user set the padding, set safearea to true, then set the safearea to false it would reset the padding to zero. After this PR it'll set the padding back to whatever the user initially set it to


### Testing Procedure ###
I added a ShellInsets test that has some automation but you can just click around on things to see if it all works to your liking as well

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
