### PR TITLE
Set do not clear app data on Xamarin UI Tests

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -60,7 +60,7 @@ namespace Xamarin.Forms.Controls
 #if __ANDROID__
 		static IApp InitializeAndroidApp()
 		{
-			var app = ConfigureApp.Android.ApkFile(AppPaths.ApkPath).Debug().StartApp();
+			var app = ConfigureApp.Android.ApkFile(AppPaths.ApkPath).Debug().StartApp(UITest.Configuration.AppDataMode.DoNotClear);
 
 			if (bool.Parse((string)app.Invoke("IsPreAppCompat")))
 			{

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/EntryUITests.cs
@@ -1,6 +1,7 @@
 using NUnit.Framework;
 using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
+using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 
 namespace Xamarin.Forms.Core.UITests
@@ -36,7 +37,11 @@ namespace Xamarin.Forms.Core.UITests
 
 		bool IsFocused()
 		{
-			var focusedText = App.Query(q => q.Marked("FocusStateLabel").All())[0].ReadText();
+			var focusedText = App.QueryUntilPresent(() =>
+			{
+				return App.Query(q => q.Marked("FocusStateLabel").All());
+			})[0].ReadText();
+
 			return System.Convert.ToBoolean(focusedText);
 		}
 


### PR DESCRIPTION
### Description of Change ###
The Xamarin UI Tests seem to fail occasionally when trying to clear the app data when restarting the app. The iOS tests already don't clear the data so this tells Android to do the same. 


### Platforms Affected ### 
- Android


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
