### PR TITLE
[Bugfix] Catching ReflectionTypeLoadException in the VisualTypeConverter

### DIFF
--- a/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
+++ b/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
@@ -96,7 +96,6 @@ namespace Xamarin.Forms
 			mappings[fullName] = registeredVisual;
 			mappings[$"{name}Visual"] = registeredVisual;
 			mappings[$"{fullName}Visual"] = registeredVisual;
-
 		}
 
 		static IVisual CreateVisual(Type visualType)

--- a/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
+++ b/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
@@ -71,9 +71,13 @@ namespace Xamarin.Forms
 			{
 				Log.Warning("Visual", $"Unable to load a dependent assembly for {assembly.FullName}. It cannot be scanned for Visual types.");
 			}
+			catch (ReflectionTypeLoadException)
+			{
+				Log.Warning("Visual", $"Unable to load a dependent assembly for {assembly.FullName}. Types cannot be loaded.");
+			}
 		}
 
-		static void Register(Type visual, Dictionary<string, IVisual> mappings)
+			static void Register(Type visual, Dictionary<string, IVisual> mappings)
 		{
 			IVisual registeredVisual = CreateVisual(visual);
 			if (registeredVisual == null)

--- a/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
+++ b/Xamarin.Forms.Core/Visuals/VisualTypeConverter.cs
@@ -63,7 +63,7 @@ namespace Xamarin.Forms
 					if (typeof(IVisual).IsAssignableFrom(type) && type != typeof(IVisual))
 						Register(type, mappings);
 			}
-			catch(NotSupportedException)
+			catch (NotSupportedException)
 			{
 				Log.Warning("Visual", $"Cannot scan assembly {assembly.FullName} for Visual types.");
 			}
@@ -77,7 +77,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-			static void Register(Type visual, Dictionary<string, IVisual> mappings)
+		static void Register(Type visual, Dictionary<string, IVisual> mappings)
 		{
 			IVisual registeredVisual = CreateVisual(visual);
 			if (registeredVisual == null)
@@ -96,7 +96,7 @@ namespace Xamarin.Forms
 			mappings[fullName] = registeredVisual;
 			mappings[$"{name}Visual"] = registeredVisual;
 			mappings[$"{fullName}Visual"] = registeredVisual;
-			
+
 		}
 
 		static IVisual CreateVisual(Type visualType)


### PR DESCRIPTION
### Description of Change ###

VisualTypeConverter throws a ReflectionTypeLoadException, when using Visual="Material". In my case, An assembly was referenced, that references System.Drawing.Common package.

### Issues Resolved ### 

No issues found.


### API Changes ###
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
None

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
