### PR TITLE
Update Android UI test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Make sure you have nuget.exe 4.0 or above and the latest dotnet core sdk (2.0.3)
 
 ### UI Tests ###
 
-#### Run Android Tests ####
+##### Run Android Tests #####
 
 Depending on your environment setup, you might need to configure a few things before being able to debug / run UI tests, especially on Windows.
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ Make sure you have nuget.exe 4.0 or above and the latest dotnet core sdk (2.0.3)
 
 ### UI Tests ###
 
-##### Run Android Tests #####
+##### Run Android UI Tests #####
 
 Depending on your environment setup, you might need to configure a few things before being able to debug / run UI tests, especially on Windows.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ Make sure you have nuget.exe 4.0 or above and the latest dotnet core sdk (2.0.3)
 Depending on your environment setup, you might need to configure a few things before being able to debug / run UI tests, especially on Windows.
 
 - If you receive an error about ANDROID_HOME, please make sure to set your environment variable to the Android SDK directory (e.g. C:\Program Files (x86)\Android\android-sdk).
-- If you receive an error about JAVA_HOME, please install the latest Java JDK and set your environment variable to the SDK directory (e.g. C:\Program Files\Java\jdk-13).
+- If you receive an error about JAVA_HOME, please install the latest Java JDK and set your environment variable to the JDK directory (e.g. C:\Program Files\Java\jdk-13).
 - If you receive an error about a missing ApkFile, please generate an APK file for Xamarin.Forms.ControlGallery.Android. The easiest way to do this is to right click the project and select "Deploy". Note that if you rebuild the solution, you might lose the APK and will need to generate it again.
 
 After these steps are taken care of, you should be good to go. You can see all UI tests in the Test Explorer, search them for your own convenience, and quickly run individual tests.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Depending on your environment setup, you might need to configure a few things be
 - If you receive an error about JAVA_HOME, please install the latest Java JDK and set your environment variable to the JDK directory (e.g. C:\Program Files\Java\jdk-13).
 - If you receive an error about a missing ApkFile, please generate an APK file for Xamarin.Forms.ControlGallery.Android. The easiest way to do this is to right click the project and select "Deploy". Note that if you rebuild the solution, you might lose the APK and will need to generate it again.
 
-After these steps are taken care of, you should be good to go. You can see all UI tests in the Test Explorer, search them for your own convenience, and quickly run individual tests.
+After these steps are taken care of, you should be good to go. You can see all UI tests in Test Explorer, search them for your own convenience, and quickly run individual tests.
 
 ##### Run UWP UI Tests #####
 

--- a/README.md
+++ b/README.md
@@ -110,6 +110,16 @@ Make sure you have nuget.exe 4.0 or above and the latest dotnet core sdk (2.0.3)
 
 ### UI Tests ###
 
+#### Run Android Tests ####
+
+Depending on your environment setup, you might need to configure a few things before being able to debug / run UI tests, especially on Windows.
+
+- If you receive an error about ANDROID_HOME, please make sure to set your environment variable to the Android SDK directory (e.g. C:\Program Files (x86)\Android\android-sdk).
+- If you receive an error about JAVA_HOME, please install the latest Java JDK and set your environment variable to the SDK directory (e.g. C:\Program Files\Java\jdk-13).
+- If you receive an error about a missing ApkFile, please generate an APK file for Xamarin.Forms.ControlGallery.Android. The easiest way to do this is to right click the project and select "Deploy". Note that if you rebuild the solution, you might lose the APK and will need to generate it again.
+
+After these steps are taken care of, you should be good to go. You can see all UI tests in the Test Explorer, search them for your own convenience, and quickly run individual tests.
+
 ##### Run UWP UI Tests #####
 
 To run the UWP UI Tests:


### PR DESCRIPTION
Added instructions for running Android UI tests on Windows.

@PureWeen @jfversluis @samhouts When I debug the test project on Windows, [ApkPath](https://github.com/xamarin/Xamarin.Forms/blob/65c6e5f59fa1776566f675d6e2e57e7068adb48e/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs#L19) isn't correct for me. We go 3 folders up from the current directory and append a substring to point to the Apk file, but I noticed my current directory does not point to the solution directory. It points to the Temp folder instead.

```
static IApp InitializeAndroidApp()
{
	var directory = Directory.GetCurrentDirectory(); // added this line for testing

	var app = ConfigureApp.Android.ApkFile(AppPaths.ApkPath).Debug().StartApp();

	if (bool.Parse((string)app.Invoke("IsPreAppCompat")))
	{
		IsFormsApplicationActivity = true;
	}

	return app;
}
```

`directory` returns `C:\Users\[user]\AppData\Local\Temp` for me. So, when we go 3 levels up and then append the rest of `ApkPath`, I end up with

`C:/Users/[user]/Xamarin.Forms.ControlGallery.Android/bin/Debug/AndroidControlGallery.AndroidControlGallery-Signed.apk` which is not correct because it's missing the parent folder I checked out XF solution to. Any of you saw this issue before?

Temporarily, I hard-coded the path to the Apk in local, but I'd like to know the root cause of this issue if possible.