### PR TITLE
[Enhancement] Add platform specific property to handle iOS UITabBar Translucent property

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -4,10 +4,8 @@
 
 	public static class TabbedPage
 	{
-		const string TranslucencyModePropertyName = "TranslucencyMode";
-
 		public static readonly BindableProperty TranslucencyModeProperty =
-			BindableProperty.Create(TranslucencyModePropertyName,
+			BindableProperty.Create("TranslucencyMode",
 				typeof(TranslucencyMode), typeof(TabbedPage), TranslucencyMode.Default);
 
 		public static TranslucencyMode GetTranslucencyMode(BindableObject element)

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.TabbedPage;
+
+	public static class TabbedPage
+	{
+		private const string TranslucencyModePropertyName = "TranslucencyMode";
+
+		public static readonly BindableProperty TranslucencyModeProperty =
+			BindableProperty.Create(TranslucencyModePropertyName,
+				typeof(TranslucencyMode), typeof(TabbedPage), TranslucencyMode.Default);
+
+		public static TranslucencyMode GetTranslucencyMode(BindableObject element)
+			=> (TranslucencyMode)element.GetValue(TranslucencyModeProperty);
+
+		public static void SetTranslucencyMode(BindableObject element, TranslucencyMode value)
+			=> element.SetValue(TranslucencyModeProperty, value);
+
+		public static TranslucencyMode GetTranslucencyMode(
+			this IPlatformElementConfiguration<iOS, FormsElement> config)
+			=> GetTranslucencyMode(config.Element);
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetTranslucencyMode(
+			this IPlatformElementConfiguration<iOS, FormsElement> config, TranslucencyMode value)
+		{
+			SetTranslucencyMode(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TabbedPage.cs
@@ -4,7 +4,7 @@
 
 	public static class TabbedPage
 	{
-		private const string TranslucencyModePropertyName = "TranslucencyMode";
+		const string TranslucencyModePropertyName = "TranslucencyMode";
 
 		public static readonly BindableProperty TranslucencyModeProperty =
 			BindableProperty.Create(TranslucencyModePropertyName,

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TranslucencyMode.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TranslucencyMode.cs
@@ -1,0 +1,10 @@
+﻿
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public enum TranslucencyMode
+	{
+		Default,
+		Translucent,
+		Opaque
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -7,6 +7,8 @@ using UIKit;
 using Xamarin.Forms.Internals;
 using static Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page;
 using PageUIStatusBarAnimation = Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
+using TabbedPageConfiguration = Xamarin.Forms.PlatformConfiguration.iOSSpecific.TabbedPage;
+using TranslucencyMode = Xamarin.Forms.PlatformConfiguration.iOSSpecific.TranslucencyMode;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -18,6 +20,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _defaultBarTextColorSet;
 		UIColor _defaultBarColor;
 		bool _defaultBarColorSet;
+		bool? _defaultBarTranslucent;
 		bool _loaded;
 		Size _queuedSize;
 
@@ -74,6 +77,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBarBackgroundColor();
 			UpdateBarTextColor();
 			UpdateSelectedTabColors();
+			UpdateBarTranslucent();
 
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 		}
@@ -240,6 +244,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateSelectedTabColors();
 			else if (e.PropertyName == PrefersHomeIndicatorAutoHiddenProperty.PropertyName)
 				UpdatePrefersHomeIndicatorAutoHiddenOnPages();
+			else if (e.PropertyName == TabbedPageConfiguration.TranslucencyModeProperty.PropertyName)
+				UpdateBarTranslucent();
 
 		}
 
@@ -389,6 +395,26 @@ namespace Xamarin.Forms.Platform.iOS
 			// set TintColor for selected icon
 			// setting the unselected icon tint is not supported by iOS
 			TabBar.TintColor = isDefaultColor ? _defaultBarTextColor : barTextColor.ToUIColor();
+		}
+
+		void UpdateBarTranslucent()
+		{
+			if (Tabbed == null || TabBar == null || Element == null)
+				return;
+
+			_defaultBarTranslucent = _defaultBarTranslucent ?? TabBar.Translucent;
+			switch (TabbedPageConfiguration.GetTranslucencyMode(Element))
+			{
+				case TranslucencyMode.Translucent:
+					TabBar.Translucent = true;
+					return;
+				case TranslucencyMode.Opaque:
+					TabBar.Translucent = false;
+					return;
+				default:
+					TabBar.Translucent = _defaultBarTranslucent.GetValueOrDefault();
+					return;
+			}
 		}
 
 		void UpdateChildrenOrderIndex(UIViewController[] viewControllers)


### PR DESCRIPTION
# Description of Change ###

Added one more platform-specific property for iOS

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7135 

### API Changes ###

Added:
- Xamarin.Forms.PlatformConfiguration.iOSSpecific.TabbedPage (IsTranslucentTabBarProperty)

### Platforms Affected ### 
- Core (iOS specific stuff)
- iOS

### Behavioral/Visual Changes ###
Can change Translucent of TabBar

### Before/After Screenshots ### 
Not applicable (it's better to use Color meter)

### Testing Procedure ###
```charp
MainPage = new TabbedPage
{
    Children = {
        new ContentPage() { BackgroundColor = Color.Red },
        new ContentPage()
    }
};
Xamarin.Forms.PlatformConfiguration.iOSSpecific.TabbedPage.SetIsTranslucentTabBar(MainPage, false);
```

- Check bar colors with a color meter
