### PR TITLE
Force iOS 13 to use Full Screen for Modal

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -1,3 +1,4 @@
+using System;
 using UIKit;
 using Xamarin.Forms.Internals;
 
@@ -71,6 +72,19 @@ namespace Xamarin.Forms.Platform.iOS
 				textInput.AutocapitalizationType = capSettings;
 				textInput.AutocorrectionType = suggestionsEnabled ? UITextAutocorrectionType.Yes : UITextAutocorrectionType.No;
 				textInput.SpellCheckingType = spellcheckEnabled ? UITextSpellCheckingType.Yes : UITextSpellCheckingType.No;
+			}
+		}
+
+		internal static UIModalPresentationStyle ToNativeModalPresentationStyle(this PlatformConfiguration.iOSSpecific.UIModalPresentationStyle style)
+		{
+			switch (style)
+			{
+				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet:
+					return UIModalPresentationStyle.FormSheet;
+				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FullScreen:
+					return UIModalPresentationStyle.FullScreen;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(style));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -14,8 +14,8 @@ namespace Xamarin.Forms.Platform.iOS
 			_modal = modal;
 
 			var elementConfiguration = modal.Element as IElementConfiguration<Page>;
-			if (elementConfiguration?.On<PlatformConfiguration.iOS>().ModalPresentationStyle() == PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet)
-				ModalPresentationStyle = UIKit.UIModalPresentationStyle.FormSheet;
+			var modalPresentationStyle = elementConfiguration?.On<PlatformConfiguration.iOS>()?.ModalPresentationStyle() ?? PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FullScreen;
+			ModalPresentationStyle = modalPresentationStyle.ToNativeModalPresentationStyle();
 
 			View.BackgroundColor = UIColor.White;
 			View.AddSubview(modal.ViewController.View);


### PR DESCRIPTION
### Description of Change ###

If running iOS13 then force the ModalPresentationStyle to Full Screen since XF can't handle swipe dismiss. Once we are on xCode 11 and have the necessary APIs then we can more easily react to swipe dismiss


### Platforms Affected ### 
- iOS

### Testing Procedure ###
Make sure Modal pages work on iOS as expected

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
