### PR TITLE
Reset transformation properly on UWP (#7385)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7385.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7385.cs
@@ -1,0 +1,39 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7385, "[Bug] [UWP] Resetting Translation/Rotation does nothing", PlatformAffected.UWP)]
+	public class Issue7385 : TestContentPage
+	{
+		View _box;
+
+		protected override void Init()
+		{
+			_box = new BoxView
+			{
+				WidthRequest = 50,
+				HeightRequest = 50,
+				HorizontalOptions = LayoutOptions.Start,
+				VerticalOptions = LayoutOptions.Start,
+				BackgroundColor = Color.Red
+			};
+
+			var button1 = new Button { Text = "Set TranslationX/Y to 30,20", Command = new Command(() => MoveBox(30, 20)) };
+			var button2 = new Button { Text = "Set TranslationX to 0", Command = new Command(() => MoveBox(x: 0)) };
+			var button3 = new Button { Text = "Set TranslationY to 0", Command = new Command(() => MoveBox(y: 0)) };
+
+			Content = new StackLayout { Children = { new StackLayout { HeightRequest = 200, Children = { _box } }, new StackLayout { Orientation = StackOrientation.Horizontal, Children = { button1, button2, button3 } } } };
+		}
+
+		private void MoveBox(double? x = null, double? y = null)
+		{
+			if (x != null)
+				_box.TranslationX = x.Value;
+
+			if (y != null)
+				_box.TranslationY = y.Value;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -30,6 +30,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7385.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -533,6 +533,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (rotationX % 360 == 0 && rotationY % 360 == 0 && rotation % 360 == 0 && translationX == 0 && translationY == 0 && scaleX == 1 && scaleY == 1)
 			{
 				frameworkElement.Projection = null;
+				frameworkElement.RenderTransform = null;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

When all translations/rotations/scaling is set to zero on a VisualElement, the RenderTransform of the element is set to null. 

### Issues Resolved ### 

- fixes #7385 

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before fix, clicking the 3 buttons in succession:
![ApplicationFrameHost_2019-09-04_15-40-41](https://user-images.githubusercontent.com/650710/64292239-88f9de00-cf2f-11e9-8936-f9bc08b0a144.png)

After fix:
![ApplicationFrameHost_2019-09-04_16-13-06](https://user-images.githubusercontent.com/650710/64291994-01ac6a80-cf2f-11e9-9d6e-04dd31813ac9.png)

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard

No UI test added (don't know how to do that), but test case showing the issue was added as part of this PR
