### PR TITLE
Fix use of ToolbarItem.Order on Android Shell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6127.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6127.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6127, "[Bug] ToolbarItem Order property ignored",
+		PlatformAffected.Android)]
+	public class Issue6127 : TestShell
+	{
+		const string PrimaryToolbarIcon = "PrimaryToolbarIcon";
+		const string SecondaryToolbarIcon = "SecondaryToolbarIcon";
+
+		protected override void Init()
+		{
+			AddTopTab(createContentPage("title 1"), "page 1");
+
+			ContentPage createContentPage(string titleView)
+			{
+				var page = new ContentPage
+				{
+					Content = new StackLayout
+					{
+						Children =
+						{
+							new Label
+							{
+								Text = "If there is one toolbar item visible and one under the overflow menu, this test passed"
+							}
+						}
+					}
+				};
+
+				page.ToolbarItems.Add(new ToolbarItem { IconImageSource = "coffee.png", Order = ToolbarItemOrder.Primary, Priority = 0, AutomationId = PrimaryToolbarIcon });
+				page.ToolbarItems.Add(new ToolbarItem { Text = "Coffee", IconImageSource = "coffee.png", Order = ToolbarItemOrder.Secondary, Priority = 0, AutomationId = SecondaryToolbarIcon });
+
+				return page;
+			}
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void Issue6127Test() 
+		{
+			RunningApp.WaitForElement (PrimaryToolbarIcon);
+
+			RunningApp.Tap("More options");
+			RunningApp.WaitForElement (SecondaryToolbarIcon);
+
+			RunningApp.Screenshot ("There is a secondary toolbar menu and item");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1027,6 +1027,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Controls\ApiLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7582.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7563.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6127.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -462,7 +462,10 @@ namespace Xamarin.Forms.Platform.Android
 
 					menuitem.SetTitleOrContentDescription(item);
 					menuitem.SetEnabled(item.IsEnabled);
-					menuitem.SetShowAsAction(ShowAsAction.Always);
+
+					if (item.Order != ToolbarItemOrder.Secondary)
+						menuitem.SetShowAsAction(ShowAsAction.Always);
+
 					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
 					
 					if(TintColor != Color.Default)


### PR DESCRIPTION
### Description of Change ###

Fixed that `ToolbarItem.Order` is taken into account when used in conjunction with Shell on Android.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6127

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

When the `ToolbarItem.Order` property is set to `ToolbarItemOrder.Secondary` when using Shell on Android, nothing would happen. From what I can tell this was simply overlooked. Implemented this functionality so it also works correctly when using Shell.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before:

![image](https://user-images.githubusercontent.com/939291/65787036-558a2800-e158-11e9-83f6-ddc1ccd126d6.png)


After:

![image](https://user-images.githubusercontent.com/939291/65786855-e57ba200-e157-11e9-8fcf-bef2633d6612.png)



### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

I've added Issue6127 to the gallery which has a secondary toolbar item and is using shell. In addition added a automated UI test to verify this

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
