### PR TITLE
[UItests]Try fix UItest for vertical carouselview

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -65,8 +65,11 @@ namespace Xamarin.Forms.Core.UITests
 			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterX, bottomY);
 
 			App.WaitForElement("pos:0", "Did not scroll to first position");
-
-			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterX, rect.Y - 1);
+			var topY = rect.Y - 1;
+#if __ANDROID__
+			topY = rect.Y - 10;
+#endif
+			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterX, topY);
 
 			App.WaitForElement("pos:1", "Did not scroll to second position");
 
@@ -79,7 +82,7 @@ namespace Xamarin.Forms.Core.UITests
 			App.Tap("SwipeSwitch");
 
 #if __ANDROID__
-			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterY, rect.Y + rect.Height - 1);
+			App.DragCoordinates(rect.CenterX, rect.CenterY, rect.CenterY, bottomY);
 
 			App.WaitForNoElement("pos:0", "Swiped while swipe is disabled");
 #endif


### PR DESCRIPTION
### Description of Change ###

UITests with current and this version pass locally , but they are failing on APpcenter when scrolling to the 2nd item.

### API Changes ###

 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
