### PR TITLE
[iOS] Fix accessibility regressions with hidden views, WebViews, and layouts

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6894.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6894.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6894, "Accessibility tags are not working with WebView", PlatformAffected.iOS)]
+	public class Issue6894 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var stack = new StackLayout
+			{
+				Children = {
+					new Label { Text = "Turn on the Screen Reader. Swipe next to the WebView. You should be able to swipe between the elements on the webpage and hear the text announced. If not, this test has failed." },
+					new WebView { Source = "https://microsoft.com" }
+				},
+			};
+
+			Content = stack;
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6894.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6894.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Children = {
 					new Label { Text = "Turn on the Screen Reader. Swipe next to the WebView. You should be able to swipe between the elements on the webpage and hear the text announced. If not, this test has failed." },
-					new WebView { Source = "https://microsoft.com" }
+					new WebView { Source = "https://microsoft.com", VerticalOptions = LayoutOptions.FillAndExpand }
 				},
 			};
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6929.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6929.cs
@@ -1,0 +1,37 @@
+﻿using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6929, "Accessibility problem with hidden views", PlatformAffected.iOS)]
+	public class Issue6929 : TestContentPage 
+	{
+		protected override void Init()
+		{
+			var label2 = new Label { IsVisible = false, Text = "Success" };
+			var button = new Button { Text = "Click me" };
+			button.Clicked += (s, e) =>
+			{
+				label2.IsVisible = true;
+			};
+			var stack = new StackLayout
+			{
+				Padding = 100,
+				Children = { new Label { Text = "Turn on the Screen Reader. Click the button. Another label should appear. If you can not swipe to access and hear the text of the new label, this test has failed." }, label2, button },
+			};
+
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7053.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7053.cs
@@ -1,0 +1,34 @@
+﻿using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7053, "Support for Accessibility automation properties on iOS is removed for Layouts", PlatformAffected.iOS)]
+	public class Issue7053 : TestContentPage
+	{
+		protected override void Init()
+		{
+
+			var stack = new StackLayout
+			{
+				AutomationId = "test",
+				Children = { new Label { Text = "Turn on the Screen Reader. If you do not hear 'I am the StackLayout', this test has failed." } },
+			};
+
+			AutomationProperties.SetIsInAccessibleTree(stack, true);
+			AutomationProperties.SetName(stack, "I am the StackLayout. This should be announced.");
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -952,6 +952,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6894.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6929.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -950,6 +950,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6368.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6472.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7053.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -951,6 +951,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6472.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6614.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7053.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6894.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/IAccessibilityElementsController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IAccessibilityElementsController.cs
@@ -6,7 +6,6 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal interface IAccessibilityElementsController
 	{
-		void ResetAccessibilityElements();
 		List<NSObject> GetAccessibilityElements();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewWillLayoutSubviews();
 
-			AccessibilityElementsController.ResetAccessibilityElements();
+			Container?.ClearAccessibilityElements();
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -322,11 +322,6 @@ namespace Xamarin.Forms.Platform.iOS
 						return UIKit.UIStatusBarAnimation.None;
 				}
 			}
-		}
-
-		void IAccessibilityElementsController.ResetAccessibilityElements()
-		{
-			Container?.ClearAccessibilityElements();
 		}
 
 		void UpdateUseSafeArea()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -68,11 +68,14 @@ namespace Xamarin.Forms.Platform.iOS
 						!(
 							child is VisualElement ve && ve.IsTabStop
 							&& AutomationProperties.GetIsInAccessibleTree(ve) != false // accessible == true
-							&& ve.GetRenderer().NativeView is ITabStop tabStop)
+							&& ve.GetRenderer().NativeView is UIView view)
 						 )
 						continue;
 
-					var thisControl = tabStop.TabStop;
+					var thisControl = view;
+
+					if (view is ITabStop tabstop)
+						thisControl = tabstop.TabStop;
 
 					if (thisControl == null)
 						continue;
@@ -125,7 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			//by default use the MainScreen Bounds so Effects can access the Container size
 			if (_pageContainer == null)
-				_pageContainer = new PageContainer(this) { Frame = UIScreen.MainScreen.Bounds};
+				_pageContainer = new PageContainer(this) { Frame = UIScreen.MainScreen.Bounds };
 
 			View = _pageContainer;
 		}
@@ -176,7 +179,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_appeared = true;
 			UpdateStatusBarPrefersHidden();
-			if(Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
+			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 
 			if (Element.Parent is CarouselPage)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var tabGroup = tabIndexes[idx];
 				foreach (var child in tabGroup)
 				{
-					if (child is Layout ||
+					if (
 						!(
 							child is VisualElement ve && ve.IsTabStop
 							&& AutomationProperties.GetIsInAccessibleTree(ve) != false // accessible == true

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -9,7 +9,7 @@ using Uri = System.Uri;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class WebViewRenderer : UIWebView, IVisualElementRenderer, IWebViewDelegate, IEffectControlProvider
+	public class WebViewRenderer : UIWebView, IVisualElementRenderer, IWebViewDelegate, IEffectControlProvider, ITabStop
 	{
 		EventTracker _events;
 		bool _ignoreSourceChanges;
@@ -290,6 +290,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			get { return null; }
 		}
+
+		UIView ITabStop.TabStop => this;
 
 		#endregion
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -11,7 +11,7 @@ using Uri = System.Uri;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class WkWebViewRenderer : WKWebView, IVisualElementRenderer, IWebViewDelegate, IEffectControlProvider
+	public class WkWebViewRenderer : WKWebView, IVisualElementRenderer, IWebViewDelegate, IEffectControlProvider, ITabStop
 	{
 		EventTracker _events;
 		bool _ignoreSourceChanges;
@@ -390,6 +390,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			get { return null; }
 		}
+
+		UIView ITabStop.TabStop => this;
 
 		#endregion
 

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -220,19 +220,19 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.KeyUp(theEvent);
 		}
 #else
-		UIKeyCommand [] tabCommands = {
+		UIKeyCommand[] tabCommands = {
 			UIKeyCommand.Create ((Foundation.NSString)"\t", 0, new ObjCRuntime.Selector ("tabForward:")),
 			UIKeyCommand.Create ((Foundation.NSString)"\t", UIKeyModifierFlags.Shift, new ObjCRuntime.Selector ("tabBackward:"))
 		};
 
-		public override UIKeyCommand [] KeyCommands => tabCommands;
+		public override UIKeyCommand[] KeyCommands => tabCommands;
 
 
-		[Foundation.Export ("tabForward:")]
-		void TabForward (UIKeyCommand cmd) => FocusSearch (forwardDirection: true);
+		[Foundation.Export("tabForward:")]
+		void TabForward(UIKeyCommand cmd) => FocusSearch(forwardDirection: true);
 
-		[Foundation.Export ("tabBackward:")]
-		void TabBackward (UIKeyCommand cmd) => FocusSearch (forwardDirection: false);
+		[Foundation.Export("tabBackward:")]
+		void TabBackward(UIKeyCommand cmd) => FocusSearch(forwardDirection: false);
 #endif
 
 		public void SetElement(TElement element)
@@ -393,6 +393,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				SetAccessibilityLabel();
 			else if (e.PropertyName == AutomationProperties.IsInAccessibleTreeProperty.PropertyName)
 				SetIsAccessibilityElement();
+			else if (e.Is(VisualElement.IsVisibleProperty))
+			{
+				UpdateParentPageAccessibilityElements();
+			}
 #endif
 
 		}
@@ -502,11 +506,16 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 #if __MOBILE__
 			UIView parentRenderer = Superview;
-			while (parentRenderer != null && !(parentRenderer is IAccessibilityElementsController))
-				parentRenderer = parentRenderer.Superview;
+			while (parentRenderer != null)
+			{
+				if (parentRenderer is PageContainer container)
+				{
+					container.ClearAccessibilityElements();
+					break;
+				}
 
-			if (parentRenderer is IAccessibilityElementsController controller)
-				controller.ResetAccessibilityElements();
+				parentRenderer = parentRenderer.Superview;
+			}
 #endif
 		}
 


### PR DESCRIPTION
### Description of Change ###

#3989 introduced focus order for Screen Readers. For iOS, we needed to implement AccessibilityElements in order to set the read order. 

1. WebViews were excluded from readers because WebViews implement the fast renderers pattern and did not implement ITabStop. We have now made it possible for any view that does not implement ITabStop to work with AccessibilityElements, and we've implemented ITabStop on the WebView renderers.
2. Layouts were explicitly excluded from AccessibilityElements; this was a mistake on my part, as I thought this was how it worked on Android. This change has been reverted.
3. AccessibilityElements was not updated when visibility changed. In addition, the code that was meant to reset AccessibilityElements when TabIndex or IsTabStop changed also wasn't working. Both of these scenarios are now supported.

### Issues Resolved ### 

- fixes #6894 
- fixes #6929 
- fixes #7053 

### API Changes ###

 
 None

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
There are test pages with instructions for manual review for all three issues.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
