### PR TITLE
Disable Touch Intercepting on Android View Pager

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
+using System.ComponentModel;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Gestures Test",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellGestures : TestShell
+	{
+		const string Success = "Success";
+		const string SuccessId = "SuccessId";
+
+		protected override void Init()
+		{
+			var gesturePage = CreateContentPage(shellItemTitle: "Gestures");
+
+			var label = new Label()
+			{
+				Text = "Swipe Right and Text Should Change to Success",
+				AutomationId = SuccessId
+			};
+
+			gesturePage.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label(){ Text = "Click through flyout items for all the tests"},
+					label
+				},
+				GestureRecognizers =
+				{
+					new SwipeGestureRecognizer()
+					{
+						Direction = SwipeDirection.Right,
+						Command = new Command(() =>
+						{
+							label.Text = Success;
+						})
+					}
+				}
+			};
+		}
+
+
+#if UITEST && (__IOS__ || __ANDROID__)
+		[Test]
+		public void GesturesTest()
+		{
+			RunningApp.WaitForElement(SuccessId);
+			RunningApp.SwipeLeftToRight(SuccessId);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -613,11 +613,13 @@ namespace Xamarin.Forms.Controls
 			return page;
 		}
 
-		public ContentPage CreateContentPage()
+		public ContentPage CreateContentPage(string shellItemTitle = null)
 		{
+			shellItemTitle = shellItemTitle ?? $"Item: {Items.Count}";
 			ContentPage page = new ContentPage();
 			ShellItem item = new ShellItem()
 			{
+				Title = shellItemTitle,
 				Items =
 				{
 					new ShellSection()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6644.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGrouping.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5412.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsViewPager.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsViewPager.cs
@@ -2,6 +2,7 @@ using System;
 using Android.Content;
 using Android.Runtime;
 using Android.Support.V4.View;
+using Android.Util;
 using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
@@ -9,6 +10,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 	internal class FormsViewPager : ViewPager
 	{
 		public FormsViewPager(Context context) : base(context)
+		{
+		}
+
+		public FormsViewPager(Context context, IAttributeSet attrs) : base(context, attrs)
 		{
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -144,6 +144,7 @@ namespace Xamarin.Forms.Platform.Android
 			_viewPager = new FormsViewPager(Context)
 			{
 				LayoutParameters = new LP(LP.MatchParent, LP.MatchParent),
+				EnableGesture = false
 			};
 
 			_viewPager.AddOnPageChangeListener(this);


### PR DESCRIPTION
### Description of Change ###
Disable the ViewPager on Shell from intercepting touches. Shell doesn't use swipe based paging. We also do this on the TabbedPageRenderer.

This PR does not fix scrolling on webview and maps.

### Issues Resolved ### 
- fixes #6310 
- fixes #6060

### Platforms Affected ### 
- Android

### Testing Procedure ###
- There's a UI test
- Test some gestures with shell that you might think are still broken

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
