### PR TITLE
Previewer fixes for loading font correctly and catching image load exceptions

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.Android
 			var fontFamily = key.Item1;
 			var fontAttribute = key.Item2;
 
-			if (fontFamily == null)
+			if (String.IsNullOrWhiteSpace(fontFamily))
 			{
 				var style = ToTypefaceStyle(fontAttribute);
 				result = Typeface.Create(Typeface.Default, style);


### PR DESCRIPTION
### Description of Change ###

- Fixed pathing for how to process fontFamily to use *IsNullOrWhiteSpace* opposed to just checking for null
- moved try catch for image loading fail to more generalized location

Regression caused here https://github.com/xamarin/Xamarin.Forms/pull/6470


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7598
- fixes #7597


### Platforms Affected ### 
- Android


### Testing Procedure ###
- create new Xamarin Forms template (MDP or Shell)
- Open the Abouts page and some of the font should be bold
- Change the image on the page to an image path that doesn't exist. The image should disappear but the rest of the page should remain visible

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
