### PR TITLE
Resolve fallback type before trying to make constructed generic type

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DesignTimeLoaderTests.cs
@@ -303,8 +303,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void InvalidGenericType()
 		{
 			int exceptionCount = 0;
+#pragma warning disable 0618 // Type or member is obsolete
 			Forms.Internals.ResourceLoader.ExceptionHandler = _ => exceptionCount++;
 			XamlLoader.FallbackTypeResolver = (p, type) => type ?? typeof(MockView);
+#pragma warning restore 0618 // Type or member is obsolete
 
 			var xaml = @"
 				<ContentPage xmlns=""http://xamarin.com/schemas/2014/forms""


### PR DESCRIPTION
### Description of Change ###

The `FallbackTypeResolver` hander in the Forms previewer does not have access to the `x:TypeArguments` attribute, so if it constructs a proxy generic type from metadata it can't construct it. So the previewer has to create an unconstructed generic type, and Forms will need to construct it.

So we need to move the code that constructs the generic type after the call to `FallbackTypeResolver`.

### Issues Resolved ### 

Part of the fix for https://devdiv.visualstudio.com/DevDiv/_workitems/edit/917689

### API Changes ###
 
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Testing requires previewer code that isn't yet merged.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
