### PR TITLE
[Tizen] Improves the initialization of VE's properties

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
@@ -58,16 +58,16 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Specific.NextFocusForwardViewProperty, UpdateFocusForwardView);
 			RegisterPropertyHandler(Specific.ToolTipProperty, UpdateToolTip);
 
-			RegisterPropertyHandler(VisualElement.AnchorXProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.AnchorYProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.ScaleProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.ScaleXProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.ScaleYProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.RotationProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.RotationXProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.RotationYProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.TranslationXProperty, ApplyTransformation);
-			RegisterPropertyHandler(VisualElement.TranslationYProperty, ApplyTransformation);
+			RegisterPropertyHandler(VisualElement.AnchorXProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.AnchorYProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.ScaleProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.ScaleXProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.ScaleYProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.RotationProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.RotationXProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.RotationYProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.TranslationXProperty, UpdateTransformation);
+			RegisterPropertyHandler(VisualElement.TranslationYProperty, UpdateTransformation);
 			RegisterPropertyHandler(VisualElement.TabIndexProperty, UpdateTabIndex);
 			RegisterPropertyHandler(VisualElement.IsTabStopProperty, UpdateIsTabStop);
 
@@ -845,10 +845,20 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 		}
 
-		void UpdateFocusAllowed()
+		void UpdateTransformation(bool initialize)
 		{
+			if (!initialize)
+				ApplyTransformation();
+		}
+
+		void UpdateFocusAllowed(bool initialize)
+		{
+			bool? isFocusAllowed = Specific.IsFocusAllowed(Element);
+			if (initialize && isFocusAllowed == null)
+				return;
+
 			var widget = NativeView as Widget;
-			if (widget != null && Specific.IsFocusAllowed(Element).HasValue)
+			if (widget != null && isFocusAllowed != null)
 			{
 				widget.AllowFocus((bool)Specific.IsFocusAllowed(Element));
 			}


### PR DESCRIPTION
### Description of Change ###
This PR improve startup performance by making the initialization of VisualElement's properties more efficient.

As shown below, the initial update time for VisualElement's properties has been reduced from approximately 10ms to 1.34ms.

_This is the result of testing with the [StopWatch](https://github.com/Samsung/Tizen-CSharp-Samples/tree/master/Wearable/XStopWatch) sample app on [Galaxy Watch Actvie](https://www.samsung.com/global/galaxy/galaxy-watch-active/)._
<img src="https://user-images.githubusercontent.com/1029134/65581570-ac57fc00-dfb6-11e9-89b6-ccda19bf2bb1.png" width=200/>

- Before
![xf_init_before](https://user-images.githubusercontent.com/1029134/65580608-f50eb580-dfb4-11e9-8823-38882c3dfe7f.png)
- After
![xf_init_after](https://user-images.githubusercontent.com/1029134/65580609-f5a74c00-dfb4-11e9-8a59-336556d18c13.png)


### Issues Resolved ### 
 None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Every UITest is a test.

### PR Checklist ###
- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
