### PR TITLE
[xaml] Fixes toolbox snippet for CollectionView

### DIFF
--- a/Xamarin.Forms.Core.Design/toolbox/Xamarin.Forms.toolbox.xml
+++ b/Xamarin.Forms.Core.Design/toolbox/Xamarin.Forms.toolbox.xml
@@ -30,10 +30,10 @@
 		<Item Class="Xamarin.Forms.CollectionView" Name="CollectionView" Image="view-ListView.png">
 			<Snippet>
 				<CollectionView ItemsSource="">
+					<CollectionView.ItemsLayout>
+						<GridItemsLayout Span="2" Orientation="Vertical"/>
+					</CollectionView.ItemsLayout>
 					<CollectionView.ItemTemplate>
-						<CollectionView.ItemsLayout>
-							<GridItemsLayout Span="2" Orientation="Vertical"/>
-						</CollectionView.ItemsLayout>
 						<DataTemplate>
 						</DataTemplate>
 					</CollectionView.ItemTemplate>


### PR DESCRIPTION
### Description of Change ###

Fixes toolbox snippet for `CollectionView`. `ItemsLayout` is placed outside of the `ItemTemplate`

### API Changes ###
 
 None

### Platforms Affected ### 

- XAML (all platforms)

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- open Toolbox in code editor
- drag control "CollectionView" into Xaml Editor

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

> VS bug [#972262](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/972262)