### PR TITLE
[iOS] ItemsViewLayout needs strategy on the ctor

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		readonly GridItemsLayout _itemsLayout;
 
-		public GridViewLayout(GridItemsLayout itemsLayout) : base(itemsLayout)
+		public GridViewLayout(GridItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy) : base(itemsLayout, itemSizingStrategy)
 		{
 			_itemsLayout = itemsLayout;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -14,9 +14,11 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _determiningCellSize;
 		bool _disposed;
 
-		protected ItemsViewLayout(ItemsLayout itemsLayout)
+		protected ItemsViewLayout(ItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy)
 		{
 			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewLayout));
+
+			ItemSizingStrategy = itemSizingStrategy;
 
 			_itemsLayout = itemsLayout;
 			_itemsLayout.PropertyChanged += LayoutOnPropertyChanged;
@@ -75,7 +77,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public Func<UICollectionViewCell> GetPrototype { get; set; }
 
-		internal ItemSizingStrategy ItemSizingStrategy { get; set; }
+		internal ItemSizingStrategy ItemSizingStrategy { get; private set; }
 
 		public abstract void ConstrainTo(CGSize size);
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -59,23 +59,23 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		protected virtual ItemsViewLayout SelectLayout(IItemsLayout layoutSpecification)
+		protected virtual ItemsViewLayout SelectLayout(IItemsLayout layoutSpecification, ItemSizingStrategy itemSizingStrategy)
 		{
 			if (layoutSpecification is GridItemsLayout gridItemsLayout)
 			{
-				return new GridViewLayout(gridItemsLayout);
+				return new GridViewLayout(gridItemsLayout, itemSizingStrategy);
 			}
 
 			if (layoutSpecification is ListItemsLayout listItemsLayout)
 			{
-				return new ListViewLayout(listItemsLayout);
+				return new ListViewLayout(listItemsLayout, itemSizingStrategy);
 			}
 
 			// Fall back to vertical list
-			return new ListViewLayout(new ListItemsLayout(ItemsLayoutOrientation.Vertical));
+			return new ListViewLayout(new ListItemsLayout(ItemsLayoutOrientation.Vertical), itemSizingStrategy);
 		}
 
-		void TearDownOldElement(ItemsView oldElement)
+		protected virtual void TearDownOldElement(ItemsView oldElement)
 		{
 			if (oldElement == null)
 			{
@@ -118,8 +118,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void UpdateLayout()
 		{
-			_layout = SelectLayout(Element.ItemsLayout);
-			_layout.ItemSizingStrategy = Element.ItemSizingStrategy;
+			_layout = SelectLayout(Element.ItemsLayout, Element.ItemSizingStrategy);	
 
 			if (ItemsViewController != null)
 			{
@@ -129,17 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void UpdateItemSizingStrategy()
 		{
-			if (ItemsViewController?.CollectionView?.VisibleCells.Length == 0)
-			{
-				// The CollectionView isn't really up and running yet, so we can just set the strategy and move on
-				_layout.ItemSizingStrategy = Element.ItemSizingStrategy;
-			}
-			else
-			{
-				// We're changing the strategy for a CollectionView mid-stream; 
-				// we'll just have to swap out the whole UICollectionViewLayout
-				UpdateLayout();
-			}
+			UpdateLayout();
 		}
 
 		protected virtual ItemsViewController CreateController(ItemsView newElement, ItemsViewLayout layout)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListViewLayout.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal class ListViewLayout : ItemsViewLayout
 	{
-		public ListViewLayout(ListItemsLayout itemsLayout): base(itemsLayout)
+		public ListViewLayout(ListItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy) : base(itemsLayout, itemSizingStrategy)
 		{
 		}
 


### PR DESCRIPTION
### Description of Change ###

The iOS CollectionView layouts should receive the ItemSizeStrategy on the constructor, this is because some methods can be called by the UICollectionView platform and the ItemSizingStrategy was not set yet.


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- helps with #5044 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
