### PR TITLE
[Android] Leave BindingContext intact when recycling TemplatedItemViewHolder

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6889.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6889.cs
@@ -1,0 +1,356 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6889, "Labels disappearing in CollectionView", PlatformAffected.Android)]
+	public class Issue6889 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			PushAsync(CreateRoot());
+#endif
+		}
+
+		public ContentPage CreateRoot()
+		{
+			var page = new ContentPage { Title = "Issue6889" };
+
+			var layout = new StackLayout();
+
+			var instructions = new Label { Text = "Scroll the CollectionView below up and down quickly several times." 
+				+ " If any rows of labels disappear, this test has failed" };
+
+			layout.Children.Add(instructions);
+
+			var cv = new CollectionView();
+
+			var template = new DataTemplate(() => {
+				var grid = new Grid
+				{
+					ColumnDefinitions = new ColumnDefinitionCollection
+					{
+						new ColumnDefinition { Width = GridLength.Auto },
+						new ColumnDefinition { Width = GridLength.Auto }
+					}
+				};
+
+				var label1 = new Label { HorizontalOptions = LayoutOptions.Start };
+				label1.SetBinding(Label.TextProperty, new Binding("Text1"));
+				grid.Children.Add(label1);
+				Grid.SetColumn(label1, 0);
+
+				var label2 = new Label { HorizontalOptions = LayoutOptions.StartAndExpand };
+				label2.SetBinding(Label.TextProperty, new Binding("Text2"));
+				grid.Children.Add(label2);
+				Grid.SetColumn(label2, 1);
+
+				return grid;
+			});
+
+			cv.ItemTemplate = template;
+			cv.SetBinding(ItemsView.ItemsSourceProperty, new Binding("SampleList"));
+
+			layout.Children.Add(cv);
+
+			page.Content = layout;
+
+			page.BindingContext = new _6889MainViewModel();
+
+			return page;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class _6889TextModel
+	{
+		public string Text1 { get; set; }
+		public string Text2 { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class _6889MainViewModel
+	{
+		public _6889MainViewModel()
+		{
+			SampleList = new ObservableCollection<_6889TextModel>
+			{
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+				new _6889TextModel { Text1="Text1",Text2="Text2"},
+			};
+		}
+
+		public ObservableCollection<_6889TextModel> SampleList { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6889.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6945.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7240.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -34,7 +34,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void Recycle(ItemsView itemsView)
 		{
-			View.BindingContext = null;
 			itemsView.RemoveLogicalChild(View);
 		}
 
@@ -51,7 +50,7 @@ namespace Xamarin.Forms.Platform.Android
 				_selectedTemplate = template;
 			}
 
-			_itemContentView.HandleItemSizingStrategy(reportMeasure, size); 
+			_itemContentView.HandleItemSizingStrategy(reportMeasure, size);
 
 			// Set the binding context before we add it as a child of the ItemsView; otherwise, it will
 			// inherit the ItemsView's binding context


### PR DESCRIPTION
### Description of Change ###

TemplatedItemViewHolder is setting the BindingContext of its View to `null` when recycling. This causes the template to update and invalidate, which hurts performance and leads to a race condition with measurement where the layout is measured as if it had empty string content and then laid out incorrectly. (For fast Label renderers; for the legacy Label renderers, the layout eventually displays correctly, but the control flashes blank briefly first).

This change eliminates the unnecessary re-binding to `null` and avoids the race condition.

### Issues Resolved ### 

- fixes #6889

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Manual test 6889 in Control Gallery

### PR Checklist ###

- [ ] Has automated tests 
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
