### PR TITLE
Wait for test to load before scrolling images

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
@@ -45,6 +45,7 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 		}
 
+		[Preserve(AllMembers = true)]
 		public class President
 		{
 			public President (string name, int position, string image)
@@ -70,7 +71,8 @@ namespace Xamarin.Forms.Controls.Issues
 				var image = new Image
 				{
 					HorizontalOptions = LayoutOptions.Start,
-					Aspect = Aspect.AspectFill
+					Aspect = Aspect.AspectFill,
+					AutomationId = "ImageLoaded",
 				};
 
 				var source = new UriImageSource {
@@ -86,6 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
+		[Preserve(AllMembers = true)]
 		public class UriConverter : IValueConverter
 		{
 
@@ -105,6 +108,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void TestDoesntCrashWithCachingDisable ()
 		{
+			RunningApp.WaitForElement("ImageLoaded");
 			RunningApp.ScrollDown ();
 			RunningApp.ScrollDown ();
 		}


### PR DESCRIPTION
### Description of Change ###
This was most likely fixed by this issue
https://github.com/xamarin/Xamarin.Forms/pull/7431

So I just cleaned up the UI test here a bit to be more deterministic 

### Issues Resolved ### 
- fixes #6773

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Android UI tests pass
- run Issue2354 and make sure the Presidents load

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
