### PR TITLE
Remove NestedScrollView from the default shell layout

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -44,6 +44,7 @@ using Xamarin.Forms.Controls.Issues;
 [assembly: ExportRenderer(typeof(Issue4561.CustomView), typeof(Issue4561CustomViewRenderer))]
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
+[assembly: ExportRenderer(typeof(ShellGestures.TouchTestView), typeof(ShellGesturesTouchTestViewRenderer))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
@@ -918,5 +919,48 @@ namespace Xamarin.Forms.ControlGallery.Android
 		}
 	}
 #pragma warning restore CS0618 // Type or member is obsolete
+
+
+	public class ShellGesturesTouchTestViewRenderer : ViewRenderer<ShellGestures.TouchTestView, global::Android.Views.View>, AView.IOnTouchListener
+	{
+		global::Android.Graphics.Paint paint;
+
+		public List<Point> pointList = new List<Point>();
+		public ShellGesturesTouchTestViewRenderer(Context context) : base(context)
+		{
+		}
+
+		public bool OnTouch(global::Android.Views.View v, MotionEvent e)
+		{
+			switch (e.Action)
+			{
+				case MotionEventActions.Up:
+					Element.Results.Text = Xamarin.Forms.Controls.Issues.ShellGestures.TouchListenerSuccess;
+					break;
+				case MotionEventActions.Cancel:
+					Element.Results.Text = "Fail";
+					break;
+			}
+			return true;
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<ShellGestures.TouchTestView> e)
+		{
+			base.OnElementChanged(e);
+			paint = new global::Android.Graphics.Paint();
+			if (e.NewElement != null)
+				SetOnTouchListener(this);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+
+			if(disposing)
+				SetOnTouchListener(null);
+
+			paint = null;
+		}
+	}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(TableViewTitle);
 			RunningApp.WaitForElement(TableViewId);
-			RunningApp.ScrollDownTo("entry30", TableViewId);
+			RunningApp.ScrollDownTo("entry30", TableViewId, ScrollStrategy.Gesture);
 		}
 
 		[NUnit.Framework.Category(UITestCategories.ListView)]
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(ListViewTitle);
 			RunningApp.WaitForElement(ListViewId);
-			RunningApp.ScrollDownTo("30 Entry", ListViewId);
+			RunningApp.ScrollDownTo("30 Entry", ListViewId, ScrollStrategy.Gesture);
 		}
 
 #if __ANDROID__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(TableViewTitle);
 			RunningApp.WaitForElement(TableViewId);
-			RunningApp.ScrollDownTo("entry99", TableViewId);
+			RunningApp.ScrollDownTo("entry30", TableViewId);
 		}
 
 		[NUnit.Framework.Category(UITestCategories.ListView)]
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(ListViewTitle);
 			RunningApp.WaitForElement(ListViewId);
-			RunningApp.ScrollDownTo("99 Entry", ListViewId);
+			RunningApp.ScrollDownTo("30 Entry", ListViewId);
 		}
 
 #if __ANDROID__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
@@ -27,17 +27,27 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class ShellGestures : TestShell
 	{
-		const string Success = "Success";
-		const string SuccessId = "SuccessId";
+		const string SwipeTitle = "Swipe";
+		const string SwipeGestureSuccess = "SwipeGesture Success";
+		const string SwipeGestureSuccessId = "SwipeGestureSuccessId";
+
+		const string TouchListenerTitle = "IOnTouchListener";
+		public const string TouchListenerSuccess = "TouchListener Success";
+		const string TouchListenerSuccessId = "TouchListenerSuccessId";
+
+		const string TableViewTitle = "Table View";
+		const string TableViewId = "TableViewId";
+
+		const string ListViewTitle = "List View";
+		const string ListViewId = "ListViewId";
 
 		protected override void Init()
 		{
-			var gesturePage = CreateContentPage(shellItemTitle: "Gestures");
-
+			var gesturePage = CreateContentPage(shellItemTitle: SwipeTitle);
 			var label = new Label()
 			{
-				Text = "Swipe Right and Text Should Change to Success",
-				AutomationId = SuccessId
+				Text = "Swipe Right and Text Should Change to SwipeGestureSuccess",
+				AutomationId = SwipeGestureSuccessId
 			};
 
 			gesturePage.Content = new StackLayout()
@@ -54,22 +64,123 @@ namespace Xamarin.Forms.Controls.Issues
 						Direction = SwipeDirection.Right,
 						Command = new Command(() =>
 						{
-							label.Text = Success;
+							label.Text = SwipeGestureSuccess;
 						})
 					}
 				}
 			};
+
+			var webViewPage = CreateContentPage(shellItemTitle: "Webview");
+			webViewPage.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "Make sure you can scroll the web page up and down"
+					},
+					new WebView()
+					{
+						VerticalOptions = LayoutOptions.FillAndExpand,
+						Source = "https://www.xamarin.com"
+					}
+				}
+			};
+
+			var tableViewPage = CreateContentPage(shellItemTitle: TableViewTitle);
+
+			TableView tableView = new TableView() { Intent = TableIntent.Settings, AutomationId = TableViewId };
+			TableRoot tableRoot = new TableRoot();
+			tableView.Root = tableRoot;
+
+			for(int i = 0; i < 100; i++)
+			{
+				TableSection tableSection = new TableSection()
+				{
+					Title = $"section{++i}"
+				};
+				var text = $"entry{++i}";
+				tableSection.Add(new EntryCell() { Label = text, AutomationId = text });
+				text = $"entry{++i}";
+				tableSection.Add(new EntryCell() { Label = text, AutomationId = text });
+
+				tableRoot.Add(tableSection);
+			}
+			tableViewPage.Content = tableView;
+
+
+			var listViewPage = CreateContentPage(shellItemTitle: ListViewTitle);
+			ListView listView = new ListView(ListViewCachingStrategy.RecycleElement) { AutomationId = ListViewId };
+			listView.ItemsSource = Enumerable.Range(0, 100).Select(x => $"{x} Entry").ToList();
+			listViewPage.Content = listView;
+
+			if(Device.RuntimePlatform == Device.Android)
+			{
+				var touchListenter = CreateContentPage(shellItemTitle: TouchListenerTitle);
+				touchListenter.Content = new TouchTestView();
+			}
 		}
 
+		[Preserve(AllMembers = true)]
+		public class TouchTestView : ContentView
+		{
+			public Label Results = new Label() { AutomationId = TouchListenerSuccessId };
+			public TouchTestView()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						Results
+					}
+				};
+
+				Results.Text = "Swipe across the screen. This label should change to say Success";
+			}
+		}
 
 #if UITEST && (__IOS__ || __ANDROID__)
+
+		[NUnit.Framework.Category(UITestCategories.Gestures)]
 		[Test]
-		public void GesturesTest()
+		public void SwipeGesture()
 		{
-			RunningApp.WaitForElement(SuccessId);
-			RunningApp.SwipeLeftToRight(SuccessId);
-			RunningApp.WaitForElement(Success);
+			TapInFlyout(SwipeTitle, usingSwipe:true);
+			RunningApp.WaitForElement(SwipeGestureSuccessId);
+			RunningApp.SwipeLeftToRight(SwipeGestureSuccessId);
+			RunningApp.WaitForElement(SwipeGestureSuccess);
 		}
+
+		[NUnit.Framework.Category(UITestCategories.TableView)]
+		[Test]
+		public void TableViewScroll()
+		{
+			TapInFlyout(TableViewTitle);
+			RunningApp.WaitForElement(TableViewId);
+			RunningApp.ScrollDownTo("entry99", TableViewId);
+		}
+
+		[NUnit.Framework.Category(UITestCategories.ListView)]
+		[Test]
+		public void ListViewScroll()
+		{
+			TapInFlyout(ListViewTitle);
+			RunningApp.WaitForElement(ListViewId);
+			RunningApp.ScrollDownTo("99 Entry", ListViewId);
+		}
+
+#if __ANDROID__
+		[NUnit.Framework.Category(UITestCategories.CustomRenderers)]
+		[Test]
+		public void TouchListener()
+		{
+			TapInFlyout(TouchListenerTitle);
+			RunningApp.WaitForElement(TouchListenerSuccessId);
+			RunningApp.SwipeLeftToRight(TouchListenerSuccessId);
+			RunningApp.WaitForElement(TouchListenerSuccess);
+		}
+#endif
+
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -665,16 +665,25 @@ namespace Xamarin.Forms.Controls
 			}
 		}
 
-		public void ShowFlyout(string flyoutIcon = "OK")
+		public void ShowFlyout(string flyoutIcon = "OK", bool usingSwipe = false)
 		{
 			RunningApp.WaitForElement(flyoutIcon);
-			RunningApp.Tap(flyoutIcon);
+
+			if(usingSwipe)
+			{
+				var rect = RunningApp.ScreenBounds();
+				RunningApp.DragCoordinates(10, rect.CenterY, rect.CenterX, rect.CenterY);
+			}
+			else
+			{
+				RunningApp.Tap(flyoutIcon);
+			}
 		}
 
 
-		public void TapInFlyout(string text, string flyoutIcon = "OK")
+		public void TapInFlyout(string text, string flyoutIcon = "OK", bool usingSwipe = false)
 		{
-			ShowFlyout(flyoutIcon);
+			ShowFlyout(flyoutIcon, usingSwipe);
 			RunningApp.WaitForElement(text);
 			RunningApp.Tap(text);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -110,6 +110,9 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnAttachedToWindow();
 
+			if (Forms.IsLollipopOrNewer && Control != null)
+				Control.NestedScrollingEnabled = (Parent.GetParentOfType<NestedScrollView>() != null);
+
 			_isAttached = true;
 			_adapter.IsAttachedToWindow = _isAttached;
 			UpdateIsRefreshing(isInitialValue: true);
@@ -156,8 +159,6 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					var ctx = Context;
 					nativeListView = CreateNativeControl();
-					if (Forms.IsLollipopOrNewer)
-						nativeListView.NestedScrollingEnabled = true;
 					_refresh = CreateNativePullToRefresh(ctx);
 					_refresh.SetOnRefreshListener(this);
 					_refresh.AddView(nativeListView, new LayoutParams(LayoutParams.MatchParent, LayoutParams.MatchParent));

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -112,7 +112,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			_root = inflater.Inflate(Resource.Layout.ShellContent, null).JavaCast<CoordinatorLayout>();
 
-			var scrollview = _root.FindViewById<NestedScrollView>(Resource.Id.shellcontent_scrollview);
 			_toolbar = _root.FindViewById<Toolbar>(Resource.Id.shellcontent_toolbar);
 
 			_renderer = Platform.CreateRenderer(_page, Context);
@@ -120,7 +119,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			_shellPageContainer = new ShellPageContainer(Context, _renderer);
 
-			scrollview.AddView(_shellPageContainer);
+			if(_root is ViewGroup vg)
+				vg.AddView(_shellPageContainer);
 
 			_toolbarTracker = _shellContext.CreateTrackerForToolbar(_toolbar);
 			_toolbarTracker.Page = _page;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -112,8 +112,7 @@ namespace Xamarin.Forms.Platform.Android
 		Toolbar _toolbar;
 		IShellToolbarAppearanceTracker _toolbarAppearanceTracker;
 		IShellToolbarTracker _toolbarTracker;
-		ViewPager _viewPager;
-		NestedScrollView _scrollview;
+		FormsViewPager _viewPager;
 
 		public ShellSectionRenderer(IShellContext shellContext)
 		{
@@ -138,14 +137,10 @@ namespace Xamarin.Forms.Platform.Android
 			var root = inflater.Inflate(Resource.Layout.RootLayout, null).JavaCast<CoordinatorLayout>();
 
 			_toolbar = root.FindViewById<Toolbar>(Resource.Id.main_toolbar);
-			_scrollview = root.FindViewById<NestedScrollView>(Resource.Id.main_scrollview);
+			_viewPager = root.FindViewById<FormsViewPager>(Resource.Id.main_viewpager);
 			_tablayout = root.FindViewById<TabLayout>(Resource.Id.main_tablayout);
 
-			_viewPager = new FormsViewPager(Context)
-			{
-				LayoutParameters = new LP(LP.MatchParent, LP.MatchParent),
-				EnableGesture = false
-			};
+			_viewPager.EnableGesture = false;
 
 			_viewPager.AddOnPageChangeListener(this);
 			_viewPager.Id = Platform.GenerateViewId();
@@ -162,7 +157,6 @@ namespace Xamarin.Forms.Platform.Android
 			_toolbarTracker.Page = currentPage;
 
 			_viewPager.CurrentItem = currentIndex;
-			_scrollview.AddView(_viewPager);
 
 			if (shellSection.Items.Count == 1)
 			{
@@ -190,7 +184,6 @@ namespace Xamarin.Forms.Platform.Android
 				adapter.Dispose();
 
 				_viewPager.RemoveOnPageChangeListener(this);
-				_scrollview.RemoveView(_viewPager);
 
 				_toolbarAppearanceTracker.Dispose();
 				_tabLayoutAppearanceTracker.Dispose();
@@ -198,7 +191,6 @@ namespace Xamarin.Forms.Platform.Android
 				_tablayout.Dispose();
 				_toolbar.Dispose();
 				_viewPager.Dispose();
-				_scrollview.Dispose();
 				_rootView.Dispose();
 			}
 
@@ -208,7 +200,6 @@ namespace Xamarin.Forms.Platform.Android
 			_tablayout = null;
 			_toolbar = null;
 			_viewPager = null;
-			_scrollview = null;
 			_rootView = null;
 
 			base.OnDestroy();

--- a/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/TableViewRenderer.cs
@@ -4,6 +4,7 @@ using Android.Views;
 using AView = Android.Views.View;
 using AListView = Android.Widget.ListView;
 using System.ComponentModel;
+using Android.Support.V4.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -57,6 +58,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			_adapter = GetModelRenderer(listView, view);
 			listView.Adapter = _adapter;
+		}
+		protected override void OnAttachedToWindow()
+		{
+			base.OnAttachedToWindow();
+
+			if (Forms.IsLollipopOrNewer && Control != null)
+				Control.NestedScrollingEnabled = (Parent.GetParentOfType<NestedScrollView>() != null);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/Resources/Layout/RootLayout.axml
+++ b/Xamarin.Forms.Platform.Android/Resources/Layout/RootLayout.axml
@@ -18,9 +18,7 @@
 				android:id="@+id/main.toolbar"
 				android:layout_width="match_parent"
 				android:layout_height="?attr/actionBarSize"
-				app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-				
-							/>
+				app:popupTheme="@style/ThemeOverlay.AppCompat.Light"/>
 			
 		<android.support.design.widget.TabLayout 
 				android:id="@+id/main.tablayout"
@@ -31,9 +29,8 @@
 		
 	</android.support.design.widget.AppBarLayout>
 
-	<android.support.v4.widget.NestedScrollView
-		android:id="@+id/main.scrollview"
-		android:fillViewport="true"
+    <xamarin.forms.platform.android.appcompat.FormsViewPager
+		android:id="@+id/main.viewpager"
 		android:layout_width="match_parent"
 		android:layout_height="match_parent"
 		app:layout_behavior="@string/appbar_scrolling_view_behavior" />

--- a/Xamarin.Forms.Platform.Android/Resources/Layout/ShellContent.axml
+++ b/Xamarin.Forms.Platform.Android/Resources/Layout/ShellContent.axml
@@ -18,16 +18,8 @@
 				android:id="@+id/shellcontent.toolbar"
 				android:layout_width="match_parent"
 				android:layout_height="?attr/actionBarSize"
-				app:popupTheme="@style/ThemeOverlay.AppCompat.Light"
-							/>
+				app:popupTheme="@style/ThemeOverlay.AppCompat.Light" />
 
 	</android.support.design.widget.AppBarLayout>
-
-	<android.support.v4.widget.NestedScrollView
-		android:id="@+id/shellcontent.scrollview"
-		android:fillViewport="true"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		app:layout_behavior="@string/appbar_scrolling_view_behavior" />
 
 </android.support.design.widget.CoordinatorLayout>

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -116,7 +116,8 @@ namespace Xamarin.Forms.Platform.Android
 		internal static T GetParentOfType<T>(this IViewParent view)
 			where T : class
 		{
-			if (view is T t)
+			T t = view as T;
+			if (view != null)
 				return t;
 
 			while (view != null)
@@ -134,7 +135,8 @@ namespace Xamarin.Forms.Platform.Android
 		internal static T GetParentOfType<T>(this AView view)
 			where T : class
 		{
-			if (view is T t)
+			T t = view as T;
+			if (view != null)
 				return t;
 
 			return view.Parent.GetParentOfType<T>();

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -112,5 +112,29 @@ namespace Xamarin.Forms.Platform.Android
 			if (!isInLayout && !view.IsLayoutRequested)
 				view.RequestLayout();
 		}
+
+		internal static T GetParentOfType<T>(this IViewParent view)
+		{
+			if (view is T t)
+				return t;
+
+			while (view != null)
+			{
+				if (view.Parent is T parent)
+					return parent;
+
+				view = view.Parent;
+			}
+
+			return default(T);
+		}
+
+		internal static T GetParentOfType<T>(this AView view) 
+		{
+			if (view is T t)
+				return t;
+
+			return view.Parent.GetParentOfType<T>();
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -114,13 +114,15 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		internal static T GetParentOfType<T>(this IViewParent view)
+			where T : class
 		{
 			if (view is T t)
 				return t;
 
 			while (view != null)
 			{
-				if (view.Parent is T parent)
+				T parent = view.Parent as T;
+				if (parent != null)
 					return parent;
 
 				view = view.Parent;
@@ -129,7 +131,8 @@ namespace Xamarin.Forms.Platform.Android
 			return default(T);
 		}
 
-		internal static T GetParentOfType<T>(this AView view) 
+		internal static T GetParentOfType<T>(this AView view)
+			where T : class
 		{
 			if (view is T t)
 				return t;


### PR DESCRIPTION
### Description of Change ###

Scrolling with a WebView and Shell currently doesn't work because all Shell content has a NestedScrollView as a parent.  This breaks scrolling the WebView because the WebView always gets sized to the ViewPort. When the WebView isn't inside a ScrollView this is fine because then all the touch events get passed to the WebView and the WebView control itself scrolls. When it's nested in a ScrollView the ScrollView intercepts all the touches so nothing makes it down to the WebView. If we had fixed this Issue https://github.com/xamarin/Xamarin.Forms/issues/1711 then you could size the WebView to its web content and it would be fine that the NestedScrollView intercepts the touches because then it would just be in charge of scrolling the WebView.

That being said I don't think nesting a WebView permanently inside a NestedScrollView is the correct way to get the behavior you want with NestedScrollView (Collapsing toolbars) 

AFAICT there are two ways to get this behavior from a control like WebView
1) stretch the height content out so that NestedScrollView takes over
2) Implement IScrollingView, INestedScrollingChild2 (i..e https://stackoverflow.com/a/45026679/953734).  If you look at the RecyclerView all it implements is *ViewGroup, ScrollingView, NestedScrollingChild2* and it's thus able to cause Collpasing Toolbar behaviors. I tested this with CollectionView and was able to easily make the toolbar on android collapse by adding *app:layout_scrollFlags="scroll|enterAlways"* to the  ToolBar element of the Shell layout

One strikes me as the easy less work way of doing it and two is the more correct way to do it. If we wanted to bring generalized NestedScrollView behavior to android then I think we should implement those two interfaces on ShellPageContainer or even PageRenderer not just nest everything inside a NestedScrollView

Now let's say that we want to just go with method one where we nest everything inside a NestedScrollView. Personally I couldn't get this to work with the current layout hierarchy of
```
NestedScrollView
    ViewPager
          Content
```

I was only able to get it to work by switching ViewPager and NestedScrollView
```
ViewPager
    NestedScrollView
          Content
```

But at that point why don't we just make it so if you want this behavior you just have to wrap your content with a Forms ScrollView? We already have this requirement on iOS with NavigationBar related behavior. Plus it seems like an excessive performance hit to just by default nest everything inside a NestedScrollView even if they don't want collapsible ToolBar behavior. 

If we end up wanting to nest all shell content inside a NestedScrollView  then I would say we change ShellPageContainer to inherit from NestedScrollView  instead of nesting the ViewPager inside the NestedScrollView


### Breaking ###
This removes a layer from the shell hierarchy so if users were doing Parent.Parent.Parent then they are going to get back a different view now.

### Issues Resolved ### 

- fixes #5205
- fixes #5306
- fixes #6611
- fixes #6545
- fixes #6381


### Platforms Affected ### 
- Android


### Testing Procedure ###
- Verify that removing the Nested Scroll View isn't a super bad idea

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
