### PR TITLE
[CarouselView] Fix CarouselView initial position on Android

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+ 	xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues"
+	x:Class="Xamarin.Forms.Controls.Issues.Issue7525"
+    Title="Issue 7525">
+    <local:TestContentPage.Resources>
+
+           <issues:CustomViewSelector x:Key="Selector"/>
+
+    </local:TestContentPage.Resources>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Label
+            Grid.Row="0"
+            Text="If the background visible in the CarouselView is blue, it is correct."/>
+        <CarouselView
+            Grid.Row="1"
+            x:Name="MainCarousel" 
+            ItemsSource="{Binding AvaiableViews}"
+            ItemTemplate="{StaticResource Selector}">
+            <CarouselView.ItemsLayout>
+                <LinearItemsLayout 
+                    Orientation="Horizontal" 
+                    SnapPointsAlignment="Center" 
+                    SnapPointsType="Mandatory"/>
+            </CarouselView.ItemsLayout>
+        </CarouselView>
+    </Grid>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml
@@ -22,7 +22,7 @@
         <CarouselView
             Grid.Row="1"
             x:Name="MainCarousel" 
-            ItemsSource="{Binding AvaiableViews}"
+            ItemsSource="{Binding AvailableViews}"
             ItemTemplate="{StaticResource Selector}">
             <CarouselView.ItemsLayout>
                 <LinearItemsLayout 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml.cs
@@ -70,14 +70,14 @@ namespace Xamarin.Forms.Controls.Issues
 			MainCarousel.Position = 1;
 		}
 
-		public List<Type> AvaiableViews { get; set; }
+		public List<Type> AvailableViews { get; set; }
 		public int Position { get { return _position; } set { _position = value; OnPropertyChanged(); } }
 
 		protected override void Init()
 		{	
 			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
 
-			AvaiableViews = new List<Type>() { typeof(Test1View), typeof(Test2View), typeof(Test3View) };
+			AvailableViews = new List<Type>() { typeof(Test1View), typeof(Test2View), typeof(Test3View) };
 
 			BindingContext = this;
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7525.xaml.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if APP
+	[Preserve(AllMembers = true)]
+	public class Test1View : ContentView
+	{
+		public Test1View()
+		{
+			BackgroundColor = Color.Red;
+		}
+	}
+	[Preserve(AllMembers = true)]
+	public class Test2View : ContentView
+	{
+		public Test2View()
+		{
+			BackgroundColor = Color.Blue;
+		}
+	}
+	[Preserve(AllMembers = true)]
+	public class Test3View : ContentView
+	{
+		public Test3View()
+		{
+			BackgroundColor = Color.Green;
+		}
+	}
+		
+	[Preserve(AllMembers = true)]
+	public class CustomViewSelector : DataTemplateSelector
+    {
+        private DataTemplate view1 = new DataTemplate(typeof(Test1View));
+        private DataTemplate view2 = new DataTemplate(typeof(Test2View));
+        private DataTemplate view3 = new DataTemplate(typeof(Test3View));
+
+        protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+        {
+            Type currentView = item as Type;
+
+            if (currentView == typeof(Test1View))
+                return view1;
+            else if (currentView == typeof(Test2View))
+                return view2;
+            return view3;
+        }
+    }
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7525, "Carousel Position property doesn't change the position on page constructor", PlatformAffected.Android)]
+	public partial class Issue7525 : TestContentPage
+	{
+		private int _position;
+
+		public Issue7525()
+		{
+			InitializeComponent();
+
+			MainCarousel.Position = 1;
+		}
+
+		public List<Type> AvaiableViews { get; set; }
+		public int Position { get { return _position; } set { _position = value; OnPropertyChanged(); } }
+
+		protected override void Init()
+		{	
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "CollectionView_Experimental" });
+
+			AvaiableViews = new List<Type>() { typeof(Test1View), typeof(Test2View), typeof(Test3View) };
+
+			BindingContext = this;
+		}
+	}
+#endif
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1052,6 +1052,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6894.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6929.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ApiLabel.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7525.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1176,6 +1177,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4356.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7525.xaml">
+      <Generator>UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
@@ -1390,7 +1394,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -230,7 +230,7 @@ namespace Xamarin.Forms.Platform.Android
 			// Goto to the Correct Position
 			_initialPosition = Carousel.Position;
 			_oldPosition = _initialPosition;
-			Carousel.ScrollTo(_initialPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+			Carousel.ScrollTo(_initialPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 			_isUpdatingPositionFromForms = false;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Fix CarouselView initial position on Android.

### Issues Resolved ### 

- fixes #7525

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="517" alt="7525-before" src="https://user-images.githubusercontent.com/6755973/65260819-44fa0200-db07-11e9-8180-8a62e71dbdac.png">

#### After
<img width="512" alt="7525-after" src="https://user-images.githubusercontent.com/6755973/65260824-46c3c580-db07-11e9-92e2-d7e5cee318ff.png">

The carousel has three elements (blue, red and green). Position is set to 1. The correct result must be, see the element with a blue background.

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the test cases. Open test case 7525. If you see a blue background is working. In other case, the test is failing.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)