### PR TITLE
Make building easier on Windows by setting PowerShell execution policy

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -7,8 +7,8 @@
 /*
 
 Windows CMD:
-./build.cmd -Target NugetPack
-./build.cmd -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
+build.cmd -Target NugetPack
+build.cmd -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
 
 PowerShell:
 ./build.ps1 -Target NugetPack

--- a/build.cake
+++ b/build.cake
@@ -6,10 +6,13 @@
 // examples
 /*
 
+Windows CMD:
+./build.cmd -Target NugetPack
+./build.cmd -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
+
+PowerShell:
 ./build.ps1 -Target NugetPack
 ./build.ps1 -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'
-
-
 
  */
 //////////////////////////////////////////////////////////////////////

--- a/build.cmd
+++ b/build.cmd
@@ -1,0 +1,6 @@
+@ECHO OFF
+SETLOCAL
+PowerShell -NoProfile -NoLogo -ExecutionPolicy Bypass -Command "[System.Threading.Thread]::CurrentThread.CurrentCulture = ''; [System.Threading.Thread]::CurrentThread.CurrentUICulture = ''; try { & '%~dp0build.ps1' %*; exit $LASTEXITCODE } catch { write-host $_; exit 1 }"
+SET exit_code=%ERRORLEVEL%
+ECHO build.cmd completed
+EXIT /b %exit_code%


### PR DESCRIPTION
### Description of Change ###

Add `build.cmd` that launches `build.ps1` with the proper execution policy so that it doesn't insta-fail.

### Issues Resolved ### 

Fixes #6617 

### API Changes ###

None

### Platforms Affected ### 

N/A

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Build on Windows.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
