### PR TITLE
CollectionView Android - Fix adapter update

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue6644">
+    <StackLayout>
+        <Button Text="Remove"
+                Clicked="Button1_Clicked" />
+        <CollectionView x:Name="cv" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6644, "Android - CollectionView won't animate item remove if EmptyViewTemplate is provided ", PlatformAffected.Android)]
+	public partial class Issue6644 : ContentPage
+	{
+		public Issue6644()
+		{
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			InitializeComponent();
+			cv.ItemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10).ToList());
+		}
+
+		void Button1_Clicked(object sender, EventArgs e)
+		{
+			var src = ((ObservableCollection<int>)cv.ItemsSource);
+			if (src.Any())
+				src.RemoveAt(0);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
@@ -25,6 +25,6 @@ namespace Xamarin.Forms.Controls.Issues
 			if (src.Any())
 				src.RemoveAt(0);
 		}
-	}
 #endif
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 6644, "Android - CollectionView won't animate item remove if EmptyViewTemplate is provided ", PlatformAffected.Android)]
 	public partial class Issue6644 : ContentPage
 	{
+#if APP
 		public Issue6644()
 		{
 			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
@@ -25,4 +26,5 @@ namespace Xamarin.Forms.Controls.Issues
 				src.RemoveAt(0);
 		}
 	}
+#endif
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1315,6 +1315,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6644.xaml">
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Github5623.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -15,6 +15,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue6609.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6644.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGrouping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5412.cs" />
@@ -1290,6 +1293,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue6130.xaml.cs">
       <DependentUpon>Issue6130.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue6644.xaml.cs">
+      <DependentUpon>Issue6644.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5268.xaml">
@@ -1299,6 +1305,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5046.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6644.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -253,13 +253,19 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateEmptyView();
 		}
 
-		protected virtual void UpdateAdapter()
+		protected virtual ItemsViewAdapter CreateAdapter()
+		{
+			return new ItemsViewAdapter(ItemsView);
+		}
+
+		void UpdateAdapter()
 		{
 			var oldItemViewAdapter = ItemsViewAdapter;
 
-			ItemsViewAdapter = new ItemsViewAdapter(ItemsView);
+			ItemsViewAdapter = CreateAdapter();
 
-			SwapAdapter(ItemsViewAdapter, true);
+			if(GetAdapter() != _emptyViewAdapter)
+				SwapAdapter(ItemsViewAdapter, true);
 
 			oldItemViewAdapter?.Dispose();
 		}
@@ -560,14 +566,15 @@ namespace Xamarin.Forms.Platform.Android
 
 			var showEmptyView = ItemsView?.EmptyView != null && ItemsViewAdapter.ItemCount == 0;
 
-			if (showEmptyView)
+			Adapter currAdapter = GetAdapter();
+			if (showEmptyView && currAdapter != _emptyViewAdapter)
 			{
 				SwapAdapter(_emptyViewAdapter, true);
 
 				// TODO hartez 2018/10/24 17:34:36 If this works, cache this layout manager as _emptyLayoutManager	
 				SetLayoutManager(new LinearLayoutManager(Context));
 			}
-			else
+			else if(!showEmptyView && currAdapter != ItemsViewAdapter)
 			{
 				SwapAdapter(ItemsViewAdapter, true);
 				SetLayoutManager(SelectLayoutManager(_layout));

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
@@ -37,10 +37,9 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateNativeSelection();
 		}
 
-		protected override void UpdateAdapter()
+		protected override ItemsViewAdapter CreateAdapter()
 		{
-			ItemsViewAdapter = new SelectableItemsViewAdapter(SelectableItemsView);
-			SwapAdapter(ItemsViewAdapter, true);
+			return new SelectableItemsViewAdapter(SelectableItemsView);
 		}
 
 		void UpdateNativeSelection()


### PR DESCRIPTION
### Description of Change ###

On Android, there's some issues with how the `ItemsViewRenderer.UpdateAdapter()` works:
1. It just resets to the `ItemsViewAdapter` instance but without taking into account if the empty view adapter is the current adapter.
2. `SelectableItemsViewRenderer` overrides `UpdateAdapter()` and it suffers from issue #1 too 
3. `SelectableItemsViewRenderer` overrides `UpdateAdapter()` it doesn't dispose the previous `ItemsViewAdapter` instance how the base class `ItemsViewRenderer` does in `UpdateAdapter()`

There's also an issue with how `ItemsViewRenderer.UpdateEmptyViewVisibility()` works.
I think it shouldn't reset the adapter and the layout manager without checking what's the current adapter, otherwise it creates issues, one is #6644

<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6644 (it resets the adapter and the layout manager hence stopping any animation)
- fixes #6839 

### API Changes ###

Added a new virtual method to ItemsViewRenderer:
```
protected virtual ItemsViewAdapter CreateAdapter()
{
    return new ItemsViewAdapter(ItemsView);
}
```

This is overridden by derived class `SelectableItemsViewRenderer` and this way makes the base class `UpdateAdapter()` work correctly with whatever the items adapter is.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
