### PR TITLE
Apply fading effect on DetailPage for MasterDetailPage on iOS

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageiOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/MasterDetailPageiOS.cs
@@ -18,7 +18,13 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 				Title = "This is the detail page's Title",
 				Padding = new Thickness(0,20,0,0)
 			};
-			
+
+			void ToggleApplyShadow()
+			{
+				On<iOS>().SetApplyShadow(!On<iOS>().GetApplyShadow());
+				IsPresented = false;
+			}
+
 			var navItems = new List<NavItem>
 			{
 				new NavItem("Display Alert", "\uE171", new Command(() => DisplayAlert("Alert", "This is an alert", "OK"))),
@@ -27,6 +33,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
 				new NavItem("Audio", "\uE189", new Command(() => DisplayAlert("Audio", "Never gonna give you up...", "OK"))),
 				new NavItem("Set Detail to Navigation Page", "\uE16F", new Command(() => Detail = CreateNavigationPage())),
 				new NavItem("Set Detail to Content Page", "\uE160", new Command(() => Detail = detail)),
+				new NavItem("Toggle Apply Shadow", "\u2728", new Command(ToggleApplyShadow))
 			};
 
 			var navList = new NavList(navItems);

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/MasterDetailPage.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/MasterDetailPage.cs
@@ -1,0 +1,33 @@
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Forms.MasterDetailPage;
+
+	public static class MasterDetailPage
+	{
+		#region ApplyShadow
+		public static readonly BindableProperty ApplyShadowProperty = BindableProperty.Create("ApplyShadow", typeof(bool), typeof(MasterDetailPage), false);
+
+		public static bool GetApplyShadow(BindableObject element)
+		{
+			return (bool)element.GetValue(ApplyShadowProperty);
+		}
+
+		public static void SetApplyShadow(BindableObject element, bool value)
+		{
+			element.SetValue(ApplyShadowProperty, value);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetApplyShadow(this IPlatformElementConfiguration<iOS, FormsElement> config, bool value)
+		{
+			SetApplyShadow(config.Element, value);
+			return config;
+		}
+
+		public static bool GetApplyShadow(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetApplyShadow(config.Element);
+		}
+		#endregion
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -242,7 +242,10 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var frame = Element.Bounds.ToRectangleF();
 			var masterFrame = frame;
+			nfloat opacity = 1;
 			masterFrame.Width = (int)(Math.Min(masterFrame.Width, masterFrame.Height) * 0.8);
+			var detailView = Platform.GetRenderer(MasterDetailPage.Detail).ViewController.View;
+			detailView.Superview.BackgroundColor = Xamarin.Forms.Color.Black.ToUIColor();
 
 			var isRTL = (Element as IVisualElementController)?.EffectiveFlowDirection.IsRightToLeft() == true;
 			if (isRTL)
@@ -254,7 +257,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var target = frame;
 			if (Presented)
+			{
 				target.X += masterFrame.Width;
+				opacity = 0.5f;
+			}
 
 			if (isRTL)
 			{
@@ -266,12 +272,16 @@ namespace Xamarin.Forms.Platform.iOS
 				UIView.BeginAnimations("Flyout");
 				var view = _detailController.View;
 				view.Frame = target;
+				detailView.Layer.Opacity = (float)opacity;
 				UIView.SetAnimationCurve(UIViewAnimationCurve.EaseOut);
 				UIView.SetAnimationDuration(250);
 				UIView.CommitAnimations();
 			}
 			else
+			{
 				_detailController.View.Frame = target;
+				detailView.Layer.Opacity = (float)opacity;
+			}
 
 			MasterDetailPage.MasterBounds = new Rectangle(masterFrame.X, 0, masterFrame.Width, masterFrame.Height);
 			MasterDetailPage.DetailBounds = new Rectangle(0, 0, frame.Width, frame.Height);
@@ -423,6 +433,8 @@ namespace Xamarin.Forms.Platform.iOS
 							targetFrame.X = (nfloat)Math.Min(_masterController.View.Frame.Width, Math.Max(0, motion));
 
 						targetFrame.X = targetFrame.X * directionModifier;
+						var openProgress = targetFrame.X / _masterController.View.Frame.Width;
+						ApplyDetailShadow((nfloat)openProgress);
 
 						detailView.Frame = targetFrame;
 						break;
@@ -475,6 +487,14 @@ namespace Xamarin.Forms.Platform.iOS
 		void IEffectControlProvider.RegisterEffect(Effect effect)
 		{
 			VisualElementRenderer<VisualElement>.RegisterEffect(effect, View);
+		}
+
+		void ApplyDetailShadow(nfloat percent)
+		{
+			var detailView = Platform.GetRenderer(MasterDetailPage.Detail).ViewController.View;
+			detailView.Superview.BackgroundColor = Xamarin.Forms.Color.Black.ToUIColor();
+			var opacity = (nfloat)(0.5 + (0.5 * (1 - percent)));
+			detailView.Layer.Opacity = (float)opacity;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -245,7 +245,6 @@ namespace Xamarin.Forms.Platform.iOS
 			nfloat opacity = 1;
 			masterFrame.Width = (int)(Math.Min(masterFrame.Width, masterFrame.Height) * 0.8);
 			var detailView = Platform.GetRenderer(MasterDetailPage.Detail).ViewController.View;
-			detailView.Superview.BackgroundColor = Xamarin.Forms.Color.Black.ToUIColor();
 
 			var isRTL = (Element as IVisualElementController)?.EffectiveFlowDirection.IsRightToLeft() == true;
 			if (isRTL)
@@ -352,6 +351,8 @@ namespace Xamarin.Forms.Platform.iOS
 			SetNeedsStatusBarAppearanceUpdate();
 			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
+
+			detailRenderer.ViewController.View.Superview.BackgroundColor = Xamarin.Forms.Color.Black.ToUIColor();
 		}
 
 		void UpdateLeftBarButton()
@@ -492,7 +493,6 @@ namespace Xamarin.Forms.Platform.iOS
 		void ApplyDetailShadow(nfloat percent)
 		{
 			var detailView = Platform.GetRenderer(MasterDetailPage.Detail).ViewController.View;
-			detailView.Superview.BackgroundColor = Xamarin.Forms.Color.Black.ToUIColor();
 			var opacity = (nfloat)(0.5 + (0.5 * (1 - percent)));
 			detailView.Layer.Opacity = (float)opacity;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Platform.iOS
 		UIGestureRecognizer _tapGesture;
 
 		VisualElementTracker _tracker;
+		bool _applyShadow;
 
 		Page Page => Element as Page;
 
@@ -236,6 +237,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateBackground();
 			else if (e.PropertyName == Page.BackgroundImageSourceProperty.PropertyName)
 				UpdateBackground();
+			else if (e.PropertyName == PlatformConfiguration.iOSSpecific.MasterDetailPage.ApplyShadowProperty.PropertyName)
+				UpdateApplyShadow(((MasterDetailPage)Element).OnThisPlatform().GetApplyShadow());
 		}
 
 		void LayoutChildren(bool animated)
@@ -258,7 +261,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Presented)
 			{
 				target.X += masterFrame.Width;
-				opacity = 0.5f;
+				if (_applyShadow)
+					opacity = 0.5f;
 			}
 
 			if (isRTL)
@@ -368,6 +372,11 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationRenderer.SetMasterLeftBarButton(firstPage, masterDetailPage);
 		}
 
+		void UpdateApplyShadow(bool value)
+		{
+			_applyShadow = value;
+		}
+
 		public override UIViewController ChildViewControllerForStatusBarHidden()
 		{
 			if (((MasterDetailPage)Element).Detail != null)
@@ -434,8 +443,11 @@ namespace Xamarin.Forms.Platform.iOS
 							targetFrame.X = (nfloat)Math.Min(_masterController.View.Frame.Width, Math.Max(0, motion));
 
 						targetFrame.X = targetFrame.X * directionModifier;
-						var openProgress = targetFrame.X / _masterController.View.Frame.Width;
-						ApplyDetailShadow((nfloat)openProgress);
+						if (_applyShadow)
+						{
+							var openProgress = targetFrame.X / _masterController.View.Frame.Width;
+							ApplyDetailShadow((nfloat)openProgress);
+						}
 
 						detailView.Frame = targetFrame;
 						break;


### PR DESCRIPTION
### Description of Change ###

Something that bugs me is the fact that iOS's MasterDetailPage doesn't fade the Detail page when opening the Menu. This leads to a bad UX, since both the menu and the detail are shown at the same z-axis level, with no "background feel" applied to the Detail page. 
Android's implementation doesn't suffer from this, **neither does iOS Shell implementation**.

Once I noticed Shell "fixed" this behavior, I wanted to do the same for the MasterDetailPage on Xamarin.Forms for iOS.

So this PR pretty much uses the same logic used in iOS Shell to fade the Detail page when MasterDetail menu is opened.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The visual rendering for MasterDetailPage would change for every Xamarin.Forms application.

I have 2 specific points that I would like to get a review:
* Since this would be a visual breaking change, maybe we could hide this behind a PlatformSpecific?
* If no background color is provided for the detail page, a white background is used, this gives the impression that the detail page is clearing instead of going to the background. Because of this I am forcing a "black fade", this could cause problems if someone is changing the background color of the Detail page for some reason. Should we suggest on documentation that people can put a black background color if they want this behavior? Maybe we can expose a way of customizing this specific color with another property?

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

#### Before
![before](https://user-images.githubusercontent.com/954102/64492507-d1c0d800-d24a-11e9-8365-e56e1c83c397.gif)

#### After
![after](https://user-images.githubusercontent.com/954102/64492508-d5545f00-d24a-11e9-9199-bc0f37f97cf4.gif)

### Testing Procedure ###
Open any MasterDetailPage (like the ControlGallery) and play with the Menu.

Not sure how I could write an automated test for this.

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
