### PR TITLE
[Shell] don't throw exception if registering same route factory to same routename

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -135,7 +135,15 @@ namespace Xamarin.Forms.Core.UnitTests
 			var route = "dogs";
 			Routing.RegisterRoute(route, typeof(ShellItem));
 
-			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute("dogs", typeof(ShellItem)));
+			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute("dogs", typeof(ContentPage)));
+		}
+
+		[Test]
+		public async Task SucceedWhenAddingDuplicateRouteOfSameType()
+		{
+			var route = "dogs";
+			Routing.RegisterRoute(route, typeof(ShellItem));
+			Routing.RegisterRoute(route, typeof(ShellItem));
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###
If you register the same factory or type then it shouldn't throw an exception. This is mainly a scenario that's coming up for the previewer which will rerun some code behind causing an exception about duplicate routes being registered.

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- UI Tests Cover this
- run control gallery store shell make sure basic route registration still works

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
