### PR TITLE
[C] Dispose the Disposable

### DIFF
--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -36,7 +36,9 @@ namespace Xamarin.Forms.StyleSheets
 		{
 			var styleSheet = new StyleSheet();
 			var resString = DependencyService.Get<IResourcesLoader>().GetResource(resourcePath, assembly, styleSheet, lineInfo);
-			Parse(styleSheet, new CssReader(new StringReader(resString)));
+			using (var textReader = new StringReader(resString))
+			using (var cssReader = new CssReader(textReader))
+				Parse(styleSheet, cssReader);
 			return styleSheet;
 		}
 
@@ -56,7 +58,8 @@ namespace Xamarin.Forms.StyleSheets
 				throw new ArgumentNullException(nameof(reader));
 
 			var sheet = new StyleSheet();
-			Parse(sheet, new CssReader(reader));
+			using (var cssReader = new CssReader(reader))
+				Parse(sheet, cssReader);
 			return sheet;
 		}
 
@@ -94,13 +97,11 @@ namespace Xamarin.Forms.StyleSheets
 			}
 		}
 
-		Type IStyle.TargetType
-			=> typeof(VisualElement);
+		Type IStyle.TargetType => typeof(VisualElement);
 
 		void IStyle.Apply(BindableObject bindable)
 		{
-			var styleable = bindable as Element;
-			if (styleable == null)
+			if (!(bindable is Element styleable))
 				return;
 			Apply(styleable);
 		}
@@ -114,8 +115,7 @@ namespace Xamarin.Forms.StyleSheets
 
 		void ApplyCore(Element styleable)
 		{
-			var visualStylable = styleable as VisualElement;
-			if (visualStylable == null)
+			if (!(styleable is VisualElement visualStylable))
 				return;
 			foreach (var kvp in Styles) {
 				var selector = kvp.Key;
@@ -126,9 +126,6 @@ namespace Xamarin.Forms.StyleSheets
 			}
 		}
 
-		void IStyle.UnApply(BindableObject bindable)
-		{
-			throw new NotImplementedException();
-		}
+		void IStyle.UnApply(BindableObject bindable) => throw new NotImplementedException();
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Dispose the disposable readers while parsing StyleSheets



<!-- Describe your changes here. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6986
### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
