### PR TITLE
[iOS] Fix usage conflict of Title and AttributedTitle on ButtonRenderer

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml
@@ -2,7 +2,7 @@
 
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.Forms.Controls.GalleryPages.CharacterSpacingGallery" Visual="Material">
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CharacterSpacingGallery">
 
     <StackLayout>
         <Label>
@@ -14,7 +14,7 @@
                 </FormattedString>
             </Label.FormattedText>
         </Label>
-        <Slider Minimum="-10" Maximum="10" Value="0" ValueChanged="Slider_OnValueChanged" MaximumTrackColor="Gray"
+        <Slider x:Name="slider" Minimum="-10" Maximum="10" Value="0" ValueChanged="Slider_OnValueChanged" MaximumTrackColor="Gray"
                 MinimumTrackColor="Gray"  Margin="20,0"/>
 
         <ScrollView>
@@ -41,7 +41,8 @@
                 </Picker>
                 <SearchBar Text="Welcome to Xamarin.Forms! - SearchBar" CharacterSpacing="0" x:Name="SearchBar" TextColor="Red" PlaceholderColor="BlueViolet"/>
                 <SearchBar Placeholder="Welcome to Xamarin.Forms! - SearchBar" CharacterSpacing="0" x:Name="PlaceholderSearchBar" TextColor="Red" PlaceholderColor="BlueViolet"/>
-                <Button Text="Welcome to Xamarin.Forms! - Button" CharacterSpacing="0" x:Name="Button" TextColor="Red"/>
+                <Button Text="Welcome to Xamarin.Forms! - Button" TextColor="Red" CharacterSpacing="0" x:Name="Button" />
+                <Button Text="Reset" Clicked="ResetButtonClicked"></Button>
             </StackLayout>
         </ScrollView>
     </StackLayout>

--- a/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml.cs
@@ -33,5 +33,10 @@ namespace Xamarin.Forms.Controls.GalleryPages
 			TimePicker.CharacterSpacing = e.NewValue;
 			Span.CharacterSpacing = e.NewValue;
 		}
+
+		void ResetButtonClicked(object sender, EventArgs e)
+		{
+			slider.Value = 0;
+		}
 	}
 }

--- a/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
@@ -77,7 +77,6 @@ namespace Xamarin.Forms.Material.iOS
 				UpdateTextColor();
 				_buttonLayoutManager?.Update();
 				ApplyTheme();
-				UpdateCharacterSpacing();
 			}
 		}
 
@@ -91,7 +90,14 @@ namespace Xamarin.Forms.Material.iOS
 			};
 		}
 
-		protected virtual void ApplyTheme() => ContainedButtonThemer.ApplyScheme(_buttonScheme, Control);
+		protected virtual void ApplyTheme()
+		{
+			ContainedButtonThemer.ApplyScheme(_buttonScheme, Control);
+
+			// Colors have to be re-applied to Character spacing
+			_buttonLayoutManager?.UpdateText();
+		}
+
 		protected override MButton CreateNativeControl() => new MButton();
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -112,10 +118,6 @@ namespace Xamarin.Forms.Material.iOS
 			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName || e.PropertyName == Button.BorderColorProperty.PropertyName)
 			{
 				UpdateBorder();
-			}
-			else if (e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
-			{
-				UpdateCharacterSpacing();
 			}
 			else if (e.PropertyName == Button.CornerRadiusProperty.PropertyName)
 			{
@@ -230,13 +232,6 @@ namespace Xamarin.Forms.Material.iOS
 			}
 		}
 
-		void UpdateCharacterSpacing()
-		{
-			var attributedString = new NSMutableAttributedString(Element.Text ?? string.Empty).AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
-			Control.SetAttributedTitle(attributedString, UIControlState.Normal);
-			Control.SetAttributedTitle(attributedString, UIControlState.Highlighted);
-			Control.SetAttributedTitle(attributedString, UIControlState.Disabled);
-		}
 		void UpdateTextColor()
 		{
 			if (_buttonScheme.ColorScheme is SemanticColorScheme colorScheme)
@@ -248,6 +243,7 @@ namespace Xamarin.Forms.Material.iOS
 				else
 					colorScheme.OnPrimaryColor = textColor.ToUIColor();
 			}
+			
 		}
 
 		// IImageVisualElementRenderer

--- a/Xamarin.Forms.Material.iOS/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialDatePickerRenderer.cs
@@ -20,7 +20,9 @@ namespace Xamarin.Forms.Material.iOS
 		protected override void OnElementChanged(ElementChangedEventArgs<DatePicker> e)
 		{
 			base.OnElementChanged(e);
-			UpdatePlaceholder();
+
+			if(e.NewElement != null)
+				UpdatePlaceholder();
 		}
 
 		void UpdatePlaceholder() => Control?.UpdatePlaceholder(this);

--- a/Xamarin.Forms.Material.iOS/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialEditorRenderer.cs
@@ -56,7 +56,9 @@ namespace Xamarin.Forms.Material.iOS
 		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
 		{
 			base.OnElementChanged(e);
-			InitialPlaceholderSetupHack();
+
+			if(e.NewElement != null)
+				InitialPlaceholderSetupHack();
 		}
 
 		protected internal override void UpdateAutoSizeOption()

--- a/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
@@ -22,8 +22,12 @@ namespace Xamarin.Forms.Material.iOS
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			base.OnElementChanged(e);
-			UpdatePlaceholder();
-			UpdateCharacterSpacing();
+
+			if (e.NewElement != null)
+			{
+				UpdatePlaceholder();
+				UpdateCharacterSpacing();
+			}
 		}
 
 		string IMaterialEntryRenderer.Placeholder => string.Empty;

--- a/Xamarin.Forms.Material.iOS/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTimePickerRenderer.cs
@@ -22,7 +22,9 @@ namespace Xamarin.Forms.Material.iOS
 		protected override void OnElementChanged(ElementChangedEventArgs<TimePicker> e)
 		{
 			base.OnElementChanged(e);
-			UpdatePlaceholder();
+
+			if(e.NewElement != null)
+				UpdatePlaceholder();
 		}
 
 		string IMaterialEntryRenderer.Placeholder => string.Empty;

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -113,25 +113,12 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		internal static NSMutableAttributedString AddCharacterSpacing(this NSMutableAttributedString attributedString, string text, double characterSpacing)
-		{
-			if (attributedString == null || attributedString.Length == 0)
-			{
-				attributedString = text == null ? new NSMutableAttributedString() : new NSMutableAttributedString(text);
-			}
-			else
-			{
-				attributedString = new NSMutableAttributedString(attributedString);
-			}
-
-			AddKerningAdjustment(attributedString, text, characterSpacing);
-
-			return attributedString;
-		}
-
 		internal static NSMutableAttributedString AddCharacterSpacing(this NSAttributedString attributedString, string text, double characterSpacing)
 		{
-			NSMutableAttributedString mutableAttributedString;
+			if (attributedString == null && characterSpacing == 0)
+				return null;
+
+			NSMutableAttributedString mutableAttributedString = attributedString as NSMutableAttributedString;
 			if (attributedString == null || attributedString.Length == 0)
 			{
 				mutableAttributedString = text == null ? new NSMutableAttributedString() : new NSMutableAttributedString(text);
@@ -146,10 +133,55 @@ namespace Xamarin.Forms.Platform.iOS
 			return mutableAttributedString;
 		}
 
+		/*internal static void RemoveCharacterAdjustment(this NSAttributedString attributedString)
+		{
+			if (attributedString is NSMutableAttributedString mutableAttributedString)
+				RemoveCharacterAdjustment(mutableAttributedString);
+		}
+
+		internal static void RemoveCharacterAdjustment(this NSMutableAttributedString mutableAttributedString)
+		{
+			if (mutableAttributedString == null)
+				return;
+
+			NSRange removalRange;
+			var attributes = mutableAttributedString.GetAttributes(0, out removalRange);
+
+			for (uint i = 0; i < attributes.Count; i++)
+			{
+				var attribute = attributes.Keys[i];
+				if (attribute is NSString nSString && nSString == UIStringAttributeKey.KerningAdjustment)
+				{
+					mutableAttributedString.RemoveAttribute(UIStringAttributeKey.KerningAdjustment, removalRange);
+				}
+			}
+
+			return;
+		}*/
+
+
+		internal static bool HasCharacterAdjustment(this NSMutableAttributedString mutableAttributedString)
+		{
+			if (mutableAttributedString == null)
+				return false;
+
+			NSRange removalRange;
+			var attributes = mutableAttributedString.GetAttributes(0, out removalRange);
+
+			for (uint i = 0; i < attributes.Count; i++)
+				if (attributes.Keys[i] is NSString nSString && nSString == UIStringAttributeKey.KerningAdjustment)
+					return true;
+
+			return false;
+		}
+
 		internal static void AddKerningAdjustment(NSMutableAttributedString mutableAttributedString, string text, double characterSpacing)
 		{
 			if (!string.IsNullOrEmpty(text))
 			{
+				if (characterSpacing == 0 && !mutableAttributedString.HasCharacterAdjustment())
+					return;
+
 				mutableAttributedString.AddAttribute
 				(
 					UIStringAttributeKey.KerningAdjustment,

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -133,33 +133,6 @@ namespace Xamarin.Forms.Platform.iOS
 			return mutableAttributedString;
 		}
 
-		/*internal static void RemoveCharacterAdjustment(this NSAttributedString attributedString)
-		{
-			if (attributedString is NSMutableAttributedString mutableAttributedString)
-				RemoveCharacterAdjustment(mutableAttributedString);
-		}
-
-		internal static void RemoveCharacterAdjustment(this NSMutableAttributedString mutableAttributedString)
-		{
-			if (mutableAttributedString == null)
-				return;
-
-			NSRange removalRange;
-			var attributes = mutableAttributedString.GetAttributes(0, out removalRange);
-
-			for (uint i = 0; i < attributes.Count; i++)
-			{
-				var attribute = attributes.Keys[i];
-				if (attribute is NSString nSString && nSString == UIStringAttributeKey.KerningAdjustment)
-				{
-					mutableAttributedString.RemoveAttribute(UIStringAttributeKey.KerningAdjustment, removalRange);
-				}
-			}
-
-			return;
-		}*/
-
-
 		internal static bool HasCharacterAdjustment(this NSMutableAttributedString mutableAttributedString)
 		{
 			if (mutableAttributedString == null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
@@ -143,7 +143,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdatePadding();
 			else if (e.PropertyName == Button.ImageSourceProperty.PropertyName)
 				_ = UpdateImageAsync();
-			else if (e.PropertyName == Button.TextProperty.PropertyName)
+			else if (e.PropertyName == Button.TextProperty.PropertyName ||
+					 e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
 				UpdateText();
 			else if (e.PropertyName == Button.ContentLayoutProperty.PropertyName)
 				UpdateEdgeInsets();
@@ -160,8 +161,11 @@ namespace Xamarin.Forms.Platform.iOS
 			if (control == null)
 				return;
 
-			control.SetTitle(_element.Text, UIControlState.Normal);
+			var attributedString = new NSMutableAttributedString(_element.Text ?? string.Empty).AddCharacterSpacing(_element.Text, _element.CharacterSpacing);
 
+			Control.SetAttributedTitle(attributedString, UIControlState.Normal);
+			Control.SetAttributedTitle(attributedString, UIControlState.Highlighted);
+			Control.SetAttributedTitle(attributedString, UIControlState.Disabled);
 			UpdateEdgeInsets();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
@@ -152,7 +152,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateEdgeInsets();
 		}
 
-		void UpdateText()
+		internal void UpdateText()
 		{
 			if (_disposed || _renderer == null || _element == null)
 				return;
@@ -161,11 +161,55 @@ namespace Xamarin.Forms.Platform.iOS
 			if (control == null)
 				return;
 
-			var attributedString = new NSMutableAttributedString(_element.Text ?? string.Empty).AddCharacterSpacing(_element.Text, _element.CharacterSpacing);
+			var normalTitle = control
+				.GetAttributedTitle(UIControlState.Normal);
 
-			Control.SetAttributedTitle(attributedString, UIControlState.Normal);
-			Control.SetAttributedTitle(attributedString, UIControlState.Highlighted);
-			Control.SetAttributedTitle(attributedString, UIControlState.Disabled);
+			if (_element.CharacterSpacing == 0 && normalTitle == null)
+			{
+				control.SetTitle(_element.Text, UIControlState.Normal);
+				return;
+			}
+
+			if (control.Title(UIControlState.Normal) != null)
+				control.SetTitle(null, UIControlState.Normal);
+
+			string text = _element.Text ?? string.Empty;
+			var colorRange = new NSRange(0, text.Length);
+
+			var normal =
+				control
+					.GetAttributedTitle(UIControlState.Normal)
+					.AddCharacterSpacing(text, _element.CharacterSpacing);
+
+			var highlighted =
+				control
+					.GetAttributedTitle(UIControlState.Highlighted)
+					.AddCharacterSpacing(text, _element.CharacterSpacing);
+
+			var disabled =
+				control
+					.GetAttributedTitle(UIControlState.Disabled)
+					.AddCharacterSpacing(text, _element.CharacterSpacing);
+
+			normal.AddAttribute(
+				UIStringAttributeKey.ForegroundColor,
+				Control.TitleColor(UIControlState.Normal),
+				colorRange);
+
+			highlighted.AddAttribute(
+				UIStringAttributeKey.ForegroundColor,
+				Control.TitleColor(UIControlState.Highlighted),
+				colorRange);
+
+			disabled.AddAttribute(
+				UIStringAttributeKey.ForegroundColor,
+				Control.TitleColor(UIControlState.Disabled),
+				colorRange);
+
+			Control.SetAttributedTitle(normal, UIControlState.Normal);
+			Control.SetAttributedTitle(highlighted, UIControlState.Highlighted);
+			Control.SetAttributedTitle(disabled, UIControlState.Disabled);
+
 			UpdateEdgeInsets();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -92,7 +92,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 				UpdateFont();
 				UpdateTextColor();
-				UpdateCharacterSpacing();
 				_buttonLayoutManager?.Update();
 			}
 		}
@@ -109,14 +108,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (e.PropertyName == Button.TextColorProperty.PropertyName)
 				UpdateTextColor();
 			else if (e.PropertyName == Button.FontProperty.PropertyName)
-			{
 				UpdateFont();
-			}
-			else if (e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
-			{
-				UpdateCharacterSpacing();
-			}
-
 		}
 
 		protected override void SetAccessibilityLabel()
@@ -157,14 +149,6 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateFont()
 		{
 			Control.TitleLabel.Font = Element.ToUIFont();
-		}
-
-		void UpdateCharacterSpacing()
-		{
-			var attributedString = new NSMutableAttributedString(Element.Text ?? string.Empty).AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
-			Control.SetAttributedTitle(attributedString, UIControlState.Normal);
-			Control.SetAttributedTitle(attributedString, UIControlState.Highlighted);
-			Control.SetAttributedTitle(attributedString, UIControlState.Disabled);
 		}
 
 		public void SetImage(UIImage image) => _buttonLayoutManager.SetImage(image);

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -154,7 +154,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCharacterSpacing()
 		{
-			Control.AttributedText = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
+			var textAttr = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
+
+			if (textAttr != null)
+				Control.AttributedText = textAttr;
 		}
 		void UpdateMaximumDate()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -66,8 +66,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected internal override void UpdateCharacterSpacing()
 		{
-			TextView.AttributedText = TextView.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
-			_placeholderLabel.AttributedText = _placeholderLabel.AttributedText.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
+			var textAttr = TextView.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
+
+			if(textAttr != null)
+				TextView.AttributedText = textAttr;
+
+			var placeHolder = TextView.AttributedText.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
+
+			if(placeHolder != null)
+				_placeholderLabel.AttributedText = placeHolder;
 		}
 
 		protected internal override void UpdatePlaceholderColor()

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -359,8 +359,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCharacterSpacing()
 		{
-			Control.AttributedText = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
-			Control.AttributedPlaceholder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
+			var textAttr = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
+
+			if (textAttr != null)
+				Control.AttributedText = textAttr;
+
+			var placeHolder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
+
+			if (placeHolder != null)
+				Control.AttributedPlaceholder = placeHolder;
 		}
 
 		void UpdateMaxLength()

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -271,8 +271,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
 
 #if __MOBILE__
-
-			Control.AttributedText = newAttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
+			UpdateCharacterSpacing();
 #else
 			Control.AttributedStringValue = newAttributedText;
 #endif
@@ -372,7 +371,11 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdateCharacterSpacing()
 		{
 #if __MOBILE__
-			Control.AttributedText = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
+
+			var textAttr = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
+
+			if (textAttr != null)
+				Control.AttributedText = textAttr;
 #endif
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -162,9 +162,16 @@ namespace Xamarin.Forms.Platform.iOS
 
         protected void UpdateCharacterSpacing()
         {
-	        Control.AttributedText = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
-			Control.AttributedPlaceholder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing);
-        }
+			var textAttr = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
+
+			if (textAttr != null)
+				Control.AttributedText = textAttr;
+
+			var placeHolder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing);
+
+			if (placeHolder != null)
+				Control.AttributedPlaceholder = placeHolder;
+		}
 
         protected internal virtual void UpdateFont()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -203,6 +203,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_textField = _textField ?? Control.FindDescendantView<UITextField>();
 			if (_textField == null)
 				return;
+
 			_textField.AttributedText = _textField.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
 			_textField.AttributedPlaceholder = _textField.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -164,7 +164,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateCharacterSpacing()
 		{
-			Control.AttributedText = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
+			var textAttr = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
+
+			if (textAttr != null)
+				Control.AttributedText = textAttr;
 		}
 
 		void UpdateTime()


### PR DESCRIPTION
### Description of Change ###

PR #5167 introduced a bug with iOS button text where it was setting a `AttributtedTitle`  and the `ButtonLayoutManager.cs ` was setting just the control `Title` when the text was changed.

### API Changes ###
<!-- List all API changes here (or just put None), example:

None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
When changing the Text button it should work, you should see the new text

### Testing Procedure ###
There are several tests on ControlGallery that should pass with this fix, iOS should be green.
Can tests for example with test case  `Bugzilla46458` after clicking the button it should read `Clicked`.
 
### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
