### PR TITLE
[Android] Fix content offset when you navigate to second page on Shell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7240.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7240.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7240, "[Android] Shell content layout hides navigated to page",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue7240 : TestShell
+	{
+		const string Success = "Page Count:3";
+		const string ClickMe = "ClickMe";
+
+		int pageCount = 1;
+		protected override void Init()
+		{
+			Func<ContentPage> createNewPage = null;
+			createNewPage = () =>
+				   new ContentPage()
+				   {
+					   Content = new StackLayout()
+					   {
+						   Children =
+						   {
+								new Button()
+								{
+									Text = "Click me and you should see a new page with this same button in the same place",
+									AutomationId = ClickMe,
+									Command = new Command(() =>
+									{
+										pageCount++;
+										Navigation.PushAsync(createNewPage());
+									})
+								},
+								new Label()
+								{
+									Text = $"Page Count:{pageCount}"
+								}
+						   }
+					   }
+				   };
+
+			AddContentPage(createNewPage());
+		}
+
+#if UITEST && (__IOS__ || __ANDROID__)
+		[Test]
+		public void ShellSecondPageHasSameLayoutAsPrimary()
+		{
+			RunningApp.WaitForElement(ClickMe);
+			RunningApp.Tap(ClickMe);
+			RunningApp.WaitForElement("Page Count:2");
+			RunningApp.Tap(ClickMe);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -568,7 +568,9 @@ namespace Xamarin.Forms.Controls
 
 
 
-
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
 	public abstract class TestShell : Shell
 	{
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7240.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">
       <DependentUpon>Issue5046.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -131,6 +131,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			((IShellController)_shellContext.Shell).AddAppearanceObserver(this, _page);
 
+			if (_shellPageContainer.LayoutParameters is CoordinatorLayout.LayoutParams layoutParams)
+				layoutParams.Behavior = new AppBarLayout.ScrollingViewBehavior();			
+
 			return _root;
 		}
 


### PR DESCRIPTION
### Description of Change ###
The layout parameters for the ShellContent needs to be set to *layoutParams.Behavior = new AppBarLayout.ScrollingViewBehavior();* so that the coordinator layout knows how you want it to display relative to the AppBar.  

### Issues Resolved ### 
- fixes #7240

### Regression Description ###
- #7032 

In #7032 we removed the NestedScrollView because it was causing issues with scrolling WebView and interfering with various other gesture commands. Prior to the regressed PR that behavior was set on the NestedScrollView that was part of the AXML layout so this same property needs to now be set on the FragmentContent when it is created. Also a lack of UI Test coverage that this PR resolves

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Tests are automated
- Test various shell features on store shell to make sure it all lays out correctly

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
