### PR TITLE
[WPF] Add missing NamedSize

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7111.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7111.cs
@@ -1,0 +1,58 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7111, "[Bug] [WPF] Label with a predefined FontSize value throws an exception", PlatformAffected.WPF)]
+	public class Issue7111 : TestContentPage
+	{
+
+		protected override void Init()
+		{
+			var stack = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var labelBody = new Label
+			{
+				Text = "If you see this, things didn't crash and it worked",
+				FontSize = Device.GetNamedSize(NamedSize.Body, typeof(Label))
+			};
+
+			var labelCaption = new Label
+			{
+				Text = "If you see this, things didn't crash and it worked",
+				FontSize = Device.GetNamedSize(NamedSize.Caption, typeof(Label))
+			};
+
+			var labelHeader = new Label
+			{
+				Text = "If you see this, things didn't crash and it worked",
+				FontSize = Device.GetNamedSize(NamedSize.Header, typeof(Label))
+			};
+
+			var labelSubtitle = new Label
+			{
+				Text = "If you see this, things didn't crash and it worked",
+				FontSize = Device.GetNamedSize(NamedSize.Subtitle, typeof(Label))
+			};
+
+			var labelTitle = new Label
+			{
+				Text = "If you see this, things didn't crash and it worked",
+				FontSize = Device.GetNamedSize(NamedSize.Title, typeof(Label))
+			};
+
+			stack.Children.Add(labelBody);
+			stack.Children.Add(labelCaption);
+			stack.Children.Add(labelHeader);
+			stack.Children.Add(labelSubtitle);
+			stack.Children.Add(labelTitle);
+
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,6 +22,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGrouping.cs" />

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -85,6 +85,16 @@ namespace Xamarin.Forms.Platform.WPF
 					return (double)System.Windows.Application.Current.Resources["FontSizeMedium"];
 				case NamedSize.Large:
 					return (double)System.Windows.Application.Current.Resources["FontSizeLarge"];
+				case NamedSize.Body:
+					return (double)System.Windows.Application.Current.Resources["FontSizeBody"];
+				case NamedSize.Caption:
+					return (double)System.Windows.Application.Current.Resources["FontSizeCaption"];
+				case NamedSize.Header:
+					return (double)System.Windows.Application.Current.Resources["FontSizeHeader"];
+				case NamedSize.Subtitle:
+					return (double)System.Windows.Application.Current.Resources["FontSizeSubtitle"];
+				case NamedSize.Title:
+					return (double)System.Windows.Application.Current.Resources["FontSizeTitle"];
 				default:
 					throw new ArgumentOutOfRangeException("size");
 			}

--- a/Xamarin.Forms.Platform.WPF/WPFResources.xaml
+++ b/Xamarin.Forms.Platform.WPF/WPFResources.xaml
@@ -29,9 +29,14 @@
 	<system:Double x:Key="FontSizeLarge">32</system:Double>
 	<system:Double x:Key="FontSizeExtraLarge">42</system:Double>
 	<system:Double x:Key="FontSizeExtraExtraLarge">72</system:Double>
-	<system:Double x:Key="FontSizeHuge">186</system:Double>
+    <system:Double x:Key="FontSizeHuge">186</system:Double>
+    <system:Double x:Key="FontSizeBody">14</system:Double>
+    <system:Double x:Key="FontSizeCaption">12</system:Double>
+    <system:Double x:Key="FontSizeHeader">46</system:Double>
+    <system:Double x:Key="FontSizeSubtitle">20</system:Double>
+    <system:Double x:Key="FontSizeTitle">24</system:Double>
 
-	<FontFamily x:Key="FontFamilyNormal">Segoe UI</FontFamily>
+    <FontFamily x:Key="FontFamilyNormal">Segoe UI</FontFamily>
 	<FontFamily x:Key="FontFamilySemiBold">Segoe UI</FontFamily>
 
 	<wpf:HeightConverter x:Key="HeightConverter" />


### PR DESCRIPTION
### Description of Change ###

Implemented missing NamedSize values for WPF.
I could not find any documentation on if and what the official values should be so I just took the ones from UWP.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7111

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

When you now use one of the "new" NamedSize enum values WPF doesn't crash.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Go to the new Issue7111 test case, if it shows and doesn't crash it works

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
