### PR TITLE
[Shell] Fail when trying to add a duplicated route

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -129,6 +129,14 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute("app://tab2/IMPL_tab21", typeof(ShellItem)));
 		}
 
+		[Test]
+		public async Task FailWhenAddingDuplicatedRouting()
+		{
+			var route = "dogs";
+			Routing.RegisterRoute(route, typeof(ShellItem));
+
+			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute("dogs", typeof(ShellItem)));
+		}
 
 		[Test]
 		public async Task RelativeGoTo()

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -153,6 +153,9 @@ namespace Xamarin.Forms
 				if (IsImplicit(part))
 					throw new ArgumentException($"Route contains invalid characters in \"{part}\"");
 			}
+
+			if (CompareWithRegisteredRoutes(route))
+				throw new ArgumentException($"Duplicated Route: \"{route}\"");
 		}
 
 		class TypeRouteFactory : RouteFactory


### PR DESCRIPTION
### Description of Change ###

Checks if a route already exists, if so, it throws an exception.

### Issues Resolved ### 
- fixes #5996

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###


### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
