### PR TITLE
[X] Allow x:Null for x:DataType

### DIFF
--- a/Xamarin.Forms.Build.Tasks/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/ExpandMarkupsVisitor.cs
@@ -14,7 +14,6 @@ namespace Xamarin.Forms.Build.Tasks
 			XmlName.xTypeArguments,
 			XmlName.xFactoryMethod,
 			XmlName.xName,
-			XmlName.xDataType
 		};
 
 		public ExpandMarkupsVisitor(ILContext context)

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -382,6 +382,11 @@ namespace Xamarin.Forms.Build.Tasks
 			if (dataTypeNode is null)
 				yield break;
 
+			if (   dataTypeNode is ElementNode enode
+				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
+				&& enode.XmlType.Name == "NullExtension")
+				yield break;
+
 			if (!((dataTypeNode as ValueNode)?.Value is string dataType))
 				throw new XamlParseException("x:DataType expects a string literal", dataTypeNode as IXmlLineInfo);
 

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh6648.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh6648.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms" 
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh6648"
+        x:DataType="Label">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="{Binding Text}" />
+            <StackLayout x:DataType="{x:Null}" x:Name="stack" >
+                <Label Text="{Binding foo}" x:Name="label" />
+            </StackLayout>
+       </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh6648.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh6648.xaml.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh6648 : ContentPage
+	{
+		public Gh6648() => InitializeComponent();
+		public Gh6648(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void DoesntFailOnNullDataType([Values(true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh6648)));
+			}
+
+			[Test]
+			public void BindingsOnxNullDataTypeWorks([Values(true, false)]bool useCompiledXaml)
+			{
+				var layout = new Gh6648(useCompiledXaml);
+				layout.stack.BindingContext = new { foo = "Foo" };
+				Assert.That(layout.label.Text, Is.EqualTo("Foo"));
+			}
+		}
+	}
+}


### PR DESCRIPTION

### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6648

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
