### PR TITLE
[ios] change checkbox to use default constructor

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FormsCheckBox.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormsCheckBox.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		public FormsCheckBox() : base(UIButtonType.System)
+		public FormsCheckBox()
 		{
 			TouchUpInside += OnTouchUpInside;
 			ContentMode = UIViewContentMode.Center;
@@ -140,10 +140,10 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			if (_checked == null)
-				_checked = CreateCheckBox(CreateCheckMark());
+				_checked = CreateCheckBox(CreateCheckMark()).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
 			if (_unchecked == null)
-				_unchecked = CreateCheckBox(null);
+				_unchecked = CreateCheckBox(null).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
 			return IsChecked ? _checked : _unchecked;
 		}


### PR DESCRIPTION
### Description of Change ###
Change the FormsCheckbox inheriting from UIBUtton to not use the UIButtonType base constructor which isn't recommended. If you use the UIButtonType base constructor it throws exceptions. This PR changes it to use the default constructor

### Platforms Affected ### 
- iOS

### Testing Procedure ###
Bring up the CheckBox in the dynamic control gallery and play with the colors and various other settings to make sure it still all works correctly

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
