### PR TITLE
 [Android] Unhook WebView.EvaluateJavascriptAsync on Dispose

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
@@ -1,0 +1,64 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.WebView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6286, "ObjectDisposedException in Android WebView.EvaluateJavascriptAsync ", PlatformAffected.Android)]
+	public class Issue6286 : TestNavigationPage
+	{
+		WebView webview;
+		WebView webview2;
+		protected override void Init()
+		{
+			webview = new WebView { Source = "http://microsoft.com" };
+			webview.Navigated += Webview_Navigated;
+			var page1 = new ContentPage { Content = webview };
+
+			webview2 = new WebView { Source = "http://xamarin.com" };
+			webview2.Navigated += Webview_Navigated;
+			var page2 = new ContentPage { Content = webview2 };
+
+			int count = 0;
+			Navigation.PushAsync(page1);
+			Device.StartTimer(TimeSpan.FromSeconds(2), () =>
+			{
+				webview.Source = "http://xamarin.com";
+				Navigation.PushAsync(page2);
+
+				webview2.Source = "http://microsoft.com";
+				Navigation.PopAsync();
+
+				var done = count++ < 3;
+
+				if (done)
+					page1.Content = new Label { Text = "success", AutomationId = "success" };
+
+				return done;
+			});
+		}
+
+		void Webview_Navigated(object sender, WebNavigatedEventArgs e)
+		{
+			webview.EvaluateJavaScriptAsync("document.write('i executed this javascript woohoo');");
+		}
+
+#if UITEST
+		[Test]
+		public void Issue6286_WebView_Test()
+		{	
+			RunningApp.WaitForElement(q => q.Marked("success"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -641,6 +641,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5724.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6132.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2577.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6286.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_Template.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla56298.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla42620.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -76,6 +76,7 @@ namespace Xamarin.Forms.Platform.Android
 					ElementController.GoBackRequested -= OnGoBackRequested;
 					ElementController.GoForwardRequested -= OnGoForwardRequested;
 					ElementController.ReloadRequested -= OnReloadRequested;
+					ElementController.EvaluateJavaScriptRequested -= OnEvaluateJavaScriptRequested;
 
 					_webViewClient?.Dispose();
 					_webChromeClient?.Dispose();


### PR DESCRIPTION
### Description of Change ###

Unhook WebView.EvaluateJavascriptAsync on Dispose to prevent any crashes.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6286 (hopefully--I was unable to reproduce it)

### API Changes ###

 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added test case 6286, but it does not exhibit the crash. Will need confirmation from @kwaclaw that this resolves the issue.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
