### PR TITLE
[iOS] Make button click easier to see when turning on CollectionView flag

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				Text = "Enable CollectionView",
 				AutomationId = "EnableCollectionView"
 			};
-			button.Clicked += Button_Clicked;
+			button.Clicked += ButtonClicked;
 
 			Content = new ScrollView
 			{
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 		}
 
-		void Button_Clicked(object sender, System.EventArgs e)
+		void ButtonClicked(object sender, System.EventArgs e)
 		{
 			var button = sender as Button;
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 		}
 
-		private void Button_Clicked(object sender, System.EventArgs e)
+		void Button_Clicked(object sender, System.EventArgs e)
 		{
 			var button = sender as Button;
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -12,6 +12,13 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			Title = "CarouselView Galleries";
 
+			var button = new Button
+			{
+				Text = "Enable CollectionView",
+				AutomationId = "EnableCollectionView"
+			};
+			button.Clicked += Button_Clicked;
+
 			Content = new ScrollView
 			{
 				Content = new StackLayout
@@ -19,7 +26,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 					Children =
 					{
 						descriptionLabel,
-						new Button { Text ="Enable CollectionView", AutomationId = "EnableCollectionView", Command = new Command(() => Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental })) },
+						button,
 						GalleryBuilder.NavButton("CarouselView (Code, Horizontal)", () =>
 							new CarouselCodeGallery(ItemsLayoutOrientation.Horizontal), Navigation),
 						GalleryBuilder.NavButton("CarouselView (Code, Vertical)", () =>
@@ -33,6 +40,17 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 					}
 				}
 			};
+		}
+
+		private void Button_Clicked(object sender, System.EventArgs e)
+		{
+			var button = sender as Button;
+
+			button.Text = "CollectionView Enabled!";
+			button.TextColor = Color.Black;
+			button.IsEnabled = false;
+
+			Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -14,13 +14,20 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 	{
 		public CollectionViewGallery()
 		{
+			var button = new Button
+			{
+				Text = "Enable CollectionView",
+				AutomationId = "EnableCollectionView"
+			};
+			button.Clicked += Button_Clicked;
+
 			Content = new ScrollView
 			{
 				Content = new StackLayout
 				{
 					Children =
 					{
-						new Button { Text ="Enable CollectionView", AutomationId = "EnableCollectionView", Command = new Command(() => Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental })) },
+						button,
 						GalleryBuilder.NavButton("Default Text Galleries", () => new DefaultTextGallery(), Navigation),
 						GalleryBuilder.NavButton("DataTemplate Galleries", () => new DataTemplateGallery(), Navigation),
 						GalleryBuilder.NavButton("Observable Collection Galleries", () => new ObservableCollectionGallery(), Navigation),
@@ -39,6 +46,17 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					}
 				}
 			};
+		}
+
+		private void Button_Clicked(object sender, System.EventArgs e)
+		{
+			var button = sender as Button;
+
+			button.Text = "CollectionView Enabled!";
+			button.TextColor = Color.Black;
+			button.IsEnabled = false;
+
+			Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 				Text = "Enable CollectionView",
 				AutomationId = "EnableCollectionView"
 			};
-			button.Clicked += Button_Clicked;
+			button.Clicked += ButtonClicked;
 
 			Content = new ScrollView
 			{
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			};
 		}
 
-		void Button_Clicked(object sender, System.EventArgs e)
+		void ButtonClicked(object sender, System.EventArgs e)
 		{
 			var button = sender as Button;
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			};
 		}
 
-		private void Button_Clicked(object sender, System.EventArgs e)
+		void Button_Clicked(object sender, System.EventArgs e)
 		{
 			var button = sender as Button;
 


### PR DESCRIPTION
Sometimes, when I tap the top button to enable the `CollectionView` flag in `CarouselViewGallery` and `CollectionViewGallery`, I miss the tappable area of the button while assuming the button was successfully tapped and so the Gallery crashes on me. The changes here will give us a better visual clue that the tap took place.