### PR TITLE
[iOS] Prevent empty cell on bounce CollectionView

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -122,6 +122,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void CellDisplayingEnded(UICollectionView collectionView, UICollectionViewCell cell, NSIndexPath indexPath)
 		{
+			if (ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+			{
+				var actualWidth = collectionView.ContentSize.Width - collectionView.Bounds.Size.Width;
+				if (collectionView.ContentOffset.X >= actualWidth || collectionView.ContentOffset.X < 0)
+					return;
+			}
+			else
+			{
+				var actualHeight = collectionView.ContentSize.Height - collectionView.Bounds.Size.Height;
+
+				if (collectionView.ContentOffset.Y >= actualHeight || collectionView.ContentOffset.Y < 0)
+					return;
+			}
+
 			ItemsViewController.PrepareCellForRemoval(cell);
 		}
 


### PR DESCRIPTION
### Description of Change ###

When you would “bounce” the CollectionView (actually ItemsView) on iOS, the cell going offscreen was marked for removal by iOS and therefor we removed the bindingcontext, etc.

This change prevents that from happening because this would leave us with unwanted empty cells.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

Was not reported in an issue yet afaik. #6988 looks somewhat related but has a different cause since bouncing does not happen on Android.

~It might be the fix to #6341, from the movie it looks like this problem.~ Verified it’s not.

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->



### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
