### PR TITLE
EntryRenderer.cs [macOS] updated

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -72,13 +72,19 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			void HandleWindowDidResignKey(object sender, EventArgs args)
 			{
-				FocusChanged?.Invoke(this, new BoolEventArgs(false));
+				if (!_disposed)
+				{
+					FocusChanged?.Invoke(this, new BoolEventArgs(false));
+				}
 			}
 
 			void HandleWindowDidBecomeKey(object sender, EventArgs args)
 			{
-				if (Window != null && CurrentEditor == Window.FirstResponder)
-					FocusChanged?.Invoke(this, new BoolEventArgs(true));
+				if (!_disposed)
+				{
+					if (Window != null && CurrentEditor == Window.FirstResponder)
+						FocusChanged?.Invoke(this, new BoolEventArgs(true));
+				}
 			}
 		}
 


### PR DESCRIPTION
`EntryRenderer.cs` for `macOS` is updated in this PR. Checks for if the current `NSWindow` is disposed where added before invoking the `FocusChanged` `EventHandler`. 

### Description of Change ###

Since the renderer already had a member `_disposed`  i used this field for the checks. 

### Issues Resolved ### 

- fixes #4268

### API Changes ###

 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I have tested the changes on macOS 10.14.5 by creating a new project adding an entry with `IsVisble=false `and displaying an Alert or ActionSheet after focusing the entry. The main window loses focus whenever an DisplayAlert or DisplayActionSheet ist called so this is a quick way to test it. It's also possible to repro the issue by clicking outside of the main window or switching windows with CMD + Tab while the Entry has focus and clicking back to the app window.
A project with a repro is reference here in this [comment-484575493](https://github.com/xamarin/Xamarin.Forms/issues/4268#issuecomment-484575493) 

### PR Checklist ###

- [ ] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
