### PR TITLE
[Android] Just check if IsDesignModeEnabled true instead of checking Context type

### DIFF
--- a/Xamarin.Forms.Platform.Android/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ContextExtensions.cs
@@ -115,19 +115,7 @@ namespace Xamarin.Forms.Platform.Android
 			return null;
 		}
 
-		internal static bool IsDesignerContext(this Context context)
-		{
-			if (context == null)
-				return false;
-			
-			if ($"{context.ToString()}".Contains("com.android.layoutlib.bridge.android.BridgeContext"))
-				return true;
-
-			if (context is ContextWrapper contextWrapper)
-				return contextWrapper.BaseContext.IsDesignerContext();
-
-			return false;
-		}
+		internal static bool IsDesignerContext(this Context context) => DesignMode.IsDesignModeEnabled;
 
 		public static AFragmentManager GetFragmentManager(this Context context)
 		{


### PR DESCRIPTION
### Description of Change ###

There's no need to check the Context type and then recurse over it ($$$$) 

Just check the static IsDesignModeEnabled for the same information

### Testing Procedure ###
Make sure previewer still works for all places on Android where IsDesignerContext is used

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
