### PR TITLE
[iOS] If ListView is disposed before callback happens, return early

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7371.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7371.cs
@@ -1,0 +1,44 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ListView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7371, "iOS race condition(or not checking for null) of refreshing(offset animation) causes NullReferenceException", PlatformAffected.iOS)]
+	public class Issue7371 : TestContentPage
+	{
+		ListView ListView => Content as ListView;
+		protected override void Init()
+		{
+			Content = new ListView();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			ListView.IsRefreshing = true;
+
+			Application.Current.MainPage = new ContentPage() { Content = new Label { Text = "Success" } };
+
+			ListView.IsRefreshing = false;
+		}
+
+#if UITEST
+		[Test]
+		public void RefreshingListViewCrashesWhenDisposedTest()
+		{
+			RunningApp.WaitForElement(q => q.Marked("Success"));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7371.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7371.cs
@@ -1,5 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -35,8 +36,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void RefreshingListViewCrashesWhenDisposedTest()
+		public async Task RefreshingListViewCrashesWhenDisposedTest()
 		{
+			await Task.Delay(500);
 			RunningApp.WaitForElement(q => q.Marked("Success"));
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7371.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7371.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			ListView.IsRefreshing = true;
 
-			Application.Current.MainPage = new ContentPage() { Content = new Label { Text = "Success" } };
+			Application.Current.MainPage = new ContentPage() { Content = new Label { Text = "Success", VerticalOptions = LayoutOptions.Center } };
 
 			ListView.IsRefreshing = false;
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -546,6 +546,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla39853.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)MultipleClipToBounds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6994.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7371.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1488,6 +1488,9 @@ namespace Xamarin.Forms.Platform.iOS
 					//This also forces the spinner color to be correct if we started refreshing immediately after changing it.
 					UpdateContentOffset(TableView.ContentOffset.Y - _refresh.Frame.Height, () =>
 					{
+						if (_refresh == null)
+							return;
+
 						_refresh.BeginRefreshing();
 						//hack: when we don't have cells in our UITableView the spinner fails to appear
 						CheckContentSize();


### PR DESCRIPTION
### Description of Change ###

If ListView is disposed before callback happens, return early.

Callback was added as part of #6473.

### Issues Resolved ### 

- fixes #7371

### API Changes ###

 None

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Automated test provided: G7371. If you just see a Success screen and no crash, it passed!

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
