### PR TITLE
Make Android ShellTabLayoutAppearanceTracker public

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellTabLayoutAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellTabLayoutAppearanceTracker.cs
@@ -3,7 +3,7 @@ using Android.Support.Design.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class ShellTabLayoutAppearanceTracker : IShellTabLayoutAppearanceTracker
+	public class ShellTabLayoutAppearanceTracker : IShellTabLayoutAppearanceTracker
 	{
 		bool _disposed;
 		IShellContext _shellContext;


### PR DESCRIPTION
### Description of Change ###

As reported in #6529 the renderer needed for this in Android is not accessible. Seeing that this class is public for iOS and all renderers seem to be public as well, I think this one should be too

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6529

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
