### PR TITLE
[Enhancement] Xamarin.Forms.Platform.WPF.ImageExtensions to public

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/ImageExtensions.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 		}
 
-		public static async Task<WImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default)
+		public static async Task<WImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
 		{
 			if (source == null || source.IsEmpty)
 				return null;

--- a/Xamarin.Forms.Platform.WPF/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/ImageExtensions.cs
@@ -10,8 +10,12 @@ using WImageSource = System.Windows.Media.ImageSource;
 
 namespace Xamarin.Forms.Platform.WPF
 {
-	internal static class ImageExtensions
+	/// <summary>Helper to convert xamarin image stuff to wpf image stuff.</summary>
+	public static class ImageExtensions
 	{
+		/// <summary>Convert xamarin stretch to wpf aspect.</summary>
+		/// <param name="aspect"></param>
+		/// <returns></returns>
 		public static Stretch ToStretch(this Aspect aspect)
 		{
 			switch (aspect)
@@ -26,12 +30,11 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 		}
 
-		public static WImageSource ToWindowsImageSource(this ImageSource source)
-		{
-			return source.ToWindowsImageSourceAsync().GetAwaiter().GetResult();
-		}
-
-		public static async Task<WImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
+		/// <summary>Convert a xamarin image source to a wpf image source.</summary>
+		/// <param name="source">Xamarin forms image source</param>
+		/// <param name="cancellationToken">Cancellation token for the operation.</param>
+		/// <returns>Wpf image source</returns>
+		public static async Task<WImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default)
 		{
 			if (source == null || source.IsEmpty)
 				return null;

--- a/Xamarin.Forms.Platform.WPF/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/ImageExtensions.cs
@@ -10,12 +10,8 @@ using WImageSource = System.Windows.Media.ImageSource;
 
 namespace Xamarin.Forms.Platform.WPF
 {
-	/// <summary>Helper to convert xamarin image stuff to wpf image stuff.</summary>
 	public static class ImageExtensions
 	{
-		/// <summary>Convert xamarin stretch to wpf aspect.</summary>
-		/// <param name="aspect"></param>
-		/// <returns></returns>
 		public static Stretch ToStretch(this Aspect aspect)
 		{
 			switch (aspect)
@@ -30,10 +26,6 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 		}
 
-		/// <summary>Convert a xamarin image source to a wpf image source.</summary>
-		/// <param name="source">Xamarin forms image source</param>
-		/// <param name="cancellationToken">Cancellation token for the operation.</param>
-		/// <returns>Wpf image source</returns>
 		public static async Task<WImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default)
 		{
 			if (source == null || source.IsEmpty)


### PR DESCRIPTION
### Description of Change ###

It would be nice for wpf-implementations, that the helper ToWindowsImageSourceAsync is public.

### Issues Resolved ### 

- fixes #7445

### API Changes ###
```C#
public static class ImageExtensions
 {
  public static Stretch ToStretch(this Aspect aspect) {}

  public static async Task<WImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken)) {}
 }
```
 
 None

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Has automated tests
- [ ] Rebased on top of the target branch at time of PR
- [ ] Changes adhere to coding standard
