### PR TITLE
Add ProfilePage.cs

### DIFF
--- a/Xamarin.Forms.Core/Internals/ProfilePage.cs
+++ b/Xamarin.Forms.Core/Internals/ProfilePage.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Internals
+{
+	public class ProfileDatum
+	{
+		public string Name;
+		public string Id;
+		public long Ticks;
+		public long SubTicks;
+		public int Depth;
+		public string Path;
+		public int Line;
+	}
+
+	public static class ContentPageEx
+	{
+		const long MS = TimeSpan.TicksPerMillisecond;
+		public static List<ProfileDatum> Data = new List<ProfileDatum>();
+
+		private static void ASSERT(bool condition)
+		{
+			if (!condition)
+				throw new Exception("assert");
+		}
+
+		private static long GatherTicks(ref int i)
+		{
+			var current = Data[i++];
+			var depth = current.Depth;
+			var total = current.Ticks;
+
+			while (i < Data.Count)
+			{
+				var next = Data[i];
+				if (next.Depth < depth)
+					break;
+
+				if (next.Depth > depth)
+				{
+					current.SubTicks = GatherTicks(ref i);
+					ASSERT(current.Ticks >= current.SubTicks);
+					continue;
+				}
+
+				i++;
+				current = next;
+				total += current.Ticks;
+			}
+
+			return total;
+		}
+
+		private static void AppendProfile(StringBuilder sb, long profiledMs, bool showZeros)
+		{
+			foreach (var datum in Data)
+			{
+				var depth = datum.Depth;
+
+				var name = datum.Name;
+				if (datum.Id != null)
+					name += $" ({datum.Id})";
+
+				var ticksMs = datum.Ticks / MS;
+				var exclusiveTicksMs = (datum.Ticks - datum.SubTicks) / MS;
+
+				var percentage = (int)Math.Round(ticksMs / (double)profiledMs * 100);
+				if (!showZeros && percentage == 0)
+					continue;
+
+				var line = $"{name} = {ticksMs}ms";
+				if (exclusiveTicksMs != ticksMs)
+					line += $" ({exclusiveTicksMs}ms)";
+				line += $", {percentage}%";
+
+				sb.AppendLine("".PadLeft(depth * 2) + line);
+			}
+		}
+
+		public static void LoadProfile(this ContentPage page)
+		{
+			Profile.Stop();
+			foreach (var datum in Profile.Data)
+			{
+				Data.Add(new ProfileDatum()
+				{
+					Name = datum.Name,
+					Id = datum.Id,
+					Depth = datum.Depth,
+					Ticks = datum.Ticks < 0 ? 0L : (long)datum.Ticks
+				});
+			}
+			var i = 0;
+			var profiledMs = GatherTicks(ref i) / MS;
+
+			var scrollView = new ScrollView();
+			var label = new Label();
+
+			var controls = new Grid();
+			var buttonA = new Button() { Text = "0s", HeightRequest = 62 };
+			controls.Children.AddHorizontal(new[] { buttonA });
+
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection {
+				new RowDefinition { Height = new GridLength(1, GridUnitType.Star) },
+				new RowDefinition { Height = GridLength.Auto },
+			},
+				ColumnDefinitions = new ColumnDefinitionCollection {
+				new ColumnDefinition { Width = GridLength.Star },
+			}
+			};
+			page.Content = grid;
+			grid.Children.Add(scrollView, 0, 0);
+			grid.Children.Add(controls, 0, 1);
+
+			scrollView.Content = label;
+
+			var showZeros = false;
+
+			Action update = delegate ()
+			{
+				var sb = new StringBuilder();
+				sb.AppendLine($"Profiled: {profiledMs}ms");
+				AppendProfile(sb, profiledMs, showZeros);
+				label.Text = sb.ToString();
+			};
+			buttonA.Clicked += delegate { showZeros = !showZeros; update(); };
+
+			update();
+		}
+	}
+}
+


### PR DESCRIPTION
### Description of Change ###

Xamarin.Forms ships it's own profiler in `Xamarin.Forms.Internals.Profile`. This PR will ship the UI to visualize the profile data. 

The profiler requires manual instrumentation. So it's not a general profiler. It profiles only what we instrument. And right now we've injected sampling points useful for profiling startup performance. And even then, this information is tailored so the Forms team can easily request a profile from a customer and determine if we're the reason the app startup is slow or not. That said, customers are free to submit PRs of sampling points they've injected into Forms they found useful while debugging their startup performance. 

To display the profile, hijack a UI element that appears just after startup and have it call the `ContentPage` extension method `LoadProfile()`. This will push a model page that displays the profile. For example, here's me hijacking the `AddItem_Clicked` method of the Shell template.

``` c#
using Xamarin.Forms.Internals;
...
        /*async*/ void AddItem_Clicked(object sender, EventArgs e)
        {
            this.LoadProfile();

            //await Navigation.PushModalAsync(new NavigationPage(new NewItemPage()));
        }
```

And you'll also need to update `MainActivity` to something like this:

``` C#
using Xamarin.Forms.Internals;
...
        protected override void OnCreate(Bundle savedInstanceState)
        {
            Profile.Start();

            Profile.FrameBegin("Startup");

            Profile.FramePartition("OnCreate");
            base.OnCreate(savedInstanceState);

            Profile.FramePartition("Forms.SetFlags");
            Forms.SetFlags("Shell_Experimental", "Visual_Experimental", "CollectionView_Experimental", "FastRenderers_Experimental");

            Profile.FramePartition("Forms.Init");
            Forms.Forms.Init(this, savedInstanceState);
            Profile.FrameEnd();

            Profile.FrameBegin("Create App");
            var app = new App();
            Profile.FrameEnd();

            Profile.FrameBegin("Render App");
            LoadApplication(app);
        }

        protected override void OnResume()
        {
            base.OnResume();
            Profile.FrameEnd();
        }
```

This should pop up a page that looks like the following (and this is running a private build with additional sampling points so you'll have to wait for those changes before reproducing this. I post this PR just to keep things moving along). In the future, we'll add all this boilerplate to the template projects.

Notice a few things:
* `Profiled: 1096ms` -- the total time profiled between `Profile.Start();` and `LoadProfile()`. This is the wall clock time. It's just what Forms contributes (which includes calls into Xamarin.Android but not things like mono startup time). Be sure to turn on AOT and build retail!
* `Startup(OnCreate) = 123ms, 11%` -- Time spent (inclusive) between `"OnCreate"` and `"SetFlags"`.
* `Startup (Forms.Init) = 44ms, (0ms), 4%` -- The `(0ms)` is the exclusive time spent in `Forms.Init` which is to say, the total time spent minus the sum of all the manually partitioned logic.
* Notice that `"Forms.SetFlags"` is not displayed in the profile. This is because it took less than 1% of the total time. To see all the frames click the `0S` button at the bottom. 

![Screenshot_2019-08-08-14-10-30](https://user-images.githubusercontent.com/4120386/62738123-42b36c80-b9cd-11e9-9443-ce45d0640006.png)

Note, this UI is subject to change. I cannot think of a way anyone could depend on it but I'll say it anyway: don't take a dependency on this UI. 

### API Changes ###

+ `public static void ContentPageEx.LoadProfile(this ContentPage page)`

### Platforms Affected ### 

- Core/XAML (all platforms) -- although only Android has any sampling points injected.

### Behavioral/Visual Changes ###

None

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
