### PR TITLE
[UITest] Change Query to WaitForElement on 45125 and change GetResult to await for Performance Gallery testing

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45125.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla45125.cs
@@ -256,8 +256,8 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement (q => q.Marked (DisappearingLabelId));
 
 			RunningApp.Screenshot ("There should be appearing and disappearing events for the Groups and Items.");
-			var appearing = int.Parse(RunningApp.Query(q => q.Marked(AppearingLabelId))[0].Text);
-			var disappearing = int.Parse(RunningApp.Query(q=> q.Marked(DisappearingLabelId))[0].Text);
+			var appearing = int.Parse(RunningApp.WaitForElement(AppearingLabelId)[0].ReadText());
+			var disappearing = int.Parse(RunningApp.WaitForElement(DisappearingLabelId)[0].ReadText());
 
 			Assert.IsTrue(appearing > 0, $"Test {_TestNumber}: No appearing events for groups found.");
 			Assert.IsTrue(disappearing > 0, $"Test {_TestNumber}: No disappearing events for groups found.");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceDataManager.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceDataManager.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		public static async Task<Dictionary<string, double>> GetScenarioResults(string deviceId)
 		{
-			var response = await _client.GetAsync(GetScenarioResultsRoute + deviceId);
+			var response = await _client.GetAsync(GetScenarioResultsRoute + deviceId).ConfigureAwait(false);
 
 			if (!response.IsSuccessStatusCode)
 				return new Dictionary<string, double>();
@@ -63,12 +63,12 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 			var json = JsonConvert.SerializeObject(data);
 			var content = new StringContent(json, Encoding.UTF8, "application/json");
-			var response = await _client.PostAsync(PostScenarioResultRoute + scenarioName, content);
-			var responseContent = await response.Content.ReadAsStringAsync();
+			var response = await _client.PostAsync(PostScenarioResultRoute + scenarioName, content).ConfigureAwait(false);
+			var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 
 			var scenarioResult = JsonConvert.DeserializeObject<ScenarioResult>(responseContent);
 
-			await PostScenarioResultDetails(scenarioResult.Id, details);
+			await PostScenarioResultDetails(scenarioResult.Id, details).ConfigureAwait(false);
 		}
 
 		static async Task PostScenarioResultDetails(Guid scenarioResultId, Dictionary<string, PerformanceProvider.Statistic> details)
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Controls.Issues
 					Name = detail.Key
 				};
 				var content = new StringContent(JsonConvert.SerializeObject(data), Encoding.UTF8, "application/json");
-				await _client.PostAsync(PostScenarioResultDetailsRoute + scenarioResultId, content);
+				await _client.PostAsync(PostScenarioResultDetailsRoute + scenarioResultId, content).ConfigureAwait(false);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
- 45125 is currently using Query()[0] which will fail sometimes because of timing issues. Changed this to a WaitForElement so that it Waits for it to show up
- The Performance Gallery has been occasionally crashing from the HttpClient call throwing a TaskCancelException so I changed it to use await/async and wrapped the call in a try/catch

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
