### PR TITLE
Ensure FlowDirection propagates to EmptyView when not using a template

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
@@ -2,7 +2,7 @@
 {
 	internal class PropagateCodeGallery : ContentPage
 	{
-		public PropagateCodeGallery(IItemsLayout itemsLayout)
+		public PropagateCodeGallery(IItemsLayout itemsLayout, int itemsCount = 2)
 		{
 			Title = $"Propagate FlowDirection=RTL";
 
@@ -21,16 +21,20 @@
 
 			var itemTemplate = ExampleTemplates.PropagationTemplate();
 
+			var emptyView = ExampleTemplates.PropagationTemplate().CreateContent() as View;
+
+
 			var collectionView = new CollectionView
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
+				EmptyView = emptyView
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: 2);
+			var generator = new ItemsSourceGenerator(collectionView, initialItems: itemsCount);
 			layout.Children.Add(generator);
 			var instructions = new Label();
-			UpdateInstructions(layout, instructions);
+			UpdateInstructions(layout, instructions, itemsCount == 0);
 			Grid.SetRow(instructions, 2);
 			layout.Children.Add(instructions);
 
@@ -44,7 +48,7 @@
 					? FlowDirection.LeftToRight 
 					: FlowDirection.RightToLeft;
 
-				UpdateInstructions(layout, instructions);
+				UpdateInstructions(layout, instructions, itemsCount == 0);
 			};
 
 			switchLayout.Children.Add(switchLabel);
@@ -62,9 +66,16 @@
 			generator.GenerateItems();
 		}
 
-		static void UpdateInstructions(Layout layout, Label instructions)
+		static void UpdateInstructions(Layout layout, Label instructions, bool isEmpty)
 		{
-			instructions.Text = $"The buttons in each item should be in order from {layout.FlowDirection}.";
+			if (isEmpty)
+			{
+				instructions.Text = $"The buttons in the empty view should be in order from {layout.FlowDirection}.";
+			}
+			else
+			{
+				instructions.Text = $"The buttons in each item should be in order from {layout.FlowDirection}.";
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagationGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagationGallery.cs
@@ -18,6 +18,9 @@
 						descriptionLabel,
 						GalleryBuilder.NavButton("Propagate FlowDirection", () =>
 							new PropagateCodeGallery(ListItemsLayout.Vertical), Navigation),
+
+						GalleryBuilder.NavButton("Propagate FlowDirection in EmptyView", () =>
+							new PropagateCodeGallery(ListItemsLayout.Vertical, 0), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -131,6 +131,11 @@ namespace Xamarin.Forms
 
 		public void AddLogicalChild(Element element)
 		{
+			if(element == null)
+			{
+				return;	
+			}
+
 			_logicalChildren.Add(element);
 
 			PropertyPropagationExtensions.PropagatePropertyChanged(null, element);
@@ -140,6 +145,11 @@ namespace Xamarin.Forms
 
 		public void RemoveLogicalChild(Element element)
 		{
+			if (element == null)
+			{
+				return;
+			}
+
 			element.Parent = null;
 			_logicalChildren.Remove(element);
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -53,26 +53,32 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				templatedItemViewHolder.Recycle(ItemsView);
 			}
+			else if (holder is EmptyViewHolder emptyViewHolder)
+			{
+				emptyViewHolder.Recycle(ItemsView);
+			}
 
 			base.OnViewRecycled(holder);
 		}
 
 		public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
 		{
-			if (EmptyView == null || EmptyViewTemplate == null)
+			if (EmptyView == null)
 			{
 				return;
 			}
 
-			if (holder is TemplatedItemViewHolder templatedItemViewHolder)
+			if (holder is EmptyViewHolder emptyViewHolder && emptyViewHolder.View != null)
+			{
+				// For templated empty views, this will happen on bind. But if we just have a plain-old View,
+				// we need to add it as a "child" of the ItemsView here so that stuff like Visual and FlowDirection
+				// propagate to the controls in the EmptyView
+				ItemsView.AddLogicalChild(emptyViewHolder.View);
+			}
+			else if (holder is TemplatedItemViewHolder templatedItemViewHolder && EmptyViewTemplate != null)
 			{
 				// Use EmptyView as the binding context for the template
 				templatedItemViewHolder.Bind(EmptyView, ItemsView);
-			}
-
-			if (!(holder is SimpleViewHolder))
-			{
-				return;
 			}
 		}
 
@@ -101,6 +107,31 @@ namespace Xamarin.Forms.Platform.Android
 		public override int GetItemViewType(int position)
 		{
 			return _itemViewType;
+		}
+
+		static TextView CreateTextView(string text, Context context)
+		{
+			var textView = new TextView(context) { Text = text };
+			var layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent,
+				ViewGroup.LayoutParams.MatchParent);
+			textView.LayoutParameters = layoutParams;
+			textView.Gravity = GravityFlags.Center;
+			return textView;
+		}
+
+		internal class EmptyViewHolder : RecyclerView.ViewHolder
+		{
+			public EmptyViewHolder(global::Android.Views.View itemView, View rootElement) : base(itemView)
+			{
+				View = rootElement;
+			}
+
+			public View View { get; }
+
+			public void Recycle(ItemsView itemsView)
+			{
+				itemsView.RemoveLogicalChild(View);
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -8,7 +8,7 @@ using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public partial class EmptyViewAdapter : RecyclerView.Adapter
+	public class EmptyViewAdapter : RecyclerView.Adapter
 	{
 		int _itemViewType;
 		object _emptyView;
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				templatedItemViewHolder.Recycle(ItemsView);
 			}
-			else if (holder is EmptyViewHolder emptyViewHolder)
+			else if (holder is SimpleViewHolder emptyViewHolder)
 			{
 				emptyViewHolder.Recycle(ItemsView);
 			}
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			if (holder is EmptyViewHolder emptyViewHolder && emptyViewHolder.View != null)
+			if (holder is SimpleViewHolder emptyViewHolder && emptyViewHolder.View != null)
 			{
 				// For templated empty views, this will happen on bind. But if we just have a plain-old View,
 				// we need to add it as a "child" of the ItemsView here so that stuff like Visual and FlowDirection
@@ -107,31 +107,6 @@ namespace Xamarin.Forms.Platform.Android
 		public override int GetItemViewType(int position)
 		{
 			return _itemViewType;
-		}
-
-		static TextView CreateTextView(string text, Context context)
-		{
-			var textView = new TextView(context) { Text = text };
-			var layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent,
-				ViewGroup.LayoutParams.MatchParent);
-			textView.LayoutParameters = layoutParams;
-			textView.Gravity = GravityFlags.Center;
-			return textView;
-		}
-
-		internal class EmptyViewHolder : RecyclerView.ViewHolder
-		{
-			public EmptyViewHolder(global::Android.Views.View itemView, View rootElement) : base(itemView)
-			{
-				View = rootElement;
-			}
-
-			public View View { get; }
-
-			public void Recycle(ItemsView itemsView)
-			{
-				itemsView.RemoveLogicalChild(View);
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -472,6 +472,8 @@ namespace Xamarin.Forms.Platform.Android
 				_emptyViewAdapter.EmptyViewTemplate = emptyViewTemplate;
 
 				_emptyCollectionObserver.Start(ItemsViewAdapter);
+
+				_emptyViewAdapter.NotifyDataSetChanged();
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.Android/CollectionView/SimpleViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SimpleViewHolder.cs
@@ -15,6 +15,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public View View { get; }
 
+		public void Recycle(ItemsView itemsView)
+		{
+			itemsView.RemoveLogicalChild(View);
+		}
+
 		public static SimpleViewHolder FromText(string text, Context context, bool fill = true)
 		{
 			var textView = new TextView(context) { Text = text };

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -328,6 +328,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_emptyViewFormsElement != null)
 				{
+					if (ItemsView.EmptyViewTemplate == null)
+					{
+						ItemsView.AddLogicalChild(_emptyViewFormsElement);
+					}
+
 					// Now that the native empty view's frame is sized to the UICollectionView, we need to handle
 					// the Forms layout for its content
 					_emptyViewFormsElement.Layout(_emptyUIView.Frame.ToRectangle());
@@ -339,6 +344,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_currentBackgroundIsEmptyView)
 				{
 					CollectionView.BackgroundView = _backgroundUIView;
+					ItemsView.RemoveLogicalChild(_emptyViewFormsElement);
 				}
 
 				_currentBackgroundIsEmptyView = false;


### PR DESCRIPTION
### Description of Change ###

Currently, if the EmptyView for a CollectionView is a simple Forms View (as opposed to one which uses a DataTemplate), propagated values like FlowDirection are not actually propagated. These changes fix that issue.

### Issues Resolved ### 

None

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Control Gallery, navigate to CollectionView Gallery -> Propagation Galleries -> Propagate FlowDirection in EmptyView and follow the on-screen instructions.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Spleticulated Rines
