### PR TITLE
[Android] Disable AndroidTicker if AnimatorDurationScale is equal or below 0

### DIFF
--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -9,7 +9,8 @@ namespace Xamarin.Forms.Platform.Android
 	internal class AndroidTicker : Ticker, IDisposable
 	{
 		ValueAnimator _val;
-		bool _systemEnabled;
+		bool _energySaveModeDisabled;
+		readonly bool _animatorEnabled;
 
 		public AndroidTicker()
 		{
@@ -17,10 +18,11 @@ namespace Xamarin.Forms.Platform.Android
 			_val.SetIntValues(0, 100); // avoid crash
 			_val.RepeatCount = ValueAnimator.Infinite;
 			_val.Update += OnValOnUpdate;
+			_animatorEnabled = IsAnimatorEnabled();
 			CheckPowerSaveModeStatus();
 		}
 
-		public override bool SystemEnabled => _systemEnabled;
+		public override bool SystemEnabled => _energySaveModeDisabled && _animatorEnabled;
 
 		internal void CheckPowerSaveModeStatus()
 		{
@@ -31,7 +33,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (!Forms.IsLollipopOrNewer)
 			{
-				_systemEnabled = true;
+				_energySaveModeDisabled = true;
 				return;
 			}
 
@@ -40,10 +42,17 @@ namespace Xamarin.Forms.Platform.Android
 			var powerSaveOn = powerManager.IsPowerSaveMode;
 
 			// If power saver is active, then animations will not run
-			_systemEnabled = !powerSaveOn;
+			_energySaveModeDisabled = !powerSaveOn;
 			
 			// Notify the ticker that this value has changed, so it can manage animations in progress
 			OnSystemEnabledChanged();
+		}
+
+		static bool IsAnimatorEnabled()
+		{
+			var resolver = global::Android.App.Application.Context.ContentResolver;
+			var scale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 0);
+			return scale > 0;
 		}
 
 		public void Dispose()

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -51,8 +51,9 @@ namespace Xamarin.Forms.Platform.Android
 		static bool IsAnimatorEnabled()
 		{
 			var resolver = global::Android.App.Application.Context?.ContentResolver;
-			if (resolver == null) {
-				return true;
+			if (resolver == null)
+			{
+				return false;
 			}
 
 			var scale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 0);

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -50,7 +50,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		static bool IsAnimatorEnabled()
 		{
-			var resolver = global::Android.App.Application.Context.ContentResolver;
+			var resolver = global::Android.App.Application.Context?.ContentResolver;
+			if (resolver == null) {
+				return true;
+			}
+
 			var scale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 0);
 			return scale > 0;
 		}


### PR DESCRIPTION
### Description of Change ###

Fixes the issue described in #5421 by disabling AndroidTicker if AnimatorDurationScale is set to 0.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5421

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

As given in the "Steps to Reproduce" in #5421:

1. Set Animator duration scale to off in developer settings on an Android device.
2. Call any animation -> var animationTask = label.FadeTo(1)
3. await the resulting task

Without the provided fix, the awaited task will never complete. If the fix is applied, no animation is shown and the task completes immediately.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard