### PR TITLE
ListView.Scrolled

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
@@ -155,7 +155,7 @@ namespace Xamarin.Forms.Controls
 							new Employee ("Eric", TimeSpan.FromDays (1000), 160),
 						}
 					),
- 					new Grouping<string, Employee> (
+					new Grouping<string, Employee> (
 						"Sales",
 						new [] {
 							new Employee ("Andrew 1", TimeSpan.FromDays (10), 160),
@@ -267,6 +267,15 @@ namespace Xamarin.Forms.Controls
 			fastScrollItemContainer.View.On<Android>().SetIsFastScrollEnabled(true);
 			fastScrollItemContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 
+			var scrolledItemContainer = new ViewContainer<ListView>(Test.ListView.Scrolled, new ListView());
+			InitializeElement(scrolledItemContainer.View);
+			scrolledItemContainer.View.ItemsSource = viewModel.Employees;
+			var scrollTitle = scrolledItemContainer.TitleLabel.Text;
+			scrolledItemContainer.View.Scrolled += (sender, args) =>
+			{
+				scrolledItemContainer.TitleLabel.Text = $"{scrollTitle}; X={args.ScrollX};Y={args.ScrollY}";
+			};
+
 			var refreshControlColorContainer = new ViewContainer<ListView>(Test.ListView.RefreshControlColor, new ListView());
 			InitializeElement(refreshControlColorContainer.View);
 			refreshControlColorContainer.View.RefreshControlColor = Color.Red;
@@ -297,6 +306,7 @@ namespace Xamarin.Forms.Controls
 			Add(rowHeightContainer);
 			Add(selectedItemContainer);
 			Add(fastScrollItemContainer);
+			Add(scrolledItemContainer);
 			Add(refreshControlColorContainer);
 			Add(scrollbarVisibilityContainer);
 		}

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create("SeparatorColor", typeof(Color), typeof(ListView), Color.Default);
 
 		public static readonly BindableProperty RefreshControlColorProperty = BindableProperty.Create(nameof(RefreshControlColor), typeof(Color), typeof(ListView), Color.Default);
-    
+	
 		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create(nameof(HorizontalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ListView), ScrollBarVisibility.Default);
 
 		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create(nameof(VerticalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ListView), ScrollBarVisibility.Default);
@@ -285,6 +285,10 @@ namespace Xamarin.Forms
 			=> ItemDisappearing?.Invoke(this, new ItemVisibilityEventArgs(cell.BindingContext, TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendScrolled(ScrolledEventArgs args)
+			=> Scrolled?.Invoke(this, args);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendRefreshing()
 		{
 			BeginRefresh();
@@ -315,6 +319,8 @@ namespace Xamarin.Forms
 		public event EventHandler<SelectedItemChangedEventArgs> ItemSelected;
 
 		public event EventHandler<ItemTappedEventArgs> ItemTapped;
+
+		public event EventHandler<ScrolledEventArgs> Scrolled;
 
 		public event EventHandler Refreshing;
 

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -431,6 +431,7 @@ namespace Xamarin.Forms.CustomAttributes
 			GroupDisplayBinding,
 			GroupShortNameBinding,
 			ScrollTo,
+			Scrolled,
 			FastScroll,
 			RefreshControlColor,
 			ScrollBarVisibility

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -170,7 +170,8 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				((IListViewController)e.NewElement).ScrollToRequested += OnScrollToRequested;
-
+				Control?.SetOnScrollListener(new ListViewScrollDetector(this));
+				
 				nativeListView.DividerHeight = 0;
 				nativeListView.Focusable = false;
 				nativeListView.DescendantFocusability = DescendantFocusability.AfterDescendants;
@@ -391,8 +392,8 @@ namespace Xamarin.Forms.Platform.Android
 					_refresh.Refreshing = false;
 					_refresh.Post(() =>
 					{
-					    if(_refresh.IsDisposed())
-						    return;
+						if(_refresh.IsDisposed())
+							return;
 						
 						_refresh.Refreshing = true;
 					});
@@ -574,6 +575,133 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				base.OnNestedScroll(target, dxConsumed, dyConsumed, dxUnconsumed, dyUnconsumed);
 				_nestedScrollCalled = true;
+			}
+		}
+		class ListViewScrollDetector : Java.Lang.Object, AbsListView.IOnScrollListener
+		{
+			class TrackElement
+			{
+				public TrackElement(int position)
+				{
+					_position = position;
+				}
+
+				readonly int _position;
+
+				AView _trackedView;
+				int _trackedViewPrevPosition;
+				int _trackedViewPrevTop;
+
+				public void SyncState(AbsListView view)
+				{
+					if (view.ChildCount > 0)
+					{
+						_trackedView = GetChild(view);
+						_trackedViewPrevTop = GetY();
+						_trackedViewPrevPosition = view.GetPositionForView(_trackedView);
+					}
+				}
+
+				public void Reset()
+				{
+					_trackedView = null;
+				}
+
+				public bool IsSafeToTrack(AbsListView view)
+				{
+					return _trackedView != null && _trackedView.Parent == view && view.GetPositionForView(_trackedView) == _trackedViewPrevPosition;
+				}
+
+				public int GetDeltaY()
+				{
+					return GetY() - _trackedViewPrevTop;
+				}
+
+				AView GetChild(AbsListView view)
+				{
+					switch (_position)
+					{
+						case 0:
+							return view.GetChildAt(0);
+						case 1:
+						case 2:
+							return view.GetChildAt(view.ChildCount / 2);
+						case 3:
+							return view.GetChildAt(view.ChildCount - 1);
+						default:
+							return null;
+					}
+				}
+				int GetY()
+				{
+					return _position <= 1 ? _trackedView.Bottom : _trackedView.Top;
+				}
+			}
+
+			readonly ListView _element;
+			readonly float _density;
+			int _contentOffset;
+
+			public ListViewScrollDetector(ListViewRenderer renderer)
+			{
+				_element = renderer.Element;
+				_density = renderer.Context.Resources.DisplayMetrics.Density;
+			}
+
+			void SendScrollEvent(double y)
+			{
+				var element = _element;
+				double offset = Math.Abs(y) / _density;
+				var args = new ScrolledEventArgs(0, offset);
+				element?.SendScrolled(args);
+			}
+
+
+			readonly TrackElement[] _trackElements =
+			{
+				new TrackElement(0), // Top view, bottom Y
+				new TrackElement(1), // Mid view, bottom Y
+				new TrackElement(2), // Mid view, top Y
+				new TrackElement(3) // Bottom view, top Y
+			};
+
+
+			public void OnScroll(AbsListView view, int firstVisibleItem, int visibleItemCount, int totalItemCount)
+			{
+				var wasTracked = false;
+				foreach (TrackElement t in _trackElements)
+				{
+					if (!wasTracked)
+					{
+						if (t.IsSafeToTrack(view))
+						{
+							wasTracked = true;
+							_contentOffset += t.GetDeltaY();
+							SendScrollEvent(_contentOffset);
+							t.SyncState(view);
+						}
+						else
+						{
+							t.Reset();
+							t.SyncState(view);
+						}
+					}
+					else
+					{
+						t.SyncState(view);
+					}
+				}
+			}
+
+			public void OnScrollStateChanged(AbsListView view, ScrollState scrollState)
+			{
+				if (scrollState == ScrollState.TouchScroll || scrollState == ScrollState.Fling)
+				{
+					foreach (TrackElement t in _trackElements)
+					{
+						t.SyncState(view);
+					}
+				}
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -59,6 +59,10 @@ namespace Xamarin.Forms.Platform.UWP
 				e.OldElement.ItemSelected -= OnElementItemSelected;
 				e.OldElement.ScrollToRequested -= OnElementScrollToRequested;
 				((ITemplatedItemsView<Cell>)e.OldElement).TemplatedItems.CollectionChanged -= OnCollectionChanged;
+				if (Control != null)
+				{
+					Control.Loaded -= ControlOnLoaded;
+				}
 			}
 
 			if (e.NewElement != null)
@@ -92,7 +96,22 @@ namespace Xamarin.Forms.Platform.UWP
 				ClearSizeEstimate();
 				UpdateVerticalScrollBarVisibility();
 				UpdateHorizontalScrollBarVisibility();
+
+				if (Control != null)
+				{
+					Control.Loaded += ControlOnLoaded;
+				}
 			}
+		}
+
+		void ControlOnLoaded(object sender, RoutedEventArgs e)
+		{
+			var scrollViewer = GetScrollViewer();
+			scrollViewer?.RegisterPropertyChangedCallback(ScrollViewer.VerticalOffsetProperty, (o, dp) =>
+			{
+				var args = new ScrolledEventArgs(0, _scrollViewer.VerticalOffset);
+				Element?.SendScrolled(args);
+			});
 		}
 
 		bool IsObservableCollection(object source)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -239,6 +239,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateRowHeight();
 
 				Control.Source = _dataSource = e.NewElement.HasUnevenRows ? new UnevenListViewDataSource(e.NewElement, _tableViewController) : new ListViewDataSource(e.NewElement, _tableViewController);
+				Control.Delegate = new ListViewTableViewDelegate(this);
 
 				UpdateHeader();
 				UpdateFooter();
@@ -1616,6 +1617,22 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateContentOffset(nfloat offset, Action completed = null)
 		{
 			UIView.Animate(0.2, () => TableView.ContentOffset = new CoreGraphics.CGPoint(TableView.ContentOffset.X, offset), completed);
+		}
+	}
+
+	internal class ListViewTableViewDelegate : UITableViewDelegate
+	{
+		readonly ListView _element;
+
+		public ListViewTableViewDelegate(ListViewRenderer renderer)
+		{
+			_element = renderer.Element;
+		}
+
+		public override void Scrolled(UIScrollView scrollView)
+		{
+			var args = new ScrolledEventArgs(scrollView.ContentOffset.X, scrollView.ContentOffset.Y);
+			_element?.SendScrolled(args);
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###
It's sometimes necessary to know when ListView has been scrolled.

![image](https://user-images.githubusercontent.com/4385716/63010395-febddd00-be8e-11e9-8361-8bbdd1ff71f5.png)


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4323

### API Changes ###
``` cs
public event EventHandler<Xamarin.Forms.ScrolledEventArgs> Scrolled;
```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android
- UWP



### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
