### PR TITLE
[iOS] Fix LayoutCompression Performance Issues #3475

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3475.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3475.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Layout)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 3475, "LayoutCompression Performance Issues", PlatformAffected.iOS | PlatformAffected.Android)]
+	[Issue(IssueTracker.Github, 3475, "[iOS] LayoutCompression Performance Issues", PlatformAffected.iOS)]
 	public class Issue3475 : TestContentPage
 	{
 		string _withoutCompressionBtnId = "button1";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3475.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3475.cs
@@ -1,0 +1,151 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Layout)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 3475, "LayoutCompression Performance Issues", PlatformAffected.iOS | PlatformAffected.Android)]
+	public class Issue3475 : TestContentPage
+	{
+		string _withoutCompressionBtnId = "button1";
+		string _withCompressionBtnId = "button2";
+		string _titleLabelId = "Label1";
+		
+		public static string BackButtonId = "back";
+		public static int ItemsCount = 150;
+		public static string ElapsedLabelId = "elapsed";
+		public static string DoneLabelId = "done";
+
+		protected override void Init()
+		{
+			var withoutCompressionBtn = new Button
+			{
+				Text    = "Without Layout Compression",
+				Command = new Command(async () => await Navigation.PushAsync(new CompressionPage())),
+				AutomationId = _withoutCompressionBtnId
+
+			};
+
+			var withCompressionBtn = new Button
+			{
+				Text    = "With Layout Compression",
+				Command = new Command(async () => await Navigation.PushAsync(new CompressionPage(true))),
+				AutomationId = _withCompressionBtnId
+			};
+
+			Content = new StackLayout
+			{
+				Padding = 10,
+				Children =
+				{
+					new Label
+					{
+						Text = "Tap buttons to test LayoutCompression Performance in iOS. It should be faster (or at least equal) with LayoutCompression enabled",
+						AutomationId = _titleLabelId
+					},
+					withoutCompressionBtn,
+					withCompressionBtn
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Issue3475TestsLayoutCompressionPerformance()
+		{
+			RunningApp.WaitForElement(_titleLabelId);
+			RunningApp.WaitForElement(_withoutCompressionBtnId);
+			RunningApp.WaitForElement(_withCompressionBtnId);
+
+			RunningApp.Tap(_withoutCompressionBtnId);
+			RunningApp.WaitForElement(DoneLabelId);
+			RunningApp.Screenshot("Without Layout Compression");
+
+			int elapsedWithoutCompression = GetMs(RunningApp.Query(ElapsedLabelId).First().Text);
+
+			RunningApp.Tap(BackButtonId);
+			RunningApp.WaitForElement(_withCompressionBtnId);
+			
+			RunningApp.Tap(_withCompressionBtnId);
+			RunningApp.WaitForElement(DoneLabelId);
+			RunningApp.Screenshot("With Layout Compression");
+
+			int elapsedWithCompression = GetMs(RunningApp.Query(ElapsedLabelId).First().Text);
+			var delta = elapsedWithCompression - elapsedWithoutCompression;
+
+			//if layoutcompressions is slower than 100 then there is a problem.
+			//it should be at least very similar and no more than 100ms slower i guess...
+			Assert.LessOrEqual(delta, 100);
+		}
+
+		public int GetMs(string text)
+		{
+			text = text.Replace($"Showing {ItemsCount} items took: ", "").Replace(" ms", "");
+			return int.TryParse(text, out int elapsed) ? elapsed : 0;
+		}
+#endif
+	}
+
+	public class CompressionPage : ContentPage
+	{
+		readonly Stopwatch _sw = new Stopwatch();
+		readonly Label _summaryLabel;
+		readonly StackLayout _scrollStack;
+
+		public CompressionPage(bool shouldUseLayoutCompression = false)
+		{
+			_summaryLabel = new Label { HorizontalOptions = LayoutOptions.Center, BackgroundColor = Color.Silver, AutomationId = Issue3475.ElapsedLabelId};
+			var backButton = new Button { AutomationId = Issue3475.BackButtonId, Text ="Back", Command = new Command(() => Navigation.PopAsync()) };
+			_scrollStack = new StackLayout();
+
+			var scrollView = new ScrollView
+			{
+				Content = _scrollStack
+			};
+
+			var mainStack = new StackLayout { Children =
+			{
+				_summaryLabel,
+				scrollView,
+				backButton
+			} };
+
+			for (int i = 0; i < Issue3475.ItemsCount; i++)
+			{
+				var childLayout = new StackLayout();
+
+				if (shouldUseLayoutCompression)
+				{
+					Xamarin.Forms.CompressedLayout.SetIsHeadless(childLayout, true);
+				}
+
+				var label = new Label { Text = $"Item {i}" };
+				childLayout.Children.Add(label);
+				_scrollStack.Children.Add(childLayout);
+			}
+
+			_sw.Start();
+			Content = mainStack;
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			_sw.Stop();
+			_summaryLabel.Text = $"Showing {Issue3475.ItemsCount} items took: {_sw.ElapsedMilliseconds} ms";
+			_scrollStack.Children.Insert(0, new Label{Text = "Done", HorizontalOptions = LayoutOptions.Center, AutomationId = Issue3475.DoneLabelId});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1208,7 +1208,7 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
-  
+
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1208,6 +1208,7 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
+  
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6945.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">
       <DependentUpon>Issue5046.xaml</DependentUpon>
@@ -1207,7 +1208,6 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -20,13 +20,15 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 		}
 
-		VisualElementPackager(IVisualElementRenderer renderer, VisualElement element)
+		VisualElementPackager(IVisualElementRenderer renderer, VisualElement element, bool isHeadless = false)
 		{
 			if (renderer == null)
 				throw new ArgumentNullException(nameof(renderer));
 
 			Renderer = renderer;
-			renderer.ElementChanged += OnRendererElementChanged;
+			if (!isHeadless)
+				renderer.ElementChanged += OnRendererElementChanged;
+
 			SetElement(null, element ?? renderer.Element);
 		}
 
@@ -88,7 +90,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			Performance.Start(out string reference);
 			if (CompressedLayout.GetIsHeadless(view))
 			{
-				var packager = new VisualElementPackager(Renderer, view);
+				var packager = new VisualElementPackager(Renderer, view, isHeadless:true);
 				view.IsPlatformEnabled = true;
 				packager.Load();
 			}


### PR DESCRIPTION
### Description of Change ###

While inspecting this issue in iOS, i noticed that the `Render` property in the `VisualElementPackager` got multiple subscriptions to `OnRendererElementChanged` when using `CompressedLayout.IsHeadless = True`.

So if we had 150 stacklayout with `CompressedLayout.IsHeadless = True`, the `Render` property, get 150 subscriptions to `OnRendererElementChanged`, slowing down a lot the page.

To solve this, i added an optional boolean property in the `VisualElementPackager` constructor, when is set to `True` (for Headless Layouts) we skip the event subscription to `OnRendererElementChanged`.
Default is `False`.

|Compression mode|Time to render|
| -------------------  | :------------------ |
|No compression|1160ms|
|With Compression before the fix|17268ms|
|**With Compression after the fix**|**745ms**|

### Issues Resolved ### 

- fixes #3475

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Testing Procedure ###

Included specific page in control gallery, with UITest

### PR Checklist ###

- [x] Has automated tests
- [X] Rebased on top of the target branch at time of PR
- [X] Changes adhere to coding standard
