### PR TITLE
- Issue 7207 - if current culture of the current thread is not set to the invariant culture then initializing the app causes a "NUnit.Framework.InconclusiveException" with the exception- message "App did not start for some reason. System.Argument.Exception: 1 is not supported code page. Parameter name: codepage."

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -217,6 +217,12 @@ namespace Xamarin.Forms.Controls
 			IApp runningApp = null;
 			try
 			{
+				// Issue 7207 - if current culture of the current thread is not set to the invariant culture
+				// then initializing the app causes a "NUnit.Framework.InconclusiveException" with the exception-
+				// message "App did not start for some reason. System.Argument.Exception: 1 is not supported code page.
+				// Parameter name: codepage."
+				if(Thread.CurrentThread.CurrentCulture != CultureInfo.InvariantCulture)
+					Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
 				runningApp = InitializeApp();
 			}
 			catch (Exception e)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -221,8 +221,9 @@ namespace Xamarin.Forms.Controls
 				// then initializing the app causes a "NUnit.Framework.InconclusiveException" with the exception-
 				// message "App did not start for some reason. System.Argument.Exception: 1 is not supported code page.
 				// Parameter name: codepage."
-				if(Thread.CurrentThread.CurrentCulture != CultureInfo.InvariantCulture)
-					Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+				if(System.Threading.Thread.CurrentThread.CurrentCulture != System.Globalization.CultureInfo.InvariantCulture)
+					System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
+
 				runningApp = InitializeApp();
 			}
 			catch (Exception e)


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. -->
if current culture of the current thread is not set to the invariant culture then initializing the app causes a "NUnit.Framework.InconclusiveException" with the exception- message "App did not start for some reason. System.Argument.Exception: 1 is not supported code page. Parameter name: codepage."
This happens only when the windows language is not set to english default language

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7207

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - if(Thread.CurrentThread.CurrentCulture != CultureInfo.InvariantCulture)
- Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Android


### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
