### PR TITLE
Fix direction of walking when calculating effective FlyoutBehavior 

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -668,7 +668,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(bindingContext, menuItem2.BindingContext);
 		}
 
-    [Test]
+		[Test]
 		public async Task TitleViewLogicalChild()
 		{
 			Shell shell = new Shell();
@@ -709,9 +709,37 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.FlyoutHeader = null;
 
 			Assert.False(shell.ChildrenNotDrawnByThisElement.Contains(layout));
-    }
-    
-    
+		}
+
+
+		[Test]
+		public async Task ShellFlyoutBehaviorCalculation()
+		{
+			Shell shell = new Shell();
+			ContentPage page = new ContentPage();
+			shell.Items.Add(CreateShellItem(page: page));
+			Assert.AreEqual(FlyoutBehavior.Flyout, shell.GetEffectiveFlyoutBehavior());
+
+			Shell.SetFlyoutBehavior(page, FlyoutBehavior.Disabled);
+			Shell.SetFlyoutBehavior(shell.Items[0].Items[0].Items[0], FlyoutBehavior.Flyout);
+			Shell.SetFlyoutBehavior(shell.Items[0].Items[0], FlyoutBehavior.Disabled);
+			Shell.SetFlyoutBehavior(shell.Items[0], FlyoutBehavior.Locked);
+
+			Assert.AreEqual(FlyoutBehavior.Disabled, shell.GetEffectiveFlyoutBehavior());
+
+			page.ClearValue(Shell.FlyoutBehaviorProperty);
+			Assert.AreEqual(FlyoutBehavior.Flyout, shell.GetEffectiveFlyoutBehavior());
+
+			shell.Items[0].Items[0].Items[0].ClearValue(Shell.FlyoutBehaviorProperty);
+			Assert.AreEqual(FlyoutBehavior.Disabled, shell.GetEffectiveFlyoutBehavior());
+
+			shell.Items[0].Items[0].ClearValue(Shell.FlyoutBehaviorProperty);
+			Assert.AreEqual(FlyoutBehavior.Locked, shell.GetEffectiveFlyoutBehavior());
+
+			shell.Items[0].ClearValue(Shell.FlyoutBehaviorProperty);
+			Assert.AreEqual(FlyoutBehavior.Flyout, shell.GetEffectiveFlyoutBehavior());
+		}
+
 		[Test]
 		public async Task TabBarAutoCreation()
 		{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1066,7 +1066,7 @@ namespace Xamarin.Forms
 
 		internal Element GetVisiblePage()
 		{
-			if (CurrentItem.CurrentItem is IShellSectionController scc)
+			if (CurrentItem?.CurrentItem is IShellSectionController scc)
 				return scc.PresentedPage;
 
 			return null;

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -954,17 +954,21 @@ namespace Xamarin.Forms
 			return lookupDict;
 		}
 
-		FlyoutBehavior GetEffectiveFlyoutBehavior()
-		{
-			var page = WalkToPage(this);
+		internal FlyoutBehavior GetEffectiveFlyoutBehavior() => GetEffectiveValue(Shell.FlyoutBehaviorProperty, FlyoutBehavior);
 
-			while (page != this && page != null)
+		T GetEffectiveValue<T>(BindableProperty property, T defaultValue)
+		{
+			Element element = GetVisiblePage();
+
+			while (element != this && element != null)
 			{
-				if (page.IsSet(FlyoutBehaviorProperty))
-					return GetFlyoutBehavior(page);
-				page = page.Parent;
+				if (element.IsSet(property))
+					return (T)element.GetValue(property);
+
+				element = element.Parent;
 			}
-			return FlyoutBehavior;
+
+			return defaultValue;
 		}
 
 		ShellAppearance GetAppearanceForPivot(Element pivot)
@@ -988,7 +992,7 @@ namespace Xamarin.Forms
 
 				// One minor deviation here. Even though a pushed page is technically the child of
 				// a ShellSection and not the ShellContent, we want the root ShellContent to 
-				// be taken into account. Yes this could behavior oddly if the developer switches
+				// be taken into account. Yes this could behave oddly if the developer switches
 				// tabs while a page is pushed, however that is in the developers wheelhouse
 				// and this will be the generally expected behavior.
 				if (!foundShellContent && pivot is ShellSection shellSection && shellSection.CurrentItem != null)
@@ -1058,6 +1062,14 @@ namespace Xamarin.Forms
 			OnNavigating(navArgs);
 			//System.Diagnostics.Debug.WriteLine("Proposed: " + proposedState.Location);
 			return !navArgs.Cancelled;
+		}
+
+		internal Element GetVisiblePage()
+		{
+			if (CurrentItem.CurrentItem is IShellSectionController scc)
+				return scc.PresentedPage;
+
+			return null;
 		}
 
 		Element WalkToPage(Element element)


### PR DESCRIPTION
### Description of Change ###

Wrong method called to get current page so FlyoutBehavior could effectively be calculated. This change retrieves the visible page and then walks up the tree correctly

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included
- test by setting the Flyout Behavior at different levels of the Shell tree

### PR Checklist ###

- [x] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [x] Rebased on top of the target branch at time of PR
- [x] Changes adhere to coding standard
