### PR TITLE
Make WkWebViewRenderer default for iOS WebView

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -72,9 +72,13 @@ namespace Xamarin.Forms.Platform
 	[RenderWith (typeof (SliderRenderer))]
 	internal class _SliderRenderer { }
 
+#if !__IOS__
 	[RenderWith (typeof (WebViewRenderer))]
 	internal class _WebViewRenderer { }
-
+#else
+	[RenderWith (typeof (WkWebViewRenderer))]
+	internal class _WebViewRenderer { }
+#endif
 	[RenderWith (typeof (SearchBarRenderer))]
 	internal class _SearchBarRenderer { }
 

--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -72,13 +72,14 @@ namespace Xamarin.Forms.Platform
 	[RenderWith (typeof (SliderRenderer))]
 	internal class _SliderRenderer { }
 
-#if !__IOS__
-	[RenderWith (typeof (WebViewRenderer))]
-	internal class _WebViewRenderer { }
-#else
+#if __IOS__
 	[RenderWith (typeof (WkWebViewRenderer))]
 	internal class _WebViewRenderer { }
+#else
+	[RenderWith(typeof(WebViewRenderer))]
+	internal class _WebViewRenderer { }
 #endif
+
 	[RenderWith (typeof (SearchBarRenderer))]
 	internal class _SearchBarRenderer { }
 

--- a/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
@@ -908,7 +908,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		}
 	}
 
-	public class PerformanceTrackingWebView : WebViewRenderer, IDrawnObservable
+	public class PerformanceTrackingWebView : WkWebViewRenderer, IDrawnObservable
 	{
 		readonly SubviewWatcher<PerformanceTrackingWebView> _watcher;
 		int _Drawn;

--- a/Xamarin.Forms.ControlGallery.iOS/local.html
+++ b/Xamarin.Forms.ControlGallery.iOS/local.html
@@ -5,6 +5,6 @@
 <body>
 <h1 id="#LocalHtmlPage">Xamarin.Forms</h1>
 <p>This is a local iOS Html page</p>
-<a href="https://www.google.com">Go to Google</a>
+<a id="#LocalHtmlPageLink" href="https://www.google.com">Go to Google</a>
 </body>
 </html>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Screenshot("I am at BZ26993");
 
 #if __IOS__
-			RunningApp.WaitForElement(q => q.Class("WKWebView"));
+			RunningApp.WaitForElement(q => q.Class("WKWebView"), postTimeout: TimeSpan.FromSeconds(5));
 
 			RunningApp.Query(q => q.Class("WKWebView").Index(0).InvokeJS("document.getElementById('LinkID0').click()"));
 			RunningApp.Screenshot("Load local HTML");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla26993.cs
@@ -3,6 +3,7 @@
 using Xamarin.Forms.CustomAttributes;
 using System.Collections.Generic;
 using Xamarin.Forms.Internals;
+using System.Linq;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
@@ -101,19 +102,33 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.Screenshot("I am at BZ26993");
 
+#if __IOS__
+			RunningApp.WaitForElement(q => q.Class("WKWebView"));
+
+			RunningApp.Query(q => q.Class("WKWebView").Index(0).InvokeJS("document.getElementById('LinkID0').click()"));
+			RunningApp.Screenshot("Load local HTML");
+
+			RunningApp.WaitForNoElement(q => q.Class("WKWebView").Css("#LinkID0"));
+			UITest.Queries.AppWebResult[] newElem =
+			  RunningApp.QueryUntilPresent(() => RunningApp.Query(q => q.Class("WKWebView").Css("a")));
+
+			Assert.AreEqual("#LocalHtmlPageLink", newElem[0].Id);
+#elif __ANDROID__
 			RunningApp.WaitForElement(q => q.WebView(0).Css("#CellID0"));
 			RunningApp.Tap(q => q.WebView(0).Css("#LinkID0"));
 
 			RunningApp.Screenshot("Load local HTML");
 
 			RunningApp.WaitForNoElement(q => q.WebView(0).Css("#LinkID0"));
+
 			UITest.Queries.AppWebResult[] newElem =
 			  RunningApp.QueryUntilPresent(() => RunningApp.Query(q => q.WebView(0).Css("h1")));
 
 			Assert.AreEqual("#LocalHtmlPage", newElem[0].Id);
+#endif
 
 			RunningApp.Screenshot("I see the Label");
 		}
 #endif
-	}
+		}
 }

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -58,4 +58,3 @@ using UIKit;
 [assembly: Xamarin.Forms.Dependency(typeof(Deserializer))]
 [assembly: Xamarin.Forms.Dependency(typeof(ResourcesProvider))]
 [assembly: ResolutionGroupName("Xamarin")]
-[assembly: Preserve]

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -58,3 +58,4 @@ using UIKit;
 [assembly: Xamarin.Forms.Dependency(typeof(Deserializer))]
 [assembly: Xamarin.Forms.Dependency(typeof(ResourcesProvider))]
 [assembly: ResolutionGroupName("Xamarin")]
+[assembly: Preserve]

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -9,6 +9,7 @@ using Uri = System.Uri;
 
 namespace Xamarin.Forms.Platform.iOS
 {
+	[Obsolete("WebViewRenderer is obsolete as of 4.4.0. Please use the WkWebViewRenderer instead.")]
 	public class WebViewRenderer : UIWebView, IVisualElementRenderer, IWebViewDelegate, IEffectControlProvider, ITabStop
 	{
 		EventTracker _events;


### PR DESCRIPTION
### Description of Change ###

Deprecates the `WebViewRenderer` for iOS and uses the `WkWebViewRenderer` instead.

No (extra) automated tests were added at this stage, the ones in place should succeeded with this replacement.

To reinstate the current behavior just add the line below to the `AssemblyInfo.cs` file of you iOS project. This will register the `WebViewRenderer` again over the `WkWebViewRenderer`.

`[assembly: ExportRenderer(typeof(Xamarin.Forms.WebView), typeof(Xamarin.Forms.Platform.iOS.WebViewRenderer))]`

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7323 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - string ListView.GroupName { get; set; } //Bindable Property
 - int ListView.GroupId { get; set; } // Bindable Property
 - void ListView.Clear ();

Changed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 Removed:
 - object ListView.SelectedItem => Cell ListView.SelectedItem
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None. Everything should function as before. Users should receive build warnings when they reference the `WebViewRenderer` directly. E.g. when there is a custom renderer in place.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
