### PR TITLE
Unhook Page from embedded Application on disposal

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -348,7 +348,7 @@ namespace Xamarin.Forms
 		protected internal virtual void CleanUp()
 		{
 			// Unhook everything that's referencing the main page so it can be collected
-			// This is only comes up if we're disposing of an embedded Forms app, and will
+			// This only comes up if we're disposing of an embedded Forms app, and will
 			// eventually go away when we fully support multiple windows
 			if (_mainPage != null)
 			{

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static void SetCurrentApplication(Application value) => Current = value;
+		public static void SetCurrentApplication(Application value) => Current = value; 
 
 		public static Application Current { get; set; }
 
@@ -107,7 +107,7 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public NavigationProxy NavigationProxy { get; }
+		public NavigationProxy NavigationProxy { get; private set; }
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public int PanGestureId { get; set; }
@@ -343,6 +343,21 @@ namespace Xamarin.Forms
 				SaveSemaphore.Release();
 			}
 
+		}
+
+		protected internal virtual void CleanUp()
+		{
+			// Unhook everything that's referencing the main page so it can be collected
+			// This is only comes up if we're disposing of an embedded Forms app, and will
+			// eventually go away when we fully support multiple windows
+			if (_mainPage != null)
+			{
+				InternalChildren.Remove(_mainPage);
+				_mainPage.Parent = null;
+				_mainPage = null;
+			}
+
+			NavigationProxy = null;
 		}
 
 		class NavigationImpl : NavigationProxy

--- a/Xamarin.Forms.Platform.iOS/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/PageExtensions.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms
 
 			if (!(page.RealParent is Application))
 			{
-				Application app = new DefaultApplication();
+				Application app = new EmbeddedApplication();
 				app.MainPage = page;
 			}
 
@@ -21,8 +21,12 @@ namespace Xamarin.Forms
 			return result.ViewController;
 		}
 
-		class DefaultApplication : Application
+		sealed internal class EmbeddedApplication : Application, IDisposable
 		{
+			public void Dispose()
+			{
+				CleanUp();
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -559,6 +559,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			foreach (var modal in _modals)
 				modal.DisposeModalAndChildRenderers();
+
+			(Page.Parent as IDisposable)?.Dispose();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Unhook Page from embedded Application on disposal so the Page can be collected. 

This is a supplementary fix to #6636; that change allowed Pages which were not hooked to the current Application object to be collected, but did not allow the most recent Page associated with the Application to be collected. This change allows the most recent page to be collected.

### Issues Resolved ### 

- additional fix for #4671

### API Changes ###
 
Application.cs

Added:
`protected internal virtual void CleanUp();`

Modified: 
`public NavigationProxy NavigationProxy { get; }` => `public NavigationProxy NavigationProxy { get; private set; }`

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
