### PR TITLE
[Android] Hamburger icon not shown when using FormsAppCompatActivity

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2577.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2577.cs
@@ -1,0 +1,53 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2577, "Hamburger icon not shown when using FormsAppCompatActivity", PlatformAffected.Android)]
+	public class Issue2577 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			Master = new ContentPage { Title = "master page" };
+			Detail = new NavigationPage(new DetailPage());
+		}
+
+		class DetailPage : ContentPage
+		{
+			public NavigationPage ParentPage => Parent as NavigationPage;
+
+			public DetailPage()
+			{
+				var button = new Button { Text = "Click me" };
+				button.Clicked += async (o, s) =>
+				{
+					var button2 = new Button { Text = "Toggle back button" };
+
+					var page = new ContentPage { Content = new StackLayout { Children = {
+							new Label { Text = "If there is no hamburger button, this test has failed. If you cannot toggle the back arrow, this test has failed." },
+							button2
+						} } };
+
+					button2.Clicked += (o2, s2) =>
+					{
+						NavigationPage.SetHasBackButton(page, !NavigationPage.GetHasBackButton(page));
+					};
+
+					NavigationPage.SetHasBackButton(page, false);
+					await ParentPage.PushAsync(page);
+				};
+				Content = button;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -632,6 +632,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5470.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5724.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6132.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2577.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -839,10 +839,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (!removed)
 				{
 					UpdateToolbar();
-					if (_drawerToggle != null && NavigationPageController.StackDepth == 2)
+					if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && _masterDetailPage == null)
 						AnimateArrowIn();
 				}
-				else if (_drawerToggle != null && NavigationPageController.StackDepth == 2)
+				else if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && _masterDetailPage == null)
 					AnimateArrowOut();
 
 				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, TransitionDuration, removed);
@@ -947,7 +947,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bar.NavigationIcon = null;
 			Page currentPage = Element.CurrentPage;
 
-			if (isNavigated)
+			if (isNavigated && _masterDetailPage == null) // GV ADDED masterdetail check
 			{
 				if (toggle != null)
 				{

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -947,7 +947,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bar.NavigationIcon = null;
 			Page currentPage = Element.CurrentPage;
 
-			if (isNavigated && _masterDetailPage == null) // GV ADDED masterdetail check
+			if (isNavigated && _masterDetailPage == null)
 			{
 				if (toggle != null)
 				{

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -839,10 +839,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (!removed)
 				{
 					UpdateToolbar();
-					if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && _masterDetailPage == null)
+					if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && (NavigationPage.GetHasBackButton(page) && _masterDetailPage != null))
 						AnimateArrowIn();
 				}
-				else if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && _masterDetailPage == null)
+				else if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && (NavigationPage.GetHasBackButton(page) && _masterDetailPage != null))
 					AnimateArrowOut();
 
 				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, TransitionDuration, removed);
@@ -947,16 +947,16 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			bar.NavigationIcon = null;
 			Page currentPage = Element.CurrentPage;
 
-			if (isNavigated && _masterDetailPage == null)
+			if (isNavigated)
 			{
-				if (toggle != null)
-				{
-					toggle.DrawerIndicatorEnabled = false;
-					toggle.SyncState();
-				}
-
 				if (NavigationPage.GetHasBackButton(currentPage) && !Context.IsDesignerContext())
 				{
+					if (toggle != null)
+					{
+						toggle.DrawerIndicatorEnabled = false;
+						toggle.SyncState();
+					}
+
 					var activity = (global::Android.Support.V7.App.AppCompatActivity)context.GetActivity();
 					var icon = new DrawerArrowDrawable(activity.SupportActionBar.ThemedContext);
 					icon.Progress = 1;
@@ -964,6 +964,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 					var prevPage = Element.Peek(1);
 					_defaultNavigationContentDescription = bar.SetNavigationContentDescription(prevPage, _defaultNavigationContentDescription);
+				}
+				else if (_masterDetailPage != null)
+				{
+					toggle.DrawerIndicatorEnabled = _masterDetailPage.ShouldShowToolbarButton();
+					toggle.SyncState();
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -839,10 +839,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (!removed)
 				{
 					UpdateToolbar();
-					if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && (NavigationPage.GetHasBackButton(page) && _masterDetailPage != null))
+					if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && NavigationPage.GetHasBackButton(page))
 						AnimateArrowIn();
 				}
-				else if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && (NavigationPage.GetHasBackButton(page) && _masterDetailPage != null))
+				else if (_drawerToggle != null && NavigationPageController.StackDepth == 2 && NavigationPage.GetHasBackButton(page))
 					AnimateArrowOut();
 
 				AddTransitionTimer(tcs, fragment, FragmentManager, fragmentsToRemove, TransitionDuration, removed);


### PR DESCRIPTION
### Description of Change ###

When using the `FormsAppCompatActivity` the hamburger icon would not respond correctly to `NavigationPage.GetHasBackButton` leaving it to show nothing at all. With this change the hamburger icon will show when `NavigationPage.GetHasBackButton` is set to false.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2577

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests (manual verification) <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
