### PR TITLE
[iOS] Extend ItemsViewRenderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLoad();
 			AutomaticallyAdjustsScrollViewInsets = false;
-			RegisterCells();
+			RegisterCellsInternal();
 		}
 
 		public override void ViewWillLayoutSubviews()
@@ -208,6 +208,10 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		protected virtual void RegisterCells()
+		{
+		}
+
 		public virtual NSIndexPath GetIndexForItem(object item)
 		{
 			for (int n = 0; n < _itemsSource.Count; n++)
@@ -283,7 +287,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return renderer;
 		}
 
-		string DetermineCellReusedId()
+		protected virtual string DetermineCellReusedId()
 		{
 			if (_itemsView.ItemTemplate != null)
 			{
@@ -309,13 +313,14 @@ namespace Xamarin.Forms.Platform.iOS
 			return GetCell(CollectionView, indexPath);
 		}
 
-		void RegisterCells()
+		void RegisterCellsInternal()
 		{
 			CollectionView.RegisterClassForCell(typeof(HorizontalDefaultCell), HorizontalDefaultCell.ReuseId);
 			CollectionView.RegisterClassForCell(typeof(VerticalDefaultCell), VerticalDefaultCell.ReuseId);
 			CollectionView.RegisterClassForCell(typeof(HorizontalTemplatedCell),
 				HorizontalTemplatedCell.ReuseId);
 			CollectionView.RegisterClassForCell(typeof(VerticalTemplatedCell), VerticalTemplatedCell.ReuseId);
+			RegisterCells();
 		}
 
 		internal void UpdateEmptyView()


### PR DESCRIPTION
### Description of Change ###

Allow a extension to register new cells for subclasses of ItemsViewRender


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- helps with #5044 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run iOS CollectionView UITests

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
