### PR TITLE
Check if the Drawer Toggle has been instantiated when using a Tablet and MDP

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -982,7 +982,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					var prevPage = Element.Peek(1);
 					_defaultNavigationContentDescription = bar.SetNavigationContentDescription(prevPage, _defaultNavigationContentDescription);
 				}
-				else if (_masterDetailPage != null)
+				else if (toggle != null && _masterDetailPage != null)
 				{
 					toggle.DrawerIndicatorEnabled = _masterDetailPage.ShouldShowToolbarButton();
 					toggle.SyncState();


### PR DESCRIPTION
### Description of Change ###
Verify that the _drawerToggle isn't null when navigating. This is a scenario that only occurs on Tablets

### Issues Resolved ### 
- fixes #7496

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Run MDP on an Android tablet , hide the back button, and make sure it doesn't crash

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
