### PR TITLE
Call the application OnResume, on Android Resume instead of Restart.

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -446,7 +446,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (_previousState == AndroidApplicationLifecycleState.OnCreate && _currentState == AndroidApplicationLifecycleState.OnStart)
 				_application.SendStart();
-			else if (_previousState == AndroidApplicationLifecycleState.OnStop && _currentState == AndroidApplicationLifecycleState.OnRestart)
+			else if (_previousState == AndroidApplicationLifecycleState.OnRestart && _currentState == AndroidApplicationLifecycleState.OnStart)	
 				_application.SendResume();
 			else if (_previousState == AndroidApplicationLifecycleState.OnPause && _currentState == AndroidApplicationLifecycleState.OnStop)
 				_application.SendSleep();

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -263,7 +263,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (_previousState == AndroidApplicationLifecycleState.OnCreate && _currentState == AndroidApplicationLifecycleState.OnStart)
 				_application.SendStart();
-			else if (_previousState == AndroidApplicationLifecycleState.OnStop && _currentState == AndroidApplicationLifecycleState.OnRestart)
+			else if (_previousState == AndroidApplicationLifecycleState.OnRestart && _currentState == AndroidApplicationLifecycleState.OnStart)	
 				_application.SendResume();
 			else if (_previousState == AndroidApplicationLifecycleState.OnPause && _currentState == AndroidApplicationLifecycleState.OnStop)
 				_application.SendSleep();


### PR DESCRIPTION
### Description of Change ###
Fix regression introduced by #4707.

The OnResume worked before due to a side effect.
#4707 fixed the previous activity destroy which incorrectly triggered the page change.
Now that the event state are consistant, this revealed that OnResume event on the application was not called during Android Resume but during Android Restart event.
This PR modify when the SendResume is triggered to be consistant with the Android lifecycle.

### Issues Resolved ### 
- Fixes #7400

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
The OnResume method is called on Android Resume

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
[issue7400.zip](https://github.com/xamarin/Xamarin.Forms/files/3600649/issue7400.zip)
The reproduction project has the framework code included. So you can test with and without the modification.

1. Start reproduction project
2. Set a breakpoint on OnResume method in the App class
3. Move app to background
4. Resume app 
5. Breakpoint must be hit

### PR Checklist ###
- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
