### PR TITLE
JavaSDK build path fix for 16.3 CI servers

### DIFF
--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -52,7 +52,7 @@ jobs:
         solution: ${{ parameters.slnPath }}
         platform: '$(BuildPlatform)'
         configuration: '$(BuildConfiguration)'
-        msbuildArguments: ${{ parameters.msbuildExtraArguments }}
+        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /p:JavaSdkDirectory="$(JAVA_HOME_8_X64)"
 
     - task: VSTest@2
       displayName: 'Unit Tests'


### PR DESCRIPTION
### Description of Change ###
Fix for running Android builds on CI Server