### PR TITLE
[macOS] PushModalAsync a 2nd time causes a crash

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
@@ -122,9 +122,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			NSViewControllerTransitionOptions option = animated
 							? NSViewControllerTransitionOptions.SlideDown
 							: NSViewControllerTransitionOptions.None;
-
 			var task = _renderer.HandleAsyncAnimation(controller, toViewController, option,
-				() => modal.DisposeModalAndChildRenderers() , modal);
+				() =>
+				{
+					modal.DisposeModalAndChildRenderers();
+					var removingIndex = Array.IndexOf(_renderer.ChildViewControllers, controller);
+					if(removingIndex > 0)
+						_renderer.RemoveChildViewController(removingIndex);
+				}, modal);
 			return task;
 		}
 	}

--- a/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/ModalPageTracker.cs
@@ -127,7 +127,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					modal.DisposeModalAndChildRenderers();
 					var removingIndex = Array.IndexOf(_renderer.ChildViewControllers, controller);
-					if(removingIndex > 0)
+					if(removingIndex >= 0)
 						_renderer.RemoveChildViewController(removingIndex);
 				}, modal);
 			return task;


### PR DESCRIPTION
### Description of Change ###

Seems removing modal controller from superview controller is missed.

### Issues Resolved ### 

- fixes #6866

### API Changes ###

None

### Platforms Affected ### 

macOS

### Behavioral/Visual Changes ###

No crash in case of several pushes/pops of modal page.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

* Try to push modal page like ```Navigation.PushModalAsync(new NavigationPage(new ModalPage()));```
* Pop from ModalPage like ```Navigation.PopModalAsync();```
* Try to push new modal page again