### PR TITLE
Modify UI Test 6286 to await push and pop

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -19,33 +20,51 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		WebView webview;
 		WebView webview2;
+		int count;
+		ContentPage page1;
+		ContentPage page2;
+
 		protected override void Init()
 		{
-			webview = new WebView { Source = "http://microsoft.com" };
+			webview = new WebView { Source = "https://microsoft.com" };
 			webview.Navigated += Webview_Navigated;
-			var page1 = new ContentPage { Content = webview };
+			page1 = new ContentPage { Content = webview };
 
-			webview2 = new WebView { Source = "http://xamarin.com" };
+			webview2 = new WebView { Source = "https://xamarin.com" };
 			webview2.Navigated += Webview_Navigated;
-			var page2 = new ContentPage { Content = webview2 };
+			page2 = new ContentPage { Content = webview2 };
 
-			int count = 0;
+			count = 0;
 			Navigation.PushAsync(page1);
+			RunTest();
+		}
+
+		void RunTest()
+		{
 			Device.StartTimer(TimeSpan.FromSeconds(2), () =>
 			{
-				webview.Source = "http://xamarin.com";
-				Navigation.PushAsync(page2);
-
-				webview2.Source = "http://microsoft.com";
-				Navigation.PopAsync();
-
-				var done = count++ < 3;
-
-				if (done)
-					page1.Content = new Label { Text = "success", AutomationId = "success" };
-
-				return done;
+				PushPopPages();
+				return false;
 			});
+		}
+
+		async Task PushPopPages()
+		{
+			webview.Source = "https://xamarin.com";
+			await Navigation.PushAsync(page2);
+
+			webview2.Source = "https://microsoft.com";
+			await Navigation.PopAsync();
+
+			var done = count++ < 3;
+
+			if (done)
+				page1.Content = new Label { Text = "success", AutomationId = "success" };
+
+			if(!done)
+			{
+				RunTest();
+			}
 		}
 
 		void Webview_Navigated(object sender, WebNavigatedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Test is occasionally throwing the following exception
```
System.InvalidOperationException: Page must not already have a parent.
  at Xamarin.Forms.Internals.NavigationProxy.PushAsync (Xamarin.Forms.Page root, System.Boolean animated) [0x0000e] in /Users/vsts/agent/2.154.3/work/1/s/Xamarin.Forms.Core/NavigationProxy.cs:116 
  at Xamarin.Forms.Internals.NavigationProxy.PushAsync (Xamarin.Forms.Page root) [0x00001] in /Users/vsts/agent/2.154.3/work/1/s/Xamarin.Forms.Core/NavigationProxy.cs:110 
  at Xamarin.Forms.Controls.Issues.Issue6286+<>c__DisplayClass2_0.<Init>b__0 () [0x0001c] in /Users/vsts/agent/2.154.3/work/1/s/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs:37 
  at Xamarin.Forms.Forms+IOSPlatformServices+<>c__DisplayClass15_0.<StartTimer>b__0 (Foundation.NSTimer t) [0x00001] in /Users/vsts/agent/2.154.3/work/1/s/Xamarin.Forms.Platform.iOS/Forms.cs:298 
  at Foundation.NSTimerActionDispatcher.Fire (Foundation.NSTimer timer) [0x00000] in /Library/Frameworks/Xamarin.iOS.framework/Versions/12.6.0.25<\M-b\M^@\M-&>
```

This is most likely happening because the `PopAsync` of page2 hasn't completed before the `PushAsync` of page2 happens again. If you set the Timer to zero then it would recreate the exception. 

With this rework if you set the timer to zero the test is still able to finish without any issues