### PR TITLE
Remove errant brace in FormsCommandBarStyle

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsCommandBarStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsCommandBarStyle.xaml
@@ -453,7 +453,7 @@
                                             </ObjectAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Y" Storyboard.TargetName="ContentTransform">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="{Binding TemplateSettings.HiddenVerticalDelta, RelativeSource={RelativeSource Mode=TemplatedParent}}"/>
-                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.167" Value="0}"/>
+                                                <SplineDoubleKeyFrame KeySpline="0.1,0.9 0.2,1.0" KeyTime="0:0:0.167" Value="0"/>
                                             </DoubleAnimationUsingKeyFrames>
                                             <DoubleAnimationUsingKeyFrames Storyboard.TargetProperty="Y" Storyboard.TargetName="OverflowContentTransform">
                                                 <DiscreteDoubleKeyFrame KeyTime="0:0:0" Value="0"/>


### PR DESCRIPTION
### Description of Change ###

Gets rid of an extra brace in an animation.

### Issues Resolved ### 
- fixes #7545

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
