### PR TITLE
Update iOS MDP Tablet Renderer to use current APIS for Master Behavior

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7556, "[iOS] Masterbehavior.popover not being observed on iOS 13",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.MasterDetailPage)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public class Issue7556 : TestMasterDetailPage
+	{
+		protected override void Init()
+		{
+			Master = new ContentPage() { Title = "Master", BackgroundColor = Color.Blue };
+			Detail = new NavigationPage(new DetailsPage(this) { Title = "Details" });
+		}
+
+		[Preserve(AllMembers = true)]
+		public class DetailsPage : ContentPage
+		{
+			MasterDetailPage MDP { get; }
+			Label lblThings;
+
+			public DetailsPage(MasterDetailPage masterDetailPage)
+			{
+				MDP = masterDetailPage;
+				lblThings = new Label();
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						lblThings,
+						new Button()
+						{
+							Text = "Click to rotate through MasterBehavior settings and test each one",
+							Command = new Command(OnChangeMasterBehavior)
+						}
+					}
+				};
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+				OnChangeMasterBehavior();
+			}
+
+			void OnChangeMasterBehavior()
+			{
+				var behavior = MDP.MasterBehavior;
+				var results = Enum.GetValues(typeof(MasterBehavior)).Cast<MasterBehavior>().ToList();
+
+				int nextIndex = results.IndexOf(behavior) + 1;
+				if (nextIndex >= results.Count)
+					nextIndex = 0;
+
+				MDP.MasterBehavior = results[nextIndex];
+				lblThings.Text = MDP.MasterBehavior.ToString();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7290.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7240.cs" />

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -52,7 +52,7 @@ jobs:
         solution: ${{ parameters.slnPath }}
         platform: '$(BuildPlatform)'
         configuration: '$(BuildConfiguration)'
-        msbuildArguments: ${{ parameters.msbuildExtraArguments }}
+        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /p:JavaSdkDirectory="$(JAVA_HOME_8_X64)"
 
     - task: VSTest@2
       displayName: 'Unit Tests'


### PR DESCRIPTION
### Description of Change ###
The *TabletMasterDetailRenderer* uses a lot of APIs that were deprecated some time ago and it seems like they all finally stopped working with iOS 13

This updates TabletMasterDetailRenderer to use more current APIs to achieve MasterBehavior

### Issues Resolved ### 
- fixes #7556 


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- Run through the different settings for MasterBehavior on the included test to make sure everything works

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
