### PR TITLE
WIP - EventToCommand as markup extension

### DIFF
--- a/Xamarin.Forms.Core/EventToCommandBinding.cs
+++ b/Xamarin.Forms.Core/EventToCommandBinding.cs
@@ -1,0 +1,25 @@
+﻿namespace Xamarin.Forms
+{
+	public class EventToCommandSource
+	{
+		public string CommandPath { get; }
+		public object CommandParameter { get; }
+		public string EventArgsParameterPath { get; }
+		public IValueConverter EventArgsConverter { get; }
+		public object EventArgsConverterParameter { get; }
+
+		public EventToCommandSource(
+			string commandPath,
+			object commandParameter,
+			string eventArgsParameterPath,
+			IValueConverter eventArgsConverter,
+			object eventArgsConverterParameter)
+		{
+			CommandPath = commandPath;
+			CommandParameter = commandParameter;
+			EventArgsParameterPath = eventArgsParameterPath;
+			EventArgsConverter = eventArgsConverter;
+			EventArgsConverterParameter = eventArgsConverterParameter;
+		}
+	}
+}

--- a/Xamarin.Forms.Sandbox/App.cs
+++ b/Xamarin.Forms.Sandbox/App.cs
@@ -8,7 +8,7 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.StyleSheets;
 using System.Reflection;
 
-[assembly: XamlCompilation(XamlCompilationOptions.Compile)]
+[assembly: XamlCompilation(XamlCompilationOptions.Skip)]
 namespace Xamarin.Forms.Sandbox
 {
 	public partial class App : Application
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Sandbox
 		public App()
 		{
 			Device.SetFlags(new[] { "Shell_Experimental", "CollectionView_Experimental" });
-			InitializeMainPage();
+			MainPage = new MainPage();
 		}
 
 		void AddStyleSheet()
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Sandbox
 			flags.Add("UseLegacyRenderers");
 			Device.SetFlags(flags.Select(x => x).Distinct().ToArray());
 		}
-				
+
 
 		ContentPage CreateContentPage(View view)
 		{
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Sandbox
 		}
 
 
-		StackLayout CreateStackLayout(IEnumerable<View> children, StackOrientation orientation = StackOrientation.Vertical )
+		StackLayout CreateStackLayout(IEnumerable<View> children, StackOrientation orientation = StackOrientation.Vertical)
 		{
 			var sl = new StackLayout() { Orientation = orientation };
 			foreach (var child in children)

--- a/Xamarin.Forms.Sandbox/MainPage.xaml
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml
@@ -3,14 +3,25 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Sandbox.MainPage"
              xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+             xmlns:sandbox="clr-namespace:Xamarin.Forms.Sandbox"
              ios:Page.UseSafeArea="true">
-
-    <NavigationPage.TitleView>
-        <Grid>
-            <Button Text="I am a Button"  />
-        </Grid>
-    </NavigationPage.TitleView>
     <StackLayout>
-        <Button Text="I am a Button"  />
+        <Button Text="Test"
+                Clicked="{EventToCommand ButtonClickedCommand}" />
+
+        <Button Text="Test with command param"
+                Clicked="{EventToCommand ButtonClicked2Command, CommandParameter={Binding SomeParam}}" />
+
+        <ListView ItemTapped="{EventToCommand ListViewItemTappedCommand, EventArgsParameterPath='Item'}"
+                  SelectionMode="None">
+            <ListView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>mono</x:String>
+                    <x:String>monodroid</x:String>
+                    <x:String>monotouch</x:String>
+                    <x:String>mononucleosis</x:String>
+                </x:Array>
+            </ListView.ItemsSource>
+        </ListView>
     </StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Sandbox/MainPage.xaml.cs
+++ b/Xamarin.Forms.Sandbox/MainPage.xaml.cs
@@ -1,20 +1,36 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
+﻿using System.Windows.Input;
 
 namespace Xamarin.Forms.Sandbox
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class MainPage : ContentPage
-    {
+	{
 		public MainPage()
 		{
 			InitializeComponent();
+			BindingContext = new ViewModel();
+		}
+	}
+
+	class ViewModel
+	{
+		public ICommand ButtonClickedCommand { get; }
+		public ICommand ButtonClicked2Command { get; }
+		public ICommand ListViewItemTappedCommand { get; }
+		public object SomeParam { get; } = 1;
+
+		public ViewModel()
+		{
+			ButtonClickedCommand = new Command(() =>
+			{
+			});
+
+			ButtonClicked2Command = new Command(o =>
+			{
+			});
+
+			ListViewItemTappedCommand = new Command<string>(o =>
+			{
+			});
 		}
 	}
 }

--- a/Xamarin.Forms.Sandbox/ShellPage.xaml.cs
+++ b/Xamarin.Forms.Sandbox/ShellPage.xaml.cs
@@ -9,7 +9,6 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Sandbox
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class ShellPage : Shell
 	{
 		public ShellPage()

--- a/Xamarin.Forms.Xaml/Event2CommandHelper.cs
+++ b/Xamarin.Forms.Xaml/Event2CommandHelper.cs
@@ -1,0 +1,130 @@
+﻿using System;
+using System.ComponentModel;
+using System.Globalization;
+using System.Linq;
+using System.Linq.Expressions;
+using System.Reflection;
+using System.Windows.Input;
+
+namespace Xamarin.Forms.Xaml
+{
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public static class Event2CommandHelper
+	{
+		public static Delegate GetHandler(BindableObject owner, EventInfo eventInfo, EventToCommandSource eventToCommandSource)
+		{
+			SetCommandPropertyAndBinding(
+				owner,
+				eventToCommandSource.CommandPath,
+				out BindableProperty bpEventToCommand);
+
+			TrySetCommandParameterPropertyAndBinding(
+				owner,
+				eventToCommandSource.CommandParameter as Binding,
+				out BindableProperty bpCommandParamBinding);
+
+			return CreateEventHandler(eventInfo, eventToCommandSource, bpEventToCommand, bpCommandParamBinding, OnEventRaised);
+		}
+
+		static void SetCommandPropertyAndBinding(BindableObject owner, string commandPath, out BindableProperty bp)
+		{
+			bp = BindableProperty.CreateAttached(
+				"eventToCommand",
+				typeof(ICommand),
+				typeof(BindableObject),
+				null);
+
+			var commandBinding = new Binding(commandPath, BindingMode.OneWay);
+			owner.SetBinding(bp, commandBinding);
+		}
+
+		static void TrySetCommandParameterPropertyAndBinding(BindableObject owner, Binding commandParamBinding, out BindableProperty bp)
+		{
+			if (commandParamBinding == null)
+			{
+				bp = null;
+				return;
+			}
+
+			bp = BindableProperty.CreateAttached(
+				"commandParam",
+				typeof(object),
+				typeof(BindableObject),
+				null);
+
+			owner.SetBinding(bp, commandParamBinding);
+		}
+
+		static Delegate CreateEventHandler(
+			EventInfo eventInfo,
+			EventToCommandSource source,
+			BindableProperty bpEventToCommand,
+			BindableProperty bpCommandParameter,
+			Action<object, EventArgs, EventToCommandSource, BindableProperty, BindableProperty> action)
+		{
+			ParameterExpression[] eventParams = eventInfo.EventHandlerType
+				.GetRuntimeMethods().First(m => m.Name == "Invoke")
+				.GetParameters()
+				.Select(p => Expression.Parameter(p.ParameterType))
+				.ToArray();
+
+			var actionInvoke = action.GetType()
+				.GetRuntimeMethods().First(m => m.Name == "Invoke");
+
+			MethodCallExpression body = Expression.Call(
+				Expression.Constant(action),
+				actionInvoke,
+				eventParams[0],
+				eventParams[1],
+				Expression.Constant(source),
+				Expression.Constant(bpEventToCommand),
+				Expression.Constant(bpCommandParameter, typeof(BindableProperty)));
+
+			return Expression.Lambda(eventInfo.EventHandlerType, body, eventParams).Compile();
+		}
+
+		static void OnEventRaised(object sender, EventArgs eventArgs, EventToCommandSource source, BindableProperty bpEventToCommand, BindableProperty bpCommandParameter)
+		{
+			var command = (ICommand)((BindableObject)sender).GetValue(bpEventToCommand);
+			if (command == null)
+				return;
+
+			object parameter;
+			if (bpCommandParameter != null)
+				parameter = ((BindableObject)sender).GetValue(bpCommandParameter);
+			else
+				parameter = source.CommandParameter;
+
+			if (parameter == null && !string.IsNullOrEmpty(source.EventArgsParameterPath))
+			{
+				// Walk the ParameterPath for nested properties.
+				string[] propertyPathParts = source.EventArgsParameterPath.Split('.');
+				object propertyValue = eventArgs;
+				foreach (var propertyPathPart in propertyPathParts)
+				{
+					PropertyInfo propInfo = propertyValue.GetType().GetRuntimeProperty(propertyPathPart);
+					if (propInfo == null)
+						throw new MissingMemberException($"Unable to find {source.EventArgsParameterPath}");
+
+					propertyValue = propInfo.GetValue(propertyValue);
+					if (propertyValue == null)
+						break;
+				}
+
+				parameter = propertyValue;
+			}
+
+			if (parameter == null &&
+				eventArgs != null &&
+				eventArgs != EventArgs.Empty &&
+				source.EventArgsConverter != null)
+			{
+				parameter = source.EventArgsConverter.Convert(
+					eventArgs, typeof(object), source.EventArgsConverterParameter, CultureInfo.CurrentUICulture);
+			}
+
+			if (command.CanExecute(parameter))
+				command.Execute(parameter);
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/EventToCommandExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/EventToCommandExtension.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Xamarin.Forms.Xaml
+{
+	[ContentProperty(nameof(CommandPath))]
+	[AcceptEmptyServiceProvider]
+	public sealed class EventToCommandExtension : IMarkupExtension<EventToCommandSource>
+	{
+		public string CommandPath { get; set; }
+		public object CommandParameter { get; set; }
+		public string EventArgsParameterPath { get; set; }
+		public IValueConverter EventArgsConverter { get; set; }
+		public object EventArgsConverterParameter { get; set; }
+
+		EventToCommandSource IMarkupExtension<EventToCommandSource>.ProvideValue(IServiceProvider serviceProvider)
+			=> new EventToCommandSource(
+				CommandPath, CommandParameter, EventArgsParameterPath, EventArgsConverter, EventArgsConverterParameter);
+
+		object IMarkupExtension.ProvideValue(IServiceProvider serviceProvider)
+			=> (this as IMarkupExtension<EventToCommandSource>).ProvideValue(serviceProvider);
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Heavily inspired by Stephane's [implementation](https://github.com/xamarin/Xamarin.Forms/pull/6771) and Prism's, I implemented an  `EventToCommand` markup extension.

**This is WIP, I need some initial feedback to know if it's something it would be worth pursuing.**

I implemented the parameters and their behavior from Prism, here's the MainPage.xaml in the Sandbox project as an example:

```
<Button Text="Test"
        Clicked="{EventToCommand ButtonClickedCommand}" />

<!-- Call command with a bound parameter -->
<Button Text="Test with command param"
        Clicked="{EventToCommand ButtonClicked2Command, CommandParameter={Binding SomeParam}}" />

<!-- Call command with the event handler's parameter property ItemTappedEventArgs.Item -->
<ListView ItemTapped="{EventToCommand ListViewItemTappedCommand, EventArgsParameterPath='Item'}"
          SelectionMode="None">
    <ListView.ItemsSource>
        <x:Array Type="{x:Type x:String}">
            <x:String>mono</x:String>
            <x:String>monodroid</x:String>
            <x:String>monotouch</x:String>
            <x:String>mononucleosis</x:String>
        </x:Array>
    </ListView.ItemsSource>
</ListView>
```

```
class ViewModel
{
	public ICommand ButtonClickedCommand { get; }
	public ICommand ButtonClicked2Command { get; }
	public ICommand ListViewItemTappedCommand { get; }
	public object SomeParam { get; } = 1;

	public ViewModel()
	{
		ButtonClickedCommand = new Command(() => { });
		ButtonClicked2Command = new Command(o => { });
		ListViewItemTappedCommand = new Command<string>(o => { });
	}
}
```
![image](https://user-images.githubusercontent.com/743918/61993370-a657a480-b073-11e9-9534-fe30a7e9372f.png)

Some notes:
- Visiting the node parameters had to be modified a tiny bit
- No unit tests for now
- No XAMLC support for now
- There's a tiny bit more work required to take a ICommand value too beside from binding.
- It works with any EventHandler<T> delegate type. Correct me if I am wrong, but I believe the current PR only works with an event of EventHandler type, it doesn't work with LisView.ItemTapped for example (which is of `EventHandler<ItemTappedEventArgs>` type)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
