### PR TITLE
Set MinimumWidth to the correctly calculated value for Auto Grid Columns

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/GridTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GridTests.cs
@@ -1541,6 +1541,115 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 
+		[Test]
+		public void MinimumWidthRequestInAutoCells()
+		{
+			var boxRow0Column0 = new BoxView
+			{
+				MinimumWidthRequest = 50,
+				WidthRequest = 200,
+				IsPlatformEnabled = true
+			};
+			var boxRow1Column0 = new BoxView
+			{
+				MinimumWidthRequest = 50,
+				WidthRequest = 200,
+				IsPlatformEnabled = true
+			};
+
+			var boxRow0Column1 = new BoxView
+			{
+				WidthRequest = 800,
+				IsPlatformEnabled = true
+			};
+			var boxRow1Column1 = new BoxView
+			{
+				WidthRequest = 800,
+				IsPlatformEnabled = true
+			};
+
+			var grid = new Grid
+			{
+				IsPlatformEnabled = true,
+				BackgroundColor = Color.Red
+			};
+
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+
+			grid.Children.Add(boxRow0Column0, 0, 0);
+			grid.Children.Add(boxRow1Column0, 0, 1);
+			grid.Children.Add(boxRow1Column1, 1, 1);
+			grid.Children.Add(boxRow0Column1, 1, 0);
+
+			var view = new ContentView
+			{
+				IsPlatformEnabled = true,
+				Content = grid,
+			};
+			view.Layout(new Rectangle(0, 0, 800, 800));
+
+
+			Assert.AreEqual(boxRow0Column0.MinimumWidthRequest, boxRow0Column0.Width);
+			Assert.AreEqual(boxRow1Column0.MinimumWidthRequest, boxRow1Column0.Width);
+		}
+
+
+		[Test]
+		public void MinimumHeightRequestInAutoCells()
+		{
+			var boxRow0Column0 = new BoxView
+			{
+				MinimumHeightRequest = 50,
+				HeightRequest = 800,
+				IsPlatformEnabled = true
+			};
+			var boxRow1Column0 = new BoxView
+			{
+				HeightRequest = 800,
+				IsPlatformEnabled = true
+			};
+
+			var boxRow0Column1 = new BoxView
+			{
+				MinimumHeightRequest = 50,
+				HeightRequest = 800,
+				IsPlatformEnabled = true
+			};
+			var boxRow1Column1 = new BoxView
+			{
+				HeightRequest = 800,
+				IsPlatformEnabled = true
+			};
+
+			var grid = new Grid
+			{
+				IsPlatformEnabled = true,
+				BackgroundColor = Color.Red
+			};
+
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			grid.Children.Add(boxRow0Column0, 0, 0);
+			grid.Children.Add(boxRow1Column0, 0, 1);
+			grid.Children.Add(boxRow1Column1, 1, 1);
+			grid.Children.Add(boxRow0Column1, 1, 0);
+
+			var view = new ContentView
+			{
+				IsPlatformEnabled = true,
+				Content = grid,
+			};
+			view.Layout(new Rectangle(0, 0, 800, 800));
+
+
+			Assert.AreEqual(boxRow0Column0.MinimumHeightRequest, boxRow0Column0.Height);
+			Assert.AreEqual(boxRow0Column1.MinimumHeightRequest, boxRow0Column1.Height);
+		}
+
+
+
 		// because the constraint is internal, we need this
 		public enum HackLayoutConstraint
 		{

--- a/Xamarin.Forms.Core/GridCalc.cs
+++ b/Xamarin.Forms.Core/GridCalc.cs
@@ -170,7 +170,7 @@ namespace Xamarin.Forms
 						if (actualWidth >= 0)
 							col.ActualWidth = actualWidth;
 						if (minimumWidth >= 0)
-							col.MinimumWidth = actualWidth;
+							col.MinimumWidth = minimumWidth;
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change ###
When calculating the MinimumWidth for an auto column the code was incorrectly throwing that value away and just using the actual width for the minimum width.

### Issues Resolved ### 
- fixes #7303 


### Platforms Affected ### 
- Core/XAML (all platforms)



### Before/After Screenshots ### 
Given the following XAML

```
<Grid>
        <Grid.RowDefinitions>
            <RowDefinition />
            <RowDefinition />
        </Grid.RowDefinitions>
        <Grid.ColumnDefinitions>
            <ColumnDefinition Width="Auto" />
            <ColumnDefinition Width="Auto" />
        </Grid.ColumnDefinitions>
        <BoxView HorizontalOptions="Start" Grid.Row="0" Grid.Column="0" BackgroundColor="Purple" MinimumWidthRequest="1" WidthRequest="500"></BoxView>
        <BoxView HorizontalOptions="Start" Grid.Row="0" Grid.Column="1" BackgroundColor="Green" MinimumWidthRequest="450" WidthRequest="500"></BoxView>
        <BoxView HorizontalOptions="Start" Grid.Row="1" Grid.Column="0" BackgroundColor="Purple" MinimumWidthRequest="250" WidthRequest="500"></BoxView>
        <BoxView HorizontalOptions="Start" Grid.Row="1" Grid.Column="1" BackgroundColor="Green" MinimumWidthRequest="250" WidthRequest="500"></BoxView>
    </Grid>
```

Before the change both BoxViews stay the same width (note the green looks smaller but that's only because it's off the screen). The purple boxview should be shrinking as the view is shrinking since it has a MinimumWidthRequest set

![image](https://user-images.githubusercontent.com/5375137/63882236-d5bd4200-c98e-11e9-9050-6f97dd89faa8.png)


After this change the left BoxView shrinks.
![image](https://user-images.githubusercontent.com/5375137/63882148-a4447680-c98e-11e9-87fd-1eeb578540e9.png)


This means anyone that is using *MinimumWidthRequest* inside a Grid with the Column width set to Auto is going to experience a new layout once they update forms. Technically if they want to fix the breaking change they just have to delete the *MinimumWidthRequest* value from the elements inside the grid as that's basically how this was operating prior to this fix


### Testing Procedure ###
- Automated tests

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
