### PR TITLE
[CarouselView] Fix default snap

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselSnapGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselSnapGallery.cs
@@ -1,0 +1,141 @@
+﻿using System;
+using System.Linq;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public class CarouselSnapGallery : ContentPage
+	{
+		public CarouselSnapGallery()
+		{
+			On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Never);
+
+			var viewModel = new CarouselItemsGalleryViewModel();
+
+			Title = $"CarouselView Snap Options";
+
+			var layout = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star }
+				}
+			};
+
+			var snapPointsStack = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var snapPointsLabel = new Label { FontSize = 10, Text = "SnapPointsType:" };
+			var snapPointsTypes = Enum.GetNames(typeof(SnapPointsType)).Select(b => b).ToList();
+
+			var snapPointsTypePicker = new Picker
+			{
+				ItemsSource = snapPointsTypes,
+				SelectedItem = snapPointsTypes[1]
+			};
+
+			snapPointsStack.Children.Add(snapPointsLabel);
+			snapPointsStack.Children.Add(snapPointsTypePicker);
+
+			layout.Children.Add(snapPointsStack, 0, 0);
+
+			var snapPointsAlignmentsStack = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var snapPointsAlignmentsLabel = new Label { FontSize = 10, Text = "SnapPointsAlignment:" };
+			var snapPointsAlignments = Enum.GetNames(typeof(SnapPointsAlignment)).Select(b => b).ToList();
+
+			var snapPointsAlignmentPicker = new Picker
+			{
+				ItemsSource = snapPointsAlignments,
+				SelectedItem = snapPointsAlignments[0]
+			};
+
+			snapPointsAlignmentsStack.Children.Add(snapPointsAlignmentsLabel);
+			snapPointsAlignmentsStack.Children.Add(snapPointsAlignmentPicker);
+
+			layout.Children.Add(snapPointsAlignmentsStack, 0, 1);
+
+			var itemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+			{
+				SnapPointsType = SnapPointsType.Mandatory,
+				SnapPointsAlignment = SnapPointsAlignment.Start
+			};
+
+			var itemTemplate = GetCarouselTemplate();
+
+			var carouselView = new CarouselView
+			{
+				ItemsSource = viewModel.Items,
+				ItemsLayout = itemsLayout,
+				ItemTemplate = itemTemplate,
+				BackgroundColor = Color.LightGray,
+				PeekAreaInsets = new Thickness(0, 0, 300, 0),
+				Margin = new Thickness(12),
+				AutomationId = "TheCarouselView"
+			};
+
+			layout.Children.Add(carouselView, 0, 2);
+
+
+			snapPointsTypePicker.SelectedIndexChanged += (sender, e) =>
+			{
+				if (carouselView.ItemsLayout is LinearItemsLayout linearItemsLayout)
+				{
+					Enum.TryParse(snapPointsTypePicker.SelectedItem.ToString(), out SnapPointsType snapPointsType);
+					linearItemsLayout.SnapPointsType = snapPointsType;
+				}
+			};
+
+			snapPointsAlignmentPicker.SelectedIndexChanged += (sender, e) =>
+			{
+				if (carouselView.ItemsLayout is LinearItemsLayout linearItemsLayout)
+				{
+					Enum.TryParse(snapPointsAlignmentPicker.SelectedItem.ToString(), out SnapPointsAlignment snapPointsAlignment);
+					linearItemsLayout.SnapPointsAlignment = snapPointsAlignment;
+				}
+			};
+
+			Content = layout;
+			BindingContext = viewModel;
+		}
+
+		internal DataTemplate GetCarouselTemplate()
+		{
+			return new DataTemplate(() =>
+			{
+				var grid = new Grid();
+
+				var info = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Margin = new Thickness(6)
+				};
+
+				info.SetBinding(Label.TextProperty, new Binding("Name"));
+
+				grid.Children.Add(info);
+
+				var frame = new Frame
+				{
+					Content = grid,
+					HasShadow = false
+				};
+
+				frame.SetBinding(BackgroundColorProperty, new Binding("Color"));
+
+				return frame;
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 							new CarouselXamlGallery(), Navigation),
 						GalleryBuilder.NavButton("CarouselView (Items)", () =>
 							new CarouselItemsGallery(), Navigation),
+	  					GalleryBuilder.NavButton("CarouselView Snap", () =>
+ 							new CarouselSnapGallery(), Navigation)
 					}
 				}
 			};


### PR DESCRIPTION
### Description of Change ###

If a CarouselView is created with an ItemsLayout without setting the SnapPointsType, the **CarouselView** does not **snap**. The problem is that, the default value of the **SnapPointsType** property is None. This is correct in the CollectionView but not in the CarouselView.

```
<CarouselView 
     Position="0"
     CurrentItem="{Binding CurrentItem, Mode=TwoWay}"
     ItemsSource="{Binding Items}"
     ItemTemplate="{StaticResource ItemTemplate}">
     <CarouselView.ItemsLayout>
          <ListItemsLayout
               Orientation="Horizontal"/>
     </CarouselView.ItemsLayout>
</CarouselView>
```
A new sample is also added in Core Gallery to test the different Snap options.

<img width="539" alt="Captura de pantalla 2019-09-09 a las 11 31 34" src="https://user-images.githubusercontent.com/6755973/64519953-6e3fb480-d2f5-11e9-825e-9724af063bcd.png">

### Issues Resolved ### 

- fixes #7443

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

With this PR, by default, the CarouselView uses a ItemsLayout with horizontal orientation and with snap.

### Before/After Screenshots ### 

### Before
![carousel-snap-issue](https://user-images.githubusercontent.com/6755973/64519690-e9549b00-d2f4-11e9-9169-703130ef0b03.gif)

### After
![expected-carousel-snap](https://user-images.githubusercontent.com/6755973/64519688-e78ad780-d2f4-11e9-88c8-0aa0ddfbde08.gif)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard