### PR TITLE
Check if Control is ready before interacting with Native control

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextDecorations()
 		{
-			if (IsElementOrControlEmpty)
+			if (Element == null || Control == null)
 				return;
 
 			if (!Element.IsSet(Label.TextDecorationsProperty))
@@ -353,7 +353,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateText()
 		{
-			if (IsElementOrControlEmpty)
+			if (Element == null || Control == null)
 				return;
 
 			_formatted = Element.FormattedText;

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -216,6 +216,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextDecorations()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			if (!Element.IsSet(Label.TextDecorationsProperty))
 				return;
 
@@ -350,6 +353,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateText()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			_formatted = Element.FormattedText;
 			if (_formatted == null && Element.LineHeight >= 0)
 				_formatted = Element.Text;

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		event EventHandler _controlChanging;
 		event EventHandler _controlChanged;
 
-		bool IsElementOrControlEmpty => Element == null || Control == null;
+		private protected bool IsElementOrControlEmpty => Element == null || Control == null;
 
 		protected virtual TNativeView CreateNativeControl()
 		{

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		event EventHandler _controlChanging;
 		event EventHandler _controlChanged;
 
-		private protected bool IsElementOrControlEmpty => Element == null || Control == null;
+		bool IsElementOrControlEmpty => Element == null || Control == null;
 
 		protected virtual TNativeView CreateNativeControl()
 		{


### PR DESCRIPTION
### Description of Change ###

Check if Control has been initialized before react on Text Changes. This fixes the failures on the `ScrollListViewInsideScrollView_apple_iphone_x` test which is being caused by the `ApiLabelRenderer` setting values on the Element before it has been initialized.

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- Automated Tests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
