### PR TITLE
return empty dictionary instead of null

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6614.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6614.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6614, "[Android] Tabindex Calculation crashing when calculating on Layout", PlatformAffected.Android)]
+	public class Issue6614 : TestContentPage
+	{
+		Button _button = null;
+
+		string _instruction1 = "Turn on Screen Reader and click me.";
+		protected override void Init()
+		{
+			_button = new Button()
+			{
+				Text = _instruction1,
+				Command = new Command(() =>
+				{							
+					if(Content is ContentView currentContentView)
+					{
+						var currentContent = currentContentView.Content;
+						currentContentView.Content = null;
+						this.Content = currentContent;
+						_button.Text = "Success";
+					}
+					else
+					{
+						var currentContent = this.Content;
+						var contentView = new ContentView();
+						this.Content = contentView;
+						contentView.Content = currentContent;
+						_button.Text = "Click me one more time";
+					}
+				}),
+				TabIndex = 1
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					_button
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -948,6 +948,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5888.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6334.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6368.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1227,7 +1228,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5268.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Forms
 				{
 					((IElement)RealParent).RemoveResourcesChangedListener(OnParentResourcesChanged);
 
-					if(value != null)
+					if(value != null && (RealParent is Layout || RealParent is IControlTemplated))
 						Log.Warning("Element", $"{this} is already a child of {RealParent}. Remove {this} from {RealParent} before adding to {value}.");
 				}
 

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -187,7 +187,13 @@ namespace Xamarin.Forms
 				OnPropertyChanging();
 
 				if (RealParent != null)
+				{
 					((IElement)RealParent).RemoveResourcesChangedListener(OnParentResourcesChanged);
+
+					if(value != null)
+						Log.Warning("Element", $"{this} is already a child of {RealParent}. Remove from {RealParent} before adding to {value}.");
+				}
+
 				RealParent = value;
 				if (RealParent != null)
 				{

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -191,7 +191,7 @@ namespace Xamarin.Forms
 					((IElement)RealParent).RemoveResourcesChangedListener(OnParentResourcesChanged);
 
 					if(value != null)
-						Log.Warning("Element", $"{this} is already a child of {RealParent}. Remove from {RealParent} before adding to {value}.");
+						Log.Warning("Element", $"{this} is already a child of {RealParent}. Remove {this} from {RealParent} before adding to {value}.");
 				}
 
 				RealParent = value;

--- a/Xamarin.Forms.Core/TabIndexExtensions.cs
+++ b/Xamarin.Forms.Core/TabIndexExtensions.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms
 		{
 			countChildrensWithTabStopWithoutThis = 0;
 
-			Element parentPage = (element as NavigableElement).Parent;
+			Element parentPage = (element as Element)?.Parent;
 			while (parentPage != null && !(parentPage is Page))
 				parentPage = parentPage.Parent;
 
@@ -26,7 +26,7 @@ namespace Xamarin.Forms
 				descendantsOnPage = shell.Items;
 
 			if (descendantsOnPage == null)
-				return null;
+				return new Dictionary<int, List<ITabStopElement>>();
 
 			var childrensWithTabStop = new List<ITabStopElement>();
 			foreach (var descendant in descendantsOnPage)
@@ -34,8 +34,9 @@ namespace Xamarin.Forms
 				if (descendant is ITabStopElement visualElement && visualElement.IsTabStop)
 					childrensWithTabStop.Add(visualElement);
 			}
+
 			if (checkContainsElement && !childrensWithTabStop.Contains(element))
-				return null;
+				return new Dictionary<int, List<ITabStopElement>>();
 
 			countChildrensWithTabStopWithoutThis = childrensWithTabStop.Count - 1;
 			return childrensWithTabStop.GroupToDictionary(c => c.TabIndex);


### PR DESCRIPTION
### Description of Change ###
- the results of GetTabIndexesOnParentPage are used as the source of a collection so it needs to just return an empty dictionary instead of null
- Part of this comes up because reparenting an element in the wrong order can have some weird side effects. I've adding a warning to Element so if the element already has a parent it advises the developer to first remove it from that control before adding it to a new one. 

### Issues Resolved ### 
- fixes #6614

### API Changes ###
Added:
- Warning message if you try to set the parent on a element that is still a child of a different parent

### Platforms Affected ### 
- Android

### Testing Procedure ###
Run the included test and follow the instructions

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
