### PR TITLE
Wrong type checked after casting to type being searched for

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/ApiLabelRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ApiLabelRenderer.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using Android.Content;
+using Android.OS;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(ApiLabel), typeof(ApiLabelRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class ApiLabelRenderer : Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer
+	{
+		public ApiLabelRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			Element.Text = ((int)Build.VERSION.SdkInt).ToString();
+			base.OnElementChanged(e);
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -123,6 +123,7 @@
     <Compile Include="..\Xamarin.Forms.Controls\GalleryPages\OpenGLGalleries\AdvancedOpenGLGallery.cs">
       <Link>GalleryPages\AdvancedOpenGLGallery.cs</Link>
     </Compile>
+    <Compile Include="ApiLabelRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />

--- a/Xamarin.Forms.ControlGallery.iOS/ApiLabelRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/ApiLabelRenderer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(ApiLabel), typeof(ApiLabelRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class ApiLabelRenderer : LabelRenderer
+	{
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			Element.Text = UIDevice.CurrentDevice.SystemVersion.ToString();
+			base.OnElementChanged(e);
+			
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -126,6 +126,7 @@
     <Compile Include="CustomEffects\GradientEffect.cs" />
     <Compile Include="CustomRenderers\CustomRenderer.cs" />
     <Compile Include="CustomRenderers\RoundedLabelRenderer.cs" />
+    <Compile Include="ApiLabelRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/ApiLabel.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/ApiLabel.cs
@@ -1,0 +1,11 @@
+﻿using System;
+namespace Xamarin.Forms.Controls
+{
+	public class ApiLabel : Label
+	{
+		public ApiLabel()
+		{
+			AutomationId = "ApiLabel";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7329.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7329.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					Children =
 					{
+						new ApiLabel(),
 						new Label() { Text = "If the List View can scroll the test has passed"},
 						listView
 					}
@@ -60,6 +61,12 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ScrollListViewInsideScrollView()
 		{
+
+#if __ANDROID__
+			if (!RunningApp.IsApiHigherThan(21))
+				return;
+#endif
+
 			RunningApp.WaitForElement("1");
 			RunningApp.ScrollDownTo("30", strategy: ScrollStrategy.Gesture);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7329.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7329.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7329, "[Android] ListView scroll not working when inside a ScrollView",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.ScrollView)]
+#endif
+	public class Issue7329 : TestContentPage
+	{
+		ListView listView = null;
+		protected override void Init()
+		{
+			listView = new ListView() { AutomationId = "NestedListView" };
+			listView.ItemsSource = Enumerable.Range(0, 200).Select(x=> new Data() { Text = x }).ToList();
+
+			Content = new ScrollView()
+			{
+				AutomationId = "ParentScrollView",
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label() { Text = "If the List View can scroll the test has passed"},
+						listView
+					}
+				}
+			};
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Data
+		{
+			public int Text { get; set; }
+
+			public override string ToString()
+			{
+				return Text.ToString();
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void ScrollListViewInsideScrollView()
+		{
+			RunningApp.WaitForElement("1");
+			RunningApp.ScrollDownTo("30", strategy: ScrollStrategy.Gesture);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7290.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7240.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5046.xaml.cs">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1021,6 +1021,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7053.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6929.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\ApiLabel.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -5,6 +5,7 @@ using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 using System.Text.RegularExpressions;
 using System.Threading;
+using Xamarin.Forms.Controls.Issues;
 #if __IOS__
 using Xamarin.UITest.iOS;
 #endif
@@ -30,6 +31,16 @@ namespace Xamarin.UITest
 			}
 
 			return results;
+		}
+
+		public static bool IsApiHigherThan(this IApp app, int apiLevel, string apiLabelId = "ApiLevel")
+		{
+			var api = Convert.ToInt32(app.WaitForElement("ApiLabel")[0].ReadText());
+
+			if (api < apiLevel)
+				return false;
+
+			return true;
 		}
 
 #if __IOS__

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal static T GetParentOfType<T>(this IViewParent view)
 			where T : class
 		{
-			if (view != null && view is T t)
+			if (view is T t)
 				return t;
 
 			while (view != null)

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -116,8 +116,7 @@ namespace Xamarin.Forms.Platform.Android
 		internal static T GetParentOfType<T>(this IViewParent view)
 			where T : class
 		{
-			T t = view as T;
-			if (view != null)
+			if (view != null && view is T t)
 				return t;
 
 			while (view != null)


### PR DESCRIPTION
### Description of Change ###
Fixed code to correctly check and return the correct type when walking up the hierarchy searching for a parent. 

Regression: 
https://github.com/xamarin/Xamarin.Forms/pull/7032/files#diff-ef4e030a3614a0c4819c7bffc5fd7b03R114

### Issues Resolved ### 
- fixes #7329 


### Platforms Affected ### 

- Android


### Testing Procedure ###
- Automated Tests

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
