### PR TITLE
Implemented Padding on WPF Button

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/ImageButtonCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ImageButtonCoreGalleryPage.cs
@@ -94,6 +94,15 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
+			var paddingContainer = new ViewContainer<ImageButton>(Test.ImageButton.Padding,
+				new ImageButton
+				{
+					Source = "oasissmall.jpg",
+					BackgroundColor = Color.Red,
+					Padding = new Thickness(20, 30, 60, 15)
+				}
+			);
+
 
 			InitializeElement(aspectFillContainer.View);
 			InitializeElement(aspectFitContainer.View);
@@ -117,6 +126,7 @@ namespace Xamarin.Forms.Controls
 			Add(corderRadiusContainer);
 			Add(imageContainer);
 			Add(pressedContainer);
+			Add(paddingContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -570,7 +570,8 @@ namespace Xamarin.Forms.CustomAttributes
 			Clicked,
 			Command,
 			Image,
-			Pressed
+			Pressed,
+			Padding
 		}
 
 		public enum ImageSource

--- a/Xamarin.Forms.Platform.WPF/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ButtonRenderer.cs
@@ -58,7 +58,10 @@ namespace Xamarin.Forms.Platform.WPF
 			else if (e.PropertyName == Button.BorderColorProperty.PropertyName)
 				UpdateBorderColor();
 			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName)
+			{
 				UpdateBorderWidth();
+				UpdatePadding();
+			}
 			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
 				UpdatePadding();
 		}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ButtonRenderer.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Element.BorderWidth != 0)
 					UpdateBorderWidth();
 
-				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
+				if (Element.IsSet(Button.PaddingProperty))
 					UpdatePadding();
 
 				UpdateFont();

--- a/Xamarin.Forms.Platform.WPF/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ButtonRenderer.cs
@@ -36,6 +36,9 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Element.BorderWidth != 0)
 					UpdateBorderWidth();
 
+				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
+					UpdatePadding();
+
 				UpdateFont();
 			}
 
@@ -56,6 +59,8 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateBorderColor();
 			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName)
 				UpdateBorderWidth();
+			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
+				UpdatePadding();
 		}
 
 		void HandleButtonClick(object sender, RoutedEventArgs e)
@@ -184,6 +189,16 @@ namespace Xamarin.Forms.Platform.WPF
 
 			_isDisposed = true;
 			base.Dispose(disposing);
+		}
+
+		void UpdatePadding()
+		{
+			Control.Padding = new WThickness(
+				Element.Padding.Left,
+				Element.Padding.Top,
+				Element.Padding.Right,
+				Element.Padding.Bottom
+			);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.WPF
 				await TryUpdateSource().ConfigureAwait(false);
 				UpdateAspect();
 
-				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
+				if (Element.IsSet(Button.PaddingProperty))
 					UpdatePadding();
 			}
 		}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
@@ -55,6 +55,9 @@ namespace Xamarin.Forms.Platform.WPF
 
 				await TryUpdateSource().ConfigureAwait(false);
 				UpdateAspect();
+
+				if (Element.IsSet(Button.PaddingProperty) && Element.Padding != (Thickness)Button.PaddingProperty.DefaultValue)
+					UpdatePadding();
 			}
 		}
 
@@ -67,9 +70,14 @@ namespace Xamarin.Forms.Platform.WPF
 			else if (e.PropertyName == ImageButton.BorderColorProperty.PropertyName)
 				UpdateBorderColor();
 			else if (e.PropertyName == ImageButton.BorderWidthProperty.PropertyName)
+			{
 				UpdateBorderWidth();
+				UpdatePadding();
+			}
 			else if (e.PropertyName == ImageButton.AspectProperty.PropertyName)
 				UpdateAspect();
+			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
+				UpdatePadding();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -189,6 +197,16 @@ namespace Xamarin.Forms.Platform.WPF
 				Control.HorizontalAlignment = System.Windows.HorizontalAlignment.Left;
 				Control.VerticalAlignment = System.Windows.VerticalAlignment.Top;
 			}
+		}
+
+		void UpdatePadding()
+		{
+			Control.Padding = new WThickness(
+				Element.Padding.Left,
+				Element.Padding.Top,
+				Element.Padding.Right,
+				Element.Padding.Bottom
+			);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

See title, nothing more, nothing less.
No additional tests included since existing tests should cover it.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6790

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

For the default value, nothing changes, but the user is now able to specify and see a padding on a Button for WPF

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before:

![image](https://user-images.githubusercontent.com/939291/60718499-18c9de80-9f25-11e9-9c3a-1f5ea3dc79cb.png)


After:

![image](https://user-images.githubusercontent.com/939291/60718435-eae49a00-9f24-11e9-9c1c-79edc1722c2c.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
