### PR TITLE
[C] Invoke ToString while setting string BP

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableObjectUnitTests.cs
@@ -1562,5 +1562,34 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(() => binding.Path = "Foo", Throws.Nothing);
 		}
+
+
+		class InfoToString
+		{
+			public override string ToString() => "converted";
+		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/6281
+		public void SetValueToTextInvokesToString()
+		{
+			var prop = BindableProperty.Create("foo", typeof(string), typeof(MockBindable), null);
+			var bindable = new MockBindable();
+			bindable.SetValue(prop, new InfoToString());
+
+			Assert.That(bindable.GetValue(prop), Is.EqualTo("converted"));
+		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/6281
+		public void SetBindingToTextInvokesToString()
+		{
+			var prop = BindableProperty.Create("foo", typeof(string), typeof(MockBindable), null);
+			var bindable = new MockBindable() { BindingContext = new { info = new InfoToString() } };
+			bindable.SetBinding(prop, "info");
+
+			Assert.That(bindable.GetValue(prop), Is.EqualTo("converted"));
+		}
+
 	}
 }

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -324,7 +324,7 @@ namespace Xamarin.Forms
 			Type type = ReturnType;
 
 			// Dont support arbitrary IConvertible by limiting which types can use this
-			if (SimpleConvertTypes.TryGetValue(valueType, out Type[] convertableTo) && Array.IndexOf(convertableTo, type) != -1) {
+			if (SimpleConvertTypes.TryGetValue(valueType, out Type[]  convertibleTo) && Array.IndexOf( convertibleTo, type) != -1) {
 				value = Convert.ChangeType(value, type);
 				return true;
 			}

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
+using System.Globalization;
 using System.Linq.Expressions;
 using System.Reflection;
 using Xamarin.Forms.Internals;
@@ -33,10 +34,15 @@ namespace Xamarin.Forms
 
 		public delegate bool ValidateValueDelegate<in TPropertyType>(BindableObject bindable, TPropertyType value);
 
-		static readonly Dictionary<Type, TypeConverter> WellKnownConvertTypes = new  Dictionary<Type,TypeConverter>
+		static readonly Dictionary<Type, TypeConverter> KnownTypeConverters = new Dictionary<Type,TypeConverter>
 		{
 			{ typeof(Uri), new UriTypeConverter() },
 			{ typeof(Color), new ColorTypeConverter() },
+		};
+
+		static readonly Dictionary<Type, IValueConverter> KnownIValueConverters = new Dictionary<Type, IValueConverter>
+		{
+			{ typeof(string), new ToStringValueConverter() },
 		};
 
 		// more or less the encoding of this, without the need to reflect
@@ -52,7 +58,7 @@ namespace Xamarin.Forms
 			{ typeof(long), new[] { typeof(string), typeof(float), typeof(double), typeof(decimal) } },
 			{ typeof(char), new[] { typeof(string), typeof(ushort), typeof(int), typeof(uint), typeof(long), typeof(ulong), typeof(float), typeof(double), typeof(decimal) } },
 			{ typeof(float), new[] { typeof(string), typeof(double) } },
-			{ typeof(ulong), new[] { typeof(string), typeof(float), typeof(double), typeof(decimal) } }
+			{ typeof(ulong), new[] { typeof(string), typeof(float), typeof(double), typeof(decimal) } },
 		};
 
 		BindableProperty(string propertyName, Type returnType, Type declaringType, object defaultValue, BindingMode defaultBindingMode = BindingMode.OneWay,
@@ -312,36 +318,34 @@ namespace Xamarin.Forms
 		internal bool TryConvert(ref object value)
 		{
 			if (value == null)
-			{
 				return !ReturnTypeInfo.IsValueType || ReturnTypeInfo.IsGenericType && ReturnTypeInfo.GetGenericTypeDefinition() == typeof(Nullable<>);
-			}
 
 			Type valueType = value.GetType();
 			Type type = ReturnType;
 
 			// Dont support arbitrary IConvertible by limiting which types can use this
-			Type[] convertableTo;
-			TypeConverter typeConverterTo;
-			if (SimpleConvertTypes.TryGetValue(valueType, out convertableTo) && Array.IndexOf(convertableTo, type) != -1)
-			{
+			if (SimpleConvertTypes.TryGetValue(valueType, out Type[] convertableTo) && Array.IndexOf(convertableTo, type) != -1) {
 				value = Convert.ChangeType(value, type);
+				return true;
 			}
-			else if (WellKnownConvertTypes.TryGetValue(type, out typeConverterTo) && typeConverterTo.CanConvertFrom(valueType))
-			{
+			if (KnownTypeConverters.TryGetValue(type, out TypeConverter typeConverterTo) && typeConverterTo.CanConvertFrom(valueType)) {
 				value = typeConverterTo.ConvertFromInvariantString(value.ToString());
+				return true;
 			}
-			else if (!ReturnTypeInfo.IsAssignableFrom(valueType.GetTypeInfo()))
-			{
-				var cast = type.GetImplicitConversionOperator(fromType: valueType, toType: type)
-						?? valueType.GetImplicitConversionOperator(fromType: valueType, toType: type);
+			if (ReturnTypeInfo.IsAssignableFrom(valueType.GetTypeInfo()))
+				return true;
 
-				if (cast == null)
-					return false;
-
+			var cast = type.GetImplicitConversionOperator(fromType: valueType, toType: type) ?? valueType.GetImplicitConversionOperator(fromType: valueType, toType: type);
+			if (cast != null) {
 				value = cast.Invoke(null, new[] { value });
+				return true;
+			}
+			if (KnownIValueConverters.TryGetValue(type, out IValueConverter valueConverter)) {
+				value = valueConverter.Convert(value, type, null, CultureInfo.CurrentUICulture);
+				return true;
 			}
 
-			return true;
+			return false;
 		}
 
 		internal delegate void BindablePropertyBindingChanging(BindableObject bindable, BindingBase oldValue, BindingBase newValue);

--- a/Xamarin.Forms.Core/ToStringValueConverter.cs
+++ b/Xamarin.Forms.Core/ToStringValueConverter.cs
@@ -8,21 +8,14 @@ namespace Xamarin.Forms
 		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 		{
 			if (value == null)
-			{
 				return null;
-			}
 
 			if (value is IFormattable formattable)
-			{
 				return formattable.ToString(parameter?.ToString(), culture);
-			}
 
 			return value.ToString();
 		}
 
-		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
-		{
-			throw new NotSupportedException();
-		}
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture) => throw new NotSupportedException();
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Invoke ToString with the CurrentUICulture when seeting a property of type string
from a non-convertible object.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6281

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Text properties (like Label.Text) will have the object ToString() result instead of staying blank. This is a behavioral change, worth indicating in the release notes, and that's why it's targeted to master, and not 4.3.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
