### PR TITLE
[macOS] Only use default font size for Time/DatePicker to avoid clipping issues

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
@@ -116,9 +116,17 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdateFont()
 		{
 			if (Control == null || Element == null)
-				return;
+				return; 
 
-			Control.Font = Element.ToNSFont();
+			var newFont = Element.ToNSFont();
+
+			// The font needs to have the default font size to avoid clipping
+			var originalFontSize = (NSNumber)Control.Font.FontDescriptor.FontAttributes[NSFont.SizeAttribute];
+			// Recreate the font with the default size
+			newFont = NSFont.FromDescription(newFont.FontDescriptor, originalFontSize.FloatValue);
+
+			// Apply the font 
+			Control.Font = newFont;
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		void UpdateFont()
-		{ 
+		{
 			if (Control == null || Element == null)
 				return;
 
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			// Recreate the font with the default size
 			newFont = NSFont.FromDescription(newFont.FontDescriptor, originalFontSize.FloatValue);
 
-			// Apply the font 
+			// Apply the font
 			Control.Font = newFont;
 		}
 

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
@@ -98,7 +98,18 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null || Element == null)
 				return;
 
-			Control.Font = Element.ToNSFont();
+			if (Control == null || Element == null)
+				return;
+
+			var newFont = Element.ToNSFont();
+
+			// The font needs to have the default font size to avoid clipping
+			var originalFontSize = (NSNumber)Control.Font.FontDescriptor.FontAttributes[NSFont.SizeAttribute];
+			// Recreate the font with the default size
+			newFont = NSFont.FromDescription(newFont.FontDescriptor, originalFontSize.FloatValue);
+
+			// Apply the font 
+			Control.Font = newFont;
 		}
 
 		void UpdateTime()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TimePickerRenderer.cs
@@ -94,10 +94,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		void UpdateFont()
-		{
-			if (Control == null || Element == null)
-				return;
-
+		{ 
 			if (Control == null || Element == null)
 				return;
 


### PR DESCRIPTION
### Description of Change ###

Using a custom font size leads to clipping issue in the date and time picker since it uses a constant size for the separators. This change enforces to use the default font size for these controls to avoid the clipping issues.

### Issues Resolved ###  

- fixes #6817

### API Changes ###

None

### Platforms Affected ### 

-macOS

### Behavioral/Visual Changes ###

- FontSize does not longer apply to Date/TimePicker on macOS

### Before/After Screenshots ### 

Old: 
![grafik](https://user-images.githubusercontent.com/11095003/63158145-e5e13300-c018-11e9-99b0-5266636595e0.png)
-> This should show 23.11.2019
![grafik](https://user-images.githubusercontent.com/11095003/63158208-08734c00-c019-11e9-8980-dfb712e7eb35.png)
-> This should show 12:59:59

New
![grafik](https://user-images.githubusercontent.com/11095003/63158008-9f8bd400-c018-11e9-9a1d-d19aa7dbd442.png)
![grafik](https://user-images.githubusercontent.com/11095003/63158047-b92d1b80-c018-11e9-917d-94cd95c7af59.png)

### Testing Procedure ###

- enter double digit times/dates

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
