### PR TITLE
[iOS] make VisualElementExtensions public on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/VisualElementExtensions.cs
@@ -3,7 +3,7 @@ using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal static class VisualElementExtensions
+	public static class VisualElementExtensions
 	{
 		public static IVisualElementRenderer GetRenderer(this VisualElement self)
 		{


### PR DESCRIPTION
### Description of Change ###
This extension is already public on UWP and Android

### Issues Resolved ### 
- fixes #7142

### API Changes ###
Added:
 - IVisualElementRenderer VisualElementExtensions.GetRenderer

### Platforms Affected ### 
- iOS

### Testing Procedure ###
No testing needed

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
