### PR TITLE
[Core] Missing await in Device.InvokeOnMainThreadAsync(Func<Task>)

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
@@ -1,0 +1,28 @@
+﻿using System;
+
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class DeviceUnitTests : BaseTestFixture
+	{
+		[Test]
+		public void TestBeginInvokeOnMainThread()
+		{
+			Device.PlatformServices = new MockPlatformServices(invokeOnMainThread: action => action());
+
+			bool invoked = false;
+			Device.BeginInvokeOnMainThread(() => invoked = true);
+
+			Assert.True(invoked);
+		}
+
+		[Test]
+		public void InvokeOnMainThreadThrowsWhenNull()
+		{
+			Device.PlatformServices = null;
+			Assert.Throws<InvalidOperationException>(() => Device.BeginInvokeOnMainThread(() => { }));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
@@ -1,5 +1,5 @@
 ﻿using System;
-
+using System.Threading.Tasks;
 using NUnit.Framework;
 using Xamarin.Forms.Internals;
 
@@ -22,10 +22,110 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task TestInvokeOnMainThreadWithSyncFunc()
+		{
+			bool calledFromMainThread = false;
+			Device.PlatformServices = MockPlatformServices(() => calledFromMainThread = true);
+
+			bool invoked = false;
+			var result = await Device.InvokeOnMainThreadAsync(() => { invoked = true; return true; });
+
+			Assert.True(invoked, "Action not invoked.");
+			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
+			Assert.True(result, "Unexpected result.");
+		}
+
+		[Test]
+		public async Task TestInvokeOnMainThreadWithSyncAction()
+		{
+			bool calledFromMainThread = false;
+			Device.PlatformServices = MockPlatformServices(() => calledFromMainThread = true);
+
+			bool invoked = false;
+			await Device.InvokeOnMainThreadAsync(() => { invoked = true; });
+
+			Assert.True(invoked, "Action not invoked.");
+			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
+		}
+
+		[Test]
+		public async Task TestInvokeOnMainThreadWithAsyncFunc()
+		{
+			bool calledFromMainThread = false;
+			Device.PlatformServices = MockPlatformServices(() => calledFromMainThread = true,
+				invokeOnMainThread: action => Task.Delay(50).ContinueWith(_ => action()));
+
+			bool invoked = false;
+			var task = Device.InvokeOnMainThreadAsync(async () => { invoked = true; return true; });
+			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
+			Assert.False(invoked, "Action invoked early.");
+
+			var result = await task;
+			Assert.True(invoked, "Action not invoked.");
+			Assert.True(result, "Unexpected result.");
+		}
+
+		[Test]
+		public async Task TestInvokeOnMainThreadWithAsyncFuncError()
+		{
+			bool calledFromMainThread = false;
+			Device.PlatformServices = MockPlatformServices(() => calledFromMainThread = true,
+				invokeOnMainThread: action => Task.Delay(50).ContinueWith(_ => action()));
+
+			bool invoked = false;
+			async Task<bool> boom() { invoked = true; throw new ApplicationException(); }
+			var task = Device.InvokeOnMainThreadAsync(boom);
+			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
+			Assert.False(invoked, "Action invoked early.");
+
+			var aggregateEx = Assert.Throws<AggregateException>(() => task.Wait(100));
+			Assert.IsInstanceOf<ApplicationException>(aggregateEx.InnerException);
+			Assert.True(invoked, "Action not invoked.");
+		}
+
+		[Test]
+		public async Task TestInvokeOnMainThreadWithAsyncAction()
+		{
+			bool calledFromMainThread = false;
+			Device.PlatformServices = MockPlatformServices(() => calledFromMainThread = true,
+				invokeOnMainThread: action => Task.Delay(50).ContinueWith(_ => action()));
+
+			bool invoked = false;
+			var task = Device.InvokeOnMainThreadAsync(async () => { invoked = true; });
+			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
+			Assert.False(invoked, "Action invoked early.");
+
+			await task;
+			Assert.True(invoked, "Action not invoked.");
+		}
+
+		[Test]
+		public async Task TestInvokeOnMainThreadWithAsyncActionError()
+		{
+			bool calledFromMainThread = false;
+			Device.PlatformServices = MockPlatformServices(() => calledFromMainThread = true,
+				invokeOnMainThread: action => Task.Delay(50).ContinueWith(_ => action()));
+
+			bool invoked = false;
+			async Task boom() { invoked = true; throw new ApplicationException(); }
+			var task = Device.InvokeOnMainThreadAsync(boom);
+			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
+			Assert.False(invoked, "Action invoked early.");
+
+			var aggregateEx = Assert.Throws<AggregateException>(() => task.Wait(100));
+			Assert.IsInstanceOf<ApplicationException>(aggregateEx.InnerException);
+			Assert.True(invoked, "Action not invoked.");
+		}
+
+		[Test]
 		public void InvokeOnMainThreadThrowsWhenNull()
 		{
 			Device.PlatformServices = null;
 			Assert.Throws<InvalidOperationException>(() => Device.BeginInvokeOnMainThread(() => { }));
+			Assert.Throws<InvalidOperationException>(() => Device.InvokeOnMainThreadAsync(() => { }).Wait(100));
+			Assert.Throws<InvalidOperationException>(() => Device.InvokeOnMainThreadAsync(() => true).Wait(100));
+			Assert.Throws<InvalidOperationException>(() => Device.InvokeOnMainThreadAsync(async () => { }).Wait(100));
+			Assert.Throws<InvalidOperationException>(() => Device.InvokeOnMainThreadAsync(async () => true).Wait(100));
 		}
 
 		private IPlatformServices MockPlatformServices(Action onInvokeOnMainThread, Action<Action> invokeOnMainThread = null)

--- a/Xamarin.Forms.Core.UnitTests/ViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ViewUnitTests.cs
@@ -564,24 +564,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TestBeginInvokeOnMainThread ()
-		{
-			Device.PlatformServices = new MockPlatformServices (invokeOnMainThread: action => action ());
-
-			bool invoked = false;
-			Device.BeginInvokeOnMainThread (() => invoked = true);
-
-			Assert.True (invoked);
-		}
-
-		[Test]
-		public void InvokeOnMainThreadThrowsWhenNull ()
-		{
-			Device.PlatformServices = null;
-			Assert.Throws<InvalidOperationException>(() => Device.BeginInvokeOnMainThread (() => { }));
-		}
-
-		[Test]
 		public void TestOpenUriAction ()
 		{
 			var uri = new Uri ("http://www.xamarin.com/");

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -73,6 +73,7 @@
     <Compile Include="CommandSourceTests.cs" />
     <Compile Include="CommandTests.cs" />
     <Compile Include="DependencyResolutionTests.cs" />
+    <Compile Include="DeviceUnitTests.cs" />
     <Compile Include="EffectiveFlowDirectionExtensions.cs" />
     <Compile Include="ShellTestBase.cs" />
     <Compile Include="ShellUriHandlerTests.cs" />

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -124,8 +124,8 @@ namespace Xamarin.Forms
 
 		public static Task InvokeOnMainThreadAsync(Action action)
 		{
-			object dummyFunc() { action(); return null; }
-			return InvokeOnMainThreadAsync(dummyFunc);
+			object wrapAction() { action(); return null; }
+			return InvokeOnMainThreadAsync(wrapAction);
 		}
 
 		public static Task<T> InvokeOnMainThreadAsync<T>(Func<Task<T>> funcTask)
@@ -151,8 +151,8 @@ namespace Xamarin.Forms
 
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask)
 		{
-			async Task<object> dummyFunc() { await funcTask().ConfigureAwait(false); return null; }
-			return InvokeOnMainThreadAsync(dummyFunc);
+			async Task<object> wrapFunction() { await funcTask().ConfigureAwait(false); return null; }
+			return InvokeOnMainThreadAsync(wrapFunction);
 		}
 
 		public static async Task<SynchronizationContext> GetMainThreadSynchronizationContextAsync()

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms
 
 		public static Task InvokeOnMainThreadAsync(Action action)
 		{
-			object wrapAction() { action(); return null; }
+			string wrapAction() { action(); return null; }
 			return InvokeOnMainThreadAsync(wrapAction);
 		}
 

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms
 
 		public static Task InvokeOnMainThreadAsync(Action action)
 		{
-			Func<object> dummyFunc = () => { action(); return null; };
+			object dummyFunc() { action(); return null; }
 			return InvokeOnMainThreadAsync(dummyFunc);
 		}
 
@@ -151,7 +151,7 @@ namespace Xamarin.Forms
 
 		public static Task InvokeOnMainThreadAsync(Func<Task> funcTask)
 		{
-			Func<Task<object>> dummyFunc = async () => { await funcTask().ConfigureAwait(false); return null; };
+			async Task<object> dummyFunc() { await funcTask().ConfigureAwait(false); return null; }
 			return InvokeOnMainThreadAsync(dummyFunc);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Stumbled on https://github.com/xamarin/Xamarin.Forms/pull/5028 as I was considering submitting an equivalent PR myself, and happened to notice a bug: `InvokeOnMainThreadAsync(Func<Task>)` doesn't `await`. I had originally just fixed the bug (note commit timestamps), but figured I might as well practice writing async tests.

**Update:** Apparently this was reported as #6705 and the fix in #6708 was merged an hour ago. Maybe the rest is still useful?

Also:
- Accepted VS suggestion to use local functions (microoptimization)
- Gave `dummyFunc` more useful names
- ~~Renamed `func`/`funcTask` to `function`, in alignment with `Task.Run(...)` overloads~~
  - Not sure if you consider renaming public arguments an API change? (It is.)

### API Changes ###

Changed:
 - ~~Names of some public arguments from `func`/`funcTask` to `function`~~

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Tried breaking the working code to hit each `Assert`.

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
