### PR TITLE
Label - Add the ability to justify text

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
@@ -102,7 +102,16 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 
-			var yAlignCenterContainer = new ViewContainer<Label> (Test.Label.VerticalTextAlignmentCenter, 
+			var xAlignJustifyContainer = new ViewContainer<Label>(Test.Label.HorizontalTextAlignmentJustify,
+				new Label {
+					Text = "HorizontalTextAlignment Justify with long text : " + longText,
+					HorizontalTextAlignment = TextAlignment.Justify,
+					HeightRequest = alignmentTestsHeightRequest,
+					WidthRequest = alignmentTestsWidthRequest
+				}
+			);
+
+			var yAlignCenterContainer = new ViewContainer<Label>(Test.Label.VerticalTextAlignmentCenter,
 				new Label {
 					Text = "VerticalTextAlignment Start",
  					VerticalTextAlignment = TextAlignment.Center,
@@ -299,6 +308,7 @@ namespace Xamarin.Forms.Controls
 			Add (xAlignCenterContainer);
 			Add (xAlignEndContainer);
 			Add (xAlignStartContainer);
+			Add (xAlignJustifyContainer);
 			Add (yAlignCenterContainer);
 			Add (yAlignEndContainer);
 			Add (yAlignStartContainer);

--- a/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/LabelGallery.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,6 +13,13 @@ namespace Xamarin.Forms.Controls
 			var normal = new Label { Text = "Normal Label" };
 			var center = new Label { Text = "Center Label" };
 			var right = new Label { Text = "Right Label" };
+			var justify = new Label
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Text = "Justify Label, with huge text : " +
+				"The five boxing wizards jump quickly. " +
+				"The quick brown fox jumps over the lazy dog. How vexingly quick daft zebras jump!",
+			};
 			var moving = new Label { Text = "Move On Click" };
 			var click = new Label { Text = "Click Label" };
 			var rotate = new Label { Text = "Rotate Label" };
@@ -122,6 +129,7 @@ namespace Xamarin.Forms.Controls
 #pragma warning restore 618
 			center.HorizontalTextAlignment = TextAlignment.Center;
 			right.HorizontalTextAlignment = TextAlignment.End;
+			justify.HorizontalTextAlignment = TextAlignment.Justify;
 			int i = 1;
 			click.GestureRecognizers.Add (new TapGestureRecognizer{Command = new Command (o=>click.Text = "Clicked " + i++)});
 			rotate.GestureRecognizers.Add (new TapGestureRecognizer{Command = new Command (o=>rotate.RelRotateTo (180))});
@@ -146,6 +154,7 @@ namespace Xamarin.Forms.Controls
 						normal,
 						center,
 						right,
+						justify,
 						huge,
 						moving,
 						click,

--- a/Xamarin.Forms.Core/TextAlignment.cs
+++ b/Xamarin.Forms.Core/TextAlignment.cs
@@ -7,7 +7,8 @@ namespace Xamarin.Forms
 	{
 		Start,
 		Center,
-		End
+		End,
+		Justify
 	}
 
 	[Xaml.TypeConversion(typeof(TextAlignment))]
@@ -32,6 +33,8 @@ namespace Xamarin.Forms
 					return TextAlignment.End;
 				if (value.Equals("Center", StringComparison.OrdinalIgnoreCase) || value.Equals("center", StringComparison.OrdinalIgnoreCase))
 					return TextAlignment.Center;
+				if (value.Equals("Justify", StringComparison.OrdinalIgnoreCase) || value.Equals("justify", StringComparison.OrdinalIgnoreCase))
+					return TextAlignment.Justify;
 
 				if (Enum.TryParse(value, out TextAlignment direction))
 					return direction;

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -639,6 +639,7 @@ namespace Xamarin.Forms.CustomAttributes
 			HorizontalTextAlignmentStart,
 			HorizontalTextAlignmentCenter,
 			HorizontalTextAlignmentEnd,
+			HorizontalTextAlignmentJustify,
 			VerticalTextAlignmentStart,
 			VerticalTextAlignmentCenter,
 			VerticalTextAlignmentEnd,

--- a/Xamarin.Forms.Platform.Android/Extensions/TextAlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextAlignmentExtensions.cs
@@ -1,6 +1,8 @@
-﻿using Android.OS;
+using Android.OS;
 using Android.Widget;
 using AGravityFlags = Android.Views.GravityFlags;
+using AJustificationMode = Android.Text.JustificationMode;
+using ATextAlignement = Android.Views.TextAlignment;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -10,8 +12,18 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if ((int)Build.VERSION.SdkInt < 17 || !hasRtlSupport)
 				view.Gravity = alignment.ToHorizontalGravityFlags() | orMask;
-			else
+			else if ((int)Build.VERSION.SdkInt < 26)
 				view.TextAlignment = alignment.ToTextAlignment();
+			else if (alignment == TextAlignment.Justify)
+			{
+				view.JustificationMode = AJustificationMode.InterWord;
+				view.TextAlignment = ATextAlignement.ViewStart;
+			}
+			else
+			{
+				view.JustificationMode = AJustificationMode.None;
+				view.TextAlignment = alignment.ToTextAlignment();
+			}
 		}
 
 		internal static void UpdateVerticalAlignment(this EditText view, TextAlignment alignment, AGravityFlags orMask = AGravityFlags.NoGravity)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -13,6 +13,7 @@ using Android.Util;
 using Android.Views;
 using Android.Widget;
 using AView = Android.Views.View;
+using Android.OS;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
 {
@@ -265,7 +266,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				if (e.OldElement?.LineBreakMode != e.NewElement.LineBreakMode)
 					UpdateLineBreakMode();
 				if (e.OldElement?.HorizontalTextAlignment != e.NewElement.HorizontalTextAlignment || e.OldElement?.VerticalTextAlignment != e.NewElement.VerticalTextAlignment)
-					UpdateGravity();
+					UpdateGravityAndJustificationModel();
 				if (e.OldElement?.MaxLines != e.NewElement.MaxLines)
 					UpdateMaxLines();
 
@@ -288,7 +289,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return;
 
 			if (e.PropertyName == Label.HorizontalTextAlignmentProperty.PropertyName || e.PropertyName == Label.VerticalTextAlignmentProperty.PropertyName)
-				UpdateGravity();
+				UpdateGravityAndJustificationModel();
 			else if (e.PropertyName == Label.TextColorProperty.PropertyName ||
 				e.PropertyName == Label.TextTypeProperty.PropertyName)
 				UpdateText();
@@ -362,10 +363,12 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				PaintFlags |= PaintFlags.UnderlineText;
 		}
 
-		void UpdateGravity()
+		void UpdateGravityAndJustificationModel()
 		{
 			Label label = Element;
-
+			
+			if ((int)Build.VERSION.SdkInt > 25)
+				JustificationMode = label.HorizontalTextAlignment == Xamarin.Forms.TextAlignment.Justify ? JustificationMode.InterWord : JustificationMode.None;
 			Gravity = label.HorizontalTextAlignment.ToHorizontalGravityFlags() | label.VerticalTextAlignment.ToVerticalGravityFlags();
 
 			_lastSizeRequest = null;

--- a/Xamarin.Forms.Platform.Android/Renderers/AlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AlignmentExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Android.Views;
 using ATextAlignment = Android.Views.TextAlignment;
 
@@ -39,6 +40,8 @@ namespace Xamarin.Forms.Platform.Android
 					return GravityFlags.Top;
 				case TextAlignment.End:
 					return GravityFlags.Bottom;
+				case TextAlignment.Justify:
+					throw new NotSupportedException("Justify is not supported for vertical alignment");
 				default:
 					return GravityFlags.CenterVertical;
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -1,6 +1,7 @@
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
+using Android.OS;
 using Android.Text;
 using Android.Util;
 using Android.Views;
@@ -120,7 +121,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateLineBreakMode();
 				UpdateCharacterSpacing();
 				UpdateLineHeight();
-				UpdateGravity();
+				UpdateGravityAndJustificationModel();
 				UpdateMaxLines();
 			}
 			else
@@ -129,7 +130,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (e.OldElement.LineBreakMode != e.NewElement.LineBreakMode)
 					UpdateLineBreakMode();
 				if (e.OldElement.HorizontalTextAlignment != e.NewElement.HorizontalTextAlignment || e.OldElement.VerticalTextAlignment != e.NewElement.VerticalTextAlignment)
-					UpdateGravity();
+					UpdateGravityAndJustificationModel();
 				if (e.OldElement.MaxLines != e.NewElement.MaxLines)
 					UpdateMaxLines();
 				if (e.OldElement.CharacterSpacing != e.NewElement.CharacterSpacing)
@@ -150,7 +151,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnElementPropertyChanged(sender, e);
 
 			if (e.PropertyName == Label.HorizontalTextAlignmentProperty.PropertyName || e.PropertyName == Label.VerticalTextAlignmentProperty.PropertyName)
-				UpdateGravity();
+				UpdateGravityAndJustificationModel();
 			else if (e.IsOneOf(Label.TextColorProperty, Label.TextTransformProperty))
 				UpdateText();
 			else if (e.PropertyName == Label.FontProperty.PropertyName)
@@ -223,10 +224,12 @@ namespace Xamarin.Forms.Platform.Android
 				_view.PaintFlags |= PaintFlags.UnderlineText;
 		}
 
-		void UpdateGravity()
+		void UpdateGravityAndJustificationModel()
 		{
 			Label label = Element;
 
+			if ((int)Build.VERSION.SdkInt > 25)
+				_view.JustificationMode = label.HorizontalTextAlignment == Xamarin.Forms.TextAlignment.Justify ? JustificationMode.InterWord : JustificationMode.None;
 			_view.Gravity = label.HorizontalTextAlignment.ToHorizontalGravityFlags() | label.VerticalTextAlignment.ToVerticalGravityFlags();
 
 			_lastSizeRequest = null;

--- a/Xamarin.Forms.Platform.MacOS/Extensions/AlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/AlignmentExtensions.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			var isLtr = flowDirection.IsLeftToRight();
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					return NSTextAlignment.Justified;
 				case TextAlignment.Center:
 					return NSTextAlignment.Center;
 				case TextAlignment.End:

--- a/Xamarin.Forms.Platform.UAP/AlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/AlignmentExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using Windows.UI.Xaml;
 
 namespace Xamarin.Forms.Platform.UWP
@@ -9,6 +10,8 @@ namespace Xamarin.Forms.Platform.UWP
 			var isLtr = flowDirection.IsLeftToRight();
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					return Windows.UI.Xaml.TextAlignment.Justify;
 				case TextAlignment.Center:
 					return Windows.UI.Xaml.TextAlignment.Center;
 				case TextAlignment.End:
@@ -28,6 +31,8 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					throw new NotSupportedException("Justify is not supported for vertical alignment");
 				case TextAlignment.Center:
 					return VerticalAlignment.Center;
 				case TextAlignment.End:

--- a/Xamarin.Forms.Platform.UAP/TextAlignmentToHorizontalAlignmentConverter.cs
+++ b/Xamarin.Forms.Platform.UAP/TextAlignmentToHorizontalAlignmentConverter.cs
@@ -11,6 +11,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			switch (alignment)
 			{
+				case Windows.UI.Xaml.TextAlignment.Justify:
+					return HorizontalAlignment.Stretch;
 				case Windows.UI.Xaml.TextAlignment.Center:
 					return HorizontalAlignment.Center;
 				case Windows.UI.Xaml.TextAlignment.Left:
@@ -28,6 +30,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			switch (alignment)
 			{
+				case HorizontalAlignment.Stretch:
+					return Windows.UI.Xaml.TextAlignment.Justify;
 				case HorizontalAlignment.Left:
 					return Windows.UI.Xaml.TextAlignment.Left;
 				case HorizontalAlignment.Center:

--- a/Xamarin.Forms.Platform.WPF/Extensions/AlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/AlignmentExtensions.cs
@@ -9,6 +9,8 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					return System.Windows.TextAlignment.Justify;
 				case TextAlignment.Center:
 					return System.Windows.TextAlignment.Center;
 				case TextAlignment.End:
@@ -22,6 +24,8 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					throw new NotSupportedException("Justify is not supported for vertical alignment");
 				case TextAlignment.Start:
 					return VerticalAlignment.Top;
 				case TextAlignment.Center:

--- a/Xamarin.Forms.Platform.iOS/Renderers/AlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/AlignmentExtensions.cs
@@ -1,3 +1,4 @@
+using System;
 using UIKit;
 using Xamarin.Forms.Internals;
 
@@ -10,6 +11,8 @@ namespace Xamarin.Forms.Platform.iOS
 			var isLtr = flowDirection.IsLeftToRight();
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					return UITextAlignment.Justified;
 				case TextAlignment.Center:
 					return UITextAlignment.Center;
 				case TextAlignment.End:
@@ -29,6 +32,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			switch (alignment)
 			{
+				case TextAlignment.Justify:
+					throw new NotSupportedException("Justify is not supported for vertical alignment");
 				case TextAlignment.Center:
 					return UIControlContentVerticalAlignment.Center;
 				case TextAlignment.End:

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -71,22 +71,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				style.LineHeightMultiple = new nfloat(lineHeight);
 			}
 
-			switch (textAlignment)
-			{
-				case TextAlignment.Start:
-					style.Alignment = UITextAlignment.Left;
-					break;
-				case TextAlignment.Center:
-					style.Alignment = UITextAlignment.Center;
-					break;
-				case TextAlignment.End:
-					style.Alignment = UITextAlignment.Right;
-					break;
-				default:
-					style.Alignment = UITextAlignment.Left;
-					break;
-			}
-
+			style.Alignment = textAlignment.ToNativeTextAlignment(EffectiveFlowDirection.Explicit);
 
 #if __MOBILE__
 			UIFont targetFont;


### PR DESCRIPTION
### Description of Change ###

Add Ability to justify text for label.
Adding TextAlignment.Justify

### Issues Resolved ### 

- fixes #6009

### API Changes ###

Added :
- TextAlignment.Justify

When TextAlignement.Justify is used in VerticalAlignment property, that throw an NotSupportedException like @adrianknight89 suggested. Feel free to ask me to change this behavior.

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android ( > API 25, TextAlignment.Start either)
- UWP
- MacOS
- WPF

### Behavioral/Visual Changes ###
Ability to justify text in label


### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
I've added a test control in ControlGallery (Label & LabelLegacy)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
