### PR TITLE
[iOS] Moved `UITableView` setup selection to `ListViewRenderer`

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -146,7 +146,6 @@ namespace Xamarin.Forms.Platform.iOS
 			var handler = new PropertyChangedEventHandler(OnMenuItemPropertyChanged);
 
 			_tableView = tableView;
-			SetupSelection(tableView);
 
 			if (_cell != null)
 			{
@@ -641,7 +640,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return null;
 		}
 
-		static void SetupSelection(UITableView table)
+		public static void SetupSelection(UITableView table)
 		{
 			if (table.GestureRecognizers == null)
 				return;

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -640,7 +640,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return null;
 		}
 
-		public static void SetupSelection(UITableView table)
+		internal static void SetupSelection(UITableView table)
 		{
 			if (table.GestureRecognizers == null)
 				return;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -944,6 +944,7 @@ namespace Xamarin.Forms.Platform.iOS
 			protected ListView List;
 			protected ITemplatedItemsView<Cell> TemplatedItemsView => List;
 			bool _isDragging;
+			bool _setupSelection;
 			bool _selectionFromNative;
 			bool _disposed;
 			bool _wasEmpty;
@@ -999,6 +1000,19 @@ namespace Xamarin.Forms.Platform.iOS
 				_isDragging = true;
 			}
 
+			void SetupSelection(UITableViewCell nativeCell, UITableView tableView)
+			{
+				if (!(nativeCell is ContextActionsCell))
+					return;
+
+				if (_setupSelection)
+					return;
+
+				ContextActionsCell.SetupSelection(tableView);
+
+				_setupSelection = true;
+			}
+
 			public override UITableViewCell GetCell(UITableView tableView, NSIndexPath indexPath)
 			{
 				Cell cell;
@@ -1035,6 +1049,8 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 				else
 					throw new NotSupportedException();
+
+				SetupSelection(nativeCell, tableView);
 
 				if (List.IsSet(Specifics.SeparatorStyleProperty))
 				{


### PR DESCRIPTION
* Setup the selection  from the `ContectActionCell` was causing the Xamarin.Forms previewer to crash.


TL;DR:  The previewer was crashing for a few scenarios, and rendering `ItemPage.xaml` from the Master Detail template.

From stack trace it seems that the `GestureReconizer` of the `ContextActionCell` was collected or disposed, when UIKit calls `GetCell` or `LayoutSubviews`, which calls `SetupSelection` https://github.com/xamarin/Xamarin.Forms/blob/57d507ef0b47d54d4026a07632f88a39a40de0c9/Xamarin.Forms.Platform.iOS/ContextActionCell.cs#L646 the GestureReconizer isn't there anymore, and X.iOS tries to resurrect it, causing a `MissingCtor` exception
https://gist.github.com/viniciusjarina/407952739b7f19eee15df6a5a021192b

The problem seems related to a regression on Mono/Xamarin.iOS, this patch workaround the problem avoiding Xamarin.Forms to try to setup the selection twice, hence avoiding calling `table.GestureRecognizers`.

[Fixes: AB#889294](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/889294/)
[Fixes: AB#927358](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/927358/)

![831M4l0BRx](https://user-images.githubusercontent.com/926868/62809670-960ae500-bac9-11e9-8c78-b2a7bed575c5.gif)
