### PR TITLE
[GTK] Fix NullReferenceException in NavigationPageRenderer

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -158,9 +158,14 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 			if (Widget?.Parent is EventBox parent)
 			{
-				parent.VisibleWindow = Page.CurrentPage?.Parent is Page parentPage
-					? parentPage.BackgroundImageSource.IsEmpty
-					: true;
+				if (Page.CurrentPage?.Parent is Page parentPage && parentPage.BackgroundImageSource != null)
+				{
+					parent.VisibleWindow = parentPage.BackgroundImageSource.IsEmpty;
+				}
+				else
+				{
+					parent.VisibleWindow = true;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix null reference exception

### Issues Resolved ### 

I think this hasn't been reported yet.

### API Changes ###

 None

### Platforms Affected ### 

- GTK

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run `Gtk-BackgroundImage.GTK` from this minimal repro repository https://github.com/mfkl/gtk-repro

It gives
```
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.Renderers.NavigationPageRenderer.UpdateBackgroundImage()	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.Renderers.NavigationPageRenderer.OnElementChanged(Xamarin.Forms.Platform.GTK.VisualElementChangedEventArgs e)	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.Renderers.AbstractPageRenderer<Gtk.Fixed, Xamarin.Forms.NavigationPage>.SetElement(Xamarin.Forms.VisualElement element)	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.Platform.CreateRenderer(Xamarin.Forms.VisualElement element)	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.Platform.AddChild(Xamarin.Forms.Page mainPage)	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.Platform.SetPage(Xamarin.Forms.Page newRoot)	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.FormsWindow.UpdateMainPage()	Unknown
Xamarin.Forms.Platform.GTK.dll!Xamarin.Forms.Platform.GTK.FormsWindow.LoadApplication(Xamarin.Forms.Application application)	Unknown
Gtk-BackgroundImage.GTK.exe!Gtk_BackgroundImage.GTK.Program.Main(string[] args) Line 17	C#
```

Because `BackgroundImageSource` is null by default.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
