### PR TITLE
Map MoveToLastRegionOnLayoutChange Property

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml
@@ -1,10 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage
-    x:Class="Xamarin.Forms.Controls.MapGallery"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    xmlns:maps="clr-namespace:Xamarin.Forms.Maps;assembly=Xamarin.Forms.Maps"
-    Title="Map Gallery">
+<ContentPage x:Class="Xamarin.Forms.Controls.MapGallery"
+             xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:maps="clr-namespace:Xamarin.Forms.Maps;assembly=Xamarin.Forms.Maps"
+             Title="Map Gallery">
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
@@ -14,43 +13,39 @@
             <RowDefinition Height="*" />
         </Grid.RowDefinitions>
 
-        <SearchBar
-            Grid.Row="0"
-            Placeholder="Search Address"
-            SearchButtonPressed="SearchForAddress" />
+        <SearchBar Grid.Row="0"
+                   Placeholder="Search Address"
+                   SearchButtonPressed="SearchForAddress" />
 
-        <Label
-            x:Name="LastPinClickLabel"
-            Grid.Row="2" />
-        <Label
-            x:Name="LastMapClickLabel"
-            Grid.Row="3" />
+        <Label x:Name="LastPinClickLabel"
+               Grid.Row="2" />
+        <Label x:Name="LastMapClickLabel"
+               Grid.Row="3" />
         <ScrollView Grid.Row="4">
             <StackLayout>
-                <Button
-                    Clicked="MapTypeClicked"
-                    Text="Map Type" />
-                <Button
-                    Clicked="ZoomInClicked"
-                    Text="Zoom In" />
-                <Button
-                    Clicked="ZoomOutClicked"
-                    Text="Zoom Out" />
-                <Button
-                    Clicked="ReverseGeocodeClicked"
-                    Text="Address From Position" />
-                <Button
-                    Clicked="HomeClicked"
-                    Text="Home" />
-                <Button
-                    Clicked="ZoomPinClicked"
-                    Text="Zoom Pin" />
-                <Button
-                    Clicked="EditPinClicked"
-                    Text="Edit Pin" />
-                <Button
-                    Clicked="RemovePinClicked"
-                    Text="Remove Pin" />
+                <Button Clicked="MapTypeClicked"
+                        Text="Map Type" />
+                <Button Clicked="ZoomInClicked"
+                        Text="Zoom In" />
+                <Button Clicked="ZoomOutClicked"
+                        Text="Zoom Out" />
+                <Button Clicked="ReverseGeocodeClicked"
+                        Text="Address From Position" />
+                <Button Clicked="HomeClicked"
+                        Text="Home" />
+                <Button Clicked="ZoomPinClicked"
+                        Text="Zoom Pin" />
+                <Button Clicked="EditPinClicked"
+                        Text="Edit Pin" />
+                <Button Clicked="RemovePinClicked"
+                        Text="Remove Pin" />
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Move to Last Region On Layout Change"
+                           VerticalOptions="Center" />
+                    <Button x:Name="_btnToggleMoveToLastRegionOnLayoutChange"
+                            Clicked="ToggleMoveToLastRegionOnLayoutChange"
+                            VerticalOptions="Center" />
+                </StackLayout>
             </StackLayout>
         </ScrollView>
     </Grid>

--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Forms.Controls
 			Map.MapClicked += MapClicked;
 
 			((Grid)Content).Children.Add(Map, 0, 1);
+
+			_btnToggleMoveToLastRegionOnLayoutChange.Text = Map.MoveToLastRegionOnLayoutChangeProperty.DefaultValue.ToString();
 		}
 
 		public static Map MakeMap()
@@ -154,6 +156,12 @@ namespace Xamarin.Forms.Controls
 		void RemovePinClicked(object sender, EventArgs e)
 		{
 			Map.Pins.RemoveAt(0);
+		}
+
+		void ToggleMoveToLastRegionOnLayoutChange(object sender, EventArgs e)
+		{
+			Map.MoveToLastRegionOnLayoutChange = !Map.MoveToLastRegionOnLayoutChange;
+			((Button)sender).Text = Map.MoveToLastRegionOnLayoutChange.ToString();
 		}
 	}
 }

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -192,7 +192,9 @@ namespace Xamarin.Forms.Maps.Android
 				{
 					UpdateVisibleRegion(NativeMap.CameraPosition.Target);
 				}
-				MoveToRegion(Element.LastMoveToRegion, false);
+
+				if(Element.MoveToLastRegionOnLayoutChange)
+					MoveToRegion(Element.LastMoveToRegion, false);
 			}
 		}
 

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -179,7 +179,7 @@ namespace Xamarin.Forms.Maps.MacOS
 			else if (e.PropertyName == Map.HasZoomEnabledProperty.PropertyName)
 				UpdateHasZoomEnabled();
 			else if (e.PropertyName == VisualElement.HeightProperty.PropertyName && ((Map)Element).LastMoveToRegion != null)
-				_shouldUpdateRegion = true;
+				_shouldUpdateRegion = ((Map)Element).MoveToLastRegionOnLayoutChange;
 		}
 
 #if __MOBILE__

--- a/Xamarin.Forms.Maps/Map.cs
+++ b/Xamarin.Forms.Maps/Map.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Forms.Maps
 		public static readonly BindableProperty ItemTemplateSelectorProperty = BindableProperty.Create(nameof(ItemTemplateSelector), typeof(DataTemplateSelector), typeof(Map), default(DataTemplateSelector),
 			propertyChanged: (b, o, n) => ((Map)b).OnItemTemplateSelectorPropertyChanged());
 
+		public static readonly BindableProperty MoveToLastRegionOnLayoutChangeProperty = BindableProperty.Create(nameof(MoveToLastRegionOnLayoutChange), typeof(bool), typeof(Map), defaultValue: true);
+
 		readonly ObservableCollection<Pin> _pins = new ObservableCollection<Pin>();
 		MapSpan _visibleRegion;
 
@@ -91,7 +93,13 @@ namespace Xamarin.Forms.Maps
 			get { return (DataTemplateSelector)GetValue(ItemTemplateSelectorProperty); }
 			set { SetValue(ItemTemplateSelectorProperty, value); }
 		}
-		
+
+		public bool MoveToLastRegionOnLayoutChange
+		{
+			get { return (bool)GetValue(MoveToLastRegionOnLayoutChangeProperty); }
+			set { SetValue(MoveToLastRegionOnLayoutChangeProperty, value); }
+		}
+
 		public event EventHandler<MapClickedEventArgs> MapClicked;
 		
 		[EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###

As described in #6222 on iOS and Android, the Map renderer moves map center to last region when device is rotated. Looking at the renderers implementation, it actually moves to the last region on a layout change.

I added a new boolean property which when it's true, it doesn't move to the last region when layout changes.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6222

### API Changes ###
 
Added:
 - bool Map.MoveToLastRegionOnLayoutChange { get; set; } //Bindable Property (default is **true**)

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->


See Map Gallery Page. I added a button which toggles the MoveToLastRegionOnLayoutChange property:

IMPORTANT: **Note that you need the fix from #6603 to run it on Android**

![image](https://user-images.githubusercontent.com/743918/59829269-a6aea280-9345-11e9-89b0-57f9521e07dc.png)


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
