### PR TITLE
Tweak unit test so it's more reliable and fix binlog path

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
@@ -113,7 +113,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.False(invoked, "Action invoked early.");
 
 			async Task MethodThatThrows() => await task;
-			Assert.ThrowsAsync<ApplicationException>(MethodThatThrows);
+			Assert.Throws<ApplicationException>(async () => await MethodThatThrows());
 			Assert.True(invoked, "Action not invoked.");
 		}
 

--- a/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
@@ -112,9 +112,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
 			Assert.False(invoked, "Action invoked early.");
 
-			await Task.Delay(1);
-			var aggregateEx = Assert.Throws<AggregateException>(() => task.Wait(1000));
-			Assert.IsInstanceOf<ApplicationException>(aggregateEx.InnerException);
+			async Task MethodThatThrows() => await task;
+			Assert.ThrowsAsync<ApplicationException>(MethodThatThrows);
 			Assert.True(invoked, "Action not invoked.");
 		}
 

--- a/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DeviceUnitTests.cs
@@ -112,7 +112,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(calledFromMainThread, "Action not invoked from main thread.");
 			Assert.False(invoked, "Action invoked early.");
 
-			var aggregateEx = Assert.Throws<AggregateException>(() => task.Wait(100));
+			await Task.Delay(1);
+			var aggregateEx = Assert.Throws<AggregateException>(() => task.Wait(1000));
 			Assert.IsInstanceOf<ApplicationException>(aggregateEx.InnerException);
 			Assert.True(invoked, "Action not invoked.");
 		}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -63,7 +63,7 @@ jobs:
     displayName: Build Android [Legacy Renderers]
     vmImage: $(macOSVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
-    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)\android-legacy.binlog'
+    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
 
 - template: build/steps/build-android.yml
@@ -72,7 +72,7 @@ jobs:
     displayName: Build Android [Pre-AppCompat]
     vmImage: $(macOSVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
-    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)\android-preappcompact.binlog'
+    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
 
 - template: build/steps/build-android.yml
@@ -81,7 +81,7 @@ jobs:
     displayName: Build Android [Fast Renderers]
     vmImage: $(macOSVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
-    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)\android-newrenderers.binlog'
+    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
 
 - job: osx


### PR DESCRIPTION
### Description of Change ###

- TestInvokeOnMainThreadWithAsyncActionError fails occasionally so I increased the wait time
- Fix binlog path "/" direction so binlog files get placed correctly into artifacts directory

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
