### PR TITLE
[UWP] fixes crash after reset corner radius

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsButton.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsButton.cs
@@ -71,9 +71,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateBorderRadius()
 		{
-
 			if (_contentPresenter != null)
-				_contentPresenter.CornerRadius = new Windows.UI.Xaml.CornerRadius(BorderRadius);
+			{
+				var radius = BorderRadius == -1 ? 0 : BorderRadius;
+				_contentPresenter.CornerRadius = new Windows.UI.Xaml.CornerRadius(radius);
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Fixes application crash when resetting `CornerRadius`

### Issues Resolved ### 

None

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

- ControlGallery
- Dynamic ViewGallery
- Button
- set CornerRadius
- reset CorerRadius
- application should't crashes

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
