### PR TITLE
Fix raising Navigating event for internal page content with WkWebRenderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -243,6 +243,11 @@ namespace Xamarin.Forms.Platform.iOS
 			// https://stackoverflow.com/questions/37509990/migrating-from-uiwebview-to-wkwebview
 			public override void DecidePolicy(WKWebView webView, WKNavigationAction navigationAction, Action<WKNavigationActionPolicy> decisionHandler)
 			{
+				if (!navigationAction.TargetFrame.MainFrame)
+                {
+                    decisionHandler(WKNavigationActionPolicy.Allow);
+                    return;
+                }
 				var navEvent = WebNavigationEvent.NewPage;
 				var navigationType = navigationAction.NavigationType;
 				switch (navigationType)


### PR DESCRIPTION
### Description of Change ###
We need to verify if the TargetFrame is the MainFrame and not raise the navigating event. If for example you have a page with an internal iframe that points to another page (for example a Video on Vimeo) you will actually raise the Navigating event even if the page doesn't change, The Navigation should be raised only if the frame is the MainFrame

### Issues Resolved ### 
When using WKWebViewRenderer on iOS we will get the Navigating event when the main page loads internal content from another link

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Testing Procedure ###
Use a page with iframe that is pointing to external content. You will get two navigating events even if the page does not change

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)