### PR TITLE
Change Query to WaitForElement

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1733.cs
@@ -5,6 +5,7 @@ using System.Linq;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Threading.Tasks;
+using System.Threading;
 #if UITEST
 using Xamarin.Forms.Core.UITests;
 using NUnit.Framework;
@@ -208,7 +209,7 @@ namespace Xamarin.Forms.Controls.Issues
 		Dictionary<string, Size> results = null;
 
 		[Test]
-		public void Issue1733Test()
+		public void EditorAutoResize()
 		{
 			string[] editors = new string[] { editorHeightShrinkWithPressureId, editorHeightGrowId, editorWidthGrow1Id, editorWidthGrow2Id };
 			RunningApp.WaitForElement(q => q.Marked(editorHeightShrinkWithPressureId));
@@ -254,8 +255,6 @@ namespace Xamarin.Forms.Controls.Issues
 				Assert.AreEqual(allTheSame.Width, results[editor].Width, editor);
 				Assert.AreEqual(allTheSame.Height, results[editor].Height, editor);
 			}
-
-
 		}
 
 		void TestGrowth(bool heightPressureShrink)
@@ -289,8 +288,8 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement($"{editorName}_height");
 			RunningApp.WaitForElement($"{editorName}_width");
 
-			var height = RunningApp.Query(x => x.Marked($"{editorName}_height")).FirstOrDefault()?.Text;
-			var width = RunningApp.Query(x => x.Marked($"{editorName}_width")).FirstOrDefault()?.Text;
+			var height = RunningApp.WaitForElement(x => x.Marked($"{editorName}_height")).FirstOrDefault()?.Text;
+			var width = RunningApp.WaitForElement(x => x.Marked($"{editorName}_width")).FirstOrDefault()?.Text;
 
 			if (height == null)
 			{
@@ -304,5 +303,5 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #endif
-	}
+    }
 }


### PR DESCRIPTION
### Description of Change ###
- for test Issue1733 it should be using WaitForElement instead of Query so that it actually waits for it to become visible.
- renamed test so that the name is immediately useful
