### PR TITLE
[iOS] Clean up Platform on PlatformRenderer disposal

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal class ModalWrapper : UIViewController
+	{
+		IVisualElementRenderer _modal;
+
+		internal ModalWrapper(IVisualElementRenderer modal)
+		{
+			_modal = modal;
+
+			var elementConfiguration = modal.Element as IElementConfiguration<Page>;
+			if (elementConfiguration?.On<PlatformConfiguration.iOS>().ModalPresentationStyle() == PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet)
+				ModalPresentationStyle = UIKit.UIModalPresentationStyle.FormSheet;
+
+			View.BackgroundColor = UIColor.White;
+			View.AddSubview(modal.ViewController.View);
+			TransitioningDelegate = modal.ViewController.TransitioningDelegate;
+			AddChildViewController(modal.ViewController);
+
+			modal.ViewController.DidMoveToParentViewController(this);
+		}
+
+		public override void DismissViewController(bool animated, Action completionHandler)
+		{
+			if (PresentedViewController == null)
+			{
+				// After dismissing a UIDocumentMenuViewController, (for instance, if a WebView with an Upload button
+				// is asking the user for a source (camera roll, etc.)), the view controller accidentally calls dismiss
+				// again on itself before presenting the UIImagePickerController; this leaves the UIImagePickerController
+				// without an anchor to the view hierarchy and it doesn't show up. This appears to be an iOS bug.
+
+				// We can work around it by ignoring the dismiss call when PresentedViewController is null.
+				return;
+			}
+
+			base.DismissViewController(animated, completionHandler);
+		}
+
+		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].GetSupportedInterfaceOrientations();
+			}
+
+			return base.GetSupportedInterfaceOrientations();
+		}
+
+		public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
+			}
+			return base.PreferredInterfaceOrientationForPresentation();
+		}
+
+		public override bool ShouldAutorotate()
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].ShouldAutorotate();
+			}
+			return base.ShouldAutorotate();
+		}
+
+		public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
+		{
+			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
+			{
+				return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+			}
+			return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
+		}
+
+		public override bool ShouldAutomaticallyForwardRotationMethods => true;
+
+		public override void ViewDidLayoutSubviews()
+		{
+			base.ViewDidLayoutSubviews();
+			if (_modal != null)
+				_modal.SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));
+		}
+
+		public override void ViewWillAppear(bool animated)
+		{
+			View.BackgroundColor = UIColor.White;
+			base.ViewWillAppear(animated);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+				_modal = null;
+			base.Dispose(disposing);
+		}
+
+		public override void ViewDidLoad()
+		{
+			base.ViewDidLoad();
+			SetNeedsStatusBarAppearanceUpdate();
+			if (Forms.IsiOS11OrNewer)
+				SetNeedsUpdateOfHomeIndicatorAutoHidden();
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+		{
+			return ChildViewControllers?.LastOrDefault();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -1,121 +1,13 @@
 using System;
 using System.Linq;
 using UIKit;
-using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal class ModalWrapper : UIViewController
-	{
-		IVisualElementRenderer _modal;
-
-		internal ModalWrapper(IVisualElementRenderer modal)
-		{
-			_modal = modal;
-
-			var elementConfiguration = modal.Element as IElementConfiguration<Page>;
-			if (elementConfiguration?.On<PlatformConfiguration.iOS>().ModalPresentationStyle() == PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet)
-				ModalPresentationStyle = UIKit.UIModalPresentationStyle.FormSheet;
-
-			View.BackgroundColor = UIColor.White;
-			View.AddSubview(modal.ViewController.View);
-			TransitioningDelegate = modal.ViewController.TransitioningDelegate;
-			AddChildViewController(modal.ViewController);
-
-			modal.ViewController.DidMoveToParentViewController(this);
-		}
-
-		public override void DismissViewController(bool animated, Action completionHandler)
-		{
-			if (PresentedViewController == null)
-			{
-				// After dismissing a UIDocumentMenuViewController, (for instance, if a WebView with an Upload button
-				// is asking the user for a source (camera roll, etc.)), the view controller accidentally calls dismiss
-				// again on itself before presenting the UIImagePickerController; this leaves the UIImagePickerController
-				// without an anchor to the view hierarchy and it doesn't show up. This appears to be an iOS bug.
-
-				// We can work around it by ignoring the dismiss call when PresentedViewController is null. 
-				return;
-			}
-
-			base.DismissViewController(animated, completionHandler);
-		}
-
-		public override UIInterfaceOrientationMask GetSupportedInterfaceOrientations()
-		{
-			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-			{
-				return ChildViewControllers[0].GetSupportedInterfaceOrientations();
-			}
-
-			return base.GetSupportedInterfaceOrientations();
-		}
-
-		public override UIInterfaceOrientation PreferredInterfaceOrientationForPresentation()
-		{
-			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-			{
-				return ChildViewControllers[0].PreferredInterfaceOrientationForPresentation();
-			}
-			return base.PreferredInterfaceOrientationForPresentation();
-		}
-
-		public override bool ShouldAutorotate()
-		{
-			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-			{
-				return ChildViewControllers[0].ShouldAutorotate();
-			}
-			return base.ShouldAutorotate();
-		}
-
-		public override bool ShouldAutorotateToInterfaceOrientation(UIInterfaceOrientation toInterfaceOrientation)
-		{
-			if ((ChildViewControllers != null) && (ChildViewControllers.Length > 0))
-			{
-				return ChildViewControllers[0].ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-			}
-			return base.ShouldAutorotateToInterfaceOrientation(toInterfaceOrientation);
-		}
-
-		public override bool ShouldAutomaticallyForwardRotationMethods => true;
-
-		public override void ViewDidLayoutSubviews()
-		{
-			base.ViewDidLayoutSubviews();
-			if (_modal != null)
-				_modal.SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));
-		}
-
-		public override void ViewWillAppear(bool animated)
-		{
-			View.BackgroundColor = UIColor.White;
-			base.ViewWillAppear(animated);
-		}
-
-		protected override void Dispose(bool disposing)
-		{
-			if (disposing)
-				_modal = null;
-			base.Dispose(disposing);
-		}
-
-		public override void ViewDidLoad()
-		{
-			base.ViewDidLoad();
-			SetNeedsStatusBarAppearanceUpdate();
-			if (Forms.IsiOS11OrNewer)
-				SetNeedsUpdateOfHomeIndicatorAutoHidden();
-		}
-
-		public override UIViewController ChildViewControllerForStatusBarStyle()
-		{
-			return ChildViewControllers?.LastOrDefault();
-		}
-	}
-
 	internal class PlatformRenderer : UIViewController
 	{
+		bool _disposed;
+
 		internal PlatformRenderer(Platform platform)
 		{
 			Platform = platform;
@@ -143,7 +35,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
-			return (UIViewController)Platform.GetRenderer(this.Platform.Page);
+			return (UIViewController)Platform.GetRenderer(Platform.Page);
 		}
 
 		public override UIViewController ChildViewControllerForStatusBarStyle()
@@ -153,7 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UIViewController ChildViewControllerForHomeIndicatorAutoHidden
 		{
-			get => (UIViewController)Platform.GetRenderer(this.Platform.Page);
+			get => (UIViewController)Platform.GetRenderer(Platform.Page);
 		}
 
 		public override bool ShouldAutorotate()
@@ -201,6 +93,24 @@ namespace Xamarin.Forms.Platform.iOS
 			SetNeedsStatusBarAppearanceUpdate();
 			if (Forms.IsiOS11OrNewer)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				Platform.UnsubscribeFromAlertsAndActionsSheets();
+				Platform.CleanUpPages();
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -144,6 +144,7 @@
     <Compile Include="Extensions\VisualElementExtensions.cs" />
     <Compile Include="Flags.cs" />
     <Compile Include="IOSDeviceInfo.cs" />
+    <Compile Include="ModalWrapper.cs" />
     <Compile Include="Renderers\FormsCheckBox.cs" />
     <Compile Include="Renderers\ImageElementManager.cs" />
     <Compile Include="IVisualNativeElementRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###

Native Forms gives the user a `PlatformRenderer` (as a `UIViewController`) to use for embedding a Forms `Page`. If the user wants to free the resources used by the embedded `Page`, there is currently no way to do so. Disposing of the controller itself is not sufficient, and the actual Platform object which needs to be disposed is inaccessible.

These changes arrange the cleanup so that calling `Dispose` on the returned `UIViewController` object will clean up all the necessary resources.

### Issues Resolved ### 

- fixes #4671

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
