### PR TITLE
Updated TemplateUtilities.cs

### DIFF
--- a/Xamarin.Forms.Core/TemplateUtilities.cs
+++ b/Xamarin.Forms.Core/TemplateUtilities.cs
@@ -5,7 +5,7 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Forms
 {
-	internal static class TemplateUtilities
+	public static class TemplateUtilities
 	{
 		public static async Task<Element> FindTemplatedParentAsync(Element element)
 		{


### PR DESCRIPTION
TemplateUtilities is now public, as it should be.

### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

- Fixes #6747

### API Changes ###
TemplateUtilities is now public, so its public methods inside can be used outside the namespace Xamarin.Forms. Especially the `GetTemplateChild` method.


Changed:
 - internal static class TemplateUtilities => public static class TemplateUtilities

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

The tests had already be done by @andreinitescu in the PR #5691

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
