### PR TITLE
move await to Begin Invoke and check for disposed

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/NSObjectExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/NSObjectExtensions.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Foundation;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal static class NSObjectExtensions
+	{
+		public static void QueueForLater(this NSObject nsObject, Action action) =>
+			nsObject.BeginInvokeOnMainThread(action);
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -360,7 +360,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Control.TableHeaderView = _headerRenderer.NativeView;
 		}
 
-		async void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
+		void OnScrollToRequested(object sender, ScrollToRequestedEventArgs e)
 		{
 			if (Superview == null)
 			{
@@ -386,14 +386,16 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.Layer.RemoveAllAnimations();
 					//iOS11 hack
 					if (Forms.IsiOS11OrNewer)
-					{
-						await Task.Delay(1);
-					}
-					Control.ScrollToRow(NSIndexPath.FromRowSection(index, 0), position, e.ShouldAnimate);
+						this.QueueForLater(() =>
+						{
+							if (Control != null && !_disposed)
+								Control.ScrollToRow(NSIndexPath.FromRowSection(index, 0), position, e.ShouldAnimate);
+						});
+					else
+						Control.ScrollToRow(NSIndexPath.FromRowSection(index, 0), position, e.ShouldAnimate);
 				}
 			}
 		}
-
 
 		void UpdateFooter()
 		{

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -147,6 +147,7 @@
     <Compile Include="ExportRendererAttribute.cs" />
     <Compile Include="Extensions\ArrayExtensions.cs" />
     <Compile Include="Extensions\FlowDirectionExtensions.cs" />
+    <Compile Include="Extensions\NSObjectExtensions.cs" />
     <Compile Include="Extensions\PlatformConfigurationExtensions.cs" />
     <Compile Include="Extensions\LabelExtensions.cs" />
     <Compile Include="Extensions\VisualElementExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###

A race condition might cause the Control to get disposed before the await returns so we need to check if the Control still exists after the await. 

I also just removed the await and used InvokeOnMainThread which I think is a bit more explicit and avoids having to mix async awaits into the code

### Issues Resolved ### 
- fixes #7139 


### Platforms Affected ### 
- iOS


### Testing Procedure ###
I wasn't able to reproduce but the user on #7139 says it resolved the crashing for them. This is also very similar to a fix we did on Android which was also using an await on a Task.Delay(1)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
