### PR TITLE
[iOS] UITableView.Appearance.BackgroundColor ignored or overridden for ListView

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
-			MessagingCenter.Subscribe<Issue5503>(this, Issue5503.ChangeUITableViewAppereanceBgColor, (s) =>
+			MessagingCenter.Subscribe<Issue5503>(this, Issue5503.ChangeUITableViewAppearanceBgColor, (s) =>
 			{
 				UITableView.Appearance.BackgroundColor = UITableView.Appearance.BackgroundColor == null ? UIColor.Red : null;
 			});

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -180,6 +180,10 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			// When the native control gallery loads up, it'll let us know so we can add the nested native controls
 			MessagingCenter.Subscribe<NestedNativeControlGalleryPage>(this, NestedNativeControlGalleryPage.ReadyForNativeControlsMessage, AddNativeControls);
 			MessagingCenter.Subscribe<Bugzilla40911>(this, Bugzilla40911.ReadyToSetUp40911Test, SetUp40911Test);
+			MessagingCenter.Subscribe<Issue5503>(this, Issue5503.ChangeUITableViewAppereanceBgColor, (s) =>
+			{
+				UITableView.Appearance.BackgroundColor = UITableView.Appearance.BackgroundColor == null ? UIColor.Red : null;
+			});
 
 			// When the native binding gallery loads up, it'll let us know so we can set up the native bindings
 			MessagingCenter.Subscribe<NativeBindingGalleryPage>(this, NativeBindingGalleryPage.ReadyForNativeBindingsMessage, AddNativeBindings);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5503.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5503.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string ChangeBackgroundButtonAutomationId = "ChangeBackgroundButton";
 		const string ListViewAutomationId = "TheListView";
 
-		public static string ChangeUITableViewAppereanceBgColor = "BIBBIDYBOBBIDIBOOOO";
+		public static string ChangeUITableViewAppearanceBgColor = "BIBBIDYBOBBIDIBOOOO";
 
 		ObservableCollection<string> _items = new ObservableCollection<string>();
 		public ObservableCollection<string> Items
@@ -59,13 +59,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var changeAppearanceButton = new Button()
 			{
-				Text = "Change Background through Appereance API",
+				Text = "Change Background through Appearance API",
 				AutomationId = ChangeBackgroundButtonAutomationId
 			};
 
 			changeAppearanceButton.Clicked += (s, a) =>
 			{
-				MessagingCenter.Send(this, ChangeUITableViewAppereanceBgColor);
+				MessagingCenter.Send(this, ChangeUITableViewAppearanceBgColor);
 			};
 
 			var stack = new StackLayout();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5503.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5503.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ListView)]
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5503, "[iOS] UITableView.Appearance.BackgroundColor ignored or overridden for ListView",
+		PlatformAffected.iOS)]
+	public class Issue5503 : TestContentPage
+	{
+		const string ChangeBackgroundButtonAutomationId = "ChangeBackgroundButton";
+		const string ListViewAutomationId = "TheListView";
+
+		public static string ChangeUITableViewAppereanceBgColor = "BIBBIDYBOBBIDIBOOOO";
+
+		ObservableCollection<string> _items = new ObservableCollection<string>();
+		public ObservableCollection<string> Items
+		{
+			get => _items;
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		protected override void Init()
+		{
+			BindingContext = this;
+
+			var listView = new ListView
+			{
+				AutomationId = ListViewAutomationId
+			};
+
+			listView.SetBinding(ItemsView<Cell>.ItemsSourceProperty, new Binding(nameof(Items)));
+
+			for (int i = 0; i < 100; i++)
+			{
+				Items.Add($"Item {i}");
+			}
+
+			Padding = new Thickness(10);
+			BackgroundColor = Color.LightGray;
+
+			var changeAppearanceButton = new Button()
+			{
+				Text = "Change Background through Appereance API",
+				AutomationId = ChangeBackgroundButtonAutomationId
+			};
+
+			changeAppearanceButton.Clicked += (s, a) =>
+			{
+				MessagingCenter.Send(this, ChangeUITableViewAppereanceBgColor);
+			};
+
+			var stack = new StackLayout();
+
+			stack.Children.Add(changeAppearanceButton);
+			stack.Children.Add(listView);
+
+			Content = stack;
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void ToggleAppearanceApiBackgroundColorListView()
+		{
+			RunningApp.WaitForElement(ChangeBackgroundButtonAutomationId);
+
+			RunningApp.Screenshot("ListView cells have clear background, default color from code");
+
+			RunningApp.Tap(ChangeBackgroundButtonAutomationId);
+			RunningApp.NavigateBack();
+			RunningApp.WaitForNoElement(ChangeBackgroundButtonAutomationId);
+			AppSetup.NavigateToIssue(typeof(Issue5503), RunningApp);
+			RunningApp.WaitForElement(ChangeBackgroundButtonAutomationId);
+
+			RunningApp.Screenshot("ListView cells have Red background, set by Appearance API");
+
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -980,6 +980,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6472.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub6926.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5503.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected void UpdateBackground(UITableViewCell tableViewCell, Cell cell)
 		{
-			var uiBgColor = UIColor.White; // Must be set to a solid color or blending issues will occur
+			var uiBgColor = UITableView.Appearance.BackgroundColor ?? UIColor.White; // Must be set to a solid color or blending issues will occur
 #if __MOBILE__
 			var defaultBgColor = cell.On<PlatformConfiguration.iOS>().DefaultBackgroundColor();
 #else


### PR DESCRIPTION
### Description of Change ###

As described in #5503 the color set in the Appearance API was not respected. Fixed this by adding a check for that in the code of #4002 that caused this behavior.

I added a UI test but could not get the color out of the `ListView` they always returned the same value. Marked it as manual review.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5503

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
