### PR TITLE
Queue Page.Display actions until platform is ready

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7290.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7290.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7290, "[Android] DisplayActionSheet or DisplayAlert in OnAppearing does not work on Shell",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue7290 : TestShell
+	{
+		protected override void Init()
+		{
+			ContentPage displayAlertPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label{ Text = "If you did not see an alert this test has failed."},
+					}
+				},
+				Title = "Display Alert"
+			};
+
+			displayAlertPage.Appearing += async (_, __) =>
+			{
+				await displayAlertPage.DisplayAlert("Title", "Close Alert", "Cancel");
+				this.CurrentItem = Items[1];
+			};
+
+
+			ContentPage actionSheetPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label{ Text = "If you did not see an Alert then an Action Sheet this test has failed"},
+					}
+				},
+				Title = "Display Action Sheet"
+			};
+
+			actionSheetPage.Appearing += async (_, __) =>
+			{
+				await actionSheetPage.DisplayActionSheet("Title", "Cancel", "Close Action Sheet", "Button");
+			};
+
+			AddContentPage(displayAlertPage);
+			AddContentPage(actionSheetPage);
+		}
+
+#if UITEST
+		[Test]
+		public void DisplayActionSheetAndDisplayAlertFromOnAppearing()
+		{
+			RunningApp.Tap("Close Alert");
+			RunningApp.Tap("Close Action Sheet");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7290.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7290.cs
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void DisplayActionSheetAndDisplayAlertFromOnAppearing()
 		{
-			RunningApp.Tap("Close Alert");
+			RunningApp.Tap("Cancel");
 			RunningApp.Tap("Close Action Sheet");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -688,14 +688,16 @@ namespace Xamarin.Forms.Controls
 			where TShellItem : ShellItem
 			where TShellSection : ShellSection
 		{
+			contentPage = contentPage ?? new ContentPage();
 			TShellItem item = Activator.CreateInstance<TShellItem>();
+			item.Title = contentPage.Title;
 			TShellSection shellSection = Activator.CreateInstance<TShellSection>();
 			Items.Add(item);
 			item.Items.Add(shellSection);
 
 			shellSection.Items.Add(new ShellContent()
 			{
-				Content = contentPage ?? new ContentPage()
+				Content = contentPage
 			});
 
 			return item;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7290.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7240.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">
       <DependentUpon>Issue5046.xaml</DependentUpon>

--- a/Xamarin.Forms.Core.UnitTests/PageTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/PageTests.cs
@@ -303,7 +303,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				sent = true;
 			});
 
-			var page = new ContentPage { IsBusy = true };
+			var page = new ContentPage { IsBusy = true, IsPlatformEnabled = true };
 
 			Assert.That (sent, Is.False, "Busy message sent while not visible");
 
@@ -348,7 +348,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void DisplayAlert ()
 		{
-			var page = new ContentPage ();
+			var page = new ContentPage() { IsPlatformEnabled = true };
 
 			AlertArguments args = null;
 			MessagingCenter.Subscribe (this, Page.AlertSignalName, (Page sender, AlertArguments e) => args = e);
@@ -371,7 +371,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void DisplayActionSheet ()
 		{
-			var page = new ContentPage ();
+			var page = new ContentPage() { IsPlatformEnabled = true };
 
 			ActionSheetArguments args = null;
 			MessagingCenter.Subscribe (this, Page.ActionSheetSignalName, (Page sender, ActionSheetArguments e) => args = e);


### PR DESCRIPTION
### Description of Change ###
DisplayAlert and DisplayActionSheet can't function until the Page has a renderer attached to it. This change queue's up requests to those methods so that once the element IsPlatformReady (renderer attached) they will execute.

### Issues Resolved ### 
- fixes #7290 

### Regression ###
https://github.com/xamarin/Xamarin.Forms/pull/6527

Shell fires OnAppearing events earlier than if the Pages are part of other layouts. 


### Platforms Affected ### 
- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
Because DisplayAlert and DisplayActionSheet  are now queue'd until the page is ready there could be scenarios where people were calling these methods and nothing was happening.  This issue also would have crept up once we implemented the new life cycles event code as well since that code would move OnAppearing earlier on both iOS and Android


### Testing Procedure ###
- Automated tests included

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
