### PR TITLE
[Android/iOS] Update CollectionView when user changes out the header/footer

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml
@@ -6,33 +6,36 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterGrid">
     <ContentPage.Content>
-        <CollectionView x:Name="CollectionView" >
-            <CollectionView.ItemsLayout>
-                <GridItemsLayout Span="3" Orientation="Vertical" HorizontalItemSpacing="4" VerticalItemSpacing="2"></GridItemsLayout>
-            </CollectionView.ItemsLayout>
-
-            <CollectionView.Header>
-
-                <StackLayout>
-                    <Image Source="oasis.jpg" Aspect="AspectFill" HeightRequest="60"></Image>
-                    <Label Text="This Is A Header" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" 
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+            </Grid.RowDefinitions>
+            <StackLayout Orientation="Horizontal">
+                <Button Text="Toggle Header" Clicked="ToggleHeader"></Button>
+                <Button Text="Toggle Footer" Clicked="ToggleFooter"></Button>
+            </StackLayout>
+            <CollectionView x:Name="CollectionView" Grid.Row="1" >
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Span="3" Orientation="Vertical" HorizontalItemSpacing="4" VerticalItemSpacing="2"></GridItemsLayout>
+                </CollectionView.ItemsLayout>
+                <CollectionView.Header>
+                    <StackLayout BackgroundColor="Transparent">
+                        <Image Source="oasis.jpg" Aspect="AspectFill" HeightRequest="60"></Image>
+                        <Label Text="This Is A Header" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" 
                            FontAttributes="Bold" FontSize="36" />
-                    <Button Text="Add Content" Clicked="Handle_Clicked"></Button>
-                </StackLayout>
-
-            </CollectionView.Header>
-
-            <CollectionView.Footer>
-
-                <StackLayout>
-                    <Image Source="cover1.jpg" Aspect="AspectFill" HeightRequest="80"></Image>
-                    <Label Text="This Is A Footer" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
+                        <Button Text="Add Content" Clicked="AddContentClicked"></Button>
+                    </StackLayout>
+                </CollectionView.Header>
+                <CollectionView.Footer>
+                    <StackLayout BackgroundColor="Transparent">
+                        <Image Source="oasis.jpg" Aspect="AspectFill" HeightRequest="80"></Image>
+                        <Label Text="This Is A Footer" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
                            FontAttributes="Bold" FontSize="20" />
-                    <Button Text="Add Content" Clicked="Handle_Clicked"></Button>
-                </StackLayout>
-
-            </CollectionView.Footer>
-
-        </CollectionView>
+                        <Button Text="Add Content" Clicked="AddContentClicked"></Button>
+                    </StackLayout>
+                </CollectionView.Footer>
+            </CollectionView>
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGrid.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms.Xaml;
+﻿using System;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries
 {
@@ -6,6 +7,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFoot
 	public partial class HeaderFooterGrid : ContentPage
 	{
 		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(10);
+
+		object header = null;
+		object footer = null;
 
 		public HeaderFooterGrid()
 		{
@@ -15,10 +19,30 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFoot
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
 		}
 
-		void Handle_Clicked(object sender, System.EventArgs e)
+		void AddContentClicked(object sender, System.EventArgs e)
 		{
 			if (sender is VisualElement ve && ve.Parent is StackLayout sl)
 				sl.Children.Add(new Label() { Text = "Grow" });
+		}
+
+		void ToggleHeader(object sender, System.EventArgs e)
+		{
+			header = CollectionView.Header ?? header;
+
+			if (CollectionView.Header == null)
+				CollectionView.Header = header;
+			else
+				CollectionView.Header = null;
+		}
+
+		void ToggleFooter(object sender, System.EventArgs e)
+		{
+			footer = CollectionView.Footer ?? footer;
+
+			if (CollectionView.Footer == null)
+				CollectionView.Footer = footer;
+			else
+				CollectionView.Footer = null;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml
@@ -6,37 +6,65 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterGridHorizontal">
     <ContentPage.Content>
-        <CollectionView x:Name="CollectionView" >
-            <CollectionView.ItemsLayout>
-                <GridItemsLayout Span="3" Orientation="Horizontal" HorizontalItemSpacing="4" VerticalItemSpacing="2"></GridItemsLayout>
-            </CollectionView.ItemsLayout>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"></RowDefinition>
+                <RowDefinition Height="Auto"></RowDefinition>
+            </Grid.RowDefinitions>
+            <StackLayout Orientation="Horizontal">
+                <Button Text="Toggle Header"
+                        Clicked="ToggleHeader"></Button>
+                <Button Text="Toggle Footer"
+                        Clicked="ToggleFooter"></Button>
+            </StackLayout>
+            <CollectionView Grid.Row="1" x:Name="CollectionView">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Span="3"
+                                     Orientation="Horizontal"
+                                     HorizontalItemSpacing="4"
+                                     VerticalItemSpacing="2"></GridItemsLayout>
+                </CollectionView.ItemsLayout>
 
-            <CollectionView.Header>
+                <CollectionView.Header>
 
-                <StackLayout>
-                    <Image Source="oasis.jpg" Aspect="AspectFill" HeightRequest="60"></Image>
-                    <Label Text="This Is A Header" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" 
-                           FontAttributes="Bold" FontSize="36" />
-                    <StackLayout Orientation="Horizontal">
-                        <Button Text="Add Content" Clicked="Handle_Clicked"></Button>
+                    <StackLayout>
+                        <Image Source="oasis.jpg"
+                               Aspect="AspectFill"
+                               HeightRequest="60"></Image>
+                        <Label Text="This Is A Header"
+                               TextColor="AntiqueWhite"
+                               HorizontalTextAlignment="Center"
+                               FontAttributes="Bold"
+                               FontSize="36" />
+                        <StackLayout Orientation="Horizontal">
+                            <Button Text="Add Content"
+                                    Clicked="AddContentClicked"></Button>
+                        </StackLayout>
                     </StackLayout>
-                </StackLayout>
 
-            </CollectionView.Header>
+                </CollectionView.Header>
 
-            <CollectionView.Footer>
+                <CollectionView.Footer>
 
-                <StackLayout>
-                    <Image Source="cover1.jpg" Aspect="AspectFill" HeightRequest="80"></Image>
-                    <Label Text="This Is A Footer" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
-                           FontAttributes="Bold" FontSize="20" />
-                    <StackLayout Orientation="Horizontal">
-                        <Button Text="Add Content" Clicked="Handle_Clicked"></Button>
+                    <StackLayout>
+                        <Image Source="cover1.jpg"
+                               Aspect="AspectFill"
+                               HeightRequest="80"></Image>
+                        <Label Text="This Is A Footer"
+                               TextColor="AntiqueWhite"
+                               HorizontalTextAlignment="Center"
+                               Rotation="10"
+                               FontAttributes="Bold"
+                               FontSize="20" />
+                        <StackLayout Orientation="Horizontal">
+                            <Button Text="Add Content"
+                                    Clicked="AddContentClicked"></Button>
+                        </StackLayout>
                     </StackLayout>
-                </StackLayout>
 
-            </CollectionView.Footer>
+                </CollectionView.Footer>
 
-        </CollectionView>
+            </CollectionView>
+        </Grid>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterGridHorizontal.xaml.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFoot
 	public partial class HeaderFooterGridHorizontal : ContentPage
 	{
 		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(10);
+		object header;
+		object footer;
 
 		public HeaderFooterGridHorizontal()
 		{
@@ -22,10 +24,32 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFoot
 			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
 		}
 
-		void Handle_Clicked(object sender, System.EventArgs e)
+
+
+		void AddContentClicked(object sender, System.EventArgs e)
 		{
 			if (sender is VisualElement ve && ve.Parent is StackLayout sl)
 				sl.Children.Add(new Label() { Text = "Grow" });
+		}
+
+		void ToggleHeader(object sender, System.EventArgs e)
+		{
+			header = CollectionView.Header ?? header;
+
+			if (CollectionView.Header == null)
+				CollectionView.Header = header;
+			else
+				CollectionView.Header = null;
+		}
+
+		void ToggleFooter(object sender, System.EventArgs e)
+		{
+			footer = CollectionView.Footer ?? footer;
+
+			if (CollectionView.Footer == null)
+				CollectionView.Footer = footer;
+			else
+				CollectionView.Footer = null;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/StructuredItemsView.cs
+++ b/Xamarin.Forms.Core/Items/StructuredItemsView.cs
@@ -38,9 +38,7 @@
 			set => SetValue(FooterTemplateProperty, value);
 		}
 
-		public static readonly BindableProperty ItemsLayoutProperty =
-			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView),
-				LinearItemsLayout.Vertical);
+		public static readonly BindableProperty ItemsLayoutProperty = InternalItemsLayoutProperty;
 
 		public IItemsLayout ItemsLayout
 		{

--- a/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
@@ -42,12 +42,13 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 				centerItemIndex = CalculateCenterItemIndex(firstVisibleItemIndex, lastVisibleItemIndex, linearLayoutManager);
 			}
 
+			var context = recyclerView.Context;
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{
-				HorizontalDelta = dx,
-				VerticalDelta = dy,
-				HorizontalOffset = _horizontalOffset,
-				VerticalOffset = _verticalOffset,
+				HorizontalDelta = context.FromPixels(dx),
+				VerticalDelta = context.FromPixels(dy),
+				HorizontalOffset = context.FromPixels(_horizontalOffset),
+				VerticalOffset = context.FromPixels(_verticalOffset),
 				FirstVisibleItemIndex = firstVisibleItemIndex,
 				CenterItemIndex = centerItemIndex,
 				LastVisibleItemIndex = lastVisibleItemIndex

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -151,6 +151,6 @@ namespace Xamarin.Forms.Platform.Android
 					}
 					return;
 			}
-		}
+		}		
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
@@ -24,10 +24,12 @@ namespace Xamarin.Forms.Platform.Android
 			if (property.Is(Xamarin.Forms.StructuredItemsView.HeaderProperty))
 			{
 				UpdateHasHeader();
+				NotifyDataSetChanged();
 			}
 			else if (property.Is(Xamarin.Forms.StructuredItemsView.FooterProperty))
 			{
 				UpdateHasFooter();
+				NotifyDataSetChanged();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -299,19 +299,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-
-		internal void UpdateLayoutMeasurements()
-		{
-			if(_headerViewFormsElement != null)
-				RemeasureLayout(_headerViewFormsElement);
-
-			if (_footerViewFormsElement != null)
-				RemeasureLayout(_footerViewFormsElement);
-
-			if (_emptyViewFormsElement != null)
-				RemeasureLayout(_emptyViewFormsElement);
-
-		}
 		void OnFormsElementMeasureInvalidated(object sender, EventArgs e)
 		{
 			if (sender is VisualElement formsElement)
@@ -323,7 +310,6 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void HandleFormsElementMeasureInvalidated(VisualElement formsElement)
 		{
 			RemeasureLayout(formsElement);
-            UpdateHeaderFooterPosition();
         }
 
 		internal void UpdateView(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Drawing;
+using System.Threading.Tasks;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
@@ -253,8 +256,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected void UpdateSubview(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)
 		{
-			if (uiView != null)
-				CollectionView.Subviews.Remove(uiView);
+			uiView?.RemoveFromSuperview();
 
 			if (formsElement != null)
 			{
@@ -265,7 +267,9 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateView(view, viewTemplate, ref uiView, ref formsElement);
 
 			if (uiView != null)
+			{
 				CollectionView.AddSubview(uiView);
+			}
 
 			if (formsElement != null)
 				ItemsView.AddLogicalChild(formsElement);
@@ -286,16 +290,29 @@ namespace Xamarin.Forms.Platform.iOS
 			if (IsHorizontal)
 			{
 				var request = formsElement.Measure(double.PositiveInfinity, CollectionView.Frame.Height, MeasureFlags.IncludeMargins);
-				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(-request.Request.Width, 0, request.Request.Width, CollectionView.Frame.Height));
+				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, 0, request.Request.Width, CollectionView.Frame.Height));
 			}
 			else
 			{
 				var request = formsElement.Measure(CollectionView.Frame.Width, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, -request.Request.Height, CollectionView.Frame.Width, request.Request.Height));
+				Xamarin.Forms.Layout.LayoutChildIntoBoundingRegion(formsElement, new Rectangle(0, 0, CollectionView.Frame.Width, request.Request.Height));
 			}
 		}
 
-		protected void OnFormsElementMeasureInvalidated(object sender, EventArgs e)
+
+		internal void UpdateLayoutMeasurements()
+		{
+			if(_headerViewFormsElement != null)
+				RemeasureLayout(_headerViewFormsElement);
+
+			if (_footerViewFormsElement != null)
+				RemeasureLayout(_footerViewFormsElement);
+
+			if (_emptyViewFormsElement != null)
+				RemeasureLayout(_emptyViewFormsElement);
+
+		}
+		void OnFormsElementMeasureInvalidated(object sender, EventArgs e)
 		{
 			if (sender is VisualElement formsElement)
 			{
@@ -306,14 +323,17 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void HandleFormsElementMeasureInvalidated(VisualElement formsElement)
 		{
 			RemeasureLayout(formsElement);
-		}
+            UpdateHeaderFooterPosition();
+        }
 
 		internal void UpdateView(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)
 		{
 			// Is view set on the ItemsView?
 			if (view == null)
 			{
-				// Clear the cached Forms and native views
+				if (formsElement != null)
+					Platform.GetRenderer(formsElement)?.DisposeRendererAndChildren();
+
 				uiView = null;
 				formsElement = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -105,6 +105,12 @@ namespace Xamarin.Forms.Platform.iOS
 			newElement.ScrollToRequested += ScrollToRequested;
 		}
 
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+			ItemsViewController.UpdateLayoutMeasurements();
+		}
+
 		protected virtual void UpdateLayout()
 		{
 			_layout = SelectLayout();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -105,12 +105,6 @@ namespace Xamarin.Forms.Platform.iOS
 			newElement.ScrollToRequested += ScrollToRequested;
 		}
 
-		public override void LayoutSubviews()
-		{
-			base.LayoutSubviews();
-			ItemsViewController.UpdateLayoutMeasurements();
-		}
-
 		protected virtual void UpdateLayout()
 		{
 			_layout = SelectLayout();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -31,12 +31,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				if (_headerViewFormsElement != null)
-					_headerViewFormsElement.MeasureInvalidated -= OnFormsElementMeasureInvalidated;
-
-				if (_footerViewFormsElement != null)
-					_footerViewFormsElement.MeasureInvalidated -= OnFormsElementMeasureInvalidated;
-
 				_headerUIView = null;
 				_headerViewFormsElement = null;
 				_footerUIView = null;
@@ -152,6 +146,15 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.HandleFormsElementMeasureInvalidated(formsElement);
 			UpdateHeaderFooterPosition();
+		}
+
+		internal void UpdateLayoutMeasurements()
+		{
+			if (_headerViewFormsElement != null)
+				HandleFormsElementMeasureInvalidated(_headerViewFormsElement);
+
+			if (_footerViewFormsElement != null)
+				HandleFormsElementMeasureInvalidated(_footerViewFormsElement);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -74,12 +74,14 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			UpdateSubview(StructuredItemsView?.Footer, StructuredItemsView?.FooterTemplate, 
 				ref _footerUIView, ref _footerViewFormsElement);
+			UpdateHeaderFooterPosition();
 		}
 
 		internal void UpdateHeaderView()
 		{
 			UpdateSubview(StructuredItemsView?.Header, StructuredItemsView?.HeaderTemplate, 
 				ref _headerUIView, ref _headerViewFormsElement);
+			UpdateHeaderFooterPosition();
 		}
 
 		void UpdateHeaderFooterPosition()
@@ -99,33 +101,49 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (CollectionView.ContentInset.Left != headerWidth || CollectionView.ContentInset.Right != footerWidth)
 				{
+					var currentOffset = CollectionView.ContentOffset;
 					CollectionView.ContentInset = new UIEdgeInsets(0, headerWidth, 0, footerWidth);
+
+					var xOffset = currentOffset.X + (currentInset.Left - CollectionView.ContentInset.Left);
+
+					if (CollectionView.ContentSize.Width + headerWidth <= CollectionView.Bounds.Width)
+						xOffset = -headerWidth;
 
 					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
 					// this changes the offset of the list by however much the header size has changed
-					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X + (currentInset.Left - CollectionView.ContentInset.Left), CollectionView.ContentOffset.Y);
+					CollectionView.ContentOffset = new CoreGraphics.CGPoint(xOffset, CollectionView.ContentOffset.Y);
 				}
 			}
 			else
 			{
 				var currentInset = CollectionView.ContentInset;
-
 				nfloat headerHeight = _headerUIView?.Frame.Height ?? 0f;
 				nfloat footerHeight = _footerUIView?.Frame.Height ?? 0f;
 
-				if (_headerUIView != null && _headerUIView.Frame.Y != headerHeight)
-					_headerUIView.Frame = new CoreGraphics.CGRect(0, -headerHeight, CollectionView.Frame.Width, headerHeight);
-
-				if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height))
-					_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height, CollectionView.Frame.Width, footerHeight);
-
 				if (CollectionView.ContentInset.Top != headerHeight || CollectionView.ContentInset.Bottom != footerHeight)
 				{
+					var currentOffset = CollectionView.ContentOffset;
 					CollectionView.ContentInset = new UIEdgeInsets(headerHeight, 0, footerHeight, 0);
 
 					// if the header grows it will scroll off the screen because if you change the content inset iOS adjusts the content offset so the list doesn't move
 					// this changes the offset of the list by however much the header size has changed
-					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, CollectionView.ContentOffset.Y + (currentInset.Top - CollectionView.ContentInset.Top));
+
+					var yOffset = currentOffset.Y + (currentInset.Top - CollectionView.ContentInset.Top);
+
+					if (CollectionView.ContentSize.Height + headerHeight <= CollectionView.Bounds.Height)
+						yOffset = -headerHeight;
+
+					CollectionView.ContentOffset = new CoreGraphics.CGPoint(CollectionView.ContentOffset.X, yOffset);
+				}
+
+				if (_headerUIView != null && _headerUIView.Frame.Y != headerHeight)
+				{
+					_headerUIView.Frame = new CoreGraphics.CGRect(0, -headerHeight, CollectionView.Frame.Width, headerHeight);
+				}
+
+				if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height))
+				{
+					_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height, CollectionView.Frame.Width, footerHeight);
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewRenderer.cs
@@ -57,5 +57,11 @@ namespace Xamarin.Forms.Platform.iOS
 			// Fall back to vertical list
 			return new ListViewLayout(new LinearItemsLayout(ItemsLayoutOrientation.Vertical), itemSizingStrategy);
 		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+			StructuredItemsViewController.UpdateLayoutMeasurements();
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplateHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplateHelpers.cs
@@ -13,8 +13,11 @@ namespace Xamarin.Forms.Platform.iOS
 				throw new ArgumentNullException(nameof(view));
 			}
 
+			Platform.GetRenderer(view)?.DisposeRendererAndChildren();
 			var renderer = Platform.CreateRenderer(view);
 			Platform.SetRenderer(view, renderer);
+
+			renderer.NativeView.Bounds = view.Bounds.ToRectangleF();
 
 			return renderer;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -46,6 +46,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (indexPathsForVisibleItems.Count == 0)
 				return;
 
+			var contentInset = scrollView.ContentInset;
+			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
+			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
+
 			var firstVisibleItemIndex = (int)indexPathsForVisibleItems.First().Item;
 			var centerPoint = new CGPoint(ItemsViewController.CollectionView.Center.X + ItemsViewController.CollectionView.ContentOffset.X, ItemsViewController.CollectionView.Center.Y + ItemsViewController.CollectionView.ContentOffset.Y);
 			var centerIndexPath = ItemsViewController.CollectionView.IndexPathForItemAtPoint(centerPoint);
@@ -53,10 +57,10 @@ namespace Xamarin.Forms.Platform.iOS
 			var lastVisibleItemIndex = (int)indexPathsForVisibleItems.Last().Item;
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{
-				HorizontalDelta = scrollView.ContentOffset.X - _previousHorizontalOffset,
-				VerticalDelta = scrollView.ContentOffset.Y - _previousVerticalOffset,
-				HorizontalOffset = scrollView.ContentOffset.X,
-				VerticalOffset = scrollView.ContentOffset.Y,
+				HorizontalDelta = contentOffsetX - _previousHorizontalOffset,
+				VerticalDelta = contentOffsetY - _previousVerticalOffset,
+				HorizontalOffset = contentOffsetX,
+				VerticalOffset = contentOffsetY,
 				FirstVisibleItemIndex = firstVisibleItemIndex,
 				CenterItemIndex = centerItemIndex,
 				LastVisibleItemIndex = lastVisibleItemIndex
@@ -64,8 +68,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			ItemsViewController.ItemsView.SendScrolled(itemsViewScrolledEventArgs);
 
-			_previousHorizontalOffset = (float)scrollView.ContentOffset.X;
-			_previousVerticalOffset = (float)scrollView.ContentOffset.Y;
+			_previousHorizontalOffset = (float)contentOffsetX;
+			_previousVerticalOffset = (float)contentOffsetY;
 
 			switch (ItemsViewController.ItemsView.RemainingItemsThreshold)
 			{


### PR DESCRIPTION
### Description of Change ###

- Fixed iOS and Android so that when you swap out or just null out the header/footer they properly show/hide
- Fixed ContentOffset adjustment on iOS to be correct when said swapping occurs
- Fixed iOS to remeasure header/footer once LayoutSubviews is called on the Adapter. The initial width of the CV when the Header/footer is realized is larger than when it actually gets to the layoutsubviews call
- on iOS dispose of the renderers when header/footer is swapped out
- On Android the Scroll Values weren't being converted back from Device pixels before being returned to Forms
- On iOS fixed the Scroll Values so that if the ContentInset is set on the CollectionView from the header that it doesn't affect the scroll values

### Issues Resolved ### 
- fixes #7453
- fixes #7347 


### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
- PR includes modifications to the CV header/footer galleries so that you can test hiding and showing

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
