### PR TITLE
[Enhancement] Shell Navigation with Models

### DIFF
--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -261,18 +261,18 @@ namespace Xamarin.Forms
 
 			application.PopCanceled -= handler;
 			return !canceled;
-        }
+		}
 
-        internal void SendParameter(object parameter)
-        {
-            OnParameter(parameter);
-        }
+		internal void SendParameter(object parameter)
+		{
+			OnParameter(parameter);
+		}
 
-        protected virtual void OnParameter(object parameter)
-        {
-        }
+		protected virtual void OnParameter(object parameter)
+		{
+		}
 
-        protected override void OnBindingContextChanged()
+		protected override void OnBindingContextChanged()
 		{
 			base.OnBindingContextChanged();
 			foreach (ToolbarItem toolbarItem in ToolbarItems)

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -261,9 +261,18 @@ namespace Xamarin.Forms
 
 			application.PopCanceled -= handler;
 			return !canceled;
-		}
+        }
 
-		protected override void OnBindingContextChanged()
+        internal void SendParameter(object parameter)
+        {
+            OnParameter(parameter);
+        }
+
+        protected virtual void OnParameter(object parameter)
+        {
+        }
+
+        protected override void OnBindingContextChanged()
 		{
 			base.OnBindingContextChanged();
 			foreach (ToolbarItem toolbarItem in ToolbarItems)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -377,7 +377,7 @@ namespace Xamarin.Forms
 			return GoToAsync(state, animate, false);
 		}
 
-		public Task GoToParametrized(string location, object parameter, bool animate = true)
+		public Task GoToParametrizedAsync(string location, object parameter, bool animate = true)
 		{
 			return GoToAsync(new ShellNavigationState(location, parameter), animate);
 		}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -375,9 +375,14 @@ namespace Xamarin.Forms
 		public Task GoToAsync(ShellNavigationState state, bool animate = true)
 		{
 			return GoToAsync(state, animate, false);
-		}
+        }
 
-		internal async Task GoToAsync(ShellNavigationState state, bool animate, bool enableRelativeShellRoutes)
+        public Task GoToParametrized(string location, object parameter, bool animate = true)
+        {
+            return GoToAsync(new ShellNavigationState(location, parameter), animate);
+        }
+
+        internal async Task GoToAsync(ShellNavigationState state, bool animate, bool enableRelativeShellRoutes)
 		{
 			// FIXME: This should not be none, we need to compute the delta and set flags correctly
 			var accept = ProposeNavigation(ShellNavigationSource.Unknown, state, true);
@@ -390,8 +395,9 @@ namespace Xamarin.Forms
 			var uri = navigationRequest.Request.FullUri;
 			var queryString = navigationRequest.Query;
 			var queryData = ParseQueryString(queryString);
+            var parameter = state.Parameter;
 
-			ApplyQueryAttributes(this, queryData, false);
+            ApplyQueryAttributes(this, queryData, false);
 
 			var shellItem = navigationRequest.Request.Item;
 			var shellSection = navigationRequest.Request.Section;
@@ -429,14 +435,14 @@ namespace Xamarin.Forms
 					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
 					Device.BeginInvokeOnMainThread(async () =>
 					{
-						await CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, false);
-					});
+						await CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameter, queryData, false);
+                    });
 				}
 			}
 			else
 			{
-				await CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate);
-			}
+				await CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameter, queryData, false);
+            }
 
 			_accumulateNavigatedEvents = false;
 

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -375,14 +375,14 @@ namespace Xamarin.Forms
 		public Task GoToAsync(ShellNavigationState state, bool animate = true)
 		{
 			return GoToAsync(state, animate, false);
-        }
+		}
 
-        public Task GoToParametrized(string location, object parameter, bool animate = true)
-        {
-            return GoToAsync(new ShellNavigationState(location, parameter), animate);
-        }
+		public Task GoToParametrized(string location, object parameter, bool animate = true)
+		{
+			return GoToAsync(new ShellNavigationState(location, parameter), animate);
+		}
 
-        internal async Task GoToAsync(ShellNavigationState state, bool animate, bool enableRelativeShellRoutes)
+		internal async Task GoToAsync(ShellNavigationState state, bool animate, bool enableRelativeShellRoutes)
 		{
 			// FIXME: This should not be none, we need to compute the delta and set flags correctly
 			var accept = ProposeNavigation(ShellNavigationSource.Unknown, state, true);
@@ -395,9 +395,9 @@ namespace Xamarin.Forms
 			var uri = navigationRequest.Request.FullUri;
 			var queryString = navigationRequest.Query;
 			var queryData = ParseQueryString(queryString);
-            var parameter = state.Parameter;
+			var parameter = state.Parameter;
 
-            ApplyQueryAttributes(this, queryData, false);
+			ApplyQueryAttributes(this, queryData, false);
 
 			var shellItem = navigationRequest.Request.Item;
 			var shellSection = navigationRequest.Request.Section;
@@ -436,13 +436,13 @@ namespace Xamarin.Forms
 					Device.BeginInvokeOnMainThread(async () =>
 					{
 						await CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameter, queryData, false);
-                    });
+					});
 				}
 			}
 			else
 			{
 				await CurrentItem.CurrentItem.GoToAsync(navigationRequest, parameter, queryData, false);
-            }
+			}
 
 			_accumulateNavigatedEvents = false;
 

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -37,12 +37,12 @@ namespace Xamarin.Forms
 		static readonly BindablePropertyKey ItemsPropertyKey = BindableProperty.CreateReadOnly(nameof(Items), typeof(ShellSectionCollection), typeof(ShellItem), null,
 				defaultValueCreator: bo => new ShellSectionCollection { Inner = new ElementCollection<ShellSection>(((ShellItem)bo)._children) });
 
-		#endregion PropertyKeys
+        #endregion PropertyKeys
 
-		#region IShellItemController
+        #region IShellItemController
 
-		internal Task GoToPart(NavigationRequest request, Dictionary<string, string> queryData)
-		{
+        internal Task GoToPart(NavigationRequest request, object parameter, Dictionary<string, string> queryData)
+        {
 			var shellSection = request.Request.Section;
 
 			if (shellSection == null)
@@ -53,8 +53,8 @@ namespace Xamarin.Forms
 			if (CurrentItem != shellSection)
 				SetValueFromRenderer(CurrentItemProperty, shellSection);
 
-			return shellSection.GoToPart(request, queryData);
-		}
+            return shellSection.GoToPart(request, parameter, queryData);
+        }
 
 		bool IShellItemController.ProposeSection(ShellSection shellSection, bool setValue)
 		{

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -37,12 +37,12 @@ namespace Xamarin.Forms
 		static readonly BindablePropertyKey ItemsPropertyKey = BindableProperty.CreateReadOnly(nameof(Items), typeof(ShellSectionCollection), typeof(ShellItem), null,
 				defaultValueCreator: bo => new ShellSectionCollection { Inner = new ElementCollection<ShellSection>(((ShellItem)bo)._children) });
 
-        #endregion PropertyKeys
+		#endregion PropertyKeys
 
-        #region IShellItemController
+		#region IShellItemController
 
-        internal Task GoToPart(NavigationRequest request, object parameter, Dictionary<string, string> queryData)
-        {
+		internal Task GoToPart(NavigationRequest request, object parameter, Dictionary<string, string> queryData)
+		{
 			var shellSection = request.Request.Section;
 
 			if (shellSection == null)
@@ -53,8 +53,8 @@ namespace Xamarin.Forms
 			if (CurrentItem != shellSection)
 				SetValueFromRenderer(CurrentItemProperty, shellSection);
 
-            return shellSection.GoToPart(request, parameter, queryData);
-        }
+			return shellSection.GoToPart(request, parameter, queryData);
+		}
 
 		bool IShellItemController.ProposeSection(ShellSection shellSection, bool setValue)
 		{

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -23,31 +23,31 @@ namespace Xamarin.Forms
 		{
 			get;
 			private set;
-        }
+		}
 
-        public object Parameter
-        {
-            get;
-            private set;
-        }
+		public object Parameter
+		{
+			get;
+			private set;
+		}
 
-        public ShellNavigationState() { }
+		public ShellNavigationState() { }
 		public ShellNavigationState(string location, object parameter = null)
-        {
+		{
 			var uri = ShellUriHandler.CreateUri(location);
 
 			if (uri.IsAbsoluteUri)
 				uri = new Uri($"/{uri.PathAndQuery}", UriKind.Relative);
 
 			FullLocation = uri;
-            Parameter = parameter;
-        }
+			Parameter = parameter;
+		}
 
-        public ShellNavigationState(Uri location, object parameter = null)
-        {
-            FullLocation = location;
-            Parameter = parameter;
-        }
+		public ShellNavigationState(Uri location, object parameter = null)
+		{
+			FullLocation = location;
+			Parameter = parameter;
+		}
 
 		public static implicit operator ShellNavigationState(Uri uri) => new ShellNavigationState(uri);
 		public static implicit operator ShellNavigationState(string value) => new ShellNavigationState(value);

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -23,20 +23,32 @@ namespace Xamarin.Forms
 		{
 			get;
 			private set;
-		}
+        }
 
-		public ShellNavigationState() { }
-		public ShellNavigationState(string location)
-		{
+        public object Parameter
+        {
+            get;
+            private set;
+        }
+
+        public ShellNavigationState() { }
+		public ShellNavigationState(string location, object parameter = null)
+        {
 			var uri = ShellUriHandler.CreateUri(location);
 
 			if (uri.IsAbsoluteUri)
 				uri = new Uri($"/{uri.PathAndQuery}", UriKind.Relative);
 
 			FullLocation = uri;
-		}
+            Parameter = parameter;
+        }
 
-		public ShellNavigationState(Uri location) => FullLocation = location;
+        public ShellNavigationState(Uri location, object parameter = null)
+        {
+            FullLocation = location;
+            Parameter = parameter;
+        }
+
 		public static implicit operator ShellNavigationState(Uri uri) => new ShellNavigationState(uri);
 		public static implicit operator ShellNavigationState(string value) => new ShellNavigationState(value);
 	}

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms
 			callback(DisplayedPage);
 		}
 
-		internal Task GoToPart(NavigationRequest request, Dictionary<string, string> queryData)
+		internal Task GoToPart(NavigationRequest request, object parameter, Dictionary<string, string> queryData)
 		{
 			ShellContent shellContent = request.Request.Content;
 
@@ -79,7 +79,7 @@ namespace Xamarin.Forms
 				// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
 				Device.BeginInvokeOnMainThread(async () =>
 				{
-					await GoToAsync(request, queryData, false);
+					await GoToAsync(request, parameter, queryData, false);
 				});
 			}
 
@@ -227,7 +227,7 @@ namespace Xamarin.Forms
 			return (ShellSection)(ShellContent)page;
 		}
 
-		internal async Task GoToAsync(NavigationRequest request, IDictionary<string, string> queryData, bool animate)
+		internal async Task GoToAsync(NavigationRequest request, object parameter, IDictionary<string, string> queryData, bool animate)
 		{
 			List<string> routes = request.Request.GlobalRoutes;
 			if (routes == null || routes.Count == 0)
@@ -264,7 +264,11 @@ namespace Xamarin.Forms
 					break;
 
 				Shell.ApplyQueryAttributes(content, queryData, isLast);
-				await OnPushAsync(content, i == routes.Count - 1 && animate);
+
+                if (parameter != null)
+                    content.SendParameter(parameter);
+
+                await OnPushAsync(content, i == routes.Count - 1 && animate);
 			}
 
 			SendAppearanceChanged();

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -265,10 +265,10 @@ namespace Xamarin.Forms
 
 				Shell.ApplyQueryAttributes(content, queryData, isLast);
 
-                if (parameter != null)
-                    content.SendParameter(parameter);
+				if (parameter != null)
+					content.SendParameter(parameter);
 
-                await OnPushAsync(content, i == routes.Count - 1 && animate);
+				await OnPushAsync(content, i == routes.Count - 1 && animate);
 			}
 
 			SendAppearanceChanged();
@@ -611,7 +611,7 @@ namespace Xamarin.Forms
 				SetInheritedBindingContext(shellContent, BindingContext);
 			}
 		}
-    
+	
 		internal override void SendDisappearing()
 		{
 			base.SendDisappearing();


### PR DESCRIPTION
### Description of Change ###
Allows to pass an object parameter via Shell.GoToAsync, which can be used via overriding the OnParameter method of the Page class.

First pull request for Xamarin, so I'm glad for any feedback - Thanks!

### Issues Resolved ### 

- fixes #6848

### API Changes ###

Added:
- virtual void Page.OnParameter(object parameter)
- static Task Shell.GoToParametrized(string location, object parameter, bool animate = true)

Changed:
- ShellNavigationState(string location) => ShellNavigationState(string location, object parameter = null)
- ShellNavigationState(Uri location) => ShellNavigationState(Uri location, object parameter = null)

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Use GoToAsync with ShellNavigationState containing an object or call GoToParametrizedAsync
Only built the Core project, having issues using it from an actual Android project, therefore couldn't test it.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
