### PR TITLE
[Android] Prevent race condition between activity create and dispose

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -3,6 +3,7 @@
 using System;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading;
 using Android.App;
 using Android.Content;
 using Android.Content.Res;
@@ -10,7 +11,6 @@ using Android.OS;
 using Android.Runtime;
 using Android.Support.V7.App;
 using Android.Views;
-using Android.Widget;
 using Xamarin.Forms.Platform.Android.AppCompat;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat;
@@ -39,6 +39,8 @@ namespace Xamarin.Forms.Platform.Android
 		bool _renderersAdded;
 		bool _activityCreated;
 		PowerSaveModeBroadcastReceiver _powerSaveModeBroadcastReceiver;
+
+		static readonly ManualResetEventSlim PreviousActivityDestroying = new ManualResetEventSlim(true);
 
 		// Override this if you want to handle the default Android behavior of restoring fragments on an application restart
 		protected virtual bool AllowFragmentRestore => false;
@@ -143,6 +145,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			application.PropertyChanged += AppOnPropertyChanged;
 
+			// Wait if old activity destroying is not finished
+			PreviousActivityDestroying.Wait();
+
 			Profile.FramePartition(nameof(SetMainPage));
 
 			SetMainPage();
@@ -206,12 +211,16 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnDestroy()
 		{
+			PreviousActivityDestroying.Reset();
+
 			if (_application != null)
 				_application.PropertyChanged -= AppOnPropertyChanged;
 
 			PopupManager.Unsubscribe(this);
 
 			Platform?.Dispose();
+
+			PreviousActivityDestroying.Set();
 
 			// call at the end to avoid race conditions with Platform dispose
 			base.OnDestroy();


### PR DESCRIPTION
### Description of Change ###
This change prevent race condition on MainPage change between the old activity OnDestroy and new activity OnCreated.

This case only appear when using a static application, often true when using an IoC container for resolve App object.

I fixed some cases that cause crash in #4707 :
- Missing App PropertyChanged handler unsubscribe
- Wrong dispose place
- Prevent the dispose if it the same page
- Prevent PropertyChanged to be called if the activity is in pause or to be destroyed

It drastically reduced the number of crash but didn't fix it completely.

So I have an edge case of an edge case to fix.

This [post](https://medium.com/androiddevelopers/the-android-lifecycle-cheat-sheet-part-ii-multiple-activities-a411fd139f24) here put me on the right path, it seemed possible that the destroy and create execute in parallel.

After some strategically placed breakpoints in the Framework I confirmed that it was this issue.
This case of race condition was very difficult to reproduce, an user have the bug in #5894, and when executing his reproduction it works for me but not for him because computer speed difference.

So after reproduce it, I identified the cause of the problem :
- When the page is reloaded, the app restart and call this method
https://github.com/xamarin/Xamarin.Forms/blob/a874f52adcbdba2491676b466bbfa84f2ff2cbb7/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs#L353
The renderer exist so the method return
- After that two cases
  - OnLayout is called but the renderer is now null, this cause the application to crash
https://github.com/xamarin/Xamarin.Forms/blob/a874f52adcbdba2491676b466bbfa84f2ff2cbb7/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs#L233
  - The app display a blank page because renderer was disposed (worse for me because unnoticed in AppCenter, so no stacktrace and impossible to identify the root cause)

After some search, that was because the `Cleanup` method in [Platform](https://github.com/xamarin/Xamarin.Forms/blob/362c683d0b8838269bc4df32ec1d10b9870fd2f0/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs#L270) was asynchronous and delayed. So I make it synchronous when dispose (part of PR #6467).
After that I didn't reproduce it with the emulator, but after published the fix on my app, I have lower crash number in AppCenter but still crashs. And issue #5894 was not fixed.

So I decided to manually sync the two methods with a synchronization primitive.
I choose the simpliest and lightest way to do that, with a `ManualResetEventSlim`.
Is unset by default and only set when dispose method run, so it have nearly no overhead.

I publish another version of my application with the fix, the result was anymore crash and it also solved the issue #5894.

I waited a week before publish this patch to be sure it is right and don't make regression.

### Issues Resolved ### 
- Fixes #5894

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Run all of the solution tests cases, there must be no regression.

### PR Checklist ###
- [ ] Has automated tests 
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
