### PR TITLE
Allow CollectionView to specify which property contains the items for a group

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -254,8 +254,6 @@ namespace Xamarin.Forms.Controls
 		{
 			public GalleryPageFactory(Func<Page> create, string title)
 			{
-				Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
-
 				Realize = () =>
 				{
 					var p = create();
@@ -287,7 +285,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new MemoryLeakGallery(), "Memory Leak"),
 				new GalleryPageFactory(() => new Issues.A11yTabIndex(), "Accessibility TabIndex"),
 				new GalleryPageFactory(() => new FontImageSourceGallery(), "Font ImageSource"),
-				new GalleryPageFactory(() => new CollectionViewGallery(), "_CollectionView Gallery"),
+				new GalleryPageFactory(() => new CollectionViewGallery(), "CollectionView Gallery"),
 				new GalleryPageFactory(() => new CollectionViewCoreGalleryPage(), "CollectionView Core Gallery"),
 				new GalleryPageFactory(() => new Issues.PerformanceGallery(), "Performance"),
 				new GalleryPageFactory(() => new EntryReturnTypeGalleryPage(), "Entry ReturnType "),

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -254,6 +254,8 @@ namespace Xamarin.Forms.Controls
 		{
 			public GalleryPageFactory(Func<Page> create, string title)
 			{
+				Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
 				Realize = () =>
 				{
 					var p = create();
@@ -285,7 +287,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new MemoryLeakGallery(), "Memory Leak"),
 				new GalleryPageFactory(() => new Issues.A11yTabIndex(), "Accessibility TabIndex"),
 				new GalleryPageFactory(() => new FontImageSourceGallery(), "Font ImageSource"),
-				new GalleryPageFactory(() => new CollectionViewGallery(), "CollectionView Gallery"),
+				new GalleryPageFactory(() => new CollectionViewGallery(), "_CollectionView Gallery"),
 				new GalleryPageFactory(() => new CollectionViewCoreGalleryPage(), "CollectionView Core Gallery"),
 				new GalleryPageFactory(() => new Issues.PerformanceGallery(), "Performance"),
 				new GalleryPageFactory(() => new EntryReturnTypeGalleryPage(), "Entry ReturnType "),

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml
@@ -3,37 +3,53 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries"
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries.GroupItemsProperty">
+
+    <ContentPage.Resources>
+        <local:PropertySelection x:Key="PropertySelection"></local:PropertySelection>
+    </ContentPage.Resources>
+    
     <ContentPage.Content>
-        <CollectionView x:Name="CollectionView" IsGrouped="True" Header="Heroes by City" 
-                        GroupItemsPath="Heroes">
+        <StackLayout>
 
-            <CollectionView.ItemTemplate>
-                <DataTemplate>
-                    <StackLayout>
-                        <Label Text="{Binding Name}" Margin="5,0,0,0"/>
-                    </StackLayout>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Heroes"/> 
+                <Switch x:Name="GroupToggle"></Switch>
+                <Label Text="Teams"/>
+            </StackLayout>
+            
+            <CollectionView x:Name="CollectionView" IsGrouped="True" 
+                            Header="{Binding Source={x:Reference GroupToggle}, Path=IsToggled, Converter={StaticResource PropertySelection}, StringFormat='{}{0} by City'}"
+                            GroupItemsMemberName="{Binding Source={x:Reference GroupToggle}, Path=IsToggled, Converter={StaticResource PropertySelection}}">
 
-            <CollectionView.GroupHeaderTemplate>
-                <DataTemplate>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Label Text="{Binding Name}" Margin="5,0,0,0"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
 
-                    <Label Text="{Binding Name}" BackgroundColor="LightGreen" FontSize="16" FontAttributes="Bold"/>
+                <CollectionView.GroupHeaderTemplate>
+                    <DataTemplate>
 
-                </DataTemplate>
-            </CollectionView.GroupHeaderTemplate>
+                        <Label Text="{Binding Name}" BackgroundColor="LightGreen" FontSize="16" FontAttributes="Bold"/>
 
-            <CollectionView.GroupFooterTemplate>
-                <DataTemplate>
-                    <StackLayout>
-                        <Label Text="{Binding Path='Heroes.Count', StringFormat='{}Total Heroes: {0:D}'}" BackgroundColor="Orange" 
-							   Margin="0,0,0,15"/>
-                    </StackLayout>
-                </DataTemplate>
-            </CollectionView.GroupFooterTemplate>
+                    </DataTemplate>
+                </CollectionView.GroupHeaderTemplate>
 
-        </CollectionView>
+                <CollectionView.GroupFooterTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Label Text="{Binding Path='Heroes.Count', StringFormat='{}Total Heroes: {0:D}'}" BackgroundColor="Orange" 
+							       Margin="0,0,0,15"/>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.GroupFooterTemplate>
+
+            </CollectionView>
+        </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries.GroupItemsProperty">
+    <ContentPage.Content>
+        <CollectionView x:Name="CollectionView" IsGrouped="True" Header="Heroes by City" 
+                        GroupItemsPath="Heroes">
+
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout>
+                        <Label Text="{Binding Name}" Margin="5,0,0,0"/>
+                    </StackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate>
+
+                    <Label Text="{Binding Name}" BackgroundColor="LightGreen" FontSize="16" FontAttributes="Bold"/>
+
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
+
+            <CollectionView.GroupFooterTemplate>
+                <DataTemplate>
+                    <StackLayout>
+                        <Label Text="{Binding Path='Heroes.Count', StringFormat='{}Total Heroes: {0:D}'}" BackgroundColor="Orange" 
+							   Margin="0,0,0,15"/>
+                    </StackLayout>
+                </DataTemplate>
+            </CollectionView.GroupFooterTemplate>
+
+        </CollectionView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml
@@ -22,7 +22,7 @@
             
             <CollectionView x:Name="CollectionView" IsGrouped="True" 
                             Header="{Binding Source={x:Reference GroupToggle}, Path=IsToggled, Converter={StaticResource PropertySelection}, StringFormat='{}{0} by City'}"
-                            GroupItemsMemberName="{Binding Source={x:Reference GroupToggle}, Path=IsToggled, Converter={StaticResource PropertySelection}}">
+                            GroupItemsPropertyName="{Binding Source={x:Reference GroupToggle}, Path=IsToggled, Converter={StaticResource PropertySelection}}">
 
                 <CollectionView.ItemTemplate>
                     <DataTemplate>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml.cs
@@ -1,10 +1,12 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries
@@ -17,6 +19,27 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 			InitializeComponent();
 
 			CollectionView.ItemsSource = new Cities();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	internal class PropertySelection : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var on = (bool)value;
+
+			if (on)
+			{
+				return "Teams";
+			}
+
+			return "Heroes";
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotImplementedException();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupItemsProperty.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class GroupItemsProperty : ContentPage
+	{
+		public GroupItemsProperty()
+		{
+			InitializeComponent();
+
+			CollectionView.ItemsSource = new Cities();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupingGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupingGallery.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 							new ObservableGrouping(), Navigation),
 						GalleryBuilder.NavButton("Grouping, Grid", () =>
 							new GridGrouping(), Navigation),
-						GalleryBuilder.NavButton("GroupItemsPath Property", () =>
+						GalleryBuilder.NavButton("GroupItemsMemberName Property", () =>
 							new GroupItemsProperty(), Navigation),
 					}
 				}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupingGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupingGallery.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 							new ObservableGrouping(), Navigation),
 						GalleryBuilder.NavButton("Grouping, Grid", () =>
 							new GridGrouping(), Navigation),
-						GalleryBuilder.NavButton("GroupItemsMemberName Property", () =>
+						GalleryBuilder.NavButton("GroupItemsPropertyName Property", () =>
 							new GroupItemsProperty(), Navigation),
 					}
 				}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupingGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GroupingGallery.cs
@@ -34,6 +34,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 							new ObservableGrouping(), Navigation),
 						GalleryBuilder.NavButton("Grouping, Grid", () =>
 							new GridGrouping(), Navigation),
+						GalleryBuilder.NavButton("GroupItemsPath Property", () =>
+							new GroupItemsProperty(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/SomeEmptyGroups.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/SomeEmptyGroups.xaml.cs
@@ -12,23 +12,23 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 
 			var teams = new List<Team>
 			{
-				new Team("Avengers", new List<Member>
+				new Team("Avengers", "New York City", new List<Member>
 				{
 					new Member("Thor"),
 					new Member("Captain America")
 				}),
 
-				new Team("Thundercats", new List<Member>()),
+				new Team("Thundercats", "Cats Lair", new List<Member>()),
 
-				new Team("Avengers", new List<Member>
+				new Team("Avengers", "New York City", new List<Member>
 				{
 					new Member("Thor"),
 					new Member("Captain America")
 				}),
 							   			
-				new Team("Bionic Six", new List<Member>()),
+				new Team("Bionic Six", "Cypress Cove", new List<Member>()),
 
-				new Team("Fantastic Four", new List<Member>
+				new Team("Fantastic Four", "New York City", new List<Member>
 				{
 					new Member("The Thing"),
 					new Member("The Human Torch"),

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/ViewModel.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/ViewModel.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGalleries
@@ -7,12 +8,14 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 	[Preserve(AllMembers = true)]
 	class Team : List<Member>
 	{
-		public Team(string name, List<Member> members) : base(members)
+		public Team(string name, string city, List<Member> members) : base(members)
 		{
 			Name = name;
+			City = city;
 		}
 
 		public string Name { get; set; }
+		public string City { get; }
 
 		public override string ToString()
 		{
@@ -38,7 +41,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 	{
 		public SuperTeams()
 		{
-			Add(new Team("Avengers", 
+			Add(new Team("Avengers", "New York City",
 				new List<Member>
 				{
 					new Member("Thor"),
@@ -56,7 +59,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 				}
 			));
 
-			Add(new Team("Fantastic Four", 
+			Add(new Team("Fantastic Four", "New York City",
 				new List<Member>
 				{
 					new Member("The Thing"),
@@ -66,7 +69,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 				}
 			));
 
-			Add(new Team("Defenders", 
+			Add(new Team("Defenders", "New York City",
 				new List<Member>
 				{
 					new Member("Doctor Strange"),
@@ -79,7 +82,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 				}
 			));
 			
-			Add(new Team("Heroes for Hire", 
+			Add(new Team("Heroes for Hire", "New York City",
 				new List<Member>
 				{
 					new Member("Luke Cage"),
@@ -90,7 +93,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 				}
 			));
 
-			Add(new Team("West Coast Avengers", 
+			Add(new Team("West Coast Avengers", "Los Angeles",
 				new List<Member>
 				{
 					new Member("Hawkeye"),
@@ -101,7 +104,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 				}
 			));
 
-			Add(new Team("Great Lakes Avengers", 
+			Add(new Team("Great Lakes Avengers", "Milwaukee",
 				new List<Member>
 				{
 					new Member("Squirrel Girl"),
@@ -208,6 +211,43 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.GroupingGa
 					new Member("Doorman"),
 				}
 			));
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	class City
+	{
+		SuperTeams _teams = new SuperTeams();
+
+		public City(string name)
+		{
+			Name = name;
+		}
+
+		public string Name { get; set; }
+
+		public List<Team> Teams
+		{
+			get { return _teams.Where(t => t.City == Name).ToList(); }
+		}
+
+		public List<Member> Heroes
+		{
+			get { return Teams.SelectMany(t => t).ToList(); }
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	class Cities : List<City>
+	{
+		public Cities()
+		{
+			var cityNames = new SuperTeams().Select(team => team.City).Distinct().OrderBy(city => city);
+
+			foreach (var superCity in cityNames.Select(name => new City(name)))
+			{
+				Add(superCity);
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/GroupableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/GroupableItemsView.cs
@@ -29,13 +29,13 @@
 			set => SetValue(GroupFooterTemplateProperty, value);
 		}
 
-		public static readonly BindableProperty GroupItemsMemberNameProperty =
-			BindableProperty.Create(nameof(GroupItemsMemberName), typeof(string), typeof(GroupableItemsView), null);
+		public static readonly BindableProperty GroupItemsPropertyNameProperty =
+			BindableProperty.Create(nameof(GroupItemsPropertyName), typeof(string), typeof(GroupableItemsView), null);
 
-		public string GroupItemsMemberName
+		public string GroupItemsPropertyName
 		{
-			get => (string)GetValue(GroupItemsMemberNameProperty);
-			set => SetValue(GroupItemsMemberNameProperty, value);
+			get => (string)GetValue(GroupItemsPropertyNameProperty);
+			set => SetValue(GroupItemsPropertyNameProperty, value);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/GroupableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/GroupableItemsView.cs
@@ -28,5 +28,14 @@
 			get => (DataTemplate)GetValue(GroupFooterTemplateProperty);
 			set => SetValue(GroupFooterTemplateProperty, value);
 		}
+
+		public static readonly BindableProperty GroupItemsPathProperty =
+			BindableProperty.Create(nameof(GroupItemsPath), typeof(string), typeof(GroupableItemsView), null);
+
+		public string GroupItemsPath
+		{
+			get => (string)GetValue(GroupItemsPathProperty);
+			set => SetValue(GroupItemsPathProperty, value);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/GroupableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/GroupableItemsView.cs
@@ -29,13 +29,13 @@
 			set => SetValue(GroupFooterTemplateProperty, value);
 		}
 
-		public static readonly BindableProperty GroupItemsPathProperty =
-			BindableProperty.Create(nameof(GroupItemsPath), typeof(string), typeof(GroupableItemsView), null);
+		public static readonly BindableProperty GroupItemsMemberNameProperty =
+			BindableProperty.Create(nameof(GroupItemsMemberName), typeof(string), typeof(GroupableItemsView), null);
 
-		public string GroupItemsPath
+		public string GroupItemsMemberName
 		{
-			get => (string)GetValue(GroupItemsPathProperty);
-			set => SetValue(GroupItemsPathProperty, value);
+			get => (string)GetValue(GroupItemsMemberNameProperty);
+			set => SetValue(GroupItemsMemberNameProperty, value);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, 
 				GroupableItemsView.GroupFooterTemplateProperty, GroupableItemsView.GroupHeaderTemplateProperty, 
-				GroupableItemsView.GroupItemsPathProperty))
+				GroupableItemsView.GroupItemsMemberNameProperty))
 			{
 				UpdateItemsSource();
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
@@ -18,7 +18,8 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnElementPropertyChanged(sender, changedProperty);
 
 			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, 
-				GroupableItemsView.GroupFooterTemplateProperty, GroupableItemsView.GroupHeaderTemplateProperty))
+				GroupableItemsView.GroupFooterTemplateProperty, GroupableItemsView.GroupHeaderTemplateProperty, 
+				GroupableItemsView.GroupItemsPathProperty))
 			{
 				UpdateItemsSource();
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, 
 				GroupableItemsView.GroupFooterTemplateProperty, GroupableItemsView.GroupHeaderTemplateProperty, 
-				GroupableItemsView.GroupItemsMemberNameProperty))
+				GroupableItemsView.GroupItemsPropertyNameProperty))
 			{
 				UpdateItemsSource();
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (itemsView.IsGrouped)
 			{
-				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter), itemsView.GroupItemsMemberName);
+				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter), itemsView.GroupItemsPropertyName);
 			}
 
 			return new UngroupedItemsSource(Create(itemsView.ItemsSource, adapter));

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (itemsView.IsGrouped)
 			{
-				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter), itemsView.GroupItemsPath);
+				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter), itemsView.GroupItemsMemberName);
 			}
 
 			return new UngroupedItemsSource(Create(itemsView.ItemsSource, adapter));

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (itemsView.IsGrouped)
 			{
-				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter));
+				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter), itemsView.GroupItemsPath);
 			}
 
 			return new UngroupedItemsSource(Create(itemsView.ItemsSource, adapter));

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// Use the BindableProperty here (instead of _isGroupingEnabled) because the cached value might not be set yet
 			if (GroupableItemsView.IsGrouped) 
 			{
-				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, CollectionView, GroupableItemsView.GroupItemsMemberName);
+				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, CollectionView, GroupableItemsView.GroupItemsPropertyName);
 			}
 
 			return base.CreateItemsViewSource();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// Use the BindableProperty here (instead of _isGroupingEnabled) because the cached value might not be set yet
 			if (GroupableItemsView.IsGrouped) 
 			{
-				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, CollectionView, GroupableItemsView.GroupItemsPath);
+				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, CollectionView, GroupableItemsView.GroupItemsMemberName);
 			}
 
 			return base.CreateItemsViewSource();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// Use the BindableProperty here (instead of _isGroupingEnabled) because the cached value might not be set yet
 			if (GroupableItemsView.IsGrouped) 
 			{
-				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, CollectionView);
+				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, CollectionView, GroupableItemsView.GroupItemsPath);
 			}
 
 			return base.CreateItemsViewSource();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
 
-			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, GroupableItemsView.GroupItemsMemberNameProperty))
+			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, GroupableItemsView.GroupItemsPropertyNameProperty))
 			{
 				GroupableItemsViewController?.UpdateItemsSource();
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
 
-			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, GroupableItemsView.GroupItemsPathProperty))
+			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, GroupableItemsView.GroupItemsMemberNameProperty))
 			{
 				GroupableItemsViewController?.UpdateItemsSource();
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
 
-			if (changedProperty.Is(GroupableItemsView.IsGroupedProperty))
+			if (changedProperty.IsOneOf(GroupableItemsView.IsGroupedProperty, GroupableItemsView.GroupItemsPathProperty))
 			{
 				GroupableItemsViewController?.UpdateItemsSource();
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
@@ -25,14 +25,14 @@ namespace Xamarin.Forms.Platform.iOS
 			return new ListSource(itemsSource);
 		}
 
-		public static IItemsViewSource CreateGrouped(IEnumerable itemsSource, UICollectionView collectionView)
+		public static IItemsViewSource CreateGrouped(IEnumerable itemsSource, UICollectionView collectionView, string groupItemsPath = null)
 		{
 			if (itemsSource == null)
 			{
 				return new EmptySource();
 			}
 
-			return new ObservableGroupedSource(itemsSource, collectionView);
+			return new ObservableGroupedSource(itemsSource, collectionView, groupItemsPath);
 		}
 	}
 }


### PR DESCRIPTION
This is a proposal/proof-of-concept implementation; I'm looking for feedback on the API proposed and the naming.

### Description of Change ###

At the moment, CollectionView grouping requires that the type used for a group be an `IEnumerable`. That is, to display groups of `Item` objects, given a top level model class like

```
class GroupsModel : IList<GroupModel> {}
```

`GroupModel` would have to be something like

```
class Group : IList<Item> {}
```

This is inconvenient and awkward for a number of reasons; it also poses some issues for common serialization scenarios (see the comments below "Issues Resolved" for an explanation). 

These changes allow for CollectionView users to specify an additional value `GroupItemsMemberName` - a string which tells the CollectionView which property on the "group" model contains the actual list of objects to display. So the `GroupModel` could be something like

```
class Group 
{
	public string Title { get; }
	public IList<Item> Items { get; }
}

```

Setting `GroupItemsMemberName` to "Items" would tell the CollectionView to look at the `Items` property for the objects to display. If `GroupItemsMemberName` is not specified, CollectionView assumes the default scenario shown above (where `GroupModel` is itself an `IEnumerable`).

### Issues Resolved ### 

- Concerns about serialization raised here: https://github.com/xamarin/Xamarin.Forms/issues/3172#issuecomment-493382178
- Inconvenience of requiring groups to inherit directly from `IEnumerable`

### API Changes ###

Added to GroupableItemsView:

`public static readonly BindableProperty GroupItemsMemberNameProperty =
	BindableProperty.Create(nameof(GroupItemsMemberName), typeof(string), typeof(GroupableItemsView), null);`

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery, CollectionView Gallery -> Grouping Gallery -> GroupItemsMemberName Property

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
