### PR TITLE
Implement CarouselView EmptyView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -38,7 +38,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 	  					GalleryBuilder.NavButton("CarouselView Snap", () =>
  							new CarouselSnapGallery(), Navigation),
 						GalleryBuilder.NavButton("ObservableCollection and CarouselView", () =>
- 							new CollectionCarouselViewGallery(), Navigation)
+ 							new CollectionCarouselViewGallery(), Navigation),
+						GalleryBuilder.NavButton("CarouselView EmptyView", () =>
+  							new EmptyCarouselGallery(), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/EmptyCarouselGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/EmptyCarouselGallery.xaml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:gallery="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.EmptyCarouselGallery"
+    Title="Carousel EmptyView">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackLayout
+                Grid.Row="0"
+                Orientation="Horizontal">
+                <Button
+                    Text="Add Items"
+                    Command="{Binding AddCommand}"/>
+                <Button
+                    Text="Clear Items"
+                    Command="{Binding ClearCommand}"/>
+            </StackLayout>
+            <CarouselView
+                Grid.Row="1"
+                AutomationId="TheCarouselView"
+                x:Name="Carousel"
+                ItemsSource="{Binding Items}"
+                Position="{Binding Position}">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                   <Grid
+                       BackgroundColor="{Binding Color}">
+                       <Label
+                           HorizontalOptions="Center"
+                           VerticalOptions="Center"
+                           Text="{Binding Name}" />
+                   </Grid>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+                <CarouselView.EmptyView>
+                    <Grid
+                        BackgroundColor="YellowGreen">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="This is the EmptyView" />
+                    </Grid>
+                </CarouselView.EmptyView>
+        </CarouselView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/EmptyCarouselGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/EmptyCarouselGallery.xaml.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public partial class EmptyCarouselGallery : ContentPage
+	{
+		public EmptyCarouselGallery()
+		{
+			InitializeComponent();
+			BindingContext = new EmptyCarouselGalleryViewModel();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class EmptyCarouselGalleryViewModel : BindableObject
+	{
+		ObservableCollection<CarouselData> _items;
+
+		public EmptyCarouselGalleryViewModel()
+		{
+			Items = new ObservableCollection<CarouselData>();
+		}
+
+		public ObservableCollection<CarouselData> Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ICommand AddCommand => new Command(Add);
+
+		public ICommand ClearCommand => new Command(Clear);
+
+		void LoadItems()
+		{
+			var random = new Random();
+
+			if (Device.RuntimePlatform == Device.iOS)
+			{
+				var items = new List<CarouselData>();
+
+				for (int n = 0; n < 5; n++)
+				{
+					items.Add(new CarouselData
+					{
+						Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
+						Name = $"{n + 1}"
+					});
+				}
+
+				Items = new ObservableCollection<CarouselData>(items);
+			}
+			else
+			{
+				for (int n = 0; n < 5; n++)
+				{
+					Items.Add(new CarouselData
+					{
+						Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
+						Name = $"{n + 1}"
+					});
+				}
+			}
+		}
+
+		void Add()
+		{
+			LoadItems();
+		}
+
+		void Clear()
+		{
+			Items?.Clear();
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Implement CarouselView EmptyView on Android, iOS and UWP.

Android
![carousel-emptyview-droid](https://user-images.githubusercontent.com/6755973/65508620-e4850f00-ded0-11e9-9b64-c639f3da06f0.gif)

iOS
![carousel-emptyview-ios](https://user-images.githubusercontent.com/6755973/65508263-1d70b400-ded0-11e9-9196-9f944aa29397.gif)

UWP
![carousel-emptyview-uwp](https://user-images.githubusercontent.com/6755973/65508493-a38cfa80-ded0-11e9-9f04-a6a6aa48e094.gif)

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

None

### Testing Procedure ###
Launch CarouselView Core Gallery and test EmptyView sample. By default, without items you should see EmptyView. Add items and EmptyView should hide.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)