### PR TITLE
[iOS] Implement CollectionView ScrollTo with groups

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollToGroup.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollToGroup.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	public class ScrollToGroup : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			FlagTestHelpers.SetCollectionViewTestFlag();
+			PushAsync(new GalleryPages.CollectionViewGalleries.ScrollToGalleries.ScrollToGroup());
+#endif
+		}
+
+#if UITEST && __IOS__ // Grouping for Android hasn't been merged yet
+		[Test]
+		public void ShouldBeAbleToScrollToGroupAndItemIndex()
+		{
+			RunningApp.WaitForElement("GroupIndexEntry");
+			RunningApp.Tap("GroupIndexEntry");
+			RunningApp.ClearText();
+			RunningApp.EnterText("5");
+
+			RunningApp.Tap("ItemIndexEntry");
+			RunningApp.ClearText();
+			RunningApp.EnterText("1");
+
+			// Should scroll enough to display this item
+			RunningApp.WaitForElement("Squirrel Girl");
+		}
+
+		[Test]
+		public void InvalidScrollToIndexShouldNotCrash()
+		{
+			RunningApp.WaitForElement("GroupIndexEntry");
+			RunningApp.Tap("GroupIndexEntry");
+			RunningApp.ClearText();
+			RunningApp.EnterText("55");
+
+			RunningApp.Tap("ItemIndexEntry");
+			RunningApp.ClearText();
+			RunningApp.EnterText("1");
+
+			// Should scroll enough to display this item
+			RunningApp.WaitForElement("Avengers");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollToGroup.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollToGroup.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST && __IOS__ // Grouping for Android hasn't been merged yet
 		[Test]
-		public void ShouldBeAbleToScrollToGroupAndItemIndex()
+		public void CanScrollToGroupAndItemIndex()
 		{
 			RunningApp.WaitForElement("GroupIndexEntry");
 			RunningApp.Tap("GroupIndexEntry");
@@ -56,6 +56,22 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// Should scroll enough to display this item
 			RunningApp.WaitForElement("Avengers");
+		}
+
+		[Test]
+		public void CanScrollToGroupAndItem()
+		{
+			RunningApp.WaitForElement("GroupNameEntry");
+			RunningApp.Tap("GroupNameEntry");
+			RunningApp.ClearText();
+			RunningApp.EnterText("Heroes for Hire");
+
+			RunningApp.Tap("ItemNameEntry");
+			RunningApp.ClearText();
+			RunningApp.EnterText("Misty Knight");
+
+			// Should scroll enough to display this item
+			RunningApp.WaitForElement("Luke Cage");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -23,6 +23,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellBackButtonBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollToGalleries.ScrollToGroup">
+    <ContentPage.Content>
+
+        <StackLayout>
+
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition></RowDefinition>
+                    <RowDefinition></RowDefinition>
+                    <RowDefinition></RowDefinition>
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+                
+                <Label Text="Group:"></Label>
+                <Entry Grid.Column="1" x:Name="GroupIndex" Keyboard="Numeric" Text="0" AutomationId="GroupIndexEntry"></Entry>
+                <Label Grid.Row="1" Text="Item:"></Label>
+                <Entry Grid.Row="1" Grid.Column="1" x:Name="ItemIndex" Keyboard="Numeric" Text="0" AutomationId="ItemIndexEntry"></Entry>
+                <Button Grid.Row="2" Grid.ColumnSpan="2" x:Name="ScrollTo" Text="Go" AutomationId="GoButton"/>
+            </Grid>
+            
+            <CollectionView x:Name="CollectionView" IsGrouped="True">
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Label Text="{Binding Name}" Margin="5,0,0,0"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+
+                <CollectionView.GroupHeaderTemplate>
+                    <DataTemplate>
+
+                        <Label Text="{Binding Name}" BackgroundColor="LightGreen" FontSize="16" FontAttributes="Bold"/>
+
+                    </DataTemplate>
+                </CollectionView.GroupHeaderTemplate>
+
+                <CollectionView.GroupFooterTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Label Text="{Binding Count, StringFormat='{}Total members: {0:D}'}" BackgroundColor="Orange" 
+							       Margin="0,0,0,15"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.GroupFooterTemplate>
+
+            </CollectionView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml
@@ -27,6 +27,25 @@
                 <Entry Grid.Row="1" Grid.Column="1" x:Name="ItemIndex" Keyboard="Numeric" Text="0" AutomationId="ItemIndexEntry"></Entry>
                 <Button Grid.Row="2" Grid.ColumnSpan="2" x:Name="ScrollTo" Text="Go" AutomationId="GoButton"/>
             </Grid>
+
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition></RowDefinition>
+                    <RowDefinition></RowDefinition>
+                    <RowDefinition></RowDefinition>
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition/>
+                    <ColumnDefinition/>
+                </Grid.ColumnDefinitions>
+
+                <Label Text="Group Name:"></Label>
+                <Entry Grid.Column="1" x:Name="GroupName" Text="" AutomationId="GroupIndexEntry"></Entry>
+                <Label Grid.Row="1" Text="Item Name:"></Label>
+                <Entry Grid.Row="1" Grid.Column="1" x:Name="ItemName" AutomationId="ItemIndexEntry"></Entry>
+                <Button Grid.Row="2" Grid.ColumnSpan="2" x:Name="ScrollToItem" Text="Go" AutomationId="GoItemButton"/>
+            </Grid>
             
             <CollectionView x:Name="CollectionView" IsGrouped="True">
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries;
 using Xamarin.Forms.Xaml;
 
@@ -7,12 +8,32 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollToGa
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class ScrollToGroup : ContentPage
 	{
+		SuperTeams _source = new SuperTeams();
+
 		public ScrollToGroup()
 		{
 			InitializeComponent();
-			CollectionView.ItemsSource = new SuperTeams();
+			CollectionView.ItemsSource = _source;
 
 			ScrollTo.Clicked += ScrollToClicked;
+			ScrollToItem.Clicked += ScrollToItemClicked;
+		}
+
+		void ScrollToItemClicked(object sender, EventArgs e)
+		{
+			var groupName = GroupName.Text;
+			var itemName = ItemName.Text;
+
+			var team = _source.FirstOrDefault(t => t.Name == groupName);
+
+			if (team == null)
+			{
+				return;
+			}
+
+			var member = team.FirstOrDefault(t => t.Name == itemName);
+
+			CollectionView.ScrollTo(member, team);
 		}
 
 		void ScrollToClicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGalleries/ScrollToGroup.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollToGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class ScrollToGroup : ContentPage
+	{
+		public ScrollToGroup()
+		{
+			InitializeComponent();
+			CollectionView.ItemsSource = new SuperTeams();
+
+			ScrollTo.Clicked += ScrollToClicked;
+		}
+
+		void ScrollToClicked(object sender, EventArgs e)
+		{
+			var groupIndex = int.Parse(GroupIndex.Text);
+			var itemIndex = int.Parse(ItemIndex.Text);
+
+			CollectionView.ScrollTo(itemIndex, groupIndex);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToGallery.cs
@@ -1,4 +1,6 @@
-﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+﻿using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollToGalleries;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
 	internal class ScrollToGallery : ContentPage
 	{
@@ -38,7 +40,13 @@
 								ScrollToMode.Element, ExampleTemplates.ScrollToItemTemplate), Navigation),
 						GalleryBuilder.NavButton("ScrollTo Item (Code, Vertical Grid)", () =>
 							new ScrollToCodeGallery(new GridItemsLayout(3, ItemsLayoutOrientation.Vertical),
-								ScrollToMode.Element, ExampleTemplates.ScrollToItemTemplate), Navigation)
+								ScrollToMode.Element, ExampleTemplates.ScrollToItemTemplate), Navigation),
+
+
+						GalleryBuilder.NavButton("ScrollTo Index (Grouped)", () =>
+							new ScrollToGroup(), Navigation)
+						
+						
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/ScrollGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ScrollGallery.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Controls
 			var btn3 = new Button { Text = "End" };
 			var btn7 = new Button { Text = "Toggle Scroll Bar Visibility" };
 			var btn6 = new Button { Text = "MakeVisible", HorizontalOptions= LayoutOptions.CenterAndExpand, BackgroundColor = Color.Accent };
-			var btn8 = new Button { Text = "Toogle Orientation" };
+			var btn8 = new Button { Text = "Toggle Orientation" };
 			var btn9 = new Button { Text = "Default Scroll Bar Visibility" };
 
 			var label = new Label { Text = string.Format ("X: {0}, Y: {1}", 0, 0) };

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -159,9 +159,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (args.Mode == ScrollToMode.Position)
 			{
-				// TODO hartez 2018/09/17 16:42:54 This will need to be overridden to account for grouping	
-				// TODO hartez 2018/09/17 16:21:19 Handle LTR	
-				return NSIndexPath.Create(0, args.Index);
+				if (args.GroupIndex == -1)
+				{
+					return NSIndexPath.Create(0, args.Index);
+				}
+
+				return NSIndexPath.Create(args.GroupIndex, args.Index);
 			}
 
 			return ItemsViewController.GetIndexForItem(args.Item);
@@ -209,15 +212,14 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var indexPath = DetermineIndex(args);
 
-			if (indexPath.Item < 0 || indexPath.Section < 0)
+			if (!IsIndexPathValid(indexPath))
 			{
-				// Nothing found, nowhere to scroll to
+				// Specified path wasn't valid, or item wasn't found
 				return;
 			}
 
 			ItemsViewController.CollectionView.ScrollToItem(indexPath, 
-				args.ScrollToPosition.ToCollectionViewScrollPosition(_layout.ScrollDirection),
-				args.IsAnimated);
+				args.ScrollToPosition.ToCollectionViewScrollPosition(_layout.ScrollDirection), args.IsAnimated);
 		}
 
 		protected override void Dispose(bool disposing)
@@ -239,6 +241,27 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			base.Dispose(disposing);
+		}
+
+		bool IsIndexPathValid(NSIndexPath indexPath)
+		{
+			if (indexPath.Item < 0 || indexPath.Section < 0)
+			{
+				return false;
+			}
+
+			var collectionView = ItemsViewController.CollectionView;
+			if (indexPath.Section >= collectionView.NumberOfSections())
+			{
+				return false;
+			}
+
+			if (indexPath.Item >= collectionView.NumberOfItemsInSection(indexPath.Section))
+			{
+				return false;
+			}
+
+			return true;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Calls to `ScrollTo()` which specify groups and group indexes now work.

### Issues Resolved ### 
- implements part of #3172 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated tests

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Suppressed skepticism about fourth Matrix film 
