### PR TITLE
[X] do not fail on generic aBP

### DIFF
--- a/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/BindablePropertyReferenceExtensions.cs
@@ -34,10 +34,9 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public static TypeReference GetBindablePropertyTypeConverter(this FieldReference bpRef, ModuleDefinition module)
 		{
-			TypeReference propertyDeclaringType;
 			var owner = bpRef.DeclaringType;
 			var bpName = bpRef.Name.EndsWith("Property", StringComparison.Ordinal) ? bpRef.Name.Substring(0, bpRef.Name.Length - 8) : bpRef.Name;
-			var property = owner.GetProperty(pd => pd.Name == bpName, out propertyDeclaringType);
+			var property = owner.GetProperty(pd => pd.Name == bpName, out TypeReference propertyDeclaringType);
 			var propertyType = property?.PropertyType?.ResolveGenericParameters(propertyDeclaringType);
 			var staticGetter = owner.GetMethods(md => md.Name == $"Get{bpName}" &&
 												md.IsStatic &&
@@ -52,8 +51,8 @@ namespace Xamarin.Forms.Build.Tasks
 				attributes.AddRange(propertyType.ResolveCached().CustomAttributes);
 			if (staticGetter != null && staticGetter.HasCustomAttributes)
 				attributes.AddRange(staticGetter.CustomAttributes);
-			if (staticGetter != null && staticGetter.ReturnType.ResolveCached().HasCustomAttributes)
-				attributes.AddRange(staticGetter.ReturnType.ResolveCached().CustomAttributes);
+			if (staticGetter != null && staticGetter.ReturnType.ResolveGenericParameters(bpRef.DeclaringType).ResolveCached().HasCustomAttributes)
+				attributes.AddRange(staticGetter.ReturnType.ResolveGenericParameters(bpRef.DeclaringType).ResolveCached().CustomAttributes);
 
 			return attributes.FirstOrDefault(cad => TypeConverterAttribute.TypeConvertersType.Contains(cad.AttributeType.FullName))?.ConstructorArguments [0].Value as TypeReference;
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7494.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7494.xaml.cs
@@ -10,10 +10,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 {
 	public partial class Gh7494 : ContentPage
 	{
-		public Gh7494()
-		{
-			InitializeComponent();
-		}
+		public Gh7494() => InitializeComponent();
 		public Gh7494(bool useCompiledXaml)
 		{
 			//this stub will be replaced at compile time

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7559.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7559.xaml
@@ -1,0 +1,8 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh7559"
+        local:Gh7559A.Icon="LetterA" >
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7559.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7559.xaml.cs
@@ -1,0 +1,60 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh7559 : ContentPage
+	{
+		public Gh7559() => InitializeComponent();
+		public Gh7559(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void GenericBPCompiles([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Gh7559));
+				var layout = new Gh7559(useCompiledXaml);
+				var value = Gh7559Generic<Gh7559Enum>.GetIcon(layout);
+				Assert.That(value, Is.EqualTo(Gh7559Enum.LetterA));
+			}
+		}
+	}
+
+	public abstract class Gh7559Generic<T>
+	{
+		public static readonly BindableProperty IconProperty = BindableProperty.Create("Icon", typeof(T), typeof(Gh7559Generic<T>), default(T));
+
+		public static T GetIcon(BindableObject bindable)
+		{
+			return (T)bindable.GetValue(IconProperty);
+		}
+
+		public static void SetIcon(BindableObject bindable, T value)
+		{
+			bindable.SetValue(IconProperty, value);
+		}
+	}
+
+	public enum Gh7559Enum
+	{
+		LetterX = 'X',
+		LetterA = 'A',
+	}
+
+	public class Gh7559A : Gh7559Generic<Gh7559Enum>
+	{ }
+}


### PR DESCRIPTION
### Description of Change ###

While looking for a potential TypeConverter attribute on the static getter of a
generic attached BP, resolve the generic return type.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7559

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
