### PR TITLE
[Android] Remove ripple effect on CollectionView item when SelectionMode is None

### DIFF
--- a/Xamarin.Forms.Core/Items/SelectableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/SelectableItemsView.cs
@@ -138,55 +138,21 @@ namespace Xamarin.Forms
 		static void SelectionModePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var selectableItemsView = (SelectableItemsView)bindable;
-
-			var oldMode = (SelectionMode)oldValue;
 			var newMode = (SelectionMode)newValue;
-
-			IList<object> previousSelection = new List<object>();
-			IList<object> newSelection = new List<object>();
-
-			switch (oldMode)
-			{
-				case SelectionMode.None:
-					break;
-				case SelectionMode.Single:
-					if (selectableItemsView.SelectedItem != null)
-					{
-						previousSelection.Add(selectableItemsView.SelectedItem);
-					}
-					break;
-				case SelectionMode.Multiple:
-					previousSelection = selectableItemsView.SelectedItems;
-					break;
-			}
 
 			switch (newMode)
 			{
 				case SelectionMode.None:
+					selectableItemsView.SelectedItem = null;
+					selectableItemsView.SelectedItems = null;
 					break;
 				case SelectionMode.Single:
-					if (selectableItemsView.SelectedItem != null)
-					{
-						newSelection.Add(selectableItemsView.SelectedItem);
-					}
+					selectableItemsView.SelectedItems = null;
 					break;
 				case SelectionMode.Multiple:
-					newSelection = selectableItemsView.SelectedItems;
+					selectableItemsView.SelectedItem = null;
 					break;
 			}
-
-			if (previousSelection.Count == newSelection.Count)
-			{
-				if (previousSelection.Count == 0 || (previousSelection[0] == newSelection[0]))
-				{
-					// Both selections are empty or have the same single item; no reason to signal a change
-					return;
-				}
-			}
-
-			var args = new SelectionChangedEventArgs(previousSelection, newSelection);
-
-			SelectionPropertyChanged(selectableItemsView, args);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/SelectableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/SelectableItemsView.cs
@@ -138,21 +138,55 @@ namespace Xamarin.Forms
 		static void SelectionModePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var selectableItemsView = (SelectableItemsView)bindable;
+
+			var oldMode = (SelectionMode)oldValue;
 			var newMode = (SelectionMode)newValue;
+
+			IList<object> previousSelection = new List<object>();
+			IList<object> newSelection = new List<object>();
+
+			switch (oldMode)
+			{
+				case SelectionMode.None:
+					break;
+				case SelectionMode.Single:
+					if (selectableItemsView.SelectedItem != null)
+					{
+						previousSelection.Add(selectableItemsView.SelectedItem);
+					}
+					break;
+				case SelectionMode.Multiple:
+					previousSelection = selectableItemsView.SelectedItems;
+					break;
+			}
 
 			switch (newMode)
 			{
 				case SelectionMode.None:
-					selectableItemsView.SelectedItem = null;
-					selectableItemsView.SelectedItems = null;
 					break;
 				case SelectionMode.Single:
-					selectableItemsView.SelectedItems = null;
+					if (selectableItemsView.SelectedItem != null)
+					{
+						newSelection.Add(selectableItemsView.SelectedItem);
+					}
 					break;
 				case SelectionMode.Multiple:
-					selectableItemsView.SelectedItem = null;
+					newSelection = selectableItemsView.SelectedItems;
 					break;
 			}
+
+			if (previousSelection.Count == newSelection.Count)
+			{
+				if (previousSelection.Count == 0 || (previousSelection[0] == newSelection[0]))
+				{
+					// Both selections are empty or have the same single item; no reason to signal a change
+					return;
+				}
+			}
+
+			var args = new SelectionChangedEventArgs(previousSelection, newSelection);
+
+			SelectionPropertyChanged(selectableItemsView, args);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.ComponentModel;
 using Android.Content;
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
@@ -27,10 +27,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_isSelected = value;
 
-				if (_isSelected)
-				{
-					EnsureSelectionStates();
-				}
+				SetSelectionStates(_isSelected);
 
 				ItemView.Activated = _isSelected;
 				OnSelectedChanged();
@@ -56,27 +53,20 @@ namespace Xamarin.Forms.Platform.Android
 			Clicked?.Invoke(this, adapterPosition);
 		}
 
-		void EnsureSelectionStates()
+		void SetSelectionStates(bool isSelected)
 		{
-			if (_selectedDrawable != null)
-			{
-				return;
-			}
-
 			if (Forms.IsMarshmallowOrNewer)
 			{
 				// We're looking for the foreground ripple effect, which is not available on older APIs
 				// Limiting this to Marshmallow and newer, because View.setForeground() is not available on lower APIs
-				_selectableItemDrawable = GetSelectableItemDrawable();
+				_selectableItemDrawable = !isSelected ? null : (_selectableItemDrawable ?? GetSelectableItemDrawable());
+
 				ItemView.Foreground = _selectableItemDrawable;
 			}
 
-			_selectedDrawable = GetSelectedDrawable();
-				
-			if (_selectedDrawable != null)
-			{
-				ItemView.Background = _selectedDrawable;
-			}
+			_selectedDrawable = !isSelected ? null : (_selectedDrawable ?? GetSelectedDrawable());
+
+			ItemView.Background = _selectedDrawable;
 		}
 
 		Drawable GetSelectedDrawable()


### PR DESCRIPTION
### Description of Change ###

Fixes a visual error with selection mode changes on Android / CollectionView. There is also a change in `Core`, which I'd like to discuss with the team to decide whether it should be merged or dismissed.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6051

### Testing Procedure ###
Please follow the test steps in #6051. I'll update this section with more detailed instructions if the changes in `SelectableItemsView` are approved.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
