### PR TITLE
Setup pipelines so they can be ran with release Configurations

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -28,5 +28,9 @@
   <PropertyGroup Condition="'$(AndroidTargetFrameworks)' == ''">
     <AndroidTargetFrameworks>MonoAndroid90;</AndroidTargetFrameworks>
   </PropertyGroup>
-  
+  <PropertyGroup>
+    <Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildRuntimeType)' == 'Mono'">$(FrameworkSDKRoot.Contains('/Versions/5'))</Use2017>
+    <Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildAssemblyVersion)' &lt; '16.0'">true</Use2017>
+    <Use2017 Condition="'$(Use2017)' == ''">false</Use2017>
+  </PropertyGroup>
  </Project>

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.props
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.props
@@ -1,0 +1,3 @@
+<Project>
+  <Import Project="..\Directory.Build.props" />
+</Project> 

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="Directory.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -54,16 +55,14 @@
     <DefineConstants>TRACE;HAVE_OPENTK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <AndroidLinkMode>SdkOnly</AndroidLinkMode>
+    <AndroidLinkMode>Full</AndroidLinkMode>
     <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
-    <AndroidLinkMode>Full</AndroidLinkMode>
     <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
-    <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
+    <AndroidDexTool Condition="'$(Use2017)' == 'false'">d8</AndroidDexTool>
+    <AndroidLinkTool Condition="'$(Use2017)' == 'false'">r8</AndroidLinkTool>
+    <AndroidEnableMultiDex>$(Use2017)</AndroidEnableMultiDex>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -47,7 +47,7 @@
     <DefineConstants>HAVE_OPENTK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchLink>Full</MtouchLink>
+    <MtouchLink>None</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -96,6 +96,9 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <MtouchLink>Full</MtouchLink>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
     <MtouchLink>Full</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -47,7 +47,7 @@
     <DefineConstants>HAVE_OPENTK</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <MtouchLink>None</MtouchLink>
+    <MtouchLink>Full</MtouchLink>
     <MtouchArch>i386, x86_64</MtouchArch>
     <ConsolePause>false</ConsolePause>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -96,8 +96,6 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
     <MtouchLink>Full</MtouchLink>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 
 namespace Xamarin.Forms.CustomAttributes
 {
-	[Conditional("DEBUG")]
+	
 	[AttributeUsage(
 		AttributeTargets.Class |
 		AttributeTargets.Event |
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.CustomAttributes
 		Default
 	}
 
-	[Conditional("DEBUG")]
+	
 	[AttributeUsage(
 		AttributeTargets.Class |
 		AttributeTargets.Method,
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.CustomAttributes
 			: $"{IssueTracker.ToString().Substring(0, 1)}{IssueNumber} ({IssueTestNumber})";
 	}
 
-	[Conditional("DEBUG")]
+	
 	public class UiTestExemptAttribute : Attribute
 	{
 		// optional string reason
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.CustomAttributes
 		public string Description => "Description: " + _description;
 	}
 
-	[Conditional("DEBUG")]
+	
 	public class UiTestFragileAttribute : Attribute
 	{
 		// optional string reason
@@ -120,7 +120,7 @@ namespace Xamarin.Forms.CustomAttributes
 		public string Description => "Description: " + _description;
 	}
 
-	[Conditional("DEBUG")]
+	
 	[AttributeUsage(AttributeTargets.All, AllowMultiple = true)]
 	public class UiTestBrokenAttribute : Attribute
 	{

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,4 @@
 variables:
-- name: DefaultBuildConfiguration
-  value: Debug
 - name: DefaultBuildPlatform
   value: 'any cpu'
 - name: ApkName
@@ -67,7 +65,6 @@ jobs:
     vmImage: $(winVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     msbuildExtraArguments: '/nowarn:VSX1000'
-    buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
     includeUwp: 'false'
@@ -79,7 +76,6 @@ jobs:
     vmImage: $(win2019VmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     msbuildExtraArguments: '/nowarn:VSX1000 /p:CreateAllAndroidTargets=true'
-    buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
     slnPath: '.Xamarin.Forms.UAP.nuget.sln'
@@ -161,6 +157,3 @@ jobs:
     steps:
       - template: build/steps/build-sign.yml
     condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
-
-
-

--- a/build.cake
+++ b/build.cake
@@ -56,14 +56,14 @@ string androidSDK_windows = "";//"https://aka.ms/xamarin-android-commercial-d15-
 string iOSSDK_windows = "";//"https://download.visualstudio.microsoft.com/download/pr/71f33151-5db4-49cc-ac70-ba835a9f81e2/d256c6c50cd80ec0207783c5c7a4bc2f/xamarin.visualstudio.apple.sdk.4.12.3.83.vsix";
 string macSDK_windows = "";
 
-monoMajorVersion = "6.4.0";
-monoPatchVersion = "198";
+monoMajorVersion = "6.6.0";
+monoPatchVersion = "161";
 monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
 string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-3-macos";
 string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
-string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
+string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-4/0d8fe219c727fc68d495c26823070b510a4aa474/36/package/notarized/xamarin.ios-13.8.3.0.pkg";
+string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-4/0d8fe219c727fc68d495c26823070b510a4aa474/36/package/notarized/xamarin.mac-6.8.3.0.pkg";
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -83,7 +83,7 @@ jobs:
         displayName: 'Copy ${{ parameters.name }}'
         inputs:
           SourceFolder: ${{ parameters.androidPath }}/bin/${{ parameters.buildConfiguration }}/
-         Contents: '**/*.apk'
+          Contents: '**/*.apk'
           TargetFolder: ${{ parameters.targetFolder }}
           CleanTargetFolder: true
           OverWrite: true

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -70,6 +70,7 @@ jobs:
         displayName: 'Build ${{ parameters.buildTaskPath  }}'
         inputs:
           solution: ${{ parameters.buildTaskPath }}
+          configuration: ${{ parameters.buildConfiguration }}
 
       - task: MSBuild@1
         displayName: 'Build Android ${{ parameters.name }}'
@@ -81,8 +82,8 @@ jobs:
       - task: CopyFiles@2
         displayName: 'Copy ${{ parameters.name }}'
         inputs:
-          SourceFolder: ${{ parameters.androidPath }}/bin/Debug/
-          Contents: '**/*.apk'
+          SourceFolder: ${{ parameters.androidPath }}/bin/${{ parameters.buildConfiguration }}/
+          Contents: '**/*AndroidControlGallery.apk'
           TargetFolder: ${{ parameters.targetFolder }}
           CleanTargetFolder: true
           OverWrite: true
@@ -97,6 +98,7 @@ jobs:
 
       - task: PublishBuildArtifacts@1
         displayName: 'Publish Artifact: AndroidApps'
+        condition: always()
         inputs:
           PathtoPublish: '$(build.artifactstagingdirectory)'
           ArtifactName: OSXArtifacts

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -83,7 +83,7 @@ jobs:
         displayName: 'Copy ${{ parameters.name }}'
         inputs:
           SourceFolder: ${{ parameters.androidPath }}/bin/${{ parameters.buildConfiguration }}/
-          Contents: '**/*AndroidControlGallery.apk'
+         Contents: '**/*.apk'
           TargetFolder: ${{ parameters.targetFolder }}
           CleanTargetFolder: true
           OverWrite: true

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -56,6 +56,7 @@ steps:
     inputs:
       solutionFile: $(slnPath)
       configuration: $(buildConfiguration)
+      args: /bl:$(Build.ArtifactStagingDirectory)/ios.binlog
 
 
   - task: CopyFiles@2
@@ -91,6 +92,7 @@ steps:
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: iOS'
+    condition: always()
     inputs:
       PathtoPublish: '$(build.artifactstagingdirectory)'
       ArtifactName: OSXArtifacts


### PR DESCRIPTION
### Description of Change ###

This PR is preparation for running UI tests in Release mode and changes the *DefaultBuildConfiguration* YAML parameter to be settable at the pipeline level so that we can run builds in Release mode

This modifies the Android ControlGallery so when running as release mode it uses r8/d8 and full linking as well.
### Platforms Affected ### 
- iOS
- Android


### Testing Procedure ###
- Make sure ui tests all run
- Make sure you can still open the solution and compile it on VSMAC

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
