### PR TITLE
[RefreshView] Fire RefreshCommand setting IsRefreshing

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
@@ -27,7 +27,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Title = "Refresh View Tests";
 			var scrollViewContent =
-				new StackLayout();
+				new StackLayout()
+				{
+					AutomationId = "LayoutContainer"
+				};
 
 			Enumerable.Range(0, 1000).Select(_ => new Label() { Text = "Pull me down to refresh me" })
 				.ForEach(x => scrollViewContent.Children.Add(x));
@@ -74,6 +77,17 @@ namespace Xamarin.Forms.Controls.Issues
 		public void IsRefreshingAndCommandTest()
 		{
 			RunningApp.Tap(q => q.Button("Toggle Refresh"));
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: True"));
+			RunningApp.Screenshot("Refreshing");
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
+			RunningApp.Screenshot("Refreshed");
+		}
+
+		[Test]
+		public void IsRefreshingAndCommandTest_SwipeDown()
+		{
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
+			RunningApp.ScrollDown("LayoutContainer", ScrollStrategy.Gesture);
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: True"));
 			RunningApp.Screenshot("Refreshing");
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
@@ -29,7 +29,6 @@ namespace Xamarin.Forms.Controls.Issues
 			var scrollViewContent =
 				new StackLayout()
 				{
-					AutomationId = "LayoutContainer"
 				};
 
 			Enumerable.Range(0, 1000).Select(_ => new Label() { Text = "Pull me down to refresh me" })
@@ -41,7 +40,8 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					HeightRequest = 2000,
 					BackgroundColor = Color.Green,
-					Content = scrollViewContent
+					Content = scrollViewContent,
+					AutomationId = "LayoutContainer"
 				},
 				Command = new Command(async () =>
 				{
@@ -87,7 +87,11 @@ namespace Xamarin.Forms.Controls.Issues
 		public void IsRefreshingAndCommandTest_SwipeDown()
 		{
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
-			RunningApp.ScrollDown("LayoutContainer", ScrollStrategy.Gesture);
+
+			var container = RunningApp.WaitForElement("LayoutContainer")[0];
+
+			RunningApp.Pan(new Drag(container.Rect, Drag.Direction.TopToBottom, Drag.DragLength.Medium));
+
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: True"));
 			RunningApp.Screenshot("Refreshing");
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 				};
 
-			Enumerable.Range(0, 1000).Select(_ => new Label() { Text = "Pull me down to refresh me" })
+			Enumerable.Range(0, 10).Select(_ => new Label() { HeightRequest = 200, Text = "Pull me down to refresh me" })
 				.ForEach(x => scrollViewContent.Children.Add(x));
 
 			_refreshView = new RefreshView()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
@@ -69,5 +69,16 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 		}
+#if UITEST
+		[Test]
+		public void IsRefreshingAndCommandTest()
+		{
+			RunningApp.Tap(q => q.Button("Toggle Refresh"));
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: True"));
+			RunningApp.Screenshot("Refreshing");
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
+			RunningApp.Screenshot("Refreshed");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1061,6 +1061,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7525.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7582.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1061,7 +1061,6 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7525.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7582.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -56,6 +56,5 @@
 		public const string Page = "Page";
 		public const string RefreshView = "RefreshView";
 		public const string TitleView = "TitleView";
-		public const string RefreshView = "RefreshView";
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -56,5 +56,6 @@
 		public const string Page = "Page";
 		public const string RefreshView = "RefreshView";
 		public const string TitleView = "TitleView";
+		public const string RefreshView = "RefreshView";
 	}
 }

--- a/Xamarin.Forms.Core/RefreshView.cs
+++ b/Xamarin.Forms.Core/RefreshView.cs
@@ -20,12 +20,18 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly BindableProperty IsRefreshingProperty =
-			BindableProperty.Create(nameof(IsRefreshing), typeof(bool), typeof(RefreshView), false);
+			BindableProperty.Create(nameof(IsRefreshing), typeof(bool), typeof(RefreshView), false, BindingMode.TwoWay);
 
 		public bool IsRefreshing
 		{
 			get { return (bool)GetValue(IsRefreshingProperty); }
-			set { SetValue(IsRefreshingProperty, value); }
+			set
+			{
+				if ((bool)GetValue(IsRefreshingProperty) == value)
+					OnPropertyChanged(nameof(IsRefreshing));
+
+				SetValue(IsRefreshingProperty, value);
+			}
 		}
 
 		public static readonly BindableProperty CommandProperty =

--- a/Xamarin.Forms.Core/RefreshView.cs
+++ b/Xamarin.Forms.Core/RefreshView.cs
@@ -25,13 +25,7 @@ namespace Xamarin.Forms
 		public bool IsRefreshing
 		{
 			get { return (bool)GetValue(IsRefreshingProperty); }
-			set
-			{
-				if ((bool)GetValue(IsRefreshingProperty) == value)
-					OnPropertyChanged(nameof(IsRefreshing));
-
-				SetValue(IsRefreshingProperty, value);
-			}
+			set { SetValue(IsRefreshingProperty, value); }
 		}
 
 		public static readonly BindableProperty CommandProperty =

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -54,10 +54,10 @@ namespace Xamarin.Forms.Platform.Android
 				if (RefreshView != null && RefreshView.IsRefreshing != _refreshing)
 					RefreshView.IsRefreshing = _refreshing;
 
-				if (base.Refreshing == _refreshing)
-					return;
-
 				base.Refreshing = _refreshing;
+
+				if (base.Refreshing && Element is RefreshView refreshView && refreshView.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
+					refreshView.Command.Execute(refreshView?.CommandParameter);
 			}
 		}
 
@@ -186,10 +186,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void OnRefresh()
 		{
-			if (RefreshView?.Command?.CanExecute(RefreshView?.CommandParameter) ?? false)
-			{
-				RefreshView.Command.Execute(RefreshView?.CommandParameter);
-			}
+			Refreshing = true;
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -22,8 +22,16 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_isRefreshing = value;
 
+				if (Element != null && Element.IsRefreshing != _isRefreshing)
+					Element.IsRefreshing = _isRefreshing;
+
 				if (_isRefreshing)
+				{
 					_refreshControl.BeginRefreshing();
+
+					if (Element is RefreshView refreshView && refreshView.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
+						refreshView.Command.Execute(refreshView?.CommandParameter);
+				}
 				else
 					_refreshControl.EndRefreshing();
 
@@ -201,10 +209,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnRefresh(object sender, EventArgs e)
 		{
-			if (Element?.Command?.CanExecute(Element?.CommandParameter) ?? false)
-			{
-				Element.Command.Execute(Element?.CommandParameter);
-			}
+			IsRefreshing = true;
 		}
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)


### PR DESCRIPTION
### Description of Change ###

Fixes some issues:
- RefreshCommand doesn't fire if you set IsRefreshing.
- Setting IsRefreshing to False inside RefreshCommand doesn't do anything.

### Issues Resolved ### 

- fixes #7388

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

Setting IsRefreshing to true will execute RefreshCommand (if it exists).

### Before/After Screenshots ### 

#### Before
![refresh-droid-before](https://user-images.githubusercontent.com/6755973/64342551-0df5fd80-cfeb-11e9-8a1a-60a56fe91655.gif)
(Same behavior on iOS).

#### After
![ios-refresh-after](https://user-images.githubusercontent.com/6755973/64342441-ccfde900-cfea-11e9-99ac-b6bf5a677fae.gif)
![refresh-droid-after](https://user-images.githubusercontent.com/6755973/64342449-ce2f1600-cfea-11e9-9daa-507169b601b8.gif)

### Testing Procedure ###
Open Core Gallery and navigate to the Test Cases. Search by "Refresh" and open the RefreshView Tests. Pressing the "Toggle Refresh" button or pulling to refresh must change the IsRefreshing property value.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard