### PR TITLE
iOS - Test and fix for VoiceOver crash on a ContentPage not having any Content defined

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub6926.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GitHub6926.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6926, "[iOS] iOS - Using VoiceOver will crash when a ContentPage has no Content", PlatformAffected.iOS)]
+	public class GitHub6926 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children = {
+					new Label()
+					{
+						Text = "Enable VoiceOver and then click either:",
+						HorizontalTextAlignment = TextAlignment.Center,
+						VerticalTextAlignment = TextAlignment.Center,
+					},
+					new Button()
+					{
+						Text = "ContentPage without content (crash)",
+						Command = new Command(() =>
+						{
+							Navigation.PushAsync(new ContentPage());
+						})
+					},
+					new Button()
+					{
+						Text = "ContentPage with content (no crash)",
+						Command = new Command(() =>
+						{
+							Navigation.PushAsync(new ContentPage() { Content = new StackLayout() });
+						})
+					}
+				},
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -979,6 +979,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3548.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6472.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)GitHub6926.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
@@ -62,6 +62,9 @@ namespace Xamarin.Forms.Platform.iOS
 		[Export("accessibilityElementCount")]
 		nint AccessibilityElementCount()
 		{
+			if (AccessibilityElements == null)
+				return 0;
+
 			// Note: this will only be called when VoiceOver is enabled
 			return AccessibilityElements.Count;
 		}


### PR DESCRIPTION
### Description of Change ###

This is #6927 by @beeradmoore rebased on 4.1.0

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6926

### API Changes ###

 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->


- iOS

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###
1. To replicate the bug you will first need to disable the [fix which was committed with this PR](https://github.com/beeradmoore/Xamarin.Forms/commit/db67a0c8582a84b7606f89be32459ea5b5638183).
2. Enable VoiceOver on your device. (as far as I know this cant be enabled on the simulator)
3. Launch Xamarin.Forms.Controls.Issues project on iOS device
4. Go into Test Cases.
5. Launch G6926.
6. As stated on the buttons, clicking the first will crash the app, clicking the second will proceed as normal. 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
