### PR TITLE
[Android/iOS/UWP] Added BarSelectedTextColorProperty for TabbedPage

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -122,17 +122,19 @@ namespace Xamarin.Forms.Controls
 		public CoreTabbedPageBase()
 		{
 			AutomationId = "TabbedPageRoot";
-
+			BarSelectedTextColor = Color.Red;
 
 			Device.StartTimer(TimeSpan.FromSeconds(6), () =>
 			{
 				BarBackgroundColor = Color.Maroon;
 				BarTextColor = Color.Yellow;
+				BarSelectedTextColor = Color.Orange;
 
 				Device.StartTimer(TimeSpan.FromSeconds(6), () =>
 				{
 					BarBackgroundColor = Color.Default;
 					BarTextColor = Color.Default;
+					BarSelectedTextColor = Color.Default;
 
 					return false;
 				});

--- a/Xamarin.Forms.Controls/RootPages/RootTabbedContentPage.cs
+++ b/Xamarin.Forms.Controls/RootPages/RootTabbedContentPage.cs
@@ -42,13 +42,10 @@ namespace Xamarin.Forms.Controls
 				}
 			};
 
-			// the tab colors appear to be fighting with the text colors
-			// this needs to be fixed.
 			UnselectedTabColor = Color.HotPink;
 			SelectedTabColor = Color.Green;
 			BarTextColor = Color.White;
 			BarSelectedTextColor = Color.Orange;
-
 
 			Children.Add (tabOne);
 			Children.Add (tabTwo);

--- a/Xamarin.Forms.Controls/RootPages/RootTabbedContentPage.cs
+++ b/Xamarin.Forms.Controls/RootPages/RootTabbedContentPage.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Controls
 			AutomationId = hierarchy + "PageId";
 
 			var tabOne = new ContentPage {
+				IconImageSource = "bell",
 				Title = "Testing 123",
 				Content = new SwapHierachyStackLayout (hierarchy)
 			};
@@ -27,6 +28,7 @@ namespace Xamarin.Forms.Controls
 			};
 
 			var tabTwo = new ContentPage {
+				IconImageSource = "bank",
 				Title = "Testing 345",
 				Content = new StackLayout {
 					Children = {
@@ -40,8 +42,13 @@ namespace Xamarin.Forms.Controls
 				}
 			};
 
+			// the tab colors appear to be fighting with the text colors
+			// this needs to be fixed.
 			UnselectedTabColor = Color.HotPink;
 			SelectedTabColor = Color.Green;
+			BarTextColor = Color.White;
+			BarSelectedTextColor = Color.Orange;
+
 
 			Children.Add (tabOne);
 			Children.Add (tabTwo);

--- a/Xamarin.Forms.Controls/RootPages/RootTabbedNavigationContentPage.cs
+++ b/Xamarin.Forms.Controls/RootPages/RootTabbedNavigationContentPage.cs
@@ -36,6 +36,9 @@ namespace Xamarin.Forms.Controls
 
 			Children.Add (tabOne);
 			Children.Add (tabTwo);
+
+			BarSelectedTextColor = Color.Green;
+			BarTextColor = Color.White;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TabbedPage.cs
+++ b/Xamarin.Forms.Core/TabbedPage.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty BarTextColorProperty = BarElement.BarTextColorProperty;
 
+		public static readonly BindableProperty BarSelectedTextColorProperty = BindableProperty.Create(nameof(BarSelectedTextColor), typeof(Color), typeof(TabbedPage), default(Color));
+
 		public static readonly BindableProperty UnselectedTabColorProperty = BindableProperty.Create(nameof(UnselectedTabColor), typeof(Color),	typeof(TabbedPage), default(Color));
 
 		public static readonly BindableProperty SelectedTabColorProperty = BindableProperty.Create(nameof(SelectedTabColor), typeof(Color),	typeof(TabbedPage), default(Color));
@@ -24,6 +26,12 @@ namespace Xamarin.Forms
 		public Color BarTextColor {
 			get => (Color)GetValue(BarElement.BarTextColorProperty);
 			set => SetValue(BarElement.BarTextColorProperty, value);
+		}
+
+		public Color BarSelectedTextColor
+		{
+			get => (Color)GetValue(BarSelectedTextColorProperty);
+			set => SetValue(BarSelectedTextColorProperty, value);
 		}
 
 		public Color UnselectedTabColor

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -335,6 +335,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				((IPageController)tabbedPage).InternalChildren.CollectionChanged += OnChildrenCollectionChanged;
 				UpdateBarBackgroundColor();
 				UpdateBarTextColor();
+				UpdateBarSelectedTextColor();
 				UpdateItemIconColor();
 				if (!isDesigner)
 				{
@@ -366,6 +367,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.TabbedPage.IsSwipePagingEnabledProperty.PropertyName)
 				UpdateSwipePaging();
+			else if (e.PropertyName == TabbedPage.BarSelectedTextColorProperty.PropertyName)
+				UpdateBarSelectedTextColor();
 		}
 
 		void SetNavigationRendererPadding(int paddingTop, int paddingBottom)
@@ -950,6 +953,41 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				_bottomNavigationView.ItemTextColor = colors;
 			else
 				_tabLayout.TabTextColors = colors;
+		}
+
+		protected virtual void UpdateBarSelectedTextColor()
+		{
+			AColor selectedColor;
+			AColor unselectedColor;
+
+			if (Element != null)
+			{
+				selectedColor = Element.BarSelectedTextColor.ToAndroid();
+				unselectedColor = Element.BarTextColor.ToAndroid();
+			}
+			else
+			{
+				selectedColor = ((Color)TabbedPage.BarSelectedTextColorProperty.DefaultValue).ToAndroid();
+				unselectedColor = ((Color)TabbedPage.BarTextColorProperty.DefaultValue).ToAndroid();
+			}
+
+			for (int index = 0; index < _tabLayout.TabCount; index++)
+			{
+				var tab = _tabLayout.GetTabAt(index);
+				var icon = tab.Icon;
+
+				if (icon == null)
+				{
+					_tabLayout.TabTextColors = GetColorStateList(unselectedColor, selectedColor);
+					break;
+				}
+				else
+				{
+					var color = tab.IsSelected ? selectedColor : unselectedColor;
+					icon = ADrawableCompat.Wrap(icon);
+					icon.SetColorFilter(color, PorterDuff.Mode.SrcIn);
+				}
+			}
 		}
 
 		void SetIconColorFilter(TabLayout.Tab tab)

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -367,7 +367,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 			else if (e.PropertyName == PlatformConfiguration.AndroidSpecific.TabbedPage.IsSwipePagingEnabledProperty.PropertyName)
 				UpdateSwipePaging();
-			else if (e.PropertyName == TabbedPage.BarSelectedTextColorProperty.PropertyName)
+			else if (e.PropertyName == TabbedPage.BarSelectedTextColorProperty.PropertyName || e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName)
 				UpdateBarSelectedTextColor();
 		}
 
@@ -962,8 +962,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (Element != null)
 			{
-				selectedColor = Element.BarSelectedTextColor.ToAndroid();
-				unselectedColor = Element.BarTextColor.ToAndroid();
+				selectedColor = (Element.BarSelectedTextColor.IsDefault ? Element.SelectedTabColor : Element.BarSelectedTextColor).ToAndroid();
+				unselectedColor = (Element.BarTextColor.IsDefault ? Element.UnselectedTabColor : Element.BarTextColor).ToAndroid();
 			}
 			else
 			{
@@ -971,23 +971,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				unselectedColor = ((Color)TabbedPage.BarTextColorProperty.DefaultValue).ToAndroid();
 			}
 
-			for (int index = 0; index < _tabLayout.TabCount; index++)
-			{
-				var tab = _tabLayout.GetTabAt(index);
-				var icon = tab.Icon;
-
-				if (icon == null)
-				{
-					_tabLayout.TabTextColors = GetColorStateList(unselectedColor, selectedColor);
-					break;
-				}
-				else
-				{
-					var color = tab.IsSelected ? selectedColor : unselectedColor;
-					icon = ADrawableCompat.Wrap(icon);
-					icon.SetColorFilter(color, PorterDuff.Mode.SrcIn);
-				}
-			}
+			_tabLayout.TabTextColors = GetColorStateList(unselectedColor, selectedColor);
 		}
 
 		void SetIconColorFilter(TabLayout.Tab tab)

--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -237,7 +237,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateBarIcons();
 			else if (e.PropertyName == PageSpecifics.ToolbarPlacementProperty.PropertyName)
 				UpdateToolbarPlacement();
-			else if (e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName || e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName)
+			else if (e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName || e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName ||
+				     e.PropertyName == TabbedPage.BarSelectedTextColorProperty.PropertyName)
 				UpdateSelectedTabColors();
 		}
 
@@ -554,6 +555,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateSelectedTabColors()
 		{
+			if (Element.BarSelectedTextColor != Element.SelectedTabColor)
+				Element.SelectedTabColor = Element.BarSelectedTextColor;
+
 			// Retrieve all tab header textblocks
 			var allTabHeaderTextBlocks = Control.GetDescendantsByName<WTextBlock>(TabBarHeaderTextBlockName).ToArray();
 			if (allTabHeaderTextBlocks.Length != Control.Items.Count)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBarTextColor();
 			UpdateSelectedTabColors();
 			UpdateBarTranslucent();
+			UpdateBarSelectedTextColors();
 
 			EffectUtilities.RegisterEffectControlProvider(this, oldElement, element);
 		}
@@ -225,6 +226,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBarBackgroundColor();
 			UpdateBarTextColor();
 			UpdateSelectedTabColors();
+			UpdateBarSelectedTextColors();
 		}
 
 		void OnPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -251,6 +253,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateCurrentPagePreferredStatusBarUpdateAnimation();
 			else if (e.PropertyName == TabbedPage.SelectedTabColorProperty.PropertyName || e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName)
 				UpdateSelectedTabColors();
+			else if (e.PropertyName == TabbedPage.BarSelectedTextColorProperty.PropertyName)
+				UpdateBarSelectedTextColors();
 			else if (e.PropertyName == PrefersHomeIndicatorAutoHiddenProperty.PropertyName)
 				UpdatePrefersHomeIndicatorAutoHiddenOnPages();
 			else if (e.PropertyName == TabbedPageConfiguration.TranslucencyModeProperty.PropertyName)
@@ -495,6 +499,32 @@ namespace Xamarin.Forms.Platform.iOS
 				TabBar.UnselectedItemTintColor = Tabbed.UnselectedTabColor.ToUIColor();
 			else
 				TabBar.UnselectedItemTintColor = UITabBar.Appearance.TintColor;
+		}
+
+		void UpdateBarSelectedTextColors()
+		{
+			var control = (TabbedPage)Element;
+			if (control == null || Tabbed == null || TabBar == null || TabBar.Items == null)
+				return;
+
+			UIColor selectedColor = control.BarSelectedTextColor.ToUIColor();
+			UIColor unselectedColor = control.BarTextColor.ToUIColor();
+
+			TabBar.UnselectedItemTintColor = unselectedColor;
+
+			for (int index = 0; index < TabBar.Items.Length; index++)
+			{
+				UpdateItem(TabBar.Items[index], selectedColor, unselectedColor);
+			}
+
+			void UpdateItem(UITabBarItem item, UIColor selected, UIColor unselected)
+			{
+				if (item == null)
+					return;
+
+				item.SetTitleTextAttributes(new UITextAttributes { TextColor = selected }, UIControlState.Selected);
+				item.SetTitleTextAttributes(new UITextAttributes { TextColor = unselected }, UIControlState.Normal);
+			}
 		}
 
 		/// <summary>


### PR DESCRIPTION
### Description of Change ###

Added new bindable property to the `TabbedPage` which provides granular control over the color of the icons and text in the `TabbedPage`. `BarSelectedTextColor` provides custom color to apply to the text on the selected tab page so the selected tab may be uniquely identified. 

### Issues Resolved ### 

- fixes #3281

### API Changes ###
Added:
 - `Color BarSelectedTextColor { get; set; } //Bindable Property`

#### New Rules
With the addition of `BarSelectedTextColor` there is now going to be color conflicts between the following properties
* BarSelectedTextColor/BarTextColor
* SelectedTabColor/UnselectedTabColor

I have adjusted the rules to handle several scenarios where some properties are set and other are set to default

| BarSelectedTextColor | BarTextColor | SelectedTabColor | UnselectedTabColor | Selected Icon Color                                   | Selected Text Color | Unselected Icon Color                                  | Unselected Text Color|
|----------------------|--------------|------------------|--------------------|-------------------------------------------------------|---------------------|--------------------------------------------------------|----------------------|
| Default              | Default      | Green            | Pink               | Green                                                 | Green               | Pink                                                   | Pink                 |
| Orange               | White        | Default          | Default            | (android) icon color from file. (iOS) uses text Color | Orange              | (android) icon color from file. (iOS) uses text color  | White                |
| Orange               | White        | Green            | Pink               | Green                                                 | Orange              | Pink                                                   | White                |

The reasoning behind this table is to not break existing expected behavior with `SelectedTabColor` and `UnselectedTabColor`. Currently those bindable properties will update the Text and Icon across the platform (except UWP). By only setting the `BarSelectedTextColor` if it is not default we have what hopefully is a non-breaking change. If there is a breaking API please make a review in the PR so we can adjust the code or discuss trade-offs.

**UWP**
- Currently there is no support for icon colors

**Android**
- If no TabColor specified the default color of the file is used

**iOS**
- If no tabColor is specified the text color will be applied

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core
- iOS
- Android
- UWP

#### UWP Limitations
Since the concept of Tabs in UWP doesn't really exist, the `TabbedPageRenderer` and the BarSelectedTextColor will overwrite the value for `SelectedTabColor` property if not set. This is to force a consistent look and feel with the text color across the 3 major platforms.

As far as I can tell there is no way for UWP to set the icon color of a tab. When that gets implemented we should come back to this and update the rules for TabColor vs TextColor to match what iOS and Android are doing. 
### Behavioral/Visual Changes ###
Not Applicable

### Before/After Screenshots ### 
![selectedTextColor](https://user-images.githubusercontent.com/17751436/64089118-98e8a680-cd12-11e9-891b-2b721cdc8032.gif)

### Testing Procedure ###
1. Open Control Gallery Project
2. Navigate to Root Gallery Pages
3. Select 'TAB->CONTENT'

Now you are on the correct page and you can swap between the tabs. If you want to test different scenarios open `RootTabbedContentPage` in the shared code and you can edit the following code:

```
UnselectedTabColor = Color.HotPink;
SelectedTabColor = Color.Green;
BarTextColor = Color.White;
BarSelectedTextColor = Color.Orange;
```

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
