### PR TITLE
[Xamarin.Forms][Android] Pressing Volume up/down hardware buttons on pickers opens them

### DIFF
--- a/Xamarin.Forms.Platform.Android/PickerManager.cs
+++ b/Xamarin.Forms.Platform.Android/PickerManager.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		static void OnKeyPress(object sender, AView.KeyEventArgs e)
 		{
-			if (availableKeys.Contains(e.KeyCode))
+			if (!availableKeys.Contains(e.KeyCode))
 			{
 				e.Handled = false;
 				return;


### PR DESCRIPTION
### Description of Change ###

IMO the check that detects which buttons should trigger the picker to open was inverted causing the volume buttons (among others) to open the picker wrongfully.

Since this is tied to actually pressing a physical button automated tests are absent.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5960

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Picker is only opened with the buttons defined in the `PickerManager.cs` file

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Go to the Gallery app Picker section on a physical device, focus a Picker control and press the volume up and down buttons.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
