### PR TITLE
Fix some flaky tests.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31333.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31333.cs
@@ -2,26 +2,23 @@ using System;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
-using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
-
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	[Preserve (AllMembers=true)]
-	[Issue (IssueTracker.Bugzilla, 31333,
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 31333,
 		"Focus() on Entry in ViewCell brings up keyboard, but doesn't have cursor in EditText", PlatformAffected.Android)]
 	public class Bugzilla31333 : TestContentPage
 	{
-		[Preserve (AllMembers=true)]
+		[Preserve(AllMembers = true)]
 		public class Model31333 : INotifyPropertyChanged
 		{
 			public string Data
@@ -30,11 +27,11 @@ namespace Xamarin.Forms.Controls.Issues
 				set
 				{
 					_data = value;
-					OnPropertyChanged ();
+					OnPropertyChanged();
 				}
 			}
 
-			bool _isFocused = false;
+			bool _isFocused;
 			string _data;
 
 			public bool IsFocused
@@ -43,94 +40,103 @@ namespace Xamarin.Forms.Controls.Issues
 				set
 				{
 					_isFocused = value;
-					OnPropertyChanged ();
+					OnPropertyChanged();
 				}
 			}
 
 			public event PropertyChangedEventHandler PropertyChanged;
 
-			protected virtual void OnPropertyChanged ([CallerMemberName] string propertyName = null)
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
 			{
-				PropertyChanged?.Invoke (this, new PropertyChangedEventArgs (propertyName));
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 			}
 		}
 
-		[Preserve (AllMembers=true)]
+		[Preserve(AllMembers = true)]
 		public interface IHaveControlFocusedProperty
 		{
-			void SetBinding ();
+			void SetBinding();
 		}
 
-		[Preserve (AllMembers=true)]
+		[Preserve(AllMembers = true)]
 		public class ExtendedEntry : Entry, IHaveControlFocusedProperty
 		{
 			public static readonly BindableProperty IsControlFocusedProperty =
-				BindableProperty.Create ("IsControlFocused", typeof(bool), typeof(ExtendedEntry), false);
+				BindableProperty.Create("IsControlFocused", typeof(bool), typeof(ExtendedEntry), false);
 
 			public bool IsControlFocused
 			{
-				get { return (bool)GetValue (IsControlFocusedProperty); }
-				set { SetValue (IsControlFocusedProperty, value); }
+				get { return (bool)GetValue(IsControlFocusedProperty); }
+				set { SetValue(IsControlFocusedProperty, value); }
 			}
 
-			protected override void OnPropertyChanged (string propertyName = null)
+			protected override void OnPropertyChanged(string propertyName = null)
 			{
-				base.OnPropertyChanged (propertyName);
-				if (propertyName == IsControlFocusedProperty.PropertyName) {
-					if (IsControlFocused) {
-						Focus ();
-					} else {
-						Unfocus ();
+				base.OnPropertyChanged(propertyName);
+				if (propertyName == IsControlFocusedProperty.PropertyName)
+				{
+					if (IsControlFocused)
+					{
+						Focus();
+					}
+					else
+					{
+						Unfocus();
 					}
 				}
 			}
 
-			public void SetBinding ()
+			public void SetBinding()
 			{
-				this.SetBinding (IsControlFocusedProperty, "IsFocused");
+				this.SetBinding(IsControlFocusedProperty, nameof(IsFocused));
 			}
 		}
 
-		[Preserve (AllMembers=true)]
+		[Preserve(AllMembers = true)]
 		public class ExtendedEditor : Editor, IHaveControlFocusedProperty
 		{
 			public static readonly BindableProperty IsControlFocusedProperty =
-				BindableProperty.Create ("IsControlFocused", typeof(bool), typeof(ExtendedEditor), false);
+				BindableProperty.Create("IsControlFocused", typeof(bool), typeof(ExtendedEditor), false);
 
 			public bool IsControlFocused
 			{
-				get { return (bool)GetValue (IsControlFocusedProperty); }
-				set { SetValue (IsControlFocusedProperty, value); }
+				get { return (bool)GetValue(IsControlFocusedProperty); }
+				set { SetValue(IsControlFocusedProperty, value); }
 			}
 
-			protected override void OnPropertyChanged (string propertyName = null)
+			protected override void OnPropertyChanged(string propertyName = null)
 			{
-				base.OnPropertyChanged (propertyName);
-				if (propertyName == IsControlFocusedProperty.PropertyName) {
-					if (IsControlFocused) {
-						Focus ();
-					} else {
-						Unfocus ();
+				base.OnPropertyChanged(propertyName);
+				if (propertyName == IsControlFocusedProperty.PropertyName)
+				{
+					if (IsControlFocused)
+					{
+						Focus();
+					}
+					else
+					{
+						Unfocus();
 					}
 				}
 			}
 
-			public void SetBinding ()
+			public void SetBinding()
 			{
-				this.SetBinding (IsControlFocusedProperty, "IsFocused");
+				this.SetBinding(IsControlFocusedProperty, nameof(IsFocused));
 			}
 		}
 
-		[Preserve (AllMembers=true)]
+		[Preserve(AllMembers = true)]
 		public class ExtendedCell<T> : ViewCell where T : View, IHaveControlFocusedProperty
 		{
-			public ExtendedCell ()
+			public ExtendedCell()
 			{
-				var control = (T)Activator.CreateInstance (typeof(T));
-				control.SetBinding ();
+				var control = (T)Activator.CreateInstance(typeof(T));
+				control.SetBinding();
 				control.HorizontalOptions = LayoutOptions.FillAndExpand;
 
-				View = new StackLayout {
+				View = new StackLayout
+				{
 					Orientation = StackOrientation.Horizontal,
 					HorizontalOptions = LayoutOptions.Fill,
 					Children = {
@@ -140,74 +146,77 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		StackLayout CreateListViewTestSection (Type controlType)
+		StackLayout CreateListViewTestSection(Type controlType)
 		{
 			var name = controlType.GenericTypeArguments[0].Name;
-			name = name.Replace ("Extended", "");
+			name = name.Replace("Extended", "");
 
-			var button = new Button () { Text = $"Focus {name} in ListView" };
+			var button = new Button() { Text = $"Focus {name} in ListView" };
 
-			var data = new ObservableCollection<Model31333> { new Model31333 () };
+			var data = new ObservableCollection<Model31333> { new Model31333() };
 
-			var listView = new ListView {
+			var listView = new ListView
+			{
 				VerticalOptions = LayoutOptions.Start,
 				ItemsSource = data,
-				ItemTemplate = new DataTemplate (controlType)
+				ItemTemplate = new DataTemplate(controlType)
 			};
 
-			button.Clicked += (sender, args) => {
+			button.Clicked += (sender, args) =>
+			{
 				var item = data[0];
-				if (item != null) {
+				if (item != null)
+				{
 					item.IsFocused = !item.IsFocused;
 				}
 			};
 
-			return new StackLayout () { Children = { button, listView } };
+			return new StackLayout() { Children = { button, listView } };
 		}
 
-		StackLayout CreateTableViewTestSection<T> () where T : View, IHaveControlFocusedProperty
+		StackLayout CreateTableViewTestSection<T>() where T : View, IHaveControlFocusedProperty
 		{
 			var name = typeof(T).Name;
-			name = name.Replace ("Extended", "");
+			name = name.Replace("Extended", "");
 
-			var button = new Button () { Text = $"Focus {name} in Table" };
+			var button = new Button() { Text = $"Focus {name} in Table" };
 
-			var data = new Model31333 ();
+			var data = new Model31333();
 
-			var tableView = new TableView {
+			var tableView = new TableView
+			{
 				VerticalOptions = LayoutOptions.Start
 			};
 
 			var tableRoot = new TableRoot();
 			var tableSection = new TableSection();
 
-			var cell = new ExtendedCell<T> ();
+			var cell = new ExtendedCell<T>();
 
 			cell.BindingContext = data;
 
 			tableSection.Add(cell);
-			tableRoot.Add (tableSection);
+			tableRoot.Add(tableSection);
 			tableView.Root = tableRoot;
 
-			button.Clicked += (sender, args) => {
+			button.Clicked += (sender, args) =>
+			{
 				var item = data;
-				if (item != null) {
-					item.IsFocused = !item.IsFocused;
-				}
+				item.IsFocused = !item.IsFocused;
 			};
 
-			return new StackLayout () { Children = { button, tableView } };
+			return new StackLayout() { Children = { button, tableView } };
 		}
 
-		protected override void Init ()
+		protected override void Init()
 		{
-			var entrySection = CreateListViewTestSection (typeof(ExtendedCell<ExtendedEntry>));
-			var editorSection = CreateListViewTestSection (typeof(ExtendedCell<ExtendedEditor>));
+			var entrySection = CreateListViewTestSection(typeof(ExtendedCell<ExtendedEntry>));
+			var editorSection = CreateListViewTestSection(typeof(ExtendedCell<ExtendedEditor>));
 
-			var entryTableSection = CreateTableViewTestSection<ExtendedEntry> ();
-			var editorTableSection = CreateTableViewTestSection<ExtendedEditor> ();
+			var entryTableSection = CreateTableViewTestSection<ExtendedEntry>();
+			var editorTableSection = CreateTableViewTestSection<ExtendedEditor>();
 
-			Content = new StackLayout () { Children = { entrySection, editorSection, entryTableSection, editorTableSection } };
+			Content = new StackLayout() { Children = { entrySection, editorSection, entryTableSection, editorTableSection } };
 		}
 
 #if UITEST
@@ -215,10 +224,11 @@ namespace Xamarin.Forms.Controls.Issues
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
 #endif
-		[UiTest (typeof(NavigationPage))]
-		public void Issue31333FocusEntryInListViewCell ()
+		[UiTest(typeof(NavigationPage))]
+		public void Issue31333FocusEntryInListViewCell()
 		{
-			RunningApp.Tap (q => q.Marked ("Focus Entry in ListView"));
+			RunningApp.Tap(q => q.Marked("Focus Entry in ListView"));
+			WaitForFocus();
 			RunningApp.EnterText("Entry in ListView Success");
 			WaitForTextQuery("Entry in ListView Success");
 			RunningApp.Tap(q => q.Marked("Focus Entry in ListView"));
@@ -228,24 +238,26 @@ namespace Xamarin.Forms.Controls.Issues
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
 #endif
-		[UiTest (typeof(NavigationPage))]
-		public void Issue31333FocusEditorInListViewCell ()
+		[UiTest(typeof(NavigationPage))]
+		public void Issue31333FocusEditorInListViewCell()
 		{
-			RunningApp.Tap (q => q.Marked ("Focus Editor in ListView"));
+			RunningApp.Tap(q => q.Marked("Focus Editor in ListView"));
+			WaitForFocus();
 			RunningApp.EnterText("Editor in ListView Success");
 			WaitForTextQuery("Editor in ListView Success");
 			RunningApp.Tap(q => q.Marked("Focus Editor in ListView"));
 		}
 
-		
+
 		[Test]
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
 #endif
-		[UiTest (typeof(NavigationPage))]
-		public void Issue31333FocusEntryInTableViewCell ()
+		[UiTest(typeof(NavigationPage))]
+		public void Issue31333FocusEntryInTableViewCell()
 		{
-			RunningApp.Tap (q => q.Marked ("Focus Entry in Table"));
+			RunningApp.Tap(q => q.Marked("Focus Entry in Table"));
+			WaitForFocus();
 			RunningApp.EnterText("Entry in TableView Success");
 			WaitForTextQuery("Entry in TableView Success");
 			RunningApp.Tap(q => q.Marked("Focus Entry in Table"));
@@ -255,13 +267,19 @@ namespace Xamarin.Forms.Controls.Issues
 #if __MACOS__
 		[Ignore("EnterText on UITest.Desktop not implemented")]
 #endif
-		[UiTest (typeof(NavigationPage))]
-		public void Issue31333FocusEditorInTableViewCell ()
+		[UiTest(typeof(NavigationPage))]
+		public void Issue31333FocusEditorInTableViewCell()
 		{
-			RunningApp.Tap (q => q.Marked ("Focus Editor in Table"));
+			RunningApp.Tap(q => q.Marked("Focus Editor in Table"));
+			WaitForFocus();
 			RunningApp.EnterText("Editor in TableView Success");
 			WaitForTextQuery("Editor in TableView Success");
 			RunningApp.Tap(q => q.Marked("Focus Editor in Table"));
+		}
+
+		void WaitForFocus()
+		{
+			Task.Delay(500).Wait();
 		}
 
 		void WaitForTextQuery(string text)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
@@ -1,10 +1,9 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
-
+using System.Globalization;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-using System.Threading.Tasks;
 #if UITEST
 using Xamarin.Forms.Core.UITests;
 using NUnit.Framework;
@@ -300,7 +299,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				throw new ArgumentException($"{editorName}_width not found");
 			}
-			return new Size(Convert.ToDouble(width), Convert.ToDouble(height));
+			return new Size(Convert.ToDouble(width, CultureInfo.InvariantCulture), Convert.ToDouble(height, CultureInfo.InvariantCulture));
 		}
 
 #endif


### PR DESCRIPTION
Found issues on some tests when running on my local machine.

### Description of Change ###
The test Bugzilla31333 dont wait the input to take focus (so on a fast machine it fail).
The test Issue1733 use the current culture to parse number which can fail (and indeed fail with my machine culture).

### Issues Resolved ### 
- Fix test Bugzilla31333
- Fix test Issue1733

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
- Run test Bugzilla31333
- Run test Issue1733

### PR Checklist ###
- [X] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
