### PR TITLE
Update ItemsViewLayout.cs to Unsubscribe from itemsLayout PropertyChanged event

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_itemsLayout != null)
 				{
-					_itemsLayout.PropertyChanged += LayoutOnPropertyChanged;
+					_itemsLayout.PropertyChanged -= LayoutOnPropertyChanged;
 				}
 			}
 


### PR DESCRIPTION
Unsubscribe from PropertyChanged during Dispose() on ItemsViewLayout (iOS).

### Description of Change ###

Altered the behavior of ItemsViewLayout (iOS) to unsubscribe from the PropertyChanged event of the private _itemsLayout field. It didn't appear this event was unsubscribed from in the ItemsViewLayout.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6582 

### API Changes ###
<!-- List all API changes here (or just put None), example:

None.

 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
