### PR TITLE
Create a platform neutral version of the Text property.

### DIFF
--- a/Xamarin.Forms.Core/Editor.cs
+++ b/Xamarin.Forms.Core/Editor.cs
@@ -42,6 +42,38 @@ namespace Xamarin.Forms
 			set { SetValue(TextProperty, value); }
 		}
 
+		public string TextPlatformNeutral
+		{
+			get
+			{
+				switch (Device.RuntimePlatform)
+				{
+					case Device.UWP:
+						return Text.Replace("\n", "\r");
+					default:
+						return Text;
+				}
+			}
+			set
+			{
+				string newContent;
+				switch (Device.RuntimePlatform)
+				{
+					case Device.UWP:
+						newContent = value.Replace("\r", "\n");
+						break;
+					default:
+						newContent = value;
+						break;
+				}
+
+				if (Text == newContent)
+					return;
+				Text = newContent;
+				OnPropertyChanged("TextPlatformNeutral");
+			}
+		}
+
 		public Color TextColor
 		{
 			get { return (Color)GetValue(TextElement.TextColorProperty); }

--- a/Xamarin.Forms.Core/EditorCrossPlatformOption.cs
+++ b/Xamarin.Forms.Core/EditorCrossPlatformOption.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms
+{
+	/// <summary>
+	/// Determines the newline behaviour of the Text
+	/// </summary>
+	public enum EditorCrossPlatformOption
+	{
+		Default = 0,
+		PreferNewline = 1,
+		PreferCrLf = 2
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Created a new property TextPlatformNeutral that mirrors the Text property. 

This property converts \n value to \r on the UWP platform and should be used to bind to the XAML control. Thereafter everything that is stored in the Text will be coded as \n. 

### Issues Resolved ### 

- fixes #3020 

### API Changes ###
Added TextPlatformNeutral to the Editor control.

### Platforms Affected ### 
- Core/XAML (all platforms)
Added to all platforms though only the UWP platform filters the control characters.

### Behavioural/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
