### PR TITLE
[X] avoid throwing in VisualDiagnostics

### DIFF
--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -346,22 +346,28 @@ namespace Xamarin.Forms.Xaml
 
 			//If it's a BindableProberty, SetValue
 			if (xpe == null && TrySetValue(xamlelement, property, attached, value, lineInfo, serviceProvider, out xpe)) {
-				VisualDiagnostics.RegisterSourceInfo(value, null, ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
-				VisualDiagnostics.SendVisualTreeChanged(xamlelement, value);
+				if (!(node is ValueNode) && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(context.RootElement) is string path) {
+					VisualDiagnostics.RegisterSourceInfo(value, new Uri(path, UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+					VisualDiagnostics.SendVisualTreeChanged(xamlelement, value);
+				}
 				return;
 			}
 
 			//If we can assign that value to a normal property, let's do it
 			if (xpe == null && TrySetProperty(xamlelement, localName, value, lineInfo, serviceProvider, context, out xpe)) {
-				VisualDiagnostics.RegisterSourceInfo(value, null, ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
-				VisualDiagnostics.SendVisualTreeChanged(xamlelement, value);
+				if (!(node is ValueNode) && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(context.RootElement) is string path) {
+					VisualDiagnostics.RegisterSourceInfo(value, new Uri(path, UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+					VisualDiagnostics.SendVisualTreeChanged(xamlelement, value);
+				}
 				return;
 			}
 
 			//If it's an already initialized property, add to it
 			if (xpe == null && TryAddToProperty(xamlelement, propertyName, value, xKey, lineInfo, serviceProvider, context, out xpe)) {
-				VisualDiagnostics.RegisterSourceInfo(value, null, ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
-				VisualDiagnostics.SendVisualTreeChanged(xamlelement, value);
+				if (!(node is ValueNode) && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(context.RootElement) is string path) {
+					VisualDiagnostics.RegisterSourceInfo(value, new Uri(path, UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+					VisualDiagnostics.SendVisualTreeChanged(xamlelement, value);
+				}
 				return;
 			}
 

--- a/Xamarin.Forms.Xaml/Diagnostics/DebuggerHelper.cs
+++ b/Xamarin.Forms.Xaml/Diagnostics/DebuggerHelper.cs
@@ -7,6 +7,10 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 {
 	static class DebuggerHelper
 	{
+#if DEBUG
+		static DebuggerHelper() => _mockDebuggerIsAttached = true;
+#endif
+
 		internal static bool _mockDebuggerIsAttached;
 		public static bool DebuggerIsAttached => _mockDebuggerIsAttached || Debugger.IsAttached;
 	}

--- a/Xamarin.Forms.Xaml/Diagnostics/VisualDiagnostics.cs
+++ b/Xamarin.Forms.Xaml/Diagnostics/VisualDiagnostics.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 		static ConditionalWeakTable<object, XamlSourceInfo> sourceInfos = new ConditionalWeakTable<object, XamlSourceInfo>();
 		internal static void RegisterSourceInfo(object target, Uri uri, int lineNumber, int linePosition)
 		{
-			if (DebuggerHelper.DebuggerIsAttached)
+			if (DebuggerHelper.DebuggerIsAttached && !sourceInfos.TryGetValue(target, out _))
 				sourceInfos.Add(target, new XamlSourceInfo(uri, lineNumber, linePosition));
 		}
 


### PR DESCRIPTION
### Description of Change ###

this fixes a regression introduced in #7474

### Issues Resolved ### 

- fixes #7570

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
