### PR TITLE
Check for null Platform in OnDestroy

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -278,9 +278,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			PopupManager.Unsubscribe(this);
 
-			_layout.RemoveView(Platform);
-
-			Platform?.Dispose();
+			if (Platform != null)
+			{
+				_layout.RemoveView(Platform);
+				Platform.Dispose();
+			}
 
 			PreviousActivityDestroying.Set();
 


### PR DESCRIPTION
Missing null check is causing NRE under some circumstances.

Fixes #7331