### PR TITLE
[iOS] Fixes for null check for Shell classes

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -172,7 +172,7 @@ namespace Xamarin.Forms
 			}
 
 			if (shellContent.Parent?.Parent is ShellItem shellItem)
-				shellItem?.SendStructureChanged();
+				shellItem.SendStructureChanged();
 		}
 
 		void MenuItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms
 				this,
 				shellSection,
 				shellSection?.CurrentItem,
-				shellSection.Stack,
+				shellSection?.Stack,
 				true
 			);
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -594,7 +594,7 @@ namespace Xamarin.Forms
 		{
 			if (Parent?.Parent is IShellController shell)
 			{
-				shell?.UpdateCurrentState(source);
+				shell.UpdateCurrentState(source);
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms
 
 			var depthStart = 0;
 
-			if (segments[0] == shell.Route)
+			if (segments[0] == shell?.Route)
 			{
 				segments = segments.Skip(1).ToArray();
 				depthStart = 1;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -87,7 +87,8 @@ namespace Xamarin.Forms.Platform.iOS
 			var currentElement = VisualElementRenderer?.Element;
 
 			// Bind the view to the data item
-			currentElement.BindingContext = bindingContext;
+			if (currentElement != null)
+				currentElement.BindingContext = bindingContext;
 
 			if (template != _currentTemplate)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -412,7 +412,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var shellContent = shellSection?.CurrentItem;
 			var stack = shellSection?.Stack.ToList();
 
-			stack.RemoveAt(stack.Count - 1);
+			stack?.RemoveAt(stack.Count - 1);
 
 			return ((IShellController)_context.Shell).ProposeNavigation(ShellNavigationSource.Pop, shellItem, shellSection, shellContent, stack, true);
 		}


### PR DESCRIPTION
### Description of Change ###
**Several fixes for null checks:**
_ShellContent.cs_ - extra null check
_ShellItem.cs_ - added a check for null, as in the previous parameter.
_ShellSection.cs_ - extra null check
_ShellUriHandler.cs_ - added a check for null, as in the previous code block.
_ShellSectionRenderer.cs_ - added a check for null, as in the previous code block.
_TemplatedCell.cs_ - added a check for null

### API Changes ###
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
