### PR TITLE
Fix iOS footer and header to layout left and right for horizontal layout

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGallery.cs
@@ -20,6 +20,7 @@
 						GalleryBuilder.NavButton("Header/Footer (Forms View)", () => new HeaderFooterView(), Navigation),
 						GalleryBuilder.NavButton("Header/Footer (Template)", () => new HeaderFooterTemplate(), Navigation),
 						GalleryBuilder.NavButton("Header/Footer (Grid)", () => new HeaderFooterGrid(), Navigation),
+						GalleryBuilder.NavButton("Header/Footer (Grid Horizontal)", () => new HeaderFooterGridHorizontal(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterGridHorizontal">
+    <ContentPage.Content>
+        <CollectionView x:Name="CollectionView" >
+            <CollectionView.ItemsLayout>
+                <GridItemsLayout Span="3" Orientation="Horizontal" HorizontalItemSpacing="4" VerticalItemSpacing="2"></GridItemsLayout>
+            </CollectionView.ItemsLayout>
+
+            <CollectionView.Header>
+
+                <StackLayout>
+                    <Image Source="oasis.jpg" Aspect="AspectFill" HeightRequest="60"></Image>
+                    <Label Text="This Is A Header" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" 
+                           FontAttributes="Bold" FontSize="36" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Add Content" Clicked="Handle_Clicked"></Button>
+                    </StackLayout>
+                </StackLayout>
+
+            </CollectionView.Header>
+
+            <CollectionView.Footer>
+
+                <StackLayout>
+                    <Image Source="cover1.jpg" Aspect="AspectFill" HeightRequest="80"></Image>
+                    <Label Text="This Is A Footer" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
+                           FontAttributes="Bold" FontSize="20" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Add Content" Clicked="Handle_Clicked"></Button>
+                    </StackLayout>
+                </StackLayout>
+
+            </CollectionView.Footer>
+
+        </CollectionView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class HeaderFooterGridHorizontal : ContentPage
+	{
+		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(10);
+
+		public HeaderFooterGridHorizontal()
+		{
+			InitializeComponent();
+
+			CollectionView.ItemTemplate = ExampleTemplates.PhotoTemplate();
+			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+		}
+
+		void Handle_Clicked(object sender, System.EventArgs e)
+		{
+			if (sender is VisualElement ve && ve.Parent is StackLayout sl)
+				sl.Children.Add(new Label() { Text = "Grow" });
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -47,6 +47,9 @@
     <EmbeddedResource Update="GalleryPages\BindableLayoutGalleryPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\HeaderFooterGalleries\HeaderFooterGridHorizontal.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\MapGallery.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -347,7 +347,7 @@ namespace Xamarin.Forms.Platform.iOS
 					CollectionView.ContentInset = new UIEdgeInsets(0, headerWidth, 0, footerWidth);
 
 					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
-					// this changes the offset of the list by how much ever the header size has changed
+					// this changes the offset of the list by however much the header size has changed
 					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X + (currentInset.Left - CollectionView.ContentInset.Left), CollectionView.ContentOffset.Y);
 				}
 			}
@@ -369,7 +369,7 @@ namespace Xamarin.Forms.Platform.iOS
 					CollectionView.ContentInset = new UIEdgeInsets(headerHeight, 0, footerHeight, 0);
 
 					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
-					// this changes the offset of the list by how much ever the header size has changed
+					// this changes the offset of the list by however much the header size has changed
 					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, CollectionView.ContentOffset.Y + (currentInset.Top - CollectionView.ContentInset.Top));
 				}
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// If we're updating from a previous layout, we should keep any settings for the SelectableItemsViewController around
 			var selectableItemsViewController = Delegator?.SelectableItemsViewController;
 			Delegator = new UICollectionViewDelegator(ItemsViewLayout, this);
-			
+
 			CollectionView.Delegate = Delegator;
 
 			if (CollectionView.CollectionViewLayout != ItemsViewLayout)
@@ -54,9 +54,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 				// Make sure the new layout is sized properly
 				ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
-				
+
 				CollectionView.SetCollectionViewLayout(ItemsViewLayout, false);
-				
+
 				// Reload the data so the currently visible cells get laid out according to the new layout
 				CollectionView.ReloadData();
 			}
@@ -154,8 +154,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// This update is only relevant if you have a footer view because it's used to place the footer view
 			// based on the ContentSize so we just update the positions if the ContentSize has changed
-			if(_footerUIView != null && _footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height)
-				UpdateHeaderFooterPosition();
+			if (_footerUIView != null)
+			{
+				if (IsHorizontal)
+				{
+					if (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width)
+						UpdateHeaderFooterPosition();
+				}
+				else
+				{
+					if (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height)
+						UpdateHeaderFooterPosition();
+				}
+			}
 		}
 
 		protected virtual IItemsViewSource CreateItemsViewSource()
@@ -172,7 +183,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override nint NumberOfSections(UICollectionView collectionView)
 		{
-			CheckForEmptySource(); 
+			CheckForEmptySource();
 			return ItemsSource.GroupCount;
 		}
 
@@ -314,26 +325,53 @@ namespace Xamarin.Forms.Platform.iOS
 			CollectionView.RegisterClassForCell(typeof(VerticalTemplatedCell), VerticalTemplatedCell.ReuseId);
 		}
 
+		bool IsHorizontal => (ItemsView?.ItemsLayout as ItemsLayout)?.Orientation == ItemsLayoutOrientation.Horizontal;
+
 		void UpdateHeaderFooterPosition()
 		{
-			var currentInset = CollectionView.ContentInset;
-
-			nfloat headerHeight = _headerUIView?.Frame.Height ?? 0f;
-			nfloat footerHeight = _footerUIView?.Frame.Height ?? 0f;
-
-			if(_headerUIView != null && _headerUIView.Frame.Y != headerHeight)
-				_headerUIView.Frame = new CoreGraphics.CGRect(0, -headerHeight, CollectionView.Frame.Width, headerHeight);
-
-			if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height))
-				_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height, CollectionView.Frame.Width, footerHeight);
-
-			if (CollectionView.ContentInset.Top != headerHeight || CollectionView.ContentInset.Bottom != footerHeight)
+			if (IsHorizontal)
 			{
-				CollectionView.ContentInset = new UIEdgeInsets(headerHeight, 0, footerHeight, 0);
+				var currentInset = CollectionView.ContentInset;
 
-				// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
-				// this changes the offset of the list by how much ever the header size has changed
-				CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, CollectionView.ContentOffset.Y + (currentInset.Top - CollectionView.ContentInset.Top));
+				nfloat headerWidth = _headerUIView?.Frame.Width ?? 0f;
+				nfloat footerWidth = _footerUIView?.Frame.Width ?? 0f;
+
+				if (_headerUIView != null && _headerUIView.Frame.X != headerWidth)
+					_headerUIView.Frame = new CoreGraphics.CGRect(-headerWidth, 0, headerWidth, CollectionView.Frame.Height);
+
+				if (_footerUIView != null && (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width))
+					_footerUIView.Frame = new CoreGraphics.CGRect(ItemsViewLayout.CollectionViewContentSize.Width, 0, footerWidth, CollectionView.Frame.Height);
+
+				if (CollectionView.ContentInset.Left != headerWidth || CollectionView.ContentInset.Right != footerWidth)
+				{
+					CollectionView.ContentInset = new UIEdgeInsets(0, headerWidth, 0, footerWidth);
+
+					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
+					// this changes the offset of the list by how much ever the header size has changed
+					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X + (currentInset.Left - CollectionView.ContentInset.Left), CollectionView.ContentOffset.Y);
+				}
+			}
+			else
+			{
+				var currentInset = CollectionView.ContentInset;
+
+				nfloat headerHeight = _headerUIView?.Frame.Height ?? 0f;
+				nfloat footerHeight = _footerUIView?.Frame.Height ?? 0f;
+
+				if (_headerUIView != null && _headerUIView.Frame.Y != headerHeight)
+					_headerUIView.Frame = new CoreGraphics.CGRect(0, -headerHeight, CollectionView.Frame.Width, headerHeight);
+
+				if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height))
+					_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height, CollectionView.Frame.Width, footerHeight);
+
+				if (CollectionView.ContentInset.Top != headerHeight || CollectionView.ContentInset.Bottom != footerHeight)
+				{
+					CollectionView.ContentInset = new UIEdgeInsets(headerHeight, 0, footerHeight, 0);
+
+					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
+					// this changes the offset of the list by how much ever the header size has changed
+					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, CollectionView.ContentOffset.Y + (currentInset.Top - CollectionView.ContentInset.Top));
+				}
 			}
 		}
 
@@ -376,9 +414,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (formsElement != null)
 			{
-				var request = formsElement.Measure(CollectionView.Frame.Width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, -request.Request.Height, CollectionView.Frame.Width, request.Request.Height));
-
+				RemeasureLayout(formsElement);
 				formsElement.MeasureInvalidated += OnFormsElementMeasureInvalidated;
 			}
 			else if (uiView != null)
@@ -387,13 +423,25 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		void OnFormsElementMeasureInvalidated(object sender, EventArgs e)
+		void RemeasureLayout(VisualElement formsElement)
 		{
-			if(sender is VisualElement formsElement)
+			if (IsHorizontal)
+			{
+				var request = formsElement.Measure(double.PositiveInfinity, CollectionView.Frame.Height, MeasureFlags.IncludeMargins);
+				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(-request.Request.Width, 0, request.Request.Width, CollectionView.Frame.Height));
+			}
+			else
 			{
 				var request = formsElement.Measure(CollectionView.Frame.Width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
 				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, -request.Request.Height, CollectionView.Frame.Width, request.Request.Height));
+			}
+		}
 
+		void OnFormsElementMeasureInvalidated(object sender, EventArgs e)
+		{
+			if (sender is VisualElement formsElement)
+			{
+				RemeasureLayout(formsElement);
 				UpdateHeaderFooterPosition();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###
Header/footer wasn't properly adjusting for a horizontal layout.



### Issues Resolved ### 
- fixes #7246

### Platforms Affected ### 
- iOS

### Testing Procedure ###
When testing this please note that there appears to be a bug (#7309) where if the CV grid doesn't fill the rows and columns then it adds an extra empty column so the footer for the included test looks like it's offset incorrectly but it is not.

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
