### PR TITLE
[Android] RequestLayout of button if measure has changed otherwise call force layout to ensure the content will layout correctly

### DIFF
--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -82,8 +82,21 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
+			var previousHeight = View.MeasuredHeight;
+			var previousWidth = View.MeasuredWidth;
+
 			View.Measure(widthConstraint, heightConstraint);
-			View.ForceLayout();
+
+			// if the measure of the view has changed then trigger a request for layout
+			// if the measure hasn't changed then force a layout of the button
+			if (previousHeight != View.MeasuredHeight || previousWidth != View.MeasuredWidth)
+			{
+				if (!View.IsLayoutRequested)
+					View.RequestLayout();
+			}
+			else
+				View.ForceLayout();
+
 			return new SizeRequest(new Size(View.MeasuredWidth, View.MeasuredHeight), Size.Zero);
 		}
 
@@ -289,7 +302,7 @@ namespace Xamarin.Forms.Platform.Android
 			Drawable existingImage = null;
 			var images = TextViewCompat.GetCompoundDrawablesRelative(view);
 			for (int i = 0; i < images.Length; i++)
-				if(images[i] != null)
+				if (images[i] != null)
 				{
 					existingImage = images[i];
 					break;
@@ -314,8 +327,8 @@ namespace Xamarin.Forms.Platform.Android
 							TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, null, null, null, image);
 							break;
 						default:
-						// Defaults to image on the left
-						TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, image, null, null, null);
+							// Defaults to image on the left
+							TextViewCompat.SetCompoundDrawablesRelativeWithIntrinsicBounds(view, image, null, null, null);
 							break;
 					}
 


### PR DESCRIPTION
### Description of Change ###

https://github.com/xamarin/Xamarin.Forms/pull/6329 added a ForceLayout call when calling GetDesiredSize.  This fixed the text layout issue but it now causes the button to not relayout if the WxH  has changed. So in a case where the button was going from not visible to visible and the height and width would go from zero to not zero then the force layout would just layout the control without redrawing it with the new width and height.

This PR calls ForceLayout only if the height and width haven't changed. If the height and width have changed then it calls RequestLayout if there's not a pending layout request. 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- ui test 53179 on various APIs with FR's enabled
- ui test Issue6282 on various APIs
- whatever other type of button layout you feel like testing

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard