### PR TITLE
[Android] Add check for multiple dispose calls on scrollview, page,  and platform

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -432,9 +432,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			protected override void Dispose(bool disposing)
 			{
-				if (disposing && !_disposed)
+				if (_disposed)
+					return;
+
+				if (disposing)
 				{
-					_disposed = true;
 					RemoveAllViews();
 					if (_renderer != null)
 					{
@@ -451,6 +453,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					}
 				}
 
+				_disposed = true;
 				base.Dispose(disposing);
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -37,10 +37,19 @@ namespace Xamarin.Forms.Platform.Android
 		IOrderedTraversalController OrderedTraversalController => this;
 
 		double _previousHeight;
+		bool _isDisposed = false;
 
 		protected override void Dispose(bool disposing)
 		{
-			PageController?.SendDisappearing();
+			if (_isDisposed)
+				return;
+
+			if (disposing)
+			{
+				PageController?.SendDisappearing();
+			}
+
+			_isDisposed = true;
 			base.Dispose(disposing);
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		readonly ScrollView _parent;
 		View _childView;
+		bool _isDisposed = false;
 
 		public ScrollViewContainer(ScrollView parent, Context context) : base(context)
 		{
@@ -44,7 +45,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
+			if (_isDisposed)
+				return;
 
 			if (disposing)
 			{
@@ -53,6 +55,9 @@ namespace Xamarin.Forms.Platform.Android
 				RemoveAllViews();
 				_childView = null;
 			}
+
+			_isDisposed = true;
+			base.Dispose(disposing);
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)


### PR DESCRIPTION
### Description of Change ###

When the previewer unloads the app process it calls dispose on every single Java.Lang.Object in memory. Meaning dispose will be called on children elements multiple times. We've occasionally been seeing an exception in the dispose call on ScrollViewContainer because dispose will be called directly on ScrollViewContainer and it will be called by the ScrollViewRenderer. If the timing is just wrong it'll throw an exception from ScrollViewContainer since the dispose happens twice

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Open a forms page with a scrollview, close it, open it, and then close it. Do that a few times and just makes sure it all works
- Run an android app with a page that has a scrollview. Pop the page off the stack and just make sure the dispose calls fro scrollview and scrollviewcontainer seem to work

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
