### PR TITLE
Fix Android FlyoutBehavior Disabled and add UI Tests

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -164,6 +164,11 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(title);
 			RunningApp.Tap(title);
 
+			// FlyoutLocked ensure that the flyout and buttons are still visible
+			RunningApp.Tap(EnableBackButtonBehavior);
+			RunningApp.Tap(LockFlyoutBehavior);
+			RunningApp.WaitForElement(title);
+			RunningApp.Tap(EnableFlyoutBehavior);
 
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -130,7 +130,7 @@ namespace Xamarin.Forms.Controls.Issues
 			// Flyout Icon is not visible but you can still swipe open
 			RunningApp.Tap(DisableFlyoutBehavior);
 			RunningApp.WaitForNoElement(FlyoutIconAutomationId);
-			ShowFlyout(usingSwipe: true);
+			ShowFlyout(usingSwipe: true, testForFlyoutIcon: false);
 			RunningApp.WaitForElement(title);
 			RunningApp.Tap(title);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -1,0 +1,172 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
+using System.ComponentModel;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Flyout Behavior",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellFlyoutBehavior : TestShell
+	{
+		BackButtonBehavior _behavior;
+		const string title = "Basic Test";
+		const string EnableFlyoutBehavior = "EnableFlyoutBehavior";
+		const string DisableFlyoutBehavior = "DisableFlyoutBehavior";
+		const string LockFlyoutBehavior = "LockFlyoutBehavior";
+		const string OpenFlyout = "OpenFlyout";
+		const string EnableBackButtonBehavior = "EnableBackButtonBehavior";
+		const string DisableBackButtonBehavior = "DisableBackButtonBehavior";
+
+		protected override void Init()
+		{
+			_behavior = new BackButtonBehavior();
+			var page = GetContentPage(title);
+			Shell.SetBackButtonBehavior(page, _behavior);
+			AddContentPage(page).Title = title;
+		}
+
+		ContentPage GetContentPage(string title)
+		{
+			ContentPage page = new ContentPage()
+			{
+				Title = title,
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Button()
+						{
+							Text = "Enable Flyout Behavior",
+							Command = new Command(() =>
+							{
+								Shell.SetFlyoutBehavior(this.CurrentItem, FlyoutBehavior.Flyout);
+								this.FlyoutIsPresented = false;
+							}),
+							AutomationId = EnableFlyoutBehavior
+						},
+						new Button()
+						{
+							Text = "Disable Flyout Behavior",
+							Command = new Command(() =>
+							{
+								Shell.SetFlyoutBehavior(this.CurrentItem, FlyoutBehavior.Disabled);
+								this.FlyoutIsPresented = false;
+							}),
+							AutomationId = DisableFlyoutBehavior
+						},
+						new Button()
+						{
+							Text = "Lock Flyout Behavior",
+							Command = new Command(() =>
+							{
+								Shell.SetFlyoutBehavior(this.CurrentItem, FlyoutBehavior.Locked);
+							}),
+							AutomationId = LockFlyoutBehavior
+						},
+						new Button()
+						{
+							Text = "Open Flyout",
+							Command = new Command(() =>
+							{
+								this.FlyoutIsPresented = true;
+							}),
+							AutomationId = OpenFlyout
+						},
+						new Button()
+						{
+							Text = "Enable Back Button Behavior",
+							Command = new Command(() =>
+							{
+								_behavior.IsEnabled = true;
+							}),
+							AutomationId = EnableBackButtonBehavior
+
+						},
+						new Button()
+						{
+							Text = "Disable Back Button Behavior",
+							Command = new Command(() =>
+							{
+								_behavior.IsEnabled = false;
+							}),
+							AutomationId = DisableBackButtonBehavior
+						}
+					}
+				}
+			};
+
+			return page;
+		}
+
+#if UITEST && __SHELL__
+
+		[NUnit.Framework.Category(UITestCategories.Gestures)]
+		[Test]
+		public void FlyoutTests()
+		{
+			// Flyout is visible
+			RunningApp.WaitForElement(EnableFlyoutBehavior);
+			RunningApp.WaitForElement(FlyoutIconAutomationId);
+
+			// Flyout Icon is not visible but you can still swipe open
+			RunningApp.Tap(DisableFlyoutBehavior);
+			RunningApp.WaitForNoElement(FlyoutIconAutomationId);
+			ShowFlyout(usingSwipe: true);
+			RunningApp.WaitForElement(title);
+			RunningApp.Tap(title);
+
+
+			// enable flyout and make sure disabling back button behavior doesn't hide icon
+			RunningApp.Tap(EnableFlyoutBehavior);
+			RunningApp.WaitForElement(FlyoutIconAutomationId);
+			RunningApp.Tap(DisableBackButtonBehavior);
+			ShowFlyout(usingSwipe: true);
+			RunningApp.WaitForElement(title);
+			RunningApp.Tap(title);
+
+			// make sure you can still open flyout via code
+			RunningApp.Tap(EnableFlyoutBehavior);
+			RunningApp.Tap(EnableBackButtonBehavior);
+			RunningApp.Tap(OpenFlyout);
+			RunningApp.WaitForElement(title);
+			RunningApp.Tap(title);
+
+			// make sure you can still open flyout via code if flyout behavior is disabled
+			RunningApp.Tap(DisableFlyoutBehavior);
+			RunningApp.Tap(EnableBackButtonBehavior);
+			RunningApp.Tap(OpenFlyout);
+			RunningApp.WaitForElement(title);
+			RunningApp.Tap(title);
+
+			// make sure you can still open flyout via code if back button behavior is disabled
+			RunningApp.Tap(EnableFlyoutBehavior);
+			RunningApp.Tap(DisableBackButtonBehavior);
+			RunningApp.Tap(OpenFlyout);
+			RunningApp.WaitForElement(title);
+			RunningApp.Tap(title);
+
+
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -24,6 +24,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellBackButtonBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;__ANDROID__;UITEST</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;__ANDROID__;UITEST;__SHELL__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0114;0108;4014;0649;0168;0169;0219</NoWarn>

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -20,7 +20,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>TRACE;DEBUG;__IOS__;UITEST</DefineConstants>
+    <DefineConstants>TRACE;DEBUG;__IOS__;UITEST;__SHELL__</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <NoWarn>0114;0108;4014;0649;0169;0168;0219;NU1201</NoWarn>

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -234,33 +234,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnBackButtonBehaviorChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if(e.PropertyName == BackButtonBehavior.IsEnabledProperty.PropertyName)
-			{
-				UpdateBackButtonBehaviorIsEnabled();
-				_drawerToggle.SyncState();
-			}
-
 			UpdateLeftBarButtonItem();
 		}
 
-		void UpdateBackButtonBehaviorIsEnabled()
-		{
-			if (_drawerLayout == null || _drawerToggle == null)
-				return;
-
-			bool isEnabled = _backButtonBehavior?.IsEnabled ?? true;
-
-			if (isEnabled)
-			{
-				_drawerLayout.SetDrawerLockMode(DrawerLayout.LockModeUnlocked);
-				_drawerToggle.OnDrawerStateChanged(DrawerLayout.LockModeUnlocked);
-			}
-			else
-			{
-				_drawerLayout.SetDrawerLockMode(DrawerLayout.LockModeLockedClosed);
-				_drawerToggle.OnDrawerStateChanged(DrawerLayout.LockModeLockedClosed);
-			}
-		}
 
 		protected virtual void OnPageToolbarItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
@@ -314,6 +290,7 @@ namespace Xamarin.Forms.Platform.Android
 			var image = backButtonHandler.GetPropertyIfSet<ImageSource>(BackButtonBehavior.IconOverrideProperty, null);
 			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
 			var command = backButtonHandler.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
+			bool isEnabled = _backButtonBehavior.GetPropertyIfSet(BackButtonBehavior.IsEnabledProperty, true);
 
 			if (image == null)
 			{
@@ -361,14 +338,23 @@ namespace Xamarin.Forms.Platform.Android
 				_drawerToggle.DrawerIndicatorEnabled = false;
 				toolbar.NavigationIcon = icon;
 			}
-			else 
+			else if(_flyoutBehavior == FlyoutBehavior.Flyout)
 			{
-				toolbar.NavigationIcon = null;
-				_drawerToggle.DrawerIndicatorEnabled = true;
-				_drawerToggle.DrawerArrowDrawable = icon;
+				_drawerToggle.DrawerIndicatorEnabled = isEnabled;
+				if(isEnabled)
+				{
+					_drawerToggle.DrawerArrowDrawable = icon;
+					toolbar.NavigationIcon = null;
+				}
+				else
+					toolbar.NavigationIcon = icon;
+			}
+			else
+			{
+				_drawerToggle.DrawerIndicatorEnabled = false;
 			}
 
-			UpdateBackButtonBehaviorIsEnabled();
+
 			_drawerToggle.SyncState();
 
 			//this needs to be set after SyncState


### PR DESCRIPTION
### Description of Change ###
The Backbutton Behavior broke the FlyoutBehavior.Disabled setting. This PR fixes that behavior and adds the much needed set of UI tests to make sure this doesn't happen again

### Issues Resolved ### 
- fixes #7238
- fixes #6261

### Regression  Details ###

- Introduced by #6762

The Back Button Behavior change incorrectly influenced the Flyout lock modes and the Flyout Behavior never had a proper set of UI tests written for it to ensure that nothing would break them.

### Platforms Affected ### 

- Android


### Testing Procedure ###
- tests are automated
- with the test page I added you can test all the permutations to see if it all works how you'd expect it to act
- verify this is fixed https://github.com/xamarin/Xamarin.Forms/issues/6261 my tests seem to indicate that it is but #6261 says this is broken on iOS but for me it works fine on iOS

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
