### PR TITLE
Reduce memory cost of struct Color

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -52,6 +52,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (Color.FromHsla (.1, .6, .2), color.WithHue (.1));
 			Assert.AreEqual (Color.FromHsla (.8, .1, .2), color.WithSaturation (.1));
 			Assert.AreEqual (Color.FromHsla (.8, .6, .1), color.WithLuminosity (.1));
+
+			color = Color.FromRgb(50, 100, 150);
+			Assert.That(color.WithHue(.1).Hue, Is.EqualTo(0.1).Within(0.01));
+			Assert.That(color.WithHue(.1).Saturation, Is.EqualTo(color.Saturation).Within(0.01));
+			Assert.That(color.WithHue(.1).Luminosity, Is.EqualTo(color.Luminosity).Within(0.01));
+
+			Assert.That(color.WithSaturation(.1).Hue, Is.EqualTo(color.Hue).Within(0.01));
+			Assert.That(color.WithSaturation(.1).Saturation, Is.EqualTo(.1).Within(0.01));
+			Assert.That(color.WithSaturation(.1).Luminosity, Is.EqualTo(color.Luminosity).Within(0.01));
+
+			Assert.That(color.WithLuminosity(.1).Hue, Is.EqualTo(color.Hue).Within(0.01));
+			Assert.That(color.WithLuminosity(.1).Saturation, Is.EqualTo(color.Saturation).Within(0.01));
+			Assert.That(color.WithLuminosity(.1).Luminosity, Is.EqualTo(.1).Within(0.01));
 		}
 
 		[Test]


### PR DESCRIPTION
### Description of Change ###

The _r, _g, _b, _h, _s, _l fields are replaced by _comp012 fields,
which are interepted to RGB values or HSL values according to the mode
flag. This approach reduces the memory cost of Color by 12 bytes.

### Issues Resolved ### 

- fixes #6978

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated test

### PR Checklist ###
- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
