### PR TITLE
[Bug] Device.Info.ScaledScreenSize Gives 0 Width and Height in iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/IOSDeviceInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/IOSDeviceInfo.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public IOSDeviceInfo()
 		{
 			_notification = UIDevice.Notifications.ObserveOrientationDidChange(OrientationChanged);
+
+			UpdateScreenSize();
 		}
 
 		public override Size PixelScreenSize => _pixelScreenSize;


### PR DESCRIPTION
### Description of Change ###

In #5975 code was implemented to take into account the orientation changes on iOS. This code caused the initialisation of the `Device.Info.ScaledScreenSize` (and probably others) to be delayed. To make sure values are filled immediately, I’ve added the update method to the ctor.

Because of timing and app lifecycle (near) impossible to add automated tests.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6799
- fixes #6834
- fixes #6645

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
