### PR TITLE
[C] Removed MatchParent value from Property Editor

### DIFF
--- a/Xamarin.Forms.Core/Visuals/VisualMarker.cs
+++ b/Xamarin.Forms.Core/Visuals/VisualMarker.cs
@@ -1,10 +1,13 @@
-﻿namespace Xamarin.Forms
+﻿using System.ComponentModel;
+
+namespace Xamarin.Forms
 {
 	public static class VisualMarker
 	{
 		static bool _isMaterialRegistered = false;
 		static bool _warnedAboutMaterial = false;
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IVisual MatchParent { get; } = new MatchParentVisual();
 		public static IVisual Default { get; } = new DefaultVisual();
 		public static IVisual Material { get; } = new MaterialVisual();


### PR DESCRIPTION
### Description of Change ###

Removed `MatchParent` value from Property Editor.

### Issues Resolved ### 


### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

**Before**
![image](https://user-images.githubusercontent.com/27482193/65040159-6bc80500-d95c-11e9-8f76-198d47ae1a73.png)

**After**
![image](https://user-images.githubusercontent.com/27482193/65040113-54891780-d95c-11e9-9309-0c01781e2f4c.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)