### PR TITLE
Use NSIndexPath.Item instead of .Row in CollectionView

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var indexPath = DetermineIndex(args);
 
-			if (indexPath.Row < 0 || indexPath.Section < 0)
+			if (indexPath.Item < 0 || indexPath.Section < 0)
 			{
 				// Nothing found, nowhere to scroll to
 				return;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.iOS
 					throw new ArgumentOutOfRangeException(nameof(indexPath));
 				}
 
-				return this[indexPath.Row];
+				return this[indexPath.Item];
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.iOS
 					throw new ArgumentOutOfRangeException(nameof(indexPath));
 				}
 
-				return this[indexPath.Item];
+				return this[(int)indexPath.Item];
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return null;
 				}
 
-				return group[indexPath.Row];
+				return group[(int)indexPath.Item];
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.iOS
 					throw new ArgumentOutOfRangeException(nameof(indexPath));
 				}
 
-				return this[indexPath.Row];
+				return this[(int)indexPath.Item];
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Using .Item instead of .Row for accuracy (horizontal collections don't necessarily have "rows") and consistency.

### Issues Resolved ### 

- fixes #6737

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] PR Checklist Items Checked