### PR TITLE
Fix for Switch on Android losing shadow

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls
 
 			var thumbColorSwitch = new Switch() { ThumbColor = Color.Yellow };
 			var thumbColorContainer = new ValueViewContainer<Switch>(Test.Switch.ThumbColor, thumbColorSwitch, nameof(Switch.ThumbColor), value => value.ToString());
-			var changeThumbColorButton = new Button { Text = "Change ThumbColor", Command = new Command(() => thumbColorSwitch.ThumbColor = Color.Azure) };
+			var changeThumbColorButton = new Button { Text = "Change ThumbColor", Command = new Command(() => thumbColorSwitch.ThumbColor = Color.Lime) };
 			var clearThumbColorButton = new Button { Text = "Clear ThumbColor", Command = new Command(() => thumbColorSwitch.ThumbColor = Color.Default) };
 			thumbColorContainer.ContainerLayout.Children.Add(changeThumbColorButton);
 			thumbColorContainer.ContainerLayout.Children.Add(clearThumbColorButton);

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -140,7 +140,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (Element == null)
 				return;
 
-			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter);
+			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter, PorterDuff.Mode.Multiply);
 		}
 
 		void HandleToggled(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.Android
 			drawable.SetColorFilter(colorFilter);
 		}
 
-		public static void SetColorFilter(this ADrawable drawable, Color color, AColorFilter defaultColorFilter)
+		public static void SetColorFilter(this ADrawable drawable, Color color, AColorFilter defaultColorFilter, PorterDuff.Mode mode)
 		{
 			if (drawable == null)
 				return;
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			drawable.SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+			drawable.SetColorFilter(color.ToAndroid(), mode);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateThumbColor()
 		{
-			Control.Thumb.SetColorFilter(Element.ThumbColor, defaultthumbcolorfilter);
+			Control.Thumb.SetColorFilter(Element.ThumbColor, defaultthumbcolorfilter, PorterDuff.Mode.SrcIn);
 		}
 
 		void UpdateThumbImage()

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element == null)
 				return;
 
-			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter);
+			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter, PorterDuff.Mode.Multiply);
 		}
 
 		void HandleToggled(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

After #6312 Switch lost shadow on Android, see Shane's comment

fixes #5415

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Android

### After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

<!-- Describe your changes here. -->
![image](https://user-images.githubusercontent.com/743918/60752085-74e63e80-9fc9-11e9-8047-880347815fe5.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
