### PR TITLE
[Android] Fix previewer exceptions with SearchBar

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -86,12 +86,14 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnElementChanged(e);
 
 			SearchView searchView = Control;
+			var isDesigner = Context.IsDesignerContext();
 
 			if (searchView == null)
 			{
 				searchView = CreateNativeControl();
 				searchView.SetIconifiedByDefault(false);
-				searchView.Iconified = false;
+				if (!isDesigner)
+					searchView.Iconified = false;
 				SetNativeControl(searchView);
 				_editText = _editText ?? Control.GetChildrenOfType<EditText>().FirstOrDefault();
 
@@ -104,7 +106,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			}
 
-			ClearFocus(searchView);
+			if (!isDesigner)
+				ClearFocus(searchView);
 			UpdateInputType();
 			UpdatePlaceholder();
 			UpdateText();
@@ -210,14 +213,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void ClearFocus(SearchView view)
 		{
-			try
-			{
-				view.ClearFocus();
-			}
-			catch (Java.Lang.UnsupportedOperationException)
-			{
-				// silently catch these as they happen in the previewer due to some bugs in Android
-			}
+			view.ClearFocus();
 		}
 
 		void UpdateFont()

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -92,6 +92,9 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				searchView = CreateNativeControl();
 				searchView.SetIconifiedByDefault(false);
+				// set Iconified calls onSearchClicked 
+				// https://github.com/aosp-mirror/platform_frameworks_base/blob/6d891937a38220b0c712a1927f969e74bea3a0f3/core/java/android/widget/SearchView.java#L674-L680
+				// which causes requestFocus. The designer does not support focuses.
 				if (!isDesigner)
 					searchView.Iconified = false;
 				SetNativeControl(searchView);


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->

### Issues Resolved ### 

- fixes #4108

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Before/After Screenshots ### 

After
![image](https://user-images.githubusercontent.com/27482193/61540082-93c2e700-aa45-11e9-945a-dcf9410c41cb.png)

### Testing Procedure ###

Create a Xamarin Forms project
Add `SearchBar` to a Xamarin Forms Page
Try to use the Previewer

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#950410](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/950410)