### PR TITLE
Fix MDP for iPads running iOS13

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
+		static bool? s_isiOS13OrNewer;
 #endif
 
 #if __MOBILE__
@@ -78,6 +79,16 @@ namespace Xamarin.Forms
 				if (!s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden.HasValue)
 					s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden = new UIViewController().RespondsToSelector(new ObjCRuntime.Selector("setNeedsUpdateOfHomeIndicatorAutoHidden"));
 				return s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden.Value;
+			}
+		}
+
+		internal static bool IsiOS13OrNewer
+		{
+			get
+			{
+				if (!s_isiOS13OrNewer.HasValue)
+					s_isiOS13OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+				return s_isiOS13OrNewer.Value;
 			}
 		}
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -174,19 +174,39 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLayoutSubviews();
 
-			if (View.Subviews.Length < 2)
+			bool layoutMaster = false;
+			bool layoutDetails = false;
+
+			if (Forms.IsiOS13OrNewer)
+			{
+				layoutMaster = _masterController?.View?.Superview != null;
+				layoutDetails = _detailController?.View?.Superview != null;
+			}
+			else if (View.Subviews.Length < 2)
+			{
 				return;
+			}
+			else
+			{
+				layoutMaster = true;
+				layoutDetails = true;
+			}
 
-			var detailsBounds = _detailController.View.Frame;
-			var masterBounds = _masterController.View.Frame;
+			if (layoutMaster)
+			{
+				var masterBounds = _masterController.View.Frame;
+				_masterWidth = (nfloat)Math.Max(_masterWidth, masterBounds.Width);
 
-			_masterWidth = (nfloat)Math.Max(_masterWidth, masterBounds.Width);
+				if (!masterBounds.IsEmpty)
+					MasterDetailPage.MasterBounds = new Rectangle(0, 0, _masterWidth, masterBounds.Height);
+			}
 
-			if (!masterBounds.IsEmpty)
-				MasterDetailPage.MasterBounds = new Rectangle(0, 0, _masterWidth, masterBounds.Height);
-
-			if (!detailsBounds.IsEmpty)
-				MasterDetailPage.DetailBounds = new Rectangle(0, 0, detailsBounds.Width, detailsBounds.Height);
+			if (layoutDetails)
+			{
+				var detailsBounds = _detailController.View.Frame;
+				if (!detailsBounds.IsEmpty)
+					MasterDetailPage.DetailBounds = new Rectangle(0, 0, detailsBounds.Width, detailsBounds.Height);
+			}
 		}
 
 		public override void ViewDidLoad()


### PR DESCRIPTION
### Description of Change ###
iOS 13 changes how the Views associated with a UISplitView get added to the SubViews list.

This PR accounts for those changes


### Platforms Affected ### 
- iOS

### Testing Procedure ###
Make sure the MDP on iOS 12 still works and make sure that MDP on iOS 13 works

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
