### PR TITLE
#3533 Bring back uap10.0/netstandard1.4 support

### DIFF
--- a/.nuspec/Xamarin.Forms.Pages.Azure.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.Azure.nuspec
@@ -21,5 +21,6 @@
   </metadata>
   <files>
     <file src="..\Xamarin.Forms.Pages.Azure\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.Azure.dll" target="lib\netstandard1.4" />
+    <file src="..\Xamarin.Forms.Pages.Azure\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.Azure.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.Pages.Azure.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.Azure.nuspec
@@ -20,6 +20,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Xamarin.Forms.Pages.Azure\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.Azure.dll" target="lib\netstandard2.0" />
+    <file src="..\Xamarin.Forms.Pages.Azure\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.Azure.dll" target="lib\netstandard1.4" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.Pages.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.nuspec
@@ -19,6 +19,6 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.dll" target="lib\netstandard2.0" />
+    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.dll" target="lib\netstandard1.4" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.Pages.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.nuspec
@@ -20,5 +20,6 @@
   </metadata>
   <files>
     <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.dll" target="lib\netstandard1.4" />
+    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.Pages.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.nuspec
@@ -19,7 +19,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Pages.dll" target="lib\netstandard1.0" />
+    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.dll" target="lib\netstandard1.4" />
     <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.Pages.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.nuspec
@@ -19,7 +19,7 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.dll" target="lib\netstandard1.4" />
+    <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Pages.dll" target="lib\netstandard1.0" />
     <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.dll" target="lib\netstandard2.0" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -25,6 +25,7 @@
         <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.0.12" />
         <dependency id="Win2D.uwp" version="1.20.0" />
         <dependency id="Microsoft.UI.Xaml" version="2.1.190606001" />
+        <dependency id="System.ValueTuple" version="4.5.0" />
       </group>
       <group targetFramework="tizen40">
         <dependency id="Tizen.NET" version="4.0.0"/>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -206,8 +206,8 @@
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Xamarin.Forms.Platform.UAP.pri" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Properties" />
 
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\FormsFlyout.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
@@ -234,11 +234,11 @@
     <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.macOS.dll" target="lib\Xamarin.Mac" />
     <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.Mac" />
 
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Core.dll" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Core.*pdb" target="lib\uap10.0" />
     <file src="..\docs\Xamarin.Forms.Core.xml" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Xaml.dll" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Xaml.*pdb" target="lib\uap10.0" />
     <file src="..\docs\Xamarin.Forms.Xaml.xml" target="lib\uap10.0" />
 
     <!-- iOS Localized String Resource Assemblies -->

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -227,7 +227,7 @@
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Microsoft.UI.Xaml\DensityStyles\Compact.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Shell\ShellStyles.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Shell" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\PickerStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Microsoft.UI.Xaml\Theme\generic.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Theme\" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Microsoft.UI.Xaml\Themes\generic.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\" />
 
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -227,6 +227,7 @@
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Microsoft.UI.Xaml\DensityStyles\Compact.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Shell\ShellStyles.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Shell" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\PickerStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\Microsoft.UI.Xaml\Theme\generic.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Theme\" />
 
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -32,6 +32,7 @@
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
+    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsEC9E.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -44,6 +45,7 @@
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
+    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsEC9E.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -32,7 +32,6 @@
     <AndroidUseSharedRuntime>True</AndroidUseSharedRuntime>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>False</EmbedAssembliesIntoApk>
-    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsEC9E.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>portable</DebugType>
@@ -45,7 +44,6 @@
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
     <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
-    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsEC9E.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
+++ b/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
@@ -11,9 +11,8 @@
     <AssemblyName>Embedding.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>		
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
+++ b/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
@@ -11,8 +11,9 @@
     <AssemblyName>Embedding.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/EmbeddingTestBeds/Embedding.XF/Embedding.XF.csproj
+++ b/EmbeddingTestBeds/Embedding.XF/Embedding.XF.csproj
@@ -1,9 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Msbuild.Sdk.Extras/2.0.41">
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
+    <TargetFramework>netstandard1.4</TargetFramework>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
  <ItemGroup>

--- a/EmbeddingTestBeds/Embedding.XF/Embedding.XF.csproj
+++ b/EmbeddingTestBeds/Embedding.XF/Embedding.XF.csproj
@@ -1,7 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Msbuild.Sdk.Extras/2.0.41">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
  <ItemGroup>

--- a/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
+++ b/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
@@ -11,9 +11,8 @@
     <AssemblyName>PagesGallery.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>		
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>
@@ -155,6 +154,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
       <Version>6.0.6</Version>
+    </PackageReference>
+    <PackageReference Include="Microsoft.UI.Xaml">
+      <Version>2.1.190606001</Version>
     </PackageReference>
     <PackageReference Include="NETStandard.Library">
       <Version>2.0.1</Version>

--- a/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
+++ b/PagesGallery/PagesGallery.UWP/PagesGallery.UWP.csproj
@@ -11,8 +11,9 @@
     <AssemblyName>PagesGallery.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>

--- a/PagesGallery/PagesGallery/App.xaml.cs
+++ b/PagesGallery/PagesGallery/App.xaml.cs
@@ -1,21 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
+﻿
 using Xamarin.Forms;
 
 namespace PagesGallery
 {
 	public partial class App : Application
 	{
-		public App ()
+		public App()
 		{
-			InitializeComponent ();
+			InitializeComponent();
 
-			var eventsPage = new EventsPage ();
-			var speakersPage = new SpeakersPage ();
-			MainPage = new NavigationPage (new TabbedPage {
+			var eventsPage = new EventsPage();
+			var speakersPage = new SpeakersPage();
+			MainPage = new NavigationPage(new TabbedPage
+			{
 				Title = "Xamarin Evolve 2016",
 				Children = {
 					eventsPage,
@@ -24,17 +21,17 @@ namespace PagesGallery
 			});
 		}
 
-		protected override void OnStart ()
+		protected override void OnStart()
 		{
 			// Handle when your app starts
 		}
 
-		protected override void OnSleep ()
+		protected override void OnSleep()
 		{
 			// Handle when your app sleeps
 		}
 
-		protected override void OnResume ()
+		protected override void OnResume()
 		{
 			// Handle when your app resumes
 		}

--- a/PagesGallery/PagesGallery/PagesGallery.csproj
+++ b/PagesGallery/PagesGallery/PagesGallery.csproj
@@ -1,6 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
+﻿<Project Sdk="Msbuild.Sdk.Extras/2.0.41">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
  <ItemGroup>

--- a/PagesGallery/PagesGallery/PagesGallery.csproj
+++ b/PagesGallery/PagesGallery/PagesGallery.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
  <ItemGroup>

--- a/PagesGallery/PagesGallery/PagesGallery.csproj
+++ b/PagesGallery/PagesGallery/PagesGallery.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="15.0">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
  <ItemGroup>

--- a/PagesGallery/PagesGallery/PagesGallery.csproj
+++ b/PagesGallery/PagesGallery/PagesGallery.csproj
@@ -1,8 +1,6 @@
-﻿<Project Sdk="Msbuild.Sdk.Extras/2.0.41">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
+    <TargetFramework>netstandard1.4</TargetFramework>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
  <ItemGroup>

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -12,7 +12,7 @@
     <AssemblyName>Xamarin.Forms.ControlGallery.WindowsUniversal</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -12,9 +12,9 @@
     <AssemblyName>Xamarin.Forms.ControlGallery.WindowsUniversal</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>		
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <EnableDotNetNativeCompatibleProfile>true</EnableDotNetNativeCompatibleProfile>
     <FileAlignment>512</FileAlignment>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla56771.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			data.CollectionChanged += (_, e) =>
 			{
-				var log = $"<{DateTime.Now.ToLongTimeString()}> {e.Action} action fired.";
+				var log = $"<{DateTime.Now.ToString("T")}> {e.Action} action fired.";
 				System.Diagnostics.Debug.WriteLine(log);
 			};
 			var label = new Label { Text = "Click the Add 2 button." };

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59718.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59718.cs
@@ -7,6 +7,8 @@ using System.Collections.Generic;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 #if UITEST
 using NUnit.Framework;
 #endif
@@ -70,7 +72,7 @@ namespace Xamarin.Forms.Controls.Issues
 				})
 			};
 
-			_list.On<Windows>().SetSelectionMode(Xamarin.Forms.PlatformConfiguration.WindowsSpecific.ListViewSelectionMode.Inaccessible);
+			_list.On<WindowsOS>().SetSelectionMode(Xamarin.Forms.PlatformConfiguration.WindowsSpecific.ListViewSelectionMode.Inaccessible);
 
 			_list.ItemTapped += ListView_ItemTapped;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
@@ -170,7 +170,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public class Model5623
 	{
-		RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
+		Random random = new Random();
 
 		public string Text { get; set; }
 
@@ -183,7 +183,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Model5623(bool isUneven)
 		{
 			var byteArray = new byte[4];
-			provider.GetBytes(byteArray);
+			random.NextBytes(byteArray);
 
 			if (isUneven)
 				Height = 100 + (BitConverter.ToInt32(byteArray, 0) % 300 + 300) % 300;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1396.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1396.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var button = new Button { Text = "Change Text" };
 			button.Clicked += (sender, args) =>
 			{
-				_label.Text = DateTime.Now.ToLongDateString() + " " + DateTime.Now.ToLongTimeString();
+				_label.Text = DateTime.Now.ToString("F");
 			};
 
 			_label = new Label

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1691_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1691_2.cs
@@ -8,6 +8,8 @@ using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
@@ -29,25 +31,25 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var searchBarWithSpellCheckLabel = new Label { Text = "SearchBar with SpellCheck Enabled:" };
 			_searchBarWithSpellCheck = new SearchBar();
-			_searchBarWithSpellCheck.On<Windows>().SetIsSpellCheckEnabled(true);
+			_searchBarWithSpellCheck.On<WindowsOS>().SetIsSpellCheckEnabled(true);
 
 			var searchBarWithoutSpellCheckLabel = new Label { Text = "SearchBar with SpellCheck Disabled:" };
 			_searchBarWithoutSpellCheck = new SearchBar();
-			_searchBarWithoutSpellCheck.On<Windows>().SetIsSpellCheckEnabled(false);
+			_searchBarWithoutSpellCheck.On<WindowsOS>().SetIsSpellCheckEnabled(false);
 
 			var searchBarToggleSpellCheck = new Label { Text = "SearchBar with Toggled SpellCheck:" };
 			_searchBarToggleSpellCheck = new SearchBar();
 
 			_toggleSpellCheckButton = new Button { Text = "Enable SpellCheck" };
 			_toggleSpellCheckButton.Clicked += (object sender, EventArgs e) => {
-				if(_searchBarToggleSpellCheck.On<Windows>().IsSpellCheckEnabled())
+				if(_searchBarToggleSpellCheck.On<WindowsOS>().IsSpellCheckEnabled())
 				{
-					_searchBarToggleSpellCheck.On<Windows>().DisableSpellCheck();
+					_searchBarToggleSpellCheck.On<WindowsOS>().DisableSpellCheck();
 					_toggleSpellCheckButton.Text = "Enable SpellCheck";
 				}
 				else
 				{
-					_searchBarToggleSpellCheck.On<Windows>().EnableSpellCheck();
+					_searchBarToggleSpellCheck.On<WindowsOS>().EnableSpellCheck();
 					_toggleSpellCheckButton.Text = "Disable SpellCheck";
 				}
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1705_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1705_2.cs
@@ -8,6 +8,8 @@ using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
@@ -59,14 +61,14 @@ namespace Xamarin.Forms.Controls.Issues
 			_toggleIconsButton = new Button();
 			_toggleIconsButton.Text = "Show Header Icons";
 			_toggleIconsButton.Clicked += (object sender, EventArgs e) => {
-				if (_target.On<Windows>().IsHeaderIconsEnabled())
+				if (_target.On<WindowsOS>().IsHeaderIconsEnabled())
 				{
-					_target.On<Windows>().DisableHeaderIcons();
+					_target.On<WindowsOS>().DisableHeaderIcons();
 					_toggleIconsButton.Text = "Show Header Icons";
 				}
 				else
 				{
-					_target.On<Windows>().EnableHeaderIcons();
+					_target.On<WindowsOS>().EnableHeaderIcons();
 					_toggleIconsButton.Text = "Hide Header Icons";
 				}
 			};
@@ -88,16 +90,16 @@ namespace Xamarin.Forms.Controls.Issues
 				if (!Int32.TryParse(_iconHeightEntry.Text, out height))
 					height = 16;
 
-				var currentSize = _target.On<Windows>().GetHeaderIconsSize();
+				var currentSize = _target.On<WindowsOS>().GetHeaderIconsSize();
 				if (currentSize.Width != width || currentSize.Height != height)
-					_target.On<Windows>().SetHeaderIconsSize(new Size(width, height));
+					_target.On<WindowsOS>().SetHeaderIconsSize(new Size(width, height));
 			};
 
 			_getCurrentIconsSizeButton = new Button();
 			_getCurrentIconsSizeButton.Text = "Load Current Header Icons Size";
 			_getCurrentIconsSizeButton.Clicked += (object sender, EventArgs e) => {
 
-				var currentSize = _target.On<Windows>().GetHeaderIconsSize();
+				var currentSize = _target.On<WindowsOS>().GetHeaderIconsSize();
 				_iconWidthEntry.Text = currentSize.Width.ToString();
 				_iconHeightEntry.Text = currentSize.Height.ToString();
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1717.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1717.cs
@@ -3,6 +3,7 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -24,21 +25,21 @@ namespace Xamarin.Forms.Controls.Issues
 
 		private void DetectFromContent(bool detect) 
 		{
-			_entry1.On<Windows>().SetDetectReadingOrderFromContent(detect);
-			_entry2.On<Windows>().SetDetectReadingOrderFromContent(detect);
-			_editor1.On<Windows>().SetDetectReadingOrderFromContent(detect);
-			_editor2.On<Windows>().SetDetectReadingOrderFromContent(detect);
-			_label5.On<Windows>().SetDetectReadingOrderFromContent(detect);
+			_entry1.On<WindowsOS>().SetDetectReadingOrderFromContent(detect);
+			_entry2.On<WindowsOS>().SetDetectReadingOrderFromContent(detect);
+			_editor1.On<WindowsOS>().SetDetectReadingOrderFromContent(detect);
+			_editor2.On<WindowsOS>().SetDetectReadingOrderFromContent(detect);
+			_label5.On<WindowsOS>().SetDetectReadingOrderFromContent(detect);
 			UpdateLabels();
 		}
 
 		void UpdateLabels()
 		{
-			_label1.Text = $"FlowDirection: {_entry1.FlowDirection}, DetectReadingOrderFromContent: {_entry1.On<Windows>().GetDetectReadingOrderFromContent()}";
-			_label2.Text = $"FlowDirection: {_entry2.FlowDirection}, DetectReadingOrderFromContent: {_entry2.On<Windows>().GetDetectReadingOrderFromContent()}";
-			_label3.Text = $"FlowDirection: {_editor1.FlowDirection}, DetectReadingOrderFromContent: {_editor1.On<Windows>().GetDetectReadingOrderFromContent()}";
-			_label4.Text = $"FlowDirection: {_editor2.FlowDirection}, DetectReadingOrderFromContent: {_editor2.On<Windows>().GetDetectReadingOrderFromContent()}";
-			_label6.Text = $"FlowDirection: {_label5.FlowDirection}, DetectReadingOrderFromContent: {_label5.On<Windows>().GetDetectReadingOrderFromContent()}";
+			_label1.Text = $"FlowDirection: {_entry1.FlowDirection}, DetectReadingOrderFromContent: {_entry1.On<WindowsOS>().GetDetectReadingOrderFromContent()}";
+			_label2.Text = $"FlowDirection: {_entry2.FlowDirection}, DetectReadingOrderFromContent: {_entry2.On<WindowsOS>().GetDetectReadingOrderFromContent()}";
+			_label3.Text = $"FlowDirection: {_editor1.FlowDirection}, DetectReadingOrderFromContent: {_editor1.On<WindowsOS>().GetDetectReadingOrderFromContent()}";
+			_label4.Text = $"FlowDirection: {_editor2.FlowDirection}, DetectReadingOrderFromContent: {_editor2.On<WindowsOS>().GetDetectReadingOrderFromContent()}";
+			_label6.Text = $"FlowDirection: {_label5.FlowDirection}, DetectReadingOrderFromContent: {_label5.On<WindowsOS>().GetDetectReadingOrderFromContent()}";
 		}
 
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1898.cs
@@ -5,6 +5,8 @@ using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AToolbarPlacement = Xamarin.Forms.PlatformConfiguration.AndroidSpecific.ToolbarPlacement;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
@@ -117,7 +119,7 @@ namespace Xamarin.Forms.Controls.Issues
 			tabbedPage.On<Android>().SetBarSelectedItemColor(Color.Green);
 #pragma warning restore CS0618 // Type or member is obsolete
 			tabbedPage.On<Android>().SetToolbarPlacement(placement);
-			tabbedPage.On<Windows>().SetHeaderIconsEnabled(true);
+			tabbedPage.On<WindowsOS>().SetHeaderIconsEnabled(true);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2595.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2595.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Timers;
+using System.Threading;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
@@ -48,7 +48,6 @@ namespace Xamarin.Forms.Controls.Issues
 		[Preserve(AllMembers = true)]
 		public class _2595ScrollPage : ContentPage
 		{
-			readonly Timer _timer = new Timer(1000);
 			protected Label Label;
 
 			public _2595ScrollPage() {
@@ -76,9 +75,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			protected override void OnAppearing() {
 				base.OnAppearing();
-				_timer.Elapsed += (s, e) => Device.BeginInvokeOnMainThread(OnTimerElapsed);
 
-				_timer.Start();
+				Timer timer = new Timer((o) => Device.BeginInvokeOnMainThread(OnTimerElapsed), new AutoResetEvent(true), 0, 1000);
 			}
 
 			void OnTimerElapsed() {

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3273.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3273.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Items.CollectionChanged += (_, e) =>
 			{
 				statusLabel.Text = "Success";
-				var log = $"<{DateTime.Now.ToLongTimeString()}> {e.Action} action fired.";
+				var log = $"<{DateTime.Now.ToString("T")}> {e.Action} action fired.";
 				actionLabel.Text += $"{log}{Environment.NewLine}";
 				System.Diagnostics.Debug.WriteLine(log);
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3988.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3988.cs
@@ -3,6 +3,8 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 #if UITEST
 using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
@@ -83,8 +85,8 @@ namespace Xamarin.Forms.Controls.Issues
 			var button = new Button() { Text = "Toggle IsDynamicOverflowEnabled" };
 			button.Clicked += (s, e) =>
 			{
-				var overflowEnabled = parent.On<Windows>().GetToolbarDynamicOverflowEnabled();
-				parent.On<Windows>().SetToolbarDynamicOverflowEnabled(!overflowEnabled);
+				var overflowEnabled = parent.On<WindowsOS>().GetToolbarDynamicOverflowEnabled();
+				parent.On<WindowsOS>().SetToolbarDynamicOverflowEnabled(!overflowEnabled);
 			};
 			var text = new Label()
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Controls.Issues
 		static IEnumerable<Type> FindPerformanceScenarios()
 		{
 			return typeof(PerformanceGallery).GetTypeInfo().Assembly.DefinedTypes.Select(o => o.AsType())
-													.Where(typeInfo => typeof(PerformanceScenario).IsAssignableFrom(typeInfo));
+													.Where(type => typeof(PerformanceScenario).GetTypeInfo().IsAssignableFrom(type.GetTypeInfo()));
 		}
 
 		static IEnumerable<PerformanceScenario> InflatePerformanceScenarios()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/Scenarios/ImageScenarios.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/Scenarios/ImageScenarios.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Reflection;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.GalleryPages.PerformanceGallery.Scenarios
@@ -53,7 +54,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PerformanceGallery.Scenarios
 		{
 			//NOTE: copy image to disk in static ctor, so not to interfere with timing
 			tempFile = Path.Combine(Path.GetTempPath(), $"{nameof(ImageScenario4)}.png");
-			using (var embeddedStream = typeof(ImageScenario4).Assembly.GetManifestResourceStream("Xamarin.Forms.Controls.GalleryPages.crimson.jpg"))
+			using (var embeddedStream = typeof(ImageScenario4).GetTypeInfo().Assembly.GetManifestResourceStream("Xamarin.Forms.Controls.GalleryPages.crimson.jpg"))
 			using (var fileStream = File.Create(tempFile))
 				embeddedStream.CopyTo(fileStream);
 		}

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -516,7 +516,7 @@ namespace Xamarin.Forms.Controls
 			if (string.IsNullOrWhiteSpace(filter))
 				ItemsSource = _pages;
 			else
-				ItemsSource = _pages.Where(p => p.Title.IndexOf(filter, StringComparison.InvariantCultureIgnoreCase) != -1);
+				ItemsSource = _pages.Where(p => p.Title.IndexOf(filter, StringComparison.OrdinalIgnoreCase) != -1);
 		}
 	}
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls/CoreGalleryPages/CarouselViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/CarouselViewCoreGalleryPage.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Controls
 				items.Add(new CarouselData
 				{
 					Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
-					Name = DateTime.Now.AddDays(n).ToLongDateString()
+					Name = DateTime.Now.AddDays(n).ToString("D")
 				});
 			}
 

--- a/Xamarin.Forms.Controls/CoreGalleryPages/CollectionViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/CollectionViewCoreGalleryPage.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls
 
 			for (int n = 0; n < 1000; n++)
 			{
-				items.Add(DateTime.Now.AddDays(n).ToLongDateString());
+				items.Add(DateTime.Now.AddDays(n).ToString("D"));
 			}
 
 			element.ItemsSource = items;

--- a/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WebViewCoreGalleryPage.cs
@@ -3,6 +3,8 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 namespace Xamarin.Forms.Controls
 {
 	internal class WebViewCoreGalleryPage : CoreGalleryPage<WebView>
@@ -132,7 +134,7 @@ namespace Xamarin.Forms.Controls
 				HeightRequest = 200
 			};
 
-			jsAlertWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+			jsAlertWebView.On<WindowsOS>().SetIsJavaScriptAlertEnabled(true);
 			
 			var javascriptAlertWebSourceContainer = new ViewContainer<WebView>(Test.WebView.JavaScriptAlert,
 				jsAlertWebView

--- a/Xamarin.Forms.Controls/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/WkWebViewCoreGalleryPage.cs
@@ -3,6 +3,8 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 namespace Xamarin.Forms.Controls
 {
 	internal class WkWebViewCoreGalleryPage : CoreGalleryPage<WkWebView>
@@ -107,7 +109,7 @@ namespace Xamarin.Forms.Controls
 				HeightRequest = 200
 			};
 
-			jsAlertWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+			jsAlertWebView.On<WindowsOS>().SetIsJavaScriptAlertEnabled(true);
 			
 			var javascriptAlertWebSourceContainer = new ViewContainer<WkWebView>(Test.WebView.JavaScriptAlert,
 				jsAlertWebView

--- a/Xamarin.Forms.Controls/GalleryPages/DynamicViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/DynamicViewGallery.cs
@@ -130,7 +130,7 @@ namespace Xamarin.Forms.Controls
 			// BindableProperty used to clean property values
 			var bindableProperties = elementType
 				.GetFields(BindingFlags.Public | BindingFlags.Static | BindingFlags.FlattenHierarchy)
-				.Where(p => p.FieldType.IsAssignableFrom(typeof(BindableProperty)))
+				.Where(p => p.FieldType.GetTypeInfo().IsAssignableFrom(typeof(BindableProperty).GetTypeInfo()))
 				.Select(p => (BindableProperty)p.GetValue(element));
 
 			foreach (var property in publicProperties)
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Controls
 				{
 					propertyLayout.Children.Add(CreateThicknessPicker(property, element));
 				}
-				else if (property.PropertyType.IsEnum)
+				else if (property.PropertyType.GetTypeInfo().IsEnum)
 				{
 					propertyLayout.Children.Add(CreateEnumPicker(property, element));
 				}

--- a/Xamarin.Forms.Controls/GalleryPages/ImageSourcesGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ImageSourcesGallery.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 
 namespace Xamarin.Forms.Controls
 {
@@ -33,7 +34,7 @@ namespace Xamarin.Forms.Controls
 				new ImageSourcePickerItem
 				{
 					Text = "Stream",
-					Getter = () => ImageSource.FromStream(() => typeof(App).Assembly.GetManifestResourceStream("Xamarin.Forms.Controls.coffee.png"))
+					Getter = () => ImageSource.FromStream(() => typeof(App).GetTypeInfo().Assembly.GetManifestResourceStream("Xamarin.Forms.Controls.coffee.png"))
 				},
 				new ImageSourcePickerItem
 				{

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageWindows.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageWindows.cs
@@ -6,13 +6,15 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 using static Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries.WindowsPlatformSpecificsGalleryHelpers;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 {
     public class MasterDetailPageWindows : MasterDetailPage
 	{
 		public MasterDetailPageWindows(ICommand restore)
 		{
-			On<Windows>()
+			On<WindowsOS>()
 				.SetCollapseStyle(CollapseStyle.Partial);
 			MasterBehavior = MasterBehavior.Popover;
 
@@ -65,10 +67,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 			Type enumType = typeof(CollapseStyle);
 
 			return CreateChanger(enumType,
-				Enum.GetName(enumType, page.On<Windows>().GetCollapseStyle()),
+				Enum.GetName(enumType, page.On<WindowsOS>().GetCollapseStyle()),
 				picker =>
 				{
-					page.On<Windows>().SetCollapseStyle((CollapseStyle)Enum.Parse(enumType, picker.Items[picker.SelectedIndex]));
+					page.On<WindowsOS>().SetCollapseStyle((CollapseStyle)Enum.Parse(enumType, picker.Items[picker.SelectedIndex]));
 				},
 				"Select Collapse Style");
 		}
@@ -81,14 +83,14 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 				VerticalTextAlignment = TextAlignment.Center,
 				VerticalOptions = LayoutOptions.Center
 			};
-			var adjustCollapseWidthEntry = new Entry { Text = page.On<Windows>().CollapsedPaneWidth().ToString() };
+			var adjustCollapseWidthEntry = new Entry { Text = page.On<WindowsOS>().CollapsedPaneWidth().ToString() };
 			var adjustCollapseWidthButton = new Button { Text = "Change", BackgroundColor = Color.Gray };
 			adjustCollapseWidthButton.Clicked += (sender, args) =>
 			{
 				double newWidth;
 				if (double.TryParse(adjustCollapseWidthEntry.Text, out newWidth))
 				{
-					page.On<Windows>().CollapsedPaneWidth(newWidth);
+					page.On<WindowsOS>().CollapsedPaneWidth(newWidth);
 				}
 			};
 

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/RefreshViewWindows.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/RefreshViewWindows.cs
@@ -3,6 +3,7 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 using static Xamarin.Forms.PlatformConfiguration.WindowsSpecific.RefreshView;
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
 
 namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 {
@@ -29,7 +30,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 			refreshView.SetBinding(RefreshView.CommandProperty, "RefreshCommand");
 			refreshView.SetBinding(RefreshView.IsRefreshingProperty, "IsRefreshing");
 
-			refreshView.On<Windows>().SetRefreshPullDirection(RefreshPullDirection.BottomToTop);
+			refreshView.On<WindowsOS>().SetRefreshPullDirection(RefreshPullDirection.BottomToTop);
 
 			var listView = new ListView
 			{

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/WindowsPlatformSpecificsGalleryHelpers.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/WindowsPlatformSpecificsGalleryHelpers.cs
@@ -4,6 +4,8 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 {
     internal static class WindowsPlatformSpecificsGalleryHelpers
@@ -86,10 +88,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
             Type enumType = typeof(ToolbarPlacement);
 
             return CreateChanger(enumType,
-                Enum.GetName(enumType, page.On<Windows>().GetToolbarPlacement()),
+                Enum.GetName(enumType, page.On<WindowsOS>().GetToolbarPlacement()),
                 picker =>
                 {
-                    page.On<Windows>().SetToolbarPlacement((ToolbarPlacement)Enum.Parse(enumType, picker.Items[picker.SelectedIndex]));
+                    page.On<WindowsOS>().SetToolbarPlacement((ToolbarPlacement)Enum.Parse(enumType, picker.Items[picker.SelectedIndex]));
                 }, "Select Toolbar Placement");
         }
 

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -1,6 +1,10 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Msbuild.Sdk.Extras/1.3.1">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup>
     <XFDisableTargetsValidation>True</XFDisableTargetsValidation>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -31,7 +35,9 @@
     <EmbeddedResource Include="GalleryPages\crimson.jpg" />
     <EmbeddedResource Include="coffee.png" />
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
+    <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" Condition="$(TargetFramework) == 'uap10.0.14393'" />
     <Compile Update="GalleryPages\BindableLayoutGalleryPage.xaml.cs">
       <DependentUpon>BindableLayoutGalleryPage.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Msbuild.Sdk.Extras/1.6.68">
+﻿<Project Sdk="Msbuild.Sdk.Extras/2.0.41">
   <PropertyGroup>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Msbuild.Sdk.Extras/2.0.41">
+﻿<Project Sdk="Msbuild.Sdk.Extras/2.0.54">
   <PropertyGroup>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Msbuild.Sdk.Extras/1.3.1">
+﻿<Project Sdk="Msbuild.Sdk.Extras/1.6.68">
   <PropertyGroup>
     <TargetFramework Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFramework>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netstandard2.0;uap10.0.14393</TargetFrameworks>
@@ -37,7 +37,6 @@
     <PackageReference Include="Newtonsoft.Json" Version="10.0.3" />
     <PackageReference Include="System.Threading.Thread" Version="4.3.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.6" Condition="$(TargetFramework) == 'uap10.0.14393'" />
     <Compile Update="GalleryPages\BindableLayoutGalleryPage.xaml.cs">
       <DependentUpon>BindableLayoutGalleryPage.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
@@ -7,6 +7,8 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 namespace Xamarin.Forms.Core.UnitTests
 {
 	[TestFixture]
@@ -135,10 +137,10 @@ namespace Xamarin.Forms.Core.UnitTests
 			var defaultWebView = new WebView();
 
 			var jsAlertsAllowedWebView = new WebView();
-			jsAlertsAllowedWebView.On<Windows>().SetIsJavaScriptAlertEnabled(true);
+			jsAlertsAllowedWebView.On<WindowsOS>().SetIsJavaScriptAlertEnabled(true);
 
-			Assert.AreEqual(defaultWebView.On<Windows>().IsJavaScriptAlertEnabled(), false);
-			Assert.AreEqual(jsAlertsAllowedWebView.On<Windows>().IsJavaScriptAlertEnabled(), true);
+			Assert.AreEqual(defaultWebView.On<WindowsOS>().IsJavaScriptAlertEnabled(), false);
+			Assert.AreEqual(jsAlertsAllowedWebView.On<WindowsOS>().IsJavaScriptAlertEnabled(), true);
 		}
 	}
 }

--- a/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
+++ b/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
+++ b/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
+++ b/Xamarin.Forms.CustomAttributes/Xamarin.Forms.CustomAttributes.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
   
   <PropertyGroup>

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -11,8 +11,9 @@
     <AssemblyName>Xamarin.Forms.Maps.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -11,9 +11,8 @@
     <AssemblyName>Xamarin.Forms.Maps.UWP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>		
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Xamarin.Forms.Pages.Azure/Xamarin.Forms.Pages.Azure.csproj
+++ b/Xamarin.Forms.Pages.Azure/Xamarin.Forms.Pages.Azure.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Mobile.Client">

--- a/Xamarin.Forms.Pages.Azure/Xamarin.Forms.Pages.Azure.csproj
+++ b/Xamarin.Forms.Pages.Azure/Xamarin.Forms.Pages.Azure.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Azure.Mobile.Client">

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
   </PropertyGroup>

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
   <PropertyGroup>
-    <TargetFramework>netstandard1.4</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
   </PropertyGroup>

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
   <PropertyGroup>
-    <TargetFramework>netstandard2.0</TargetFramework>
+    <TargetFramework>netstandard1.4</TargetFramework>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
   </PropertyGroup>

--- a/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
+++ b/Xamarin.Forms.Pages/Xamarin.Forms.Pages.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk" DefaultTargets="Build">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netstandard1.0</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;netstandard1.4</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.GTK/Controls/DatePicker.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/DatePicker.cs
@@ -388,9 +388,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 
 		private void UpdateEntryText()
 		{
-			_comboBox.Entry.Text = string.IsNullOrEmpty(_dateFormat)
-				? _currentDate.ToLongDateString()
-				: _currentDate.ToString(_dateFormat);
+			_comboBox.Entry.Text = _currentDate.ToString(string.IsNullOrEmpty(_dateFormat)? "D" : _dateFormat);
 		}
 
 		private void OnBtnShowCalendarClicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Reflection;
 using System.Threading.Tasks;
 using Windows.Foundation;
 using Windows.UI.Xaml;
@@ -117,8 +118,8 @@ namespace Xamarin.Forms.Platform.UWP
 		bool IsObservableCollection(object source)
 		{
 			var type = source.GetType();
-			return type.IsGenericType &&
-				   type.GetGenericTypeDefinition() == typeof(ObservableCollection<>);
+			return type.GetTypeInfo().IsGenericType &&
+				type.GetGenericTypeDefinition() == typeof(ObservableCollection<>);
 		}
 
 		void ReloadData()

--- a/Xamarin.Forms.Platform.UAP/WindowsIsolatedStorage.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsIsolatedStorage.cs
@@ -4,9 +4,9 @@ using System.Threading.Tasks;
 using Windows.Storage;
 using Windows.Storage.FileProperties;
 using Windows.Storage.Streams;
-//using FileMode = Xamarin.Forms.Internals.FileMode;
-//using FileAccess = Xamarin.Forms.Internals.FileAccess;
-//using FileShare = Xamarin.Forms.Internals.FileShare;
+using FileMode = Xamarin.Forms.Internals.FileMode;
+using FileAccess = Xamarin.Forms.Internals.FileAccess;
+using FileShare = Xamarin.Forms.Internals.FileShare;
 
 namespace Xamarin.Forms.Platform.UWP
 {

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -17,7 +17,6 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -16,6 +16,7 @@
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -11,9 +11,8 @@
     <AssemblyName>Xamarin.Forms.Platform.UAP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
+    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -11,8 +11,9 @@
     <AssemblyName>Xamarin.Forms.Platform.UAP</AssemblyName>
     <DefaultLanguage>en-US</DefaultLanguage>
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
-    <TargetPlatformVersion>10.0.18362.0</TargetPlatformVersion>
+    <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.14393.0</TargetPlatformMinVersion>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
+++ b/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
@@ -24,7 +24,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsE886.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -32,7 +31,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsE886.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(OS)' != 'Unix' ">
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
+++ b/Xamarin.Forms.Xaml.Design/Xamarin.Forms.Xaml.Design.csproj
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-   <PropertyGroup>
+  <PropertyGroup>
     <Description>Provides the design-time metadata for the XAML language service.</Description>
     <AssemblyName>Xamarin.Forms.Xaml.Design</AssemblyName>
   </PropertyGroup>
@@ -24,6 +24,7 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsE886.tmp\Debug\</IntermediateOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
@@ -31,6 +32,7 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
+    <IntermediateOutputPath>C:\Users\shane\AppData\Local\Temp\vsE886.tmp\Release\</IntermediateOutputPath>
   </PropertyGroup>
   <ItemGroup Condition=" '$(OS)' != 'Unix' ">
     <Reference Include="Microsoft.Windows.Design.Extensibility, Version=4.3.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/Xamarin.Forms.Xaml.UnitTests/PlatformSpecifics.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/PlatformSpecifics.xaml.cs
@@ -6,6 +6,8 @@ using NUnit.Framework;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
+using WindowsOS = Xamarin.Forms.PlatformConfiguration.Windows;
+
 namespace Xamarin.Forms.Xaml.UnitTests
 {
 	public partial class PlatformSpecific : MasterDetailPage
@@ -28,8 +30,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			public void PlatformSpecificPropertyIsSet(bool useCompiledXaml)
 			{
 				var layout = new PlatformSpecific(useCompiledXaml);
-				Assert.AreEqual(layout.On<Windows>().GetCollapseStyle(), CollapseStyle.Partial);
-				Assert.AreEqual(layout.On<Windows>().CollapsedPaneWidth(), 96d);
+				Assert.AreEqual(layout.On<WindowsOS>().GetCollapseStyle(), CollapseStyle.Partial);
+				Assert.AreEqual(layout.On<WindowsOS>().CollapsedPaneWidth(), 96d);
 			}
 		}
 	}

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -78,6 +78,11 @@ jobs:
         inputs:
           solution: ${{ parameters.buildTaskPath }}
 
+      - task: NuGetCommand@2
+        displayName: 'Nuget restore ${{ parameters.buildControlsPath  }}'
+        inputs:
+          solution: ${{ parameters.buildControlsPath }}
+
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildControlsPath  }}'
         inputs:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -9,6 +9,7 @@ parameters:
   postBuildSteps: []  # any additional steps to run after the build
   slnPath : 'Xamarin.Forms.sln'
   buildTaskPath : 'Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
+  buildControlsPath : 'Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj'
   androidPath : 'Xamarin.Forms.ControlGallery.Android'
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
   androidProjectArguments : ''
@@ -76,6 +77,11 @@ jobs:
         displayName: 'Build ${{ parameters.buildTaskPath  }}'
         inputs:
           solution: ${{ parameters.buildTaskPath }}
+
+      - task: MSBuild@1
+        displayName: 'Build ${{ parameters.buildControlsPath  }}'
+        inputs:
+          solution: ${{ parameters.buildControlsPath }}
 
       - task: MSBuild@1
         displayName: 'Build Android ${{ parameters.name }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -9,7 +9,6 @@ parameters:
   postBuildSteps: []  # any additional steps to run after the build
   slnPath : 'Xamarin.Forms.sln'
   buildTaskPath : 'Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
-  buildControlsPath : 'Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj'
   androidPath : 'Xamarin.Forms.ControlGallery.Android'
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
   androidProjectArguments : ''
@@ -77,16 +76,6 @@ jobs:
         displayName: 'Build ${{ parameters.buildTaskPath  }}'
         inputs:
           solution: ${{ parameters.buildTaskPath }}
-
-      - task: NuGetCommand@2
-        displayName: 'Nuget restore ${{ parameters.buildControlsPath  }}'
-        inputs:
-          solution: ${{ parameters.buildControlsPath }}
-
-      - task: MSBuild@1
-        displayName: 'Build ${{ parameters.buildControlsPath  }}'
-        inputs:
-          solution: ${{ parameters.buildControlsPath }}
 
       - task: MSBuild@1
         displayName: 'Build Android ${{ parameters.name }}'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -1,6 +1,3 @@
-parameters:
-  buildControlsPath : 'Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj'
-
 steps:
   - checkout: self
     clean: true
@@ -48,16 +45,6 @@ steps:
     displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
     inputs:
       solution: Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
-
-  - task: NuGetCommand@2
-    displayName: 'Nuget restore ${{ parameters.buildControlsPath  }}'
-    inputs:
-      solution: ${{ parameters.buildControlsPath }}
-
-  - task: MSBuild@1
-    displayName: 'Build ${{ parameters.buildControlsPath  }}'
-    inputs:
-      solution: ${{ parameters.buildControlsPath }}
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -1,3 +1,6 @@
+parameters:
+  buildControlsPath : 'Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj'
+
 steps:
   - checkout: self
     clean: true
@@ -45,6 +48,16 @@ steps:
     displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
     inputs:
       solution: Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+
+  - task: NuGetCommand@2
+    displayName: 'Nuget restore ${{ parameters.buildControlsPath  }}'
+    inputs:
+      solution: ${{ parameters.buildControlsPath }}
+
+  - task: MSBuild@1
+    displayName: 'Build ${{ parameters.buildControlsPath  }}'
+    inputs:
+      solution: ${{ parameters.buildControlsPath }}
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'


### PR DESCRIPTION
### Description of Change ###
Target netstandard 1.4 in order to support uap10.0.

### Issues Resolved ### 
fixes #3533 

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
