### PR TITLE
[Android] Check if Shell Flyout header is null before trying to use it

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Environment.txt
+++ b/Xamarin.Forms.ControlGallery.Android/Environment.txt
@@ -1,0 +1,1 @@
+﻿MONO_GC_PARAMS=bridge-implementation=new

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -57,6 +57,7 @@
     <NoWarn>
     </NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+<MandroidExtraArgs>MONO_GC_PARAMS=bridge-implementation=new</MandroidExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -377,6 +378,9 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateGeneratedFiles</Generator>
     </TransformFile>
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidEnvironment Include="Environment.txt" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -57,7 +57,6 @@
     <NoWarn>
     </NoWarn>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-<MandroidExtraArgs>MONO_GC_PARAMS=bridge-implementation=new</MandroidExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
@@ -35,10 +35,14 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// At this point, the counter can be any value, but it's most likely not zero.
 			// Invoking GC once is enough to clean up all garbage data and set counter to zero
-			RunningApp.WaitForElement(q => q.Marked("GC"));
-			RunningApp.Tap(q => q.Marked("GC"));
+			RunningApp.WaitForElement("GC");
+			RunningApp.QueryUntilPresent(() =>
+			{
+				RunningApp.Tap("GC");
+				return RunningApp.Query("Counter: 0");
+			});
 
-			RunningApp.WaitForElement(q => q.Marked("Counter: 0"));
+			
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1342,7 +1342,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1455.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5268.xaml">
       <SubType>Designer</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -292,22 +292,28 @@ namespace Xamarin.Forms.Platform.Android
 			bool _isdisposed = false;
 			public HeaderContainer(Context context, View view) : base(context, view)
 			{
-				view.PropertyChanged += OnViewPropertyChanged;
+				Initialize(view);
 			}
 
 			public HeaderContainer(Context context, IAttributeSet attribs) : base(context, attribs)
 			{
-				View.PropertyChanged += OnViewPropertyChanged;
+				Initialize(View);
 			}
 
 			public HeaderContainer(Context context, IAttributeSet attribs, int defStyleAttr) : base(context, attribs, defStyleAttr)
 			{
-				View.PropertyChanged += OnViewPropertyChanged;
+				Initialize(View);
 			}
 
 			protected HeaderContainer(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 			{
-				View.PropertyChanged += OnViewPropertyChanged;
+				Initialize(View);
+			}
+
+			void Initialize(View view)
+			{
+				if (view != null)
+					view.PropertyChanged += OnViewPropertyChanged;
 			}
 
 			void OnViewPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -336,7 +342,9 @@ namespace Xamarin.Forms.Platform.Android
 				height -= paddingTop + paddingBottom;
 
 				UpdateElevation();
-				View.Layout(new Rectangle(paddingLeft, paddingTop, width, height));
+
+				if(View != null)
+					View.Layout(new Rectangle(paddingLeft, paddingTop, width, height));
 			}
 
 			protected override void Dispose(bool disposing)
@@ -347,7 +355,8 @@ namespace Xamarin.Forms.Platform.Android
 				_isdisposed = true;
 				if (disposing)
 				{
-					View.PropertyChanged -= OnViewPropertyChanged;
+					if(View != null)
+						View.PropertyChanged -= OnViewPropertyChanged;
 				}
 
 				View = null;


### PR DESCRIPTION
### Description of Change ###
- Check for null on the HeaderContainer
- change the MONO_GC_PARAMS implementation to new because the default one keeps crashing the UI tests
- Adjusted one of the UI Tests that looks to not be collection as fast from the new GC settings

### Regression ### 
Regression introduced by not checking null on this PR
https://github.com/xamarin/Xamarin.Forms/pull/6970

### Platforms Affected ### 
- Android

### Testing Procedure ###
- tests are automated
- test shell without a flyout header specified

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
