### PR TITLE
[X] allow x:Type markup as x:DataType value

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -384,11 +384,23 @@ namespace Xamarin.Forms.Build.Tasks
 
 			if (   dataTypeNode is ElementNode enode
 				&& enode.XmlType.NamespaceUri == XamlParser.X2009Uri
-				&& enode.XmlType.Name == "NullExtension")
+				&& enode.XmlType.Name == nameof(Xamarin.Forms.Xaml.NullExtension))
 				yield break;
 
-			if (!((dataTypeNode as ValueNode)?.Value is string dataType))
-				throw new XamlParseException("x:DataType expects a string literal", dataTypeNode as IXmlLineInfo);
+			string dataType = null;
+
+			if (   dataTypeNode is ElementNode elementNode
+				&& elementNode.XmlType.NamespaceUri == XamlParser.X2009Uri
+				&& elementNode.XmlType.Name == nameof(Xamarin.Forms.Xaml.TypeExtension)
+				&& elementNode.Properties.ContainsKey(new XmlName("", nameof(Xamarin.Forms.Xaml.TypeExtension.TypeName)))
+				&& (elementNode.Properties[new XmlName("", nameof(Xamarin.Forms.Xaml.TypeExtension.TypeName))] as ValueNode)?.Value is string stringtype)
+				dataType = stringtype;
+
+			if ((dataTypeNode as ValueNode)?.Value is string sType)
+				dataType = sType;
+
+			if (dataType is null)
+				throw new XamlParseException("x:DataType expects a string literal, an {x:Type} markup or {x:Null}", dataTypeNode as IXmlLineInfo);
 
 			var prefix = dataType.Contains(":") ? dataType.Substring(0, dataType.IndexOf(":", StringComparison.Ordinal)) : "";
 			var namespaceuri = node.NamespaceResolver.LookupNamespace(prefix) ?? "";

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml
@@ -4,5 +4,5 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         x:Class="Xamarin.Forms.Xaml.UnitTests.Gh5330"
         x:DataType="{x:Type Button}">
-    <Label Text="{Binding foo}" />
+    <Label x:Name="label" Text="{Binding Text}" />
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh5330.xaml.cs
@@ -1,12 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using NUnit.Framework;
-using Xamarin.Forms;
+﻿using NUnit.Framework;
 using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
-	[XamlCompilation(XamlCompilationOptions.Skip)]
 	public partial class Gh5330 : ContentPage
 	{
 		public Gh5330() => InitializeComponent();
@@ -22,10 +18,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TearDown] public void TearDown() => Device.PlatformServices = null;
 
 			[Test]
-			public void FailOnUnresolvedDataType([Values(true)]bool useCompiledXaml)
+			public void DoesntFailOnxType([Values(true)]bool useCompiledXaml)
 			{
 				if (useCompiledXaml)
-					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(Gh5330)));
+					Assert.DoesNotThrow(() => MockCompiler.Compile(typeof(Gh5330)));
+			}
+
+			[Test]
+			public void CompiledBindingWithxType([Values(true)]bool useCompiledXaml)
+			{
+				var layout = new Gh5330(useCompiledXaml) { BindingContext = new Button { Text = "Foo" } };
+				Assert.That(layout.label.Text, Is.EqualTo("Foo"));
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

see discussion on #6492 and related issues


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->


### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
