### PR TITLE
Fix compiler warnings in WPF platform project

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Deserializer.cs
+++ b/Xamarin.Forms.Platform.WPF/Deserializer.cs
@@ -15,22 +15,22 @@ namespace Xamarin.Forms.Platform.WPF
 	{
 		const string PropertyStoreFile = "PropertyStore.forms";
 
-		public async Task<IDictionary<string, object>> DeserializePropertiesAsync()
+		public Task<IDictionary<string, object>> DeserializePropertiesAsync()
 		{
 			IsolatedStorageFile isoStore = IsolatedStorageFile.GetStore(IsolatedStorageScope.User | IsolatedStorageScope.Assembly, null, null);
 
 			if (!isoStore.FileExists(PropertyStoreFile))
-				return new Dictionary<string, object>(4);
+				return Task.FromResult<IDictionary<string, object>>(new Dictionary<string, object>(4));
 			
 			using (IsolatedStorageFileStream stream = new IsolatedStorageFileStream(PropertyStoreFile, FileMode.Open, isoStore))
 			{
 				if (stream.Length == 0)
-					return new Dictionary<string, object>(4);
+					return Task.FromResult<IDictionary<string, object>>(new Dictionary<string, object>(4));
 
 				try
 				{
 					var serializer = new DataContractSerializer(typeof(IDictionary<string, object>));
-					return (IDictionary<string, object>)serializer.ReadObject(stream);
+					return Task.FromResult((IDictionary<string, object>)serializer.ReadObject(stream));
 				}
 				catch (Exception e)
 				{
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.WPF
 					Log.Warning("Xamarin.Forms PropertyStore", $"Exception while reading Application properties: {e}");
 				}
 
-				return null;
+				return Task.FromResult<IDictionary<string, object>>(null);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageRenderer.cs
@@ -145,7 +145,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 	public sealed class UriImageSourceHandler : IImageSourceHandler
 	{
-		public async Task<System.Windows.Media.ImageSource> LoadImageAsync(ImageSource imagesoure, CancellationToken cancelationToken = new CancellationToken())
+		public Task<System.Windows.Media.ImageSource> LoadImageAsync(ImageSource imagesoure, CancellationToken cancelationToken = new CancellationToken())
 		{
 			BitmapImage bitmapimage = null;
 			var imageLoader = imagesoure as UriImageSource;
@@ -156,7 +156,7 @@ namespace Xamarin.Forms.Platform.WPF
 				bitmapimage.UriSource = imageLoader.Uri;
 				bitmapimage.EndInit();
 			}
-			return bitmapimage;
+			return Task.FromResult<System.Windows.Media.ImageSource>(bitmapimage);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ListViewRenderer.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateVerticalScrollBarVisibility();
 
 				if (Element.SelectedItem != null)
-					OnElementItemSelected(null, new SelectedItemChangedEventArgs(Element.SelectedItem));
+					OnElementItemSelected(null, new SelectedItemChangedEventArgs(Element.SelectedItem, -1));
 			}
 
 			base.OnElementChanged(e);

--- a/Xamarin.Forms.Platform.WPF/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.WPF/VisualElementTracker.cs
@@ -30,7 +30,9 @@ namespace Xamarin.Forms.Platform.WPF
 
 		bool _invalidateArrangeNeeded;
 		bool _isPanning;
+#pragma warning disable 0414 // The private field 'field' is assigned but its value is never used
 		bool _isPinching;
+#pragma warning restore 0414
 
 		bool _touchFrameReportedEventSet;
 		int _touchPoints = 1;

--- a/Xamarin.Forms.Platform.WPF/WPFDeviceInfo.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFDeviceInfo.cs
@@ -11,7 +11,9 @@ namespace Xamarin.Forms.Platform.WPF
 	internal class WPFDeviceInfo : DeviceInfo
 	{
 		internal const string BWPorientationChangedName = "Xamarin.WPF.OrientationChanged";
+#pragma warning disable 0649 // Field 'field' is never assigned to, and will always have its default value 'value'
 		readonly double _scalingFactor;
+#pragma warning restore 0649
 
 		public WPFDeviceInfo()
 		{


### PR DESCRIPTION
### Description of Change ###

Fix these compiler warnings in the WPF platform project:

```
"C:\GitHub\Xamarin.Forms\Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj" (default target) (38:9) ->
  Deserializer.cs(18,50): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [C:\GitHub\Xamarin.Forms\Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj]
  Renderers\ImageRenderer.cs(148,55): warning CS1998: This async method lacks 'await' operators and will run synchronously. Consider using the 'await' operator to await non-blocking API calls, or 'await Task.Run(...)' to do CPU-bound work on a background thread. [C:\GitHub\Xamarin.Forms\Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj]
  Renderers\ListViewRenderer.cs(66,34): warning CS0618: 'SelectedItemChangedEventArgs.SelectedItemChangedEventArgs(object)' is obsolete: 'This constructor is obsolete as of version 3.5. Please use SelectedItemChangedEventArgs(object selectedItem, int selectedItemIndex) instead.'
[C:\GitHub\Xamarin.Forms\Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj]
  WPFDeviceInfo.cs(14,19): warning CS0649: Field 'WPFDeviceInfo._scalingFactor' is never assigned to, and will always have its default value 0 [C:\GitHub\Xamarin.Forms\Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj]
  VisualElementTracker.cs(33,8): warning CS0414: The field 'VisualElementTracker<TElement, TNativeElement>._isPinching' is assigned but its value is never used [C:\GitHub\Xamarin.Forms\Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj]
```

The code was either changed to avoid the warning, or the warning was ignored on the offending line.

### API Changes ###

 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run build.

### PR Checklist ###

- [ ] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
