### PR TITLE
Disable UWP CollectionViewSource CurrentItem synchronization

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.FilterSelection">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="*"></RowDefinition>
+            </Grid.RowDefinitions>
+
+            <Label Text="Select an item in the CollectionView below. Tap the Reset button to change the ItemsSource. The item should no longer be selected. If an item is still selected, this test has failed."/>
+
+            <SearchBar x:Name="SearchBar" Placeholder="Filter" Grid.Row="1" />
+
+            <Button x:Name="ResetButton" Text="Reset" Grid.Row="2" AutomationId="Reset" />
+
+            <Label x:Name="CurrentSelection" Grid.Row="3" />
+
+            <CollectionView x:Name="CollectionView" Grid.Row="4" SelectionMode="Single">
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Label Text="{Binding Caption}"/>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml
@@ -11,7 +11,6 @@
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="Auto"></RowDefinition>
-                <RowDefinition Height="Auto"></RowDefinition>
                 <RowDefinition Height="*"></RowDefinition>
             </Grid.RowDefinitions>
 
@@ -21,9 +20,7 @@
 
             <Button x:Name="ResetButton" Text="Reset" Grid.Row="2" AutomationId="Reset" />
 
-            <Label x:Name="CurrentSelection" Grid.Row="3" />
-
-            <CollectionView x:Name="CollectionView" Grid.Row="4" SelectionMode="Single">
+            <CollectionView x:Name="CollectionView" Grid.Row="3" SelectionMode="Single">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
                         <Label Text="{Binding Caption}"/>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml.cs
@@ -1,10 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
@@ -19,7 +13,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 			InitializeComponent();
 
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
-			CollectionView.SelectionChanged += CollectionViewSelectionChanged;
 
 			SearchBar.SearchCommand = new Command(() =>
 			{
@@ -29,31 +22,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionG
 			ResetButton.Clicked += ResetButtonClicked;
 		}
 
-		private void CollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
-		{
-			UpdateSelectionInfo();
-		}
-
 		void ResetButtonClicked(object sender, EventArgs e)
 		{
 			_demoFilteredItemSource = new DemoFilteredItemSource(new Random().Next(3, 50));
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
-		}
-
-		void UpdateSelectionInfo()
-		{
-			var current = "[none]";
-
-			if (CollectionView.SelectionMode == SelectionMode.Multiple)
-			{
-				current = CollectionView?.SelectedItems.ToCommaSeparatedList();
-			}
-			else if (CollectionView.SelectionMode == SelectionMode.Single)
-			{
-				current = ((CollectionViewGalleryTestItem)CollectionView?.SelectedItem)?.Caption;
-			}
-
-			CurrentSelection.Text = $"Selection: {current}";
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/FilterSelection.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class FilterSelection : ContentPage
+	{
+		DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource();
+
+		public FilterSelection()
+		{
+			InitializeComponent();
+
+			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+			CollectionView.SelectionChanged += CollectionViewSelectionChanged;
+
+			SearchBar.SearchCommand = new Command(() =>
+			{
+				_demoFilteredItemSource.FilterItems(SearchBar.Text);
+			});
+
+			ResetButton.Clicked += ResetButtonClicked;
+		}
+
+		private void CollectionViewSelectionChanged(object sender, SelectionChangedEventArgs e)
+		{
+			UpdateSelectionInfo();
+		}
+
+		void ResetButtonClicked(object sender, EventArgs e)
+		{
+			_demoFilteredItemSource = new DemoFilteredItemSource(new Random().Next(3, 50));
+			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+		}
+
+		void UpdateSelectionInfo()
+		{
+			var current = "[none]";
+
+			if (CollectionView.SelectionMode == SelectionMode.Multiple)
+			{
+				current = CollectionView?.SelectedItems.ToCommaSeparatedList();
+			}
+			else if (CollectionView.SelectionMode == SelectionMode.Single)
+			{
+				current = ((CollectionViewGalleryTestItem)CollectionView?.SelectedItem)?.Caption;
+			}
+
+			CurrentSelection.Text = $"Selection: {current}";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SelectionGallery.cs
@@ -28,6 +28,8 @@
 							new MultipleBoundSelection(), Navigation),
 						GalleryBuilder.NavButton("SelectionChangedCommandParameter", () =>
 							new SelectionChangedCommandParameter(), Navigation),
+						GalleryBuilder.NavButton("Filterable Single Selection", () =>
+							new FilterSelection(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.UWP
 					IsSourceGrouped = false
 				};
 			}
-
+			
 			ListViewBase.ItemsSource = _collectionViewSource.View;
 		}
 
@@ -317,6 +317,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (ListViewBase == null)
 			{
 				ListViewBase = SelectLayout(newElement.ItemsLayout);
+				ListViewBase.IsSynchronizedWithCurrentItem = false;
 
 				_layout = newElement.ItemsLayout;
 				_layout.PropertyChanged += LayoutPropertyChanged;
@@ -540,9 +541,5 @@ namespace Xamarin.Forms.Platform.UWP
 				await JumpTo(list, targetItem, args.ScrollToPosition);
 			}
 		}
-
-		
-
-		
 	}
 }


### PR DESCRIPTION
### Description of Change ###

UWP defaults IsSynchronizedWithCurrentItem to `true`, so when changing to a new CollectionViewSource the first item is automatically selected in the UI. 

For reference: https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.controls.primitives.selector.issynchronizedwithcurrentitem#selection-behavior-and-collectionviewsource

This change disables that option and fixes some minor double-subscription bugs when dealing with native selected item changes.

### Issues Resolved ### 

- fixes #7194

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery, navigate to CollectionView Gallery -> Selection Galleries -> Filterable Single Selection and follow the on-screen instructions.

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] No animals were harmed in the making of this pull request