### PR TITLE
Reimplement ITabStop on Android Material renderers

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialDatePickerRenderer.cs
@@ -10,7 +10,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Material.Android
 {
-	public class MaterialDatePickerRenderer : DatePickerRendererBase<MaterialPickerTextInputLayout>
+	public class MaterialDatePickerRenderer : DatePickerRendererBase<MaterialPickerTextInputLayout>, ITabStop
 	{
 		MaterialPickerTextInputLayout _textInputLayout;
 		MaterialPickerEditText _textInputEditText;
@@ -50,6 +50,7 @@ namespace Xamarin.Forms.Material.Android
 		protected override void UpdateTextColor() => ApplyTheme();
 		void ApplyTheme() => _textInputLayout?.ApplyTheme(Element.TextColor, Color.Default);
 
+		AView ITabStop.TabStop => EditText;
 	}
 }
 #endif

--- a/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
@@ -11,7 +11,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Material.Android
 {
-	public class MaterialEditorRenderer : EditorRendererBase<MaterialFormsTextInputLayout>
+	public class MaterialEditorRenderer : EditorRendererBase<MaterialFormsTextInputLayout>, ITabStop
 	{
 		bool _disposed;
 		MaterialFormsEditText _textInputEditText;
@@ -75,6 +75,8 @@ namespace Xamarin.Forms.Material.Android
 			_disposed = true;
 			base.Dispose(disposing);
 		}
+
+		AView ITabStop.TabStop => EditText;
 	}
 }
 #endif

--- a/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEntryRenderer.cs
@@ -10,7 +10,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Material.Android
 {
-	public class MaterialEntryRenderer : EntryRendererBase<MaterialFormsTextInputLayout>
+	public class MaterialEntryRenderer : EntryRendererBase<MaterialFormsTextInputLayout>, ITabStop
 	{
 		MaterialFormsEditText _textInputEditText;
 		MaterialFormsTextInputLayout _textInputLayout;
@@ -66,6 +66,7 @@ namespace Xamarin.Forms.Material.Android
 			_textInputEditText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
+		AView ITabStop.TabStop => EditText;
 	}
 }
 #endif

--- a/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
@@ -10,7 +10,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Material.Android
 {
-	public class MaterialPickerRenderer : Platform.Android.AppCompat.PickerRendererBase<MaterialPickerTextInputLayout>
+	public class MaterialPickerRenderer : Platform.Android.AppCompat.PickerRendererBase<MaterialPickerTextInputLayout>, ITabStop
 	{
 		MaterialPickerTextInputLayout _textInputLayout;
 		MaterialPickerEditText _textInputEditText;
@@ -50,6 +50,8 @@ namespace Xamarin.Forms.Material.Android
 		protected override void UpdateTitleColor() => ApplyTheme();
 		protected override void UpdateTextColor() => ApplyTheme();
 		protected virtual void ApplyTheme() => _textInputLayout?.ApplyTheme(Element.TextColor, Color.Default);
+
+		AView ITabStop.TabStop => EditText;
 	}
 }
 #endif

--- a/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialTimePickerRenderer.cs
@@ -10,7 +10,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Material.Android
 {
-	public class MaterialTimePickerRenderer : TimePickerRendererBase<MaterialPickerTextInputLayout>
+	public class MaterialTimePickerRenderer : TimePickerRendererBase<MaterialPickerTextInputLayout>, ITabStop
 	{
 		MaterialPickerTextInputLayout _textInputLayout;
 		MaterialPickerEditText _textInputEditText;
@@ -55,6 +55,7 @@ namespace Xamarin.Forms.Material.Android
 			_textInputLayout?.ApplyTheme(Element.TextColor, Color.Default);
 		}
 
+		AView ITabStop.TabStop => EditText;
 	}
 }
 #endif


### PR DESCRIPTION
### Description of Change ###

Reimplement `ITabStop` on Android Material renderers to return the `EditText` instead of the `TextInputLayout`.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5102

### API Changes ###

Changed: 
Reimplemented `ITabStop` on the following renderers to return `EditText` instead of `Control`:
- MaterialDatePickerRenderer
- MaterialEditorRenderer
- MaterialEntryRenderer
- MaterialPickerRenderer
- MaterialTimePickerRenderer

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Users will be able to correctly tab to/between TextInputLayout-based material controls.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Use the Entry Material Demos page in the Control Gallery to tab between entries.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
