### PR TITLE
[UWP] Fix list views leaking cells due to missing event unsubscription

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
@@ -16,6 +16,12 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers = true)]
 	[Issue (IssueTracker.Bugzilla, 34561, "[A] Navigation.PushAsync crashes when used in Context Actions (legacy)", PlatformAffected.Android)]
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.ContextActions)]
+	[NUnit.Framework.Category(UITestCategories.Navigation)]
+#endif
 	public class Bugzilla34561 : TestContentPage
 	{
 		protected override void Init ()

--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -352,6 +352,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				oldCell.PropertyChanged -= _propertyChangedHandler;
 				oldCell.SendDisappearing();
+				oldCell.Parent = null;
 			}
 
 			if (newCell != null)


### PR DESCRIPTION
### Description of Change ###
This change fixes a memory leak where view cells and the bound models are leaked. The list view creates new cells but keeps a reference to cells that are no longer needed, thus creating a memory leak.
In our production case, this causes an app to crash with OOM after 3 days of intensive use.

The code that ultimately needs to run to remove the owning reference from the list to the cell is https://github.com/xamarin/Xamarin.Forms/blob/471e9f81250e777fe194a764270bfda70a1e4dfe/Xamarin.Forms.Core/Cells/Cell.cs#L183-L187 - event handlers on `RealParent` must be unsubscribed at some point.

The creation stack trace dotMemory shows for the retaining event handlers is `SetCell()` at (https://github.com/xamarin/Xamarin.Forms/blob/471e9f81250e777fe194a764270bfda70a1e4dfe/Xamarin.Forms.Platform.UAP/CellControl.cs#L334-L336) being called via `MeasureOverride()`.

The issue can be reproduced by creating a ListView using ViewCell in data templates. See linked issues for repro projects.

Currently, a workaround is possible by subclassing the cell and nulling the `.Parent` property on disappearing: https://gist.github.com/dasMulli/64d0e3627ea2e982f56b5ca8209a681f

### Issues Resolved ### 

- fixes #3065
- fixes #3339

May also help #5451 though part of this may be a duplicate of the above.

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

When a view is disappearing (after OnDisappearing event), it's Parent property will no longer reference the parent list and the cell may be garbage collected.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Tested the change using our application and the included gallery application. Please let me know other needed tests (!).

The testing for the memory issue was performed using dotMemory by creating a ListView binding to an observable collection of pseudo elements, using a ViewCell with a Label as template. After a bit of rapid scrolling around, the number of ViewCells after a forced GC was in excess (>480) of the number of collection items (70). After the change, only around 30 view cells stayed in memory after GC (depending on the window size).

### PR Checklist ###

- Has automated tests : ⚠️ no. I do not know how to properly test this change
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard: ⚠️ please correct me if this change does not adhere to the coding standard

⚠️ First time contributor to Xamarin.Forms, please review with care. Please advise if there is a more desirable way of fixing the underlying issue instead of the way proposed in this PR.