### PR TITLE
Modal Page with transparent background

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -409,6 +409,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new ViewCellGallery(), "ViewCell Gallery - Legacy"),
 				new GalleryPageFactory(() => new WebViewGallery(), "WebView Gallery - Legacy"),
 				new GalleryPageFactory(() => new BindableLayoutGalleryPage(), "BindableLayout Gallery - Legacy"),
+				new GalleryPageFactory(() => new ShowModalWithTransparentBkgndGalleryPage(), "Modal With Transparent Bkgnd Gallery - Legacy"),
 			};
 
 		public CorePageView(Page rootPage, NavigationBehavior navigationBehavior = NavigationBehavior.PushAsync)

--- a/Xamarin.Forms.Controls/GalleryPages/PageWithTransparentBkgnd.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/PageWithTransparentBkgnd.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.PageWithTransparentBkgnd"
+             xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             ios:Page.UseSafeArea="true"
+             BackgroundColor="Transparent"
+             ModalBackgroundColor="#700000FF"
+             ios:Page.ModalPresentationStyle="OverFullScreen">
+    <Frame VerticalOptions="Center"
+           HorizontalOptions="Center"
+           WidthRequest="300"
+           HeightRequest="200"
+           Padding="15, 10"
+           BackgroundColor="LightGreen">
+        <StackLayout>
+            <Label Text="Modal page with custom modal background"
+                   HorizontalOptions="Center"
+                   VerticalOptions="CenterAndExpand" />
+            <Button Text="Close"
+                    HorizontalOptions="End"
+                    Clicked="ClosePageButtonClicked"
+                    VerticalOptions="End" />
+        </StackLayout>
+    </Frame>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/PageWithTransparentBkgnd.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PageWithTransparentBkgnd.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages
+{
+	[Preserve(AllMembers = true)]
+	public partial class PageWithTransparentBkgnd : ContentPage
+	{
+		public PageWithTransparentBkgnd()
+		{
+			InitializeComponent();
+		}
+
+		void ClosePageButtonClicked(object sender, EventArgs e)
+		{
+			Navigation.PopModalAsync();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/ShowModalWithTransparentBkgndGalleryPage.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShowModalWithTransparentBkgndGalleryPage.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages
+{
+	class ShowModalWithTransparentBkgndGalleryPage : ContentPage
+	{
+		public ShowModalWithTransparentBkgndGalleryPage()
+		{
+			BackgroundColor = Color.LightPink;
+
+			var btn = new Button()
+			{
+				Text = "Show page",
+				VerticalOptions = LayoutOptions.Start,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			btn.Clicked += ShowModalBtnClicked;
+
+			Content = btn;
+		}
+
+		void ShowModalBtnClicked(object sender, System.EventArgs e)
+		{
+			Navigation.PushModalAsync(new PageWithTransparentBkgnd());
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -71,6 +71,9 @@
     <EmbeddedResource Update="GalleryPages\MapWithItemsSourceGallery.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\PageWithTransparentBkgnd.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\TitleView.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -40,6 +40,8 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly BindableProperty IconProperty = IconImageSourceProperty;
 
+		public static readonly BindableProperty ModalBackgroundColorProperty = BindableProperty.Create(nameof(ModalBackgroundColor), typeof(Color), typeof(Page), Color.Default);
+
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;
 
 		bool _allocatedFlag;
@@ -143,6 +145,12 @@ namespace Xamarin.Forms
 
         [EditorBrowsable(EditorBrowsableState.Never)]
         public ObservableCollection<Element> InternalChildren { get; } = new ObservableCollection<Element>();
+
+		public Color ModalBackgroundColor
+		{
+			get { return (Color)GetValue(ModalBackgroundColorProperty); }
+			set { SetValue(ModalBackgroundColorProperty, value); }
+		}
 
 		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement
 		{

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
@@ -3,6 +3,7 @@
 	public enum UIModalPresentationStyle
 	{
 		FullScreen,
-		FormSheet
+		FormSheet,
+		OverFullScreen
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -8,6 +8,7 @@ using Android.Views;
 using Android.Views.Animations;
 using AView = Android.Views.View;
 using Xamarin.Forms.Internals;
+using System.ComponentModel;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -429,7 +430,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_modal = modal;
 
 				_backgroundView = new AView(context);
-				_backgroundView.SetWindowBackground();
+				UpdateBackgroundColor();
 				AddView(_backgroundView);
 
 				_renderer = Android.Platform.CreateRenderer(modal, context);
@@ -438,6 +439,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				AddView(_renderer.View);
 
 				Id = Platform.GenerateViewId();
+
+				_modal.PropertyChanged += OnModalPagePropertyChanged;
 			}
 
 			protected override void Dispose(bool disposing)
@@ -451,6 +454,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 						_renderer.Dispose();
 						_renderer = null;
 						_modal.ClearValue(Android.Platform.RendererProperty);
+						_modal.PropertyChanged -= OnModalPagePropertyChanged;
 						_modal = null;
 					}
 
@@ -473,6 +477,21 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 
 				_renderer.UpdateLayout();
+			}
+
+			void OnModalPagePropertyChanged(object sender, PropertyChangedEventArgs e)
+			{
+				if (e.PropertyName == Page.ModalBackgroundColorProperty.PropertyName)
+					UpdateBackgroundColor();
+			}
+
+			void UpdateBackgroundColor()
+			{
+				Color modalBkgndColor = _modal.ModalBackgroundColor;
+				if (modalBkgndColor.IsDefault)
+					_backgroundView.SetWindowBackground();
+				else
+					_backgroundView.SetBackgroundColor(modalBkgndColor.ToAndroid());
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -1,3 +1,4 @@
+using System;
 using UIKit;
 using Xamarin.Forms.Internals;
 
@@ -71,6 +72,21 @@ namespace Xamarin.Forms.Platform.iOS
 				textInput.AutocapitalizationType = capSettings;
 				textInput.AutocorrectionType = suggestionsEnabled ? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
 				textInput.SpellCheckingType = spellcheckEnabled ? UITextSpellCheckingType.Yes : UITextSpellCheckingType.No;
+			}
+		}
+
+		public static UIModalPresentationStyle ToNativeModalPresentationStyle(this PlatformConfiguration.iOSSpecific.UIModalPresentationStyle style)
+		{
+			switch (style)
+			{
+				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet:
+					return UIModalPresentationStyle.FormSheet;
+				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FullScreen:
+					return UIModalPresentationStyle.FullScreen;
+				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.OverFullScreen:
+					return UIModalPresentationStyle.OverFullScreen;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(style));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -6,6 +6,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -112,6 +113,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			modal.DisposeModalAndChildRenderers();
 
+			if (IsModalPresentedOverContext(modal))
+				GetCurentPage(Page)?.SendAppearing();
+
 			return modal;
 		}
 
@@ -143,6 +147,9 @@ namespace Xamarin.Forms.Platform.iOS
 		Task INavigation.PushModalAsync(Page modal, bool animated)
 		{
 			EndEditing();
+
+			if (_appeared && IsModalPresentedOverContext(modal))
+				GetCurentPage(Page)?.SendDisappearing();
 
 			_modals.Add(modal);
 
@@ -561,6 +568,25 @@ namespace Xamarin.Forms.Platform.iOS
 				modal.DisposeModalAndChildRenderers();
 
 			(Page.Parent as IDisposable)?.Dispose();
+		}
+
+		Page GetCurentPage(Page currentPage)
+		{
+			if (_modals.LastOrDefault() is Page modal)
+				return modal;
+			else if (currentPage is MasterDetailPage mdp)
+				return GetCurentPage(mdp.Detail);
+			else if (currentPage is IPageContainer<Page> pc)
+				return GetCurentPage(pc.CurrentPage);
+			else
+				return currentPage;
+		}
+
+		static bool IsModalPresentedOverContext(Page modal)
+		{
+			var elementConfiguration = modal as IElementConfiguration<Page>;
+			var presentationStyle = elementConfiguration?.On<PlatformConfiguration.iOS>()?.ModalPresentationStyle();
+			return presentationStyle != null && presentationStyle == PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.OverFullScreen;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR changes the background color of the **modal container** of a **modal page**, from white to transparent. This way, if the **modal page** has the background color with transparency, the content behind the modal page is now visible. In other words, this PR makes the opacity of the `BackgroundColor` on a Page really work (every Xamarin.Forms developer must have tried this and discovered it doesn't work ?? ).

With this change, there's now a very easy way to finally be able to create **popup pages**, and the nice thing is it can be done using the existing simple modal navigation API.

Creating a popup page only requires a `ContentPage` with a semi-transparent `BackgroundColor`, and some content not covering the whole page (the content position can be customized easily).

```
<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
             BackgroundColor="#A0000000"
             x:Class="Xamarin.Forms.Controls.GalleryPages.PageWithTransparentBkgnd">
    <Frame VerticalOptions="Center"
           HorizontalOptions="Center"
           WidthRequest="300"
           HeightRequest="200"
           Padding="15, 10"
           BackgroundColor="LightGreen">
        <StackLayout>
            <Label Text="Welcome to Xamarin.Forms Popups!"
                   HorizontalOptions="Center"
                   VerticalOptions="CenterAndExpand" />
            <Button Text="Close"
                    HorizontalOptions="End"
                    Clicked="ClosePageButtonClicked"
                    VerticalOptions="End" />
        </StackLayout>
    </Frame>
</ContentPage
```

Show the page as a modal page:
```
	void ShowModalBtnClicked(object sender, System.EventArgs e)
	{
		Navigation.PushModalAsync(new PageWithTransparentBkgnd());
	}
```

Closing the page is done using existing API:

		void ClosePageButtonClicked(object sender, EventArgs e)
		{
			Navigation.PopModalAsync();
		}

On Android, since the "popup" is a simple modal page, the back button just works.

Once this is implemented, more features can be added, for example popping the modal page automatically when tapping anywhere on the page except its content.

### Don't animate the overlay, only the content

If someone doesn't want to have the overlay animated but only the Page content, this can be achieved relatively easily by calling `Navigation.PushModalAsync(modalPage, animation: false)` and animating the page content.

### Animate the overlay and/or content

Similar to the previous, with `Navigation.PushModalAsync(modalPage, animation: false)` this can be done by:
- Set the Page `BackgroundColor="Transparent"`
- Add an overlay using a `BoxView` with a semi transparent `BackgroundColor=#A0000000`
- Animate the `BoxView` overlay (animate the opacity, animate scaling it, etc.)

Popups are a very common feature, so if possible it would be great to get this feature sooner.

### API Changes ###

The only public API change is on iOS, where I added a new value for the UIModalPresentationStyle platform specific enum. This is needed because the default presentation style for the modal container changed from `UIModalPresentationStyle.FullScreen` to `UIModalPresentationStyle.OverCurrentContext` in order to support a transparent background. 

AFAIK, this change should not have any backward compatibility implications, since for the page modal container, the OverCurrentContext value behaves exactly like the previous value, FullScreen.

### Issue fixed ###

This doesn't (completely) fix the #1778, but I think it opens up new possibilities with very little changes. 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None. If you don't set semi-transparent background, there's no visual change. This is because all pages have the white color as background color by default.

### Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

![modal](https://user-images.githubusercontent.com/743918/59623668-641a7980-913d-11e9-9c94-ccdd0f84db99.gif)

![modal_android](https://user-images.githubusercontent.com/743918/59623678-68df2d80-913d-11e9-81c5-de88c737be10.gif)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

See the "Modal With Transparent Bkgnd Gallery - Legacy" page.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
