### PR TITLE
[GTK] Added missing NamedSizes for GTK

### DIFF
--- a/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
@@ -52,14 +52,22 @@ namespace Xamarin.Forms.Platform.GTK
 				case NamedSize.Default:
 					return 11;
 				case NamedSize.Micro:
-					return 12;
-				case NamedSize.Small:
-					return 14;
+                case NamedSize.Caption:
+                    return 12;
 				case NamedSize.Medium:
 					return 17;
 				case NamedSize.Large:
 					return 22;
-				default:
+                case NamedSize.Small:
+                case NamedSize.Body:
+                    return 14;
+                case NamedSize.Header:
+                    return 46;
+                case NamedSize.Subtitle:
+                    return 20;
+                case NamedSize.Title:
+                    return 24;
+                default:
 					throw new ArgumentOutOfRangeException(nameof(size));
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Implemented missing NamedSize values for GTK.
Fix an exception using Label with a predefined FontSize value.
Related to https://github.com/xamarin/Xamarin.Forms/pull/7116.

### API Changes ###
None

### Platforms Affected ### 
- GTK

### Behavioral/Visual Changes ###
When you now use one of the "new" NamedSize enum values GTK doesn't crash.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Go to the new Issue7111 test case, if it shows and doesn't crash it works.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
