### PR TITLE
Fix crash on iOS with elements that have Layout Compression and VoiceOver active

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7563.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7563.cs
@@ -1,0 +1,36 @@
+﻿using System.Threading;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7563, "iOS Layout Compression should not crash when VoiceOver is active", PlatformAffected.iOS)]
+	public class Issue7563 : TestContentPage
+	{
+		protected override void Init()
+		{
+
+			var stack = new StackLayout
+			{
+				AutomationId = "test",
+				Children = { new Label { Text = "Turn on the Screen Reader. If you do not hear 'I am the StackLayout', this test has failed." } },
+			};
+			
+			Xamarin.Forms.CompressedLayout.SetIsHeadless(stack, true);
+			
+			AutomationProperties.SetIsInAccessibleTree(stack, true);
+			AutomationProperties.SetName(stack, "I am the StackLayout. This should be announced.");
+			Content = stack;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1026,6 +1026,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6929.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ApiLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7582.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7563.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -72,7 +72,7 @@ namespace Xamarin.Forms.Platform.iOS
 						!(
 							child is VisualElement ve && ve.IsTabStop
 							&& AutomationProperties.GetIsInAccessibleTree(ve) != false // accessible == true
-							&& ve.GetRenderer().NativeView is UIView view)
+							&& ve.GetRenderer()?.NativeView is UIView view)
 						 )
 						continue;
 


### PR DESCRIPTION
### Fix crash on iOS with elements that have Layout Compression and VoiceOver active 
Fixes #7563

Screenshot from test (previously crashed):
![IMG_2149](https://user-images.githubusercontent.com/1341446/65138488-f06d5e80-da02-11e9-9f44-a58520716d41.PNG)


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
