### PR TITLE
[Android] Click on the center of the down stepper button

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -46,19 +46,20 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// Find the control we're testing
 			var result = RunningApp.WaitForElement(q => q.Marked(TargetAutomationId));
+
+			// In theory we want to tap the center of the control. But Stepper lays out differently than the other controls,
+			// (it doesn't center vertically within its layout), so we need to adjust for it until someone fixes it
+			if (menuItem == "Stepper")
+			{
+				result = RunningApp.WaitForElement(q => q.Marked("−"));
+			}
+
 			var target = result.First().Rect;
 
 			// Tap the control
 			var y = target.CenterY;
 			var x = target.CenterX;
 
-			// In theory we want to tap the center of the control. But Stepper lays out differently than the other controls,
-			// (it doesn't center vertically within its layout), so we need to adjust for it until someone fixes it
-			if (menuItem == "Stepper")
-			{
-				y = target.Y;
-				x = target.X;
-			}
 
 			RunningApp.TapCoordinates(x, y);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -93,7 +93,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 #endif
 
-			ContentPage CreateTestPage(View view)
+		ContentPage CreateTestPage(View view)
 		{
 			var layout = new Grid();
 			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/InputTransparentTests.cs
@@ -49,10 +49,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// In theory we want to tap the center of the control. But Stepper lays out differently than the other controls,
 			// (it doesn't center vertically within its layout), so we need to adjust for it until someone fixes it
+
+#if __ANDROID__
 			if (menuItem == "Stepper")
 			{
 				result = RunningApp.WaitForElement(q => q.Marked("−"));
 			}
+#endif
 
 			var target = result.First().Rect;
 
@@ -90,7 +93,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 #endif
 
-		ContentPage CreateTestPage(View view)
+			ContentPage CreateTestPage(View view)
 		{
 			var layout = new Grid();
 			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });


### PR DESCRIPTION
### Description of Change ###
The stepper is currently setup to click on the top left corner of the buttons but it looks like occasionally this is off just enough that it clicks on the layout and not the button. This PR grabs the actual button from the stepper on Android and then clicks the center of it. 