### PR TITLE
Setup public and provisionator based provisioning of SDKS

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Environment.txt
+++ b/Xamarin.Forms.ControlGallery.Android/Environment.txt
@@ -1,0 +1,1 @@
+﻿MONO_GC_PARAMS=bridge-implementation=new

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -380,6 +380,9 @@
     </TransformFile>
   </ItemGroup>
   <ItemGroup>
+    <AndroidEnvironment Include="Environment.txt" />
+  </ItemGroup>
+  <ItemGroup>
     <ProguardConfiguration Include="..\.nuspec\proguard.cfg">
       <Link>proguard.cfg</Link>
     </ProguardConfiguration>

--- a/Xamarin.Forms.ControlGallery.Android/_1909CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_1909CustomRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 					var nativeButton = (global::Android.Widget.Button)Control;
 					nativeButton.SetShadowLayer(0, 0, 0, global::Android.Graphics.Color.Transparent);
 
-					nativeButton.Elevation = 0;
+					Platform.Android.ViewExtensions.SetElevation(nativeButton, 0);
 				}
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla43941.cs
@@ -35,10 +35,14 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// At this point, the counter can be any value, but it's most likely not zero.
 			// Invoking GC once is enough to clean up all garbage data and set counter to zero
-			RunningApp.WaitForElement(q => q.Marked("GC"));
-			RunningApp.Tap(q => q.Marked("GC"));
+			RunningApp.WaitForElement("GC");
+			RunningApp.QueryUntilPresent(() =>
+			{
+				RunningApp.Tap("GC");
+				return RunningApp.Query("Counter: 0");
+			});
 
-			RunningApp.WaitForElement(q => q.Marked("Counter: 0"));
+			
 		}
 #endif
 	}

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
+using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 
 namespace Xamarin.Forms.Core.UITests
@@ -36,7 +37,11 @@ namespace Xamarin.Forms.Core.UITests
 
 		bool IsFocused()
 		{
-			var focusedText = App.Query(q => q.Marked("FocusStateLabel").All())[0].ReadText();
+			var focusedText = App.QueryUntilPresent(() =>
+			{
+				return App.Query(q => q.Marked("FocusStateLabel").All());
+			})[0].ReadText();
+
 			return System.Convert.ToBoolean(focusedText);
 		}
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,7 +62,7 @@ jobs:
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
     DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-    nugetVersion: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
+    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
     
 - template: build/steps/build-android.yml
   parameters:
@@ -73,6 +73,8 @@ jobs:
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
+    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 - template: build/steps/build-android.yml
   parameters:
@@ -83,6 +85,8 @@ jobs:
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
+    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 - template: build/steps/build-android.yml
   parameters:
@@ -93,6 +97,8 @@ jobs:
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
+    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 - job: osx
   displayName: OSX Phase
@@ -109,7 +115,8 @@ jobs:
     provisionator.signPath : 'build/provisioning/provisioning_sign.csx'
     buildConfiguration: $(DefaultBuildConfiguration)
     slnPath: $(SolutionFile)
-    nugetVersion: $(NUGET_VERSION)
+    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
     iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
     iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
   steps:
@@ -125,7 +132,7 @@ jobs:
   variables:
     FormsIdAppend: ''
     buildConfiguration: $(DefaultBuildConfiguration)
-    nugetVersion: $(NUGET_VERSION)
+    NUGET_VERSION: $(NUGET_VERSION)
     nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
   steps:
      - template: build/steps/build-nuget.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,7 +18,7 @@ variables:
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: winVmImage
-  value: Hosted Windows 2019 with VS2019
+  value: Hosted VS2017
   
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,9 @@ variables:
   value: true
 - name: winVmImage
   value: Hosted Windows 2019 with VS2019
-
+- name: provisioning
+  value: true
+  
 resources:
   repositories:
     - repository: xamarin-templates

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 - name: NUGET_VERSION
   value: 5.2.0
 - name: DOTNET_VERSION
-  value: 3.0.100
+  value: 2.1.801
 - name: winVmImage
   value: Hosted Windows 2019 with VS2019
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,8 +13,6 @@ variables:
   value: $[counter('$(Build.SourceBranchName)_counter', 1)]
 - name: NUGET_VERSION
   value: 5.0.2
-- name: DOTNET_VERSION
-  value: 2.2.402
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: winVmImage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,12 +11,18 @@ variables:
   value: Xamarin.Forms.sln
 - name: BuildVersion
   value: $[counter('$(Build.SourceBranchName)_counter', 1)]
-- name: MONO_VERSION
-  value: 5_18_1
 - name: XCODE_VERSION
   value: 10.2
 - name: NUGET_VERSION
-  value: 5.0.2
+  value: 5.2.0
+- name: DOTNET_VERSION
+  value: 2.1.801
+- name: winVmImage
+  value: Hosted Windows 2019 with VS2019
+- name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
+  value: true
+- name: provisioning
+  value: false
 
 resources:
   repositories:
@@ -56,6 +62,7 @@ jobs:
     msbuildExtraArguments: '/nowarn:VSX1000 /p:CreateAllAndroidTargets=true /bl:$(Build.ArtifactStagingDirectory)\win.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
+    provisionatorPath : 'build/provisioning/provisioning.csx'
 
 - template: build/steps/build-android.yml
   parameters:
@@ -65,6 +72,7 @@ jobs:
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
+    provisionatorPath : 'build/provisioning/provisioning.csx'
 
 - template: build/steps/build-android.yml
   parameters:
@@ -74,6 +82,7 @@ jobs:
     targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
+    provisionatorPath : 'build/provisioning/provisioning.csx'
 
 - template: build/steps/build-android.yml
   parameters:
@@ -83,6 +92,7 @@ jobs:
     targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
+    provisionatorPath : 'build/provisioning/provisioning.csx'
 
 - job: osx
   displayName: OSX Phase

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,11 +11,9 @@ variables:
   value: Xamarin.Forms.sln
 - name: BuildVersion
   value: $[counter('$(Build.SourceBranchName)_counter', 1)]
-- name: XCODE_VERSION
-  value: 10.2
-- name: NUGET_VERSION
+- name: NUGET_VERSION_DEFAULT
   value: 5.2.0
-- name: DOTNET_VERSION
+- name: DOTNET_VERSION_DEFAULT
   value: 2.1.801
 - name: winVmImage
   value: Hosted Windows 2019 with VS2019
@@ -63,7 +61,9 @@ jobs:
     buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-
+    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+    nugetVersion: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
+    
 - template: build/steps/build-android.yml
   parameters:
     name: android_legacy

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,6 @@ variables:
   value: true
 - name: winVmImage
   value: Hosted Windows 2019 with VS2019
-- name: provisioning
-  value: true
   
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,7 +12,7 @@ variables:
 - name: BuildVersion
   value: $[counter('$(Build.SourceBranchName)_counter', 1)]
 - name: NUGET_VERSION
-  value: 5.2.0
+  value: 5.0.2
 - name: DOTNET_VERSION
   value: 2.1.801
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@ variables:
 - name: NUGET_VERSION
   value: 5.2.0
 - name: DOTNET_VERSION
-  value: 2.1.801
+  value: 3.0.100
 - name: winVmImage
   value: Hosted Windows 2019 with VS2019
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,8 +19,6 @@ variables:
   value: Hosted Windows 2019 with VS2019
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
-- name: provisioning
-  value: false
 
 resources:
   repositories:
@@ -110,7 +108,6 @@ jobs:
       - msbuild
       - Xamarin.iOS
   variables:
-    provisioningOSX : $(provisioning)
     provisionator.osxPath : 'build/provisioning/provisioning.csx'
     provisionator.signPath : 'build/provisioning/provisioning_sign.csx'
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -132,7 +129,7 @@ jobs:
   variables:
     FormsIdAppend: ''
     buildConfiguration: $(DefaultBuildConfiguration)
-    NUGET_VERSION: $(NUGET_VERSION)
+    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
     nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
   steps:
      - template: build/steps/build-nuget.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -14,7 +14,7 @@ variables:
 - name: NUGET_VERSION
   value: 5.0.2
 - name: DOTNET_VERSION
-  value: 2.1.801
+  value: 2.2.402
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: winVmImage

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,10 +15,10 @@ variables:
   value: 5.2.0
 - name: DOTNET_VERSION
   value: 2.1.801
-- name: winVmImage_default
-  value: Hosted Windows 2019 with VS2019
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: winVmImage
+  value: Hosted Windows 2019 with VS2019
 
 resources:
   repositories:
@@ -53,7 +53,7 @@ jobs:
   parameters:
     name: win
     displayName: Build Windows Phase
-    vmImage: ${{ coalesce(variables.winVmImage, variables.winVmImage_default) }}
+    vmImage: $(winVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     msbuildExtraArguments: '/nowarn:VSX1000 /p:CreateAllAndroidTargets=true /bl:$(Build.ArtifactStagingDirectory)\win.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,11 +11,11 @@ variables:
   value: Xamarin.Forms.sln
 - name: BuildVersion
   value: $[counter('$(Build.SourceBranchName)_counter', 1)]
-- name: NUGET_VERSION_DEFAULT
+- name: NUGET_VERSION
   value: 5.2.0
-- name: DOTNET_VERSION_DEFAULT
+- name: DOTNET_VERSION
   value: 2.1.801
-- name: winVmImage
+- name: winVmImage_default
   value: Hosted Windows 2019 with VS2019
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
@@ -53,14 +53,12 @@ jobs:
   parameters:
     name: win
     displayName: Build Windows Phase
-    vmImage: $(winVmImage)
+    vmImage: ${{ coalesce(variables.winVmImage, variables.winVmImage_default) }}
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     msbuildExtraArguments: '/nowarn:VSX1000 /p:CreateAllAndroidTargets=true /bl:$(Build.ArtifactStagingDirectory)\win.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
     
 - template: build/steps/build-android.yml
   parameters:
@@ -71,8 +69,6 @@ jobs:
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 - template: build/steps/build-android.yml
   parameters:
@@ -83,8 +79,6 @@ jobs:
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 - template: build/steps/build-android.yml
   parameters:
@@ -95,8 +89,6 @@ jobs:
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 - job: osx
   displayName: OSX Phase
@@ -112,8 +104,6 @@ jobs:
     provisionator.signPath : 'build/provisioning/provisioning_sign.csx'
     buildConfiguration: $(DefaultBuildConfiguration)
     slnPath: $(SolutionFile)
-    DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
     iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
     iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
   steps:
@@ -129,7 +119,6 @@ jobs:
   variables:
     FormsIdAppend: ''
     buildConfiguration: $(DefaultBuildConfiguration)
-    NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
     nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
   steps:
      - template: build/steps/build-nuget.yml

--- a/build.cake
+++ b/build.cake
@@ -79,7 +79,7 @@ Task("Clean")
 Task("provision-macsdk")
     .Does(async () =>
     {
-        if(!IsRunningOnWindows() && String.IsNullOrWhiteSpace(macSDK))
+        if(!IsRunningOnWindows() && !String.IsNullOrWhiteSpace(macSDK))
         {
             await Boots(macSDK);
         }

--- a/build.cake
+++ b/build.cake
@@ -46,19 +46,19 @@ var nugetversion = Argument<string>("packageVersion", gitVersion.NuGetVersion);
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ?? 
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
-string monoMajorVersion = "6.4.0";
-string monoPatchVersion = "198";
+string monoMajorVersion = "5.8.1";
+string monoPatchVersion = "0";
 string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
-string monoSDK_windows = ""; //$"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = ""; //"https://aka.ms/xamarin-android-commercial-d16-3-windows";
+string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
+string androidSDK_windows = "https://bosstoragemirror.azureedge.net/wrench/monodroid-mavericks-d15-9/9b/9bf5bd5cacf066a9fc0e8a29087beace08642a11/Xamarin.Android.Sdk.9.1.8.0.vsix";
 string iOSSDK_windows = "";
 string macSDK_windows = "";
 
-string androidSDK_macos = ""; //"https://aka.ms/xamarin-android-commercial-d16-3-macos";
-string monoSDK_macos = ""; //$"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = ""; //$"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
-string macSDK_macos = ""; //$"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
+string androidSDK_macos = "https://bosstoragemirror.azureedge.net/wrench/monodroid-mavericks-d15-9/9b/9bf5bd5cacf066a9fc0e8a29087beace08642a11/xamarin.android-9.1.8-0.pkg";
+string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.ios-12.4.0.64.pkg";
+string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build.cake
+++ b/build.cake
@@ -50,15 +50,15 @@ string monoMajorVersion = "6.4.0";
 string monoPatchVersion = "198";
 string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
-string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "https://aka.ms/xamarin-android-commercial-d16-3-windows";
+string monoSDK_windows = ""; //$"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
+string androidSDK_windows = ""; //"https://aka.ms/xamarin-android-commercial-d16-3-windows";
 string iOSSDK_windows = "";
 string macSDK_windows = "";
 
-string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-3-macos";
-string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
-string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
+string androidSDK_macos = ""; //"https://aka.ms/xamarin-android-commercial-d16-3-macos";
+string monoSDK_macos = ""; //$"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+string iOSSDK_macos = ""; //$"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
+string macSDK_macos = ""; //$"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build.cake
+++ b/build.cake
@@ -76,7 +76,26 @@ Task("Clean")
     CleanDirectories("./**/bin", (fsi)=> !fsi.Path.FullPath.Contains("XFCorePostProcessor") && !fsi.Path.FullPath.StartsWith("tools"));
 });
 
-Task("provision")
+Task("provision-macsdk")
+    .Does(async () =>
+    {
+        if(!IsRunningOnWindows() && String.IsNullOrWhiteSpace(macSDK))
+        {
+            await Boots(macSDK);
+        }
+    });
+
+Task("provision-iossdk")
+    .Does(async () =>
+    {
+        if(!IsRunningOnWindows())
+        {   
+            if(!String.IsNullOrWhiteSpace(iosSDK))
+                await Boots(iosSDK);
+        }
+    });
+
+Task("provision-androidsdk")
     .Does(async () =>
     {
         Information ("ANDROID_HOME: {0}", ANDROID_HOME);
@@ -96,7 +115,11 @@ Task("provision")
 
         if(!String.IsNullOrWhiteSpace(androidSDK))
             await Boots (androidSDK);
+    });
 
+Task("provision-monosdk")
+    .Does(async () =>
+    {
         if(IsRunningOnWindows())
         {
             if(!String.IsNullOrWhiteSpace(monoSDK))
@@ -116,15 +139,15 @@ Task("provision")
         else
         {
             if(!String.IsNullOrWhiteSpace(monoSDK))
-                await Boots(monoSDK);      
-
-            if(!String.IsNullOrWhiteSpace(iosSDK))
-                await Boots(iosSDK);
-                
-            if(!String.IsNullOrWhiteSpace(macSDK))
-                await Boots(macSDK);
+                await Boots(monoSDK); 
         }
     });
+
+Task("provision")
+    .IsDependentOn("provision-macsdk")
+    .IsDependentOn("provision-iossdk")
+    .IsDependentOn("provision-monosdk")
+    .IsDependentOn("provision-androidsdk");
 
 Task("NuGetPack")
     .IsDependentOn("Build")

--- a/build.cake
+++ b/build.cake
@@ -46,19 +46,19 @@ var nugetversion = Argument<string>("packageVersion", gitVersion.NuGetVersion);
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ?? 
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
-string monoMajorVersion = "6.0.0";
-string monoPatchVersion = "319";
+string monoMajorVersion = "6.4.0";
+string monoPatchVersion = "198";
 string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
 string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "https://aka.ms/xamarin-android-commercial-d16-2-windows";
+string androidSDK_windows = "https://aka.ms/xamarin-android-commercial-d16-3-windows";
 string iOSSDK_windows = "";
 string macSDK_windows = "";
 
-string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-2-macos";
+string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-3-macos";
 string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-2/a8bceccedcc8366455ffd941b8fafce1d97f4676/39/package/xamarin.ios-12.14.0.110.pkg";
-string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-2/a8bceccedcc8366455ffd941b8fafce1d97f4676/39/package/xamarin.mac-5.14.0.110.pkg";
+string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
+string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build.cake
+++ b/build.cake
@@ -94,8 +94,8 @@ Task("provision")
 
         var platform = IsRunningOnWindows() ? "windows" : "macos";
 
-        //if(!String.IsNullOrWhiteSpace(androidSDK))
-          //  await Boots (androidSDK);
+        if(!String.IsNullOrWhiteSpace(androidSDK))
+            await Boots (androidSDK);
 
         if(IsRunningOnWindows())
         {

--- a/build.cake
+++ b/build.cake
@@ -94,8 +94,8 @@ Task("provision")
 
         var platform = IsRunningOnWindows() ? "windows" : "macos";
 
-        if(!String.IsNullOrWhiteSpace(androidSDK))
-            await Boots (androidSDK);
+        //if(!String.IsNullOrWhiteSpace(androidSDK))
+          //  await Boots (androidSDK);
 
         if(IsRunningOnWindows())
         {

--- a/build.cake
+++ b/build.cake
@@ -46,16 +46,16 @@ var nugetversion = Argument<string>("packageVersion", gitVersion.NuGetVersion);
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ?? 
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
-string monoMajorVersion = "5.8.1";
-string monoPatchVersion = "0";
+string monoMajorVersion = "5.14.0";
+string monoPatchVersion = "177";
 string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
 string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "https://bosstoragemirror.azureedge.net/wrench/monodroid-mavericks-d15-9/9b/9bf5bd5cacf066a9fc0e8a29087beace08642a11/Xamarin.Android.Sdk.9.1.8.0.vsix";
-string iOSSDK_windows = "";
+string androidSDK_windows = "https://aka.ms/xamarin-android-commercial-d15-9-windows";
+string iOSSDK_windows = "https://download.visualstudio.microsoft.com/download/pr/71f33151-5db4-49cc-ac70-ba835a9f81e2/d256c6c50cd80ec0207783c5c7a4bc2f/xamarin.visualstudio.apple.sdk.4.12.3.83.vsix";
 string macSDK_windows = "";
 
-string androidSDK_macos = "https://bosstoragemirror.azureedge.net/wrench/monodroid-mavericks-d15-9/9b/9bf5bd5cacf066a9fc0e8a29087beace08642a11/xamarin.android-9.1.8-0.pkg";
+string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d15-9-macos";
 string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
 string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.ios-12.4.0.64.pkg";
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";

--- a/build.cake
+++ b/build.cake
@@ -65,6 +65,8 @@ string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;
 string iosSDK = IsRunningOnWindows() ? "" : iOSSDK_macos;
 string macSDK  = IsRunningOnWindows() ? "" : macSDK_macos;
 
+string[] androidSdkManagerInstalls = new string[0]; //new [] { "platforms;android-29"};
+            
 //////////////////////////////////////////////////////////////////////
 // TASKS
 //////////////////////////////////////////////////////////////////////
@@ -100,19 +102,17 @@ Task("provision-androidsdk")
     {
         Information ("ANDROID_HOME: {0}", ANDROID_HOME);
 
-        var androidSdkSettings = new AndroidSdkManagerToolSettings { 
-            SdkRoot = ANDROID_HOME,
-            SkipVersionCheck = true
-        };
+        if(androidSdkManagerInstalls.Length > 0)
+        {
+            var androidSdkSettings = new AndroidSdkManagerToolSettings { 
+                SdkRoot = ANDROID_HOME,
+                SkipVersionCheck = true
+            };
 
-        try { AcceptLicenses (androidSdkSettings); } catch { }
+            try { AcceptLicenses (androidSdkSettings); } catch { }
 
-        AndroidSdkManagerInstall (new [] {
-                "platforms;android-29"
-            }, androidSdkSettings);
-
-        var platform = IsRunningOnWindows() ? "windows" : "macos";
-
+            AndroidSdkManagerInstall (androidSdkManagerInstalls, androidSdkSettings);
+        }
         if(!String.IsNullOrWhiteSpace(androidSDK))
             await Boots (androidSDK);
     });

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -1,8 +1,34 @@
-var channel = Env("CHANNEL") ?? "Stable";
-
 if (IsMac)
 {
-  Item (XreItem.Xcode_10_1_0).XcodeSelect ();
+	Item (XreItem.Xcode_10_3_0).XcodeSelect ();
+	Item ("https://download.visualstudio.microsoft.com/download/pr/edd7782e-dc4f-4be5-9b55-8a51eeb7a718/ed8c238ec095b5d1051e2539cea38113/xamarin.android-10.0.0.40.pkg");
+	Item ("https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg");
+	Item ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11/dc5fc120e090317bbd78049f25dacd84e4f3dc48/254/package/xamarin.ios-12.99.4.5.pkg");
+	Item ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11/dc5fc120e090317bbd78049f25dacd84e4f3dc48/254/package/xamarin.mac-5.99.4.5.pkg");
+	ForceJavaCleanup();
+
+    var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
+    if (!string.IsNullOrEmpty(dotnetVersion))
+        DotNetCoreSdk(dotnetVersion);
+
+  // VSTS installs into a non-default location. Let's hardcode it here because why not.
+	var vstsBaseInstallPath = Path.Combine (Environment.GetEnvironmentVariable ("HOME"), ".dotnet", "sdk");
+	var vstsInstallPath = Path.Combine (vstsBaseInstallPath, dotnetVersion);
+	var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
+	if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
+		ln (defaultInstallLocation, vstsInstallPath);
 }
-Console.WriteLine(channel);
-XamarinChannel(channel);
+else
+{
+	Item("https://download.visualstudio.microsoft.com/download/pr/68e5a599-5d9b-4d59-b41a-8348d23faa73/abd0a8f9a6b6253facfaaa97e5e138509b004263134d310cc6d49c2f1ac734b9/Xamarin.Android.Sdk-10.0.0.40.vsix");	
+}
+
+Item(XreItem.Java_OpenJDK_1_8_0_25);
+AndroidSdk ().ApiLevel((AndroidApiLevel)29);
+
+void ln (string source, string destination)
+{
+	Console.WriteLine ($"ln -sf {source} {destination}");
+	if (!Config.DryRun)
+		Exec ("/bin/ln", "-sf", source, destination);
+}

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -4,11 +4,11 @@ string monoPatchVersion = "198";
 string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
 string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "https://aka.ms/xamarin-android-commercial-d16-3-windows";
+string androidSDK_windows = "https://download.visualstudio.microsoft.com/download/pr/1131a8f5-99f5-4326-93b1-f5827b54ecd5/e7bd0f680004131157a22982c389b05f2d3698cc04fab3901ce2d7ded47ad8e0/Xamarin.Android.Sdk-10.0.0.43.vsix";
 string iOSSDK_windows = "";
 string macSDK_windows = "";
 
-string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-3-macos";
+string androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/d5a432e4-09f3-4da6-9bdd-1d4fdd87f34c/c4ce0854064ffc16b957f22ccc08f9df/xamarin.android-10.0.0.43.pkg";
 string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
 string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -13,44 +13,65 @@ string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVer
 string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
-
-Item ("Mono", monoVersion).Condition (FxVersionDiffers);
-Item ("Xamarin.iOS", "13.2.0.42").Condition (FxVersionDiffers);
-Item ("Xamarin.Mac", "6.2.0.42").Condition (FxVersionDiffers);
-Item ("Xamarin.Android", "10.0.0.43").Condition (FxVersionDiffers);
-
 if (IsMac)
 {
-	Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
+	// Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
 
-	/*if(!String.IsNullOrEmpty(androidSDK_macos))
-		Item (androidSDK_macos);
+  if(!String.IsNullOrEmpty(monoSDK_macos))
+    Item ("Mono", monoVersion)
+      .Condition (FxVersionDiffers)  
+      .Source (_ => monoSDK_macos);
+
+	if(!String.IsNullOrEmpty(androidSDK_macos))
+		Item ("Xamarin.Android", "10.0.0.43")
+      .Condition (FxVersionDiffers)  
+      .Source (_ => androidSDK_macos);
+
 	if(!String.IsNullOrEmpty(iOSSDK_macos))
-		Item (iOSSDK_macos);
+		Item ("Xamarin.iOS", "13.2.0.42")
+      .Condition (FxVersionDiffers)  
+      .Source (_ => iOSSDK_macos);
+
 	if(!String.IsNullOrEmpty(macSDK_macos))
-		Item (macSDK_macos);
-    */
+		Item ("Xamarin.Mac", "6.2.0.42")
+      .Condition (FxVersionDiffers)  
+      .Source (_ => macSDK_macos);
+    
 	ForceJavaCleanup();
 
     var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
     if (!string.IsNullOrEmpty(dotnetVersion))
-	{
+	  {
 		// VSTS installs into a non-default location. Let's hardcode it here because why not.
 		var vstsBaseInstallPath = Path.Combine (Environment.GetEnvironmentVariable ("HOME"), ".dotnet", "sdk");
 		var vstsInstallPath = Path.Combine (vstsBaseInstallPath, dotnetVersion);
 		var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
 		if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
 			ln (defaultInstallLocation, vstsInstallPath);
-	}
+	  }
 }
 else
 {
-/*	if(!String.IsNullOrEmpty(androidSDK_windows))
-		Item (androidSDK_windows);
+	if(!String.IsNullOrEmpty(androidSDK_windows))
+		Item ("Xamarin.Android", "10.0.0.43")
+      .Condition (FxVersionDiffers)  
+      .Source (_ => androidSDK_windows);
+
 	if(!String.IsNullOrEmpty(iOSSDK_windows))
-		Item (iOSSDK_windows);
+		Item ("Xamarin.iOS", "13.2.0.42")
+      .Condition (FxVersionDiffers)  
+      .Source (_ => iOSSDK_windows);
+
 	if(!String.IsNullOrEmpty(macSDK_windows))
-		Item (macSDK_windows);*/
+		Item ("Xamarin.Mac", "6.2.0.42")
+      .Condition (FxVersionDiffers)  
+      .Source (_ => macSDK_windows);
+      
+	if(!String.IsNullOrEmpty(monoSDK_windows))
+    Item ("Mono", monoVersion)
+      .Condition (FxVersionDiffers)  
+      .Source (_ => monoSDK_windows);
+
 }
 
 Item(XreItem.Java_OpenJDK_1_8_0_25);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -15,7 +15,7 @@ string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/je
 
 if (IsMac)
 {
-	// Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
+	Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
 
   if(!String.IsNullOrEmpty(monoSDK_macos))
     Item ("Mono", monoVersion)

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -14,10 +14,10 @@ string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/je
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
 
-Item ("Mono", monoVersion);
-Item ("Xamarin.iOS", "13.2.0.42");
-Item ("Xamarin.Mac", "6.2.0.42");
-Item ("Xamarin.Android", "10.0.0.43");
+Item ("Mono", monoVersion).Condition (FxVersionDiffers);
+Item ("Xamarin.iOS", "13.2.0.42").Condition (FxVersionDiffers);
+Item ("Xamarin.Mac", "6.2.0.42").Condition (FxVersionDiffers);
+Item ("Xamarin.Android", "10.0.0.43").Condition (FxVersionDiffers);
 
 if (IsMac)
 {

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -19,22 +19,18 @@ if (IsMac)
 
   if(!String.IsNullOrEmpty(monoSDK_macos))
     Item ("Mono", monoVersion)
-      .Condition (FxVersionDiffers)  
       .Source (_ => monoSDK_macos);
 
 	if(!String.IsNullOrEmpty(androidSDK_macos))
 		Item ("Xamarin.Android", "10.0.0.43")
-      .Condition (FxVersionDiffers)  
       .Source (_ => androidSDK_macos);
 
 	if(!String.IsNullOrEmpty(iOSSDK_macos))
 		Item ("Xamarin.iOS", "13.2.0.42")
-      .Condition (FxVersionDiffers)  
       .Source (_ => iOSSDK_macos);
 
 	if(!String.IsNullOrEmpty(macSDK_macos))
 		Item ("Xamarin.Mac", "6.2.0.42")
-      .Condition (FxVersionDiffers)  
       .Source (_ => macSDK_macos);
     
 	ForceJavaCleanup();
@@ -54,22 +50,18 @@ else
 {
 	if(!String.IsNullOrEmpty(androidSDK_windows))
 		Item ("Xamarin.Android", "10.0.0.43")
-      .Condition (FxVersionDiffers)  
       .Source (_ => androidSDK_windows);
 
 	if(!String.IsNullOrEmpty(iOSSDK_windows))
 		Item ("Xamarin.iOS", "13.2.0.42")
-      .Condition (FxVersionDiffers)  
       .Source (_ => iOSSDK_windows);
 
 	if(!String.IsNullOrEmpty(macSDK_windows))
 		Item ("Xamarin.Mac", "6.2.0.42")
-      .Condition (FxVersionDiffers)  
       .Source (_ => macSDK_windows);
-      
+
 	if(!String.IsNullOrEmpty(monoSDK_windows))
     Item ("Mono", monoVersion)
-      .Condition (FxVersionDiffers)  
       .Source (_ => monoSDK_windows);
 
 }

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -1,26 +1,54 @@
+
+string monoMajorVersion = "6.4.0";
+string monoPatchVersion = "198";
+string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
+
+string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
+string androidSDK_windows = "https://aka.ms/xamarin-android-commercial-d16-3-windows";
+string iOSSDK_windows = "";
+string macSDK_windows = "";
+
+string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-3-macos";
+string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
+string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
+
+
 if (IsMac)
 {
-	Item (XreItem.Xcode_11_1_0).XcodeSelect ();
-	Item ("https://download.visualstudio.microsoft.com/download/pr/edd7782e-dc4f-4be5-9b55-8a51eeb7a718/ed8c238ec095b5d1051e2539cea38113/xamarin.android-10.0.0.40.pkg");
-	Item ("https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg");
-	Item ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11/dc5fc120e090317bbd78049f25dacd84e4f3dc48/254/package/xamarin.ios-12.99.4.5.pkg");
-	Item ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11/dc5fc120e090317bbd78049f25dacd84e4f3dc48/254/package/xamarin.mac-5.99.4.5.pkg");
+	Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
+
+	if(!String.IsNullOrEmpty(androidSDK_macos))
+		Item (androidSDK_macos);
+	if(!String.IsNullOrEmpty(monoSDK_macos))
+		Item (monoSDK_macos);
+	if(!String.IsNullOrEmpty(iOSSDK_macos))
+		Item (iOSSDK_macos);
+	if(!String.IsNullOrEmpty(macSDK_macos))
+		Item (macSDK_macos);
 	ForceJavaCleanup();
 
     var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
     if (!string.IsNullOrEmpty(dotnetVersion))
-        DotNetCoreSdk(dotnetVersion);
-
-  // VSTS installs into a non-default location. Let's hardcode it here because why not.
-	var vstsBaseInstallPath = Path.Combine (Environment.GetEnvironmentVariable ("HOME"), ".dotnet", "sdk");
-	var vstsInstallPath = Path.Combine (vstsBaseInstallPath, dotnetVersion);
-	var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
-	if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
-		ln (defaultInstallLocation, vstsInstallPath);
+	{
+		// VSTS installs into a non-default location. Let's hardcode it here because why not.
+		var vstsBaseInstallPath = Path.Combine (Environment.GetEnvironmentVariable ("HOME"), ".dotnet", "sdk");
+		var vstsInstallPath = Path.Combine (vstsBaseInstallPath, dotnetVersion);
+		var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
+		if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
+			ln (defaultInstallLocation, vstsInstallPath);
+	}
 }
 else
 {
-	Item("https://download.visualstudio.microsoft.com/download/pr/68e5a599-5d9b-4d59-b41a-8348d23faa73/abd0a8f9a6b6253facfaaa97e5e138509b004263134d310cc6d49c2f1ac734b9/Xamarin.Android.Sdk-10.0.0.40.vsix");	
+	if(!String.IsNullOrEmpty(androidSDK_windows))
+		Item (androidSDK_windows);
+	if(!String.IsNullOrEmpty(monoSDK_windows))
+		Item (monoSDK_windows);
+	if(!String.IsNullOrEmpty(iOSSDK_windows))
+		Item (iOSSDK_windows);
+	if(!String.IsNullOrEmpty(macSDK_windows))
+		Item (macSDK_windows);
 }
 
 Item(XreItem.Java_OpenJDK_1_8_0_25);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -1,6 +1,6 @@
 if (IsMac)
 {
-	Item (XreItem.Xcode_10_3_0).XcodeSelect ();
+	Item (XreItem.Xcode_11_1_0).XcodeSelect ();
 	Item ("https://download.visualstudio.microsoft.com/download/pr/edd7782e-dc4f-4be5-9b55-8a51eeb7a718/ed8c238ec095b5d1051e2539cea38113/xamarin.android-10.0.0.40.pkg");
 	Item ("https://download.mono-project.com/archive/6.4.0/macos-10-universal/MonoFramework-MDK-6.4.0.189.macos10.xamarin.universal.pkg");
 	Item ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11/dc5fc120e090317bbd78049f25dacd84e4f3dc48/254/package/xamarin.ios-12.99.4.5.pkg");

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -14,18 +14,22 @@ string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/je
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
 
+Item ("Mono", monoVersion);
+Item ("Xamarin.iOS", "13.2.0.42");
+Item ("Xamarin.Mac", "6.2.0.42");
+Item ("Xamarin.Android", "10.0.0.43");
+
 if (IsMac)
 {
 	Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
 
-	if(!String.IsNullOrEmpty(androidSDK_macos))
+	/*if(!String.IsNullOrEmpty(androidSDK_macos))
 		Item (androidSDK_macos);
-	if(!String.IsNullOrEmpty(monoSDK_macos))
-		Item (monoSDK_macos);
 	if(!String.IsNullOrEmpty(iOSSDK_macos))
 		Item (iOSSDK_macos);
 	if(!String.IsNullOrEmpty(macSDK_macos))
 		Item (macSDK_macos);
+    */
 	ForceJavaCleanup();
 
     var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
@@ -41,14 +45,12 @@ if (IsMac)
 }
 else
 {
-	if(!String.IsNullOrEmpty(androidSDK_windows))
+/*	if(!String.IsNullOrEmpty(androidSDK_windows))
 		Item (androidSDK_windows);
-	if(!String.IsNullOrEmpty(monoSDK_windows))
-		Item (monoSDK_windows);
 	if(!String.IsNullOrEmpty(iOSSDK_windows))
 		Item (iOSSDK_windows);
 	if(!String.IsNullOrEmpty(macSDK_windows))
-		Item (macSDK_windows);
+		Item (macSDK_windows);*/
 }
 
 Item(XreItem.Java_OpenJDK_1_8_0_25);

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -51,7 +51,7 @@ jobs:
         inputs:
           restoreSolution:  ${{ parameters.slnPath }}
           
-      ${{ if ne(variables['DOTNET_VERSION'], '') }}:
+      - ${{ if ne(variables['DOTNET_VERSION'], '') }}:
         - task: DotNetCoreInstaller@0
           displayName: 'Install .net core $(DOTNET_VERSION)'
           inputs:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -46,7 +46,7 @@ jobs:
       - task: NuGetToolInstaller@0
         displayName: 'Use NuGet'
         inputs:
-          versionSpec: ${{ parameters.nugetVersion }}
+          versionSpec: ${{ parameters.NUGET_VERSION }}
 
       - task: NuGetCommand@2
         displayName: 'NuGet restore ${{ parameters.slnPath }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -28,13 +28,14 @@ jobs:
       - checkout: self
       
       - task: xamops.azdevex.provisionator-task.provisionator@1
-        displayName: Provisionate Xamarin
+        displayName: 'Provisionator'
         condition: eq(variables['provisioning'], 'true')
         inputs:
           provisioning_script: ${{ parameters.provisionatorPath }}
           provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
       
       - task: Bash@3
+        displayName: 'Cake Provision'
         condition: eq(variables['provisioning'], 'false')
         inputs:
           targetType: 'filePath'
@@ -51,6 +52,7 @@ jobs:
           export PATH="$PATH:/Users/vsts/.dotnet/tools"
           export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
           dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+        displayName: 'Add globaljson file'
         condition: ne(variables['DOTNET_VERSION'], '')
 
       - task: NuGetToolInstaller@0

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -40,16 +40,6 @@ jobs:
           targetType: 'filePath'
           filePath: 'build.sh'
           arguments: --target provision
-
-      - task: NuGetToolInstaller@0
-        displayName: 'Use NuGet'
-        inputs:
-          versionSpec: $(NUGET_VERSION)
-
-      - task: NuGetCommand@2
-        displayName: 'NuGet restore ${{ parameters.slnPath }}'
-        inputs:
-          restoreSolution:  ${{ parameters.slnPath }}
           
       - task: DotNetCoreInstaller@0
         displayName: 'Install .net core $(DOTNET_VERSION)'
@@ -62,6 +52,17 @@ jobs:
           export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
           dotnet new globaljson --sdk-version $(DOTNET_VERSION)
         condition: ne(variables['DOTNET_VERSION'], '')
+
+      - task: NuGetToolInstaller@0
+        displayName: 'Use NuGet'
+        condition: ne(variables['NUGET_VERSION'], '')
+        inputs:
+          versionSpec: $(NUGET_VERSION)
+
+      - task: NuGetCommand@2
+        displayName: 'NuGet restore ${{ parameters.slnPath }}'
+        inputs:
+          restoreSolution:  ${{ parameters.slnPath }}
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -13,8 +13,8 @@ parameters:
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
   androidProjectArguments : ''
   buildConfiguration : 'Debug'
-  DOTNET_VERSION: ''
-  NUGET_VERSION: ''
+  DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+  NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
   apkTargetFolder: '$(build.artifactstagingdirectory)/androidApp'
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''
@@ -54,14 +54,14 @@ jobs:
           restoreSolution:  ${{ parameters.slnPath }}
           
       - task: DotNetCoreInstaller@0
-        displayName: 'Install .net core $(DOTNET_VERSION)'
+        displayName: 'Install .net core ${{ parameters.DOTNET_VERSION }}'
         inputs:
-          version: $(DOTNET_VERSION)
+          version: ${{ parameters.DOTNET_VERSION }}
 
       - script: |
           export PATH="$PATH:/Users/vsts/.dotnet/tools"
           export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
-          dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+          dotnet new globaljson --sdk-version ${{ parameters.DOTNET_VERSION }}
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -15,6 +15,8 @@ parameters:
   buildConfiguration : 'Debug'
   nugetVersion: $(NUGET_VERSION)
   apkTargetFolder: '$(build.artifactstagingdirectory)/androidApp'
+  provisionatorPath: 'build/provisioning/provisioning.csx'
+  provisionatorExtraArguments: ''
 
 jobs:
   - job: ${{ parameters.name }}
@@ -27,14 +29,24 @@ jobs:
       - checkout: self
 
       - task: NuGetToolInstaller@0
-        displayName: 'Use NuGet ${{ parameters.nugetVersion }}'
+        displayName: 'Use NuGet'
         inputs:
           versionSpec: ${{ parameters.nugetVersion }}
 
       - task: NuGetCommand@2
         displayName: 'NuGet restore ${{ parameters.slnPath }}'
         inputs:
-          restoreSolution: ${{ parameters.slnPath }}
+          restoreSolution:  ${{ parameters.slnPath }}
+          
+      - task: DotNetCoreInstaller@0
+        displayName: 'Install .net core $(DOTNET_VERSION)'
+        inputs:
+          version: $(DOTNET_VERSION)
+
+      - script: |
+          export PATH="$PATH:/Users/vsts/.dotnet/tools"
+          export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
+          dotnet new globaljson --sdk-version $(DOTNET_VERSION)
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -13,7 +13,8 @@ parameters:
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
   androidProjectArguments : ''
   buildConfiguration : 'Debug'
-  nugetVersion: $(NUGET_VERSION)
+  DOTNET_VERSION: ''
+  NUGET_VERSION: ''
   apkTargetFolder: '$(build.artifactstagingdirectory)/androidApp'
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -51,10 +51,11 @@ jobs:
         inputs:
           restoreSolution:  ${{ parameters.slnPath }}
           
-      - task: DotNetCoreInstaller@0
-        displayName: 'Install .net core $(DOTNET_VERSION)'
-        inputs:
-          version: $(DOTNET_VERSION)
+      ${{ if ne(variables['DOTNET_VERSION'], '') }}:
+        - task: DotNetCoreInstaller@0
+          displayName: 'Install .net core $(DOTNET_VERSION)'
+          inputs:
+            version: $(DOTNET_VERSION)
 
       - script: |
           export PATH="$PATH:/Users/vsts/.dotnet/tools"

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -13,8 +13,6 @@ parameters:
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
   androidProjectArguments : ''
   buildConfiguration : 'Debug'
-  DOTNET_VERSION: ''
-  NUGET_VERSION: ''
   apkTargetFolder: '$(build.artifactstagingdirectory)/androidApp'
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''
@@ -46,7 +44,7 @@ jobs:
       - task: NuGetToolInstaller@0
         displayName: 'Use NuGet'
         inputs:
-          versionSpec: ${{ parameters.NUGET_VERSION }}
+          versionSpec: $(NUGET_VERSION)
 
       - task: NuGetCommand@2
         displayName: 'NuGet restore ${{ parameters.slnPath }}'
@@ -54,14 +52,14 @@ jobs:
           restoreSolution:  ${{ parameters.slnPath }}
           
       - task: DotNetCoreInstaller@0
-        displayName: 'Install .net core ${{ parameters.DOTNET_VERSION }}'
+        displayName: 'Install .net core $(DOTNET_VERSION)'
         inputs:
-          version: ${{ parameters.DOTNET_VERSION }}
+          version: $(DOTNET_VERSION)
 
       - script: |
           export PATH="$PATH:/Users/vsts/.dotnet/tools"
           export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
-          dotnet new globaljson --sdk-version ${{ parameters.DOTNET_VERSION }}
+          dotnet new globaljson --sdk-version $(DOTNET_VERSION)
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -51,16 +51,17 @@ jobs:
         inputs:
           restoreSolution:  ${{ parameters.slnPath }}
           
-      - ${{ if ne(variables['DOTNET_VERSION'], '') }}:
-        - task: DotNetCoreInstaller@0
-          displayName: 'Install .net core $(DOTNET_VERSION)'
-          inputs:
-            version: $(DOTNET_VERSION)
+      - task: DotNetCoreInstaller@0
+        displayName: 'Install .net core $(DOTNET_VERSION)'
+        condition: ne(variables['DOTNET_VERSION'], '')  
+        inputs:
+          version: $(DOTNET_VERSION)
 
       - script: |
           export PATH="$PATH:/Users/vsts/.dotnet/tools"
           export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
           dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+        condition: ne(variables['DOTNET_VERSION'], '')
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -27,6 +27,20 @@ jobs:
     dependsOn: ${{ parameters.dependsOn }}
     steps:
       - checkout: self
+      
+      - task: xamops.azdevex.provisionator-task.provisionator@1
+        displayName: Provisionate Xamarin
+        condition: eq(variables['provisioning'], 'true')
+        inputs:
+          provisioning_script: ${{ parameters.provisionatorPath }}
+          provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
+      
+      - task: Bash@3
+        condition: eq(variables['provisioning'], 'false')
+        inputs:
+          targetType: 'filePath'
+          filePath: 'build.sh'
+          arguments: --target provision
 
       - task: NuGetToolInstaller@0
         displayName: 'Use NuGet'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -13,8 +13,8 @@ parameters:
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
   androidProjectArguments : ''
   buildConfiguration : 'Debug'
-  DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-  NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
+  DOTNET_VERSION: ''
+  NUGET_VERSION: ''
   apkTargetFolder: '$(build.artifactstagingdirectory)/androidApp'
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -22,7 +22,7 @@ steps:
       failOnStandardError: false
 
   - task: NuGetToolInstaller@0
-    displayName: 'Use NuGet'
+    displayName: 'Use NuGet: $(NUGET_VERSION)'
     inputs:
       versionSpec: $(NUGET_VERSION)
 

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -24,7 +24,7 @@ steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet'
     inputs:
-      versionSpec: $(nugetVersion)
+      versionSpec: $(NUGET_VERSION)
 
   - task: NuGetCommand@2
     displayName: 'Make NuGet Package'
@@ -40,12 +40,12 @@ steps:
 
   - powershell: |
        $buildConfiguration = "Release"
-       $formsNugetVersion = "" + $env:nugetPackageVersion
+       $formsNUGET_VERSION = "" + $env:nugetPackageVersion
 
        Write-Host("Update nuspecs")
        Get-ChildItem './.nuspec/*.nuspec' -Recurse | Foreach-Object {
             (Get-Content $_) | Foreach-Object  {
-                $_ -replace '\$version\$', $formsNugetVersion `
+                $_ -replace '\$version\$', $formsNUGET_VERSION `
                    -replace '\$Configuration\$', $buildConfiguration `
            } | Set-Content $_
        }

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -40,12 +40,12 @@ steps:
 
   - powershell: |
        $buildConfiguration = "Release"
-       $formsNUGET_VERSION = "" + $env:nugetPackageVersion
+       $formsNugetVersion = "" + $env:nugetPackageVersion
 
        Write-Host("Update nuspecs")
        Get-ChildItem './.nuspec/*.nuspec' -Recurse | Foreach-Object {
             (Get-Content $_) | Foreach-Object  {
-                $_ -replace '\$version\$', $formsNUGET_VERSION `
+                $_ -replace '\$version\$', $formsNugetVersion `
                    -replace '\$Configuration\$', $buildConfiguration `
            } | Set-Content $_
        }

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -3,17 +3,28 @@ steps:
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: Provisionate Xamarin
-    condition: eq(variables['provisioningOSX'], 'true')
+    condition: eq(variables['provisioning'], 'true')
     inputs:
       provisioning_script: $(provisionator.osxPath)
       provisioning_extra_args: $(provisionator.extraArguments)
+      
+  - task: Bash@3
+    condition: eq(variables['provisioning'], 'false')
+    inputs:
+      targetType: 'filePath'
+      filePath: 'build.sh'
+      arguments: --target provision
+  
+  - task: DotNetCoreInstaller@0
+    displayName: 'Install .net core $(DOTNET_VERSION)'
+    inputs:
+      version: $(DOTNET_VERSION)
 
-  - bash: sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh $(MONO_VERSION)
-    displayName: Switch to the latest Xamarin SDK
-
-  - bash: echo '##vso[task.setvariable variable=MD_APPLE_SDK_ROOT;]'/Applications/Xcode_$(XCODE_VERSION).app;sudo xcode-select --switch /Applications/Xcode_$(XCODE_VERSION).app/Contents/Developer
-    displayName: Switch to the latest Xcode
-
+  - script: |
+      export PATH="$PATH:/Users/vsts/.dotnet/tools"
+      export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
+      dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+      
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet'
     inputs:

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -28,7 +28,7 @@ steps:
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet'
     inputs:
-      versionSpec: $(nugetVersion)
+      versionSpec: $(NUGET_VERSION)
 
   - task: NuGetCommand@2
     displayName: 'NuGet restore'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -2,13 +2,14 @@ steps:
   - checkout: self
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
-    displayName: Provisionate Xamarin
+    displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')
     inputs:
       provisioning_script: $(provisionator.osxPath)
       provisioning_extra_args: $(provisionator.extraArguments)
       
   - task: Bash@3
+    displayName: 'Cake Provision'
     condition: eq(variables['provisioning'], 'false')
     inputs:
       targetType: 'filePath'
@@ -25,6 +26,7 @@ steps:
       export PATH="$PATH:/Users/vsts/.dotnet/tools"
       export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
       dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+    displayName: 'Add globaljson file'
     condition: ne(variables['DOTNET_VERSION'], '')
       
   - task: NuGetToolInstaller@0

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -15,7 +15,7 @@ steps:
       filePath: 'build.sh'
       arguments: --target provision
   
-  ${{ if ne(variables['DOTNET_VERSION'], '') }}:
+  - ${{ if ne(variables['DOTNET_VERSION'], '') }}:
     - task: DotNetCoreInstaller@0
       displayName: 'Install .net core $(DOTNET_VERSION)'
       inputs:

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -15,10 +15,11 @@ steps:
       filePath: 'build.sh'
       arguments: --target provision
   
-  - task: DotNetCoreInstaller@0
-    displayName: 'Install .net core $(DOTNET_VERSION)'
-    inputs:
-      version: $(DOTNET_VERSION)
+  ${{ if ne(variables['DOTNET_VERSION'], '') }}:
+    - task: DotNetCoreInstaller@0
+      displayName: 'Install .net core $(DOTNET_VERSION)'
+      inputs:
+        version: $(DOTNET_VERSION)
 
   - script: |
       export PATH="$PATH:/Users/vsts/.dotnet/tools"

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -15,16 +15,17 @@ steps:
       filePath: 'build.sh'
       arguments: --target provision
   
-  - ${{ if ne(variables['DOTNET_VERSION'], '') }}:
-    - task: DotNetCoreInstaller@0
-      displayName: 'Install .net core $(DOTNET_VERSION)'
-      inputs:
-        version: $(DOTNET_VERSION)
+  - task: DotNetCoreInstaller@0
+    displayName: 'Install .net core $(DOTNET_VERSION)'
+    condition: ne(variables['DOTNET_VERSION'], '')
+    inputs:
+      version: $(DOTNET_VERSION)
 
   - script: |
       export PATH="$PATH:/Users/vsts/.dotnet/tools"
       export DOTNET_ROOT="$(dirname "$(readlink "$(command -v dotnet)")")"
       dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+    condition: ne(variables['DOTNET_VERSION'], '')
       
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -29,6 +29,7 @@ steps:
       
   - task: NuGetToolInstaller@0
     displayName: 'Use NuGet'
+    condition: ne(variables['NUGET_VERSION'], '')
     inputs:
       versionSpec: $(NUGET_VERSION)
 

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -34,6 +34,23 @@ jobs:
           BuildConfiguration:  ${{ parameters.releaseBuildConfiguration }}
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
+    - script: build.cmd -Target provision
+      condition: eq(variables['provisioning'], 'false')
+  
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: Provisionate Xamarin
+      condition: eq(variables['provisioning'], 'true')
+      inputs:
+        provisioning_script: ${{ parameters.provisionatorPath }}
+        provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
+          
+    - task: DotNetCoreInstaller@0
+      displayName: 'Install .net core $(DOTNET_VERSION)'
+      inputs:
+        version: $(DOTNET_VERSION)
+
+    - script: |
+        dotnet new globaljson --sdk-version $(DOTNET_VERSION)
 
     - task: NuGetToolInstaller@0
       displayName: 'Use NuGet ${{ parameters.nugetVersion }}'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -34,14 +34,15 @@ jobs:
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
 
-    - ${{ if ne(variables['DOTNET_VERSION'], '') }}:
-      - task: DotNetCoreInstaller@0
-        displayName: "Install .net core $(DOTNET_VERSION)"
-        inputs:
-          version: $(DOTNET_VERSION)
+    - task: DotNetCoreInstaller@0
+      displayName: "Install .net core $(DOTNET_VERSION)"
+      condition: ne(variables['DOTNET_VERSION'], '')
+      inputs:
+        version: $(DOTNET_VERSION)
 
     - script: |
         dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+      condition: ne(variables['DOTNET_VERSION'], '')
 
     - task: NuGetToolInstaller@0
       displayName: 'Use NuGet $(NUGET_VERSION)'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -34,10 +34,11 @@ jobs:
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
     - script: build.cmd -Target provision
+      displayName: 'Cake Provision'
       condition: eq(variables['provisioning'], 'false')
   
     - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: Provisionate Xamarin
+      displayName: 'Provisionator'
       condition: eq(variables['provisioning'], 'true')
       inputs:
         provisioning_script: ${{ parameters.provisionatorPath }}
@@ -51,6 +52,7 @@ jobs:
 
     - script: |
         dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+      displayName: 'Add globaljson file'
       condition: ne(variables['DOTNET_VERSION'], '')
 
     - task: NuGetToolInstaller@0

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -16,8 +16,8 @@ parameters:
   artifactsName: 'win_build'
   nunitTestAdapterFolder: 'packages/NUnitTestAdapter.AnyVersion/tools/'
   nunitTestFolder: '$(build.sourcesdirectory)'
-  DOTNET_VERSION: ''
-  NUGET_VERSION: ''
+  DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
+  NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
 
 jobs:
   - job: ${{ parameters.name }}

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -34,11 +34,11 @@ jobs:
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
 
-
-    - task: DotNetCoreInstaller@0
-      displayName: "Install .net core $(DOTNET_VERSION)"
-      inputs:
-        version: $(DOTNET_VERSION)
+    ${{ if ne(variables['DOTNET_VERSION'], '') }}:
+      - task: DotNetCoreInstaller@0
+        displayName: "Install .net core $(DOTNET_VERSION)"
+        inputs:
+          version: $(DOTNET_VERSION)
 
     - script: |
         dotnet new globaljson --sdk-version $(DOTNET_VERSION)

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -45,9 +45,9 @@ jobs:
         dotnet new globaljson --sdk-version ${{ parameters.DOTNET_VERSION }}
 
     - task: NuGetToolInstaller@0
-      displayName: 'Use NuGet ${{ parameters.nugetVersion }}'
+      displayName: 'Use NuGet ${{ parameters.NUGET_VERSION }}'
       inputs:
-        versionSpec: ${{ parameters.nugetVersion }}
+        versionSpec: ${{ parameters.NUGET_VERSION }}
 
     - script: build.cmd -Target provision
       condition: eq(variables['provisioning'], 'false')

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -12,11 +12,12 @@ parameters:
   releaseBuildConfiguration : 'Release'
   buildPlatform : 'any cpu'
   msbuildExtraArguments : ''
-  nugetVersion: $(NUGET_VERSION)
   artifactsTargetFolder: '$(build.artifactstagingdirectory)'
   artifactsName: 'win_build'
   nunitTestAdapterFolder: 'packages/NUnitTestAdapter.AnyVersion/tools/'
   nunitTestFolder: '$(build.sourcesdirectory)'
+  DOTNET_VERSION: ''
+  NUGET_VERSION: ''
 
 jobs:
   - job: ${{ parameters.name }}
@@ -34,6 +35,20 @@ jobs:
           BuildConfiguration:  ${{ parameters.releaseBuildConfiguration }}
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
+
+    - task: DotNetCoreInstaller@0
+      displayName: 'Install .net core ${{ parameters.DOTNET_VERSION }}'
+      inputs:
+        version: ${{ parameters.DOTNET_VERSION }}
+
+    - script: |
+        dotnet new globaljson --sdk-version ${{ parameters.DOTNET_VERSION }}
+
+    - task: NuGetToolInstaller@0
+      displayName: 'Use NuGet ${{ parameters.nugetVersion }}'
+      inputs:
+        versionSpec: ${{ parameters.nugetVersion }}
+
     - script: build.cmd -Target provision
       condition: eq(variables['provisioning'], 'false')
   
@@ -44,19 +59,6 @@ jobs:
         provisioning_script: ${{ parameters.provisionatorPath }}
         provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
           
-    - task: DotNetCoreInstaller@0
-      displayName: 'Install .net core $(DOTNET_VERSION)'
-      inputs:
-        version: $(DOTNET_VERSION)
-
-    - script: |
-        dotnet new globaljson --sdk-version $(DOTNET_VERSION)
-
-    - task: NuGetToolInstaller@0
-      displayName: 'Use NuGet ${{ parameters.nugetVersion }}'
-      inputs:
-        versionSpec: ${{ parameters.nugetVersion }}
-
     - task: NuGetCommand@2
       displayName: 'NuGet restore ${{ parameters.slnPath }}'
       inputs:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -70,7 +70,7 @@ jobs:
         solution: ${{ parameters.slnPath }}
         platform: '$(BuildPlatform)'
         configuration: '$(BuildConfiguration)'
-        msbuildArguments: ${{ parameters.msbuildExtraArguments }}
+        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /p:JavaSdkDirectory="$(JAVA_HOME_8_X64)"
 
     - task: VSTest@2
       displayName: 'Unit Tests'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -16,8 +16,8 @@ parameters:
   artifactsName: 'win_build'
   nunitTestAdapterFolder: 'packages/NUnitTestAdapter.AnyVersion/tools/'
   nunitTestFolder: '$(build.sourcesdirectory)'
-  DOTNET_VERSION: ${{ coalesce(variables.DOTNET_VERSION, variables.DOTNET_VERSION_DEFAULT) }}
-  NUGET_VERSION: ${{ coalesce(variables['NUGET_VERSION'], variables['NUGET_VERSION_DEFAULT']) }}
+  DOTNET_VERSION: ''
+  NUGET_VERSION: ''
 
 jobs:
   - job: ${{ parameters.name }}

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -16,8 +16,6 @@ parameters:
   artifactsName: 'win_build'
   nunitTestAdapterFolder: 'packages/NUnitTestAdapter.AnyVersion/tools/'
   nunitTestFolder: '$(build.sourcesdirectory)'
-  DOTNET_VERSION: ''
-  NUGET_VERSION: ''
 
 jobs:
   - job: ${{ parameters.name }}
@@ -36,18 +34,19 @@ jobs:
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
 
+
     - task: DotNetCoreInstaller@0
-      displayName: 'Install .net core ${{ parameters.DOTNET_VERSION }}'
+      displayName: "Install .net core $(DOTNET_VERSION)"
       inputs:
-        version: ${{ parameters.DOTNET_VERSION }}
+        version: $(DOTNET_VERSION)
 
     - script: |
-        dotnet new globaljson --sdk-version ${{ parameters.DOTNET_VERSION }}
+        dotnet new globaljson --sdk-version $(DOTNET_VERSION)
 
     - task: NuGetToolInstaller@0
-      displayName: 'Use NuGet ${{ parameters.NUGET_VERSION }}'
+      displayName: 'Use NuGet $(NUGET_VERSION)'
       inputs:
-        versionSpec: ${{ parameters.NUGET_VERSION }}
+        versionSpec: $(NUGET_VERSION)
 
     - script: build.cmd -Target provision
       condition: eq(variables['provisioning'], 'false')

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -34,7 +34,7 @@ jobs:
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
 
-    ${{ if ne(variables['DOTNET_VERSION'], '') }}:
+    - ${{ if ne(variables['DOTNET_VERSION'], '') }}:
       - task: DotNetCoreInstaller@0
         displayName: "Install .net core $(DOTNET_VERSION)"
         inputs:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -33,6 +33,15 @@ jobs:
           BuildConfiguration:  ${{ parameters.releaseBuildConfiguration }}
           BuildPlatform: ${{ parameters.buildPlatform }}
     steps:
+    - script: build.cmd -Target provision
+      condition: eq(variables['provisioning'], 'false')
+  
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: Provisionate Xamarin
+      condition: eq(variables['provisioning'], 'true')
+      inputs:
+        provisioning_script: ${{ parameters.provisionatorPath }}
+        provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
 
     - task: DotNetCoreInstaller@0
       displayName: "Install .net core $(DOTNET_VERSION)"
@@ -46,18 +55,9 @@ jobs:
 
     - task: NuGetToolInstaller@0
       displayName: 'Use NuGet $(NUGET_VERSION)'
+      condition: ne(variables['NUGET_VERSION'], '')
       inputs:
         versionSpec: $(NUGET_VERSION)
-
-    - script: build.cmd -Target provision
-      condition: eq(variables['provisioning'], 'false')
-  
-    - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: Provisionate Xamarin
-      condition: eq(variables['provisioning'], 'true')
-      inputs:
-        provisioning_script: ${{ parameters.provisionatorPath }}
-        provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
           
     - task: NuGetCommand@2
       displayName: 'NuGet restore ${{ parameters.slnPath }}'


### PR DESCRIPTION
### Description of Change ###

This PR sets up two paths for provisioning
- Public path all public sdks
  - This uses Cake to install the sdks versions desired. I realize we had stepped away from using cake for this and just used inline scripts on the YAML file but I'd really prefer to use cake because of the reduced amount of effort it takes to make it work and for it to work cross platform. For example provisioning android APIs is a lot easier with @Redth 's cake plugins than using command line. Plus with cake it makes it easier if people want to run the provision task from the time line
- Internal path for master branches and alpha testing
  - This is the path used when we want to use provisionator and need to install things that we can only access internally. This is the path we will use for our weekly tests against the master branches of the sdks and whatever the latest xcode version is

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP