### PR TITLE
[iOS9] Check unselectedItemTintColor support

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SafeShellTabBarAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SafeShellTabBarAppearanceTracker.cs
@@ -29,20 +29,29 @@ namespace Xamarin.Forms.Platform.iOS
 			var titleColor = appearanceElement.EffectiveTabBarTitleColor;
 
 			var tabBar = controller.TabBar;
+			bool operatingSystemSupportsUnselectedTint = Forms.IsiOS10OrNewer;
 
 			if (_defaultTint == null)
 			{
 				_defaultBarTint = tabBar.BarTintColor;
 				_defaultTint = tabBar.TintColor;
-				_defaultUnselectedTint = tabBar.UnselectedItemTintColor;
+
+				if (operatingSystemSupportsUnselectedTint)
+				{
+					_defaultUnselectedTint = tabBar.UnselectedItemTintColor;
+				}
 			}
 
 			if (!backgroundColor.IsDefault)
 				tabBar.BarTintColor = backgroundColor.ToUIColor();
 			if (!titleColor.IsDefault)
 				tabBar.TintColor = titleColor.ToUIColor();
-			if (!unselectedColor.IsDefault)
-				tabBar.UnselectedItemTintColor = unselectedColor.ToUIColor();
+
+			if (operatingSystemSupportsUnselectedTint)
+			{
+				if (!unselectedColor.IsDefault)
+					tabBar.UnselectedItemTintColor = unselectedColor.ToUIColor();
+			}
 		}
 
 		public void UpdateLayout(UITabBarController controller)


### PR DESCRIPTION
### Description of Change ###

To make Shell work on iOS 9 we need to check if there is support for the unselectedItemTintColor which is only supported from iOS 10 and up.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6739

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Go to a Shell page on an iOS 9 device/simulator and observe that it does not end in an NRE

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
