### PR TITLE
Use the MoreNavigationController DidShowViewController callback for shell sections

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6784.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6784.cs
@@ -1,0 +1,91 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using System.Linq;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6784, "ShellItem.CurrentItem is not set when selecting shell section aggregated in more tab", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue6784 : TestShell
+	{
+		protected override void Init()
+		{
+			var shellItem = new ShellItem()
+			{
+				Title = "ShellItem"
+			};
+
+			Items.Add(shellItem);
+
+			AddBottomTab("Tab 1");
+			AddBottomTab("Tab 2");
+			AddBottomTab("Tab 3");
+			AddBottomTab("Tab 4").AutomationId = "Tab 4 Content";
+			var contentPage5 = AddBottomTab("Tab 5");
+			AddBottomTab("Tab 6");
+
+			shellItem.PropertyChanged += (sender, e) =>
+			{
+				if (e.PropertyName == CurrentItemProperty.PropertyName)
+				{
+					if (((ShellItem)sender).CurrentItem.AutomationId == "Tab 5")
+					{
+						contentPage5.Content = new Label()
+						{
+							Text = "Success"
+						};
+					}
+				}
+			};
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CurrentItemIsSetWhenSelectingShellSectionAggregatedInMoreTab()
+		{
+			RunningApp.WaitForElement(x => x.Class("UITabBarButton").Marked("More"));
+			RunningApp.Tap(x => x.Class("UITabBarButton").Marked("More"));
+
+			RunningApp.WaitForElement(x => x.Class("UITableViewCell").Text("Tab 5"));
+			RunningApp.Tap(x => x.Class("UITableViewCell").Text("Tab 5"));
+
+			RunningApp.WaitForElement(x => x.Text("Success"));
+		}
+
+		[Test]
+		public void MoreControllerOpensOnFirstClick()
+		{
+			RunningApp.WaitForElement(x => x.Class("UITabBarButton").Marked("More"));
+			RunningApp.Tap(x => x.Class("UITabBarButton").Marked("More"));
+
+			RunningApp.WaitForElement(x => x.Class("UITableViewCell").Text("Tab 5"));
+			RunningApp.Tap(x => x.Class("UITableViewCell").Text("Tab 5"));
+
+			RunningApp.Tap(x => x.Class("UITabBarButton").Marked("Tab 4"));
+			RunningApp.WaitForElement("Tab 4 Content");
+
+			RunningApp.Tap(x => x.Class("UITabBarButton").Marked("More"));
+			RunningApp.WaitForElement(x => x.Class("UITableViewCell").Text("Tab 6"));
+		}
+
+		[Test]
+		public void MoreControllerDoesNotShowEditButton()
+		{
+			RunningApp.WaitForElement(x => x.Class("UITabBarButton").Marked("More"));
+			RunningApp.Tap(x => x.Class("UITabBarButton").Marked("More"));
+
+			RunningApp.WaitForElement(x => x.Class("UITableViewCell").Text("Tab 5"));
+
+			Assert.AreEqual(RunningApp.Query(x => x.Marked("Edit")).Count(), 0);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -70,6 +70,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					ShellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, renderer.ShellSection);
 					CurrentRenderer = renderer;
+					MoreNavigationController?.PopToRootViewController(false);
 				}
 
 				if (ReferenceEquals(value, MoreNavigationController))
@@ -163,6 +164,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (renderer != null)
 					{
 						ViewControllers = ViewControllers.Remove(renderer.ViewController);
+						CustomizableViewControllers = Array.Empty<UIViewController>();
 						RemoveRenderer(renderer);
 					}
 				}
@@ -199,6 +201,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				ViewControllers = viewControllers;
+				CustomizableViewControllers = Array.Empty<UIViewController>();
 
 				if (goTo)
 					GoTo(ShellItem.CurrentItem);
@@ -264,6 +267,7 @@ namespace Xamarin.Forms.Platform.iOS
 				viewControllers[i++] = renderer.ViewController;
 			}
 			ViewControllers = viewControllers;
+			CustomizableViewControllers = Array.Empty<UIViewController>();
 
 			// No sense showing a bar that has a single icon
 			if (ViewControllers.Length == 1)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -4,11 +4,13 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using Foundation;
+using ObjCRuntime;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class ShellItemRenderer : UITabBarController, IShellItemRenderer, IAppearanceObserver
+	public class ShellItemRenderer : UITabBarController, IShellItemRenderer, IAppearanceObserver, IUINavigationControllerDelegate
 	{
 		#region IShellItemRenderer
 
@@ -69,8 +71,24 @@ namespace Xamarin.Forms.Platform.iOS
 					ShellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, renderer.ShellSection);
 					CurrentRenderer = renderer;
 				}
+
+				if (ReferenceEquals(value, MoreNavigationController))
+				{
+					MoreNavigationController.WeakDelegate = this;
+				}
 			}
-		}		
+		}
+
+		[Export("navigationController:didShowViewController:animated:")]
+		public virtual void DidShowViewController(UINavigationController navigationController, [Transient]UIViewController viewController, bool animated)
+		{
+			var renderer = RendererForViewController(this.SelectedViewController);
+			if (renderer != null)
+			{
+				ShellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, renderer.ShellSection);
+				CurrentRenderer = renderer;
+			}
+		}
 
 		public override void ViewDidLayoutSubviews()
 		{


### PR DESCRIPTION
### Description of Change ###

When `SelectedViewController` is called for `MoreNavigationController`, register for `DidShowViewController` to make it possible to set `ShellItem.CurrentItem` when selecting shell sections aggregated in more tab. Implementation is based on this [SO](https://stackoverflow.com/questions/5803352/didselectviewcontroller-not-getting-called-when-in-more-section) thread.

~~Automated test is skipped because lack of information (is there any guidance available?) of how to setup UI tests for XF.~~

### Issues Resolved ### 

- fixes #6784

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Testing Procedure ###

Check #6784.

### PR Checklist ###

- [x] Has automated tests
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
