### PR TITLE
Intellisense for CollectionView basic list options

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/CollectionViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/CollectionViewCoreGalleryPage.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls
 
 			element.HeightRequest = 250;
 
-			element.ItemsLayout = ListItemsLayout.VerticalList;
+			element.ItemsLayout = ListItemsLayout.Vertical;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
@@ -17,9 +17,9 @@
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("Vertical List (Code)", () => 
-							new TemplateCodeCollectionViewGallery(ListItemsLayout.VerticalList), Navigation),
+							new TemplateCodeCollectionViewGallery(ListItemsLayout.Vertical), Navigation),
 						GalleryBuilder.NavButton("Horizontal List (Code)", () => 
-							new TemplateCodeCollectionViewGallery(ListItemsLayout.HorizontalList), Navigation),
+							new TemplateCodeCollectionViewGallery(ListItemsLayout.Horizontal), Navigation),
 						GalleryBuilder.NavButton("Vertical Grid (Code)", () => 
 							new TemplateCodeCollectionViewGridGallery (), Navigation),
 						GalleryBuilder.NavButton("Horizontal Grid (Code)", () => 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DefaultTextGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DefaultTextGallery.cs
@@ -22,9 +22,9 @@
 						// so we can demonstrate switching between them
 						descriptionLabel,
 						GalleryBuilder.NavButton("Vertical List (Code)", () => 
-							new TextCodeCollectionViewGallery(ListItemsLayout.VerticalList), Navigation),
+							new TextCodeCollectionViewGallery(ListItemsLayout.Vertical), Navigation),
 						GalleryBuilder.NavButton("Horizontal List (Code)", () => 
-							new TextCodeCollectionViewGallery(ListItemsLayout.HorizontalList), Navigation),
+							new TextCodeCollectionViewGallery(ListItemsLayout.Horizontal), Navigation),
 						GalleryBuilder.NavButton("Vertical Grid (Code)", () => 
 							new TextCodeCollectionViewGridGallery(), Navigation),
 						GalleryBuilder.NavButton("Horizontal Grid (Code)", () => 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ItemsSizeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ItemsSizeGallery.cs
@@ -17,9 +17,9 @@
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("Expanding Text (Vertical List)", () =>
-							new DynamicItemSizeGallery(ListItemsLayout.VerticalList), Navigation),
+							new DynamicItemSizeGallery(ListItemsLayout.Vertical), Navigation),
 						GalleryBuilder.NavButton("Expanding Text (Horizontal List)", () =>
-							new DynamicItemSizeGallery(ListItemsLayout.HorizontalList), Navigation),
+							new DynamicItemSizeGallery(ListItemsLayout.Horizontal), Navigation),
 						GalleryBuilder.NavButton("ItemSizing Strategy", () =>
 							new VariableSizeTemplateGridGallery (ItemsLayoutOrientation.Horizontal), Navigation)
 					}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagationGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagationGallery.cs
@@ -17,7 +17,7 @@
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("Propagate FlowDirection", () =>
-							new PropagateCodeGallery(ListItemsLayout.VerticalList), Navigation),
+							new PropagateCodeGallery(ListItemsLayout.Vertical), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGallery.cs
@@ -17,9 +17,9 @@
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("ScrollTo Index (Code, Horizontal List)", () =>
-							new ScrollToCodeGallery(ListItemsLayout.HorizontalList), Navigation),
+							new ScrollToCodeGallery(ListItemsLayout.Horizontal), Navigation),
 						GalleryBuilder.NavButton("ScrollTo Index (Code, Vertical List)", () =>
-							new ScrollToCodeGallery(ListItemsLayout.VerticalList), Navigation),
+							new ScrollToCodeGallery(ListItemsLayout.Vertical), Navigation),
 						GalleryBuilder.NavButton("ScrollTo Index (Code, Horizontal Grid)", () =>
 								new ScrollToCodeGallery(new GridItemsLayout(3, ItemsLayoutOrientation.Horizontal)),
 							Navigation),
@@ -28,10 +28,10 @@
 							Navigation),
 
 						GalleryBuilder.NavButton("ScrollTo Item (Code, Horizontal List)", () =>
-							new ScrollToCodeGallery(ListItemsLayout.HorizontalList, ScrollToMode.Element,
+							new ScrollToCodeGallery(ListItemsLayout.Horizontal, ScrollToMode.Element,
 								ExampleTemplates.ScrollToItemTemplate), Navigation),
 						GalleryBuilder.NavButton("ScrollTo Item (Code, Vertical List)", () =>
-							new ScrollToCodeGallery(ListItemsLayout.VerticalList, ScrollToMode.Element,
+							new ScrollToCodeGallery(ListItemsLayout.Vertical, ScrollToMode.Element,
 								ExampleTemplates.ScrollToItemTemplate), Navigation),
 						GalleryBuilder.NavButton("ScrollTo Item (Code, Horizontal Grid)", () =>
 							new ScrollToCodeGallery(new GridItemsLayout(3, ItemsLayoutOrientation.Horizontal),

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SnapPointsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SnapPointsGallery.cs
@@ -19,9 +19,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("Snap Points (Code, Horizontal List)", () =>
-							new SnapPointsCodeGallery(ListItemsLayout.HorizontalList as ItemsLayout), Navigation),
+							new SnapPointsCodeGallery(ListItemsLayout.Horizontal as ItemsLayout), Navigation),
 						GalleryBuilder.NavButton("Snap Points (Code, Vertical List)", () =>
-							new SnapPointsCodeGallery(ListItemsLayout.VerticalList as ItemsLayout), Navigation),
+							new SnapPointsCodeGallery(ListItemsLayout.Vertical as ItemsLayout), Navigation),
 						GalleryBuilder.NavButton("Snap Points (Code, Horizontal Grid)", () =>
 							new SnapPointsCodeGallery(new GridItemsLayout(2, ItemsLayoutOrientation.Horizontal)), Navigation),
 						GalleryBuilder.NavButton("Snap Points (Code, Vertical Grid)", () =>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SpacingGalleries/ItemsSpacingGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SpacingGalleries/ItemsSpacingGallery.cs
@@ -17,9 +17,9 @@
 					{
 						descriptionLabel,
 						GalleryBuilder.NavButton("Vertical List Spacing", () =>
-							new SpacingGallery (ListItemsLayout.VerticalList), Navigation),
+							new SpacingGallery (ListItemsLayout.Vertical), Navigation),
 						GalleryBuilder.NavButton("Horizontal List Spacing", () =>
-							new SpacingGallery (ListItemsLayout.HorizontalList), Navigation),
+							new SpacingGallery (ListItemsLayout.Horizontal), Navigation),
 						GalleryBuilder.NavButton("Vertical Grid Spacing", () =>
 							new SpacingGallery (new GridItemsLayout(3, ItemsLayoutOrientation.Vertical)), Navigation),
 						GalleryBuilder.NavButton("Horizontal Grid Spacing", () =>

--- a/Xamarin.Forms.Core.Design/AttributeTableBuilder.cs
+++ b/Xamarin.Forms.Core.Design/AttributeTableBuilder.cs
@@ -39,6 +39,10 @@ namespace Xamarin.Forms.Core.Design
 			   "Visual",
 			   new System.ComponentModel.TypeConverterAttribute(typeof(VisualDesignTypeConverter))));
 
+			AddCallback(typeof(ItemsView), builder => builder.AddCustomAttributes(
+				"ItemsLayout",
+			   new System.ComponentModel.TypeConverterAttribute(typeof(ItemsLayoutDesignTypeConverter))));
+
 			// TODO: OnPlatform/OnIdiom
 			// These two should be proper markup extensions, to follow WPF syntax for those.
 			// That would allow us to turn on XAML validation, which otherwise fails.

--- a/Xamarin.Forms.Core.Design/ItemsLayoutDesignTypeConverter.cs
+++ b/Xamarin.Forms.Core.Design/ItemsLayoutDesignTypeConverter.cs
@@ -1,0 +1,52 @@
+﻿namespace Xamarin.Forms.Core.Design
+{
+	using System;
+	using System.Collections.Generic;
+	using System.ComponentModel;
+
+	public class ItemsLayoutDesignTypeConverter : TypeConverter
+	{
+		public ItemsLayoutDesignTypeConverter()
+		{
+		}
+
+		protected StandardValuesCollection Values
+		{
+			get;
+			set;
+		}
+
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+		{
+			// This tells XAML this converter can be used to process strings
+			// Without this the values won't show up as hints
+			if (sourceType == typeof(string))
+			{
+				return true;
+			}
+
+			return base.CanConvertFrom(context, sourceType);
+		}
+
+		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+		{
+			if (Values == null)
+			{
+				var names = new List<string>() { "VerticalList", "HorizontalList" };
+				Values = new StandardValuesCollection(names);
+			}
+
+			return Values;
+		}
+
+		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+		{
+			return false;
+		}
+
+		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+		{
+			return true;
+		}
+	}
+}

--- a/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
+++ b/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
@@ -11,8 +11,9 @@
     <ProjectGuid>{98637471-8E5C-4DDE-89CA-2EAA664FB0EF}</ProjectGuid>
     <OutputType>Library</OutputType>
     <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace></RootNamespace>
-     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
+    <RootNamespace>
+    </RootNamespace>
+    <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
@@ -71,6 +72,9 @@
     <EmbeddedResource Include="toolbox\Xamarin.Forms.toolbox.xml">
       <LogicalName>Xamarin.Forms.toolbox.xml</LogicalName>
     </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="ItemsLayoutDesignTypeConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Ensure that all images in the 'mac' and 'win' subdirectories are included as embedded resources -->

--- a/Xamarin.Forms.Core/Items/IItemsLayout.cs
+++ b/Xamarin.Forms.Core/Items/IItemsLayout.cs
@@ -2,5 +2,6 @@
 
 namespace Xamarin.Forms
 {
+	[TypeConverter(typeof(ItemsLayoutTypeConverter))]
 	public interface IItemsLayout : INotifyPropertyChanged {}
 }

--- a/Xamarin.Forms.Core/Items/ItemsLayoutTypeConverter.cs
+++ b/Xamarin.Forms.Core/Items/ItemsLayoutTypeConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	[Xaml.TypeConversion(typeof(IItemsLayout))]
+	public class ItemsLayoutTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value == "HorizontalList")
+			{
+				return ListItemsLayout.Horizontal;
+			}
+
+			if (value == "VerticalList")
+			{
+				return ListItemsLayout.Vertical;
+			}
+
+			throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(IItemsLayout)}");
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty ItemsLayoutProperty =
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView), 
-				ListItemsLayout.VerticalList);
+				ListItemsLayout.Vertical);
 
 		public IItemsLayout ItemsLayout
 		{

--- a/Xamarin.Forms.Core/Items/ListItemsLayout.cs
+++ b/Xamarin.Forms.Core/Items/ListItemsLayout.cs
@@ -1,15 +1,15 @@
-﻿namespace Xamarin.Forms
+﻿using System;
+
+namespace Xamarin.Forms
 {
 	public class ListItemsLayout : ItemsLayout
 	{
-		// TODO hartez 2018/08/29 17:28:42 Consider changing this name to LinearItemsLayout; not everything using it is a list (e.g., Carousel)	
 		public ListItemsLayout(ItemsLayoutOrientation orientation) : base(orientation)
 		{
 		}
 
-		// TODO hartez 2018/05/31 15:56:23 Should these just be called Vertical and Horizontal (without List)?	
-		public static readonly IItemsLayout VerticalList = new ListItemsLayout(ItemsLayoutOrientation.Vertical); 
-		public static readonly IItemsLayout HorizontalList = new ListItemsLayout(ItemsLayoutOrientation.Horizontal);
+		public static readonly IItemsLayout Vertical = new ListItemsLayout(ItemsLayoutOrientation.Vertical); 
+		public static readonly IItemsLayout Horizontal = new ListItemsLayout(ItemsLayoutOrientation.Horizontal);
 
 		// TODO hartez 2018/08/29 20:31:54 Need something like these previous two, but as a carousel default	
 


### PR DESCRIPTION
### Description of Change ###

CollectionView provides pre-allocated static instances of the unspaced horizontal and vertical list layouts, but to use them from XAML required doing something like 

```
<CollectionView ItemsLayout="{x:Static ListItemsLayout.HorizontalList}">
```

and the user was given no Intellisense for discoverability. 

These changes provide Intellisense for the basic list options.

### Issues Resolved ### 

None

### API Changes ###

Changed: 
 `public static readonly IItemsLayout VerticalList` -> `public static readonly IItemsLayout Vertical`
 `public static readonly IItemsLayout HorizontalList` -> `public static readonly IItemsLayout Horziontal`

Added:
`public class ItemsLayoutTypeConverter`
`public class ItemsLayoutDesignTypeConverter`

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![listlayout_intellisense](https://user-images.githubusercontent.com/538025/59544529-99ba2b00-8ecf-11e9-87c7-844bb8b167b2.GIF)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
