### PR TITLE
Fix of #7340 : Fixed Reseting of SelectedItem property to null when BindingContext or ItemsSource changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7340.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7340.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Threading.Tasks;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7340, "Picker sets null to bound property on BindingContext change", PlatformAffected.All)]
+	public class Issue7340 : TestContentPage, System.ComponentModel.INotifyPropertyChanged
+	{
+		//TODO: Someone needs to fix this test. It doesn't get executed and I have no idea how this test setup should be used or works internally.
+
+		const string Success = "Success";
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+		private List<string> _items;
+		public List<string> Items {
+			get
+			{
+				return _items;
+			}
+			set
+			{
+				_items = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(Items)));
+			}
+		}
+		private string _selectedItem;
+		public string SelectedItem
+		{
+			get
+			{
+				return _selectedItem;
+			}
+			set
+			{
+				_selectedItem = value;
+				PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(nameof(SelectedItem)));
+			}
+		}
+
+		protected override void Init()
+		{
+			var picker = new Picker();
+			Items = new List<string>() { "test1", "test2" };
+			SelectedItem = Items.First();
+			picker.SetBinding(Picker.SelectedItemProperty, nameof(SelectedItem));
+			picker.SetBinding(Picker.ItemsSourceProperty, nameof(Items));
+			picker.BindingContext = this;
+
+			if (Items.First() == (string)picker.SelectedItem)
+			{
+				//found this in another test ¯\_(ツ)_/¯
+				var success = new Label { Text = Success };
+				Content= success;
+			}
+		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.Picker)]
+		public void TestSelectedItemNullOnItemSourceChanged()
+		{
+			Assert.AreEqual(Items.First(), SelectedItem);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -25,6 +25,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7340.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellBackButtonBehavior.cs" />

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -184,7 +184,12 @@ namespace Xamarin.Forms
 
 			if (newValue != null) {
 				((LockableObservableListWrapper)Items).IsLocked = true;
-				ResetItems();
+
+				//ResetItems(); // ResetItems can't be used here because it sets the SelectedItem to an Index that is out of date (at the first time -1) because SelectedItem and SelectedIndex can only be valid after the ItemsSource changed.
+
+				((LockableObservableListWrapper)Items).InternalClear();
+				foreach (object item in ItemsSource)
+					((LockableObservableListWrapper)Items).InternalAdd(GetDisplayMember(item));
 			} else {
 				((LockableObservableListWrapper)Items).InternalClear();
 				((LockableObservableListWrapper)Items).IsLocked = false;


### PR DESCRIPTION
### Description of Change ###
Removed the Method Invokation of `ResetItems `from the `OnItemsSourceChanged `Method.

### Issues Resolved ### 
- fixes #7340 
- fixes #1879


### API Changes ###
none

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None - I don't really now if this changes the intended behaviour

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
I tried adding a Unit Test but I couldn't figure out how your Testing System works. Maybe someone can assist and fix the Unit Test?

### PR Checklist ###

- [kinda] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
