### PR TITLE
Use XF Size instead of Android.Util.Size

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalle
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollModeGalleries;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.AlternateLayoutGalleries;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries;
+using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ItemSizeGalleries;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
@@ -26,6 +27,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					GalleryBuilder.NavButton("Selection Galleries", () => new SelectionGallery(), Navigation),
 					GalleryBuilder.NavButton("Propagation Galleries", () => new PropagationGallery(), Navigation),
 					GalleryBuilder.NavButton("Grouping Galleries", () => new GroupingGallery(), Navigation),
+					GalleryBuilder.NavButton("Item Size Galleries", () => new ItemsSizeGallery(), Navigation),
 					GalleryBuilder.NavButton("Scroll Mode Galleries", () => new ScrollModeGallery(), Navigation),
 					GalleryBuilder.NavButton("Alternate Layout Galleries", () => new AlternateLayoutGallery(), Navigation),
 					GalleryBuilder.NavButton("Header/Footer Galleries", () => new HeaderFooterGallery(), Navigation),

--- a/Xamarin.Forms.Controls/GalleryPages/GalleryBuilder.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GalleryBuilder.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.Controls.GalleryPages
 		public static Button NavButton(string galleryName, Func<ContentPage> gallery, INavigation nav)
 		{
 			var automationId = System.Text.RegularExpressions.Regex.Replace(galleryName, " |\\(|\\)", string.Empty);
-			var button = new Button { Text = $"{galleryName}", AutomationId = automationId, FontSize = 10, HeightRequest = 40 };
+			var button = new Button { Text = $"{galleryName}", AutomationId = automationId, FontSize = 10, HeightRequest = 30 };
 			button.Clicked += (sender, args) => { nav.PushAsync(gallery()); };
 			return button;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
@@ -1,15 +1,14 @@
 using System;
 using Android.Content;
 using Android.Views;
-using ASize = Android.Util.Size;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	internal class ItemContentView : ViewGroup
 	{
 		protected IVisualElementRenderer Content;
-		ASize _size;
-		Action<ASize> _reportMeasure;
+		Size? _size;
+		Action<Size> _reportMeasure;
 
 		public ItemContentView(Context context) : base(context)
 		{
@@ -43,7 +42,7 @@ namespace Xamarin.Forms.Platform.Android
 			_size = null;
 		}
 
-		internal void HandleItemSizingStrategy(Action<ASize> reportMeasure, ASize size)
+		internal void HandleItemSizingStrategy(Action<Size> reportMeasure, Size? size)
 		{
 			_reportMeasure = reportMeasure;
 			_size = size;
@@ -74,7 +73,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_size != null)
 			{
 				// If we're using ItemSizingStrategy.MeasureFirstItem and now we have a set size, use that
-				SetMeasuredDimension(_size.Width, _size.Height);
+				SetMeasuredDimension((int)_size.Value.Width, (int)_size.Value.Height);
 				return;
 			}
 
@@ -101,7 +100,7 @@ namespace Xamarin.Forms.Platform.Android
 				pixelHeight = (int)Context.ToPixels(measure.Request.Height);
 			}
 
-			_reportMeasure?.Invoke(new ASize(pixelWidth, pixelHeight));
+			_reportMeasure?.Invoke(new Size(pixelWidth, pixelHeight));
 			_reportMeasure = null; // Make sure we only report back the measure once
 
 			SetMeasuredDimension(pixelWidth, pixelHeight);

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -4,7 +4,6 @@ using Android.Support.V7.Widget;
 using Android.Widget;
 using Object = Java.Lang.Object;
 using ViewGroup = Android.Views.ViewGroup;
-using ASize = Android.Util.Size;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -15,7 +14,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal readonly IItemsViewSource ItemsSource;
 
 		bool _disposed;
-		ASize _size;
+		Size? _size;
 
 		bool _usingItemTemplate = false;
 		int _headerOffset = 0;
@@ -119,7 +118,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		void SetStaticSize(ASize size)
+		void SetStaticSize(Size size)
 		{
 			_size = size;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -1,6 +1,5 @@
 using System;
 using Xamarin.Forms.Internals;
-using ASize = Android.Util.Size;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -39,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		public void Bind(object itemBindingContext, ItemsView itemsView, 
-			Action<ASize> reportMeasure = null, ASize size = null)
+			Action<Size> reportMeasure = null, Size? size = null)
 		{
 			var template = _template.SelectDataTemplate(itemBindingContext, itemsView);
 


### PR DESCRIPTION
### Description of Change ###

Replaces use of Android.Util.Size (not available until API 21) with Xamarin.Forms.Size to avoid missing class definition crashes on API < 21.

Also fixes transposed parameters when using ItemSizingStrategy.MeasureFirstItem.

### Issues Resolved ### 

- fixes #6815

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Launch Control Gallery on API 19, navigate to
CollectionView Gallery -> Item Sizing Gallery -> Item Sizing Strategies. Should no longer crash.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
