### PR TITLE
Verify sections exist before calling NumberOfItemsInSection

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7338.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7338, "[Bug] CollectionView crash if source is empty in XF 4.2.0.709249",
+		PlatformAffected.iOS)]
+	class Issue7338 : TestNavigationPage
+	{
+		const string Success = "success";
+
+		protected override void Init()
+		{
+			FlagTestHelpers.SetCollectionViewTestFlag();
+			PushAsync(CreateRoot());
+		}
+
+		Page CreateRoot()
+		{
+			var page = new ContentPage() { Title = "Issue7338" };
+
+			var instructions = new Label { AutomationId = Success, Text = "If you can see this label, the test has passed." };
+
+			var layout = new StackLayout();
+
+			var cv = new CollectionView
+			{
+				ItemsLayout = new GridItemsLayout(orientation: ItemsLayoutOrientation.Horizontal),
+				ItemTemplate = new DataTemplate(() =>
+				{
+					return Template();
+				})
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(cv);
+
+			page.Content = layout;
+
+			return page;
+		}
+
+		View Template()
+		{
+			var label1 = new Label { Text = "Text", HeightRequest = 100 };
+			return label1;
+		}
+
+#if UITEST
+		[Test]
+		public void EmptyHorizontalCollectionShouldNotCrash()
+		{
+			// If the instructions are visible at all, then this has succeeded
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -32,6 +32,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBehavior.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -138,6 +138,12 @@ namespace Xamarin.Forms.Platform.iOS
 				return false; 
 			}
 
+			if (CollectionView.NumberOfSections() == 0)
+			{
+				// And it only happens if there are items
+				return false;
+			}
+
 			if (EstimatedItemSize.IsEmpty)
 			{
 				// The bug only occurs when using Autolayout; with a set ItemSize, we don't have to worry about it


### PR DESCRIPTION
### Description of Change ###

The `NeedsPartialColumnAdjustment` method was checking the numbers of items in section 0 even if section 0 did not exist, causing a crash. 

Props to @jfversluis, who'd already fixed this in another PR.

### Issues Resolved ### 

- fixes #7338

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated Test

### PR Checklist ###

- [x] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Books balanced
