### PR TITLE
[macOS] Switch focus on TAB pressed

### DIFF
--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -205,7 +205,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 #if __MACOS__
-		public override void KeyUp(NSEvent theEvent)
+		public override void KeyDown(NSEvent theEvent)
 		{
 			if (theEvent.KeyCode == (ushort)NSKey.Tab)
 			{


### PR DESCRIPTION
### Description of Change ###
Tab switching hasn't been working.

The problem is that macOS switched views itself. And KeyUp is called by NEXT view. 
+ it doesn't make sense to switch focus on UP event. Because native behavior is switching on KeyDown

### Issues Resolved ### 
- fixes #6074
- related #6671

### API Changes ###
None

### Platforms Affected ### 
macOS

### Behavioral/Visual Changes ###
Switching via tab seems to be working

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Run any sample with entries / editors etc. and try to switch views with Tab and Shift+Tab
