### PR TITLE
In macOS Mojave, navigation bar title text is not centered

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
@@ -140,7 +140,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				AllowsUserCustomization = false,
 				ShowsBaselineSeparator = true,
 				SizeMode = NSToolbarSizeMode.Regular,
-				Delegate = this
+				Delegate = this,
+				CenteredItemIdentifier = TitleGroupIdentifier
 			};
 
 			return toolbar;
@@ -325,16 +326,15 @@ namespace Xamarin.Forms.Platform.MacOS
 			_titleGroup.Group.MinSize = new CGSize(NavigationTitleMinSize, ToolbarHeight);
 			_titleGroup.Group.Subitems = new NSToolbarItem[] { item };
 			view.AddSubview(titleField);
+
+			titleField.CenterXAnchor.ConstraintEqualToAnchor(view.CenterXAnchor).Active = true;
+			titleField.CenterYAnchor.ConstraintEqualToAnchor(view.CenterYAnchor).Active = true;
+			titleField.TranslatesAutoresizingMaskIntoConstraints = false;
+			view.TranslatesAutoresizingMaskIntoConstraints = false;
+
 			_titleGroup.Group.View = view;
 			//save a reference so we can paint this for the background
 			_nsToolbarItemViewer = _titleGroup.Group.View.Superview;
-			if (_nsToolbarItemViewer == null)
-				return;
-			//position is hard .. we manually set the title to be centered 
-			var totalWidth = _nsToolbarItemViewer.Superview.Frame.Width;
-			var fieldWidth = titleField.Frame.Width;
-			var x = ((totalWidth - fieldWidth) / 2) - _nsToolbarItemViewer.Frame.X;
-			titleField.Frame = new CGRect(x, 0, fieldWidth, ToolbarHeight);
 		}
 
 		void UpdateToolbarItems()


### PR DESCRIPTION
### Description of Change ###
Made title centered.

### Issues Resolved ### 
- fixes #5575

### API Changes ###
None

### Platforms Affected ### 
macOs

### Behavioral/Visual Changes ###
macOS title became centered 

### Before/After Screenshots ### 
Check "before" screenshot in original issue ticket please

Now:
![5d3a1d8664caa948420280](https://user-images.githubusercontent.com/10124814/61910035-34307400-af3c-11e9-9e60-0d946de5ae53.gif)


### Testing Procedure ###
Run macOS samples and check title's behavior

P.S. @davidortinau *challenge* https://twitter.com/Andrik_Just4Fun/status/1154482058229624832