### PR TITLE
Nullable DatePicker 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60001.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60001.cs
@@ -23,7 +23,9 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			StackLayout layout = new StackLayout() { Orientation = StackOrientation.Vertical };
 			DatePicker picker = new DatePicker();
+#pragma warning disable 0618 // Retain until Date is removed
 			picker.Date = new DateTime(2017, 10, 7, 0, 0, 0, DateTimeKind.Utc);
+#pragma warning restore
 			Label label = new Label() { Text = "On Droid this will show as 10/7/2017, on UWP it will show as 10/06/2017.  Local TimeZone for this test was EDT.", LineBreakMode = LineBreakMode.WordWrap };
 			layout.Children.Add(picker);
 			layout.Children.Add(label);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/DefaultColorToggleTest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/DefaultColorToggleTest.cs
@@ -344,9 +344,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 		static ContentPage DatePickerPage()
 		{
+#pragma warning disable 0618 // Retain until Date is removed
 			var pickerInit = new DatePicker { Date = new DateTime(1978, 12, 24), TextColor = Color.Red };
 			var pickerColorDefaultToggle = new DatePicker { Date = new DateTime(1978, 12, 24) };
-
+#pragma warning restore
 			var defaultText = "Should have default color text";
 			var pickerColorLabel = new Label { Text = defaultText };
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2987.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2987.cs
@@ -16,11 +16,16 @@ namespace Xamarin.Forms.Controls.Issues
 			var datePicker = new DatePicker { AutomationId = "datePicker" };
 			datePicker.MinimumDate = new DateTime (2015, 1, 1);
 			datePicker.MaximumDate = new DateTime (2015, 6, 1);
+#pragma warning disable 0618 // Retain until Date is removed
 			datePicker.Date = DateTime.Now;
+#pragma warning restore
 			datePicker.Format = "MMM dd, yyyy";
+
+#pragma warning disable 0618 // Retain until Date is removed
 			datePicker.DateSelected += (object sender, DateChangedEventArgs e) => {
 				Debug.WriteLine ("Date changed");
 			};
+#pragma warning restore
 
 			Padding = Device.RuntimePlatform == Device.iOS ? new Thickness(10, 20, 10, 5) : new Thickness(10, 0, 10, 5);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4187.cs
@@ -102,8 +102,9 @@ namespace Xamarin.Forms.Controls.Issues
 			picker.SetBinding(Picker.ItemsSourceProperty, new Binding(nameof(Issue4187Model.PickerSource)));
 
 			var datePicker = new DatePicker();
+#pragma warning disable 0618 // Retain until Date is removed
 			datePicker.SetBinding(DatePicker.DateProperty, new Binding(nameof(Issue4187Model.Date)));
-
+#pragma warning restore
 			var entry = new Entry();
 			entry.SetBinding(Entry.TextProperty, new Binding(nameof(Issue4187Model.Text)));
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6947.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6947.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue6947"
+             Padding="10">
+    <StackLayout>
+        <DatePicker SelectedDate="{Binding SelectedDate}"/>
+        <Button Text="Clear" 
+                Clicked="ClearBtn_Clicked"/>
+        <Label Text="{Binding SelectedDate}" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6947.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6947.xaml.cs
@@ -1,0 +1,46 @@
+﻿#if APP
+using System;
+using System.ComponentModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6947, "DatePicker SelectedDate", PlatformAffected.All)]
+	public partial class Issue6947 : ContentPage
+	{
+		public Issue6947()
+		{
+			InitializeComponent();
+			BindingContext = new Issue6947ViewModel();
+		}
+
+		void ClearBtn_Clicked(object sender, EventArgs e)
+		{
+			((Issue6947ViewModel)BindingContext).SelectedDate = null;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue6947ViewModel : INotifyPropertyChanged
+	{
+		DateTime? _selectedDate = DateTime.Today;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public DateTime? SelectedDate
+		{
+			get => _selectedDate;
+			set
+			{
+				if (_selectedDate != value)
+				{
+					_selectedDate = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(SelectedDate)));
+				}
+			}
+		}
+	}
+}
+#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1290,6 +1290,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue6130.xaml.cs">
       <DependentUpon>Issue6130.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue6947.xaml.cs">
+      <DependentUpon>Issue6947.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5268.xaml">
@@ -1299,6 +1302,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5046.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6947.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Controls/ControlGalleryPages/AutomationIDGallery.cs
+++ b/Xamarin.Forms.Controls/ControlGalleryPages/AutomationIDGallery.cs
@@ -54,7 +54,10 @@ namespace Xamarin.Forms.Controls
 					BackgroundColor = Color.Red
 				});
 				rootLayout.Children.Add (new Button { AutomationId = "btnHello", Text = "Hello" });
+
+#pragma warning disable 0618 // Retain until Date is removed
 				rootLayout.Children.Add (new DatePicker { AutomationId = "dtPicker", Date = DateTime.Parse ("01/01/2014") });
+#pragma warning restore
 				rootLayout.Children.Add (new TimePicker { AutomationId = "tPicker", Time = new TimeSpan (14, 45, 50)  });
 				rootLayout.Children.Add (new Label { AutomationId = "lblHello", Text = "Hello Label" });
 				rootLayout.Children.Add (new Editor { AutomationId = "editorHello", Text = "Hello Editor" });

--- a/Xamarin.Forms.Controls/CoreGalleryPages/DatePickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/DatePickerCoreGalleryPage.cs
@@ -12,18 +12,29 @@ namespace Xamarin.Forms.Controls
 			base.Build(stackLayout);
 
 			var dateContainer = new ViewContainer<DatePicker>(Test.DatePicker.Date,
+#pragma warning disable 0618 // Retain until Date is removed
 				new DatePicker { Date = new DateTime(1987, 9, 13) });
-
+#pragma warning restore
 			var dateSelectedContainer = new EventViewContainer<DatePicker>(Test.DatePicker.DateSelected, new DatePicker());
+
+#pragma warning disable 0618 // Retain until Date is removed
 			dateSelectedContainer.View.DateSelected += (sender, args) => dateSelectedContainer.EventFired();
+#pragma warning restore
+
+			var selectedDateContainer = new ViewContainer<DatePicker>(Test.DatePicker.SelectedDate,
+				new DatePicker { SelectedDate = new DateTime(1980, 11, 1) });
+			var selectedDateChangedContainer = new EventViewContainer<DatePicker>(Test.DatePicker.SelectedDateChanged, new DatePicker());
+			selectedDateChangedContainer.View.SelectedDateChanged += (sender, args) => selectedDateChangedContainer.EventFired();
 
 			var formatDateContainer = new ViewContainer<DatePicker>(Test.DatePicker.Format, new DatePicker { Format = "ddd" });
 			var minimumDateContainer = new ViewContainer<DatePicker>(Test.DatePicker.MinimumDate,
 				new DatePicker { MinimumDate = new DateTime(1987, 9, 13) });
 			var maximumDateContainer = new ViewContainer<DatePicker>(Test.DatePicker.MaximumDate,
 				new DatePicker { MaximumDate = new DateTime(2087, 9, 13) });
+#pragma warning disable 0618 // Retain until Date is removed
 			var textColorContainer = new ViewContainer<DatePicker>(Test.DatePicker.TextColor,
 				new DatePicker { Date = new DateTime(1978, 12, 24), TextColor = Color.Lime });
+#pragma warning restore
 			var fontAttributesContainer = new ViewContainer<DatePicker>(Test.DatePicker.FontAttributes,
 				new DatePicker { FontAttributes = FontAttributes.Bold });
 
@@ -48,6 +59,8 @@ namespace Xamarin.Forms.Controls
 
 			Add(dateContainer);
 			Add(dateSelectedContainer);
+			Add(selectedDateContainer);
+			Add(selectedDateChangedContainer);
 			Add(formatDateContainer);
 			Add(minimumDateContainer);
 			Add(maximumDateContainer);

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/CodeOnlyExample.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/CodeOnlyExample.cs
@@ -10,11 +10,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
 
 			var calendar = new DatePicker();
 
-			VisualStateManager.SetVisualStateGroups(calendar, new VisualStateGroupList { SetUpMonths() }); 
+			VisualStateManager.SetVisualStateGroups(calendar, new VisualStateGroupList { SetUpMonths() });
 
+#pragma warning disable 0618 // Retain until Date is removed
 			calendar.DateSelected += CalendarOnDateSelected;
 			calendar.Date = new DateTime(2017, 12, 25);
-			
+#pragma warning restore
 			layout.Children.Add(calendar);
 
 			var context = new Label { Text = "The DatePicker above changes its colors based on the selected date's month. The colors are all VisualStates created and added in code." };

--- a/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
@@ -39,8 +39,10 @@ namespace Xamarin.Forms.Core.UnitTests
 			picker.Date = new DateTime (2050, 1, 1);
 
 			Assert.AreEqual (new DateTime (2050, 1, 1), picker.Date);
+			Assert.AreEqual(new DateTime(2050, 1, 1), picker.SelectedDate);
 
 			bool dateChanged = false;
+			bool selectedDateChanged = false;
 			bool maximumDateChanged = false;
 			picker.PropertyChanged += (sender, e) => {
 				switch (e.PropertyName) {
@@ -51,6 +53,10 @@ namespace Xamarin.Forms.Core.UnitTests
 					dateChanged = true;
 					Assert.IsFalse (maximumDateChanged);
 					break;
+				case nameof(DatePicker.SelectedDate):
+					selectedDateChanged = true;
+					Assert.IsFalse(maximumDateChanged);
+					break;
 				}
 			};
 
@@ -59,10 +65,54 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.IsTrue (maximumDateChanged);
 			Assert.IsTrue (dateChanged);
+			Assert.IsTrue (selectedDateChanged);
 
 			Assert.AreEqual (newDate, picker.MaximumDate);
 			Assert.AreEqual (newDate, picker.Date);
+			Assert.AreEqual (newDate, picker.SelectedDate);
 			Assert.AreEqual (picker.MaximumDate, picker.Date);
+		}
+
+		[Test]
+		public void SelectedDateShouldStayNullWhenMaximumDateIsChanged()
+		{
+			DatePicker picker = new DatePicker();
+			picker.SelectedDate = null;
+			Assert.IsNull(picker.SelectedDate);
+
+			var newDate = ((DateTime)DatePicker.MinimumDateProperty.DefaultValue).AddDays(1);
+			Assert.IsTrue(picker.Date > newDate);
+
+			bool dateChanged = false;
+			bool selectedDateChanged = false;
+			bool maximumDateChanged = false;
+			picker.PropertyChanged += (sender, e) => {
+				switch (e.PropertyName)
+				{
+					case nameof(DatePicker.MaximumDate):
+						maximumDateChanged = true;
+						break;
+					case nameof(DatePicker.Date):
+						dateChanged = true;
+						Assert.IsFalse(maximumDateChanged);
+						break;
+					case nameof(DatePicker.SelectedDate):
+						selectedDateChanged = true;
+						Assert.IsFalse(maximumDateChanged);
+						break;
+				}
+			};
+
+			picker.MaximumDate = newDate;
+
+			Assert.IsTrue(maximumDateChanged);
+			Assert.IsTrue(dateChanged);
+			Assert.IsFalse(selectedDateChanged);
+
+			Assert.AreEqual(newDate, picker.MaximumDate);
+			Assert.AreEqual(newDate, picker.Date);
+			Assert.IsNull(picker.SelectedDate);
+			Assert.AreEqual(picker.MaximumDate, picker.Date);
 		}
 
 		[Test]
@@ -75,6 +125,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (new DateTime (1950, 1, 1), picker.Date);
 			
 			bool dateChanged = false;
+			bool selectedDateChanged = false;
 			bool minimumDateChanged = false;
 			picker.PropertyChanged += (sender, e) => {
 				switch (e.PropertyName) {
@@ -85,6 +136,10 @@ namespace Xamarin.Forms.Core.UnitTests
 					dateChanged = true;
 					Assert.IsFalse (minimumDateChanged);
 					break;
+				case nameof(DatePicker.SelectedDate):
+					selectedDateChanged = true;
+					Assert.IsFalse(minimumDateChanged);
+					break;
 				}
 			};
 			
@@ -93,10 +148,54 @@ namespace Xamarin.Forms.Core.UnitTests
 			
 			Assert.IsTrue (minimumDateChanged);
 			Assert.IsTrue (dateChanged);
-			
+			Assert.IsTrue (selectedDateChanged);
+
 			Assert.AreEqual (newDate, picker.MinimumDate);
 			Assert.AreEqual (newDate, picker.Date);
+			Assert.AreEqual (newDate, picker.SelectedDate);
 			Assert.AreEqual (picker.MinimumDate, picker.Date);
+		}
+
+		[Test]
+		public void SelectedDateShouldStayNullWhenMinimumDateIsChanged()
+		{
+			DatePicker picker = new DatePicker();
+			picker.SelectedDate = null;
+			Assert.IsNull(picker.SelectedDate);
+
+			var newDate = ((DateTime)DatePicker.MaximumDateProperty.DefaultValue).AddDays(-1);
+			Assert.IsTrue(picker.Date < newDate);
+
+			bool dateChanged = false;
+			bool selectedDateChanged = false;
+			bool minDateChanged = false;
+			picker.PropertyChanged += (sender, e) => {
+				switch (e.PropertyName)
+				{
+					case nameof(DatePicker.MinimumDate):
+						minDateChanged = true;
+						break;
+					case nameof(DatePicker.Date):
+						dateChanged = true;
+						Assert.IsFalse(minDateChanged);
+						break;
+					case nameof(DatePicker.SelectedDate):
+						selectedDateChanged = true;
+						Assert.IsFalse(minDateChanged);
+						break;
+				}
+			};
+
+			picker.MinimumDate = newDate;
+
+			Assert.IsTrue(minDateChanged);
+			Assert.IsTrue(dateChanged);
+			Assert.IsFalse(selectedDateChanged);
+
+			Assert.AreEqual(newDate, picker.MinimumDate);
+			Assert.AreEqual(newDate, picker.Date);
+			Assert.IsNull(picker.SelectedDate);
+			Assert.AreEqual(picker.MinimumDate, picker.Date);
 		}
 
 		[Test]
@@ -107,10 +206,30 @@ namespace Xamarin.Forms.Core.UnitTests
 			picker.Date = new DateTime (1500, 1, 1);
 
 			Assert.AreEqual (picker.MinimumDate, picker.Date);
+			Assert.AreEqual (picker.MinimumDate, picker.SelectedDate);
 
 			picker.Date = new DateTime (2500, 1, 1);
 
 			Assert.AreEqual (picker.MaximumDate, picker.Date);
+			Assert.AreEqual (picker.MaximumDate, picker.SelectedDate);
+		}
+
+		[Test]
+		public void TestDateClampingWhenSelectedDateIsNull()
+		{
+			DatePicker picker = new DatePicker();
+
+			picker.Date = new DateTime(1500, 1, 1);
+			picker.SelectedDate = null;
+
+			Assert.AreEqual(picker.MinimumDate, picker.Date);
+			Assert.IsNull(picker.SelectedDate);
+
+			picker.Date = new DateTime(2500, 1, 1);
+			picker.SelectedDate = null;
+
+			Assert.AreEqual(picker.MaximumDate, picker.Date);
+			Assert.IsNull(picker.SelectedDate);
 		}
 
 		[Test]
@@ -119,12 +238,32 @@ namespace Xamarin.Forms.Core.UnitTests
 			var picker = new DatePicker ();
 
 			bool selected = false;
+			bool selectedDateChanged = false;
 			picker.DateSelected += (sender, arg) => selected = true;
+			picker.SelectedDateChanged += (sender, arg) => selectedDateChanged = true;
 
 			// we can be fairly sure it wont ever be 2008 again
 			picker.Date = new DateTime (2008, 5, 5);
 
 			Assert.True (selected);
+			Assert.True (selectedDateChanged);
+		}
+
+		[Test]
+		public void TestSelectedDate()
+		{
+			var picker = new DatePicker();
+
+			bool selected = false;
+			bool selectedDateChanged = false;
+			picker.DateSelected += (sender, arg) => selected = true;
+			picker.SelectedDateChanged += (sender, arg) => selectedDateChanged = true;
+
+			// we can be fairly sure it wont ever be 2008 again
+			picker.SelectedDate = new DateTime(2008, 5, 5);
+
+			Assert.True(selected);
+			Assert.True(selectedDateChanged);
 		}
 
 		public static object[] DateTimes = {
@@ -156,6 +295,29 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (finalDate, newDate);
 		}
 
+		[Test, TestCaseSource("DateTimes")]
+		public void DatePickerDateSelectedEventArgs(DateTime initialDate, DateTime finalDate)
+		{
+			var datePicker = new DatePicker();
+			datePicker.Date = initialDate;
+
+			DatePicker pickerFromSender = null;
+			DateTime? oldDate = new DateTime();
+			DateTime? newDate = new DateTime();
+
+			datePicker.SelectedDateChanged += (s, e) => {
+				pickerFromSender = (DatePicker)s;
+				oldDate = e.OldDate;
+				newDate = e.NewDate;
+			};
+
+			datePicker.SelectedDate = finalDate;
+
+			Assert.AreEqual(datePicker, pickerFromSender);
+			Assert.AreEqual(initialDate, oldDate);
+			Assert.AreEqual(finalDate, newDate);
+		}
+
 		[Test]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=32144
 		public void SetNullValueDoesNotThrow ()
@@ -163,6 +325,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var datePicker = new DatePicker ();
 			Assert.DoesNotThrow (() => datePicker.SetValue (DatePicker.DateProperty, null));
 			Assert.AreEqual (DateTime.Today, datePicker.Date);
+			Assert.AreEqual (DateTime.Today, datePicker.SelectedDate);
 		}
 
 		[Test]
@@ -173,6 +336,37 @@ namespace Xamarin.Forms.Core.UnitTests
 			DateTime? nullableDateTime = dateTime;
 			datePicker.SetValue (DatePicker.DateProperty, nullableDateTime);
 			Assert.AreEqual (dateTime, datePicker.Date);
+			Assert.AreEqual (dateTime, datePicker.SelectedDate);
+		}
+
+		[Test]
+		public void SelectedDateIsSyncedWithDate()
+		{
+			var dp = new DatePicker();
+			Assert.AreEqual (dp.SelectedDate, dp.Date);
+
+			dp = new DatePicker();
+			dp.Date = dp.Date.AddDays(1);
+			Assert.AreEqual(dp.SelectedDate, dp.Date);
+
+			dp = new DatePicker();
+			dp.SelectedDate = dp.SelectedDate?.AddDays(1);
+			Assert.AreEqual(dp.SelectedDate, dp.Date);
+
+			// Setting a new SelectedDate after SelectedDate was null
+			dp = new DatePicker();
+			DateTime dateTime = dp.Date;
+			dp.SelectedDate = null;
+			Assert.AreEqual(dateTime, dp.Date);
+
+			dp.SelectedDate = dateTime.AddDays(1);
+			Assert.AreEqual(dp.SelectedDate, dp.Date);
+
+			// Setting a new Date after SelectedDate was null
+			dp = new DatePicker();
+			dp.SelectedDate = null;
+			dp.Date = dp.Date.AddDays(1);
+			Assert.AreEqual(dp.SelectedDate, dp.Date);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/SelectedDateChangedEventArgs.cs
+++ b/Xamarin.Forms.Core/SelectedDateChangedEventArgs.cs
@@ -1,0 +1,16 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	public class SelectedDateChangedEventArgs : EventArgs
+	{
+		public DateTime? OldDate { get; }
+		public DateTime? NewDate { get; }
+
+		public SelectedDateChangedEventArgs(DateTime? oldDate, DateTime? newDate)
+		{
+			OldDate = oldDate;
+			NewDate = newDate;
+		}
+	}
+}

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -480,8 +480,10 @@ namespace Xamarin.Forms.CustomAttributes
 		public enum DatePicker
 		{
 			DateSelected,
+			SelectedDateChanged,
 			Format,
 			Date,
+			SelectedDate,
 			MinimumDate,
 			MaximumDate,
 			Focus,

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Platform.Android
 				_originalHintTextColor = EditText.CurrentHintTextColor;
 			}
 
-			SetDate(Element.Date);
+			UpdateDisplayedDate();
 
 			UpdateFont();
 			UpdateMinimumDate();
@@ -76,9 +76,8 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-
-			if (e.PropertyName == DatePicker.DateProperty.PropertyName || e.PropertyName == DatePicker.FormatProperty.PropertyName)
-				SetDate(Element.Date);
+			if (e.PropertyName == DatePicker.SelectedDateProperty.PropertyName || e.PropertyName == DatePicker.FormatProperty.PropertyName)
+				UpdateDisplayedDate();
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
 				UpdateMinimumDate();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
@@ -112,7 +111,7 @@ namespace Xamarin.Forms.Platform.Android
 			DatePicker view = Element;
 			var dialog = new DatePickerDialog(Context, (o, e) =>
 			{
-				view.Date = e.Date;
+				view.SelectedDate = e.Date;
 				((IElementController)view).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 			}, year, month, day);
 
@@ -144,8 +143,10 @@ namespace Xamarin.Forms.Platform.Android
 
 			DatePicker view = Element;
 			((IElementController)view).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
-
+	
+#pragma warning disable 0618
 			ShowPickerDialog(view.Date.Year, view.Date.Month - 1, view.Date.Day);
+#pragma warning restore
 		}
 
 		void ShowPickerDialog(int year, int month, int day)
@@ -165,9 +166,9 @@ namespace Xamarin.Forms.Platform.Android
 			Element.Unfocus();
 		}
 
-		void SetDate(DateTime date)
+		void UpdateDisplayedDate()
 		{
-			EditText.Text = date.ToString(Element.Format);
+			EditText.Text = Element.SelectedDate?.ToString(Element.Format);
 		}
 
 		void UpdateFont()

--- a/Xamarin.Forms.Platform.GTK/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/DatePickerRenderer.cs
@@ -33,8 +33,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 					datePicker.DateChanged += OnDateChanged;
 					SetNativeControl(datePicker);
 				}
-
+#pragma warning disable 0618
 				UpdateDate(e.NewElement.Date);
+#pragma warning restore
 				UpdateMaximumDate();
 				UpdateMinimumDate();
 				UpdateTextColor();
@@ -47,9 +48,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-
-			if (e.PropertyName == DatePicker.DateProperty.PropertyName)
+#pragma warning disable 0618
+			if (e.PropertyName == DatePicker.DateProperty.PropertyName ||
+				e.PropertyName == DatePicker.SelectedDateProperty.PropertyName)
 				UpdateDate(Element.Date);
+#pragma warning restore
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
 				UpdateMinimumDate();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
@@ -134,7 +137,9 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		private void OnDateChanged(object sender, EventArgs e)
 		{
+#pragma warning disable 0618
 			ElementController?.SetValueFromRenderer(DatePicker.DateProperty, Control.CurrentDate.Date);
+#pragma warning restore
 		}
 
 		private bool OpenPicker()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
@@ -47,8 +47,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-
+#pragma warning disable 0618
 			if (e.PropertyName == DatePicker.DateProperty.PropertyName ||
+#pragma warning restore
 				e.PropertyName == DatePicker.FormatProperty.PropertyName)
 				UpdateDateFromModel();
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
@@ -101,16 +102,19 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Control == null || Element == null)
 				return;
-
+#pragma warning disable 0618
 			ElementController?.SetValueFromRenderer(DatePicker.DateProperty, e.ProposedDateValue.ToDateTime().Date);
+#pragma warning restore
 		}
 
 		void UpdateDateFromModel()
 		{
 			if (Control == null || Element == null)
 				return;
+#pragma warning disable 0618
 			if (_picker.DateValue.ToDateTime().Date != Element.Date.Date)
 				_picker.DateValue = Element.Date.ToNSDate();
+#pragma warning restore
 		}
 
 		void UpdateFont()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		public DatePickerRenderer()
 		{
-			RegisterPropertyHandler(DatePicker.DateProperty, UpdateDate);
+			RegisterPropertyHandler(DatePicker.SelectedDateProperty, UpdateDate);
 			RegisterPropertyHandler(DatePicker.FormatProperty, UpdateDate);
 			RegisterPropertyHandler(DatePicker.TextColorProperty, UpdateTextColor);
 			RegisterPropertyHandler(DatePicker.FontAttributesProperty, UpdateFontAttributes);
@@ -86,7 +86,9 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Element.IsEnabled)
 			{
 				var dialog = _lazyDialog.Value;
+#pragma warning disable 0618
 				dialog.Picker.DateTime = Element.Date;
+#pragma warning restore
 				dialog.Picker.MaximumDateTime = Element.MaximumDate;
 				dialog.Picker.MinimumDateTime = Element.MinimumDate;
 				// You need to call Show() after ui thread occupation because of EFL problem.
@@ -97,13 +99,13 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void OnDateTimeChanged(object sender, Native.DateChangedEventArgs dcea)
 		{
-			Element.Date = dcea.NewDate;
+			Element.SelectedDate = dcea.NewDate;
 			Control.Text = dcea.NewDate.ToString(Element.Format);
 		}
 
 		void UpdateDate()
 		{
-			Control.Text = Element.Date.ToString(Element.Format);
+			Control.Text = Element.SelectedDate?.ToString(Element.Format);
 		}
 
 		void UpdateTextColor()

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -43,7 +43,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 				UpdateMinimumDate();
 				UpdateMaximumDate();
+#pragma warning disable 0618
 				UpdateDate(e.NewElement.Date);
+#pragma warning restore
 				UpdateFlowDirection();
 			}
 
@@ -80,8 +82,10 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == DatePicker.DateProperty.PropertyName)
+#pragma warning disable 0618
+			if (e.PropertyName == DatePicker.DateProperty.PropertyName || e.PropertyName == DatePicker.SelectedDateProperty.PropertyName)
 				UpdateDate(Element.Date);
+#pragma warning restore
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
@@ -100,12 +104,14 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (Element == null)
 				return;
-
+#pragma warning disable 0618
 			if (Element.Date.CompareTo(e.NewDate.Date) != 0)
+#pragma warning restore
 			{
 				var date = e.NewDate.Date.Clamp(Element.MinimumDate, Element.MaximumDate);
+#pragma warning disable 0618
 				Element.Date = date;
-
+#pragma warning restore
 				// set the control date-time to clamped value, if it exceeded the limits at the time of installation.
 				if (date != e.NewDate.Date)
 				{

--- a/Xamarin.Forms.Platform.WPF/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/DatePickerRenderer.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == DatePicker.DateProperty.PropertyName)
+			if (e.PropertyName == DatePicker.SelectedDateProperty.PropertyName)
 				UpdateDate();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
 				UpdateMaximumDate();
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.WPF
 		
 		void UpdateDate()
 		{
-			Control.SelectedDate = Element.Date;
+			Control.SelectedDate = Element.SelectedDate;
 		}
 
 		void UpdateMaximumDate()
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.WPF
 		void OnNativeSelectedDateChanged(object sender, System.Windows.Controls.SelectionChangedEventArgs e)
 		{
 			if (Control.SelectedDate.HasValue)
-				((IElementController)Element).SetValueFromRenderer(DatePicker.DateProperty, Control.SelectedDate.Value);
+				((IElementController)Element).SetValueFromRenderer(DatePicker.SelectedDateProperty, Control.SelectedDate.Value);
 		}
 
 		bool _isDisposed;

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -95,8 +95,11 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-
-			if (e.PropertyName == DatePicker.DateProperty.PropertyName || e.PropertyName == DatePicker.FormatProperty.PropertyName)
+#pragma warning disable 0618
+			if (e.PropertyName == DatePicker.DateProperty.PropertyName ||
+#pragma warning restore
+				e.PropertyName == DatePicker.SelectedDateProperty.PropertyName ||
+				e.PropertyName == DatePicker.FormatProperty.PropertyName)
 				UpdateDateFromModel(true);
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
 				UpdateMinimumDate();
@@ -112,7 +115,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HandleValueChanged(object sender, EventArgs e)
 		{
-			ElementController?.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
+			ElementController?.SetValueFromRenderer(DatePicker.SelectedDateProperty, _picker.Date.ToDateTime().Date);
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
@@ -127,10 +130,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateDateFromModel(bool animate)
 		{
+#pragma warning disable 0618
 			if (_picker.Date.ToDateTime().Date != Element.Date.Date)
 				_picker.SetDate(Element.Date.ToNSDate(), animate);
-
-			Control.Text = Element.Date.ToString(Element.Format);
+#pragma warning restore
+			Control.Text = Element.SelectedDate?.ToString(Element.Format);
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Xaml.UnitTests/BuiltInConversions.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/BuiltInConversions.xaml.cs
@@ -37,9 +37,12 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void Datetime (bool useCompiledXaml)
 			{
 				var layout = new BuiltInConversions (useCompiledXaml);
-
+#pragma warning disable 0618 // Retain until Date is removed
 				Assert.AreEqual (new DateTime (2015, 01, 16), layout.datetime0.Date);
 				Assert.AreEqual (new DateTime (2015, 01, 16), layout.datetime1.Date);
+#pragma warning restore
+				Assert.AreEqual(new DateTime(2015, 01, 16), layout.datetime0.SelectedDate);
+				Assert.AreEqual(new DateTime(2015, 01, 16), layout.datetime1.SelectedDate);
 			}
 
 			[TestCase(false)]

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported008.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Unreported008.xaml.cs
@@ -36,7 +36,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			{
 				var page = new Unreported008(useCompiledXaml);
 				var picker = page.picker0;
+#pragma warning disable 0618 // Retain until Date is removed
 				Assert.AreEqual(DateTime.Today, picker.Date.Date);
+#pragma warning restore
+				Assert.AreEqual(DateTime.Today, picker.SelectedDate);
 				Assert.AreEqual(new DateTime(2000, 1, 1), picker.MinimumDate);
 				Assert.AreEqual(new DateTime(2050, 12, 31), picker.MaximumDate);
 			}


### PR DESCRIPTION
### Description of Change ###

Add nullable DateTime property to DatePicker.

Please see the [comment ](https://github.com/xamarin/Xamarin.Forms/pull/6947#issuecomment-514321150 )below for detailed description of the behavior

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #3728 

### API Changes ###


Added:
 - DateTime? DatePicker.SelectedDate { get; set; } //Bindable Property
 - event DatePicker.SelectedDateChanged;

Obsoleted:
 - object DatePicker.Date { get; set; }
 - event DatePicker.DateSelected; 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
