### PR TITLE
[Shell] Apply Query string parameters even if they aren't present and correctly apply them to nested pages

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -42,7 +42,11 @@ namespace Xamarin.Forms.Core.UnitTests
 		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
 		public class ShellTestPage : ContentPage
 		{
-			public string SomeQueryParameter { get; set; }
+			public string SomeQueryParameter
+			{
+				get;
+				set;
+			}
 		}
 
 		protected ShellItem CreateShellItem(TemplatedPage page = null, bool asImplicit = false, string shellContentRoute = null, string shellSectionRoute = null, string shellItemRoute = null)

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -221,6 +221,64 @@ namespace Xamarin.Forms.Core.UnitTests
 
 
 		[Test]
+		public async Task NavigationWithQueryStringThenWithoutQueryString()
+		{
+			var shell = new Shell();
+
+			var one = new ShellItem { Route = "one" };
+			var two = new ShellItem { Route = "two" };
+
+			var tabone = MakeSimpleShellSection("tabone", "content");
+			var tabfour = MakeSimpleShellSection("tabfour", "content", null);
+
+			one.Items.Add(tabone);
+			two.Items.Add(tabfour);
+
+			shell.Items.Add(one);
+			shell.Items.Add(two);
+
+			ShellTestPage pagetoTest = new ShellTestPage();
+			await shell.GoToAsync(new ShellNavigationState($"//two/tabfour/content?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			two.CurrentItem.CurrentItem.ContentTemplate = new DataTemplate(() =>
+			{
+				pagetoTest = new ShellTestPage();
+				pagetoTest.BindingContext = pagetoTest;
+				return pagetoTest;
+			});
+
+
+			await shell.GoToAsync(new ShellNavigationState($"//one/tabone/content"));
+			await shell.GoToAsync(new ShellNavigationState($"//two/tabfour/content"));
+
+			var page = (two.CurrentItem.CurrentItem as IShellContentController).GetOrCreateContent();
+			Assert.AreEqual(null, (page as ShellTestPage).SomeQueryParameter);
+		}
+
+
+		[Test]
+		public async Task NavigationBetweenShellContentsPassesQueryString()
+		{
+			var shell = new Shell();
+
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			var content = CreateShellContent(shellContentRoute: "content");
+			item.Items[0].Items.Add(content);
+
+			Routing.RegisterRoute("details", typeof(ShellTestPage));
+
+			shell.Items.Add(item);
+
+
+			await shell.GoToAsync(new ShellNavigationState($"//section2/details?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			await shell.GoToAsync(new ShellNavigationState($"//content?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			await shell.GoToAsync(new ShellNavigationState($"//section2/details?{nameof(ShellTestPage.SomeQueryParameter)}=4321"));
+
+			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
+			Assert.AreEqual("4321", testPage.SomeQueryParameter);
+		}
+
+
+		[Test]
 		public async Task NavigationWithQueryStringAndNoDataTemplate()
 		{
 			var shell = new Shell();
@@ -239,7 +297,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await shell.GoToAsync(new ShellNavigationState($"//two/tabfour/content?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
 			Assert.AreEqual("1234", (two.CurrentItem.CurrentItem.Content as ShellTestPage).SomeQueryParameter);
-
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -449,9 +449,6 @@ namespace Xamarin.Forms
 
 		internal static void ApplyQueryAttributes(Element element, IDictionary<string, string> query, bool isLastItem)
 		{
-			if (query.Count == 0)
-				return;
-
 			string prefix = "";
 			if (!isLastItem)
 			{
@@ -487,7 +484,7 @@ namespace Xamarin.Forms
 				filteredQuery.Add(key, q.Value);
 			}
 
-			if (baseShellItem != null)
+			if (baseShellItem != null && baseShellItem is ShellContent)
 				baseShellItem.ApplyQueryAttributes(filteredQuery);
 			else if (isLastItem)
 				element.SetValue(ShellContent.QueryAttributesProperty, query);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -484,7 +484,7 @@ namespace Xamarin.Forms
 				filteredQuery.Add(key, q.Value);
 			}
 
-			if (baseShellItem != null && baseShellItem is ShellContent)
+			if (baseShellItem is ShellContent)
 				baseShellItem.ApplyQueryAttributes(filteredQuery);
 			else if (isLastItem)
 				element.SetValue(ShellContent.QueryAttributesProperty, query);

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms
 			var shellSection = request.Request.Section;
 
 			if (shellSection == null)
-				return Task.FromResult(true);
+				shellSection = Items[0];
 
 			Shell.ApplyQueryAttributes(shellSection, queryData, request.Request.Content == null);
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Forms
 			ShellContent shellContent = request.Request.Content;
 
 			if (shellContent == null)
-				return Task.FromResult(true);
+				shellContent = Items[0];
 
 			if (request.Request.GlobalRoutes.Count > 0)
 			{


### PR DESCRIPTION
### Description of Change ###
- The code that applies query string parameters wouldn't execute if the user didn't supply any query string parameters. But it should still set whatever parameters the user has to null if no Query String Parameters are specified. 
- Nested content pages are parented to ShellSection not ShellContent so the code that applied query parameters to them wasn't correct. The only reason it worked during the first navigation was a fluke because the Parent hadn't been set yet on the content page

### Issues Resolved ### 
- fixes #6543 

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android

### Testing Procedure ###
- UI tests cover the scenarios to test

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
