### PR TITLE
Add check to see if ShellContent is Visible one before firing OnAppearing

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
@@ -342,6 +342,37 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 
+		[Test]
+		public void AppearingOnlyForVisiblePage()
+		{
+			Shell shell = new Shell();
+			var pageAppearing = new ContentPage();
+			var pageNotAppearing = new ContentPage();
+
+			FlyoutItem flyoutItem = new FlyoutItem();
+			Tab tab = new Tab();
+			ShellContent content = new ShellContent() { Content = pageAppearing };
+
+			bool pageAppearingFired = false;
+			bool pageNotAppearingFired = false;
+
+			pageAppearing.Appearing += (_, __) => pageAppearingFired = true;
+			pageNotAppearing.Appearing += (_, __) =>
+			{
+				pageNotAppearingFired = true;
+			};
+
+			shell.Items.Add(flyoutItem);
+			flyoutItem.Items.Add(tab);
+			tab.Items.Add(content);
+
+			var notAppearingContent = new ShellContent();
+			tab.Items.Add(notAppearingContent);
+			notAppearingContent.Content = pageNotAppearing;
+
+			Assert.True(pageAppearingFired, "Correct Page Appearing Fired");
+			Assert.False(pageNotAppearingFired, "Incorrect Page Appearing Fired");
+		}
 
 
 		class ShellLifeCycleState

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms
 
 		public ShellContent() => ((INotifyCollectionChanged)MenuItems).CollectionChanged += MenuItemsCollectionChanged;
 
-		internal bool IsVisibleContent => Parent is ShellSection shellSection && shellSection.IsVisibleSection;
+		internal bool IsVisibleContent => Parent is ShellSection shellSection && shellSection.IsVisibleSection && shellSection.CurrentItem == this;
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
 
 		internal override void SendDisappearing()


### PR DESCRIPTION
### Description of Change ###
OnAppearing is firing for all ShellContents that are part of a ShellSection on first load. We need to check to see if the current ShellContent is even the active one before firing *OnAppearing*

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- automated tests
- Create a shell with two ShellContent items for the same Tab and make sure OnAppearing is only firing for one of them when the application loads. 

### PR Checklist ###

- [ ] Has automated tests <!-- (if tests are omitted or manual, state reason in description) -->
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
