### PR TITLE
[Shell] MenuItem font image fix

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/Icons.cs
+++ b/Xamarin.Forms.Controls/XamStore/Icons.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.XamStore
+{
+	static class Icons
+	{
+		public const string Card = "\uf585";
+	}
+}

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -99,7 +99,13 @@
 
 	<ShellContent Route="account" Title="Account" Icon="person.png" ContentTemplate="{DataTemplate local:AccountsPage}" />
 
-	<MenuItem Text="Redeem" Icon="card.png" />
+    <MenuItem Text="Redeem">
+        <MenuItem.IconImageSource>
+            <FontImageSource
+                Glyph="{x:Static local:Icons.Card}"
+                Color="Black"/>
+        </MenuItem.IconImageSource>
+    </MenuItem>
 
 	<ShellContent Route="wishlist" Title="Wishlist" Icon="star.png" ContentTemplate="{DataTemplate local:WishlistPage}" />
 	

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -46,9 +46,9 @@ namespace Xamarin.Forms
 
 		[Obsolete("Icon is obsolete as of 4.0.0. Please use IconImageSource instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public FileImageSource Icon
+		public ImageSource Icon
 		{
-			get => GetValue(IconProperty) as FileImageSource ?? default(FileImageSource);
+			get => (ImageSource)GetValue(IconProperty);
 			set => SetValue(IconProperty, value);
 		}
 

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -46,9 +46,9 @@ namespace Xamarin.Forms
 
 		[Obsolete("Icon is obsolete as of 4.0.0. Please use IconImageSource instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public ImageSource Icon
+		public FileImageSource Icon
 		{
-			get => (ImageSource)GetValue(IconProperty);
+			get => GetValue(IconProperty) as FileImageSource ?? default(FileImageSource);
 			set => SetValue(IconProperty, value);
 		}
 

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -8,9 +8,9 @@ namespace Xamarin.Forms
 		{
 			MenuItem = menuItem;
 
-			SetBinding(TitleProperty, new Binding("Text", BindingMode.OneWay, source: menuItem));
-			SetBinding(IconProperty, new Binding("IconImageSource", BindingMode.OneWay, source: menuItem));
-			SetBinding(FlyoutIconProperty, new Binding("IconImageSource", BindingMode.OneWay, source: menuItem));
+			SetBinding(TitleProperty, new Binding(nameof(MenuItem.Text), BindingMode.OneWay, source: menuItem));
+			SetBinding(IconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
+			SetBinding(FlyoutIconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
 
 			Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
 			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Forms
 			MenuItem = menuItem;
 
 			SetBinding(TitleProperty, new Binding("Text", BindingMode.OneWay, source: menuItem));
-			SetBinding(IconProperty, new Binding("Icon", BindingMode.OneWay, source: menuItem));
-			SetBinding(FlyoutIconProperty, new Binding("Icon", BindingMode.OneWay, source: menuItem));
+			SetBinding(IconProperty, new Binding("IconImageSource", BindingMode.OneWay, source: menuItem));
+			SetBinding(FlyoutIconProperty, new Binding("IconImageSource", BindingMode.OneWay, source: menuItem));
 
 			Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
 			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -160,6 +160,7 @@ namespace Xamarin.Forms
 			result.SetBinding(TitleProperty, new Binding(nameof(Title), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(FlyoutDisplayOptionsProperty, new Binding(nameof(FlyoutDisplayOptions), BindingMode.OneTime, source: shellSection));
+			result.SetBinding(FlyoutIconProperty, new Binding(nameof(FlyoutIcon), BindingMode.OneWay, source: shellSection));
 			return result;
 		}
 


### PR DESCRIPTION
### Description of Change ###

- MenuItem was using FileImageSource and it doesn't work with font icons. I've changed to ImageSource, the same way it's used on ShellItem. 
- There was a missing binding on ShellItem, so I've added it as well.

### Issues Resolved ### 
- fixes #6559

### API Changes ###

 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Before:
<img width="508" alt="Screen Shot 2019-06-21 at 11 53 39" src="https://user-images.githubusercontent.com/6777353/59931406-425e1280-941b-11e9-96b0-ab5538a0b242.png">

After:
<img width="508" alt="Screen Shot 2019-06-21 at 11 51 52" src="https://user-images.githubusercontent.com/6777353/59931462-66215880-941b-11e9-8797-270685e4db8c.png">

### Testing Procedure ###
1. Run XamControl app
2. Tap "SwapRoot - Store Shell"
3. Check "Redeem" MenuItem's icon on Hamburger menu

### PR Checklist ###

- [ ] Has automated tests (it's visual changes)
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
