### PR TITLE
[Android] Don't dispose the _labelTextColorDefault on Label Fast Renderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
@@ -74,7 +74,9 @@ namespace Xamarin.Forms.Controls.Issues
 						await Task.Delay(20);
 						source.Clear();
 						await Task.Delay(2000);
+#pragma warning disable CS4014
 						Device.InvokeOnMainThreadAsync(() => instructions.Text = "Success");
+#pragma warning restore CS4014
 					});
 
 				stackLayout.Children.Remove(instructions);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
@@ -14,8 +14,8 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	[Category(UITestCategories.ListView)]
-	[Category(UITestCategories.Label)]
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.Label)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
@@ -1,0 +1,147 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ListView)]
+	[Category(UITestCategories.Label)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6994, "Regression in Xamarin.Forms 4.2.0-pre1 (Java.Lang.NullPointerException when using FastRenderers)", PlatformAffected.Android)]
+	public class Issue6994 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var source = new ObservableCollection<ItemViewModel>(Enumerable.Range(0, 100).Select(i => new ItemViewModel(i.ToString(), false)).ToList());
+			var button = new Button { Text = "Click me" };
+
+			var listView = new ListView
+			{
+				ItemsSource = source,
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+
+					var trigger = new DataTrigger(typeof(Label)) { Binding = new Binding(nameof(ItemViewModel.Pink)), Value = true };
+					trigger.Setters.Add(new Setter { Value = Color.Magenta, Property = Label.TextColorProperty });
+					label.Triggers.Add(trigger);
+
+					label.SetBinding(Label.TextProperty, nameof(ItemViewModel.Id));
+					return new ViewCell { View = label };
+				})
+			};
+
+			var instructions = new Label { FormattedText = "Enable Fast Renderers. Click the button. If the app crashes, this test has failed." };
+
+			var stackLayout = new StackLayout
+			{
+				Children = {
+					instructions,
+					button,
+					listView,
+				}
+			};
+			Content = stackLayout;
+
+			button.Clicked += (s, e) =>
+			{
+				//This seems needlessly complicated, but this test requires both removing a Label (to trigger Dispose) and updating the TextColor of another set of Labels.
+				instructions.Text = "Please wait...";
+
+				Parallel.Invoke(
+					() =>
+					{
+						for (int j = 0; j < source.Count; j++)
+						{
+							var i = source[j];
+							i.Pink = int.TryParse(i.Id, out int o) && o % 2 == 0;
+						}
+					},
+					async () =>
+					{
+						await Task.Delay(20);
+						source.Clear();
+						await Task.Delay(2000);
+						Device.InvokeOnMainThreadAsync(() => instructions.Text = "Success");
+					});
+
+				stackLayout.Children.Remove(instructions);
+				instructions.TextColor = Color.Green;
+				stackLayout.Children.Insert(0, instructions);
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void NullPointerExceptionOnFastLabelTextColorChange()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Click me"));
+			RunningApp.Tap(q => q.Marked("Click me"));
+			RunningApp.WaitForElement(q => q.Marked("Success"));
+		}
+#endif
+
+		[Preserve(AllMembers = true)]
+		public class ItemViewModel : INotifyPropertyChanged
+		{
+			string _id;
+			bool _pink;
+
+			public ItemViewModel(string i, bool pink)
+			{
+				Pink = pink;
+				Id = i;
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public string Id
+			{
+				get
+				{
+					return _id;
+				}
+				set
+				{
+					if (_id == value)
+					{
+						return;
+					}
+
+					_id = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Id)));
+				}
+			}
+
+			public bool Pink
+			{
+				get
+				{
+					return _pink;
+				}
+				set
+				{
+					if (_pink == value)
+					{
+						return;
+					}
+
+					_pink = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(Pink)));
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
@@ -74,9 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 						await Task.Delay(20);
 						source.Clear();
 						await Task.Delay(2000);
-#pragma warning disable CS4014
-						Device.InvokeOnMainThreadAsync(() => instructions.Text = "Success");
-#pragma warning restore CS4014
+						await Device.InvokeOnMainThreadAsync(() => instructions.Text = "Success");
 					});
 
 				stackLayout.Children.Remove(instructions);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -540,6 +540,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MultipleClipToBounds.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6994.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		int? _defaultLabelFor;
 		bool _disposed;
 		Label _element;
+		// Do not dispose _labelTextColorDefault
 		readonly ColorStateList _labelTextColorDefault;
 		int _lastConstraintHeight;
 		int _lastConstraintWidth;
@@ -196,7 +197,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				}
 
 				_spannableString?.Dispose();
-				_labelTextColorDefault?.Dispose();
 
 				if (Element != null)
 				{

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -411,7 +411,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			Cell item = GetPrototypicalCell(position);
-			return item.IsEnabled;
+			return item?.IsEnabled ?? false;
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

#6467 disposes the `_labelTextColorDefault` on the fast LabelRenderer for Android. This causes a NullPointerException when attempting to access it later.

This does not happen on the legacy renderer, which now also has the same dispose but a slightly different pattern of setting the value. Using the same pattern does not fix the crash on the Fast Renderer, so the best thing is to remove the dispose and possibly revisit this later.

### Issues Resolved ### 

- fixes #6994 

### API Changes ###

 
 None

### Platforms Affected ### 

- Android


### Behavioral/Visual Changes ###


### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

There is an automated test with instructions.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
