### PR TITLE
[iOS,Android] Better way to get CurrentItem 

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -37,6 +37,8 @@ namespace Xamarin.Forms.Core.UITests
 
 			App.Tap("Item: 1");
 
+			App.WaitForElement("Button works");
+
 #if __ANDROID__
 			Assert.AreEqual(App.Query(c => c.Class("AlertDialogLayout")).Count(), 1, "Alert not shown");
 #elif __iOS__
@@ -74,6 +76,8 @@ namespace Xamarin.Forms.Core.UITests
 			App.WaitForElement("pos:1", "Did not scroll to second position");
 
 			App.Tap("Item: 1");
+
+			App.WaitForElement("Button works");
 
 #if __ANDROID__
 			Assert.AreEqual(App.Query(c => c.Class("AlertDialogLayout")).Count(), 1, "Alert not shown");

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -60,11 +60,16 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
-			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterY, rect.Y + rect.Height - 1);
+
+			var centerX = rect.CenterX;
+			var centerY = rect.CenterY;
+			var bottomY = rect.Y + rect.Height - 1;
+
+			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterX, bottomY);
 
 			App.WaitForElement("pos:0", "Did not scroll to first position");
 
-			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterY, rect.Y - 1);
+			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterX, rect.Y - 1);
 
 			App.WaitForElement("pos:1", "Did not scroll to second position");
 

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -39,11 +39,6 @@ namespace Xamarin.Forms.Core.UITests
 
 			App.WaitForElement("Button works");
 
-#if __ANDROID__
-			Assert.AreEqual(App.Query(c => c.Class("AlertDialogLayout")).Count(), 1, "Alert not shown");
-#elif __iOS__
-			App.Query(c => c.ClassFull("_UIAlertControllerView"));
-#endif
 			App.Tap(c => c.Marked("Ok"));
 
 			App.Tap("SwipeSwitch");
@@ -79,11 +74,6 @@ namespace Xamarin.Forms.Core.UITests
 
 			App.WaitForElement("Button works");
 
-#if __ANDROID__
-			Assert.AreEqual(App.Query(c => c.Class("AlertDialogLayout")).Count(), 1, "Alert not shown");
-#elif __iOS__
-			App.Query(c => c.ClassFull("_UIAlertControllerView"));
-#endif
 			App.Tap(c => c.Marked("Ok"));
 
 			App.Tap("SwipeSwitch");

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Windows.Input;
 using Xamarin.Forms.Platform;
+using System.Linq;
 
 namespace Xamarin.Forms
 {
@@ -186,6 +187,13 @@ namespace Xamarin.Forms
 		{
 		}
 
+		protected override void OnScrolled(ItemsViewScrolledEventArgs e)
+		{
+			CurrentItem = GetItemForPosition(this, e.CenterItemIndex);
+
+			base.OnScrolled(e);
+		}
+
 		static void PositionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var carousel = (CarouselView)bindable;
@@ -211,6 +219,14 @@ namespace Xamarin.Forms
 				carousel.ScrollTo(args.CurrentPosition, position: ScrollToPosition.Center, animate: carousel.IsScrollAnimated);
 
 			carousel.OnPositionChanged(args);
+		}
+
+		static object GetItemForPosition(CarouselView carouselView, int index)
+		{
+			if (!(carouselView?.ItemsSource is IList itemSource))
+				return null;
+
+			return itemSource[index];
 		}
 
 		static int GetPositionForItem(CarouselView carouselView, object item)

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Forms.Platform.Android
 		protected CarouselView Carousel;
 		ItemDecoration _itemDecoration;
 		bool _isSwipeEnabled;
-		bool _isUpdatingPositionFromForms;
 		int _oldPosition;
 		int _initialPosition;
 
@@ -41,10 +40,8 @@ namespace Xamarin.Forms.Platform.Android
 			base.SetUpNewElement(newElement);
 
 			if (newElement == null)
-			{
 				return;
-			}
-
+			
 			UpdateIsSwipeEnabled();
 			UpdateInitialPosition();
 			UpdateItemSpacing();
@@ -71,7 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (!_isSwipeEnabled)
 				return false;
-			
+
 			return base.OnInterceptTouchEvent(ev);
 		}
 
@@ -86,13 +83,6 @@ namespace Xamarin.Forms.Platform.Android
 				else
 					Carousel.SetIsDragging(false);
 			}
-		}
-
-		public override void OnScrolled(int dx, int dy)
-		{
-			base.OnScrolled(dx, dy);
-
-			UpdatePositionFromScroll();
 		}
 
 		protected override ItemDecoration CreateSpacingDecoration(IItemsLayout itemsLayout)
@@ -162,19 +152,6 @@ namespace Xamarin.Forms.Platform.Android
 			_isSwipeEnabled = Carousel.IsSwipeEnabled;
 		}
 
-		void UpdatePosition(int position)
-		{
-			if (position == -1 || _isUpdatingPositionFromForms)
-				return;
-
-			var item = ItemsViewAdapter?.ItemsSource.GetItem(position);
-
-			if (item == null)
-				throw new InvalidOperationException("Visible item not found");
-
-			Carousel.SetCurrentItem(item);
-		}
-
 		void UpdateIsBounceEnabled()
 		{
 			OverScrollMode = Carousel.IsBounceEnabled ? OverScrollMode.Always : OverScrollMode.Never;
@@ -201,37 +178,11 @@ namespace Xamarin.Forms.Platform.Android
 			oldItemViewAdapter?.Dispose();
 		}
 
-		void UpdatePositionFromScroll()
-		{
-			var snapHelper = GetSnapManager()?.GetCurrentSnapHelper();
-
-			if (snapHelper == null)
-				return;
-
-			var layoutManager = GetLayoutManager() as LayoutManager;
-
-			var snapView = snapHelper.FindSnapView(layoutManager);
-
-			if (snapView != null)
-			{
-				int middleCenterPosition = layoutManager.GetPosition(snapView);
-	
-				if (_oldPosition != middleCenterPosition)
-				{
-					_oldPosition = middleCenterPosition;
-					UpdatePosition(middleCenterPosition);
-				}
-			}
-		}
-
 		void UpdateInitialPosition()
 		{
-			_isUpdatingPositionFromForms = true;
-			// Goto to the Correct Position
 			_initialPosition = Carousel.Position;
 			_oldPosition = _initialPosition;
-			Carousel.ScrollTo(_initialPosition, position: Xamarin.Forms.ScrollToPosition.Center);
-			_isUpdatingPositionFromForms = false;
+			Carousel.ScrollTo(_initialPosition, -1, Xamarin.Forms.ScrollToPosition.Center, false);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -182,8 +182,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_initialPosition = Carousel.Position;
 			_oldPosition = _initialPosition;
-      Carousel.ScrollTo(_initialPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
-			_isUpdatingPositionFromForms = false;
+			Carousel.ScrollTo(_initialPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -177,13 +177,14 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var cells = CollectionView.VisibleCells;
 
+			var epsilon = 1;
 
 			TemplatedCell currentCell = null;
 			TemplatedCell previousCell = null;
 			TemplatedCell nextCell = null;
 
-			var x = (float)(CollectionView.Center.X + CollectionView.ContentOffset.X);
-			var y = (float)(CollectionView.Center.Y + CollectionView.ContentOffset.Y);
+			var x = CollectionView.Center.X + CollectionView.ContentOffset.X;
+			var y = CollectionView.Center.Y + CollectionView.ContentOffset.Y;
 
 			var previousIndex = -1;
 			var currentIndex = -1;
@@ -191,11 +192,11 @@ namespace Xamarin.Forms.Platform.iOS
 			for (int i = 0; i < cells.Count(); i++)
 			{
 				var cell = cells[i];
-				var cellCenterX = (float)cell.Center.X;
-				var cellCenterY = (float)cell.Center.Y;
+				var cellCenterX = cell.Center.X;
+				var cellCenterY = cell.Center.Y;
 
-				if ((_layout.ScrollDirection == UICollectionViewScrollDirection.Horizontal && cellCenterX == x)
-					|| (_layout.ScrollDirection == UICollectionViewScrollDirection.Vertical && cellCenterY == y))
+				if ((_layout.ScrollDirection == UICollectionViewScrollDirection.Horizontal && Math.Abs(cellCenterX - x) < epsilon)
+					|| (_layout.ScrollDirection == UICollectionViewScrollDirection.Vertical && Math.Abs(cellCenterY - y) < epsilon))
 				{
 					currentIndex = i;
 					if (i > 0)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -10,11 +11,6 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		CarouselView _carouselView;
 		ItemsViewLayout _layout;
-		nfloat _previousOffSetX;
-		nfloat _previousOffSetY;
-		object _currentItem;
-		NSIndexPath _currentItemIdex;
-		List<UICollectionViewCell> _cells;
 		bool _viewInitialized;
 
 		public CarouselViewController(CarouselView itemsView, ItemsViewLayout layout) : base(itemsView, layout)
@@ -45,7 +41,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!_viewInitialized)
 			{
 				UpdateInitialPosition();
-				UpdateVisualStates();
 
 				_viewInitialized = true;
 			}
@@ -71,159 +66,20 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 		}
 
-		public override void ScrollAnimationEnded(UIScrollView scrollView)
-		{
-
-		}
-
-		public override void DecelerationStarted(UIScrollView scrollView)
-		{
-
-		}
-
 		public override void DraggingStarted(UIScrollView scrollView)
 		{
 			_carouselView.SetIsDragging(true);
-			UpdateVisualStates();
 		}
 
 		public override void DraggingEnded(UIScrollView scrollView, bool willDecelerate)
 		{
 			_carouselView.SetIsDragging(false);
-			UpdateVisualStates();
-		}
-
-		public override void DecelerationEnded(UIScrollView scrollView)
-		{
-			var templatedCells = FindVisibleCells();
-
-			//TODO: Improve storing this state here
-			_currentItem = templatedCells.currentCell?.VisualElementRenderer?.Element?.BindingContext;
-			_currentItemIdex = GetIndexForItem(_currentItem);
-
-			if (_currentItem != null)
-				_carouselView.SetCurrentItem(_currentItem);
-		}
-
-		public override void Scrolled(UIScrollView scrollView)
-		{
-			//TODO: How to handle the inertial values it would be easy for negative values but not for overscroll 
-			var newOffSetX = scrollView.ContentOffset.X;
-			var newOffSetY = scrollView.ContentOffset.Y;
-
-			UpdateVisualStateForOfScreenCell();
-
-			UpdateVisualStates();
-
-			_previousOffSetX = newOffSetX;
-			_previousOffSetY = newOffSetY;
-		}
-
-		void UpdateVisualStateForOfScreenCell()
-		{
-			var newCells = CollectionView.VisibleCells.ToList();
-
-			if (_cells != null)
-			{
-				foreach (var _oldCell in _cells)
-				{
-					if (!newCells.Contains(_oldCell))
-					{
-						var oldElement = (_oldCell as TemplatedCell)?.VisualElementRenderer?.Element;
-						if (oldElement != null)
-						{
-							VisualStateManager.GoToState(oldElement, CarouselView.DefaultItemVisualState);
-						}
-					}
-
-				}
-			}
-
-			_cells = newCells;
-		}
-
-		void UpdateVisualStates()
-		{
-			var templatedCells = FindVisibleCells();
-
-			if (templatedCells.previousCell != null)
-			{
-				var previousElement = templatedCells.previousCell.VisualElementRenderer?.Element;
-				VisualStateManager.GoToState(previousElement, CarouselView.PreviousItemVisualState);
-			}
-			if (templatedCells.nextCell != null)
-			{
-				var nextElement = templatedCells.nextCell.VisualElementRenderer?.Element;
-				VisualStateManager.GoToState(nextElement, CarouselView.NextItemVisualState);
-			}
-			if (templatedCells.currentCell != null)
-			{
-				var currentElement = templatedCells.currentCell.VisualElementRenderer?.Element;
-				VisualStateManager.GoToState(currentElement, CarouselView.CurrentItemVisualState);
-			}
-		}
-
-		void UpdateDefaultVisualState()
-		{
-			var cells = CollectionView.VisibleCells;
-			for (int i = 0; i < cells.Count(); i++)
-			{
-				var cell = (cells[i] as TemplatedCell)?.VisualElementRenderer.Element;
-				VisualStateManager.GoToState(cell, CarouselView.DefaultItemVisualState);
-			}
-		}
-
-		(TemplatedCell currentCell, TemplatedCell previousCell, TemplatedCell nextCell) FindVisibleCells()
-		{
-			var cells = CollectionView.VisibleCells;
-
-			var epsilon = 1;
-
-			TemplatedCell currentCell = null;
-			TemplatedCell previousCell = null;
-			TemplatedCell nextCell = null;
-
-			var x = CollectionView.Center.X + CollectionView.ContentOffset.X;
-			var y = CollectionView.Center.Y + CollectionView.ContentOffset.Y;
-
-			var previousIndex = -1;
-			var currentIndex = -1;
-			var nextIndex = -1;
-			for (int i = 0; i < cells.Count(); i++)
-			{
-				var cell = cells[i];
-				var cellCenterX = cell.Center.X;
-				var cellCenterY = cell.Center.Y;
-
-				if ((_layout.ScrollDirection == UICollectionViewScrollDirection.Horizontal && Math.Abs(cellCenterX - x) < epsilon)
-					|| (_layout.ScrollDirection == UICollectionViewScrollDirection.Vertical && Math.Abs(cellCenterY - y) < epsilon))
-				{
-					currentIndex = i;
-					if (i > 0)
-					{
-						previousIndex = currentIndex - 1;
-					}
-					if (i < cells.Count() - 1)
-					{
-						nextIndex = currentIndex + 1;
-					}
-				}
-			}
-
-			if (currentIndex != -1)
-				currentCell = cells[currentIndex] as TemplatedCell;
-			if (previousIndex != -1)
-				previousCell = cells[previousIndex] as TemplatedCell;
-			if (nextIndex != -1)
-				nextCell = cells[nextIndex] as TemplatedCell;
-
-			return (currentCell, previousCell, nextCell);
 		}
 
 		void UpdateInitialPosition()
 		{
 			if (_carouselView.Position != 0)
-				_carouselView.ScrollTo(_carouselView.Position, -1, ScrollToPosition.Center);
+				_carouselView.ScrollTo(_carouselView.Position, -1, ScrollToPosition.Center, false);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -166,20 +166,9 @@ namespace Xamarin.Forms.Platform.iOS
 			return GroupableItemsViewController.GetReferenceSizeForFooter(collectionView, layout, section);
 		}
 
-		public override void DecelerationEnded(UIScrollView scrollView)
-		{
-			CarouselViewController?.DecelerationEnded(scrollView);
-		}
-
-		public override void DecelerationStarted(UIScrollView scrollView)
-		{
-			CarouselViewController?.DecelerationStarted(scrollView);
-		}
-
 		public override void ScrollAnimationEnded(UIScrollView scrollView)
 		{
 			GroupableItemsViewController?.HandleScrollAnimationEnded();
-			CarouselViewController?.ScrollAnimationEnded(scrollView);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Comparing the floating point is not easy on the scrollview , this is a better approach to check with a error margin the current item.

### Issues Resolved ### 

- fixes failing uitests on iOS
- fixes #7525 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
