### PR TITLE
Check to see if the BeginRefresh request is no longer needed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5728.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5728.cs
@@ -20,7 +20,14 @@ namespace Xamarin.Forms.Controls.Issues
 				RefreshControlColor = Color.Cyan
 			};
 			_listView.Refreshing += HandleListViewRefreshing;
-			Content = _listView;
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label() {Text = "If the refresh circle is Cyan this test has passed"},
+					_listView
+				}
+			};
 		}
 
 		protected override void OnAppearing()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7313.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7313.cs
@@ -1,0 +1,69 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7313, "ListView RefreshControl Not Hiding", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue7313 : TestContentPage
+	{
+		ListView _listView;
+		Label _testLoaded;
+		string _testReady = "If you see the refresh circle this test has failed";
+
+		protected override void Init()
+		{
+			_listView = new ListView
+			{
+				BackgroundColor = Color.Transparent,
+				IsPullToRefreshEnabled = true,
+				RefreshControlColor = Color.Cyan,
+				ItemsSource = new []{ "ListLoaded" }
+			};
+
+			_testLoaded = new Label();
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					_testLoaded,
+					_listView
+				}
+			};
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+			_listView.IsRefreshing = true;
+			await Task.Delay(1);
+			_listView.IsRefreshing = false;
+			await Task.Delay(1);
+			_testLoaded.Text = _testReady;
+
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void RefreshControlTurnsOffSuccessfully()
+		{
+			RunningApp.WaitForElement(_testReady);
+
+			RunningApp.WaitForNoElement("RefreshControl");
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1495,8 +1495,9 @@ namespace Xamarin.Forms.Platform.iOS
 						if (_refresh == null || _disposed)
 							return;
 
-						if(_isStartRefreshingPending)
+						if( _isStartRefreshingPending)
 							StartRefreshing();
+
 
 						//hack: when we don't have cells in our UITableView the spinner fails to appear
 						CheckContentSize();
@@ -1669,6 +1670,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public FormsRefreshControl(bool usingLargeTitles)
 		{
 			_usingLargeTitles = usingLargeTitles;
+			AccessibilityIdentifier = "RefreshControl";
 		}
 
 		public override bool Hidden

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1457,6 +1457,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _disposed;
 		internal bool _usingLargeTitles;
 		bool _isRefreshing;
+		bool _isStartRefreshingPending;
 
 		public FormsUITableViewController(ListView element, bool usingLargeTitles)
 		: base(element.OnThisPlatform().GetGroupHeaderStyle() == GroupHeaderStyle.Plain
@@ -1485,15 +1486,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (!_refresh.Refreshing)
 				{
+					_isStartRefreshingPending = true;
 					//hack: On iOS11 with large titles we need to adjust the scroll offset manually
 					//since our UITableView is not the first child of the UINavigationController
 					//This also forces the spinner color to be correct if we started refreshing immediately after changing it.
 					UpdateContentOffset(TableView.ContentOffset.Y - _refresh.Frame.Height, () =>
 					{
-						if (_refresh == null)
+						if (_refresh == null || _disposed)
 							return;
 
-						_refresh.BeginRefreshing();
+						if(_isStartRefreshingPending)
+							StartRefreshing();
+
 						//hack: when we don't have cells in our UITableView the spinner fails to appear
 						CheckContentSize();
 						TableView.ScrollRectToVisible(new RectangleF(0, 0, _refresh.Bounds.Width, _refresh.Bounds.Height), true);
@@ -1505,7 +1509,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (RefreshControl == null)
 					return;
 
-				_refresh.EndRefreshing();
+				EndRefreshing();
 
 				UpdateContentOffset(-1);
 
@@ -1513,6 +1517,24 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!_list.IsPullToRefreshEnabled)
 					RemoveRefresh();
 			}
+		}
+
+		void StartRefreshing()
+		{
+			_isStartRefreshingPending = false;
+			if (_refresh?.Refreshing == true)
+				return;
+
+			_refresh.BeginRefreshing();
+		}
+
+		void EndRefreshing()
+		{
+			_isStartRefreshingPending = false;
+			if (_refresh?.Refreshing == false)
+				return;
+
+			_refresh.EndRefreshing();
 		}
 
 		public void UpdatePullToRefreshEnabled(bool pullToRefreshEnabled)
@@ -1544,7 +1566,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!_refresh.Refreshing && !_isRefreshing)
 			{
 				_isRefreshing = true;
-				UpdateContentOffset(TableView.ContentOffset.Y - _refresh.Frame.Height, _refresh.BeginRefreshing);
+				UpdateContentOffset(TableView.ContentOffset.Y - _refresh.Frame.Height, StartRefreshing);
 				_list.SendRefreshing();
 			}
 		}
@@ -1592,7 +1614,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_refresh != null)
 				{
 					_refresh.ValueChanged -= OnRefreshingChanged;
-					_refresh.EndRefreshing();
+					EndRefreshing();
 					_refresh.Dispose();
 					_refresh = null;
 				}
@@ -1627,7 +1649,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			if (_refresh.Refreshing || _isRefreshing)
-				_refresh.EndRefreshing();
+				EndRefreshing();
 
 			RefreshControl = null;
 			_refreshAdded = false;


### PR DESCRIPTION
### Description of Change ###
The code added here https://github.com/xamarin/Xamarin.Forms/pull/6473/files#diff-198607f4ce97efcc515a271473524b08R1482 causes a queue'd request to *BeginRefresh*. If some other processes *Begins* and then *Ends* the refresh before this process is able to run then it needs to ignore the queue'd *BeginRefresh*


### Issues Resolved ### 
- fixes #7313

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- Included automated tests
- Also manually test 5728 
- Test all your favorite iOS ListView refreshing scenarios!! Make sure they all work as expected

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
