### PR TITLE
Rename some tests to better identify purpose and change query to WaitForElement

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla30353.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Bugzilla, 30353, "MasterDetailPage.IsPresentedChanged is not raised")]
 #if UITEST
 	[Category(UITestCategories.UwpIgnore)]
+	[Category(UITestCategories.MasterDetailPage)]
 #endif
 	public class Bugzilla30353 : TestMasterDetailPage
 	{
@@ -78,7 +79,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Bugzilla30353Test ()
+		public void MasterDetailPageIsPresentedChangedRaised()
 		{
 			var dontRun = RunningApp.Query (q => q.Marked ("Don't run"));
 			if (dontRun.Length > 0)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33578.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla33578.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST && __IOS__
 		[Test]
-		public void Bugzilla33578Test ()
+		public void TableViewEntryCellShowsDefaultKeyboardThenNumericKeyboardAfterScrolling()
 		{
 			RunningApp.ScrollDown ();
 			RunningApp.ScrollDown ();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42620.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42620.cs
@@ -296,7 +296,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
-		public void Issue42620Test()
+		public void GridChildrenAddHorizontalDoesNotSpanAllRows()
 		{
 			Issue42620Test("RCRHVHVHVHVHV");
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56896.cs
@@ -9,18 +9,21 @@ using System.Diagnostics;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.ListView)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 56896, "ListViews for lists with many elements regressed in performance on iOS", PlatformAffected.iOS)]
 	public class Bugzilla56896 : TestContentPage
 	{
-		const string Instructions = "The number in blue is the number of constructor calls. The number in red is the initial load time in milliseconds.";
+		const string Instructions = "The number in blue is the number of constructor calls. The number in purple is the initial load time in milliseconds.";
+		const string InstructionsId = "InstructionsId";
 		const string ConstructorCountId = "constructorCount";
 		const string TimeId = "time";
 
@@ -196,11 +199,11 @@ namespace Xamarin.Forms.Controls.Issues
 				// Also note that performance will degrade if the first cell does not have a specified height or
 				// if most of the cells do not have a specified height. It is recommended to specify a height on all
 				// or none of the cells when possible.
-				RowHeight = 50, 
+				RowHeight = 50,
 				ItemsSource = Enumerable.Range(1, 5001),
 				ItemTemplate = new MyDataTemplateSelector(vm)
 			};
-			Content = new StackLayout { Children = { new Label { Text = Instructions }, label, _timeLabel, _listView } };
+			Content = new StackLayout { Children = { new Label { Text = Instructions, AutomationId = InstructionsId }, label, _timeLabel, _listView } };
 		}
 
 		protected override void OnAppearing()
@@ -214,14 +217,14 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Bugzilla56896Test()
+		public void ListViewsWithManyElementsPerformanceCheck()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Instructions));
 			RunningApp.WaitForElement(q => q.Marked(ConstructorCountId));
 			RunningApp.WaitForElement(q => q.Marked(TimeId));
-			var count = int.Parse(RunningApp.Query(q => q.Marked(ConstructorCountId))[0].Text);
+			var count = int.Parse(RunningApp.WaitForElement(q => q.Marked(ConstructorCountId))[0].Text);
 			Assert.IsTrue(count < 100); // Failing test makes ~15000 constructor calls
-			var time = int.Parse(RunningApp.Query(q => q.Marked(TimeId))[0].Text);
+			var time = int.Parse(RunningApp.WaitForElement(q => q.Marked(TimeId))[0].Text);
 			Assert.IsTrue(count < 2000); // Failing test takes ~4000ms
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59580.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue59580Test()
+		public void RaisingCommandCanExecuteChangedCausesCrashOnAndroid()
 		{
 			RunningApp.WaitForElement(c => c.Marked("Cell"));
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1414.cs
@@ -76,12 +76,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1414Test()
+		public void InvalidCastExceptionWhenScrollingAndRefreshingTableView()
 		{
 			RunningApp.Screenshot("Start G1414");
-			RunningApp.WaitForElement(q => q.Marked("TableView"));
-
-			var tableFrame = RunningApp.Query(q => q.Marked("TableView"))[0].Rect;
+			var tableFrame = RunningApp.WaitForElement(q => q.Marked("TableView"))[0].Rect;
 			RunningApp.ScrollForElement("* marked:'Row-4-24'", new Drag(tableFrame, Drag.Direction.BottomToTop, Drag.DragLength.Long));
 			RunningApp.Screenshot("Scrolled to end without crashing!");
 			RunningApp.ScrollForElement("* marked:'Row-0-0'", new Drag(tableFrame, Drag.Direction.TopToBottom, Drag.DragLength.Long));

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -13,8 +13,8 @@ namespace Xamarin.Forms.Core.UITests
 		public static AppResult[] RetryUntilPresent(
 			this IApp app,
 			Func<AppResult[]> func,
-			int retryCount,
-			int delayInMs)
+			int retryCount = 10,
+			int delayInMs = 2000)
 		{
 			var results = func();
 


### PR DESCRIPTION
### Description of Change ###
- 1414 and 56896 are occasionally failing. This is most likely due to the use of Query opposed to just using WaitForElement 
- Renamed a few other tests that I had seen previous failures on 

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
