### PR TITLE
[Android] Fix KeyNotFoundException during Shell Navigation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Ignore("Shell test is only supported on Android and iOS")]
 #endif
 		[Test]
-		public void Issue6738Test()
+		public void FlyoutNavigationBetweenItemsWithNavigationStacks()
 		{
 			RunningApp.WaitForElement(pushPageButton.AutomationId);
 			RunningApp.Tap(pushPageButton.AutomationId);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
@@ -18,9 +18,15 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 6738, "Flyout Navigation fails when coupled with tabs that have a stack", PlatformAffected.Android)]
 	public class Issue6738 : TestShell
 	{
+		const string pushAutomationId = "PushPageButton";
+		const string insertAutomationId = "InsertPageButton";
+		const string returnAutomationId = "ReturnPageButton";
+		const string flyoutMainTitle = "Main";
+		const string flyoutOtherTitle = "Other Page";
+
 		Tab flyoutContent = new Tab();
-		Button pushPageButton = new Button { Text = "Tap to push new page to stack" };
-		Button insertPageButton = new Button { Text = "Push another page to the stack, then go to tab two" };
+		Button pushPageButton = new Button { Text = "Tap to push new page to stack", AutomationId = pushAutomationId };
+		Button insertPageButton = new Button { Text = "Push another page to the stack, then go to tab two", AutomationId = insertAutomationId };
 		ContentPage pushedPage;
 		Tab tabOne = new Tab { Title = "TabOne" };
 		Tab tabTwo = new Tab { Title = "TabTwo " };
@@ -31,10 +37,10 @@ namespace Xamarin.Forms.Controls.Issues
 			ForceTabSwitch();
 		}
 
-		void OnPushTapped(object sender, EventArgs e)
+		async void OnPushTapped(object sender, EventArgs e)
 		{
 			pushedPage = new ContentPage { Content = insertPageButton };
-			Navigation.PushAsync(pushedPage);
+			await Navigation.PushAsync(pushedPage);
 		}
 
 		void OnInsertTapped(object sender, EventArgs e)
@@ -61,8 +67,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var tabOnePage = new ContentPage { Content = pushPageButton };
 			var stackLayout = new StackLayout();
 			stackLayout.Children.Add(new Label { Text = "If you've been here already, go to tab one now. Otherwise, go to Other Page in the flyout." });
-			var returnButton = new Button { Text = "Go back to tab 1" };
-			returnButton.AutomationId = "GoToFirstTabButton";
+			var returnButton = new Button { Text = "Go back to tab 1", AutomationId = returnAutomationId };
 			returnButton.Clicked += OnReturnTapped;
 			stackLayout.Children.Add(returnButton);
 
@@ -70,21 +75,19 @@ namespace Xamarin.Forms.Controls.Issues
 			tabOne.Items.Add(tabOnePage);
 			tabTwo.Items.Add(tabTwoPage);
 
-			pushPageButton.AutomationId = "PushPageButton";
 			pushPageButton.Clicked += OnPushTapped;
-			insertPageButton.AutomationId = "InsertPageButton";
 			insertPageButton.Clicked += OnInsertTapped;
 			flyoutContent.Items.Add(new ContentPage { Content = new Label { Text = "Go back to main page via the flyout" } });
 
 			Items.Add(
 					new FlyoutItem
 					{
-						Title = "Main",
+						Title = flyoutMainTitle,
 						Items = { tabOne, tabTwo }
 					}
 			);
 			Items.Add(new FlyoutItem {
-				Title = "Other Page",
+				Title = flyoutOtherTitle,
 				Items = { flyoutContent }
 			});
 		}
@@ -96,16 +99,16 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void FlyoutNavigationBetweenItemsWithNavigationStacks()
 		{
-			RunningApp.WaitForElement(pushPageButton.AutomationId);
-			RunningApp.Tap(pushPageButton.AutomationId);
-			RunningApp.WaitForElement(insertPageButton.AutomationId);
-			RunningApp.Tap(insertPageButton.AutomationId);
+			RunningApp.WaitForElement(pushAutomationId);
+			RunningApp.Tap(pushAutomationId);
+			RunningApp.WaitForElement(insertAutomationId);
+			RunningApp.Tap(insertAutomationId);
 
-			TapInFlyout("Other Page");
-			TapInFlyout("Main");
+			TapInFlyout(flyoutOtherTitle);
+			TapInFlyout(flyoutMainTitle);
 
-			RunningApp.WaitForElement("GoToFirstTabButton");
-			RunningApp.Tap("GoToFirstTabButton");
+			RunningApp.WaitForElement(returnAutomationId);
+			RunningApp.Tap(returnAutomationId);
 			RunningApp.NavigateBack();
 			RunningApp.NavigateBack();
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
@@ -1,0 +1,61 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Controls;
+using System;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shell)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6738, "Flyout Navigation fails when coupled with tabs that have a stack", PlatformAffected.Android)]
+	public class Issue6738 : TestShell
+	{
+		Tab tabOne = new Tab { Title = "One" };
+		Tab tabTwo = new Tab { Title = "Two " };
+		Tab flyoutContent = new Tab();
+		Button pushPageButton = new Button { Text = "Tap to push new page to stack" };
+
+		void OnPushTapped(object sender, EventArgs e)
+		{
+			Navigation.PushAsync(new ContentPage { Content = new Label { Text = "If this is the second time you have been to this page, the test has passed. Otherwise, go to tab two now." } });
+		}
+
+		protected override void Init()
+		{
+			pushPageButton.Clicked += OnPushTapped;
+			tabOne.Items.Add(new ContentPage { Content = pushPageButton });
+			tabTwo.Items.Add(new ContentPage { Content = new Label { Text = "If you've been here already, go to tab one now. Otherwise, go to Other Page in the flyout." } });
+			flyoutContent.Items.Add(new ContentPage { Content = new Label { Text = "Go back to main page via the flyout" } });
+
+			Items.Add(
+					new FlyoutItem
+					{
+						Title = "Main",
+						Items = { tabOne, tabTwo }
+					}
+			);
+			Items.Add(new FlyoutItem {
+				Title = "Other Page",
+				Items = { flyoutContent }
+			});
+		}
+
+#if UITEST
+#if !(__ANDROID__ || __IOS__)
+		[Ignore("Shell test is only supported on Android and iOS")]
+#endif
+		[Test]
+		public void Issue6738Test()
+		{
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -982,6 +982,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5239.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6738.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
@@ -115,13 +115,19 @@ namespace Xamarin.Forms.Platform.Android
 			if (!_fragmentMap.ContainsKey(ShellSection))
 			{
 				_fragmentMap[ShellSection] = GetOrCreateFragmentForTab(ShellSection);
+				foreach (var pageItem in stack)
+				{
+					if (pageItem != null && !_fragmentMap.ContainsKey(pageItem))
+						_fragmentMap[pageItem] = CreateFragmentForPage(pageItem);
+				}
 			}
 
 			switch (navSource)
 			{
 				case ShellNavigationSource.Push:
 				case ShellNavigationSource.Insert:
-					_fragmentMap[page] = CreateFragmentForPage(page);
+					if (!_fragmentMap.ContainsKey(page))
+						_fragmentMap[page] = CreateFragmentForPage(page);
 					if (!isForCurrentTab)
 					{
 						return Task.FromResult(true);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
@@ -115,23 +115,25 @@ namespace Xamarin.Forms.Platform.Android
 			if (!_fragmentMap.ContainsKey(ShellSection))
 			{
 				_fragmentMap[ShellSection] = GetOrCreateFragmentForTab(ShellSection);
-				foreach (var pageItem in stack)
-				{
-					if (pageItem != null && !_fragmentMap.ContainsKey(pageItem))
-						_fragmentMap[pageItem] = CreateFragmentForPage(pageItem);
-				}
+			}
+			if (stack.Count > 1)
+			{
+				var pageItem = stack[stack.Count - 1];
+				if (! _fragmentMap.ContainsKey(pageItem))
+					_fragmentMap[pageItem] = CreateFragmentForPage(pageItem);
 			}
 
 			switch (navSource)
 			{
 				case ShellNavigationSource.Push:
-				case ShellNavigationSource.Insert:
 					if (!_fragmentMap.ContainsKey(page))
 						_fragmentMap[page] = CreateFragmentForPage(page);
 					if (!isForCurrentTab)
-					{
 						return Task.FromResult(true);
-					}
+					break;
+				case ShellNavigationSource.Insert:
+					if (!isForCurrentTab)
+						return Task.FromResult(true);
 					break;
 
 				case ShellNavigationSource.Pop:

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
@@ -108,19 +108,11 @@ namespace Xamarin.Forms.Platform.Android
 		protected virtual Task<bool> HandleFragmentUpdate(ShellNavigationSource navSource, ShellSection shellSection, Page page, bool animated)
 		{
 			TaskCompletionSource<bool> result = new TaskCompletionSource<bool>();
-
-			var stack = ShellSection.Stack;
 			bool isForCurrentTab = shellSection == ShellSection;
 
 			if (!_fragmentMap.ContainsKey(ShellSection))
 			{
 				_fragmentMap[ShellSection] = GetOrCreateFragmentForTab(ShellSection);
-			}
-			if (stack.Count > 1)
-			{
-				var pageItem = stack[stack.Count - 1];
-				if (! _fragmentMap.ContainsKey(pageItem))
-					_fragmentMap[pageItem] = CreateFragmentForPage(pageItem);
 			}
 
 			switch (navSource)
@@ -173,6 +165,7 @@ namespace Xamarin.Forms.Platform.Android
 					throw new InvalidOperationException("Unexpected navigation type");
 			}
 
+			IReadOnlyList<Page> stack = ShellSection.Stack;
 			Element targetElement = null;
 			IShellObservableFragment target = null;
 			if (stack.Count == 1 || navSource == ShellNavigationSource.PopToRoot)
@@ -183,6 +176,8 @@ namespace Xamarin.Forms.Platform.Android
 			else
 			{
 				targetElement = stack[stack.Count - 1];
+				if (!_fragmentMap.ContainsKey(targetElement))
+					_fragmentMap[targetElement] = CreateFragmentForPage(targetElement as Page);
 				target = _fragmentMap[targetElement];
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -18,6 +18,12 @@ namespace Xamarin.Forms.Platform.iOS
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
+#if DEBUG
+				if (oldvalue != null && newvalue != null)
+				{
+					Log.Warning("Renderer", $"{bindable} already has a renderer attached to it: {oldvalue}. Please figure out why and then fix it.", nameof(oldvalue));
+				}
+#endif
 				var view = bindable as VisualElement;
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -253,7 +253,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
-			if (disposing && !_disposed)
+			if (_disposed)
+				return;
+
+			if (disposing)
 			{
 				if (_shellSection != null)
 				{
@@ -289,8 +292,9 @@ namespace Xamarin.Forms.Platform.iOS
 				Element = null;
 				Container?.Dispose();
 				_pageContainer = null;
-				_disposed = true;
 			}
+
+			_disposed = true;
 
 			base.Dispose(disposing);
 		}
@@ -442,11 +446,11 @@ namespace Xamarin.Forms.Platform.iOS
 					}
 				}
 			}
-			
+
 			Page.SetValueFromRenderer(Page.PaddingProperty, SafeAreaInsets);
 		}
 
-		
+
 		void UpdateStatusBarPrefersHidden()
 		{
 			if (Element == null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -266,7 +266,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			barButtonItem.AccessibilityIdentifier = "OK";
 			NavigationItem.LeftBarButtonItem = barButtonItem;
-			if(image == null)
+			if (image == null)
 				return;
 			NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = image.AutomationId;
 			NavigationItem.LeftBarButtonItem.SetAccessibilityHint(image);
@@ -292,7 +292,7 @@ namespace Xamarin.Forms.Platform.iOS
 			float start = 4f;
 			ctx.SetLineWidth(size);
 
-			for(int i = 0; i< 3; i++)
+			for (int i = 0; i < 3; i++)
 			{
 				ctx.MoveTo(1f, start + i * (size * 2));
 				ctx.AddLineToPoint(22f, start + i * (size * 2));
@@ -578,27 +578,26 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposed)
+			if (_disposed)
+				return;
+
+			if (disposing)
 			{
-				if (disposing)
-				{
-					_searchHandlerAppearanceTracker?.Dispose();
-					Page.Appearing -= PageAppearing;
-					Page.PropertyChanged -= OnPagePropertyChanged;
-					((INotifyCollectionChanged)Page.ToolbarItems).CollectionChanged -= OnToolbarItemsChanged;
-					((IShellController)_context.Shell).RemoveFlyoutBehaviorObserver(this);
-				}
-
-				SearchHandler = null;
-				Page = null;
-				SetBackButtonBehavior(null);
-				_rendererRef = null;
-				NavigationItem = null;
-				_searchHandlerAppearanceTracker = null;
-				_disposed = true;
+				_searchHandlerAppearanceTracker?.Dispose();
+				Page.Appearing -= PageAppearing;
+				Page.PropertyChanged -= OnPagePropertyChanged;
+				((INotifyCollectionChanged)Page.ToolbarItems).CollectionChanged -= OnToolbarItemsChanged;
+				((IShellController)_context.Shell).RemoveFlyoutBehaviorObserver(this);
 			}
-		}
 
+			SearchHandler = null;
+			Page = null;
+			SetBackButtonBehavior(null);
+			_rendererRef = null;
+			NavigationItem = null;
+			_searchHandlerAppearanceTracker = null;
+			_disposed = true;
+		}
 		#endregion IDisposable Support
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -130,9 +130,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+				return;
+
 			base.Dispose(disposing);
 
-			if (disposing && !_disposed)
+
+			if (disposing)
 			{
 				_disposed = true;
 				_renderer.Dispose();
@@ -145,8 +149,17 @@ namespace Xamarin.Forms.Platform.iOS
 				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
 				((IShellController)_context.Shell).RemoveAppearanceObserver(this);
 				((IShellSectionController)ShellSection).RemoveDisplayedPageObserver(this);
+
+				foreach (var tracker in ShellSection.Stack)
+				{
+					if (tracker == null)
+						continue;
+
+					DisposePage(tracker);
+				}
 			}
 
+			_disposed = true;
 			_displayedPage = null;
 			_shellSection = null;
 			_appearanceTracker = null;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UIVisualEffect blurEffect = UIBlurEffect.FromStyle(UIBlurEffectStyle.ExtraLight);
 			_blurView = new UIVisualEffectView(blurEffect);
 
-			View.AddSubview(_blurView);		
+			View.AddSubview(_blurView);
 
 			UpdateHeaderVisibility();
 
@@ -106,7 +106,10 @@ namespace Xamarin.Forms.Platform.iOS
 						_renderers.Remove(shellContent);
 						oldRenderer.NativeView.RemoveFromSuperview();
 						oldRenderer.ViewController.RemoveFromParentViewController();
+						var element = oldRenderer.Element;
 						oldRenderer.Dispose();
+						element?.ClearValue(Platform.RendererProperty);
+
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change ###
If you have a tabbed page where one of the tabs has pages pushed to it due to `GoToAsync`, then leaving the tabbed page via the flyout and then returning to that tab will cause a crash. This change resolves the crash and instead allows you to return to that tab in the state that is expected.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6738 

### Platforms Affected ### 
- Android

### PR Checklist ###

- [X] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
