### PR TITLE
[X] OnPlatform use BP.DefaultValue

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7156.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7156.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh7156">
+    <StackLayout>
+        <Label x:Name="l0" Text="{OnPlatform iOS=foo}" WidthRequest="{OnPlatform iOS=10}"/>
+        <Label x:Name="l1" Text="{OnPlatform iOS=foo, Default=bar}" WidthRequest="{OnPlatform iOS=10, Default=20}"/>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7156.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7156.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh7156 : ContentPage
+	{
+		public Gh7156() => InitializeComponent();
+		public Gh7156(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void OnPlatformDefaultToBPDefaultValue([Values(true, false)]bool useCompiledXaml)
+			{
+				((MockPlatformServices)Device.PlatformServices).RuntimePlatform = Device.Android;
+				var layout = new Gh7156(useCompiledXaml);
+				Assert.That(layout.l0.Text, Is.EqualTo(Label.TextProperty.DefaultValue));
+				Assert.That(layout.l0.WidthRequest, Is.EqualTo(VisualElement.WidthRequestProperty.DefaultValue));
+				Assert.That(layout.l1.Text, Is.EqualTo("bar"));
+				Assert.That(layout.l1.WidthRequest, Is.EqualTo(20d));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

If no default is provided for {OnPlatform}, default to DefaultValue if this is targetting a BindableProperty.

Also use other value than null as sentinel, as {x:Null} is a
perfectly valid value.

This is a breaking change, but the risk is very low

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7156

<!-- Describe your changes here. -->

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
