### PR TITLE
[UITests] wait for animation to complete

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Remotes/BaseViewContainerRemote.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Remotes/BaseViewContainerRemote.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Linq;
 using System.Runtime.CompilerServices;
+using System.Threading;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 
@@ -144,6 +145,26 @@ namespace Xamarin.Forms.Core.UITests
 		}
 
 		public T GetProperty<T>(BindableProperty formProperty)
+		{
+			T returnValue = GetPropertyFromBindableProperty<T>(formProperty);
+			int loopCount = 0;
+			while(loopCount < 5)
+			{
+				Thread.Sleep(100);
+				T newValue = GetPropertyFromBindableProperty<T>(formProperty);
+
+				if(newValue.Equals(returnValue))
+					break;
+				else
+					returnValue = newValue;
+
+				loopCount++;
+			}
+
+			return returnValue;
+		}
+
+		T GetPropertyFromBindableProperty<T>(BindableProperty formProperty)
 		{
 			Tuple<string[], bool> property = formProperty.GetPlatformPropertyQuery();
 			string[] propertyPath = property.Item1;


### PR DESCRIPTION
### Description of Change ###

- For cases where we are testing changes to Scale, Rotation, etc. it looks like the value being read for testing is being read too early. These changes take readings until the value has settled to improve reliability. 

The ViewUITests still might fail occasionally for unrelated reasons that I think are mostly cleaned up with (https://github.com/xamarin/Xamarin.Forms/pull/6395)

If none of the failures are of the format
*Expected value: 9, Actual Value: 12*

Then we can merge this one in 
