### PR TITLE
[Android] Fixed issue changing the ItemTemplate on CarouselView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7395.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7395.cs
@@ -18,7 +18,6 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 7395, "Changing ItemTemplate does not work as expected", PlatformAffected.Android)]
 	public class Issue7395 : TestContentPage
 	{
-		Label _instructions;
 		CollectionView _collectionView;
 
 		public Issue7395()
@@ -28,9 +27,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			_instructions = new Label
+			var instructions = new Label
 			{
-				Text = "Press a button to apply an ItemTemplate."
+				Text = "Click Two Columns. If all cells render correctly with 2 columns, then click Three Columns. If all cells render correctly with 3 columns, then the test passes."
 			};
 
 			var button1 = new Button
@@ -67,7 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var stack = new StackLayout();
 
-			stack.Children.Add(_instructions);
+			stack.Children.Add(instructions);
 			stack.Children.Add(button1);
 			stack.Children.Add(button2);
 			stack.Children.Add(_collectionView);
@@ -78,13 +77,11 @@ namespace Xamarin.Forms.Controls.Issues
 		void OnButton1Clicked(object sender, EventArgs e)
 		{
 			_collectionView.ItemTemplate = CreateDataGridTemplate(2);
-			_instructions.Text = "If all cells are rendering correctly with 2 columns, everything is correct.";
 		}
 
 		void OnButton2Clicked(object sender, EventArgs e)
 		{
 			_collectionView.ItemTemplate = CreateDataGridTemplate(3);
-			_instructions.Text = "If all cells are rendering correctly with 3 columns, everything is correct.";
 		}
 
 		DataTemplate CreateDataGridTemplate(int columns)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7395.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7395.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Linq;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif	
+ 	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7395, "Changing ItemTemplate does not work as expected", PlatformAffected.Android)]
+	public class Issue7395 : TestContentPage
+	{
+		CollectionView _collectionView;
+
+		public Issue7395()
+		{
+			Title = "Issue 7395";
+		}
+
+		protected override void Init()
+		{
+			var button1 = new Button
+			{
+				Text = "Two columns",
+				AutomationId = "TwoCol"
+			};
+
+			button1.Clicked += Button1_Clicked;
+
+			var button2 = new Button
+			{
+				Text = "Three columns",
+				AutomationId = "ThreeCol"
+			};
+
+			button2.Clicked += Button2_Clicked;
+
+			_collectionView = new CollectionView
+			{
+				BackgroundColor = Color.LightGreen,
+				SelectionMode = SelectionMode.None,
+				HeightRequest = 500
+			};
+
+			var lines = new List<Issue7395Model>();
+
+			for (int i = 0; i < 30; i++)
+			{
+				lines.Add(new Issue7395Model() { Text = i.ToString() });
+			}
+
+			_collectionView.ItemsSource = lines;
+
+			var stack = new StackLayout();
+			stack.Children.Add(button1);
+			stack.Children.Add(button2);
+			stack.Children.Add(_collectionView);
+
+			Content = stack;
+		}
+
+		void Button1_Clicked(object sender, EventArgs e)
+		{
+			_collectionView.ItemTemplate = CreateDataGridTemplate(2);
+		}
+
+		void Button2_Clicked(object sender, EventArgs e)
+		{
+			_collectionView.ItemTemplate = CreateDataGridTemplate(3);
+		}
+
+		private DataTemplate CreateDataGridTemplate(int columns)
+		{
+			DataTemplate template = new DataTemplate(() =>
+			{
+				var grid = new Grid() { Padding = new Thickness(0), Margin = 0, RowSpacing = 0, ColumnSpacing = 0 };
+
+				grid.RowDefinitions.Clear();
+				grid.ColumnDefinitions.Clear();
+				grid.Children.Clear();
+				grid.RowDefinitions.Add(new RowDefinition() { Height = 40 });
+				grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
+				Label cell;
+				cell = new Label() { };
+				cell.SetBinding(Label.TextProperty, "Text");
+				cell.FontSize = 20;
+				cell.FontAttributes = FontAttributes.Bold;
+				cell.BackgroundColor = Color.LightBlue;
+				grid.Children.Add(cell, 0, 0);
+
+				for (int i = 0; i < columns; i++)
+				{
+					grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(1, GridUnitType.Star) });
+					cell = new Label() { };
+					cell.Text = "Col:" + i;
+					cell.FontAttributes = FontAttributes.Bold;
+					cell.BackgroundColor = Color.Beige;
+					grid.Children.Add(cell, i + 1, 0);
+				}
+				return grid;
+			});
+			return template;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7395Model
+	{
+		public string Text { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7395.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7395.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 7395, "Changing ItemTemplate does not work as expected", PlatformAffected.Android)]
 	public class Issue7395 : TestContentPage
 	{
+		Label _instructions;
 		CollectionView _collectionView;
 
 		public Issue7395()
@@ -27,13 +28,18 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
+			_instructions = new Label
+			{
+				Text = "Press a button to apply an ItemTemplate."
+			};
+
 			var button1 = new Button
 			{
 				Text = "Two columns",
 				AutomationId = "TwoCol"
 			};
 
-			button1.Clicked += Button1_Clicked;
+			button1.Clicked += OnButton1Clicked;
 
 			var button2 = new Button
 			{
@@ -41,7 +47,7 @@ namespace Xamarin.Forms.Controls.Issues
 				AutomationId = "ThreeCol"
 			};
 
-			button2.Clicked += Button2_Clicked;
+			button2.Clicked += OnButton2Clicked;
 
 			_collectionView = new CollectionView
 			{
@@ -60,6 +66,8 @@ namespace Xamarin.Forms.Controls.Issues
 			_collectionView.ItemsSource = lines;
 
 			var stack = new StackLayout();
+
+			stack.Children.Add(_instructions);
 			stack.Children.Add(button1);
 			stack.Children.Add(button2);
 			stack.Children.Add(_collectionView);
@@ -67,17 +75,19 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = stack;
 		}
 
-		void Button1_Clicked(object sender, EventArgs e)
+		void OnButton1Clicked(object sender, EventArgs e)
 		{
 			_collectionView.ItemTemplate = CreateDataGridTemplate(2);
+			_instructions.Text = "If all cells are rendering correctly with 2 columns, everything is correct.";
 		}
 
-		void Button2_Clicked(object sender, EventArgs e)
+		void OnButton2Clicked(object sender, EventArgs e)
 		{
 			_collectionView.ItemTemplate = CreateDataGridTemplate(3);
+			_instructions.Text = "If all cells are rendering correctly with 3 columns, everything is correct.";
 		}
 
-		private DataTemplate CreateDataGridTemplate(int columns)
+		DataTemplate CreateDataGridTemplate(int columns)
 		{
 			DataTemplate template = new DataTemplate(() =>
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1056,6 +1056,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6929.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ApiLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7525.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7395.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1400,7 +1401,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7357.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -213,6 +213,10 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateItemsSource();
 			}
+			else if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemTemplateProperty))
+			{
+				UpdateAdapter();
+			}
 			else if (changedProperty.Is(VisualElement.BackgroundColorProperty))
 			{
 				UpdateBackgroundColor();
@@ -221,7 +225,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateFlowDirection();
 			}
-			else if (changedProperty.IsOneOf(Xamarin.Forms.ItemsView.EmptyViewProperty, 
+			else if (changedProperty.IsOneOf(Xamarin.Forms.ItemsView.EmptyViewProperty,
 				Xamarin.Forms.ItemsView.EmptyViewTemplateProperty))
 			{
 				UpdateEmptyView();
@@ -276,7 +280,10 @@ namespace Xamarin.Forms.Platform.Android
 			ItemsViewAdapter = CreateAdapter();
 
 			if (GetAdapter() != _emptyViewAdapter)
+			{
+				SetAdapter(null);
 				SwapAdapter(ItemsViewAdapter, true);
+			}
 
 			oldItemViewAdapter?.Dispose();
 		}


### PR DESCRIPTION
### Description of Change ###

Fixed a bug changing the **ItemTemplate** dynamically. The change of the Template was not applied or partially when scrolling.

### Issues Resolved ### 

- fixes #7395

### API Changes ###
 
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![7395-before](https://user-images.githubusercontent.com/6755973/65418676-42482700-ddfd-11e9-89f8-8d7f97a83529.gif)

#### After
![7395-after](https://user-images.githubusercontent.com/6755973/65418682-4411ea80-ddfd-11e9-9309-dd65a90c8517.gif)

### Testing Procedure ###
Launch Core Gallery on Android and navigate to the Issue 7395. Press the buttons and see if the CollectionView ItemTemplate changes.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)