### PR TITLE
Set ExceptionHandler on HydrationContext in SetTemplate()

### DIFF
--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -695,7 +695,7 @@ namespace Xamarin.Forms.Xaml
 			((IDataTemplate)dt).LoadTemplate = () => {
 #pragma warning restore 0612
 				var cnode = node.Clone();
-				var context = new HydrationContext { ParentContext = Context, RootElement = Context.RootElement };
+				var context = new HydrationContext { ParentContext = Context, RootElement = Context.RootElement, ExceptionHandler = Context.ExceptionHandler };
 				cnode.Accept(new XamlNodeVisitor((n, parent) => n.Parent = parent), node.Parent); //set parents for {StaticResource}
 				cnode.Accept(new ExpandMarkupsVisitor(context), null);
 				cnode.Accept(new NamescopingVisitor(context), null);


### PR DESCRIPTION
### Description of Change ###

`ApplyPropertiesVisitor.SetTemplate()` creates a new `HydrationContext`, but it doesn't set the ExceptionHandler, so exceptions aren't caught in the previewer.

### Issues Resolved ### 

- fixes https://devdiv.visualstudio.com/DevDiv/_workitems/edit/844877

### API Changes ###
 
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Tested exception is correctly caught in previewer.

### PR Checklist ###

- [ ] Has automated tests - we'll test on the previewer side.
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
