### PR TITLE
 [iOS] Reset anchor point before reapplying transforms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6945.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6945.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6945, "[iOS] Wrong anchor behavior when setting HeightRequest ",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue6946 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var boxView = new BoxView()
+			{
+				AnchorX = 0,
+				AnchorY = 0,
+				HeightRequest = 150,
+				WidthRequest = 150,
+				Color = Color.Red,
+				TranslationX = 101,
+				TranslationY = 201,
+				AutomationId = "BoxViewId"
+			};
+
+			Button button = new Button()
+			{
+				Text = "Click Me. Box X/Y position should not change",
+				TranslationY = 171,
+				TranslationX = 0,
+				Command = new Command(() =>
+				{
+					boxView.HeightRequest = 160;
+				}),
+				AutomationId = "ClickMeId"
+			};
+
+			Content =
+				new AbsoluteLayout()
+				{
+					Children =
+					{
+						boxView,
+						button
+					}
+				};
+		}
+
+
+#if UITEST
+		[Test]
+		public void WrongTranslationBehaviorWhenChangingHeightRequestAndSettingAnchor()
+		{
+			var rect = RunningApp.WaitForElement("BoxViewId")[0].Rect;
+			RunningApp.Tap("ClickMeId");
+			var rect2 = RunningApp.WaitForElement("BoxViewId")[0].Rect;
+
+			Assert.AreEqual(rect.X, rect2.X);
+			Assert.AreEqual(rect.Y, rect2.Y);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6945.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6945.cs
@@ -22,6 +22,9 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class Issue6946 : TestContentPage
 	{
+		const string ClickMeId = "ClickMeAutomationId";
+		const string BoxViewId = "BoxViewAutomationId";
+
 		protected override void Init()
 		{
 			var boxView = new BoxView()
@@ -33,7 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Color = Color.Red,
 				TranslationX = 101,
 				TranslationY = 201,
-				AutomationId = "BoxViewId"
+				AutomationId = BoxViewId
 			};
 
 			Button button = new Button()
@@ -45,7 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					boxView.HeightRequest = 160;
 				}),
-				AutomationId = "ClickMeId"
+				AutomationId = ClickMeId
 			};
 
 			Content =
@@ -64,9 +67,9 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void WrongTranslationBehaviorWhenChangingHeightRequestAndSettingAnchor()
 		{
-			var rect = RunningApp.WaitForElement("BoxViewId")[0].Rect;
-			RunningApp.Tap("ClickMeId");
-			var rect2 = RunningApp.WaitForElement("BoxViewId")[0].Rect;
+			var rect = RunningApp.WaitForElement(BoxViewId)[0].Rect;
+			RunningApp.Tap(ClickMeId);
+			var rect2 = RunningApp.WaitForElement(BoxViewId)[0].Rect;
 
 			Assert.AreEqual(rect.X, rect2.X);
 			Assert.AreEqual(rect.Y, rect2.Y);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6945.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">
       <DependentUpon>Issue5046.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using System.Threading;
 using CoreAnimation;
+using CoreGraphics;
 using Xamarin.Forms.Internals;
 #if __MOBILE__
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -29,6 +30,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		Rectangle _lastParentBounds;
 #endif
 		CALayer _layer;
+		CGPoint _originalAnchor;
 		int _updateCount;
 
 		public VisualElementTracker(IVisualElementRenderer renderer) : this(renderer, true)
@@ -241,6 +243,9 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 
 					// must reset transform prior to setting frame...
+					if(caLayer.AnchorPoint != _originalAnchor)
+						caLayer.AnchorPoint = _originalAnchor;
+
 					caLayer.Transform = transform;
 					uiview.Frame = target;
 					if (shouldRelayoutSublayers)
@@ -348,6 +353,8 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 				_isInteractive = Renderer.NativeView.UserInteractionEnabled;
 #endif
+
+				_originalAnchor = _layer.AnchorPoint;
 			}
 
 			OnUpdateNativeControl(_layer);


### PR DESCRIPTION
### Description of Change ###
At the beginning of a transform cycle the transform on the iOS CALayer would get reset to 0 but it wasn't resetting the anchor. This was causing the Identity transform to layout the view relative to whatever the anchor was changed to. This PR resets the anchor back to default when it starts the transform pass.

### Issues Resolved ### 
- fixes #6945 
- fixes #5610

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- UI test included
- Test additional transformations like scale and rotate to make sure they still all work

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard