### PR TITLE
fix NRE in InvokeOnMainThreadAsync

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6705.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6705.cs
@@ -1,0 +1,73 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6705, "InvokeOnMainThreadAsync throws NullReferenceException", PlatformAffected.All)]
+	public class Issue6705 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			StackLayout stack = null;
+			stack = new StackLayout
+			{
+				Children =
+				{
+					new Button
+					{
+						AutomationId = "Button1",
+						Text = "BeginInvokeOnMainThread",
+						Command = new Command(() => Device.BeginInvokeOnMainThread(() => stack.Children.Add(new Label { Text = "1" })))
+					},
+					new Button
+					{
+						AutomationId = "Button2",
+						Text = "InvokeOnMainThreadAsync Action",
+						Command = new Command(async () => await Device.InvokeOnMainThreadAsync(() => stack.Children.Add(new Label { Text = "2" })))
+					},
+					new Button
+					{
+						AutomationId = "Button3",
+						Text = "InvokeOnMainThreadAsync Func<Task>",
+						Command = new Command(async () => await Device.InvokeOnMainThreadAsync(() => { stack.Children.Add(new Label { Text = "3" }); return Task.CompletedTask; }))
+					},
+					new Button
+					{
+						AutomationId = "Button4",
+						Text = "InvokeOnMainThreadAsync Func<int>",
+						Command = new Command(async () => await Device.InvokeOnMainThreadAsync(() => { stack.Children.Add(new Label { Text = "4" }); return 4; }))
+					},
+					new Button
+					{
+						AutomationId = "Button5",
+						Text = "InvokeOnMainThreadAsync Func<Task<int>>",
+						Command = new Command(async () => await Device.InvokeOnMainThreadAsync(() => { stack.Children.Add(new Label { Text = "5" }); return Task.FromResult(5); }))
+					},
+				}
+			};
+
+			Content = stack;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue6705Test()
+		{
+			for (var i = 1; i < 6; i++)
+			{
+				RunningApp.WaitForElement($"Button{i}");
+				RunningApp.Tap($"Button{i}");
+				RunningApp.WaitForElement($"{i}");
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -504,6 +504,7 @@
       <DependentUpon>Issue5268.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6705.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ModalActivityIndicatorTest.cs" />

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -151,7 +151,7 @@ namespace Xamarin.Forms
 
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask)
 		{
-			Func<Task<object>> dummyFunc = () => { funcTask(); return null; };
+			Func<Task<object>> dummyFunc = async () => { await funcTask().ConfigureAwait(false); return null; };
 			return InvokeOnMainThreadAsync(dummyFunc);
 		}
 


### PR DESCRIPTION
### Description of Change ###
Don't return a `null` task from `InvokeOnMainThreadAsync`

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/6705

### API Changes ###
 None

### Platforms Affected ### 
- Core

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
See issue

### PR Checklist ###

- [X] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
