### PR TITLE
[Android] Update webview to use correct value for WebNavigationEvent

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (navigate)
 			{
-				var args = new WebNavigatedEventArgs(WebNavigationEvent.NewPage, source, url, _navigationResult);
+				var args = new WebNavigatedEventArgs(_renderer.GetCurrentWebNavigationEvent(), source, url, _navigationResult);
 				_renderer.ElementController.SendNavigated(args);
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public const string AssetBaseUrl = "file:///android_asset/";
 
-		WebNavigationEvent _lastBackForwardEvent = WebNavigationEvent.NewPage;
+		WebNavigationEvent _eventState;
 		WebViewClient _webViewClient;
 		FormsWebChromeClient _webChromeClient;
 		bool _isDisposed = false;
@@ -37,13 +37,17 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void LoadHtml(string html, string baseUrl)
 		{
+			_eventState = WebNavigationEvent.NewPage;
 			Control.LoadDataWithBaseURL(baseUrl ?? AssetBaseUrl, html, "text/html", "UTF-8", null);
 		}
 
 		public void LoadUrl(string url)
 		{
 			if (!SendNavigatingCanceled(url))
+			{
+				_eventState = WebNavigationEvent.NewPage;
 				Control.LoadUrl(url);
+			}	
 		}
 
 		protected internal bool SendNavigatingCanceled(string url)
@@ -54,7 +58,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (url == AssetBaseUrl)
 				return false;
 
-			var args = new WebNavigatingEventArgs(_lastBackForwardEvent, new UrlWebViewSource { Url = url }, url);
+			var args = new WebNavigatingEventArgs(_eventState, new UrlWebViewSource { Url = url }, url);
 			ElementController.SendNavigating(args);
 			UpdateCanGoBackForward();
 			UrlCanceled = args.Cancel ? null : url;
@@ -109,7 +113,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal WebNavigationEvent GetCurrentWebNavigationEvent()
 		{
-			return _lastBackForwardEvent;
+			return _eventState;
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<WebView> e)
@@ -217,7 +221,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (Control.CanGoBack())
 			{
-				_lastBackForwardEvent = WebNavigationEvent.Back;
+				_eventState = WebNavigationEvent.Back;
 				Control.GoBack();
 			}	
 
@@ -228,7 +232,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (Control.CanGoForward())
 			{
-				_lastBackForwardEvent = WebNavigationEvent.Forward;
+				_eventState = WebNavigationEvent.Forward;
 				Control.GoForward();
 			}	
 
@@ -237,7 +241,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnReloadRequested(object sender, EventArgs eventArgs)
 		{
-			_lastBackForwardEvent = WebNavigationEvent.Refresh;
+			_eventState = WebNavigationEvent.Refresh;
 			Control.Reload();
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public const string AssetBaseUrl = "file:///android_asset/";
 
+		WebNavigationEvent _lastBackForwardEvent = WebNavigationEvent.NewPage;
 		WebViewClient _webViewClient;
 		FormsWebChromeClient _webChromeClient;
 		bool _isDisposed = false;
@@ -53,7 +54,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (url == AssetBaseUrl)
 				return false;
 
-			var args = new WebNavigatingEventArgs(WebNavigationEvent.NewPage, new UrlWebViewSource { Url = url }, url);
+			var args = new WebNavigatingEventArgs(_lastBackForwardEvent, new UrlWebViewSource { Url = url }, url);
 			ElementController.SendNavigating(args);
 			UpdateCanGoBackForward();
 			UrlCanceled = args.Cancel ? null : url;
@@ -104,6 +105,11 @@ namespace Xamarin.Forms.Platform.Android
 		protected override AWebView CreateNativeControl()
 		{
 			return new AWebView(Context);
+		}
+
+		internal WebNavigationEvent GetCurrentWebNavigationEvent()
+		{
+			return _lastBackForwardEvent;
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<WebView> e)
@@ -210,7 +216,10 @@ namespace Xamarin.Forms.Platform.Android
 		void OnGoBackRequested(object sender, EventArgs eventArgs)
 		{
 			if (Control.CanGoBack())
+			{
+				_lastBackForwardEvent = WebNavigationEvent.Back;
 				Control.GoBack();
+			}	
 
 			UpdateCanGoBackForward();
 		}
@@ -218,13 +227,17 @@ namespace Xamarin.Forms.Platform.Android
 		void OnGoForwardRequested(object sender, EventArgs eventArgs)
 		{
 			if (Control.CanGoForward())
+			{
+				_lastBackForwardEvent = WebNavigationEvent.Forward;
 				Control.GoForward();
+			}	
 
 			UpdateCanGoBackForward();
 		}
 
 		void OnReloadRequested(object sender, EventArgs eventArgs)
 		{
+			_lastBackForwardEvent = WebNavigationEvent.Refresh;
 			Control.Reload();
 		}
 


### PR DESCRIPTION
### Description of Change ###
When using webview in Xamarin.Forms on Android whenever the Navigated/Navigating event is fired, in args it always has the same value for all the events i.e. WebNavigationEvent.NewPage. It should return the correct value ([API Doc](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.webnavigationevent?view=xamarin-forms)) based on the event.

### Issues Resolved ### 
Now returning different values for WebNavigationEvent based on event.

### API Changes ###
Nona

### Platforms Affected ### 
- Android

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
