### PR TITLE
Clear global routes on unit tests and process global routes in the right place

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using System.Threading;
+using System.ComponentModel;
 
 
 #if UITEST
@@ -120,7 +121,7 @@ namespace Xamarin.Forms.Controls.Issues
 		void EmptyPageSafeArea()
 		{
 			var page = CreateContentPage();
-			var topLabel = new Label() { Text = "Top Label", HeightRequest = 200, AutomationId = SafeAreaTopLabel, VerticalOptions = LayoutOptions.Start };
+			var topLabel = new Label() { Text = "Top Label", HeightRequest = 0, AutomationId = SafeAreaTopLabel, VerticalOptions = LayoutOptions.Start };
 			page.Content =
 				new StackLayout()
 				{
@@ -143,10 +144,20 @@ namespace Xamarin.Forms.Controls.Issues
 
 			page.BackgroundColor = Color.Yellow;
 
-			page.Appearing += (_, __) =>
+			PropertyChangedEventHandler propertyChangedEventHandler = null;
+			propertyChangedEventHandler = (sender, args) =>
 			{
-				topLabel.HeightRequest = page.On<iOS>().SafeAreaInsets().Top;
+				if(args.PropertyName == PlatformConfiguration.iOSSpecific.Page.SafeAreaInsetsProperty.PropertyName)
+				{
+					if (page.On<iOS>().SafeAreaInsets().Top > 0)
+					{
+						page.PropertyChanged -= propertyChangedEventHandler;
+						topLabel.HeightRequest = page.On<iOS>().SafeAreaInsets().Top;
+					}
+				}
 			};
+
+			page.PropertyChanged += propertyChangedEventHandler;
 
 			Shell.SetTabBarIsVisible(page, false);
 			Shell.SetNavBarIsVisible(page, false);

--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -20,6 +20,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		public override void TearDown()
 		{
 			base.TearDown();
+			Routing.Clear();
 
 		}
 

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -429,7 +429,7 @@ namespace Xamarin.Forms
 					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
 					Device.BeginInvokeOnMainThread(async () =>
 					{
-						await shellSection.GoToAsync(navigationRequest, queryData, false);
+						await CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, false);
 					});
 				}
 			}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -421,17 +421,16 @@ namespace Xamarin.Forms
 						{
 							shellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);							
 						}
-
-						if (navigationRequest.Request.GlobalRoutes.Count > 0)
-						{
-							// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
-							Device.BeginInvokeOnMainThread(async () =>
-							{
-								await shellSection.GoToAsync(navigationRequest, queryData, false);
-							});
-						}
-
 					}
+				}
+
+				if (navigationRequest.Request.GlobalRoutes.Count > 0)
+				{
+					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
+					Device.BeginInvokeOnMainThread(async () =>
+					{
+						await shellSection.GoToAsync(navigationRequest, queryData, false);
+					});
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					aswitch.SetOnCheckedChangeListener(this);
 					SetNativeControl(aswitch);
 					_defaultTrackDrawable = aswitch.TrackDrawable;
-					_defaultThumbColorFilter = Control.ThumbDrawable.ColorFilter;
+					_defaultThumbColorFilter = Control.ThumbDrawable.GetColorFilter();
 				}
 				else
 					UpdateEnabled(); // Normally set by SetNativeControl, but not when the Control is reused.
@@ -140,11 +140,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (Element == null)
 				return;
 
-			Color thumbColor = Element.ThumbColor;
-			if (thumbColor.IsDefault)
-				Control.ThumbDrawable.SetColorFilter(_defaultThumbColorFilter);
-			else
-				Control.ThumbDrawable.SetColorFilter(thumbColor.ToAndroid(), PorterDuff.Mode.SrcIn);
+			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter);
 		}
 
 		void HandleToggled(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using ADrawable = Android.Graphics.Drawables.Drawable;
+using AColorFilter = Android.Graphics.ColorFilter;
+using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
+using Android.Graphics;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal static class DrawableExtensions
+	{
+		public static AColorFilter GetColorFilter(this ADrawable drawable)
+		{
+			if (drawable == null)
+				return null;
+
+			return ADrawableCompat.GetColorFilter(drawable);
+		}
+
+		public static void SetColorFilter(this ADrawable drawable, AColorFilter colorFilter)
+		{
+			if (drawable == null)
+				return;
+
+			if (colorFilter == null)
+				ADrawableCompat.ClearColorFilter(drawable);
+
+			drawable.SetColorFilter(colorFilter);
+		}
+
+		public static void SetColorFilter(this ADrawable drawable, Color color, AColorFilter defaultColorFilter)
+		{
+			if (drawable == null)
+				return;
+
+			if (color == Color.Default)
+			{
+				SetColorFilter(drawable, defaultColorFilter);
+				return;
+			}
+
+			drawable.SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (Build.VERSION.SdkInt > BuildVersionCodes.Kitkat)
 				{
-					defaultthumbcolorfilter = seekBar.Thumb.ColorFilter;
+					defaultthumbcolorfilter = seekBar.Thumb.GetColorFilter();
 					defaultprogresstintmode = seekBar.ProgressTintMode;
 					defaultprogressbackgroundtintmode = seekBar.ProgressBackgroundTintMode;
 					defaultprogresstintlist = seekBar.ProgressTintList;
@@ -178,23 +178,12 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		private void UpdateThumbColor()
+		void UpdateThumbColor()
 		{
-			if (Element != null)
-			{
-				if (Element.ThumbColor == Color.Default)
-				{
-					Control.Thumb.SetColorFilter(defaultthumbcolorfilter);
-				}
-				else
-				{
-					Control.Thumb.SetColorFilter(Element.ThumbColor.ToAndroid(), PorterDuff.Mode.SrcIn);
-				}
-
-			}
+			Control.Thumb.SetColorFilter(Element.ThumbColor, defaultthumbcolorfilter);
 		}
 
-		private void UpdateThumbImage()
+		void UpdateThumbImage()
 		{
 			this.ApplyDrawableAsync(Slider.ThumbImageSourceProperty, Context, drawable =>
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -83,8 +83,8 @@ namespace Xamarin.Forms.Platform.Android
 					var aswitch = CreateNativeControl();
 					aswitch.SetOnCheckedChangeListener(this);
 					SetNativeControl(aswitch);
-					_defaultTrackDrawable = Control.TrackDrawable;
-					_defaultThumbColorFilter = Control.ThumbDrawable.ColorFilter;
+					_defaultTrackDrawable = Control.TrackDrawable;					
+					_defaultThumbColorFilter = Control.ThumbDrawable.GetColorFilter();
 				}
 				else
 				{
@@ -138,11 +138,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element == null)
 				return;
 
-			Color thumbColor = Element.ThumbColor;
-			if (thumbColor.IsDefault)
-				Control.ThumbDrawable.SetColorFilter(_defaultThumbColorFilter);
-			else
-				Control.ThumbDrawable.SetColorFilter(thumbColor.ToAndroid(), PorterDuff.Mode.SrcIn);
+			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter);
 		}
 
 		void HandleToggled(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -98,6 +98,7 @@
     <Compile Include="CollectionView\TemplatedItemViewHolder.cs" />
     <Compile Include="CollectionView\TextViewHolder.cs" />
     <Compile Include="Elevation.cs" />
+    <Compile Include="Extensions\DrawableExtensions.cs" />
     <Compile Include="Extensions\EntryRendererExtensions.cs" />
     <Compile Include="Extensions\FragmentManagerExtensions.cs" />
     <Compile Include="Extensions\ScrollViewExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###
- Since we throw an exception now if you register the same route twice we need to clear the global routes in the teardown of the unit tests
- Global Routes were moved to only be processed if the ShellContent was specified as part of the uri but they should just be processed regardless

### Testing Procedure ###
- UI tests cover

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
