### PR TITLE
[UITests] Ignore flaky tests 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1939.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1939.cs
@@ -7,11 +7,16 @@ using System.Threading.Tasks;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
+#if UITEST
+	[Ignore("Ignoring this test as it fails sometimes on TestCloud")]
+	[Category(UITestCategories.ManualReview)]
+#endif
 	[Issue(IssueTracker.Github, 1939, "ArgumentOutOfRangeException on clearing a group on a grouped ListView on Android", PlatformAffected.Android)]
 	public class Issue1939 : TestContentPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1975.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1975.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 1975, "[iOS] ListView throws NRE when grouping enabled and data changed",
 		PlatformAffected.iOS)]
 #if UITEST
+	[Ignore("Ignoring this test as it fails sometimes on TestCloud")]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
 	[NUnit.Framework.Category(UITestCategories.ListView)]
 #endif
 	public class Issue1975 : TestNavigationPage

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ToolbarItemTests.cs
@@ -9,6 +9,8 @@ namespace Xamarin.Forms.Core.UITests
 	[TestFixture]
 	[Category(UITestCategories.ToolbarItem)]
 	[Category(UITestCategories.UwpIgnore)]
+	[Ignore("Ignoring this test as it fails sometimes on TestCloud")]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
 	internal class ToolbarItemTests : BaseTestFixture
 	{
 		string btn1Id = "tb1";


### PR DESCRIPTION
### Description of Change ###

Some of these uitests work fine locally but sometimes fail on AppCenter.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
