### PR TITLE
[CollectionView] Fix crash on iOS adding items (ObservableCollection)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7678.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7678.cs
@@ -17,13 +17,142 @@ namespace Xamarin.Forms.Controls.Issues
 	[NUnit.Framework.Category(UITestCategories.CarouselView)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 7678, "[Android] CarouselView binded to a new ObservableCollection filled with Items does not render content", PlatformAffected.Android)]
+	[Issue(IssueTracker.Github, 7678, "[iOS] CarouselView binded to a ObservableCollection and add Items later, crash", PlatformAffected.iOS)]
+	public class Issue7678Ios : TestContentPage
+	{
+		public Issue7678Ios()
+		{
+#if APP
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
+			Title = "Issue 7678";
+			BindingContext = new Issue7678IosViewModel();
+#endif
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Margin = new Thickness(6),
+				Text = "The CarouselView below should render 5 items."
+			};
+
+			var itemsLayout =
+				new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+				{
+					SnapPointsType = SnapPointsType.MandatorySingle,
+					SnapPointsAlignment = SnapPointsAlignment.Center
+				};
+
+			var carouselView = new CarouselView
+			{
+				ItemsLayout = itemsLayout,
+				ItemTemplate = GetCarouselTemplate()
+			};
+
+			carouselView.SetBinding(ItemsView.ItemsSourceProperty, "Items");
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(carouselView);
+
+			Content = layout;
+		}
+
+		protected override async void OnAppearing()
+		{
+			base.OnAppearing();
+
+			await ((Issue7678IosViewModel)BindingContext).LoadItemsAsync();
+		}
+
+		internal DataTemplate GetCarouselTemplate()
+		{
+			return new DataTemplate(() =>
+			{
+				var grid = new Grid();
+
+				var info = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Margin = new Thickness(6)
+				};
+
+				info.SetBinding(Label.TextProperty, new Binding("Name"));
+
+				grid.Children.Add(info);
+
+				var frame = new Frame
+				{
+					Content = grid,
+					HasShadow = false
+				};
+
+				frame.SetBinding(BackgroundColorProperty, new Binding("Color"));
+
+				return frame;
+			});
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7678IosModel
+	{
+		public Color Color { get; set; }
+		public string Name { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7678IosViewModel : BindableObject
+	{
+		ObservableCollection<Issue7678IosModel> _items;
+
+		public ObservableCollection<Issue7678IosModel> Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public async Task LoadItemsAsync()
+		{
+			Items = new ObservableCollection<Issue7678IosModel>();
+
+			await Task.Delay(500);
+
+			var random = new Random();
+
+			for (int n = 0; n < 5; n++)
+			{
+				Items.Add(new Issue7678IosModel
+				{
+					Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
+					Name = $"{n + 1}"
+				});
+			}
+		}
+	}
+
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CarouselView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 7678, "[Android] CarouselView binded to a new ObservableCollection filled with Items does not render content", PlatformAffected.Android)]
 	public class Issue7678Droid : TestContentPage
 	{
 		public Issue7678Droid()
 		{
+#if APP
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
 			Title = "Issue 7678";
 			BindingContext = new Issue7678DroidViewModel();
+#endif
 		}
 
 		protected override void Init()
@@ -105,7 +234,7 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Issue7678DroidViewModel : BindableObject
 	{
 		ObservableCollection<Issue7678DroidModel> _items;
-  
+
 		public ObservableCollection<Issue7678DroidModel> Items
 		{
 			get { return _items; }


### PR DESCRIPTION
### Description of Change ###

Both, CollectionView and CarouselView, had a crash when adding items to a binder ObservableCollection (mainly played using asynchronous calls, etc.).

The native error was something like:
_"Invalid update: invalid number of items in section 0. The number of items contained in an existing section after the update (1) must be equal to the number of items contained in that section before the update (1), plus or minus the number of items inserted or deleted from that section (1 inserted, 0 deleted) and plus or minus the number of items moved into or out of that section (0 moved in, 0 moved out)"._

_NOTE: We could get the same error in other cases (removing items, etc)._

Using performBatchUpdates the item count returned by collectionView(_:numberOfItemsInSection:) should be sync with the updates made inside. We had a mismatch sometimes between the number of items in the ObservableCollection and the UICollectionView.

This article describe a similar issue: https://fangpenlin.com/posts/2016/04/29/uicollectionview-invalid-number-of-items-crash-issue/

### Issues Resolved ### 

- fixes #7678

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="444" alt="Captura de pantalla 2019-09-27 a las 13 54 29" src="https://user-images.githubusercontent.com/6755973/65767517-6160f480-e12e-11e9-88e5-f6c650c35901.png">

#### After
![7578-ios-after](https://user-images.githubusercontent.com/6755973/65767429-2232a380-e12e-11e9-9ce8-a7825d668a6e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7678. Without a crash, everything is working fine.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
