### PR TITLE
Add retry logic for IsFocus test

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1396,13 +1396,13 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7357.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
+using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 
 namespace Xamarin.Forms.Core.UITests
@@ -36,7 +37,11 @@ namespace Xamarin.Forms.Core.UITests
 
 		bool IsFocused()
 		{
-			var focusedText = App.Query(q => q.Marked("FocusStateLabel").All())[0].ReadText();
+			var focusedText = App.QueryUntilPresent(() =>
+			{
+				return App.Query(q => q.Marked("FocusStateLabel").All());
+			})[0].ReadText();
+
 			return System.Convert.ToBoolean(focusedText);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Occasionally the Entry field doesn't load fast enough for the focus test to read the element. This adds retry logic


### Testing Procedure ###
- If all the android tests pass for the focus tests then merge

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
