### PR TITLE
[Android] Fix ItemSpacing for last item in CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7357.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7357.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    mc:Ignorable="d" x:Class="Xamarin.Forms.Controls.Issues.Issue7357">
+
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="50"/>
+            <RowDefinition Height="50"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+
+        <Label Grid.Row="0" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" Text="Verify that item 49 has spacing below it." Margin="15,0"/>
+
+        <Label Grid.Row="1" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" Text="Verify that item 99 has NO spacing below it." Margin="15,0"/>
+
+        <CollectionView x:Name="CollectionView7357" Grid.Row="2" ItemsSource="{Binding ItemsSource}" RemainingItemsThreshold="5" RemainingItemsThresholdReached="CollectionView_RemainingItemsThresholdReached">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical"/>
+            </CollectionView.ItemsLayout>
+            
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <ContentView HeightRequest="100" BackgroundColor="{Binding BackgroundColor}">
+                        <Label Text="{Binding Text}" HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+                    </ContentView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7357.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7357.xaml.cs
@@ -1,0 +1,118 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Security.Cryptography;
+using Xamarin.Forms.Xaml;
+using System.Threading;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Linq;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7357, "[Android] Setting ItemSpacing creates spacing for the last item in CollectionView", PlatformAffected.Android)]
+	public partial class Issue7357 : TestContentPage
+	{
+#if APP
+		SemaphoreSlim _semaphoreSlim = new SemaphoreSlim(1, 1);
+		bool _isUpdatingSource;
+
+		public Issue7357()
+		{
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+
+			InitializeComponent();
+
+			(CollectionView7357.ItemsLayout as LinearItemsLayout).ItemSpacing = 5;
+
+			BindingContext = new ViewModel7357();
+		}
+
+		async void CollectionView_RemainingItemsThresholdReached(object sender, System.EventArgs e)
+		{
+			if (_isUpdatingSource)
+				return;
+
+			await _semaphoreSlim.WaitAsync();
+
+			try
+			{
+				_isUpdatingSource = true;
+
+				var itemsSource = ((sender as CollectionView).ItemsSource as ObservableCollection<Model7357>);
+				var count = itemsSource.Count;
+
+				if (count == 100)
+					return;
+
+				for (var i = count; i < count + 50; i++)
+				{
+					var model = new Model7357 { Text = "Item " + i };
+
+					if (i == 99)
+						model.BackgroundColor = Color.Pink;
+
+					itemsSource.Add(model);
+				}
+			}
+			finally
+			{
+				_semaphoreSlim.Release();
+				_isUpdatingSource = false;
+			}
+		}
+#endif
+
+		protected override void Init()
+		{
+			
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModel7357
+	{
+		public ObservableCollection<Model7357> ItemsSource { get; set; } = new ObservableCollection<Model7357>();
+
+		public ViewModel7357()
+		{
+			for (var i = 0; i < 50; i++)
+			{
+				var model = new Model7357 { Text = "Item " + i };
+
+				if (i == 49)
+					model.BackgroundColor = Color.Pink;
+
+				ItemsSource.Add(model);
+			}
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Model7357
+	{
+		public string Text { get; set; }
+
+		public Color BackgroundColor { get; set; } = Color.Beige;
+
+		public Model7357()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1362,7 +1362,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue6254.xaml.cs">
       <DependentUpon>Issue6254.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\Users\def\Desktop\x\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7357.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
     <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -36,6 +36,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7049.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7061.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7111.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <SubType>Code</SubType>
@@ -1359,6 +1362,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue6254.xaml.cs">
       <DependentUpon>Issue6254.xaml</DependentUpon>
     </Compile>
+    <Compile Update="C:\Users\def\Desktop\x\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7357.xaml.cs">
+      <DependentUpon>Issue7357.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
@@ -1385,6 +1391,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Github5623.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7357.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.Android/CollectionView/SpacingItemDecoration.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SpacingItemDecoration.cs
@@ -74,13 +74,17 @@ namespace Xamarin.Forms.Platform.Android
 			if (_orientation == ItemsLayoutOrientation.Vertical)
 			{
 				outRect.Left = spanIndex == 0 ? 0 : (int)_adjustedHorizontalSpacing;
-				outRect.Bottom = (int)_adjustedVerticalSpacing;
+
+				if (parent.GetChildAdapterPosition(view) != parent.GetAdapter().ItemCount - 1)
+					outRect.Bottom = (int)_adjustedVerticalSpacing;
 			}
 
 			if (_orientation == ItemsLayoutOrientation.Horizontal)
 			{
 				outRect.Top = spanIndex == 0 ? 0 : (int)_adjustedVerticalSpacing;
-				outRect.Right = (int)_adjustedHorizontalSpacing;
+
+				if (parent.GetChildAdapterPosition(view) != parent.GetAdapter().ItemCount - 1)
+					outRect.Right = (int)_adjustedHorizontalSpacing;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

`ItemSpacing` for the last item in CollectionView should work now. I added a manual test with instructions.

@hartez I noticed that setting `ItemsSpacing` for `LinearItemsLayout` in XAML did not work, but it seems to be working for `ListItemsLayout` in an earlier Nuget. See #7519.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7357

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
