### PR TITLE
[iOS] fixes material checkbox color

### DIFF
--- a/Xamarin.Forms.Material.iOS/MaterialFormsCheckBox.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialFormsCheckBox.cs
@@ -7,8 +7,6 @@ namespace Xamarin.Forms.Material.iOS
 {
 	public class MaterialFormsCheckBox : FormsCheckBox
 	{
-		const float _defaultSize = 18.0f;
-		const float _lineWidth = 2.0f;
 		static UIImage _checked;
 		static UIImage _unchecked;
 
@@ -40,10 +38,10 @@ namespace Xamarin.Forms.Material.iOS
 			}
 
 			if (_checked == null)
-				_checked = CreateCheckBox(CreateCheckMark());
+				_checked = CreateCheckBox(CreateCheckMark()).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
 			if (_unchecked == null)
-				_unchecked = CreateCheckBox(null);
+				_unchecked = CreateCheckBox(null).ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate);
 
 			if (IsChecked)
 				return _checked;


### PR DESCRIPTION
### Description of Change ###

Fixes rendering mode of the image in material checkbox.

### Issues Resolved ### 

- fixes #6816

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Before/After Screenshots ### 

![image](https://user-images.githubusercontent.com/27482193/60821631-9c493100-a1ac-11e9-81f8-a3120684fca6.png)

### Testing Procedure ###

- Control Gallery
- Dynamic ViewGallery with Material visual
- select Checkbox
- try to change Color

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
