### PR TITLE
[XamlC] throw XPE on missing resource key

### DIFF
--- a/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/ModuleDefinitionExtensions.cs
@@ -193,6 +193,28 @@ namespace Xamarin.Forms.Build.Tasks
 		}
 
 		public static MethodReference ImportMethodReference(this ModuleDefinition module,
+													 TypeReference type,
+													 string methodName,
+													 TypeReference[] parameterTypes = null,
+													 TypeReference[] classArguments = null,
+													 bool isStatic = false)
+		{
+			return module.ImportMethodReference(type,
+												methodName: methodName,
+												predicate: md => {
+													if (md.IsStatic != isStatic)
+														return false;
+													if (md.Parameters.Count != (parameterTypes?.Length ?? 0))
+														return false;
+													for (var i = 0; i < md.Parameters.Count; i++)
+														if (!TypeRefComparer.Default.Equals(md.Parameters[i].ParameterType, parameterTypes[i]))
+															return false;
+													return true;
+												},
+												classArguments: classArguments);
+		}
+
+		public static MethodReference ImportMethodReference(this ModuleDefinition module,
 															(string assemblyName, string clrNamespace, string typeName) type,
 															string methodName,
 															(string assemblyName, string clrNamespace, string typeName)[] parameterTypes,

--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -1334,9 +1334,9 @@ namespace Xamarin.Forms.Build.Tasks
 			//is there a RD.Add() overrides that accepts this ?
 			var nodeTypeRef = context.Variables[node].VariableType;
 			var module = context.Body.Method.Module;
-			if (module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary"),
+			if (module.ImportMethodReference(module.GetTypeDefinition(("Xamarin.Forms.Core", "Xamarin.Forms", "ResourceDictionary")),
 											 methodName: "Add",
-											 parameterTypes: new[] { (nodeTypeRef.Scope.Name, nodeTypeRef.Namespace, nodeTypeRef.Name) }) != null)
+											 parameterTypes: new[] { (nodeTypeRef) }) != null)
 				return true;
 
 			throw new XamlParseException("resources in ResourceDictionary require a x:Key attribute", lineInfo);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/AB946693.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/AB946693.xaml
@@ -1,0 +1,10 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.AB946693"
+        xmlns:local="clr-namespace:Xamarin.Forms.Xaml.UnitTests">
+    <ContentPage.Resources>
+        <local:Gh6192Template/>
+    </ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/AB946693.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/AB946693.xaml.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class AB946693 : ContentPage
+	{
+		public AB946693() => InitializeComponent();
+		public AB946693(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void KeylessResourceThrowsMeaningfulException([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<XamlParseException>(() => MockCompiler.Compile(typeof(AB946693)));
+				else
+					Assert.Throws<XamlParseException>(() => new AB946693(useCompiledXaml));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

When a resource was missing a key (non-implicit resource), XamlC was throwing
an AssemblyResolutionException instead of a proper XamlParseException when the
type of the resource was in a different xmlns than the default Forms one.

All the other cases are fine (default xmlns, or non-compiled Xaml)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes AB#946693

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
