### PR TITLE
Fix NullReferenceException in Obfuscate (#7589)

### DIFF
--- a/Xamarin.Forms.Platform.WPF/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.WPF/FormsTextBox.cs
@@ -167,9 +167,9 @@ namespace Xamarin.Forms.Platform.WPF
 		string Obfuscate(string text, bool leaveLastVisible = false)
 		{
 			if (!leaveLastVisible)
-				return new string(ObfuscationCharacter, text.Length);
+				return new string(ObfuscationCharacter, text?.Length ?? 0);
 
-			return text.Length == 1
+			return text == null || text.Length == 1
 				? text
 				: new string(ObfuscationCharacter, text.Length - 1) + text.Substring(text.Length - 1, 1);
 		}


### PR DESCRIPTION
### Description of Change ###

This change makes `Obfuscate` of `FormsTextBox` null safe.

### Issues Resolved ### 
- fixes #7589 

### API Changes ###
None

Added:
None

Changed:
None

### Platforms Affected ### 
- Wpf

### Behavioral/Visual Changes ###
None

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
