### PR TITLE
[iOS] Make ShouldChangeText virtual

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -331,7 +331,7 @@ namespace Xamarin.Forms.Platform.iOS
 				TextView.Text = currentControlText.Substring(0, Element.MaxLength);
 		}
 
-		bool ShouldChangeText(UITextView textView, NSRange range, string text)
+		protected virtual bool ShouldChangeText(UITextView textView, NSRange range, string text)
 		{
 			var newLength = textView.Text.Length + text.Length - range.Length;
 			return newLength <= Element.MaxLength;
@@ -364,10 +364,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override RectangleF Frame
 			{
-				get
-				{
-					return base.Frame;
-				}
+				get => base.Frame;
 				set
 				{
 					base.Frame = value;


### PR DESCRIPTION
I have a need to intercept Editor keys on iOS and selectively ignore some like the Return key. The current implementation of `ShouldChangeText` is not open for runtime polymorphism. This change fixes that.