### PR TITLE
Validate style target at runtime

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StyleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleTests.cs
@@ -759,5 +759,29 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That(label0.TextColor, Is.EqualTo(Color.Pink));
 			Assert.That(label1.TextColor, Is.EqualTo(Color.Lavender));
 		}
+
+		[Test]
+		public void MismatchTargetTypeThrowsError1()
+		{
+			var s = new Style(typeof(Button));
+			var t = new View();
+			Assert.Throws<ArgumentException>(() => t.Style = s);
+		}
+
+		[Test]
+		public void MismatchTargetTypeThrowsError2()
+		{
+			var s = new Style(typeof(Button));
+			var t = new Label();
+			Assert.Throws<ArgumentException>(() => t.Style = s);
+		}
+
+		[Test]
+		public void MatchTargetTypeDoesntThrowError()
+		{
+			var s = new Style(typeof(View));
+			var t = new Button();
+			Assert.DoesNotThrow(() => t.Style = s);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/MergedStyle.cs
+++ b/Xamarin.Forms.Core/MergedStyle.cs
@@ -34,7 +34,14 @@ namespace Xamarin.Forms
 		public IStyle Style
 		{
 			get { return _style; }
-			set { SetStyle(ImplicitStyle, ClassStyles, value); }
+			set
+			{
+				if (_style == value)
+					return;
+				if (value != null && !value.TargetType.IsAssignableFrom(TargetType))
+					throw new ArgumentException($"Style TargetType {value.TargetType.FullName} is not compatible with element target type {TargetType}");
+				SetStyle(ImplicitStyle, ClassStyles, value);
+			}
 		}
 
 		public IList<string> StyleClass

--- a/Xamarin.Forms.Core/MergedStyle.cs
+++ b/Xamarin.Forms.Core/MergedStyle.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {


### PR DESCRIPTION
### Description of Change ###

Checks if Style can be set on an element based on the type compatibility between Style TargetType and element's type. In case of type incompatibility, it throws an exception with type names:

```
Style TargetType Xamarin.Forms.Button is not compatible with element target type Xamarin.Forms.Label
```

Includes unit tests.

**This doesn't cover XAMLC.**

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6268
- fixes #6535

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
