### PR TITLE
Anticipate .cctors

### DIFF
--- a/Xamarin.Forms.Platform.Android/Anticipator.cs
+++ b/Xamarin.Forms.Platform.Android/Anticipator.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using System.Threading;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal class Anticipator
+	{
+		const int ThreadLifeTimeSeconds = 5;
+		readonly static TimeSpan LoopTimeOut = TimeSpan.FromSeconds(ThreadLifeTimeSeconds);
+
+		readonly Thread[] _threads;
+		readonly AutoResetEvent[] _signals;
+		readonly ConcurrentQueue<Action> _actions;
+
+		internal Anticipator()
+		{
+			_actions = new ConcurrentQueue<Action>();
+
+			_threads = new Thread[Environment.ProcessorCount];
+			_signals = new AutoResetEvent[Environment.ProcessorCount];
+
+			_signals[0] = new AutoResetEvent(true);
+			_threads[0] = new Thread(Loop);
+			_threads[0].Start(_signals[0]);
+
+			Anticipate(() =>
+			{
+				for (var i = 1; i < _threads.Length; i++)
+				{
+					_signals[i] = new AutoResetEvent(true);
+					_threads[i] = new Thread(Loop);
+					_threads[i].Start(_signals[i]);
+				}
+			});
+		}
+
+		void Loop(object argument)
+		{
+			var signal = (AutoResetEvent)argument;
+
+			while (signal.WaitOne(LoopTimeOut))
+			{
+				// process actions
+				while (_actions.Count > 0)
+				{
+					if (!_actions.TryDequeue(out Action action))
+						continue; // lost race to dequeue
+
+					action();
+				}
+			}
+		}
+
+		void Signal()
+		{
+			for (var i = 0; i < _signals.Length; i++)
+			{
+				if (_signals[i] != null)
+					_signals[i].Set();
+			}
+		}
+
+		internal void Anticipate(Action action)
+		{
+			if (action == null)
+				throw new ArgumentNullException(nameof(action));
+
+			_actions.Enqueue(action);
+
+			Signal();
+		}
+
+		internal void AnticipateClassConstruction(Type type)
+		{
+			Anticipate(() => RuntimeHelpers.RunClassConstructor(type.TypeHandle));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -67,6 +67,10 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = AndroidApplicationLifecycleState.Uninitialized;
 			_currentState = AndroidApplicationLifecycleState.Uninitialized;
 			PopupManager.Subscribe(this);
+
+			var anticipator = new Anticipator();
+			anticipator.AnticipateClassConstruction(typeof(Resource.Layout));
+			anticipator.AnticipateClassConstruction(typeof(Resource.Attribute));
 		}
 
 		public event EventHandler ConfigurationChanged;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -56,6 +56,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Anticipator.cs" />
     <Compile Include="ActivityResultCallbackRegistry.cs" />
     <Compile Include="AndroidApplicationLifecycleState.cs" />
     <Compile Include="AndroidTitleBarVisibility.cs" />


### PR DESCRIPTION
### Description of Change ###

Speed up startup by making use of any extra processors on the phone to eagerly execute class constructors off the UIThread which we know the UIThread will need during startup.

_This change helps more with non-AOT debug development startup by JITting a big chunk of code off the UIThread (poor man's AOT). So, honestly, this change just lays the ground work for the more significant change (which speeds up release performance) of pre-inflating views off the UIThread by demonstrating how the `Anticipator` works (it's just a hand rolled thread pool)._ 

### Issues Resolved ### 

None.

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

### Testing Procedure ###

Every UITest is a test. If the app starts, then this worked!

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
