### PR TITLE
[Android] Change elevation to use float.minvalue instead of negative infinity

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Forms.Platform.Android
 			_bgImage = new ImageView(context)
 			{
 				LayoutParameters = new LP(coordinator.LayoutParameters),
-				Elevation = float.NegativeInfinity
+				Elevation = float.MinValue
 			};
 
 			UpdateFlyoutHeaderBehavior();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -92,8 +92,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			_bgImage = new ImageView(context)
 			{
-				LayoutParameters = new LP(coordinator.LayoutParameters),
-				Elevation = float.MinValue
+				LayoutParameters = new LP(coordinator.LayoutParameters)
 			};
 
 			UpdateFlyoutHeaderBehavior();
@@ -167,7 +166,12 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				if (_rootView.IndexOfChild(_bgImage) == -1)
-					_rootView.AddView(_bgImage);
+				{
+					if(_bgImage.SetElevation(float.MinValue))
+						_rootView.AddView(_bgImage);
+					else
+						_rootView.AddView(_bgImage, 0);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -93,5 +93,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			view.ClipToOutline = value;
 		}
+
+		public static bool SetElevation(this AView view, float value)
+		{
+			if (view.IsDisposed() || !Forms.IsLollipopOrNewer)
+				return false;
+
+			view.Elevation = value;
+			return true;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
API 28 on Android appears to be a fan of setting the elevation to negative infinity and expects you to use 
float.minvalue


### Platforms Affected ### 
- Android

### Testing Procedure ###
- Run shell on android api 28 and ensure 5132 is passing on all ui tests
- store shell also has some backgrounds you can interact with for the flyout if you want to test that it all still works to expectation

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
