### PR TITLE
[BUG/iOS] Fixed CollectionView Insets ItemSpacing

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			App.IOSVersion = int.Parse(versionPart[0]);
 
 			Xamarin.Calabash.Start();
-			Forms.SetFlags("CollectionView_Experimental");
+			// Forms.SetFlags("CollectionView_Experimental", "Shell_Experimental");
 			Forms.Init();
 			FormsMaps.Init();
 			FormsMaterial.Init();

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			App.IOSVersion = int.Parse(versionPart[0]);
 
 			Xamarin.Calabash.Start();
-			// Forms.SetFlags("CollectionView_Experimental", "Shell_Experimental");
+			Forms.SetFlags("CollectionView_Experimental");
 			Forms.Init();
 			FormsMaps.Init();
 			FormsMaterial.Init();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml
@@ -1,0 +1,73 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7035">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="300"/>
+        </Grid.RowDefinitions>
+        <BoxView BackgroundColor="Red" WidthRequest="400" HeightRequest="300" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
+    <CarouselView
+        x:Name="CV"
+        HeightRequest="225"
+        HorizontalOptions="Center" 
+        VerticalOptions="CenterAndExpand" 
+        Margin="15,10,0,20">
+        <CarouselView.ItemsLayout>
+            <GridItemsLayout
+                Orientation="Horizontal"
+                HorizontalItemSpacing="15"
+                SnapPointsAlignment="Center" 
+                SnapPointsType="Mandatory"/>
+        </CarouselView.ItemsLayout>
+        <CarouselView.ItemTemplate>
+            <DataTemplate>
+                <Frame
+                    Padding="0"
+                    Margin="0"
+                    HeightRequest="200"
+                    WidthRequest="300"
+                    BorderColor="LightGray"
+                    CornerRadius="10"
+                    HasShadow="False"
+                    IsClippedToBounds="True">
+                    <Grid
+                        ColumnSpacing="0"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="70*" />
+                            <RowDefinition Height="15*" />
+                            <RowDefinition Height="15*" />
+                        </Grid.RowDefinitions>
+                        <Image
+                            Grid.Row="0"
+                            Aspect="Fill"
+                            Source="xamarinlogo" />
+                        <Label
+                            Grid.Row="1"
+                            Margin="20,0,0,0"
+                            FontSize="Medium"
+                            Text="SUB"
+                            HorizontalOptions="Start"
+                            VerticalOptions="End" />
+                        <Label
+                            Grid.Row="2"
+                            Margin="20,0,0,0"
+                            FontSize="Large"
+                            Text="TITLE"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Start" />
+                        <Image
+                            Margin="0,0,8,0"
+                            Grid.Row="1"
+                            Grid.RowSpan="2"
+                            HorizontalOptions="End"
+                            Aspect="AspectFit"
+                            Source="xamarinlogo" />
+                    </Grid>
+                </Frame>
+            </DataTemplate>
+        </CarouselView.ItemTemplate>
+    </CarouselView>
+    </Grid>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml
@@ -15,10 +15,9 @@
         VerticalOptions="CenterAndExpand" 
         Margin="15,10,0,20">
         <CarouselView.ItemsLayout>
-            <GridItemsLayout
+            <LinearItemsLayout
                 Orientation="Horizontal"
-                HorizontalItemSpacing="25"
-                />
+                ItemSpacing="25" />
         </CarouselView.ItemsLayout>
         <CarouselView.ItemTemplate>
             <DataTemplate>
@@ -77,11 +76,9 @@
         HeightRequest="225"
         Margin="15,10,0,20">
             <CarouselView.ItemsLayout>
-                <GridItemsLayout
+                <LinearItemsLayout
                 Orientation="Horizontal"
-                HorizontalItemSpacing="25"
-                Span="3"
-                />
+                ItemSpacing="25" />
             </CarouselView.ItemsLayout>
             <CarouselView.ItemTemplate>
                 <DataTemplate>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml
@@ -5,6 +5,7 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="300"/>
+            <RowDefinition Height="400"/>
         </Grid.RowDefinitions>
         <BoxView BackgroundColor="Red" WidthRequest="400" HeightRequest="300" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand"/>
     <CarouselView
@@ -16,9 +17,8 @@
         <CarouselView.ItemsLayout>
             <GridItemsLayout
                 Orientation="Horizontal"
-                HorizontalItemSpacing="15"
-                SnapPointsAlignment="Center" 
-                SnapPointsType="Mandatory"/>
+                HorizontalItemSpacing="25"
+                />
         </CarouselView.ItemsLayout>
         <CarouselView.ItemTemplate>
             <DataTemplate>
@@ -69,5 +69,69 @@
             </DataTemplate>
         </CarouselView.ItemTemplate>
     </CarouselView>
+
+
+    <CarouselView
+        Grid.Row="1"
+        x:Name="CV2"
+        HeightRequest="225"
+        Margin="15,10,0,20">
+            <CarouselView.ItemsLayout>
+                <GridItemsLayout
+                Orientation="Horizontal"
+                HorizontalItemSpacing="25"
+                Span="3"
+                />
+            </CarouselView.ItemsLayout>
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Frame
+                    Padding="0"
+                    Margin="0"
+                    HeightRequest="200"
+                    WidthRequest="300"
+                    BorderColor="LightGray"
+                    CornerRadius="10"
+                    HasShadow="False"
+                    IsClippedToBounds="True">
+                        <Grid
+                        ColumnSpacing="0"
+                        RowSpacing="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="70*" />
+                                <RowDefinition Height="15*" />
+                                <RowDefinition Height="15*" />
+                            </Grid.RowDefinitions>
+                            <Image
+                            Grid.Row="0"
+                            Aspect="Fill"
+                            Source="xamarinlogo" />
+                            <Label
+                            Grid.Row="1"
+                            Margin="20,0,0,0"
+                            FontSize="Medium"
+                            Text="SUB"
+                            HorizontalOptions="Start"
+                            VerticalOptions="End" />
+                            <Label
+                            Grid.Row="2"
+                            Margin="20,0,0,0"
+                            FontSize="Large"
+                            Text="TITLE"
+                            HorizontalOptions="Start"
+                            VerticalOptions="Start" />
+                            <Image
+                            Margin="0,0,8,0"
+                            Grid.Row="1"
+                            Grid.RowSpan="2"
+                            HorizontalOptions="End"
+                            Aspect="AspectFit"
+                            Source="xamarinlogo" />
+                        </Grid>
+                    </Frame>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if APP
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7035, "[Bug][iOS] CarouselView last element is clipped", 
+		PlatformAffected.iOS)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue7035 : ContentPage
+	{
+        List<AdItem> announcements = new List<AdItem>();
+
+		public Issue7035()
+		{
+			InitializeComponent();
+		}
+
+	protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            for (int i = 0; i < 5; i++)
+            {
+                announcements.Add(new AdItem("no_artwork", "Card Title", "SUBHEAD"));
+            }
+            CV.ItemsSource = announcements;
+		}
+
+	}
+
+	public class AdItem
+    {
+        public string ImgUrl { get; set; }
+        public string Title { get; set; }
+        public string SubTitle { get; set; }
+        public AdItem()
+        {
+
+        }
+        public AdItem(string img, string ttl, string sttl)
+        {
+            ImgUrl = img;
+            Title = ttl;
+            SubTitle = sttl;
+        }
+    }
+#endif
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7035.xaml.cs
@@ -25,14 +25,15 @@ namespace Xamarin.Forms.Controls.Issues
 			InitializeComponent();
 		}
 
-	protected override void OnAppearing()
+		protected override void OnAppearing()
         {
             base.OnAppearing();
-            for (int i = 0; i < 5; i++)
+            for (int i = 0; i < 20; i++)
             {
                 announcements.Add(new AdItem("no_artwork", "Card Title", "SUBHEAD"));
             }
             CV.ItemsSource = announcements;
+			CV2.ItemsSource = announcements;
 		}
 
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1305,6 +1305,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Github3847.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4684.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
@@ -1398,13 +1404,13 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7357.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1055,6 +1055,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6929.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ApiLabel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7035.xaml.cs">
+      <DependentUpon>Issue7035.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1178,6 +1182,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4356.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7035.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1355,12 +1355,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Github3847.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <Compile Update="$(MSBuildThisFileDirectory)Issue6130.xaml.cs">
       <DependentUpon>Issue6130.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -150,6 +150,9 @@ namespace Xamarin.Forms.Platform.iOS
 				return false;
 			}
 
+			if (CollectionView.NumberOfSections() == 0)
+				return false;
+
 			var itemCount = CollectionView.NumberOfItemsInSection(section);
 
 			if (itemCount < _itemsLayout.Span)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return new UIEdgeInsets(0, 0, 0, (nfloat)gridItemsLayout.HorizontalItemSpacing * collectionView.NumberOfItemsInSection(section));
 				}
 
-				return new UIEdgeInsets(0,0,0,(nfloat)gridItemsLayout.VerticalItemSpacing*collectionView.NumberOfItemsInSection(section));
+				return new UIEdgeInsets(0,0, (nfloat)gridItemsLayout.VerticalItemSpacing * collectionView.NumberOfItemsInSection(section), 0);
 			}
 
 			return UIEdgeInsets.Zero;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -88,6 +88,16 @@ namespace Xamarin.Forms.Platform.iOS
 		public virtual UIEdgeInsets GetInsetForSection(UICollectionView collectionView, UICollectionViewLayout layout,
 			nint section)
 		{
+			if (_itemsLayout is GridItemsLayout gridItemsLayout)
+			{
+				if (ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+				{
+					return new UIEdgeInsets(0, 0, 0, (nfloat)gridItemsLayout.HorizontalItemSpacing * collectionView.NumberOfItemsInSection(section));
+				}
+
+				return new UIEdgeInsets(0,0,0,(nfloat)gridItemsLayout.VerticalItemSpacing*collectionView.NumberOfItemsInSection(section));
+			}
+
 			return UIEdgeInsets.Zero;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Instead of returning a fixed UIEdgeInset.Zero, we now take in account the ItemSpacing so the last item will not be offscreen.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7035

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Go to the Issue7035 case, if you are able to scroll to the right and the last item is fully visible, this worked!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
