### PR TITLE
fix NRE on _itemsSource when using IEnumerable

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsSourceTypes.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsSourceTypes.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "CollectionView ItemsSource Types", PlatformAffected.All)]
+	public class CollectionViewItemsSourceTypes : TestContentPage
+	{
+		protected override void Init()
+		{
+#if APP
+			FlagTestHelpers.SetCollectionViewTestFlag();
+#endif
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "If you see three 900s this test has passed"
+					},
+					new CollectionView()
+					{
+						ItemsSource = new[] { 900 },
+						HeightRequest = 50
+					},
+					new CollectionView()
+					{
+						ItemsSource = new[] { "900" }.ToList<object>(),
+						HeightRequest = 50
+					},
+					new CollectionView()
+					{
+						ItemsSource = new ObservableCollection<string>(new[] { "900" }),
+						HeightRequest = 50
+					}
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionViewItemsSourceTypesDisplayAndDontCrash()
+		{
+			RunningApp.QueryUntilPresent(() =>
+			{
+				var result = RunningApp.WaitForElement("900");
+
+				if (result.Length == 3)
+					return result;
+
+				return null;
+			});
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">
       <DependentUpon>Issue1455.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ListSource.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public ListSource(IEnumerable enumerable)
 		{
+			_itemsSource = new List<object>();
 			foreach (object item in enumerable)
 			{
 				_itemsSource.Add(item);


### PR DESCRIPTION
### Description of Change ###

When ItemsSource is set to an IEnumerable or primitives the _itemsSource wasn't being instantiated and it was throwing an NRE

### Platforms Affected ### 
- Android

### Testing Procedure ###
- tests are automated

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
