### PR TITLE
[Android] Fix entry cursor jump

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -208,7 +208,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (EditText.Text != Element.Text)
 				{
 					EditText.Text = Element.Text;
-					if (EditText.IsFocused)
+					if (Element.IsFocused)
 					{
 						EditText.SetSelection(EditText.Text.Length);
 						EditText.ShowKeyboard();


### PR DESCRIPTION
### Description of Change ###
It seems that under certains circonstances, native android control IsFocused state can be out of sync.

![image](https://user-images.githubusercontent.com/1446221/60472523-7df1ab80-9c69-11e9-9266-e87dfa42d0e6.png)

This cause the **SetSelection** to not run and the **SelectionStart** to be equal to 0 after text selection.
As a result the cursor jump.

### Issues Resolved ### 
- fixes #3923

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Before
![before](https://user-images.githubusercontent.com/1446221/60472665-08d2a600-9c6a-11e9-9d0f-ae83d4afdcec.gif)

After
![after](https://user-images.githubusercontent.com/1446221/60472668-0bcd9680-9c6a-11e9-8d27-6b6a1cf47299.gif)

### Testing Procedure ###
See #3923

### PR Checklist ###
- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
