### PR TITLE
[CarouselView] Fixed issue updating PeekAreaInsets

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -57,19 +57,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void UpdateItemsSource()
 		{
-			// By default the CollectionViewAdapter creates the items at whatever size the template calls for
-			// But for the Carousel, we want it to create the items to fit the width/height of the viewport
-			// So we give it an alternate delegate for creating the views
-			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView,
-				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
-
-			SwapAdapter(ItemsViewAdapter, false);
+			UpdateAdapter();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs changedProperty)
 		{
 			if (changedProperty.Is(CarouselView.PeekAreaInsetsProperty))
-				Tracker?.UpdateLayout();
+				UpdatePeekAreaInsets();
 			else if (changedProperty.Is(CarouselView.IsSwipeEnabledProperty))
 				UpdateIsSwipeEnabled();
 			else if (changedProperty.Is(CarouselView.IsBounceEnabledProperty))
@@ -184,6 +178,27 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateIsBounceEnabled()
 		{
 			OverScrollMode = Carousel.IsBounceEnabled ? OverScrollMode.Always : OverScrollMode.Never;
+		}
+
+		void UpdatePeekAreaInsets()
+		{
+			UpdateAdapter();
+		}
+
+		void UpdateAdapter()
+		{
+			// By default the CollectionViewAdapter creates the items at whatever size the template calls for
+			// But for the Carousel, we want it to create the items to fit the width/height of the viewport
+			// So we give it an alternate delegate for creating the views
+
+			var oldItemViewAdapter = ItemsViewAdapter;
+
+			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView,
+				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
+
+			SwapAdapter(ItemsViewAdapter, false);
+
+			oldItemViewAdapter?.Dispose();
 		}
 
 		void UpdatePositionFromScroll()


### PR DESCRIPTION
### Description of Change ###

The value of **PeekAreaInsets** was set correctly initially. However, in case of any change in the value of the property, the UI was not updated. This PR fixes the issue.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
Dynamically changing PeekAreaInsets property must update the UI.

### Before/After Screenshots ### 

#### Before
![before-peek](https://user-images.githubusercontent.com/6755973/64267949-9024ea00-cf37-11e9-8c6f-3fd38340f5fd.gif)

#### After
![fix-peek1](https://user-images.githubusercontent.com/6755973/64267081-0c1e3280-cf36-11e9-99d4-6a47c867dde8.gif)

### Testing Procedure ###
Open Core Gallery Sample and change dynamically the PeekAreaInsets in some of the available CarouselView samples.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard