### PR TITLE
Implement Move, Replace, and Reset for UWP CollectionView changes

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -104,12 +104,17 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			var itemTemplate = Element.ItemTemplate;
+
+			if (_collectionViewSource != null)
+			{
+				if (_collectionViewSource.Source is ObservableItemTemplateCollection observableItemTemplateCollection)
+				{
+					observableItemTemplateCollection.CleanUp();
+				}
+			}
+
 			if (itemTemplate != null)
 			{
-				// The ItemContentControls need the actual data item and the template so they can inflate the template
-				// and bind the result to the data item.
-				// ItemTemplateEnumerator handles pairing them up for the ItemContentControls to consume
-
 				_collectionViewSource = new CollectionViewSource
 				{
 					Source = TemplatedItemSourceFactory.Create(itemsSource, itemTemplate, Element),
@@ -135,33 +140,9 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 
-			var formsTemplate = Element.ItemTemplate;
-			var itemsControlItemTemplate = ListViewBase.ItemTemplate;
+			ListViewBase.ItemTemplate = Element.ItemTemplate == null ? null : ItemsViewTemplate;
 
-			if (formsTemplate == null)
-			{
-				ListViewBase.ItemTemplate = null;
-
-				if (itemsControlItemTemplate != null)
-				{
-					// We've removed the template; the itemssource should be updated
-					// TODO hartez 2018/06/25 21:25:24 I don't love that changing the template might reset the whole itemssource. We should think about a way to make that unnecessary	
-					UpdateItemsSource();
-				}
-
-				return;
-			}
-
-			// TODO hartez 2018/06/23 13:47:27 Handle DataTemplateSelector case
-			// Actually, DataTemplateExtensions CreateContent might handle the selector for us
-
-			ListViewBase.ItemTemplate = ItemsViewTemplate;
-
-			if (itemsControlItemTemplate == null)
-			{
-				// We're using a data template now, so we'll need to update the itemsource
-				UpdateItemsSource();
-			}
+			UpdateItemsSource();
 		}
 
 		protected virtual void UpdateHeader()

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ObservableItemTemplateCollection.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ObservableItemTemplateCollection.cs
@@ -7,9 +7,10 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	internal class ObservableItemTemplateCollection : ObservableCollection<ItemTemplateContext>
 	{
-		readonly IList _innerSource;
+		readonly IList _itemsSource;
 		readonly DataTemplate _itemTemplate;
 		readonly BindableObject _container;
+		readonly INotifyCollectionChanged _notifyCollectionChanged;
 
 		public ObservableItemTemplateCollection(IList itemsSource, DataTemplate itemTemplate, BindableObject container)
 		{
@@ -18,7 +19,9 @@ namespace Xamarin.Forms.Platform.UWP
 				throw new ArgumentException($"{nameof(itemsSource)} must implement {nameof(INotifyCollectionChanged)}");
 			}
 
-			_innerSource = itemsSource;
+			_notifyCollectionChanged = notifyCollectionChanged;
+
+			_itemsSource = itemsSource;
 			_itemTemplate = itemTemplate;
 			_container = container;
 			for (int n = 0; n < itemsSource.Count; n++)
@@ -26,25 +29,32 @@ namespace Xamarin.Forms.Platform.UWP
 				Add(new ItemTemplateContext (itemTemplate, itemsSource[n], container));
 			}
 
-			notifyCollectionChanged.CollectionChanged += InnerCollectionChanged;
+			_notifyCollectionChanged.CollectionChanged += InnerCollectionChanged;
+		}
+
+		public void CleanUp()
+		{
+			_notifyCollectionChanged.CollectionChanged -= InnerCollectionChanged;
 		}
 
 		void InnerCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
-			// TODO hartez 2018/07/31 16:02:50 Handle the rest of these cases 
 			switch (args.Action)
 			{
 				case NotifyCollectionChangedAction.Add:
 					Add(args);
 					break;
 				case NotifyCollectionChangedAction.Move:
+					Move(args);
 					break;
 				case NotifyCollectionChangedAction.Remove:
 					Remove(args);
 					break;
 				case NotifyCollectionChangedAction.Replace:
+					Replace(args);
 					break;
 				case NotifyCollectionChangedAction.Reset:
+					Reset();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();
@@ -53,24 +63,90 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			// TODO hartez 2018-07-31 01:47 PM Figure out what scenarios might cause a NewStartingIndex of -1
-			// I'm worried that the IndexOf lookup could cause problems when the list has duplicate items
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _innerSource.IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 
-			for (int n = args.NewItems.Count - 1; n >= 0; n--)
+			var count = args.NewItems.Count;
+
+			for(int n = 0; n < count; n++)
 			{
 				Insert(startIndex, new ItemTemplateContext(_itemTemplate, args.NewItems[n], _container));
 			}
 		}
 
+		void Move(NotifyCollectionChangedEventArgs args)
+		{
+			var count = args.NewItems.Count;
+
+			if (args.OldStartingIndex > args.NewStartingIndex)
+			{
+				for (int n = 0; n < count; n++)
+				{
+					Move(args.OldStartingIndex + n, args.NewStartingIndex + n);
+				}
+
+				return;
+			}
+
+			for(int n = count - 1; n >= 0; n--)
+			{
+				Move(args.OldStartingIndex + n, args.NewStartingIndex + n);
+			}
+		}
+
 		void Remove(NotifyCollectionChangedEventArgs args)
 		{
-			var startIndex = args.OldStartingIndex > -1 ? args.OldStartingIndex : _innerSource.IndexOf(args.OldItems[0]);
+			var startIndex = args.OldStartingIndex;
 
-			for (int n = 0; n < args.OldItems.Count; n++)
+			if (startIndex < 0)
 			{
-				RemoveAt(startIndex);
+				// INCC implementation isn't giving us enough information to know where the removed items were in the
+				// collection. So the best we can do is a full Reset.
+				Reset();
+				return;
 			}
+
+			var count = args.OldItems.Count;
+
+			for(int n = startIndex + count - 1; n >= startIndex; n--)
+			{
+				RemoveAt(n);
+			}
+		}
+
+		void Replace(NotifyCollectionChangedEventArgs args)
+		{
+			var newItemCount = args.NewItems.Count;
+
+			if (newItemCount == args.OldItems.Count)
+			{
+				for (int n = 0; n < newItemCount; n++)
+				{
+					var index = args.OldStartingIndex + n;
+					var oldItem = this[index];
+					var newItem = new ItemTemplateContext(_itemTemplate, args.NewItems[n], _container);
+					Items[index] = newItem;
+					var update = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Replace, newItem, oldItem, index);
+					OnCollectionChanged(update);
+				}
+			}
+			else
+			{
+				// If we're replacing one set with an equal size set, we can do a soft reset; if not, we have to completely
+				// rebuild the collection
+				Reset();
+			}
+		}
+
+		void Reset()
+		{
+			Items.Clear();
+			for (int n = 0; n < _itemsSource.Count; n++)
+			{
+				Items.Add(new ItemTemplateContext(_itemTemplate, _itemsSource[n], _container));
+			}
+
+			var reset = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
+			OnCollectionChanged(reset);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Makes the CollectionView on UWP responsive to INotifyCollectionChanged Reset, Replace, and Move events; also fixes some issues with Add and Remove handling.

### Issues Resolved ### 

- partially implements #3172

### API Changes ###
None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Control Gallery, CollectionView Gallery -> ObservableCollection Galleries -> [all]

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
- [x] Form 27B/6 completed