### PR TITLE
Fix Android foreground coloring on Shell

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -19,6 +19,9 @@ namespace Xamarin.Forms.Controls.XamStore
 
 		public BasePage(string title, Color tint)
 		{
+			ToolbarItems.Add(new ToolbarItem() { Text = "text" });
+			ToolbarItems.Add(new ToolbarItem() { IconImageSource = "coffee.png" });
+
 			Title = title;
 			Shell.SetForegroundColor(this, tint);
 			var grid = new Grid()
@@ -475,7 +478,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	[Preserve (AllMembers = true)]
 	public class HomePage : BasePage
 	{
-		public HomePage() : base("Store Home", Color.Default)
+		public HomePage() : base("Store Home", Color.Black)
 		{
 			AddSearchHandler("Search Apps", SearchBoxVisibility.Expanded);
 		}
@@ -484,7 +487,7 @@ namespace Xamarin.Forms.Controls.XamStore
 	[Preserve (AllMembers = true)]
 	public class GamesPage : BasePage
 	{
-		public GamesPage() : base("Games", Color.Default)
+		public GamesPage() : base("Games", Color.Black)
 		{
 			AddSearchHandler("Search Games", SearchBoxVisibility.Expanded);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -17,6 +17,7 @@ using LP = Android.Views.ViewGroup.LayoutParams;
 using R = Android.Resource;
 using Toolbar = Android.Support.V7.Widget.Toolbar;
 using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
+using ATextView = global::Android.Widget.TextView;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -326,9 +327,7 @@ namespace Xamarin.Forms.Platform.Android
 			if(icon == null)
 			{
 				icon = new DrawerArrowDrawable(context.GetThemedContext());
-
-				ADrawableCompat.SetTint(icon, tintColor.ToAndroid());
-				ADrawableCompat.SetTintMode(icon, PorterDuff.Mode.SrcAtop);
+				icon.SetColorFilter(tintColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
 			}
 
 			icon.Progress = (CanNavigateBack) ? 1 : 0;
@@ -460,11 +459,21 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					var menuitem = menu.Add(title);
 					UpdateMenuItemIcon(_shellContext.AndroidContext, menuitem, item);
+
 					menuitem.SetTitleOrContentDescription(item);
 					menuitem.SetEnabled(item.IsEnabled);
 					menuitem.SetShowAsAction(ShowAsAction.Always);
 					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
+					
+					if(TintColor != Color.Default)
+					{
+						var view = toolbar.FindViewById(menuitem.ItemId);
+						if (view is ATextView  textView)
+							textView.SetTextColor(TintColor.ToAndroid());
+					}
+
 					menuitem.Dispose();
+
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

This fixes a regression with the Hamburger Icon on Android not changing its color based on the *Shell.ForegroundColor*

This also has a breaking change on Android which will also set the color of the ToolBarItems which makes it consistent with how iOS works

Regression caused by: https://github.com/xamarin/Xamarin.Forms/pull/6762

### Issues Resolved ### 
- fixes #7577

### Platforms Affected ### 
- Android


### Testing Procedure ###
- Open the store gallery and click through the bottom tabs. The Home page and the Games page should have a Black hamburger and ToolBarItem

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
