### PR TITLE
Stop the madness; 

### DIFF
--- a/Xamarin.Forms.Core/Internals/Ticker.cs
+++ b/Xamarin.Forms.Core/Internals/Ticker.cs
@@ -41,7 +41,13 @@ namespace Xamarin.Forms.Internals
 		public static void SetDefault(Ticker ticker) => Default = ticker;
 		public static Ticker Default
 		{
-			internal set { s_ticker = value; }
+			internal set {
+				if (value == null && s_ticker != null)
+				{
+					(s_ticker as IDisposable)?.Dispose();
+				}
+				s_ticker = value;
+			}
 			get
 			{
 				if (s_ticker == null)

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -265,11 +265,7 @@ namespace Xamarin.Forms
 			Device.SetFlags(s_flags);
 
 			Profile.FramePartition("AndroidTicker");
-
-			var ticker = Ticker.Default as AndroidTicker;
-			if (ticker != null)
-				ticker.Dispose();
-			Ticker.SetDefault(new AndroidTicker());
+			Ticker.SetDefault(null);
 
 			Profile.FramePartition("RegisterAll");
 


### PR DESCRIPTION
### Description of Change ###

Optimize `AndroidTicker` initialization to speed up startup. 

Note: The code assumes a ticker can somehow already exist at startup (backgrounding?) but the common case is that the ticker doesn't exist at startup. So I keep the startup check; This logic shouldn't result in any logical difference.

**Expected**: If ticker exists, dispose and null reference (so do nothing in common case). Lazily activate a ticker (again, do nothing as the ticker is not used during startup).

**Actual**: If ticker doesn't exist, then activate (so always activate in the common case). If ticker exists, dispose and null reference (so we throw away the ticker we just created). Eagerly activate a ticker (so we activate a second ticker that we don't immediately use).

### Issues Resolved ### 

We were activating two (count em, two!) tickers during startup whereas I think we could do nothing and simply lazily activate the ticker. We'll see if CI slaps me down...

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None. Simply restores sanity to the universe. 

### Testing Procedure ###

Throw it at CI and cross fingers. But seriously, every single initialization is a test.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
