### PR TITLE
Fix crash with nested CollectionViews on UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/NestedCollectionViews.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/NestedCollectionViews.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6620, "[iOS] Crash when creating a CollectionView inside a CollectionView",
+		PlatformAffected.iOS | PlatformAffected.UWP)]
+	public class NestedCollectionViews : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			FlagTestHelpers.SetCollectionViewTestFlag();
+			PushAsync(new GalleryPages.CollectionViewGalleries.NestedGalleries.NestedCollectionViewGallery());
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void NestedCollectionViewsShouldNotCrash()
+		{
+			// If this page loaded and didn't crash, we're good.
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -20,7 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6945.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">
-      <DependentUpon>Issue5046.xaml</DependentUpon>	
+      <DependentUpon>Issue5046.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue6609.cs" />
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellBackButtonBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellInsets.cs" />
@@ -1213,7 +1214,6 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
-
   <ItemGroup>
     <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					GalleryBuilder.NavButton("Scroll Mode Galleries", () => new ScrollModeGallery(), Navigation),
 					GalleryBuilder.NavButton("Alternate Layout Galleries", () => new AlternateLayoutGallery(), Navigation),
 					GalleryBuilder.NavButton("Header/Footer Galleries", () => new HeaderFooterGallery(), Navigation),
+					GalleryBuilder.NavButton("Nested CollectionViews", () => new NestedGalleries.NestedCollectionViewGallery(), Navigation),
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/NestedCollectionViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/NestedCollectionViewGallery.xaml
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.NestedGalleries.NestedCollectionViewGallery">
+    <ContentPage.Content>
+        <StackLayout>
+
+            <Label Text="It's CollectionViews all the way down." AutomationId="Success"/>
+
+            <CollectionView ItemsSource="{Binding Items}" ItemsLayout="VerticalList">
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid Margin="5,5,5,15">
+
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto"></RowDefinition>
+                                <RowDefinition Height="100"></RowDefinition>
+                            </Grid.RowDefinitions>
+
+                            <Label TextColor="Red" Text="{Binding Title}" FontAttributes="Italic" />
+
+                            <CollectionView Grid.Row="1" HeightRequest="100" ItemsSource="{Binding Items}" 
+                                            ItemsLayout="HorizontalList" HorizontalScrollBarVisibility="Never"
+                                            VerticalScrollBarVisibility="Never">
+
+                                <!-- Yo, dawg, we heard you like CollectionViews so we put some CollectionViews in your CollectionView -->
+
+                                <CollectionView.ItemTemplate>
+                                    <DataTemplate>
+                                        <Grid Margin="10" WidthRequest="100">
+                                            <Grid.RowDefinitions>
+                                                <RowDefinition Height="80"></RowDefinition>
+                                                <RowDefinition Height="40"></RowDefinition>
+                                            </Grid.RowDefinitions>
+
+                                            <Image Source="{Binding Image}" Aspect="AspectFill" HeightRequest="70" 
+                                                   WidthRequest="70" VerticalOptions="Center" HorizontalOptions="Center"/>
+
+                                            <Label Grid.Row="1" TextColor="Blue" FontSize="10" Text="{Binding Caption}" 
+                                                   HorizontalTextAlignment="Center" />
+
+                                        </Grid>
+                                    </DataTemplate>
+                                </CollectionView.ItemTemplate>
+                            </CollectionView>
+
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/NestedCollectionViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/NestedCollectionViewGallery.xaml.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.NestedGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class NestedCollectionViewGallery : ContentPage
+	{
+		public NestedCollectionViewGallery()
+		{
+			InitializeComponent();
+			BindingContext = new NestedCollectionViewModel();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	internal class NestedItemSource
+	{
+		public List<CollectionViewGalleryTestItem> Items { get; set; }
+		public string Title { get; set; }
+
+		public NestedItemSource(string title)
+		{
+			Items = new List<CollectionViewGalleryTestItem>();
+
+			int count = new Random().Next(6, 15);
+
+			var source = new DemoFilteredItemSource(count);
+
+			for (int n = 0; n < count; n++)
+			{
+				Items.Add(source.Items[n]);
+			}
+
+			Title = title;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	internal class NestedCollectionViewModel
+	{
+		public List<NestedItemSource> Items { get; set; }
+
+		public NestedCollectionViewModel()
+		{
+			Items = new List<NestedItemSource>();
+
+			for (int n = 0; n < 20; n++)
+			{
+				Items.Add(new NestedItemSource($"Source {n}"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -56,6 +56,9 @@
     <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\EmptyViewGalleries\EmptyViewSwapGallery.xaml">
 	<Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\NestedGalleries\NestedCollectionViewGallery.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\SelectionGalleries\MultipleBoundSelection.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -97,6 +97,12 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var itemsSource = Element.ItemsSource;
 
+			if (itemsSource == null)
+			{
+				_collectionViewSource = null;
+				return;
+			}
+
 			var itemTemplate = Element.ItemTemplate;
 			if (itemTemplate != null)
 			{


### PR DESCRIPTION
Closes #6620

### Description of Change ###

At one point, iOS crashed if you tried to use a CollectionView in the ItemTemplate of another CollectionView. That's no longer the case (I suspect this was fixed as a side effect of changes in 4.1).

But while investigating this, it turned out that UWP also had this issue. So this PR fixes that, and adds an automated test so we can prevent this problem in the future.

### Issues Resolved ### 

- fixes #6620

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery, navigate to CollectionView Galleries -> Nested CollectionViews. The app should not crash.

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Memes generated
