### PR TITLE
[GTK] Fix navigation

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkToolbarTracker.cs
@@ -395,6 +395,11 @@ namespace Xamarin.Forms.Platform.GTK
 			}
 		}
 
+		internal void ResetToolBar()
+		{
+			_toolbar = null;
+		}
+
 		private void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName)

--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -248,6 +248,10 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			if (_currentPage != null)
 			{
 				_currentPage.PropertyChanged += OnCurrentPagePropertyChanged;
+				if (_toolbarTracker != null)
+				{
+					_toolbarTracker.ResetToolBar();
+				}
 			}
 
 			UpdateTitle();


### PR DESCRIPTION
Commit 491947606d03647124bffffcea8547e135869027
introduced this change :

* [GTK] Don't recreate the toolbar on each change

However when changing page, toolbar needs to be recreated.

### Description of Change ###

See commit

### Issues Resolved ###

- fixes #4409 

### API Changes ###

None

### Platforms Affected ### 

- GTK

### Behavioral/Visual Changes ###

Navigation bar is now visible when changing page.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Created a Xamarin Forms application with navigation and checked if toolbar is still here when changing page. Also checked by @VladislavAntonyuk

### PR Checklist ###

- [ ] Has automated tests (check visually)
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
