### PR TITLE
[Android] Fix FlowDirection for Labels

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue7512">
+    
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+
+        <StackLayout Orientation="Vertical" Spacing="5" Grid.Row="0" VerticalOptions="Center" BackgroundColor="Beige">
+            <Label LineBreakMode="WordWrap" Margin="10,0" Text="Verify that when you switch to RTL, images are placed on the right side of the screen and labels are right aligned so that the last character of each label is immediately next to an image." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+            <Label LineBreakMode="WordWrap" Margin="10,0" Text="Verify that when you switch to LTR, images are placed on the left side of the screen and labels are left aligned so that the first character of each label is immediately next to an image." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+            <Button Text="Switch to RTL" HorizontalOptions="Center" VerticalOptions="Center" Clicked="HandleButtonClick"/>
+        </StackLayout>
+
+        <CollectionView Grid.Row="1" ItemsSource="{Binding Monkeys}" FlowDirection="LeftToRight">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid Padding="10">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="Auto" />
+                            <ColumnDefinition Width="Auto" />
+                        </Grid.ColumnDefinitions>
+
+                        <Image Grid.RowSpan="2" 
+                               Source="{Binding ImageUrl}" 
+                               Aspect="AspectFill"
+                               HeightRequest="60" 
+                               WidthRequest="60" />
+                        <Label Grid.Column="1" 
+                               Text="{Binding Name}" 
+                               FontAttributes="Bold" BackgroundColor="Red" />
+                        <Label Grid.Row="1"
+                               Grid.Column="1" 
+                               Text="{Binding Location}"
+                               FontAttributes="Italic" 
+                               VerticalOptions="End" BackgroundColor="Yellow" />
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
@@ -75,7 +75,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Baboon",
 				Location = "Africa & Asia",
-				Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
 			});
 
@@ -83,7 +82,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Capuchin Monkey",
 				Location = "Central & South America",
-				Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
 			});
 
@@ -91,7 +89,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Blue Monkey",
 				Location = "Central and East Africa",
-				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
 			});
 
@@ -99,7 +96,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Squirrel Monkey",
 				Location = "Central & South America",
-				Details = "The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Saimiri_sciureus-1_Luc_Viatour.jpg/220px-Saimiri_sciureus-1_Luc_Viatour.jpg"
 			});
 
@@ -107,7 +103,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Golden Lion Tamarin",
 				Location = "Brazil",
-				Details = "The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Golden_lion_tamarin_portrait3.jpg/220px-Golden_lion_tamarin_portrait3.jpg"
 			});
 
@@ -115,7 +110,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Howler Monkey",
 				Location = "South America",
-				Details = "Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Alouatta_guariba.jpg/200px-Alouatta_guariba.jpg"
 			});
 
@@ -123,7 +117,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Japanese Macaque",
 				Location = "Japan",
-				Details = "The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Macaca_fuscata_fuscata1.jpg/220px-Macaca_fuscata_fuscata1.jpg"
 			});
 
@@ -131,7 +124,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Mandrill",
 				Location = "Southern Cameroon, Gabon, Equatorial Guinea, and Congo",
-				Details = "The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandrill_at_san_francisco_zoo.jpg/220px-Mandrill_at_san_francisco_zoo.jpg"
 			});
 
@@ -139,7 +131,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Proboscis Monkey",
 				Location = "Borneo",
-				Details = "The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo.",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Proboscis_Monkey_in_Borneo.jpg/250px-Proboscis_Monkey_in_Borneo.jpg"
 			});
 
@@ -147,7 +138,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Red-shanked Douc",
 				Location = "Vietnam, Laos",
-				Details = "The red-shanked douc is a species of Old World monkey, among the most colourful of all primates. This monkey is sometimes called the \"costumed ape\" for its extravagant appearance. From its knees to its ankles it sports maroon-red \"stockings\", and it appears to wear white forearm length gloves. Its attire is finished with black hands and feet. The golden face is framed by a white ruff, which is considerably fluffier in males. The eyelids are a soft powder blue. The tail is white with a triangle of white hair at the base. Males of all ages have a white spot on both sides of the corners of the rump patch, and red and white genitals.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Portrait_of_a_Douc.jpg/159px-Portrait_of_a_Douc.jpg"
 			});
 
@@ -155,7 +145,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Gray-shanked Douc",
 				Location = "Vietnam",
-				Details = "The gray-shanked douc langur is a douc species native to the Vietnamese provinces of Quảng Nam, Quảng Ngãi, Bình Định, Kon Tum, and Gia Lai. The total population is estimated at 550 to 700 individuals. In 2016, Dr Benjamin Rawson, Country Director of Fauna & Flora International - Vietnam Programme, announced a discovery of an additional population of more than 500 individuals found in Central Vietnam, bringing the total population up to approximately 1000 individuals.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Cuc.Phuong.Primate.Rehab.center.jpg/320px-Cuc.Phuong.Primate.Rehab.center.jpg"
 			});
 
@@ -163,7 +152,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Golden Snub-nosed Monkey",
 				Location = "China",
-				Details = "The golden snub-nosed monkey is an Old World monkey in the Colobinae subfamily. It is endemic to a small area in temperate, mountainous forests of central and Southwest China. They inhabit these mountainous forests of Southwestern China at elevations of 1,500-3,400 m above sea level. The Chinese name is Sichuan golden hair monkey. It is also widely referred to as the Sichuan snub-nosed monkey. Of the three species of snub-nosed monkeys in China, the golden snub-nosed monkey is the most widely distributed throughout China.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg/165px-Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg"
 			});
 
@@ -171,7 +159,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Black Snub-nosed Monkey",
 				Location = "China",
-				Details = "The black snub-nosed monkey, also known as the Yunnan snub-nosed monkey, is an endangered species of primate in the family Cercopithecidae. It is endemic to China, where it is known to the locals as the Yunnan golden hair monkey and the black golden hair monkey. It is threatened by habitat loss. It was named after Bishop Félix Biet.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/RhinopitecusBieti.jpg/320px-RhinopitecusBieti.jpg"
 			});
 
@@ -179,7 +166,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Tonkin Snub-nosed Monkey",
 				Location = "Vietnam",
-				Details = "The Tonkin snub-nosed monkey or Dollman's snub-nosed monkey is a slender-bodied arboreal Old World monkey, endemic to northern Vietnam. It is a black and white monkey with a pink nose and lips and blue patches round the eyes. It is found at altitudes of 200 to 1,200 m (700 to 3,900 ft) on fragmentary patches of forest on craggy limestone areas. First described in 1912, the monkey was rediscovered in 1990 but is exceedingly rare. In 2008, fewer than 250 individuals were thought to exist, and the species was the subject of intense conservation effort. The main threats faced by these monkeys is habitat loss and hunting, and the International Union for Conservation of Nature has rated the species as \"critically endangered\".",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg/320px-Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg"
 			});
 
@@ -187,7 +173,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Thomas's Langur",
 				Location = "Indonesia",
-				Details = "Thomas's langur is a species of primate in the family Cercopithecidae. It is endemic to North Sumatra, Indonesia. Its natural habitat is subtropical or tropical dry forests. It is threatened by habitat loss. Its native names are reungkah in Acehnese and kedih in Alas.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
 			});
 
@@ -195,7 +180,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Purple-faced Langur",
 				Location = "Sri Lanka",
-				Details = "The purple-faced langur, also known as the purple-faced leaf monkey, is a species of Old World monkey that is endemic to Sri Lanka. The animal is a long-tailed arboreal species, identified by a mostly brown appearance, dark face (with paler lower face) and a very shy nature. The species was once highly prevalent, found in suburban Colombo and the \"wet zone\" villages (areas with high temperatures and high humidity throughout the year, whilst rain deluges occur during the monsoon seasons), but rapid urbanization has led to a significant decrease in the population level of the monkeys.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
 			});
 
@@ -203,7 +187,6 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Name = "Gelada",
 				Location = "Ethiopia",
-				Details = "The gelada, sometimes called the bleeding-heart monkey or the gelada baboon, is a species of Old World monkey found only in the Ethiopian Highlands, with large populations in the Semien Mountains. Theropithecus is derived from the Greek root words for \"beast-ape.\" Like its close relatives the baboons, it is largely terrestrial, spending much of its time foraging in grasslands.",
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Gelada-Pavian.jpg/320px-Gelada-Pavian.jpg"
 			});
 
@@ -216,7 +199,6 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public string Name { get; set; }
 		public string Location { get; set; }
-		public string Details { get; set; }
 		public string ImageUrl { get; set; }
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		}
 
-		private void HandleButtonClick(object sender, EventArgs e)
+	 void HandleButtonClick(object sender, EventArgs e)
 		{
 			var button = sender as Button;
 			var stackLayout = button.Parent as StackLayout;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
@@ -1,0 +1,222 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7512, "RTL CollectionView looks odd", PlatformAffected.Android)]
+	public partial class Issue7512 : TestContentPage
+	{
+		bool isRTL = false;
+
+#if APP
+		public Issue7512()
+		{
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+
+			InitializeComponent();
+
+			BindingContext = new ViewModel7512();
+		}
+#endif
+
+		protected override void Init()
+		{
+
+		}
+
+		private void HandleButtonClick(object sender, EventArgs e)
+		{
+			var button = sender as Button;
+			var stackLayout = button.Parent as StackLayout;
+			var grid = stackLayout.Parent as Grid;
+			var collectionView = grid.Children[1] as CollectionView;
+
+			isRTL = !isRTL;
+
+			button.Text = isRTL ? "Switch to LTR" : "Switch to RTL";
+			collectionView.FlowDirection = isRTL ? FlowDirection.RightToLeft : FlowDirection.LeftToRight;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModel7512
+	{
+		public ObservableCollection<Model7512> Monkeys { get; private set; }
+
+		public ViewModel7512()
+		{
+			Monkeys = CreateMonkeyCollection();
+		}
+
+		ObservableCollection<Model7512> CreateMonkeyCollection()
+		{
+			var source = new ObservableCollection<Model7512>();
+
+			source.Add(new Model7512
+			{
+				Name = "Baboon",
+				Location = "Africa & Asia",
+				Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Capuchin Monkey",
+				Location = "Central & South America",
+				Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Blue Monkey",
+				Location = "Central and East Africa",
+				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Squirrel Monkey",
+				Location = "Central & South America",
+				Details = "The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Saimiri_sciureus-1_Luc_Viatour.jpg/220px-Saimiri_sciureus-1_Luc_Viatour.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Golden Lion Tamarin",
+				Location = "Brazil",
+				Details = "The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Golden_lion_tamarin_portrait3.jpg/220px-Golden_lion_tamarin_portrait3.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Howler Monkey",
+				Location = "South America",
+				Details = "Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Alouatta_guariba.jpg/200px-Alouatta_guariba.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Japanese Macaque",
+				Location = "Japan",
+				Details = "The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Macaca_fuscata_fuscata1.jpg/220px-Macaca_fuscata_fuscata1.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Mandrill",
+				Location = "Southern Cameroon, Gabon, Equatorial Guinea, and Congo",
+				Details = "The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandrill_at_san_francisco_zoo.jpg/220px-Mandrill_at_san_francisco_zoo.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Proboscis Monkey",
+				Location = "Borneo",
+				Details = "The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Proboscis_Monkey_in_Borneo.jpg/250px-Proboscis_Monkey_in_Borneo.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Red-shanked Douc",
+				Location = "Vietnam, Laos",
+				Details = "The red-shanked douc is a species of Old World monkey, among the most colourful of all primates. This monkey is sometimes called the \"costumed ape\" for its extravagant appearance. From its knees to its ankles it sports maroon-red \"stockings\", and it appears to wear white forearm length gloves. Its attire is finished with black hands and feet. The golden face is framed by a white ruff, which is considerably fluffier in males. The eyelids are a soft powder blue. The tail is white with a triangle of white hair at the base. Males of all ages have a white spot on both sides of the corners of the rump patch, and red and white genitals.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Portrait_of_a_Douc.jpg/159px-Portrait_of_a_Douc.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Gray-shanked Douc",
+				Location = "Vietnam",
+				Details = "The gray-shanked douc langur is a douc species native to the Vietnamese provinces of Quảng Nam, Quảng Ngãi, Bình Định, Kon Tum, and Gia Lai. The total population is estimated at 550 to 700 individuals. In 2016, Dr Benjamin Rawson, Country Director of Fauna & Flora International - Vietnam Programme, announced a discovery of an additional population of more than 500 individuals found in Central Vietnam, bringing the total population up to approximately 1000 individuals.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Cuc.Phuong.Primate.Rehab.center.jpg/320px-Cuc.Phuong.Primate.Rehab.center.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Golden Snub-nosed Monkey",
+				Location = "China",
+				Details = "The golden snub-nosed monkey is an Old World monkey in the Colobinae subfamily. It is endemic to a small area in temperate, mountainous forests of central and Southwest China. They inhabit these mountainous forests of Southwestern China at elevations of 1,500-3,400 m above sea level. The Chinese name is Sichuan golden hair monkey. It is also widely referred to as the Sichuan snub-nosed monkey. Of the three species of snub-nosed monkeys in China, the golden snub-nosed monkey is the most widely distributed throughout China.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg/165px-Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Black Snub-nosed Monkey",
+				Location = "China",
+				Details = "The black snub-nosed monkey, also known as the Yunnan snub-nosed monkey, is an endangered species of primate in the family Cercopithecidae. It is endemic to China, where it is known to the locals as the Yunnan golden hair monkey and the black golden hair monkey. It is threatened by habitat loss. It was named after Bishop Félix Biet.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/RhinopitecusBieti.jpg/320px-RhinopitecusBieti.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Tonkin Snub-nosed Monkey",
+				Location = "Vietnam",
+				Details = "The Tonkin snub-nosed monkey or Dollman's snub-nosed monkey is a slender-bodied arboreal Old World monkey, endemic to northern Vietnam. It is a black and white monkey with a pink nose and lips and blue patches round the eyes. It is found at altitudes of 200 to 1,200 m (700 to 3,900 ft) on fragmentary patches of forest on craggy limestone areas. First described in 1912, the monkey was rediscovered in 1990 but is exceedingly rare. In 2008, fewer than 250 individuals were thought to exist, and the species was the subject of intense conservation effort. The main threats faced by these monkeys is habitat loss and hunting, and the International Union for Conservation of Nature has rated the species as \"critically endangered\".",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg/320px-Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Thomas's Langur",
+				Location = "Indonesia",
+				Details = "Thomas's langur is a species of primate in the family Cercopithecidae. It is endemic to North Sumatra, Indonesia. Its natural habitat is subtropical or tropical dry forests. It is threatened by habitat loss. Its native names are reungkah in Acehnese and kedih in Alas.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Purple-faced Langur",
+				Location = "Sri Lanka",
+				Details = "The purple-faced langur, also known as the purple-faced leaf monkey, is a species of Old World monkey that is endemic to Sri Lanka. The animal is a long-tailed arboreal species, identified by a mostly brown appearance, dark face (with paler lower face) and a very shy nature. The species was once highly prevalent, found in suburban Colombo and the \"wet zone\" villages (areas with high temperatures and high humidity throughout the year, whilst rain deluges occur during the monsoon seasons), but rapid urbanization has led to a significant decrease in the population level of the monkeys.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
+			});
+
+			source.Add(new Model7512
+			{
+				Name = "Gelada",
+				Location = "Ethiopia",
+				Details = "The gelada, sometimes called the bleeding-heart monkey or the gelada baboon, is a species of Old World monkey found only in the Ethiopian Highlands, with large populations in the Semien Mountains. Theropithecus is derived from the Greek root words for \"beast-ape.\" Like its close relatives the baboons, it is largely terrestrial, spending much of its time foraging in grasslands.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Gelada-Pavian.jpg/320px-Gelada-Pavian.jpg"
+			});
+
+			return source;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Model7512
+	{
+		public string Name { get; set; }
+		public string Location { get; set; }
+		public string Details { get; set; }
+		public string ImageUrl { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -42,6 +42,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7512.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <SubType>Code</SubType>
@@ -1390,6 +1393,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <DependentUpon>Issue7621.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7512.xaml.cs">
+      <DependentUpon>Issue7512.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1455.xaml">
@@ -1429,6 +1435,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7621.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7512.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FlowDirectionExtensions.cs
@@ -1,7 +1,7 @@
-﻿using Android.OS;
+﻿using Android.Widget;
 using ALayoutDirection = Android.Views.LayoutDirection;
+using ATextDirection = Android.Views.TextDirection;
 using AView = Android.Views.View;
-
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -27,9 +27,19 @@ namespace Xamarin.Forms.Platform.Android
 
 			// if android:targetSdkVersion < 17 setting these has no effect
 			if (controller.EffectiveFlowDirection.IsRightToLeft())
+			{
 				view.LayoutDirection = ALayoutDirection.Rtl;
+
+				if (view is TextView textView)
+					textView.TextDirection = ATextDirection.Rtl;
+			}
 			else if (controller.EffectiveFlowDirection.IsLeftToRight())
+			{
 				view.LayoutDirection = ALayoutDirection.Ltr;
+
+				if (view is TextView textView)
+					textView.TextDirection = ATextDirection.Ltr;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

I was looking at #7512 and noticed the issue is not a `CollectionView` problem. If you go to `FlowDirection` gallery, you'll see that RTL flow is broken. At the level of `VisualElementRenderer`, flow direction is being applied only to the layout direction. This does not seem to be working for `TextView`. Instead, we could use a different method for that.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7512

### Testing Procedure ###
Run the attached test. Also, go to `FlowDirection` gallery and make sure the labels are aligned properly when you change the flow direction.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
