### PR TITLE
add wait before WaitForNoElement

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27731.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla27731.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla27731Test()
 		{
+			RunningApp.WaitForElement("Click");
 			RunningApp.WaitForNoElement(_pageTitle);
 		}
 #endif


### PR DESCRIPTION
### Description of Change ###
The test only calls WaitForNoElement which isn't very definitive if it hasn't made sure that the test itself hasn't loaded.  When looking at AppCenter runs the test after this had screen shots of this test because this test was just passing before it actually finished running which would then cause the next test to fail

### Testing Procedure ###
Automated

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
