### PR TITLE
[Android] fix animations not animating

### DIFF
--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -6,104 +6,105 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
 {
-    internal class AndroidTicker : Ticker, IDisposable
-    {
-        ValueAnimator _val;
-        bool _energySaveModeDisabled;
-        readonly bool _animatorEnabled;
+	internal class AndroidTicker : Ticker, IDisposable
+	{
+		ValueAnimator _val;
+		bool _energySaveModeDisabled;
+		readonly bool _animatorEnabled;
 
-        public AndroidTicker()
-        {
-            _val = new ValueAnimator();
-            _val.SetIntValues(0, 100); // avoid crash
-            _val.RepeatCount = ValueAnimator.Infinite;
-            _val.Update += OnValOnUpdate;
-            _animatorEnabled = IsAnimatorEnabled();
-            CheckPowerSaveModeStatus();
-        }
+		public AndroidTicker()
+		{
+			_val = new ValueAnimator();
+			_val.SetIntValues(0, 100); // avoid crash
+			_val.RepeatCount = ValueAnimator.Infinite;
+			_val.Update += OnValOnUpdate;
+			_animatorEnabled = IsAnimatorEnabled();
+			CheckPowerSaveModeStatus();
+		}
 
-        public override bool SystemEnabled => _energySaveModeDisabled && _animatorEnabled;
+		public override bool SystemEnabled => _energySaveModeDisabled && _animatorEnabled;
 
-        internal void CheckPowerSaveModeStatus()
-        {
-            // Android disables animations when it's in power save mode
-            // So we need to keep track of whether we're in that mode and handle animations accordingly
-            // We can't just check ValueAnimator.AreAnimationsEnabled() because there's no event for that, and it's
-            // only supported on API >= 26
+		internal void CheckPowerSaveModeStatus()
+		{
+			// Android disables animations when it's in power save mode
+			// So we need to keep track of whether we're in that mode and handle animations accordingly
+			// We can't just check ValueAnimator.AreAnimationsEnabled() because there's no event for that, and it's
+			// only supported on API >= 26
 
-            if (!Forms.IsLollipopOrNewer)
-            {
-                _energySaveModeDisabled = true;
-                return;
-            }
+			if (!Forms.IsLollipopOrNewer)
+			{
+				_energySaveModeDisabled = true;
+				return;
+			}
 
-            var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);
+			var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);
 
-            var powerSaveOn = powerManager.IsPowerSaveMode;
+			var powerSaveOn = powerManager.IsPowerSaveMode;
 
-            // If power saver is active, then animations will not run
-            _energySaveModeDisabled = !powerSaveOn;
+			// If power saver is active, then animations will not run
+			_energySaveModeDisabled = !powerSaveOn;
 
-            // Notify the ticker that this value has changed, so it can manage animations in progress
-            OnSystemEnabledChanged();
-        }
+			// Notify the ticker that this value has changed, so it can manage animations in progress
+			OnSystemEnabledChanged();
+		}
 
-        static bool IsAnimatorEnabled()
-        {
-            var resolver = global::Android.App.Application.Context?.ContentResolver;
-            if (resolver == null)
-            {
-                return true;
-            }
+		static bool IsAnimatorEnabled()
+		{
+			var resolver = global::Android.App.Application.Context?.ContentResolver;
+			if (resolver == null)
+			{
+				return false;
+			}
 
-            float animationScale;
+			float animationScale;
 
-            if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
-            {
-                animationScale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 1);
-            }
-            else
-            {
-#pragma warning disable
-                animationScale = global::Android.Provider.Settings.System.GetFloat(resolver, global::Android.Provider.Settings.System.AnimatorDurationScale, 1);
-            }
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
+			{
+				animationScale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 1);
+			}
+			else
+			{
+#pragma warning disable 0618
+				animationScale = global::Android.Provider.Settings.System.GetFloat(resolver, global::Android.Provider.Settings.System.AnimatorDurationScale, 1);
+#pragma warning restore 0618
+			}
 
-            return animationScale > 0;
-        }
+			return animationScale > 0;
+		}
 
-        public void Dispose()
-        {
-            if (_val != null)
-            {
-                _val.Update -= OnValOnUpdate;
-                _val.Dispose();
-            }
-            _val = null;
-        }
+		public void Dispose()
+		{
+			if (_val != null)
+			{
+				_val.Update -= OnValOnUpdate;
+				_val.Dispose();
+			}
+			_val = null;
+		}
 
-        protected override void DisableTimer()
-        {
-            if (Device.IsInvokeRequired)
-            {
-                Device.BeginInvokeOnMainThread(new Action(() =>
-                {
-                    _val?.Cancel();
-                }));
-            }
-            else
-            {
-                _val?.Cancel();
-            }
-        }
+		protected override void DisableTimer()
+		{
+			if (Device.IsInvokeRequired)
+			{
+				Device.BeginInvokeOnMainThread(new Action(() =>
+				{
+					_val?.Cancel();
+				}));
+			}
+			else
+			{
+				_val?.Cancel();
+			}
+		}
 
-        protected override void EnableTimer()
-        {
-            _val?.Start();
-        }
+		protected override void EnableTimer()
+		{
+			_val?.Start();
+		}
 
-        void OnValOnUpdate(object sender, ValueAnimator.AnimatorUpdateEventArgs e)
-        {
-            SendSignals();
-        }
-    }
+		void OnValOnUpdate(object sender, ValueAnimator.AnimatorUpdateEventArgs e)
+		{
+			SendSignals();
+		}
+	}
 }

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -6,112 +6,104 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class AndroidTicker : Ticker, IDisposable
-	{
-		ValueAnimator _val;
-		bool _energySaveModeDisabled;
-		readonly bool _animatorEnabled;
+    internal class AndroidTicker : Ticker, IDisposable
+    {
+        ValueAnimator _val;
+        bool _energySaveModeDisabled;
+        readonly bool _animatorEnabled;
 
-		public AndroidTicker()
-		{
-			_val = new ValueAnimator();
-			_val.SetIntValues(0, 100); // avoid crash
-			_val.RepeatCount = ValueAnimator.Infinite;
-			_val.Update += OnValOnUpdate;
-			_animatorEnabled = IsAnimatorEnabled();
-			CheckPowerSaveModeStatus();
-		}
+        public AndroidTicker()
+        {
+            _val = new ValueAnimator();
+            _val.SetIntValues(0, 100); // avoid crash
+            _val.RepeatCount = ValueAnimator.Infinite;
+            _val.Update += OnValOnUpdate;
+            _animatorEnabled = IsAnimatorEnabled();
+            CheckPowerSaveModeStatus();
+        }
 
-		public override bool SystemEnabled => _energySaveModeDisabled && _animatorEnabled;
+        public override bool SystemEnabled => _energySaveModeDisabled && _animatorEnabled;
 
-		internal void CheckPowerSaveModeStatus()
-		{
-			// Android disables animations when it's in power save mode
-			// So we need to keep track of whether we're in that mode and handle animations accordingly
-			// We can't just check ValueAnimator.AreAnimationsEnabled() because there's no event for that, and it's
-			// only supported on API >= 26
+        internal void CheckPowerSaveModeStatus()
+        {
+            // Android disables animations when it's in power save mode
+            // So we need to keep track of whether we're in that mode and handle animations accordingly
+            // We can't just check ValueAnimator.AreAnimationsEnabled() because there's no event for that, and it's
+            // only supported on API >= 26
 
-			if (!Forms.IsLollipopOrNewer)
-			{
-				_energySaveModeDisabled = true;
-				return;
-			}
+            if (!Forms.IsLollipopOrNewer)
+            {
+                _energySaveModeDisabled = true;
+                return;
+            }
 
-			var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);
+            var powerManager = (PowerManager)Forms.ApplicationContext.GetSystemService(Context.PowerService);
 
-			var powerSaveOn = powerManager.IsPowerSaveMode;
+            var powerSaveOn = powerManager.IsPowerSaveMode;
 
-			// If power saver is active, then animations will not run
-			_energySaveModeDisabled = !powerSaveOn;
-			
-			// Notify the ticker that this value has changed, so it can manage animations in progress
-			OnSystemEnabledChanged();
-		}
+            // If power saver is active, then animations will not run
+            _energySaveModeDisabled = !powerSaveOn;
 
-		static bool IsAnimatorEnabled()
-		{
-			var resolver = global::Android.App.Application.Context?.ContentResolver;
-			if (resolver == null)
-			{
-				return true;
-			}
+            // Notify the ticker that this value has changed, so it can manage animations in progress
+            OnSystemEnabledChanged();
+        }
 
-float animationScale;
+        static bool IsAnimatorEnabled()
+        {
+            var resolver = global::Android.App.Application.Context?.ContentResolver;
+            if (resolver == null)
+            {
+                return true;
+            }
 
-if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
-{
-    animationScale = global::Android.Provider.Settings.Global.GetFloat(
-        resolver,
-        global::Android.Provider.Settings.Global.AnimatorDurationScale,
-        1);
-}
-else
-{
-    animationScale = global::Android.Provider.Settings.System.GetFloat(
-        resolver,
+            float animationScale;
+
+            if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
+            {
+                animationScale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 1);
+            }
+            else
+            {
 #pragma warning disable
-        global::Android.Provider.Settings.System.AnimatorDurationScale,
-#pragma warning disable
-        1);
-}
+                animationScale = global::Android.Provider.Settings.System.GetFloat(resolver, global::Android.Provider.Settings.System.AnimatorDurationScale, 1);
+            }
 
-return animationScale > 0;
-			return scale > 0;
-		}
+            return animationScale > 0;
+        }
 
-		public void Dispose()
-		{
-			if (_val != null)
-			{
-				_val.Update -= OnValOnUpdate;
-				_val.Dispose();
-			}
-			_val = null;
-		}
+        public void Dispose()
+        {
+            if (_val != null)
+            {
+                _val.Update -= OnValOnUpdate;
+                _val.Dispose();
+            }
+            _val = null;
+        }
 
-		protected override void DisableTimer()
-		{
-			if (Device.IsInvokeRequired)
-			{
-				Device.BeginInvokeOnMainThread(new Action(() =>
-				{
-					_val?.Cancel();
-				}));
-			}
-			else
-			{
-				_val?.Cancel();
-			}
-		}
+        protected override void DisableTimer()
+        {
+            if (Device.IsInvokeRequired)
+            {
+                Device.BeginInvokeOnMainThread(new Action(() =>
+                {
+                    _val?.Cancel();
+                }));
+            }
+            else
+            {
+                _val?.Cancel();
+            }
+        }
 
-		protected override void EnableTimer()
-		{
-			_val?.Start();
-		}
+        protected override void EnableTimer()
+        {
+            _val?.Start();
+        }
 
-		void OnValOnUpdate(object sender, ValueAnimator.AnimatorUpdateEventArgs e)
-		{
-			SendSignals();
-		}
-	}
+        void OnValOnUpdate(object sender, ValueAnimator.AnimatorUpdateEventArgs e)
+        {
+            SendSignals();
+        }
+    }
 }

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -56,7 +56,26 @@ namespace Xamarin.Forms.Platform.Android
 				return true;
 			}
 
-			var scale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 1);
+float animationScale;
+
+if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBeanMr1)
+{
+    animationScale = global::Android.Provider.Settings.Global.GetFloat(
+        resolver,
+        global::Android.Provider.Settings.Global.AnimatorDurationScale,
+        1);
+}
+else
+{
+    animationScale = global::Android.Provider.Settings.System.GetFloat(
+        resolver,
+#pragma warning disable
+        global::Android.Provider.Settings.System.AnimatorDurationScale,
+#pragma warning disable
+        1);
+}
+
+return animationScale > 0;
 			return scale > 0;
 		}
 

--- a/Xamarin.Forms.Platform.Android/AndroidTicker.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidTicker.cs
@@ -53,10 +53,10 @@ namespace Xamarin.Forms.Platform.Android
 			var resolver = global::Android.App.Application.Context?.ContentResolver;
 			if (resolver == null)
 			{
-				return false;
+				return true;
 			}
 
-			var scale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 0);
+			var scale = global::Android.Provider.Settings.Global.GetFloat(resolver, global::Android.Provider.Settings.Global.AnimatorDurationScale, 1);
 			return scale > 0;
 		}
 


### PR DESCRIPTION
fixes #7255
fixes #7291
fixes #7278

Same PR as https://github.com/xamarin/Xamarin.Forms/pull/7292 but on the correct branch

I found that if the Animation duration scale setting has never been changed in the developer settings, the scale we get will allways be 0. So instead of defaulting to 0 we default to 1. This means if i havent touched the setting it will behave as it did pre 4.2.

Also if somehow the context is null, we should default to enabling animations since this is far more "normal" than disabling animations.
