### PR TITLE
Added Device.TryOpenUri

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -409,6 +409,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new ViewCellGallery(), "ViewCell Gallery - Legacy"),
 				new GalleryPageFactory(() => new WebViewGallery(), "WebView Gallery - Legacy"),
 				new GalleryPageFactory(() => new BindableLayoutGalleryPage(), "BindableLayout Gallery - Legacy"),
+				new GalleryPageFactory(() => new DeviceTryOpenUriPage(), "Device TryOpenUri - Legacy"),
 			};
 
 		public CorePageView(Page rootPage, NavigationBehavior navigationBehavior = NavigationBehavior.PushAsync)

--- a/Xamarin.Forms.Controls/GalleryPages/DeviceTryOpenUri.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/DeviceTryOpenUri.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.Controls.GalleryPages
+{
+	class DeviceTryOpenUriPage : ContentPage
+	{
+		public DeviceTryOpenUriPage()
+		{
+			var instructions = new Label
+			{
+				Text = "This calls Device.TryOpenUri with the given uri." +
+				"\nDifferent than OpenUri, TryOpenUri never throws an exception if the call failed." +
+				"\nOn Android for example, calling OpenUri with an invalid uri throws an exception."
+			};
+
+			Title = "Issue 6221";
+
+			var entry = new Entry() { Text = "someProtocol:Something" };
+
+			var label = new Label();
+
+			var btn = new Button() { Text = "Call Device.TryOpenUri" };
+			btn.Clicked += (s, e) =>
+			{
+				label.Text = "Result: " + Device.TryOpenUri(new Uri(entry.Text, UriKind.Absolute)).ToString();
+			};
+
+			var layout = new StackLayout
+			{
+				Spacing = 10,
+				Children =  {
+					instructions,
+					entry,
+					label,
+					btn,
+				}
+			};
+
+			Padding = 15;
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -229,7 +229,12 @@ namespace Xamarin.Forms
             PlatformServices.OpenUriAction(uri);
         }
 
-        public static void StartTimer(TimeSpan interval, Func<bool> callback)
+		public static bool TryOpenUri(Uri uri)
+		{
+			return PlatformServices.TryOpenUriAction(uri);
+		}
+
+		public static void StartTimer(TimeSpan interval, Func<bool> callback)
         {
             PlatformServices.StartTimer(interval, callback);
         }

--- a/Xamarin.Forms.Core/IPlatformServices.cs
+++ b/Xamarin.Forms.Core/IPlatformServices.cs
@@ -29,6 +29,8 @@ namespace Xamarin.Forms.Internals
 
 		void OpenUriAction(Uri uri);
 
+		bool TryOpenUriAction(Uri uri);
+
 		void StartTimer(TimeSpan interval, Func<bool> callback);
 
 		string RuntimePlatform { get; }

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms
 			//this doesn't seem to work
 			using (var value = new TypedValue())
 			{
-				if (context.Theme.ResolveAttribute(Resource.Attribute.TextSize, value, true)) 
+				if (context.Theme.ResolveAttribute(Resource.Attribute.TextSize, value, true))
 				{
 					size = value.Data;
 				}
@@ -670,6 +670,19 @@ namespace Xamarin.Forms
 				// foreground). If we run into a situation where that's not the case, we'll have to do some work to
 				// make sure this uses the active activity when launching the Intent
 				_context.StartActivity(intent);
+			}
+
+			public bool TryOpenUriAction(Uri uri)
+			{
+				try
+				{
+					OpenUriAction(uri);
+					return true;
+				}
+				catch
+				{
+					return false;
+				}
 			}
 
 			public void StartTimer(TimeSpan interval, Func<bool> callback)

--- a/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
@@ -90,6 +90,19 @@ namespace Xamarin.Forms.Platform.GTK
 			System.Diagnostics.Process.Start(uri.AbsoluteUri);
 		}
 
+		public bool TryOpenUriAction(Uri uri)
+		{
+			try
+			{
+				OpenUriAction(uri);
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		public void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
 			GLib.Timeout.Add((uint)interval.TotalMilliseconds, () =>

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -145,6 +145,19 @@ namespace Xamarin.Forms.Platform.UWP
 			Launcher.LaunchUriAsync(uri).WatchForError();
 		}
 
+		public bool TryOpenUriAction(Uri uri)
+		{
+			try
+			{
+				OpenUriAction(uri);
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		public void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
 			var timerTick = 0L;

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -27,7 +27,20 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			System.Diagnostics.Process.Start(uri.AbsoluteUri);
 		}
-		
+
+		public bool TryOpenUriAction(Uri uri)
+		{
+			try
+			{
+				OpenUriAction(uri);
+				return true;
+			}
+			catch
+			{
+				return false;
+			}
+		}
+
 		public void BeginInvokeOnMainThread(Action action)
 		{
 			System.Windows.Application.Current.Dispatcher.BeginInvoke(action);

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -278,6 +278,11 @@ namespace Xamarin.Forms
 
 			public void OpenUriAction(Uri uri)
 			{
+				TryOpenUriAction(uri);
+			}
+
+			public bool TryOpenUriAction(Uri uri)
+			{
 				NSUrl url;
 
 				if (uri.Scheme == "tel" || uri.Scheme == "mailto")
@@ -285,9 +290,9 @@ namespace Xamarin.Forms
 				else
 					url = NSUrl.FromString(uri.OriginalString) ?? new NSUrl(uri.Scheme, uri.Host, uri.PathAndQuery);
 #if __MOBILE__
-				UIApplication.SharedApplication.OpenUrl(url);
+				return UIApplication.SharedApplication.OpenUrl(url);
 #else
-				NSWorkspace.SharedWorkspace.OpenUrl(url);
+				return NSWorkspace.SharedWorkspace.OpenUrl(url);
 #endif
 			}
 


### PR DESCRIPTION
### Description of Change ###

The current `Device.OpenUri(Uri uri)` has no return value.
On iOS, the native call has a boolean return value which is not surfaced. This makes it impossible to know in iOS whether the call to `Device.OpenUri` call succeeded.

Following Microsoft's `TryXXXX` pattern, this PR adds an alternate method `bool Device.TryOpenUri(Uri)`. This method never throws an exception.

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6621

### API Changes ###
Added:
 - bool Device.TryOpenUri(Uri);

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

![image](https://user-images.githubusercontent.com/743918/59918724-45163300-942e-11e9-8649-d0764120a375.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

See Device.TryOpenUri gallery page

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
