### PR TITLE
Fix android to not duplicate TitleView with Shell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
@@ -1,0 +1,80 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Title View Test",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.TitleView)]
+#endif
+	public class ShellTitleView : TestShell
+	{
+		protected override void Init()
+		{
+			AddTopTab(createContentPage("title 1"), "page 1");
+			AddTopTab(createContentPage(null), "page 2");
+			AddTopTab(createContentPage("title 3"), "page 3");
+			AddTopTab(createContentPage("title 4"), "page 4");
+
+			ContentPage createContentPage(string titleView)
+			{
+				ContentPage page = new ContentPage()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "Click through the tabs and make sure title view changes and doesn't duplicate"
+							}
+						}
+					}
+				};
+
+				page.ToolbarItems.Add(new ToolbarItem() { IconImageSource = "coffee.png", Order = ToolbarItemOrder.Primary, Priority = 0 });
+
+				if (!string.IsNullOrWhiteSpace(titleView))
+				{
+					Shell.SetTitleView(page,
+						new StackLayout()
+						{
+							AutomationId = "TitleViewId",
+							Children = { new Label() { Text = titleView } }
+						});
+				}
+
+				return page;
+			}
+		}
+
+
+#if UITEST && (__IOS__ || __ANDROID__)
+
+		[Test]
+		public void NoDuplicateTitleViews()
+		{
+			var titleView = RunningApp.WaitForElement("TitleViewId");
+
+			Assert.AreEqual(1, titleView.Length);
+
+			RunningApp.Tap("page 2");
+			RunningApp.Tap("page 3");
+			RunningApp.Tap("page 4");
+			titleView = RunningApp.WaitForElement("TitleViewId");
+
+			Assert.AreEqual(1, titleView.Length);
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -586,13 +586,26 @@ namespace Xamarin.Forms.Controls
 
 		public ContentPage AddTopTab(string title)
 		{
-			ContentPage page = new ContentPage();
+			var page = new ContentPage();
+			AddTopTab(page, title);
+			return page;
+		}
+
+
+		public void AddTopTab(ContentPage page, string title = null)
+		{
+			if(Items.Count == 0)
+			{
+				var item = AddContentPage(page);
+				item.Items[0].Items[0].Title = title ?? page.Title;
+				return;
+			}
+
 			Items[0].Items[0].Items.Add(new ShellContent()
 			{
-				Title = title,
+				Title = title ?? page.Title,
 				Content = page
 			});
-			return page;
 		}
 
 		public ContentPage AddBottomTab(string title)
@@ -642,7 +655,7 @@ namespace Xamarin.Forms.Controls
 
 		public ShellItem AddContentPage(ContentPage contentPage)
 		{
-			ContentPage page = new ContentPage();
+			ContentPage page = contentPage ?? new ContentPage();
 			ShellItem item = new ShellItem()
 			{
 				Items =

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1013,6 +1013,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6738.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)GitHub6926.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5503.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellTitleView.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1263,7 +1264,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5801.xaml">
       <SubType>Designer</SubType>
@@ -1324,7 +1325,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5046.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
@@ -1332,7 +1333,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Github5623.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -52,5 +52,6 @@
 		public const string TabbedPage = "TabbedPage";
 		public const string CustomRenderers = "CustomRenderers";
 		public const string Page = "Page";
+		public const string TitleView = "TitleView";
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -443,7 +443,7 @@ namespace Xamarin.Forms.Platform.Android
 					_titleViewContainer = null;
 				}
 			}
-			else
+			else if(_titleViewContainer == null)
 			{
 				_titleViewContainer = new ContainerView(context, titleView);
 				_titleViewContainer.MatchHeight = _titleViewContainer.MatchWidth = true;
@@ -456,6 +456,10 @@ namespace Xamarin.Forms.Platform.Android
 				};
 
 				_toolbar.AddView(_titleViewContainer);
+			}
+			else
+			{
+				_titleViewContainer.View = titleView;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
Android wasn't correctly replacing the titleview content on change it would just create a new container over and over again. 

### Issues Resolved ### 
- fixes #7244

### Platforms Affected ### 
- Android

### Testing Procedure ###
- There are automated UI tests
- Test shell store title view 

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
