### PR TITLE
DefaultDataTemplateSelector (#6649)

### DIFF
--- a/Xamarin.Forms.Core/DefaultDataTemplateSelector.cs
+++ b/Xamarin.Forms.Core/DefaultDataTemplateSelector.cs
@@ -1,0 +1,13 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	public class DefaultDataTemplateSelector : DataTemplateSelector
+	{
+		readonly Func<object, BindableObject, DataTemplate> _func;
+
+		public DefaultDataTemplateSelector(Func<object, BindableObject, DataTemplate> func) => _func = func;
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container) => _func(item, container);
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Currently, in order to get an instance of a `DataTemplateSelector`, you need to add your own class and implement the `DataTemplateSelector` abstract class. It should be easier, because after all, the `DataTemplateSelector` works as a mere function anyway. 

This PR makes using `DataTemplateSelector` easier by providing a default implementation for the `DataTemplateSelector`  and taking a `Func<object, BindableObject, DataTemplate>`.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6649

### API Changes ###

Added:

	public class DefaultDataTemplateSelector : DataTemplateSelector
	{
		public DefaultDataTemplateSelector(Func<object, BindableObject, DataTemplate> func);
	}



### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
