### PR TITLE
[XamlC] Do not try to set a value to bound source property if unavailable

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml
@@ -16,6 +16,7 @@
             <Label Text="{Binding I}" x:Name="label5" />
             <Label Text="{Binding Model.Text}" x:Name="label6" x:DataType="local:MockStructViewModel" />
 			<Entry Text="{Binding Text, Mode=TwoWay}" x:Name="entry0"/>
+			<Entry Text="{Binding Model.Text, Mode=TwoWay}" x:Name="entry1" />
             <Label Text="{Binding .}" x:Name="label7" x:DataType="sys:Int32"/>
             <Label Text="{Binding Text, Mode=OneTime}" x:Name="label8" />
 			<Label Text="{Binding StructModel.Text, Mode=TwoWay}" x:Name="label9" />

--- a/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BindingsCompiler.xaml.cs
@@ -97,6 +97,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.AreEqual("Text2", layout.entry0.Text);
 				((IElementController)layout.entry0).SetValueFromRenderer(Entry.TextProperty, "Text3");
 				Assert.AreEqual("Text3", layout.entry0.Text);
+				Assert.AreEqual("Text3", vm.Text);
+				((IElementController)layout.entry1).SetValueFromRenderer(Entry.TextProperty, "Text4");
+				Assert.AreEqual("Text4", layout.entry1.Text);
+				Assert.AreEqual("Text4", vm.Model.Text);
+				vm.Model = null;
+				layout.entry1.BindingContext = null;
 
 				//testing invalid bindingcontext type
 				layout.BindingContext = new object();


### PR DESCRIPTION
### Description of Change ###

Do not try to set a value to bound source property if unavailable and prevent `System.NullReferenceException`.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
