### PR TITLE
Fixes issue #7109 in XF 4.0 branch

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS9OrNewer;
 		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
+		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
 #endif
 
 #if __MOBILE__
@@ -65,6 +66,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS11OrNewer.HasValue)
 					s_isiOS11OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
 				return s_isiOS11OrNewer.Value;
+			}
+		}
+
+		internal static bool RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden
+		{
+			get
+			{
+				if (!s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden.HasValue)
+					s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden = new UIViewController().RespondsToSelector(new ObjCRuntime.Selector("setNeedsUpdateOfHomeIndicatorAutoHidden"));
+				return s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden.Value;
 			}
 		}
 #endif

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -104,7 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLoad();
 			SetNeedsStatusBarAppearanceUpdate();
-			if (Forms.IsiOS11OrNewer)
+			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 
@@ -199,7 +199,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLoad();
 			SetNeedsStatusBarAppearanceUpdate();
-			if (Forms.IsiOS11OrNewer)
+			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -231,7 +231,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBarTextColor();
 			UpdateUseLargeTitles();
 			UpdateHideNavigationBarSeparator();
-			if (Forms.IsiOS11OrNewer)
+			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			// If there is already stuff on the stack we need to push it

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -176,7 +176,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_appeared = true;
 			UpdateStatusBarPrefersHidden();
-			if(Forms.IsiOS11OrNewer)
+			if(Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			if (Element.Parent is CarouselPage)
@@ -439,7 +439,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateHomeIndicatorAutoHidden()
 		{
-			if (Element == null || !Forms.IsiOS11OrNewer)
+			if (Element == null || !Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				return;
 
 			SetNeedsUpdateOfHomeIndicatorAutoHidden();

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -339,7 +339,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_detailController.AddChildViewController(detailRenderer.ViewController);
 
 			SetNeedsStatusBarAppearanceUpdate();
-			if (Forms.IsiOS11OrNewer)
+			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Changes check for iOS version >= 11 to a check to see if the `setNeedsUpdateOfHomeIndicatorAutoHidden` selector is available before calling the `SetNeedsUpdateOfHomeIndicatorAutoHidden` method.

 No automated test created as there should be no difference in behavior except to avoid a crash due to calling an Obj-C selector that may not be available on all devices running iOS >= 11. In this case, it seems that checking that the selector is available is better than checking for the iOS version as it will be a valid check regardless of iOS version, where as just the version check alone is not guaranteeing the availability of this particular selector as devices pre iPhone X do not have a Home Indicator. 

### Issues Resolved ### 

- fixes #7109 in XF 4.0.0 branch

### API Changes ###

None

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###

Users app won't crash when running on an iPhone 6 with iOS version 11 (and potentially other iPhones pre the iPhone X when running iOS 11)

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I was unable to test as I do not have an iPhone 6 running iOS 11. However the native stack trace provided by the customer clearly indicates that the crash is due to calling an Obj-C selector that does not exist.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
