### PR TITLE
wait for test to finish so it doesn't break later tests

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1905.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1905.cs
@@ -75,6 +75,7 @@ namespace Xamarin.Forms.Controls.Issues
 			lst.RefreshCommand = new Command(async () =>
 			{
 				var newitems = new List<string>();
+				newitems.Add("data refreshed");
 				await Task.Delay(5000);
 				for (int i = 0; i < 1000; i++)
 				{
@@ -98,7 +99,13 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void TestIssue1905RefreshShows()
 		{
+			// wait for test to load
+			RunningApp.WaitForElement("btnRefresh");
 			RunningApp.Screenshot("Should show refresh control");
+
+			// wait for test to finish so it doesn't keep working
+			// in the background and break the next test
+			RunningApp.WaitForElement("data refreshed");
 		}
 #endif
 	}


### PR DESCRIPTION
### Description of Change ###

The screen shot for the 1939 test failure in app center has a picture of the test that runs during 1905 and the screen shot for 1905 is just a screen shot of the control gallery home page.

I added some waits to the 1905 test so that it waits for the test to actually load before screenshot is taken and then waits for it to finish before existing. 

