### PR TITLE
[Core] Add ability to show modal prompts

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
@@ -1,0 +1,46 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6713, "[Enhancement] Display prompts", PlatformAffected.iOS | PlatformAffected.Android)]
+	public class Issue6713 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var scrollView = new ScrollView();
+
+			var stackLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				Spacing = 10,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var button = new Button { Text = "Default keyboard" };
+			button.Clicked += async (sender, e) =>
+			{
+				var result = await DisplayPromptAsync("What’s the most useless product around today?", "The USB pet rock is definitely up there. What items do you have a hard time believing they actually exist?");
+
+				if (result != null)
+					(sender as Button).Text = result;
+			};
+            stackLayout.Children.Add(button);
+
+            var button2 = new Button { Text = "Numeric keyboard" };
+            button2.Clicked += async (sender, e) =>
+            {
+	            var result = await DisplayPromptAsync("What’s the meaning of life?", "You know that number.", maxLength:2, keyboard:Keyboard.Numeric);
+
+	            if (result != null)
+					(sender as Button).Text = result;
+			};
+            stackLayout.Children.Add(button2);
+
+			scrollView.Content = stackLayout;
+			Content = scrollView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -510,6 +510,7 @@
       <DependentUpon>Issue5268.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6713.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6705.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MapsModalCrash.cs" />

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default(Keyboard))
+		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
 			MessagingCenter.Send(this, PromptSignalName, args);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
+		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default(Keyboard))
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
 			MessagingCenter.Send(this, PromptSignalName, args);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Forms
 
 		public const string AlertSignalName = "Xamarin.SendAlert";
 
+		public const string PromptSignalName = "Xamarin.SendPrompt";
+
 		public const string ActionSheetSignalName = "Xamarin.ShowActionSheet";
 
 		internal static readonly BindableProperty IgnoresContainerAreaProperty = BindableProperty.Create("IgnoresContainerArea", typeof(bool), typeof(Page), false);
@@ -189,6 +191,13 @@ namespace Xamarin.Forms
 			var args = new AlertArguments(title, message, accept, cancel);
 			MessagingCenter.Send(this, AlertSignalName, args);
 			return args.Result.Task;
+		}
+
+		public Task<string> DisplayPromptAsync(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null)
+		{
+			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength);
+			MessagingCenter.Send(this, PromptSignalName, args);
+			return args.PromptResult.Task;
 		}
 
 		public void ForceLayout()

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -197,7 +197,7 @@ namespace Xamarin.Forms
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
 			MessagingCenter.Send(this, PromptSignalName, args);
-			return args.PromptResult.Task;
+			return args.Result.Task;
 		}
 
 		public void ForceLayout()

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -193,7 +193,7 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task<string> DisplayPromptAsync(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
+		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
 			MessagingCenter.Send(this, PromptSignalName, args);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -193,9 +193,9 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task<string> DisplayPromptAsync(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null)
+		public Task<string> DisplayPromptAsync(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
 		{
-			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength);
+			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
 			MessagingCenter.Send(this, PromptSignalName, args);
 			return args.PromptResult.Task;
 		}

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -1,15 +1,13 @@
-﻿using System;
+﻿using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{
-		public PromptArguments(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default(Keyboard))
+		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
 		{
-			if (string.IsNullOrWhiteSpace(accept) || string.IsNullOrWhiteSpace(cancel))
-				throw new Exception($"You must provide a value for {nameof(accept)} and {nameof(cancel)}.");
-
 			Title = title;
 			Message = message;
 			Accept = accept;
@@ -30,7 +28,7 @@ namespace Xamarin.Forms.Internals
 
 		public string Placeholder { get; }
 
-		public int? MaxLength { get; }
+		public int MaxLength { get; }
 
 		public Keyboard Keyboard { get; }
 

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -4,7 +4,7 @@ namespace Xamarin.Forms.Internals
 {
 	public class PromptArguments
 	{
-		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null)
+		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
 		{
 			Title = title;
 			Message = message;
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Internals
 			Cancel = cancel;
 			Placeholder = placeholder;
 			MaxLength = maxLength;
+			Keyboard = keyboard ?? Keyboard.Default;
 			PromptResult = new TaskCompletionSource<string>();
 		}
 
@@ -26,6 +27,8 @@ namespace Xamarin.Forms.Internals
 		public string Placeholder { get; }
 
 		public int? MaxLength { get; }
+
+		public Keyboard Keyboard { get; }
 
 		public TaskCompletionSource<string> PromptResult { get; }
 

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Internals
 		public PromptArguments(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
 		{
 			if (string.IsNullOrWhiteSpace(accept) || string.IsNullOrWhiteSpace(cancel))
-				throw new Exception($"You must provide a value for {nameof(accept)} and {nameof(cancel)}");
+				throw new Exception($"You must provide a value for {nameof(accept)} and {nameof(cancel)}.");
 
 			Title = title;
 			Message = message;

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Internals
+{
+	public class PromptArguments
+	{
+		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null)
+		{
+			Title = title;
+			Message = message;
+			Accept = accept;
+			Cancel = cancel;
+			Placeholder = placeholder;
+			MaxLength = maxLength;
+			PromptResult = new TaskCompletionSource<string>();
+		}
+
+		public string Title { get; }
+
+		public string Message { get; }
+
+		public string Accept { get; }
+
+		public string Cancel { get; }
+
+		public string Placeholder { get; }
+
+		public int? MaxLength { get; }
+
+		public TaskCompletionSource<string> PromptResult { get; }
+
+		public void SetPromptResult(string text)
+		{
+			PromptResult.TrySetResult(text);
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Internals
 			Placeholder = placeholder;
 			MaxLength = maxLength;
 			Keyboard = keyboard ?? Keyboard.Default;
-			PromptResult = new TaskCompletionSource<string>();
+			Result = new TaskCompletionSource<string>();
 		}
 
 		public string Title { get; }
@@ -34,11 +34,11 @@ namespace Xamarin.Forms.Internals
 
 		public Keyboard Keyboard { get; }
 
-		public TaskCompletionSource<string> PromptResult { get; }
+		public TaskCompletionSource<string> Result { get; }
 
-		public void SetPromptResult(string text)
+		public void SetResult(string text)
 		{
-			PromptResult.TrySetResult(text);
+			Result.TrySetResult(text);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -1,11 +1,15 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
 	public class PromptArguments
 	{
-		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
+		public PromptArguments(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
 		{
+			if (string.IsNullOrWhiteSpace(accept) || string.IsNullOrWhiteSpace(cancel))
+				throw new Exception($"You must provide a value for {nameof(accept)} and {nameof(cancel)}");
+
 			Title = title;
 			Message = message;
 			Accept = accept;

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms.Internals
 {
 	public class PromptArguments
 	{
-		public PromptArguments(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default)
+		public PromptArguments(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default(Keyboard))
 		{
 			if (string.IsNullOrWhiteSpace(accept) || string.IsNullOrWhiteSpace(cancel))
 				throw new Exception($"You must provide a value for {nameof(accept)} and {nameof(cancel)}.");

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -152,8 +152,8 @@ namespace Xamarin.Forms.Platform.Android
 				if (arguments.Keyboard == Keyboard.Numeric)
 					editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
 
-				if (arguments.MaxLength != null)
-					editText.SetFilters(new IInputFilter[]{ new InputFilterLengthFilter(arguments.MaxLength.Value)});
+				if (arguments.MaxLength > -1)
+					editText.SetFilters(new IInputFilter[]{ new InputFilterLengthFilter(arguments.MaxLength)});
 
 				frameLayout.AddView(editText);
 				alertDialog.SetView(frameLayout);

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -158,9 +158,9 @@ namespace Xamarin.Forms.Platform.Android
 				frameLayout.AddView(editText);
 				alertDialog.SetView(frameLayout);
 
-				alertDialog.SetButton((int)DialogButtonType.Positive, arguments.Accept, (o, args) => arguments.SetPromptResult(editText.Text));
-				alertDialog.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetPromptResult(null));
-				alertDialog.CancelEvent += (o, args) => { arguments.SetPromptResult(null); };
+				alertDialog.SetButton((int)DialogButtonType.Positive, arguments.Accept, (o, args) => arguments.SetResult(editText.Text));
+				alertDialog.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetResult(null));
+				alertDialog.CancelEvent += (o, args) => { arguments.SetResult(null); };
 
 				alertDialog.Window.SetSoftInputMode(SoftInput.StateVisible);
 				alertDialog.Show();

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -3,6 +3,9 @@ using System.Collections.Generic;
 using System.Linq;
 using Android.App;
 using Android.Content;
+using Android.Text;
+using Android.Views;
+using Android.Widget;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
@@ -46,6 +49,7 @@ namespace Xamarin.Forms.Platform.Android
 				Activity = context;
 				MessagingCenter.Subscribe<Page, bool>(Activity, Page.BusySetSignalName, OnPageBusy);
 				MessagingCenter.Subscribe<Page, AlertArguments>(Activity, Page.AlertSignalName, OnAlertRequested);
+				MessagingCenter.Subscribe<Page, PromptArguments>(Activity, Page.PromptSignalName, OnPromptRequested);
 				MessagingCenter.Subscribe<Page, ActionSheetArguments>(Activity, Page.ActionSheetSignalName, OnActionSheetRequested);
 			}
 
@@ -53,8 +57,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			public void Dispose()
 			{
-				MessagingCenter.Unsubscribe<Page, AlertArguments>(Activity, Page.AlertSignalName);
 				MessagingCenter.Unsubscribe<Page, bool>(Activity, Page.BusySetSignalName);
+				MessagingCenter.Unsubscribe<Page, AlertArguments>(Activity, Page.AlertSignalName);
+				MessagingCenter.Unsubscribe<Page, PromptArguments>(Activity, Page.PromptSignalName);
 				MessagingCenter.Unsubscribe<Page, ActionSheetArguments>(Activity, Page.ActionSheetSignalName);
 			}
 
@@ -120,6 +125,43 @@ namespace Xamarin.Forms.Platform.Android
 				alert.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetResult(false));
 				alert.CancelEvent += (o, args) => { arguments.SetResult(false); };
 				alert.Show();
+			}
+
+			void OnPromptRequested(Page sender, PromptArguments arguments)
+			{
+				// Verify that the page making the request is part of this activity 
+				if (!PageIsInThisContext(sender))
+				{
+					return;
+				}
+
+				AlertDialog alertDialog = new AlertDialog.Builder(Activity).Create();
+				alertDialog.SetTitle(arguments.Title);
+				alertDialog.SetMessage(arguments.Message);
+
+				var frameLayout = new FrameLayout(Activity);
+				var editText = new EditText(Activity) { Hint = arguments.Placeholder };
+				var layoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent)
+				{
+					LeftMargin = (int)(22 * Activity.Resources.DisplayMetrics.Density),
+					RightMargin = (int)(22 * Activity.Resources.DisplayMetrics.Density)
+				};
+
+				editText.LayoutParameters = layoutParams;
+
+				if(arguments.MaxLength != null)
+					editText.SetFilters(new IInputFilter[]{ new InputFilterLengthFilter(arguments.MaxLength.Value)});
+
+				frameLayout.AddView(editText);
+				alertDialog.SetView(frameLayout);
+
+				alertDialog.SetButton((int)DialogButtonType.Positive, arguments.Accept, (o, args) => arguments.SetPromptResult(editText.Text));
+				alertDialog.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetPromptResult(null));
+				alertDialog.CancelEvent += (o, args) => { arguments.SetPromptResult(null); };
+
+				alertDialog.Window.SetSoftInputMode(SoftInput.StateVisible);
+				alertDialog.Show();
+				editText.RequestFocus();
 			}
 
 			void UpdateProgressBarVisibility(bool isBusy)

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -148,8 +148,11 @@ namespace Xamarin.Forms.Platform.Android
 				};
 
 				editText.LayoutParameters = layoutParams;
+				editText.InputType = arguments.Keyboard.ToInputType();
+				if (arguments.Keyboard == Keyboard.Numeric)
+					editText.KeyListener = LocalizedDigitsKeyListener.Create(editText.InputType);
 
-				if(arguments.MaxLength != null)
+				if (arguments.MaxLength != null)
 					editText.SetFilters(new IInputFilter[]{ new InputFilterLengthFilter(arguments.MaxLength.Value)});
 
 				frameLayout.AddView(editText);

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -360,7 +360,7 @@ namespace Xamarin.Forms.Platform.iOS
 			alert.AddTextField(uiTextField =>
 			{
 				uiTextField.Placeholder = arguments.Placeholder;
-				uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength == null || field.Text.Length <= arguments.MaxLength.Value;
+				uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength == null || field.Text.Length + replacementString.Length - range.Length <= arguments.MaxLength.Value;
 				uiTextField.ApplyKeyboard(arguments.Keyboard);
 			});
 			var oldFrame = alert.View.Frame;

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -361,6 +361,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				uiTextField.Placeholder = arguments.Placeholder;
 				uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength == null || field.Text.Length <= arguments.MaxLength.Value;
+				uiTextField.ApplyKeyboard(arguments.Keyboard);
 			});
 			var oldFrame = alert.View.Frame;
 			alert.View.Frame = new RectangleF(oldFrame.X, oldFrame.Y, oldFrame.Width, oldFrame.Height - _alertPadding * 2);

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -360,7 +360,7 @@ namespace Xamarin.Forms.Platform.iOS
 			alert.AddTextField(uiTextField =>
 			{
 				uiTextField.Placeholder = arguments.Placeholder;
-				uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength == null || field.Text.Length + replacementString.Length - range.Length <= arguments.MaxLength.Value;
+				uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength <= -1 || field.Text.Length + replacementString.Length - range.Length <= arguments.MaxLength;
 				uiTextField.ApplyKeyboard(arguments.Keyboard);
 			});
 			var oldFrame = alert.View.Frame;

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -366,8 +366,8 @@ namespace Xamarin.Forms.Platform.iOS
 			var oldFrame = alert.View.Frame;
 			alert.View.Frame = new RectangleF(oldFrame.X, oldFrame.Y, oldFrame.Width, oldFrame.Height - _alertPadding * 2);
 
-			alert.AddAction(CreateActionWithWindowHide(arguments.Cancel, UIAlertActionStyle.Cancel, () => arguments.SetPromptResult(null), window));
-			alert.AddAction(CreateActionWithWindowHide(arguments.Accept, UIAlertActionStyle.Default, () => arguments.SetPromptResult(alert.TextFields[0].Text), window));
+			alert.AddAction(CreateActionWithWindowHide(arguments.Cancel, UIAlertActionStyle.Cancel, () => arguments.SetResult(null), window));
+			alert.AddAction(CreateActionWithWindowHide(arguments.Accept, UIAlertActionStyle.Default, () => arguments.SetResult(alert.TextFields[0].Text), window));
 
 			PresentPopUp(window, alert);
 		}


### PR DESCRIPTION
### Description of Change ###

See #6713 for more explanation. This only implements iOS and Android.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6713

### API Changes ###

Added:
 - `Task<string> DisplayPromptAsync(string title, string message, string accept, string cancel, string placeholder = null, int? maxLength = null, Keyboard keyboard = default)`
- `PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int? maxLength = null, Keyboard keyboard = default)`
 
### Platforms Affected ### 

- iOS
- Android

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

![thumbnail_Image-49](https://user-images.githubusercontent.com/16855542/60387233-ad37cb00-9a65-11e9-80d0-3181fd9cc89e.png)

![thumbnail_Image-50](https://user-images.githubusercontent.com/16855542/60387239-b032bb80-9a65-11e9-9ce7-3fa1cf669c49.png)


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
