### PR TITLE
[Android] don't setup webview if running as designer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -17,14 +17,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		WebViewClient _webViewClient;
 		FormsWebChromeClient _webChromeClient;
-
+		bool _isDisposed = false;
 		protected internal IWebViewController ElementController => Element;
 		protected internal bool IgnoreSourceChanges { get; set; }
 		protected internal string UrlCanceled { get; set; }
 
 		public WebViewRenderer(Context context) : base(context)
 		{
-			AutoPackage = false;
+			AutoPackage = false;			
 		}
 
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use WebViewRenderer(Context) instead.")]
@@ -62,6 +62,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_isDisposed)
+				return;
+
+			_isDisposed = true;
 			if (disposing)
 			{
 				if (Element != null)
@@ -118,6 +122,12 @@ namespace Xamarin.Forms.Platform.Android
 				_webChromeClient = GetFormsWebChromeClient();
 				_webChromeClient.SetContext(Context);
 				webView.SetWebChromeClient(_webChromeClient);
+
+				if(Context.IsDesignerContext())
+				{
+					SetNativeControl(webView);
+					return;
+				}
 
 				webView.Settings.JavaScriptEnabled = true;
 				webView.Settings.DomStorageEnabled = true;


### PR DESCRIPTION
### Description of Change ###
For designer purposes android uses a Mock web view (https://stackoverflow.com/a/31984038/953734) that doesn't have a 1:1 version of all the available properties

From the Android source
```
 * Mock version of the WebView.
 * Only non override public methods from the real WebView have been added in there.
 * Methods that take an unknown class as parameter or as return object, have been removed for now.
```

>  * Methods that take an unknown class as parameter or as return object, have been removed for now.

Is the reason we are seeing crashes on No Method found "getSettings"

This is how we would fix this problem in the SDK but if the plan is to just handle it previewer side by using a box view then this change may not be needed.