### PR TITLE
Fix binding to nullable types

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -449,6 +449,8 @@ namespace Xamarin.Forms
 					return false;
 				}
 
+				convertTo = Nullable.GetUnderlyingType(convertTo) ?? convertTo;
+
 				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
 				return true;
 			}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Issue6280.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Issue6280.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.Issue6280"
+             x:DataType="local:Issue6280ViewModel">
+    <Entry x:Name="_entry"
+           Text="{Binding NullableInt}"
+           VerticalOptions="Start" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Issue6280.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Issue6280.xaml.cs
@@ -1,0 +1,35 @@
+﻿using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Issue6280 : ContentPage
+	{
+		public Issue6280() => InitializeComponent();
+		public Issue6280(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void BindingToNullable([Values(false, true)]bool useCompiledXaml)
+			{
+				var vm = new Issue6280ViewModel();
+				var page = new Issue6280(useCompiledXaml) { BindingContext = vm };
+				page._entry.SetValueFromRenderer(Entry.TextProperty, 1);
+				Assert.AreEqual(vm.NullableInt, 1);
+			}
+		}
+	}
+
+	public class Issue6280ViewModel
+	{
+		public int? NullableInt { get; set; }
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Fixes binding to nullable types. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6280

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
