### PR TITLE
Rename InitializationFlags -> ActivationFlags

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms
 	[Flags]
 	public enum InitializationFlags : long
 	{
-		NoCss = 1 << 0
+		DisableCss = 1 << 0
 	}
 
 
@@ -363,7 +363,7 @@ namespace Xamarin.Forms.Internals
 				Profile.FrameEnd();
 			}
 
-			if ((flags & InitializationFlags.NoCss) == 0)
+			if ((flags & InitializationFlags.DisableCss) == 0)
 				RegisterStylesheets();
 
 			Profile.FramePartition("DependencyService.Initialize");

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -9,9 +9,9 @@ using Xamarin.Forms.StyleSheets;
 namespace Xamarin.Forms
 {
 	[Flags]
-	public enum ActivationFlags
+	public enum InitializationFlags : long
 	{
-		NoCss = 1 << 0,
+		NoCss = 1 << 0
 	}
 
 
@@ -296,9 +296,9 @@ namespace Xamarin.Forms.Internals
 
 		public static void RegisterAll(Type[] attrTypes)
 		{
-			RegisterAll(attrTypes, default(ActivationFlags));
+			RegisterAll(attrTypes, default(InitializationFlags));
 		}
-		public static void RegisterAll(Type[] attrTypes, ActivationFlags flags)
+		public static void RegisterAll(Type[] attrTypes, InitializationFlags flags)
 		{
 			Profile.FrameBegin();
 
@@ -363,7 +363,7 @@ namespace Xamarin.Forms.Internals
 				Profile.FrameEnd();
 			}
 
-			if ((flags & ActivationFlags.NoCss) == 0)
+			if ((flags & InitializationFlags.NoCss) == 0)
 				RegisterStylesheets();
 
 			Profile.FramePartition("DependencyService.Initialize");

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 	[Flags]
 	public enum ActivationFlags : long
 	{
-		FixedStatusBarColor = 1 << 0,
+		DisableSetStatusBarColor = 1 << 0,
 	}
 
 	public struct ActivationOptions
@@ -106,8 +106,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (current != filter)
 				return;
 
-				Registrar.Registered.Register(target, handler);
-			}
+			Registrar.Registered.Register(target, handler);
+		}
 
 		// This is currently being used by the previewer please do not change or remove this
 		static void RegisterHandlers()
@@ -188,7 +188,7 @@ namespace Xamarin.Forms.Platform.Android
 			OnCreate(savedInstanceState, default(ActivationFlags));
 		}
 
-		private void OnCreate(
+		void OnCreate(
 			Bundle savedInstanceState, 
 			ActivationFlags flags)
 		{
@@ -225,12 +225,12 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnCreate;
 
-				OnStateChanged();
+			OnStateChanged();
 
 			if (Forms.IsLollipopOrNewer)
 			{
 				// Allow for the status bar color to be changed
-				if ((flags & ActivationFlags.FixedStatusBarColor) == 0)
+				if ((flags & ActivationFlags.DisableSetStatusBarColor) == 0)
 				{
 					Window.AddFlags(WindowManagerFlags.DrawsSystemBarBackgrounds);
 				}

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -150,7 +150,7 @@ namespace Xamarin.Forms
 			Profile.FrameEnd();
 		}
 
-		public static void Initialize(InitializationOptions options)
+		public static void Init(InitializationOptions options)
 		{
 			Profile.FrameBegin();
 			SetupInit(
@@ -296,7 +296,7 @@ namespace Xamarin.Forms
 					}
 
 					// css
-					var noCss = (flags & InitializationFlags.NoCss) != 0;
+					var noCss = (flags & InitializationFlags.DisableCss) != 0;
 					if (!noCss)
 						Registrar.RegisterStylesheets();
 				}

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -25,7 +25,7 @@ using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
-	public struct ActivationOptions
+	public struct InitializationOptions
 	{
 		public struct EffectScope
 		{
@@ -33,9 +33,9 @@ namespace Xamarin.Forms
 			public ExportEffectAttribute[] Effects;
 		}
 
-		public ActivationOptions(Context activity, Bundle bundle, Assembly resourceAssembly)
+		public InitializationOptions(Context activity, Bundle bundle, Assembly resourceAssembly)
 		{
-			this = default(ActivationOptions);
+			this = default(InitializationOptions);
 			this.Activity = activity;
 			this.Bundle = bundle;
 			this.ResourceAssembly = resourceAssembly;
@@ -45,7 +45,7 @@ namespace Xamarin.Forms
 		public Assembly ResourceAssembly;
 		public HandlerAttribute[] Handlers;
 		public EffectScope[] EffectScopes;
-		public ActivationFlags Flags;
+		public InitializationFlags Flags;
 	}
 
 	public static class Forms
@@ -150,13 +150,13 @@ namespace Xamarin.Forms
 			Profile.FrameEnd();
 		}
 
-		public static void Initialize(ActivationOptions activation)
+		public static void Initialize(InitializationOptions options)
 		{
 			Profile.FrameBegin();
 			SetupInit(
-				activation.Activity,
-				activation.ResourceAssembly,
-				activation
+				options.Activity,
+				options.ResourceAssembly,
+				options
 			);
 			Profile.FrameEnd();
 		}
@@ -211,10 +211,11 @@ namespace Xamarin.Forms
 		static void SetupInit(
 			Context activity,
 			Assembly resourceAssembly,
-			ActivationOptions? maybeOptions = null
+			InitializationOptions? maybeOptions = null
 		)
 		{
 			Profile.FrameBegin();
+
 			if (!IsInitialized)
 			{
 				// Only need to get this once; it won't change
@@ -295,7 +296,7 @@ namespace Xamarin.Forms
 					}
 
 					// css
-					var noCss = (flags & ActivationFlags.NoCss) != 0;
+					var noCss = (flags & InitializationFlags.NoCss) != 0;
 					if (!noCss)
 						Registrar.RegisterStylesheets();
 				}


### PR DESCRIPTION
### Description of Change ###

Rename `InitializationFlags` to `ActivationFlags` so I could use `ActivationFlags` during activation and `InitializationFlags` during the `Forms.Initialization` call. Duh.

This is technically a breaking change but no one should be using the flags. I introduced them to establish a mechanism whereby we can supply developers a way to disable unused feature initialization at startup. Disabling the one sample feature (css initialization) won't be noticeable by itself so that's why no one is using it. Only when all the perf tweaks are taken together is the gain noticeable. 

Introduce a new `ActivationFlags` with a flag `FixedStatusBarColor`. If the developer specifies the flag, then the developer is asking that we not burn time at startup making a system call whose only purpose is to allow the color to be changed.

Also renamed the flag from `NoCss` to `DisableCss` and `Initialize` to `Init` because that matches the method I'm overloading. 

### API Changes ###
+/- `ActivationFlags.NoCss` -> `InitializationFlags.DisableCss`
+/- `ActivationOptions` -> `InitializationOptions`
+/- `void Forms.Initialization(ActivationOptions)` -> `void Forms.Init(InitializationOptions)`

+ `InitializationFlags.FixedStatusBarColor`
+ `InitializationOptions`
+ `Forms(InitializationOptions)`

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None, unless you opt-in to using the flags.

### Testing Procedure ###

UITests, XFShellStartup

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
