### PR TITLE
[UWP] Value does not fall with in the expected range Exception while creating NativeView

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -128,6 +128,7 @@
     <Compile Include="_2489CustomRenderer.cs" />
     <Compile Include="_57114Renderer.cs" />
     <Compile Include="_58406EffectRenderer.cs" />
+    <Compile Include="_5886DependencyService.cs" />
     <Compile Include="_60122ImageRenderer.cs" />
     <Content Include="Assets\Fonts\OFL.txt" />
     <Content Include="bank.png" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/_5886DependencyService.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/_5886DependencyService.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Platform.UWP;
+using static Xamarin.Forms.Controls.Issues.Issue5886;
+
+[assembly: Dependency(typeof(MyInterfaceImplementation))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class MyInterfaceImplementation : IReplaceUWPRendererService
+	{
+		public MyInterfaceImplementation()
+		{
+		}
+
+		public void ConvertToNative(View formsView)
+		{
+			var renderer = Xamarin.Forms.Platform.UWP.Platform.GetRenderer(formsView);
+			if (renderer != null)
+			{
+				renderer.Dispose();
+				Platform.UWP.Platform.SetRenderer(formsView, null);
+			}
+
+			var newRenderer = formsView.GetOrCreateRenderer();
+		}
+
+		public void CreateRenderer(View formsView)
+		{
+			var newRenderer = formsView.GetOrCreateRenderer();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5886.cs
@@ -1,0 +1,98 @@
+﻿using System;
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Linq;
+#endif
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Layout)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5886, "Value does not fall with in the expected range Exception while creating NativeView Xamarin Forms UWP", PlatformAffected.UWP)]
+	public class Issue5886 : TestContentPage
+	{
+		public interface IReplaceUWPRendererService
+		{
+			void ConvertToNative(View formsView);
+			void CreateRenderer(View formsView);
+		}
+
+		ScrollView scrollView;
+		Label label;
+		Button button0;
+		Button button1;
+		protected override void Init()
+		{
+			scrollView = new ScrollView();
+
+			var grid = new Grid();
+			grid.Children.Add(new Label { Text = "Discard Draft ?" });
+
+			scrollView.Content = grid;
+
+			button0 = new Button
+			{
+				Text = "Create native renderer",
+				AutomationId = "Step1"
+			};
+
+			button0.Clicked += Button_Clicked1;
+
+			button1 = new Button
+			{
+				Text = "Start native view conversion",
+				AutomationId = "Step2",
+				IsVisible = false
+			};
+
+			button1.Clicked += Button_Clicked;
+
+			label = new Label
+			{
+				Text = "You should be able to push first the top button, then the bottom without any exception (Element is already the child of another element.)",
+				AutomationId = "ResultLabel"
+			};
+
+			var stack = new StackLayout();
+			stack.Children.Add(button0);
+			stack.Children.Add(button1);
+			stack.Children.Add(label);
+
+			Content = stack;
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			DependencyService.Get<IReplaceUWPRendererService>().ConvertToNative(this.scrollView);
+			label.Text = "Step 2 OK";
+		}
+
+		private void Button_Clicked1(object sender, EventArgs e)
+		{
+			DependencyService.Get<IReplaceUWPRendererService>().CreateRenderer(this.scrollView);
+			label.Text = "Step 1 OK";
+			button1.IsVisible = true;
+		}
+
+#if UITEST
+		[Test]
+		public void ReplaceRenderer()
+		{
+			RunningApp.WaitForElement("Step1");
+			RunningApp.Tap("Step1");
+
+			RunningApp.WaitForElement("Step2");
+			RunningApp.Tap("Step2");
+
+			RunningApp.WaitFor(() => RunningApp.Query("ResultLabel").FirstOrDefault()?.Text == "Step 2 OK");
+
+			Assert.AreEqual("Step 2 OK", label.Text);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5886.cs
@@ -66,13 +66,13 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = stack;
 		}
 
-		private void Button_Clicked(object sender, EventArgs e)
+		void Button_Clicked(object sender, EventArgs e)
 		{
 			DependencyService.Get<IReplaceUWPRendererService>().ConvertToNative(this.scrollView);
 			label.Text = "Step 2 OK";
 		}
 
-		private void Button_Clicked1(object sender, EventArgs e)
+		void Button_Clicked1(object sender, EventArgs e)
 		{
 			DependencyService.Get<IReplaceUWPRendererService>().CreateRenderer(this.scrollView);
 			label.Text = "Step 1 OK";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5886.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5886.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Forms.Controls.Issues
 			button1.IsVisible = true;
 		}
 
-#if UITEST
+#if UITEST && __WINDOWS__
 		[Test]
 		public void ReplaceRenderer()
 		{
@@ -89,9 +89,9 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Step2");
 			RunningApp.Tap("Step2");
 
-			RunningApp.WaitFor(() => RunningApp.Query("ResultLabel").FirstOrDefault()?.Text == "Step 2 OK");
+			var resultLabel = RunningApp.Query("ResultLabel").FirstOrDefault();
 
-			Assert.AreEqual("Step 2 OK", label.Text);
+			Assert.AreEqual("Step 2 OK", resultLabel.Description);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1270,7 +1270,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue6130.xaml.cs">
       <DependentUpon>Issue6130.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\Users\jfversluis\Documents\GitHub\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue6254.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Issue6254.xaml.cs">
       <DependentUpon>Issue6254.xaml</DependentUpon>
     </Compile>
   </ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -20,7 +20,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlagTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5886.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue6262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6260.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundMultiSelection.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,6 +19,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlagTestHelpers.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5886.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6260.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewBoundMultiSelection.cs" />
@@ -1267,6 +1269,9 @@
   <ItemGroup>
     <Compile Update="$(MSBuildThisFileDirectory)Issue6130.xaml.cs">
       <DependentUpon>Issue6130.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="C:\Users\jfversluis\Documents\GitHub\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue6254.xaml.cs">
+      <DependentUpon>Issue6254.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ScrollViewRenderer.cs
@@ -72,6 +72,9 @@ namespace Xamarin.Forms.Platform.UWP
 					element.LayoutUpdated -= SetInitialRtlPosition;
 				}
 			}
+
+			if (_currentView != null)
+				_currentView.Cleanup();
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<ScrollView> e)


### PR DESCRIPTION
### Description of Change ###

When setting the renderer for a second time for the `ScrollView` there was some leftovers in terms of the children that were already added to the visual tree. In the case of this issue (#5886) the `Grid` would stay in existence and when another renderer was added we would get an error on this.

Added a existing cleanup call to the cleanup of the `ScrollViewRenderer` that recursively cleans up all the children which fixes the issue. Also added the reproduction and automated UI tests for it.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5886

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
