### PR TITLE
[UITest] Fix 2951 and moved extension method to be more visible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			RunningApp.WaitForNoElement (q=>q.WebView(0).Css("#LinkID0"));
 			UITest.Queries.AppWebResult[] newElem = 
-			  RunningApp.RetryUntilPresent(()=>	RunningApp.Query (q => q.WebView (0).Css ("h1")));
+			  RunningApp.QueryUntilPresent(()=>	RunningApp.Query (q => q.WebView (0).Css ("h1")));
 
 			Assert.AreEqual ("#LocalHtmlPage", newElem[0].Id);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
@@ -14,28 +14,30 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
-	[Preserve (AllMembers = true)]
-	[Issue (IssueTracker.Bugzilla, 26993, "https://bugzilla.xamarin.com/show_bug.cgi?id=26993")]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 26993, "https://bugzilla.xamarin.com/show_bug.cgi?id=26993")]
 	public class Bugzilla26993 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
-		[Preserve (AllMembers = true)]
-		public class Bz26993ViewCell : ViewCell 
+		[Preserve(AllMembers = true)]
+		public class Bz26993ViewCell : ViewCell
 		{
 			public static int s_id = 0;
 
-			public Bz26993ViewCell ()
+			public Bz26993ViewCell()
 			{
-				View = new WebView {
+				View = new WebView
+				{
 					AutomationId = "AutomationId" + s_id,
 					HeightRequest = 300,
-					Source = new HtmlWebViewSource {
+					Source = new HtmlWebViewSource
+					{
 						Html = "<html><head><link rel=\"stylesheet\" href=\"default.css\"></head><body><h1 id=\"CellID" + s_id + "\">Xamarin.Forms " + s_id + "</h1><p>The CSS and image are loaded from local files!</p><img src='WebImages/XamarinLogo.png'/><p><a id=\"LinkID" + s_id++ + "\" href=\"local.html\">next page</a></p></body></html>"
 					}
 				};
 			}
 		}
 
-		protected override void Init ()
+		protected override void Init()
 		{
 			Bz26993ViewCell.s_id = 0;
 
@@ -77,9 +79,10 @@ namespace Xamarin.Forms.Controls.Issues
 				"",
 				"",
 			};
-				
-			Content = new StackLayout {
-				Children = { 
+
+			Content = new StackLayout
+			{
+				Children = {
 					new ListView {
 						RowHeight = 300,
 						ItemsSource = itemSource,
@@ -94,22 +97,22 @@ namespace Xamarin.Forms.Controls.Issues
 #if __MACOS__
 		[Ignore("Webview query is not implemented yet on UITEst desktop")]
 #endif
-		public void Bugzilla26993Test ()
+		public void Bugzilla26993Test()
 		{
-			RunningApp.Screenshot ("I am at BZ26993");
+			RunningApp.Screenshot("I am at BZ26993");
 
-			RunningApp.WaitForElement (q=>q.WebView(0).Css("#CellID0"));
-			RunningApp.Tap (q=>q.WebView(0).Css("#LinkID0"));
+			RunningApp.WaitForElement(q => q.WebView(0).Css("#CellID0"));
+			RunningApp.Tap(q => q.WebView(0).Css("#LinkID0"));
 
-			RunningApp.Screenshot ("Load local HTML");
+			RunningApp.Screenshot("Load local HTML");
 
-			RunningApp.WaitForNoElement (q=>q.WebView(0).Css("#LinkID0"));
-			UITest.Queries.AppWebResult[] newElem = 
-			  RunningApp.QueryUntilPresent(()=>	RunningApp.Query (q => q.WebView (0).Css ("h1")));
+			RunningApp.WaitForNoElement(q => q.WebView(0).Css("#LinkID0"));
+			UITest.Queries.AppWebResult[] newElem =
+			  RunningApp.QueryUntilPresent(() => RunningApp.Query(q => q.WebView(0).Css("h1")));
 
-			Assert.AreEqual ("#LocalHtmlPage", newElem[0].Id);
+			Assert.AreEqual("#LocalHtmlPage", newElem[0].Id);
 
-			RunningApp.Screenshot ("I see the Label");
+			RunningApp.Screenshot("I see the Label");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
@@ -24,10 +24,10 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 #endif
-    [Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Github, 5623, "CollectionView with Incremental Collection (RemainingItemsThreshold)", PlatformAffected.All)]
-    public partial class Github5623 : TestContentPage
-    {
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5623, "CollectionView with Incremental Collection (RemainingItemsThreshold)", PlatformAffected.All)]
+	public partial class Github5623 : TestContentPage
+	{
 #if APP
 		int _itemCount = 10;
 		const int MaximumItemCount = 100;
@@ -108,16 +108,16 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 #endif
 
-        protected override void Init()
-        {
+		protected override void Init()
+		{
 
-        }
+		}
 
 #if UITEST
 		[Test]
 		public void CollectionViewInfiniteScroll()
 		{
-			RunningApp.WaitForElement ("CollectionView5623");
+			RunningApp.WaitForElement("CollectionView5623");
 
 			var colView = RunningApp.Query("CollectionView5623").Single();
 
@@ -135,62 +135,62 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.IsTrue(lastCellResults?.Any() ?? false);
 		}
 #endif
-    }
+	}
 
-    [Preserve(AllMembers = true)]
-    public class ViewModel5623
-    {
-        public ObservableCollection<Model5623> Items { get; set; }
+	[Preserve(AllMembers = true)]
+	public class ViewModel5623
+	{
+		public ObservableCollection<Model5623> Items { get; set; }
 
-        public Command RemainingItemsThresholdReachedCommand { get; set; }
+		public Command RemainingItemsThresholdReachedCommand { get; set; }
 
-        public ItemSizingStrategy ItemSizingStrategy { get; set; } = ItemSizingStrategy.MeasureAllItems;
+		public ItemSizingStrategy ItemSizingStrategy { get; set; } = ItemSizingStrategy.MeasureAllItems;
 
-        public ViewModel5623()
-        {
-            var collection = new ObservableCollection<Model5623>();
-            var pageSize = 10;
+		public ViewModel5623()
+		{
+			var collection = new ObservableCollection<Model5623>();
+			var pageSize = 10;
 
-            for (var i = 0; i < pageSize; i++)
-            {
-                collection.Add(new Model5623(ItemSizingStrategy == ItemSizingStrategy.MeasureAllItems)
-                {
-                    Text = i.ToString(),
-                    BackgroundColor = i % 2 == 0 ? Color.AntiqueWhite : Color.Lavender
-                });
-            }
+			for (var i = 0; i < pageSize; i++)
+			{
+				collection.Add(new Model5623(ItemSizingStrategy == ItemSizingStrategy.MeasureAllItems)
+				{
+					Text = i.ToString(),
+					BackgroundColor = i % 2 == 0 ? Color.AntiqueWhite : Color.Lavender
+				});
+			}
 
-            Items = collection;
+			Items = collection;
 
-            RemainingItemsThresholdReachedCommand = new Command(() =>
-            {
-                System.Diagnostics.Debug.WriteLine($"{nameof(RemainingItemsThresholdReachedCommand)} called");
-            });
-        }
-    }
+			RemainingItemsThresholdReachedCommand = new Command(() =>
+			{
+				System.Diagnostics.Debug.WriteLine($"{nameof(RemainingItemsThresholdReachedCommand)} called");
+			});
+		}
+	}
 
-    [Preserve(AllMembers = true)]
-    public class Model5623
-    {
-        RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
+	[Preserve(AllMembers = true)]
+	public class Model5623
+	{
+		RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
 
-        public string Text { get; set; }
+		public string Text { get; set; }
 
-        public Color BackgroundColor { get; set; }
+		public Color BackgroundColor { get; set; }
 
-        public int Height { get; set; } = 200;
+		public int Height { get; set; } = 200;
 
-        public string HeightText { get; private set; }
+		public string HeightText { get; private set; }
 
-        public Model5623(bool isUneven)
-        {
-            var byteArray = new byte[4];
-            provider.GetBytes(byteArray);
+		public Model5623(bool isUneven)
+		{
+			var byteArray = new byte[4];
+			provider.GetBytes(byteArray);
 
-            if (isUneven)
-                Height = 100 + (BitConverter.ToInt32(byteArray, 0) % 300 + 300) % 300;
+			if (isUneven)
+				Height = 100 + (BitConverter.ToInt32(byteArray, 0) % 300 + 300) % 300;
 
-            HeightText = "(Height: " + Height + ")";
-        }
-    }
+			HeightText = "(Height: " + Height + ")";
+		}
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
@@ -24,10 +24,10 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 #endif
-	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 5623, "CollectionView with Incremental Collection (RemainingItemsThreshold)", PlatformAffected.All)]
-	public partial class Github5623 : TestContentPage
-	{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 5623, "CollectionView with Incremental Collection (RemainingItemsThreshold)", PlatformAffected.All)]
+    public partial class Github5623 : TestContentPage
+    {
 #if APP
 		int _itemCount = 10;
 		const int MaximumItemCount = 100;
@@ -108,10 +108,10 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 #endif
 
-		protected override void Init()
-		{
+        protected override void Init()
+        {
 
-		}
+        }
 
 #if UITEST
 		[Test]
@@ -123,74 +123,74 @@ namespace Xamarin.Forms.Controls.Issues
 
 			AppResult[] lastCellResults = null;
 
-			RunningApp.RetryUntilPresent(() =>
-			{
-				RunningApp.DragCoordinates(colView.Rect.CenterX, colView.Rect.Y + colView.Rect.Height - 50, colView.Rect.CenterX, colView.Rect.Y + 5);
+			RunningApp.QueryUntilPresent(() =>
+			 {
+				 RunningApp.DragCoordinates(colView.Rect.CenterX, colView.Rect.Y + colView.Rect.Height - 50, colView.Rect.CenterX, colView.Rect.Y + 5);
 
-				lastCellResults = RunningApp.Query("99");
+				 lastCellResults = RunningApp.Query("99");
 
-				return lastCellResults;
-			}, 100, 1);
+				 return lastCellResults;
+			 }, 100, 1);
 
 			Assert.IsTrue(lastCellResults?.Any() ?? false);
 		}
 #endif
-	}
+    }
 
-	[Preserve(AllMembers = true)]
-	public class ViewModel5623
-	{
-		public ObservableCollection<Model5623> Items { get; set; }
+    [Preserve(AllMembers = true)]
+    public class ViewModel5623
+    {
+        public ObservableCollection<Model5623> Items { get; set; }
 
-		public Command RemainingItemsThresholdReachedCommand { get; set; }
+        public Command RemainingItemsThresholdReachedCommand { get; set; }
 
-		public ItemSizingStrategy ItemSizingStrategy { get; set; } = ItemSizingStrategy.MeasureAllItems;
+        public ItemSizingStrategy ItemSizingStrategy { get; set; } = ItemSizingStrategy.MeasureAllItems;
 
-		public ViewModel5623()
-		{
-			var collection = new ObservableCollection<Model5623>();
-			var pageSize = 10;
+        public ViewModel5623()
+        {
+            var collection = new ObservableCollection<Model5623>();
+            var pageSize = 10;
 
-			for (var i = 0; i < pageSize; i++)
-			{
-				collection.Add(new Model5623(ItemSizingStrategy == ItemSizingStrategy.MeasureAllItems)
-				{
-					Text = i.ToString(),
-					BackgroundColor = i % 2 == 0 ? Color.AntiqueWhite : Color.Lavender
-				});
-			}
+            for (var i = 0; i < pageSize; i++)
+            {
+                collection.Add(new Model5623(ItemSizingStrategy == ItemSizingStrategy.MeasureAllItems)
+                {
+                    Text = i.ToString(),
+                    BackgroundColor = i % 2 == 0 ? Color.AntiqueWhite : Color.Lavender
+                });
+            }
 
-			Items = collection;
+            Items = collection;
 
-			RemainingItemsThresholdReachedCommand = new Command(() =>
-			{
-				System.Diagnostics.Debug.WriteLine($"{nameof(RemainingItemsThresholdReachedCommand)} called");
-			});
-		}
-	}
+            RemainingItemsThresholdReachedCommand = new Command(() =>
+            {
+                System.Diagnostics.Debug.WriteLine($"{nameof(RemainingItemsThresholdReachedCommand)} called");
+            });
+        }
+    }
 
-	[Preserve(AllMembers = true)]
-	public class Model5623
-	{
-		RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
+    [Preserve(AllMembers = true)]
+    public class Model5623
+    {
+        RNGCryptoServiceProvider provider = new RNGCryptoServiceProvider();
 
-		public string Text { get; set; }
+        public string Text { get; set; }
 
-		public Color BackgroundColor { get; set; }
+        public Color BackgroundColor { get; set; }
 
-		public int Height { get; set; } = 200;
+        public int Height { get; set; } = 200;
 
-		public string HeightText { get; private set; }
+        public string HeightText { get; private set; }
 
-		public Model5623(bool isUneven)
-		{
-			var byteArray = new byte[4];
-			provider.GetBytes(byteArray);
+        public Model5623(bool isUneven)
+        {
+            var byteArray = new byte[4];
+            provider.GetBytes(byteArray);
 
-			if (isUneven)
-				Height = 100 + (BitConverter.ToInt32(byteArray, 0) % 300 + 300) % 300;
+            if (isUneven)
+                Height = 100 + (BitConverter.ToInt32(byteArray, 0) % 300 + 300) % 300;
 
-			HeightText = "(Height: " + Height + ")";
-		}
-	}
+            HeightText = "(Height: " + Height + ")";
+        }
+    }
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -9,7 +9,9 @@ using System.Threading.Tasks;
 
 #if UITEST
 using Xamarin.UITest.Queries;
+using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 
@@ -112,14 +114,41 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("Ready");
 			var bt = RunningApp.WaitForElement (c => c.Marked ("btnChangeStatus"));
-			var buttons = RunningApp.Query (c => c.Marked ("btnChangeStatus"));
+
+			var buttons = RunningApp.QueryUntilPresent(() =>
+			 {
+				 var results = RunningApp.Query("btnChangeStatus");
+				 if (results.Length == 3)
+					 return results;
+
+				 return null;
+			 });
+
 			Assert.That (buttons.Length, Is.EqualTo (3));
 			RunningApp.Tap(c => c.Marked ("btnChangeStatus").Index(1));
-			buttons = RunningApp.Query (c => c.Marked ("btnChangeStatus"));
+
+			buttons = RunningApp.QueryUntilPresent(() =>
+			 {
+				 var results = RunningApp.Query("btnChangeStatus");
+				 if ((results[1].Text ?? results[1].Label) == "B")
+					 return results;
+
+				 return null;
+			 });
+
 			var text = buttons [1].Text ?? buttons [1].Label;
 			Assert.That (text, Is.EqualTo ("B"));
 			RunningApp.Tap(c => c.Marked ("btnChangeStatus").Index(1));
-			buttons = RunningApp.Query (c => c.Marked ("btnChangeStatus"));
+
+			buttons = RunningApp.QueryUntilPresent(() =>
+			 {
+				 var results = RunningApp.Query("btnChangeStatus");
+				 if (results.Length == 2)
+					 return results;
+
+				 return null;
+			 });
+
 			Assert.That (buttons.Length, Is.EqualTo (2));
 			//TODO: we should check the color of the button
 			//var buttonTextColor = GetProperty<Color> ("btnChangeStatus", Button.BackgroundColorProperty);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2951.xaml.cs
@@ -20,11 +20,11 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
-	[Preserve (AllMembers = true)]
-	[Issue (IssueTracker.Github, 2951, "On Android, button background is not updated when color changes ")]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2951, "On Android, button background is not updated when color changes ")]
 	public partial class Issue2951 : TestContentPage
 	{
-		public Issue2951 ()
+		public Issue2951()
 		{
 #if APP
 			InitializeComponent ();
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		async void ListView_ItemAppearing(object sender, ItemVisibilityEventArgs e)
 		{
-			if(e.ItemIndex == 2)
+			if (e.ItemIndex == 2)
 			{
 				await Task.Delay(10);
 #if APP
@@ -42,78 +42,86 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		protected override void Init ()
+		protected override void Init()
 		{
-			BindingContext = new MyViewModel ();
+			BindingContext = new MyViewModel();
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		public class MyViewModel
 		{
 			public ObservableCollection<MyItemViewModel> Items { get; private set; }
 
 			public Command<MyItemViewModel> ButtonTapped { get; private set; }
 
-			public MyViewModel ()
+			public MyViewModel()
 			{
-				ButtonTapped = new Command<MyItemViewModel> (OnItemTapped);
+				ButtonTapped = new Command<MyItemViewModel>(OnItemTapped);
 
-				Items = new ObservableCollection<MyItemViewModel> ();
+				Items = new ObservableCollection<MyItemViewModel>();
 
-				Items.Add (new MyItemViewModel { Name = "A", IsStarted = false });
-				Items.Add (new MyItemViewModel { Name = "B", IsStarted = false });
-				Items.Add (new MyItemViewModel { Name = "C", IsStarted = false });
+				Items.Add(new MyItemViewModel { Name = "A", IsStarted = false });
+				Items.Add(new MyItemViewModel { Name = "B", IsStarted = false });
+				Items.Add(new MyItemViewModel { Name = "C", IsStarted = false });
 			}
 
-			void OnItemTapped (MyItemViewModel model)
+			void OnItemTapped(MyItemViewModel model)
 			{
-				if (model.IsStarted) {
-					Items.Remove (model);
-				} else {
+				if (model.IsStarted)
+				{
+					Items.Remove(model);
+				}
+				else
+				{
 					model.IsStarted = true;
 				}
 			}
 		}
 
-		[Preserve (AllMembers = true)]
+		[Preserve(AllMembers = true)]
 		public class MyItemViewModel : INotifyPropertyChanged
 		{
 			public event PropertyChangedEventHandler PropertyChanged;
 
 			string _name;
 
-			public string Name {
-				get { return _name; } 
-				set {
+			public string Name
+			{
+				get { return _name; }
+				set
+				{
 					_name = value;
-					OnPropertyChanged ("Name");
+					OnPropertyChanged("Name");
 				}
 			}
 
 			bool _isStarted;
 
-			public bool IsStarted {
-				get { return _isStarted; } 
-				set {
+			public bool IsStarted
+			{
+				get { return _isStarted; }
+				set
+				{
 					_isStarted = value;
-					OnPropertyChanged ("IsStarted");
+					OnPropertyChanged("IsStarted");
 				}
 			}
 
-			void OnPropertyChanged (string propertyName)
+			void OnPropertyChanged(string propertyName)
 			{
-				if (PropertyChanged != null) {
-					PropertyChanged (this, new PropertyChangedEventArgs (propertyName));
+				if (PropertyChanged != null)
+				{
+					PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
 				}
 			}
 		}
 
 #if UITEST
 		[Test]
-		public void Issue2951Test ()
+		public void Issue2951Test()
 		{
 			RunningApp.WaitForElement("Ready");
-			var bt = RunningApp.WaitForElement (c => c.Marked ("btnChangeStatus"));
+			var bt = RunningApp.WaitForElement(c => c.Marked("btnChangeStatus"));
 
 			var buttons = RunningApp.QueryUntilPresent(() =>
 			 {
@@ -124,8 +132,8 @@ namespace Xamarin.Forms.Controls.Issues
 				 return null;
 			 });
 
-			Assert.That (buttons.Length, Is.EqualTo (3));
-			RunningApp.Tap(c => c.Marked ("btnChangeStatus").Index(1));
+			Assert.That(buttons.Length, Is.EqualTo(3));
+			RunningApp.Tap(c => c.Marked("btnChangeStatus").Index(1));
 
 			buttons = RunningApp.QueryUntilPresent(() =>
 			 {
@@ -136,9 +144,9 @@ namespace Xamarin.Forms.Controls.Issues
 				 return null;
 			 });
 
-			var text = buttons [1].Text ?? buttons [1].Label;
-			Assert.That (text, Is.EqualTo ("B"));
-			RunningApp.Tap(c => c.Marked ("btnChangeStatus").Index(1));
+			var text = buttons[1].Text ?? buttons[1].Label;
+			Assert.That(text, Is.EqualTo("B"));
+			RunningApp.Tap(c => c.Marked("btnChangeStatus").Index(1));
 
 			buttons = RunningApp.QueryUntilPresent(() =>
 			 {
@@ -149,13 +157,13 @@ namespace Xamarin.Forms.Controls.Issues
 				 return null;
 			 });
 
-			Assert.That (buttons.Length, Is.EqualTo (2));
+			Assert.That(buttons.Length, Is.EqualTo(2));
 			//TODO: we should check the color of the button
 			//var buttonTextColor = GetProperty<Color> ("btnChangeStatus", Button.BackgroundColorProperty);
 			//Assert.AreEqual (Color.Pink, buttonTextColor);
 		}
 
-	
+
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -15,160 +15,160 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-    [Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Github, 4597, "[Android] ImageCell not loading images and setting ImageSource to null has no effect",
-        PlatformAffected.Android)]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4597, "[Android] ImageCell not loading images and setting ImageSource to null has no effect",
+		PlatformAffected.Android)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Image)]
 	[NUnit.Framework.Category(UITestCategories.ListView)]
 	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
-    public class Issue4597 : TestContentPage
-    {
-        ImageButton _imageButton;
-        Button _button;
-        Image _image;
-        ListView _listView;
+	public class Issue4597 : TestContentPage
+	{
+		ImageButton _imageButton;
+		Button _button;
+		Image _image;
+		ListView _listView;
 
-        string _disappearText = "You should see an Image. Clicking this should cause the image to disappear";
-        string _appearText = "Clicking this should cause the image to reappear";
-        string _theListView = "theListViewAutomationId";
-        string _fileName = "xamarinlogo.png";
-        string _fileNameAutomationId = "CoffeeAutomationId";
-        string _uriImage = "https://github.com/xamarin/Xamarin.Forms/blob/3216ce4ccd096f8b9f909bbeea572dcf2a8c4466/Xamarin.Forms.ControlGallery.iOS/Resources/xamarinlogo.png?raw=true";
-        bool _isUri = false;
-        string _nextTestId = "NextTest";
-        string _activeTestId = "activeTestId";
-        string _switchUriId = "SwitchUri";
-        string _imageFromUri = "Image From Uri";
-        string _imageFromFile = "Image From File";
+		string _disappearText = "You should see an Image. Clicking this should cause the image to disappear";
+		string _appearText = "Clicking this should cause the image to reappear";
+		string _theListView = "theListViewAutomationId";
+		string _fileName = "xamarinlogo.png";
+		string _fileNameAutomationId = "CoffeeAutomationId";
+		string _uriImage = "https://github.com/xamarin/Xamarin.Forms/blob/3216ce4ccd096f8b9f909bbeea572dcf2a8c4466/Xamarin.Forms.ControlGallery.iOS/Resources/xamarinlogo.png?raw=true";
+		bool _isUri = false;
+		string _nextTestId = "NextTest";
+		string _activeTestId = "activeTestId";
+		string _switchUriId = "SwitchUri";
+		string _imageFromUri = "Image From Uri";
+		string _imageFromFile = "Image From File";
 
-        protected override void Init()
-        {
-            Label labelActiveTest = new Label()
-            {
-                AutomationId = _activeTestId
-            };
+		protected override void Init()
+		{
+			Label labelActiveTest = new Label()
+			{
+				AutomationId = _activeTestId
+			};
 
-            _image = new Image() { Source = _fileName, AutomationId = _fileNameAutomationId };
-            _button = new Button() { ImageSource = _fileName, AutomationId = _fileNameAutomationId };
-            _imageButton = new ImageButton() { Source = _fileName, AutomationId = _fileNameAutomationId };
-            _listView = new ListView()
-            {
-                ItemTemplate = new DataTemplate(() =>
-                {
-                    var cell = new ImageCell();
-                    cell.SetBinding(ImageCell.ImageSourceProperty, ".");
-                    cell.AutomationId = _fileNameAutomationId;
-                    return cell;
-                }),
-                AutomationId = _theListView,
-                ItemsSource = new[] { _fileName },
-                HasUnevenRows = true,
-                BackgroundColor = Color.Purple
-            };
+			_image = new Image() { Source = _fileName, AutomationId = _fileNameAutomationId };
+			_button = new Button() { ImageSource = _fileName, AutomationId = _fileNameAutomationId };
+			_imageButton = new ImageButton() { Source = _fileName, AutomationId = _fileNameAutomationId };
+			_listView = new ListView()
+			{
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var cell = new ImageCell();
+					cell.SetBinding(ImageCell.ImageSourceProperty, ".");
+					cell.AutomationId = _fileNameAutomationId;
+					return cell;
+				}),
+				AutomationId = _theListView,
+				ItemsSource = new[] { _fileName },
+				HasUnevenRows = true,
+				BackgroundColor = Color.Purple
+			};
 
-            View[] imageControls = new View[] { _image, _button, _imageButton, _listView };
+			View[] imageControls = new View[] { _image, _button, _imageButton, _listView };
 
-            Button button = null;
-            button = new Button()
-            {
-                AutomationId = "ClickMe",
-                Text = _disappearText,
-                Command = new Command(() =>
-                {
-                    if (button.Text == _disappearText)
-                    {
-                        _image.Source = null;
-                        _button.ImageSource = null;
-                        _imageButton.Source = null;
-                        _listView.ItemsSource = new string[] { null };
-                        Device.BeginInvokeOnMainThread(() => button.Text = _appearText);
-                    }
-                    else
-                    {
-                        _image.Source = _isUri ? _uriImage : _fileName;
-                        _button.ImageSource = _isUri ? _uriImage : _fileName;
-                        _imageButton.Source = _isUri ? _uriImage : _fileName;
-                        _listView.ItemsSource = new string[] { _isUri ? _uriImage : _fileName };
-                        Device.BeginInvokeOnMainThread(() => button.Text = _disappearText);
-                    }
-                })
-            };
+			Button button = null;
+			button = new Button()
+			{
+				AutomationId = "ClickMe",
+				Text = _disappearText,
+				Command = new Command(() =>
+				{
+					if (button.Text == _disappearText)
+					{
+						_image.Source = null;
+						_button.ImageSource = null;
+						_imageButton.Source = null;
+						_listView.ItemsSource = new string[] { null };
+						Device.BeginInvokeOnMainThread(() => button.Text = _appearText);
+					}
+					else
+					{
+						_image.Source = _isUri ? _uriImage : _fileName;
+						_button.ImageSource = _isUri ? _uriImage : _fileName;
+						_imageButton.Source = _isUri ? _uriImage : _fileName;
+						_listView.ItemsSource = new string[] { _isUri ? _uriImage : _fileName };
+						Device.BeginInvokeOnMainThread(() => button.Text = _disappearText);
+					}
+				})
+			};
 
-            var switchToUri = new Switch
-            {
-                AutomationId = _switchUriId,
-                IsToggled = false,
-                HeightRequest = 60
-            };
-            var sourceLabel = new Label { Text = _imageFromFile };
+			var switchToUri = new Switch
+			{
+				AutomationId = _switchUriId,
+				IsToggled = false,
+				HeightRequest = 60
+			};
+			var sourceLabel = new Label { Text = _imageFromFile };
 
-            switchToUri.Toggled += (_, e) =>
-            {
-                _isUri = e.Value;
+			switchToUri.Toggled += (_, e) =>
+			{
+				_isUri = e.Value;
 
-                // reset the images to visible
-                button.Text = _appearText;
-                button.SendClicked();
+				// reset the images to visible
+				button.Text = _appearText;
+				button.SendClicked();
 
-                if (_isUri)
-                    sourceLabel.Text = _imageFromUri;
-                else
-                    sourceLabel.Text = _imageFromFile;
-            };
+				if (_isUri)
+					sourceLabel.Text = _imageFromUri;
+				else
+					sourceLabel.Text = _imageFromFile;
+			};
 
 
-            foreach (var view in imageControls)
-            {
-                view.BackgroundColor = Color.Red;
-            }
+			foreach (var view in imageControls)
+			{
+				view.BackgroundColor = Color.Red;
+			}
 
-            StackLayout layout = null;
-            layout = new StackLayout()
-            {
-                AutomationId = "layoutContainer",
-                Children =
-                {
-                    new StackLayout()
-                    {
-                        Orientation = StackOrientation.Horizontal,
-                        Children =
-                        {
-                            labelActiveTest,
-                            switchToUri,
-                            sourceLabel
-                        }
-                    },
-                    button,
-                    new Button()
-                    {
-                        Text = "Load Next Image Control to Test",
-                        Command = new Command(() =>
-                        {
-                            var activeImage = layout.Children.Last();
-                            int nextIndex = imageControls.IndexOf(activeImage) + 1;
+			StackLayout layout = null;
+			layout = new StackLayout()
+			{
+				AutomationId = "layoutContainer",
+				Children =
+				{
+					new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							labelActiveTest,
+							switchToUri,
+							sourceLabel
+						}
+					},
+					button,
+					new Button()
+					{
+						Text = "Load Next Image Control to Test",
+						Command = new Command(() =>
+						{
+							var activeImage = layout.Children.Last();
+							int nextIndex = imageControls.IndexOf(activeImage) + 1;
 
-                            if(nextIndex >= imageControls.Length)
-                                nextIndex = 0;
+							if(nextIndex >= imageControls.Length)
+								nextIndex = 0;
 
-                            layout.Children.Remove(activeImage);
-                            layout.Children.Add(imageControls[nextIndex]);
-                            labelActiveTest.Text = imageControls[nextIndex].GetType().Name;
+							layout.Children.Remove(activeImage);
+							layout.Children.Add(imageControls[nextIndex]);
+							labelActiveTest.Text = imageControls[nextIndex].GetType().Name;
 
 							// reset the images to visible
 							button.Text = _appearText;
-                            button.SendClicked();
-                        }),
-                        AutomationId = _nextTestId
-                    },
-                    imageControls[0]
-                }
-            };
+							button.SendClicked();
+						}),
+						AutomationId = _nextTestId
+					},
+					imageControls[0]
+				}
+			};
 
-            Content = layout;
-            labelActiveTest.Text = imageControls[0].GetType().Name;
-        }
+			Content = layout;
+			labelActiveTest.Text = imageControls[0].GetType().Name;
+		}
 #if UITEST
 
 #if !__WINDOWS__
@@ -273,7 +273,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Assert.AreEqual(1, images.Length);
 			var imageVisible = images[0];
-						
+
 			Assert.Greater(imageVisible.Rect.Height, 1);
 			Assert.Greater(imageVisible.Rect.Width, 1);
 			return imageVisible;
@@ -308,5 +308,5 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.Tap(_switchUriId);
 		}
 #endif
-    }
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -15,160 +15,160 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 4597, "[Android] ImageCell not loading images and setting ImageSource to null has no effect",
-		PlatformAffected.Android)]
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 4597, "[Android] ImageCell not loading images and setting ImageSource to null has no effect",
+        PlatformAffected.Android)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Image)]
 	[NUnit.Framework.Category(UITestCategories.ListView)]
 	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
-	public class Issue4597 : TestContentPage
-	{
-		ImageButton _imageButton;
-		Button _button;
-		Image _image;
-		ListView _listView;
+    public class Issue4597 : TestContentPage
+    {
+        ImageButton _imageButton;
+        Button _button;
+        Image _image;
+        ListView _listView;
 
-		string _disappearText = "You should see an Image. Clicking this should cause the image to disappear";
-		string _appearText = "Clicking this should cause the image to reappear";
-		string _theListView = "theListViewAutomationId";
-		string _fileName = "xamarinlogo.png";
-		string _fileNameAutomationId = "CoffeeAutomationId";
-		string _uriImage = "https://github.com/xamarin/Xamarin.Forms/blob/3216ce4ccd096f8b9f909bbeea572dcf2a8c4466/Xamarin.Forms.ControlGallery.iOS/Resources/xamarinlogo.png?raw=true";
-		bool _isUri = false;
-		string _nextTestId = "NextTest";
-		string _activeTestId = "activeTestId";
-		string _switchUriId = "SwitchUri";
-		string _imageFromUri = "Image From Uri";
-		string _imageFromFile = "Image From File";
+        string _disappearText = "You should see an Image. Clicking this should cause the image to disappear";
+        string _appearText = "Clicking this should cause the image to reappear";
+        string _theListView = "theListViewAutomationId";
+        string _fileName = "xamarinlogo.png";
+        string _fileNameAutomationId = "CoffeeAutomationId";
+        string _uriImage = "https://github.com/xamarin/Xamarin.Forms/blob/3216ce4ccd096f8b9f909bbeea572dcf2a8c4466/Xamarin.Forms.ControlGallery.iOS/Resources/xamarinlogo.png?raw=true";
+        bool _isUri = false;
+        string _nextTestId = "NextTest";
+        string _activeTestId = "activeTestId";
+        string _switchUriId = "SwitchUri";
+        string _imageFromUri = "Image From Uri";
+        string _imageFromFile = "Image From File";
 
-		protected override void Init()
-		{
-			Label labelActiveTest = new Label()
-			{
-				AutomationId = _activeTestId
-			};
+        protected override void Init()
+        {
+            Label labelActiveTest = new Label()
+            {
+                AutomationId = _activeTestId
+            };
 
-			_image = new Image() { Source = _fileName, AutomationId = _fileNameAutomationId };
-			_button = new Button() { ImageSource = _fileName, AutomationId = _fileNameAutomationId };
-			_imageButton = new ImageButton() { Source = _fileName, AutomationId = _fileNameAutomationId };
-			_listView = new ListView()
-			{
-				ItemTemplate = new DataTemplate(() =>
-				{
-					var cell = new ImageCell();
-					cell.SetBinding(ImageCell.ImageSourceProperty, ".");
-					cell.AutomationId = _fileNameAutomationId;
-					return cell;
-				}),
-				AutomationId = _theListView,
-				ItemsSource = new[] { _fileName },
-				HasUnevenRows = true,
-				BackgroundColor = Color.Purple
-			};
+            _image = new Image() { Source = _fileName, AutomationId = _fileNameAutomationId };
+            _button = new Button() { ImageSource = _fileName, AutomationId = _fileNameAutomationId };
+            _imageButton = new ImageButton() { Source = _fileName, AutomationId = _fileNameAutomationId };
+            _listView = new ListView()
+            {
+                ItemTemplate = new DataTemplate(() =>
+                {
+                    var cell = new ImageCell();
+                    cell.SetBinding(ImageCell.ImageSourceProperty, ".");
+                    cell.AutomationId = _fileNameAutomationId;
+                    return cell;
+                }),
+                AutomationId = _theListView,
+                ItemsSource = new[] { _fileName },
+                HasUnevenRows = true,
+                BackgroundColor = Color.Purple
+            };
 
-			View[] imageControls = new View[] { _image, _button, _imageButton, _listView };
+            View[] imageControls = new View[] { _image, _button, _imageButton, _listView };
 
-			Button button = null;
-			button = new Button()
-			{
-				AutomationId = "ClickMe",
-				Text = _disappearText,
-				Command = new Command(() =>
-				{
-					if (button.Text == _disappearText)
-					{
-						_image.Source = null;
-						_button.ImageSource = null;
-						_imageButton.Source = null;
-						_listView.ItemsSource = new string[] { null };
-						Device.BeginInvokeOnMainThread(() => button.Text = _appearText);
-					}
-					else
-					{
-						_image.Source = _isUri ? _uriImage : _fileName;
-						_button.ImageSource = _isUri ? _uriImage : _fileName;
-						_imageButton.Source = _isUri ? _uriImage : _fileName;
-						_listView.ItemsSource = new string[] { _isUri ? _uriImage : _fileName };
-						Device.BeginInvokeOnMainThread(() => button.Text = _disappearText);
-					}
-				})
-			};
+            Button button = null;
+            button = new Button()
+            {
+                AutomationId = "ClickMe",
+                Text = _disappearText,
+                Command = new Command(() =>
+                {
+                    if (button.Text == _disappearText)
+                    {
+                        _image.Source = null;
+                        _button.ImageSource = null;
+                        _imageButton.Source = null;
+                        _listView.ItemsSource = new string[] { null };
+                        Device.BeginInvokeOnMainThread(() => button.Text = _appearText);
+                    }
+                    else
+                    {
+                        _image.Source = _isUri ? _uriImage : _fileName;
+                        _button.ImageSource = _isUri ? _uriImage : _fileName;
+                        _imageButton.Source = _isUri ? _uriImage : _fileName;
+                        _listView.ItemsSource = new string[] { _isUri ? _uriImage : _fileName };
+                        Device.BeginInvokeOnMainThread(() => button.Text = _disappearText);
+                    }
+                })
+            };
 
-			var switchToUri = new Switch
-			{
-				AutomationId = _switchUriId,
-				IsToggled = false,
-				HeightRequest = 60
-			};
-			var sourceLabel = new Label { Text = _imageFromFile };
+            var switchToUri = new Switch
+            {
+                AutomationId = _switchUriId,
+                IsToggled = false,
+                HeightRequest = 60
+            };
+            var sourceLabel = new Label { Text = _imageFromFile };
 
-			switchToUri.Toggled += (_, e) =>
-			{
-				_isUri = e.Value;
+            switchToUri.Toggled += (_, e) =>
+            {
+                _isUri = e.Value;
 
-				// reset the images to visible
-				button.Text = _appearText;
-				button.SendClicked();
+                // reset the images to visible
+                button.Text = _appearText;
+                button.SendClicked();
 
-				if (_isUri)
-					sourceLabel.Text = _imageFromUri;
-				else
-					sourceLabel.Text = _imageFromFile;
-			};
+                if (_isUri)
+                    sourceLabel.Text = _imageFromUri;
+                else
+                    sourceLabel.Text = _imageFromFile;
+            };
 
 
-			foreach(var view in imageControls)
-			{
-				view.BackgroundColor = Color.Red;
-			}
+            foreach (var view in imageControls)
+            {
+                view.BackgroundColor = Color.Red;
+            }
 
-			StackLayout layout = null;
-			layout = new StackLayout()
-			{
-				AutomationId = "layoutContainer",
-				Children =
-				{					
-					new StackLayout()
-					{
-						Orientation = StackOrientation.Horizontal,
-						Children =
-						{
-							labelActiveTest,
-							switchToUri,
-							sourceLabel						
-						}
-					},
-					button,
-					new Button()
-					{
-						Text = "Load Next Image Control to Test",
-						Command = new Command(() =>
-						{
-							var activeImage = layout.Children.Last();
-							int nextIndex = imageControls.IndexOf(activeImage) + 1;
+            StackLayout layout = null;
+            layout = new StackLayout()
+            {
+                AutomationId = "layoutContainer",
+                Children =
+                {
+                    new StackLayout()
+                    {
+                        Orientation = StackOrientation.Horizontal,
+                        Children =
+                        {
+                            labelActiveTest,
+                            switchToUri,
+                            sourceLabel
+                        }
+                    },
+                    button,
+                    new Button()
+                    {
+                        Text = "Load Next Image Control to Test",
+                        Command = new Command(() =>
+                        {
+                            var activeImage = layout.Children.Last();
+                            int nextIndex = imageControls.IndexOf(activeImage) + 1;
 
-							if(nextIndex >= imageControls.Length)
-								nextIndex = 0;
+                            if(nextIndex >= imageControls.Length)
+                                nextIndex = 0;
 
-							layout.Children.Remove(activeImage);
-							layout.Children.Add(imageControls[nextIndex]);
-							labelActiveTest.Text = imageControls[nextIndex].GetType().Name;
+                            layout.Children.Remove(activeImage);
+                            layout.Children.Add(imageControls[nextIndex]);
+                            labelActiveTest.Text = imageControls[nextIndex].GetType().Name;
 
 							// reset the images to visible
 							button.Text = _appearText;
-							button.SendClicked();
-						}),
-						AutomationId = _nextTestId
-					},
-					imageControls[0]
-				}
-			};
+                            button.SendClicked();
+                        }),
+                        AutomationId = _nextTestId
+                    },
+                    imageControls[0]
+                }
+            };
 
-			Content = layout;
-			labelActiveTest.Text = imageControls[0].GetType().Name;
-		}
+            Content = layout;
+            labelActiveTest.Text = imageControls[0].GetType().Name;
+        }
 #if UITEST
 
 #if !__WINDOWS__
@@ -228,7 +228,7 @@ namespace Xamarin.Forms.Controls.Issues
 			SetupTest(nameof(ListView), fileSource);
 
 			var imageVisible =
-				RunningApp.RetryUntilPresent(GetImage, 10, 2000);
+				RunningApp.QueryUntilPresent(GetImage, 10, 2000);
 
 			Assert.AreEqual(1, imageVisible.Length);
 			SetImageSourceToNull();
@@ -261,7 +261,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		UITest.Queries.AppResult TestForImageVisible()
 		{
-			var images = RunningApp.RetryUntilPresent(() =>
+			var images = RunningApp.QueryUntilPresent(() =>
 			{
 				var result = RunningApp.WaitForElement(_fileNameAutomationId);
 
@@ -308,5 +308,5 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.Tap(_switchUriId);
 		}
 #endif
-	}
+    }
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void LegacyImageSourceProperties()
 		{
 			RunningApp.WaitForElement("Nothing Crashed");
-			RunningApp.RetryUntilPresent(
+			RunningApp.QueryUntilPresent(
 				() =>
 				{
 					var result = RunningApp.WaitForElement("Image1");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue6286_WebView_Test()
 		{
-			RunningApp.RetryUntilPresent(() => RunningApp.WaitForElement("success"));
+			RunningApp.QueryUntilPresent(() => RunningApp.WaitForElement("success"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Controls.Issues
 				page1.Content = new Label { Text = "success", AutomationId = "success" };
 
 			}
-			catch(Exception exc)
+			catch (Exception exc)
 			{
 				page1.Content = new Label { Text = $"{exc}", AutomationId = "failure" };
 			}

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -6,11 +6,11 @@ using Xamarin.UITest.Queries;
 using System.Text.RegularExpressions;
 using System.Threading;
 
-namespace Xamarin.Forms.Core.UITests
+namespace Xamarin.UITest
 {
 	internal static class AppExtensions
 	{
-		public static T[] RetryUntilPresent<T>(
+		public static T[] QueryUntilPresent<T>(
 			this IApp app,
 			Func<T[]> func,
 			int retryCount = 10,
@@ -28,7 +28,13 @@ namespace Xamarin.Forms.Core.UITests
 
 			return results;
 		}
+	}
+}
 
+namespace Xamarin.Forms.Core.UITests
+{
+	internal static class AppExtensions
+	{
 		public static AppRect ScreenBounds(this IApp app)
 		{
 			return app.Query(Queries.Root()).First().Rect;


### PR DESCRIPTION
### Description of Change ###

- Fixed 2951 to retry querying for buttons. It looks like the UI tests are querying before the buttons have time to disappear
- Renamed the RetryUntilPresent  to QueryUntilPresent and moved it to the same namespace as Query so when people are using Query they'll see *QueryUntilPresent* and think "Hey I bet that's better to use"

### Testing Procedure ###
- Automated

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
