### PR TITLE
Dispose of HttpResponseMessage after stream is used

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -648,15 +648,18 @@ namespace Xamarin.Forms
 
 			public async Task<Stream> GetStreamAsync(Uri uri, CancellationToken cancellationToken)
 			{
-				using (var client = new HttpClient())
-				using (HttpResponseMessage response = await client.GetAsync(uri, cancellationToken))
+				using (var client = new HttpClient())				
 				{
+					HttpResponseMessage response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
 					if (!response.IsSuccessStatusCode)
 					{
 						Internals.Log.Warning("HTTP Request", $"Could not retrieve {uri}, status code {response.StatusCode}");
 						return null;
 					}
-					return await response.Content.ReadAsStreamAsync();
+
+					// the HttpResponseMessage needs to be disposed of after the calling code is done with the stream 
+					// otherwise the stream may get disposed before the caller can use it
+					return new StreamWrapper(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), response);					
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/StreamWrapper.cs
+++ b/Xamarin.Forms.Platform.Android/StreamWrapper.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Forms
 {
 	internal class StreamWrapper : Stream
 	{
-		readonly Stream _wrapped;
-		readonly IDisposable _additionalDisposable;
+		Stream _wrapped;
+		IDisposable _additionalDisposable;
 
 		public StreamWrapper(Stream wrapped, IDisposable additionalDisposable)
 		{
@@ -43,8 +43,6 @@ namespace Xamarin.Forms
 			set { _wrapped.Position = value; }
 		}
 
-		public event EventHandler Disposed;
-
 		public override void Flush()
 		{
 			_wrapped.Flush();
@@ -73,8 +71,10 @@ namespace Xamarin.Forms
 		protected override void Dispose(bool disposing)
 		{
 			_wrapped.Dispose();
+
 			_additionalDisposable?.Dispose();
-			Disposed?.Invoke(this, EventArgs.Empty);
+			_additionalDisposable = null;
+
 			base.Dispose(disposing);
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/StreamWrapper.cs
+++ b/Xamarin.Forms.Platform.Android/StreamWrapper.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.IO;
+
+namespace Xamarin.Forms
+{
+	internal class StreamWrapper : Stream
+	{
+		readonly Stream _wrapped;
+		readonly IDisposable _additionalDisposable;
+
+		public StreamWrapper(Stream wrapped, IDisposable additionalDisposable)
+		{
+			if (wrapped == null)
+				throw new ArgumentNullException("wrapped");
+
+			_wrapped = wrapped;
+			_additionalDisposable = additionalDisposable;
+		}
+
+		public override bool CanRead
+		{
+			get { return _wrapped.CanRead; }
+		}
+
+		public override bool CanSeek
+		{
+			get { return _wrapped.CanSeek; }
+		}
+
+		public override bool CanWrite
+		{
+			get { return _wrapped.CanWrite; }
+		}
+
+		public override long Length
+		{
+			get { return _wrapped.Length; }
+		}
+
+		public override long Position
+		{
+			get { return _wrapped.Position; }
+			set { _wrapped.Position = value; }
+		}
+
+		public event EventHandler Disposed;
+
+		public override void Flush()
+		{
+			_wrapped.Flush();
+		}
+
+		public override int Read(byte[] buffer, int offset, int count)
+		{
+			return _wrapped.Read(buffer, offset, count);
+		}
+
+		public override long Seek(long offset, SeekOrigin origin)
+		{
+			return _wrapped.Seek(offset, origin);
+		}
+
+		public override void SetLength(long value)
+		{
+			_wrapped.SetLength(value);
+		}
+
+		public override void Write(byte[] buffer, int offset, int count)
+		{
+			_wrapped.Write(buffer, offset, count);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_wrapped.Dispose();
+			_additionalDisposable?.Dispose();
+			Disposed?.Invoke(this, EventArgs.Empty);
+			base.Dispose(disposing);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -244,6 +244,7 @@
     <Compile Include="Renderers\ViewCellExtensions.cs" />
     <Compile Include="Renderers\ViewGroupExtensions.cs" />
     <AndroidResource Include="Resources\Layout\RootLayout.axml" />
+    <Compile Include="StreamWrapper.cs" />
     <Compile Include="TapGestureHandler.cs" />
     <Compile Include="TextColorSwitcher.cs" />
     <Compile Include="ViewInitializedEventArgs.cs" />


### PR DESCRIPTION
### Description of Change ###

It appears that a race condition with how fast the stream is returned from HttpResponse leads to an image from a stream sometimes being loaded and then sometimes not

The Dispose on HttpContent class will only dispose of the returned stream if the status on the task returned from *ReadAsStreamAsync* is *RantoCompletion*

https://github.com/dotnet/corefx/blob/d3911035f2ba3eb5c44310342cc1d654e42aa316/src/System.Net.Http/src/System/Net/Http/HttpContent.cs#L540

So I think in some cases the stream will run to completion before the dispose is called and in other cases it won't

The call to ReadAsStreamAsync returns an invoked task. It doesn't start reading once awaited

I tried moving the await after the dispose explicitly

```C#
using (var client = new HttpClient())
                using (HttpResponseMessage response = await client.GetAsync(uri, cancellationToken))
                {
                    if (!response.IsSuccessStatusCode)
                    {
                        Internals.Log.Warning("HTTP Request", $"Could not retrieve {uri}, status code {response.StatusCode}");
                        return null;
                    }
                    returnValue = response.Content.ReadAsStreamAsync();
                }

                return await returnValue;
```

to see if that would keep it around but it doesn't

We could just not dispose of *HttpResponseMessage* and in theory it would be fine because the GC will eventually dispose of it but since it might be holding on to a large byte array I'd rather it get disposed of quickly. Which is why the solution is a bit more than just not disposing of *HttpResponseMessage*

I also opted out of using the Disposed event on StreamWrapper because I don't want to create a closure 

### Issues Resolved ### 
- fixes #7248 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- UI tests have a few scenarios that use URLs though it seems like it's hit or miss if those catch this one
- the original issue has a few scenarios you can test as well

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
