### PR TITLE
Fixes for MonoAndroid10.0 deprecations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -26,7 +26,7 @@
   
   <!-- This is used by the libraries -->
   <PropertyGroup Condition="'$(AndroidTargetFrameworks)' == ''">
-    <AndroidTargetFrameworks>MonoAndroid90;</AndroidTargetFrameworks>
+    <AndroidTargetFrameworks Condition="'$(MSBuildAssemblyVersion)' != '16.0'">MonoAndroid90;</AndroidTargetFrameworks>
+    <AndroidTargetFrameworks Condition="'$(MSBuildAssemblyVersion)' == '16.0'">MonoAndroid90;MonoAndroid10.0;</AndroidTargetFrameworks>
   </PropertyGroup>
-  
- </Project>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -24,9 +24,15 @@
     <CI Condition="'$(TF_BUILD)' == 'true'">true</CI>
   </PropertyGroup>
   
+  <PropertyGroup>
+    <Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildRuntimeType)' == 'Mono'">$(FrameworkSDKRoot.Contains('/Versions/5'))</Use2017>
+    <Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildAssemblyVersion)' &lt; '16.0'">true</Use2017>
+    <Use2017 Condition="'$(Use2017)' == ''">false</Use2017>
+  </PropertyGroup>
+
   <!-- This is used by the libraries -->
   <PropertyGroup Condition="'$(AndroidTargetFrameworks)' == ''">
-    <AndroidTargetFrameworks Condition="'$(MSBuildAssemblyVersion)' != '16.0'">MonoAndroid90;</AndroidTargetFrameworks>
-    <AndroidTargetFrameworks Condition="'$(MSBuildAssemblyVersion)' == '16.0'">MonoAndroid90;MonoAndroid10.0;</AndroidTargetFrameworks>
+    <AndroidTargetFrameworks Condition="'$(Use2017)' == 'true'">MonoAndroid90;</AndroidTargetFrameworks>
+    <AndroidTargetFrameworks Condition="'$(Use2017)' == 'false'">MonoAndroid90;MonoAndroid10.0;</AndroidTargetFrameworks>
   </PropertyGroup>
 </Project>

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -260,7 +260,7 @@
       <Version>4.3.0</Version>
     </PackageReference>
   </ItemGroup>
-  <ItemGroup Condition=" '$(TargetFrameworkVersion)' == 'v9.0' ">
+  <ItemGroup Condition=" '$(TargetFrameworkVersion)' != 'v8.1' ">
     <ProjectReference Include="..\..\Xamarin.Forms.Material.Android\Xamarin.Forms.Material.Android.csproj">
       <Project>{e1586ce6-8eac-4388-a15a-1aabf108b5f8}</Project>
       <Name>Xamarin.Forms.Material.Android</Name>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -10,7 +10,7 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup  Condition="'$(Use2017)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.props
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+</Project> 

--- a/Xamarin.Forms.ControlGallery.Android/DrawableExtensions.cs
+++ b/Xamarin.Forms.ControlGallery.Android/DrawableExtensions.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Forms.Platform.Android
 		public static void SetColorFilter(this ADrawable drawable, AColor color, FilterMode mode)
 		{
 #if __ANDROID_29__
-			if(Forms.Is29OrNewer)
+			if((int)global::Android.OS.Build.VERSION.SdkInt >= 29)
 				drawable.SetColorFilter(new BlendModeColorFilter(color, GetFilterMode(mode)));
 			else
 #pragma warning disable CS0612 // Type or member is obsolete

--- a/Xamarin.Forms.ControlGallery.Android/Issue7249SwitchRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Issue7249SwitchRenderer.cs
@@ -31,15 +31,14 @@ namespace Xamarin.Forms.ControlGallery.Android
 				{
 					if (Control.Checked)
 					{
-						Control.TrackDrawable.SetColorFilter(_view.SwitchOnColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+						Control.TrackDrawable.SetColorFilter(_view.SwitchOnColor, FilterMode.SrcAtop);
 					}
 					else
 					{
-						Control.TrackDrawable.SetColorFilter(_view.SwitchOffColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+						Control.TrackDrawable.SetColorFilter(_view.SwitchOffColor, FilterMode.SrcAtop);
 					}
 
-					Control.ThumbDrawable.SetColorFilter(_view.SwitchThumbColor.ToAndroid(), PorterDuff.Mode.Multiply);
-
+					Control.TrackDrawable.SetColorFilter(_view.SwitchThumbColor, FilterMode.Multiply);
 					Control.CheckedChange += OnCheckedChange;
 				}
 			}
@@ -55,11 +54,20 @@ namespace Xamarin.Forms.ControlGallery.Android
 		{
 			if (Control.Checked)
 			{
+
+#if __ANDROID_29__
+				Control.TrackDrawable.SetColorFilter(new BlendModeColorFilter(_view.SwitchOffColor.ToAndroid(), BlendMode.SrcAtop));
+#else
 				Control.TrackDrawable.SetColorFilter(_view.SwitchOnColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+#endif
 			}
 			else
 			{
+#if __ANDROID_29__
+				Control.TrackDrawable.SetColorFilter(new BlendModeColorFilter(_view.SwitchOffColor.ToAndroid(), BlendMode.SrcAtop));
+#else
 				Control.TrackDrawable.SetColorFilter(_view.SwitchOffColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+#endif
 			}
 		}
 	}

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest28.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest28.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="AndroidControlGallery.AndroidControlGallery" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -15,9 +15,11 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == '' AND '$(MSBuildAssemblyVersion)' != '16.0'">v9.0</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v10.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
-    <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v9.0'">Properties\AndroidManifest28.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
@@ -84,6 +86,7 @@
     <Compile Include="BorderEffect.cs" />
     <Compile Include="BrokenNativeControl.cs" />
     <Compile Include="CacheService.cs" />
+    <Compile Include="DrawableExtensions.cs" />
     <Compile Include="FormsApplicationActivity.cs" />
     <Compile Include="DisposeLabelRenderer.cs" />
     <Compile Include="DisposePageRenderer.cs" />
@@ -220,7 +223,8 @@
     </AndroidResource>
   </ItemGroup>
   <ItemGroup>
-    <None Include="Properties\AndroidManifest.xml" />
+    <None Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'" Include="Properties\AndroidManifest.xml" />
+    <None Condition="$(AndroidTargetFrameworkVersion) == 'v9.0'" Include="Properties\AndroidManifest28.xml" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\error.xml" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -16,8 +16,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == '' AND '$(Use2017)' == 'true'">v9.0</AndroidTargetFrameworkVersion>
-    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v10.0</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v9.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v9.0'">Properties\AndroidManifest28.xml</AndroidManifest>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -56,14 +56,16 @@
     <DefineConstants>TRACE;HAVE_OPENTK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>Full</AndroidLinkMode>
+    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
+    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
-    <AndroidDexTool Condition="'$(Use2017)' == 'false'">d8</AndroidDexTool>
-    <AndroidLinkTool Condition="'$(Use2017)' == 'false'">r8</AndroidLinkTool>
-    <AndroidEnableMultiDex>$(Use2017)</AndroidEnableMultiDex>
+    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Directory.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -56,16 +57,14 @@
     <DefineConstants>TRACE;HAVE_OPENTK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
-    <AndroidLinkMode>Full</AndroidLinkMode>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
-    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+    <AndroidDexTool Condition="'$(Use2017)' == 'false'">d8</AndroidDexTool>
+    <AndroidLinkTool Condition="'$(Use2017)' == 'false'">r8</AndroidLinkTool>
+    <AndroidEnableMultiDex>$(Use2017)</AndroidEnableMultiDex>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -16,7 +16,7 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == '' AND '$(MSBuildAssemblyVersion)' != '16.0'">v9.0</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == '' AND '$(Use2017)' == 'true'">v9.0</AndroidTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion Condition="$(AndroidTargetFrameworkVersion) == ''">v10.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'">Properties\AndroidManifest.xml</AndroidManifest>

--- a/Xamarin.Forms.ControlGallery.Android/_59457CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_59457CustomRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			if (Control != null)
 			{
 				Drawable drawable = Control.Background;
-				drawable.SetColorFilter(global::Android.Graphics.Color.Blue, PorterDuff.Mode.SrcAtop);
+				drawable.SetColorFilter(global::Android.Graphics.Color.Blue, FilterMode.SrcAtop);
 				Control.Background = drawable;
 			}
 		}

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -9,7 +9,7 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup  Condition="'$(Use2017)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>

--- a/Xamarin.Forms.Material.Android/MaterialColors.cs
+++ b/Xamarin.Forms.Material.Android/MaterialColors.cs
@@ -201,7 +201,7 @@ namespace Xamarin.Forms.Material.Tizen
 			}
 			else
 			{
-				seekBar.Thumb.SetColorFilter(thumbColor.ToAndroid(), PorterDuff.Mode.SrcIn);
+				seekBar.Thumb.SetColorFilter(thumbColor.ToAndroid(), FilterMode.SrcIn);
 			}
 		}
 
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Material.Tizen
 			else
 			{
 				(progressBar.Indeterminate ? progressBar.IndeterminateDrawable :
-						   progressBar.ProgressDrawable).SetColorFilter(progressColor, PorterDuff.Mode.SrcIn);
+						   progressBar.ProgressDrawable).SetColorFilter(progressColor, FilterMode.SrcIn);
 
 			}
 		}

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup  Condition="'$(Use2017)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -12,7 +12,7 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup  Condition="'$(Use2017)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PageExtensions.cs
@@ -48,6 +48,9 @@ namespace Xamarin.Forms.Platform.Android
 				_platform = platform;
 			}
 
+#if __ANDROID_29__
+			[Obsolete]
+#endif
 			public override global::Android.Views.View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 			{
 				return _content;

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 				else
 				{
-					Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
+					Control.TrackDrawable?.SetColorFilter(Element.OnColor, FilterMode.Multiply);
 				}
 			}
 			else
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (Element.ThumbColor != Color.Default)
 			{
-				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor.ToAndroid(), PorterDuff.Mode.Multiply);
+				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
 				_changedThumbColor = true;
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/SwitchCellRenderer.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Forms.Platform.Android
 					{
 						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
 						{
-							aSwitch.TrackDrawable.SetColorFilter(switchCell.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
+							aSwitch.TrackDrawable.SetColorFilter(switchCell.OnColor, FilterMode.Multiply);
 						}
 					}
 				}

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -54,6 +54,7 @@ namespace Xamarin.Forms
 		const int TabletCrossover = 600;
 
 		static bool? s_isLollipopOrNewer;
+		static bool? s_is29OrNewer;
 		static bool? s_isMarshmallowOrNewer;
 		static bool? s_isNougatOrNewer;
 
@@ -72,6 +73,17 @@ namespace Xamarin.Forms
 		public static Color ColorButtonNormalOverride { get; set; }
 
 		internal static BuildVersionCodes SdkInt => Anticipator.SdkInt;
+
+		internal static bool Is29OrNewer
+		{
+			get
+			{
+				if (!s_is29OrNewer.HasValue)
+					s_is29OrNewer = (int)SdkInt >= 29;
+				return s_is29OrNewer.Value;
+			}
+		}
+
 		internal static bool IsLollipopOrNewer
 		{
 			get

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -633,7 +633,8 @@ namespace Xamarin.Forms.Platform.Android
 			TabbedPage currentTabs = CurrentTabbedPage;
 
 			var atab = actionBar.NewTab();
-			atab.SetText(page.Title);
+			
+			atab.SetText(new Java.Lang.String(page.Title));
 			atab.TabSelected += (sender, e) =>
 			{
 				if (!_ignoreAndroidSelection)
@@ -860,7 +861,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				var page = sender as Page;
 				var atab = actionBar.GetTabAt(currentTabs.Children.IndexOf(page));
-				atab.SetText(page.Title);
+				atab.SetText(new Java.Lang.String(page.Title));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ActivityIndicatorRenderer.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Platform.Android
 			Color color = Element.Color;
 
 			if (!color.IsDefault)
-				Control.IndeterminateDrawable?.SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+				Control.IndeterminateDrawable?.SetColorFilter(color.ToAndroid(), FilterMode.SrcIn);
 			else
 				Control.IndeterminateDrawable?.ClearColorFilter();
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				(Indeterminate ? IndeterminateDrawable : ProgressDrawable).SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+				(Indeterminate ? IndeterminateDrawable : ProgressDrawable).SetColorFilter(color.ToAndroid(), FilterMode.SrcIn);
 			}
 		}
 
@@ -59,21 +59,21 @@ namespace Xamarin.Forms.Platform.Android
 			(Background as GradientDrawable)?.SetColor(_backgroudColor);
 		}
 
-		AnimatedVectorDrawable CurrentDrawable => IndeterminateDrawable.Current as AnimatedVectorDrawable;
+		AnimatedVectorDrawable AnimatedDrawable => IndeterminateDrawable.Current as AnimatedVectorDrawable;
 
 		public bool IsRunning
 		{
-			get => CurrentDrawable?.IsRunning ?? false;
+			get => AnimatedDrawable?.IsRunning ?? false;
 			set
 			{
-				if (CurrentDrawable == null)
+				if (AnimatedDrawable == null)
 					return;
 
 				_isRunning = value;
-				if (_isRunning && !CurrentDrawable.IsRunning)
-						CurrentDrawable.Start();
-				else if (CurrentDrawable.IsRunning)
-						CurrentDrawable.Stop();
+				if (_isRunning && !AnimatedDrawable.IsRunning)
+						AnimatedDrawable.Start();
+				else if (AnimatedDrawable.IsRunning)
+						AnimatedDrawable.Stop();
 				
 				PostInvalidate();
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ProgressBarRenderer.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (Forms.SdkInt < BuildVersionCodes.Lollipop)
 				{
 					(Control.Indeterminate ? Control.IndeterminateDrawable :
-						Control.ProgressDrawable).SetColorFilter(color.ToAndroid(), PorterDuff.Mode.SrcIn);
+						Control.ProgressDrawable).SetColorFilter(color, FilterMode.SrcIn);
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -206,7 +206,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (image != null && image.Drawable != null)
 				{
 					if (Element.CancelButtonColor != Color.Default)
-						image.Drawable.SetColorFilter(Element.CancelButtonColor.ToAndroid(), PorterDuff.Mode.SrcIn);
+						image.Drawable.SetColorFilter(Element.CancelButtonColor, FilterMode.SrcIn);
 					else
 						image.Drawable.ClearColorFilter();
 				}

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
@@ -162,7 +162,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (image != null && image.Drawable != null)
 			{
 				if (!toColor.IsDefault)
-					image.Drawable.SetColorFilter(toColor.ToAndroid(), PorterDuff.Mode.SrcIn);
+					image.Drawable.SetColorFilter(toColor, FilterMode.SrcIn);
 				else
 					image.Drawable.ClearColorFilter();
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -350,7 +350,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (icon == null)
 			{
 				icon = new DrawerArrowDrawable(context.GetThemedContext());
-				icon.SetColorFilter(tintColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+				icon.SetColorFilter(tintColor, FilterMode.SrcAtop);
 			}
 
 			icon.Progress = (CanNavigateBack) ? 1 : 0;
@@ -422,7 +422,7 @@ namespace Xamarin.Forms.Platform.Android
 					using (var newDrawable = constant.NewDrawable())
 					using (var iconDrawable = newDrawable.Mutate())
 					{
-						iconDrawable.SetColorFilter(TintColor.ToAndroid(Color.White), PorterDuff.Mode.SrcAtop);
+						iconDrawable.SetColorFilter(TintColor.ToAndroid(Color.White), FilterMode.SrcAtop);
 						menuItem.SetIcon(iconDrawable);
 					}
 				}
@@ -551,7 +551,7 @@ namespace Xamarin.Forms.Platform.Android
 					item.SetEnabled(SearchHandler.IsSearchEnabled);
 					item.SetIcon(Resource.Drawable.abc_ic_search_api_material);
 					using (var icon = item.Icon)
-						icon.SetColorFilter(TintColor.ToAndroid(Color.White), PorterDuff.Mode.SrcAtop);
+						icon.SetColorFilter(TintColor.ToAndroid(Color.White), FilterMode.SrcAtop);
 					item.SetShowAsAction(ShowAsAction.IfRoom | ShowAsAction.CollapseActionView);
 
 					if (_searchView.View.Parent != null)

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateThumbColor()
 		{
-			Control.Thumb.SetColorFilter(Element.ThumbColor, defaultthumbcolorfilter, PorterDuff.Mode.SrcIn);
+			Control.Thumb.SetColorFilter(Element.ThumbColor, defaultthumbcolorfilter, FilterMode.SrcIn);
 		}
 
 		void UpdateThumbImage()

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -600,7 +600,7 @@ namespace Xamarin.Forms.Platform.Android
 			_ = this.ApplyDrawableAsync(formsSwipeItem, MenuItem.IconImageSourceProperty, Context, drawable =>
 			{
 				drawable.SetBounds(0, 0, iconSize, iconSize);
-				drawable.SetColorFilter(textColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+				drawable.SetColorFilter(textColor.ToAndroid(), FilterMode.SrcAtop);
 				swipeButton.SetCompoundDrawables(null, drawable, null, null);
 			});
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.Android
 					{
 						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
 						{
-							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), PorterDuff.Mode.Multiply);
+							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), FilterMode.Multiply);
 						}
 					}
 				}
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (Element.ThumbColor != Color.Default)
 			{
-				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor.ToAndroid(), PorterDuff.Mode.Multiply);
+				Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
 				_changedThumbColor = true;
 			}
 			else
@@ -150,6 +150,7 @@ namespace Xamarin.Forms.Platform.Android
 					_changedThumbColor = false;
 				}
 			}
+			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
 		}
 
 		void HandleToggled(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -11,7 +11,7 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup  Condition="'$(Use2017)' == 'true'">
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
     <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -8,7 +8,7 @@
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <GenerateLibraryLayout Condition="'$(MSBuildAssemblyVersion)' != '16.0'">true</GenerateLibraryLayout>
+    <GenerateLibraryLayout Condition="'$(Use2017)' == 'true'">true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>


### PR DESCRIPTION
### Description of Change ###

SDK changes to fix APIs that have been made obsolete with API 29. This doesn't package the MonoAndroid10.0 binaries with nuspec because we can't currently build MonoAndroid10.0 on our CI. This PR is setup so it'll only build the MonoAndroid10.0 targets if you are on MsbuildVersion 16.0

The main purpose of this PR is to get all the fixes in for the API 29 fixes to make life easier with all the PRs we have going to test things like AndroidX and to make merging and such easier. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- partially fixes #7169


### Platforms Affected ### 
- Android


### Testing Procedure ###
- ui tests pass

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
