### PR TITLE
[X] Pass the current assembly to parsing context

### DIFF
--- a/Xamarin.Forms.Core/TypeTypeConverter.cs
+++ b/Xamarin.Forms.Core/TypeTypeConverter.cs
@@ -5,31 +5,24 @@ using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms
 {
-	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.TypeTypeConverter")]
-	[Xaml.TypeConversion(typeof(Type))]
+	[ProvideCompiled("Xamarin.Forms.Core.XamlC.TypeTypeConverter")]
+	[TypeConversion(typeof(Type))]
 	public sealed class TypeTypeConverter : TypeConverter, IExtendedTypeConverter
 	{
-		[Obsolete("IExtendedTypeConverter.ConvertFrom is obsolete as of version 2.2.0. Please use ConvertFromInvariantString (string, IServiceProvider) instead.")]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		object IExtendedTypeConverter.ConvertFrom(CultureInfo culture, object value, IServiceProvider serviceProvider)
-		{
-			return ((IExtendedTypeConverter)this).ConvertFromInvariantString((string)value, serviceProvider);
-		}
-
 		object IExtendedTypeConverter.ConvertFromInvariantString(string value, IServiceProvider serviceProvider)
 		{
 			if (serviceProvider == null)
-				throw new ArgumentNullException("serviceProvider");
-			var typeResolver = serviceProvider.GetService(typeof(IXamlTypeResolver)) as IXamlTypeResolver;
-			if (typeResolver == null)
+				throw new ArgumentNullException(nameof(serviceProvider));
+			if (!(serviceProvider.GetService(typeof(IXamlTypeResolver)) is IXamlTypeResolver typeResolver))
 				throw new ArgumentException("No IXamlTypeResolver in IServiceProvider");
 
 			return typeResolver.Resolve(value, serviceProvider);
 		}
 
-		public override object ConvertFromInvariantString(string value)
-		{
-			throw new NotImplementedException();
-		}
+		public override object ConvertFromInvariantString(string value) => throw new NotImplementedException();
+
+		[Obsolete("IExtendedTypeConverter.ConvertFrom is obsolete as of version 2.2.0. Please use ConvertFromInvariantString (string, IServiceProvider) instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		object IExtendedTypeConverter.ConvertFrom(CultureInfo culture, object value, IServiceProvider serviceProvider) => ((IExtendedTypeConverter)this).ConvertFromInvariantString((string)value, serviceProvider);
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/AppResources/Colors.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AppResources/Colors.xaml
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <ResourceDictionary
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"> 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"> 
   <Color x:Key="AccentColor">#FF4B14</Color>
   <Color x:Key="BlackOpacityColor">#99253748</Color>
   <Color x:Key="BlackTextColor">#253748</Color>
@@ -19,4 +20,8 @@
   <Color x:Key="DarkBackgroundColor">#C0C0C0</Color>
   <Color x:Key="MediumGrayTextColor">#4d4d4d</Color>
   <Color x:Key="LightTextColor">#999999</Color>
+    
+  <Style TargetType="local:Gh7531" x:Key="style">
+    <Setter Property="BackgroundColor" Value="HotPink"/>
+  </Style>
 </ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/AppResources/CompiledColors.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/AppResources/CompiledColors.xaml
@@ -2,7 +2,9 @@
 <?xaml-comp compile="true" ?>
 <ResourceDictionary
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"> 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"> 
+
   <Color x:Key="AccentColor">#FF4B14</Color>
   <Color x:Key="BlackOpacityColor">#99253748</Color>
   <Color x:Key="BlackTextColor">#253748</Color>
@@ -20,4 +22,8 @@
   <Color x:Key="DarkBackgroundColor">#C0C0C0</Color>
   <Color x:Key="MediumGrayTextColor">#4d4d4d</Color>
   <Color x:Key="LightTextColor">#999999</Color>
+    
+  <Style TargetType="local:Gh7531" x:Key="style">
+    <Setter Property="BackgroundColor" Value="HotPink"/>
+  </Style>
 </ResourceDictionary>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7531.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7531.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh7531">
+    <ContentPage.Resources>
+        <ResourceDictionary Source="../AppResources/Colors.xaml" x:Key="Colors" />
+        <ResourceDictionary Source="../AppResources/CompiledColors.xaml" x:Key="CompiledColors" />
+    </ContentPage.Resources>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7531.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7531.xaml.cs
@@ -1,0 +1,32 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using NUnit.Framework;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh7531 : ContentPage
+	{
+		public Gh7531() => InitializeComponent();
+		public Gh7531(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void XamlOnlyResourceResolvesLocalAssembly([Values(false, true)]bool useCompiledXaml)
+			{
+				Gh7531 layout = null;
+				Assert.DoesNotThrow(() => layout = new Gh7531(useCompiledXaml));
+				var style = ((ResourceDictionary)layout.Resources["Colors"])["style"] as Style;
+				Assert.That(style.TargetType, Is.EqualTo(typeof(Gh7531)));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/HydrationContext.cs
+++ b/Xamarin.Forms.Xaml/HydrationContext.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -16,5 +17,6 @@ namespace Xamarin.Forms.Xaml
 		public HydrationContext ParentContext { get; set; }
 		public Action<Exception> ExceptionHandler { get; set; }
 		public object RootElement { get; set; }
+		public Assembly RootAssembly { get; internal set; }
 	}
 }

--- a/Xamarin.Forms.Xaml/ResourcesLoader.cs
+++ b/Xamarin.Forms.Xaml/ResourcesLoader.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Xaml
 				if (stream == null)
 					throw new XamlParseException($"No resource found for '{resourceId}'.", lineInfo);
 				using (var reader = new StreamReader(stream)) {
-					rd.LoadFromXaml(reader.ReadToEnd());
+					rd.LoadFromXaml(reader.ReadToEnd(), assembly);
 					return rd;
 				}
 			}

--- a/Xamarin.Forms.Xaml/ViewExtensions.cs
+++ b/Xamarin.Forms.Xaml/ViewExtensions.cs
@@ -26,6 +26,7 @@
 // THE SOFTWARE.
 
 using System;
+using System.Reflection;
 
 namespace Xamarin.Forms.Xaml
 {
@@ -40,6 +41,12 @@ namespace Xamarin.Forms.Xaml
 		public static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml)
 		{
 			XamlLoader.Load(view, xaml);
+			return view;
+		}
+
+		internal static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml, Assembly rootAssembly)
+		{
+			XamlLoader.Load(view, xaml, rootAssembly);
 			return view;
 		}
 	}

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -71,8 +71,10 @@ namespace Xamarin.Forms.Xaml
 		}
 
 		public static void Load(object view, string xaml) => Load(view, xaml, false);
+		public static void Load(object view, string xaml, bool useDesignProperties) => Load(view, xaml, null, useDesignProperties);
+		public static void Load(object view, string xaml, Assembly rootAssembly) => Load(view, xaml, rootAssembly, false);
 
-		public static void Load(object view, string xaml, bool useDesignProperties)
+		public static void Load(object view, string xaml, Assembly rootAssembly, bool useDesignProperties)
 		{
 			using (var textReader = new StringReader(xaml))
 			using (var reader = XmlReader.Create(textReader)) {
@@ -95,7 +97,7 @@ namespace Xamarin.Forms.Xaml
 					void ehandler(Exception e) => ResourceLoader.ExceptionHandler2?.Invoke((e, XamlFilePathAttribute.GetFilePathForObject(view)));
 					Visit(rootnode, new HydrationContext {
 						RootElement = view,
-
+						RootAssembly = rootAssembly ?? view.GetType().GetTypeInfo().Assembly,
 						ExceptionHandler = doNotThrow ? ehandler : (Action<Exception>)null
 					}, useDesignProperties);
 					break;

--- a/Xamarin.Forms.Xaml/XamlServiceProvider.cs
+++ b/Xamarin.Forms.Xaml/XamlServiceProvider.cs
@@ -17,11 +17,8 @@ namespace Xamarin.Forms.Xaml.Internals
 				IProvideValueTarget = new XamlValueTargetProvider(targetObject, node, context, null);
 			if (context != null)
 				IRootObjectProvider = new XamlRootObjectProvider(context.RootElement);
-			if (context != null && node != null)
-			{
-				IXamlTypeResolver = new XamlTypeResolver(node.NamespaceResolver, XamlParser.GetElementType,
-					context.RootElement.GetType().GetTypeInfo().Assembly);
-
+			if (context != null && node != null) {
+				IXamlTypeResolver = new XamlTypeResolver(node.NamespaceResolver, XamlParser.GetElementType, context.RootAssembly);
 				Add(typeof(IReferenceProvider), new ReferenceProvider(node));
 			}
 
@@ -31,52 +28,49 @@ namespace Xamarin.Forms.Xaml.Internals
 			IValueConverterProvider = new ValueConverterProvider();
 		}
 
-		public XamlServiceProvider()
-		{
-			IValueConverterProvider = new ValueConverterProvider();
-		}
+		public XamlServiceProvider() => IValueConverterProvider = new ValueConverterProvider();
 
 		internal IProvideValueTarget IProvideValueTarget
 		{
-			get { return (IProvideValueTarget)GetService(typeof (IProvideValueTarget)); }
-			set { services[typeof (IProvideValueTarget)] = value; }
+			get => (IProvideValueTarget)GetService(typeof(IProvideValueTarget));
+			set => services[typeof(IProvideValueTarget)] = value;
 		}
 
 		internal IXamlTypeResolver IXamlTypeResolver
 		{
-			get { return (IXamlTypeResolver)GetService(typeof (IXamlTypeResolver)); }
-			set { services[typeof (IXamlTypeResolver)] = value; }
+			get => (IXamlTypeResolver)GetService(typeof(IXamlTypeResolver));
+			set => services[typeof(IXamlTypeResolver)] = value;
 		}
 
 		internal IRootObjectProvider IRootObjectProvider
 		{
-			get { return (IRootObjectProvider)GetService(typeof (IRootObjectProvider)); }
-			set { services[typeof (IRootObjectProvider)] = value; }
+			get => (IRootObjectProvider)GetService(typeof(IRootObjectProvider));
+			set => services[typeof(IRootObjectProvider)] = value;
 		}
 
 		internal IXmlLineInfoProvider IXmlLineInfoProvider
 		{
-			get { return (IXmlLineInfoProvider)GetService(typeof (IXmlLineInfoProvider)); }
-			set { services[typeof (IXmlLineInfoProvider)] = value; }
-		}
-
-		[Obsolete]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		internal INameScopeProvider INameScopeProvider
-		{
-			get { return (INameScopeProvider)GetService(typeof (INameScopeProvider)); }
-			set { services[typeof (INameScopeProvider)] = value; }
+			get => (IXmlLineInfoProvider)GetService(typeof(IXmlLineInfoProvider));
+			set => services[typeof(IXmlLineInfoProvider)] = value;
 		}
 
 		internal IValueConverterProvider IValueConverterProvider
 		{
-			get { return (IValueConverterProvider)GetService(typeof (IValueConverterProvider)); }
-			set { services[typeof (IValueConverterProvider)] = value; }
+			get => (IValueConverterProvider)GetService(typeof(IValueConverterProvider));
+			set => services[typeof(IValueConverterProvider)] = value;
 		}
 
 		public object GetService(Type serviceType) => services.TryGetValue(serviceType, out var service) ? service : null;
 
 		public void Add(Type type, object service) => services.Add(type, service);
+
+		[Obsolete]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		internal INameScopeProvider INameScopeProvider
+		{
+			get { return (INameScopeProvider)GetService(typeof(INameScopeProvider)); }
+			set { services[typeof(INameScopeProvider)] = value; }
+		}
 	}
 
 	class XamlValueTargetProvider : IProvideParentValues, IProvideValueTarget
@@ -227,7 +221,7 @@ namespace Xamarin.Forms.Xaml.Internals
 
 			var namespaceuri = namespaceResolver.LookupNamespace(prefix);
 			if (namespaceuri == null) {
-				exception = new XamlParseException(string.Format("No xmlns declaration for prefix \"{0}\"", prefix), xmlLineInfo);
+				exception = new XamlParseException($"No xmlns declaration for prefix \"{prefix}\"", xmlLineInfo);
 				return null;
 			}
 
@@ -239,20 +233,14 @@ namespace Xamarin.Forms.Xaml.Internals
 
 	class XamlRootObjectProvider : IRootObjectProvider
 	{
-		public XamlRootObjectProvider(object rootObject)
-		{
-			RootObject = rootObject;
-		}
+		public XamlRootObjectProvider(object rootObject) => RootObject = rootObject;
 
 		public object RootObject { get; }
 	}
 
 	public class XmlLineInfoProvider : IXmlLineInfoProvider
 	{
-		public XmlLineInfoProvider(IXmlLineInfo xmlLineInfo)
-		{
-			XmlLineInfo = xmlLineInfo;
-		}
+		public XmlLineInfoProvider(IXmlLineInfo xmlLineInfo) => XmlLineInfo = xmlLineInfo;
 
 		public IXmlLineInfo XmlLineInfo { get; }
 	}


### PR DESCRIPTION
### Description of Change ###

In case of Xaml-only RD, the rootAssembly is different from the assembly
of the rootType


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7531

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
