### PR TITLE
Cache Droid SDK ver

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -202,7 +202,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if(Drawable != null)
 			{
-				if ((int)Build.VERSION.SdkInt >= 18 && backgroundDrawable != null)
+				if ((int)Forms.SdkInt >= 18 && backgroundDrawable != null)
 				{
 					var outlineBounds = backgroundDrawable.GetPaddingBounds(canvas.Width, canvas.Height);
 					var width = (float)MeasuredWidth;

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -417,7 +417,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (tabs.Visibility != ViewStates.Gone)
 				{
 					//MinimumHeight is only available on API 16+
-					if ((int)Build.VERSION.SdkInt >= 16)
+					if ((int)Forms.SdkInt >= 16)
 						tabsHeight = Math.Min(height, Math.Max(tabs.MeasuredHeight, tabs.MinimumHeight));
 					else
 						tabsHeight = Math.Min(height, tabs.MeasuredHeight);

--- a/Xamarin.Forms.Platform.Android/BorderBackgroundManager.cs
+++ b/Xamarin.Forms.Platform.Android/BorderBackgroundManager.cs
@@ -127,7 +127,7 @@ namespace Xamarin.Forms.Platform.Android
 					shadowColor = _backgroundDrawable.PressedBackgroundColor.ToAndroid();
 				}
 				// Otherwise get values from the control (but only for supported APIs)
-				else if ((int)Build.VERSION.SdkInt >= 16)
+				else if ((int)Forms.SdkInt >= 16)
 				{
 					shadowRadius = _renderer.ShadowRadius;
 					shadowDy = _renderer.ShadowDy;

--- a/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/BaseCellView.cs
@@ -83,7 +83,7 @@ namespace Xamarin.Forms.Platform.Android
 			SetMinimumHeight((int)context.ToPixels(DefaultMinHeight));
 			_androidDefaultTextColor = Color.FromUint((uint)_mainText.CurrentTextColor);
 
-			if ((int)Build.VERSION.SdkInt > 16)
+			if ((int)Forms.SdkInt > 16)
 			{
 				_mainText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
 				_detailText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;

--- a/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
@@ -97,7 +97,7 @@ namespace Xamarin.Forms.Platform.Android
 					}
 					else
 					{
-						if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
+						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
 						{
 							aSwitch.TrackDrawable.SetColorFilter(switchCell.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
 						}

--- a/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static void UpdateFlowDirection(this AView view, IVisualElementController controller)
 		{
-			if (view == null || controller == null || (int)Build.VERSION.SdkInt < 17)
+			if (view == null || controller == null || (int)Forms.SdkInt < 17)
 				return;
 
 			// if android:targetSdkVersion < 17 setting these has no effect

--- a/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ScrollViewExtensions.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		internal static void HandleScrollBarVisibilityChange(this IScrollView scrollView)
 		{
-			if (Build.VERSION.SdkInt <= BuildVersionCodes.Kitkat)
+			if (Forms.SdkInt <= BuildVersionCodes.Kitkat)
 				return;
 
 			// According to the Android Documentation

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -73,12 +73,9 @@ namespace Xamarin.Forms
 
 		internal static BuildVersionCodes SdkInt {
 			get {
-				lock (s_lock)
-				{
-					if (!s_sdkInt.HasValue)
-						s_sdkInt = Build.VERSION.SdkInt;
-					return (BuildVersionCodes)s_sdkInt;
-				}
+				if (!s_sdkInt.HasValue)
+					s_sdkInt = Build.VERSION.SdkInt;
+				return (BuildVersionCodes)s_sdkInt;
 			}
 		}
 		internal static bool IsLollipopOrNewer

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Forms
 
 		const int TabletCrossover = 600;
 
+		static BuildVersionCodes? s_sdkInt;
 		static bool? s_isLollipopOrNewer;
 		static bool? s_isMarshmallowOrNewer;
 
@@ -70,12 +71,22 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
+		internal static BuildVersionCodes SdkInt {
+			get {
+				lock (s_lock)
+				{
+					if (!s_sdkInt.HasValue)
+						s_sdkInt = Build.VERSION.SdkInt;
+					return (BuildVersionCodes)s_sdkInt;
+				}
+			}
+		}
 		internal static bool IsLollipopOrNewer
 		{
 			get
 			{
 				if (!s_isLollipopOrNewer.HasValue)
-					s_isLollipopOrNewer = (int)Build.VERSION.SdkInt >= 21;
+					s_isLollipopOrNewer = (int)SdkInt >= 21;
 				return s_isLollipopOrNewer.Value;
 			}
 		}
@@ -85,7 +96,7 @@ namespace Xamarin.Forms
 			get
 			{
 				if (!s_isMarshmallowOrNewer.HasValue)
-					s_isMarshmallowOrNewer = (int)Build.VERSION.SdkInt >= 23;
+					s_isMarshmallowOrNewer = (int)SdkInt >= 23;
 				return s_isMarshmallowOrNewer.Value;
 			}
 		}
@@ -307,7 +318,7 @@ namespace Xamarin.Forms
 			int minWidthDp = activity.Resources.Configuration.SmallestScreenWidthDp;
 			Device.SetIdiom(minWidthDp >= TabletCrossover ? TargetIdiom.Tablet : TargetIdiom.Phone);
 
-			if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
+			if (SdkInt >= BuildVersionCodes.JellyBeanMr1)
 				Device.SetFlowDirection(activity.Resources.Configuration.LayoutDirection.ToFlowDirection());
 
 			if (ExpressionSearch.Default == null)
@@ -355,7 +366,7 @@ namespace Xamarin.Forms
 				{
 					// Detect if legacy device and use appropriate accent color
 					// Hardcoded because could not get color from the theme drawable
-					var sdkVersion = (int)Build.VERSION.SdkInt;
+					var sdkVersion = (int)SdkInt;
 					if (sdkVersion <= 10)
 					{
 						// legacy theme button pressed color

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1138,7 +1138,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal static int GenerateViewId()
 		{
 			// getting unique Id's is an art, and I consider myself the Jackson Pollock of the field
-			if ((int)Build.VERSION.SdkInt >= 17)
+			if ((int)Forms.SdkInt >= 17)
 				return global::Android.Views.View.GenerateViewId();
 
 			// Numbers higher than this range reserved for xml

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.Android
 			l += (width - squareSize) / 2;
 			t += (height - squareSize) / 2;
 			int strokeWidth;
-			if (Build.VERSION.SdkInt < BuildVersionCodes.N)
+			if (Forms.SdkInt < BuildVersionCodes.N)
 				strokeWidth = squareSize / _paddingRatio23;
 			else
 				strokeWidth = squareSize / _paddingRatio;

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			EditText.SetSingleLine(false);
 			EditText.Gravity = GravityFlags.Top;
-			if ((int)Build.VERSION.SdkInt > 16)
+			if ((int)Forms.SdkInt > 16)
 				EditText.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
 			EditText.SetHorizontallyScrolling(false);
 

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Forms.Platform.Android
 		void IOrderedTraversalController.UpdateTraversalOrder()
 		{
 			// traversal order wasn't added until API 22
-			if ((int)Build.VERSION.SdkInt < 22)
+			if ((int)Forms.SdkInt < 22)
 				return;
 
 			// since getting and updating the traversal order is expensive, let's only do it when a screen reader is active

--- a/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				if (Build.VERSION.SdkInt < BuildVersionCodes.Lollipop)
+				if (Forms.SdkInt < BuildVersionCodes.Lollipop)
 				{
 					(Control.Indeterminate ? Control.IndeterminateDrawable :
 						Control.ProgressDrawable).SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.Android
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
 			var sizerequest = base.GetDesiredSize(widthConstraint, heightConstraint);
-			if (Build.VERSION.SdkInt == BuildVersionCodes.N && heightConstraint == 0 && sizerequest.Request.Height == 0)
+			if (Forms.SdkInt == BuildVersionCodes.N && heightConstraint == 0 && sizerequest.Request.Height == 0)
 			{
 				sizerequest.Request = new Size(sizerequest.Request.Width, _defaultHeight);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.Android
 				seekBar.Max = 1000;
 				seekBar.SetOnSeekBarChangeListener(this);
 
-				if (Build.VERSION.SdkInt > BuildVersionCodes.Kitkat)
+				if (Forms.SdkInt > BuildVersionCodes.Kitkat)
 				{
 					defaultthumbcolorfilter = seekBar.Thumb.GetColorFilter();
 					defaultprogresstintmode = seekBar.ProgressTintMode;
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.Android
 			_min = slider.Minimum;
 			_max = slider.Maximum;
 			Value = slider.Value;
-			if (Build.VERSION.SdkInt > BuildVersionCodes.Kitkat)
+			if (Forms.SdkInt > BuildVersionCodes.Kitkat)
 			{
 				UpdateSliderColors();
 			}
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 			}
 
-			if (Build.VERSION.SdkInt > BuildVersionCodes.Kitkat)
+			if (Forms.SdkInt > BuildVersionCodes.Kitkat)
 			{
 				if (e.PropertyName == Slider.MinimumTrackColorProperty.PropertyName)
 					UpdateMinimumTrackColor();
@@ -195,7 +195,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnLayout(changed, l, t, r, b);
 
-			BuildVersionCodes androidVersion = Build.VERSION.SdkInt;
+			BuildVersionCodes androidVersion = Forms.SdkInt;
 			if (androidVersion < BuildVersionCodes.JellyBean)
 				return;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.Platform.Android
 					}
 					else
 					{
-						if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
+						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
 						{
 							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
 						}

--- a/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TimePickerRenderer.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateCharacterSpacing();
 			UpdateFont();
 
-			if ((int)Build.VERSION.SdkInt > 16)
+			if ((int)Forms.SdkInt > 16)
 				Control.TextAlignment = global::Android.Views.TextAlignment.ViewStart;
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -238,7 +238,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateMixedContentMode()
 		{
-			if (Control != null && ((int)Build.VERSION.SdkInt >= 21))
+			if (Control != null && ((int)Forms.SdkInt >= 21))
 			{
 				Control.Settings.MixedContentMode = (MixedContentHandling)Element.OnThisPlatform().MixedContentMode();
 			}

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		static ViewExtensions()
 		{
-			s_apiLevel = (int)Build.VERSION.SdkInt;
+			s_apiLevel = (int)Forms.SdkInt;
 		}
 
 		public static void RemoveFromParent(this AView view)

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			// If we're running sufficiently new Android, we have to make sure to update the ClipBounds to
 			// match the new size of the ViewGroup
-			if ((int)Build.VERSION.SdkInt >= 18)
+			if ((int)Forms.SdkInt >= 18)
 			{
 				UpdateClipToBounds();
 			}
@@ -280,7 +280,7 @@ namespace Xamarin.Forms.Platform.Android
 			bool shouldClip = layout.IsClippedToBounds;
 
 			// setClipBounds is only available in API 18 +
-			if ((int)Build.VERSION.SdkInt >= 18)
+			if ((int)Forms.SdkInt >= 18)
 			{
 				if (!(_renderer.View is ViewGroup viewGroup))
 				{
@@ -299,7 +299,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (!(_renderer.View.Parent is ViewGroup parent))
 					return;
 
-				if ((int)Build.VERSION.SdkInt >= 18 && parent.ClipChildren == shouldClip)
+				if ((int)Forms.SdkInt >= 18 && parent.ClipChildren == shouldClip)
 					return;
 
 				parent.SetClipChildren(shouldClip);


### PR DESCRIPTION
### Description of Change ###
Change `Build.VERSION` to `Forms.SdkInt`. The latter will cache the result of `Build.VERSION` which saves us an interop call which improves startup performance. 

```
		internal static BuildVersionCodes SdkInt {
			get {
				if (!s_sdkInt.HasValue)
					s_sdkInt = Build.VERSION.SdkInt;
				return (BuildVersionCodes)s_sdkInt;
			}
		}
```
### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
