### PR TITLE
Fix corner clipping on ImageButton and Button (FR)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4606.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4606.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4606, "[Android] ImageButton on android is not clipping view to corner radius",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Button)]
+	[NUnit.Framework.Category(UITestCategories.ImageButton)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public class Issue4606 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "Make sure all the images are clipped to the corner radius. Button will only clip when using a fast renderer.",
+					},
+					new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							new Button()
+							{
+								HeightRequest = 50,
+								WidthRequest = 50,
+								CornerRadius = 25,
+								BackgroundColor = Color.Purple,
+								BorderColor = Color.Green,
+								ImageSource = "coffee.png"
+							},
+							new ImageButton()
+							{
+								HeightRequest = 50,
+								WidthRequest = 50,
+								CornerRadius = 25,
+								BackgroundColor = Color.Purple,
+								BorderColor = Color.Green,
+								Source = "coffee.png"
+							}
+						}
+					},
+					new StackLayout()
+					{
+						Visual = VisualMarker.Material,
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							new Button()
+							{
+								HeightRequest = 50,
+								WidthRequest = 50,
+								CornerRadius = 25,
+								BackgroundColor = Color.Purple,
+								BorderColor = Color.Green,
+								ImageSource = "coffee.png"
+							},
+							new ImageButton()
+							{
+								HeightRequest = 50,
+								WidthRequest = 50,
+								CornerRadius = 25,
+								BackgroundColor = Color.Purple,
+								BorderColor = Color.Green,
+								Source = "coffee.png"
+							}
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4606.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8186.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5830.cs" />

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -103,6 +103,40 @@ namespace Xamarin.Forms.Material.Android
 			}
 		}
 
+		public override void Draw(Canvas canvas)
+		{
+			if(Element == null || Element.CornerRadius <= 0)
+			{
+				base.Draw(canvas);
+				return;
+			}
+
+			try
+			{
+				var radiusToPixels = (float)Context.ToPixels(Element.CornerRadius);
+
+				using (var path = new Path())
+				{
+					RectF rect = new RectF(0, 0, canvas.Width, canvas.Height);
+					path.AddRoundRect(rect, radiusToPixels, radiusToPixels, Path.Direction.Ccw);
+					canvas.Save();
+					canvas.ClipPath(path);
+					base.Draw(canvas);
+				}
+
+				canvas.Restore();
+				return;
+			}
+			catch (Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine("Unable to create circle image: " + ex);
+			}
+
+			base.Draw(canvas);
+
+
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -129,7 +129,7 @@ namespace Xamarin.Forms.Material.Android
 			}
 			catch (Exception ex)
 			{
-				System.Diagnostics.Debug.WriteLine("Unable to create circle image: " + ex);
+				Internals.Log.Warning(nameof(MaterialButtonRenderer), $"Unable to create circle image: {ex}");
 			}
 
 			base.Draw(canvas);

--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -192,6 +192,7 @@ namespace Xamarin.Forms.Platform.Android
 			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 
+
 		public override void Draw(Canvas canvas)
 		{
 			if (Element == null)
@@ -232,9 +233,15 @@ namespace Xamarin.Forms.Platform.Android
 					Drawable.SetBounds((int)drawableBounds.Left, (int)drawableBounds.Top, (int)drawableBounds.Right, (int)drawableBounds.Bottom);
 			}
 
-			base.Draw(canvas);
 			if (_backgroundTracker?.BackgroundDrawable != null)
+			{
+				_backgroundTracker.BackgroundDrawable.DrawCircle(canvas, canvas.Width, canvas.Height, base.Draw);
 				_backgroundTracker.BackgroundDrawable.DrawOutline(canvas, canvas.Width, canvas.Height);
+			}
+			else
+			{
+				base.Draw(canvas);
+			}
 		}
 
 		void IVisualElementRenderer.SetLabelFor(int? id)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -147,6 +147,15 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			ViewRenderer.MeasureExactly(this, Element, Context);
 		}
 
+
+		public override void Draw(Canvas canvas)
+		{
+			if (_backgroundTracker?.BackgroundDrawable != null)
+				_backgroundTracker.BackgroundDrawable.DrawCircle(canvas, canvas.Width, canvas.Height, base.Draw);
+			else
+				base.Draw(canvas);
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_isDisposed)

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -219,6 +219,48 @@ namespace Xamarin.Forms.Platform.Android
 			return rect;
 		}
 
+		public void DrawCircle(Canvas canvas, int width, int height, Action<Canvas> finishDraw)
+		{
+			try
+			{
+				var radius = (float)BorderElement.CornerRadius;
+				if(radius <= 0)
+				{
+					finishDraw(canvas);
+					return;
+				}
+
+				var borderThickness = _convertToPixels(BorderElement.BorderWidth);
+
+				using (var path = new Path())
+				{
+					float borderWidth = _convertToPixels(BorderElement.BorderWidth);
+					float inset = borderWidth / 2;
+
+					// adjust border radius so outer edge of stroke is same radius as border radius of background
+					float borderRadius = Math.Max(ConvertCornerRadiusToPixels() - inset, 0);
+
+					RectF rect = new RectF(0, 0, width, height);
+					rect.Inset(inset + PaddingLeft, inset + PaddingTop);
+					path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Ccw);
+
+					canvas.Save();
+					canvas.ClipPath(path);
+
+					finishDraw(canvas);
+				}
+
+				canvas.Restore();
+				return;
+			}
+			catch (Exception ex)
+			{
+				System.Diagnostics.Debug.WriteLine("Unable to create circle image: " + ex);
+			}
+
+			finishDraw(canvas);
+		}
+
 		public void DrawOutline(Canvas canvas, int width, int height)
 		{
 			if (BorderElement.BorderWidth <= 0)

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -255,7 +255,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			catch (Exception ex)
 			{
-				System.Diagnostics.Debug.WriteLine("Unable to create circle image: " + ex);
+				Internals.Log.Warning(nameof(BorderDrawable), $"Unable to create circle image: {ex}");
 			}
 
 			finishDraw(canvas);


### PR DESCRIPTION
### Description of Change ###
Clip button and image button so if the user specifies a corner radius the image will get clipped as well.

This is how iOS and UWP already work

### Issues Resolved ### 
- fixes #4606


### Platforms Affected ### 
- Android


### Before/After Screenshots ### 
```XAML
<StackLayout>
        <StackLayout Orientation="Horizontal">
            <ImageButton BorderWidth="2" BorderColor="Blue" WidthRequest="50" CornerRadius="25" Source="coffee.png" BackgroundColor="Purple"  />
            <ImageButton BorderWidth="2" BorderColor="Blue" WidthRequest="50" CornerRadius="25" Source="coffee.png" BackgroundColor="Purple"  />
        </StackLayout>
        <StackLayout Orientation="Horizontal" Visual="Material">
            <ImageButton BorderWidth="2" BorderColor="Blue" WidthRequest="50" CornerRadius="25" Source="coffee.png" BackgroundColor="Purple"  />
            <ImageButton BorderWidth="2" BorderColor="Blue" WidthRequest="50" CornerRadius="25" Source="coffee.png" BackgroundColor="Purple"  />            
        </StackLayout>
    </StackLayout>
```

Before

![image](https://user-images.githubusercontent.com/5375137/65807740-38039100-e14d-11e9-8c2a-ffcf136753c9.png)

After

![image](https://user-images.githubusercontent.com/5375137/65807981-b9a7ee80-e14e-11e9-9e5a-71be3f89bd1c.png)


### Testing Procedure ###
- run the included UI Test (make sure to enable fast renderers)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
