### PR TITLE
[UWP] Make EmptyView work in UWP CarouselView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -38,7 +38,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				ItemTemplate = itemTemplate,
 				ItemsSource = viewModel.Items,
 				IsScrollAnimated = true,
-				IsBounceEnabled = true
+				IsBounceEnabled = true,
+				EmptyView = "This is the empty view"
 			};
 
 			layout.Children.Add(carouselView, 0, 0);

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -234,7 +234,6 @@ namespace Xamarin.Forms
 			return itemSource[index];
 		}
 
-
 		static int GetPositionForItem(CarouselView carouselView, object item)
 		{
 			var itemSource = carouselView?.ItemsSource as IList;

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -226,8 +226,14 @@ namespace Xamarin.Forms
 			if (!(carouselView?.ItemsSource is IList itemSource))
 				return null;
 
+			if (index < 0 || index >= itemSource.Count)
+			{
+				return null;
+			}
+
 			return itemSource[index];
 		}
+
 
 		static int GetPositionForItem(CarouselView carouselView, object item)
 		{

--- a/Xamarin.Forms.Platform.UAP/CollectionView/FormsGridView.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/FormsGridView.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Globalization;
-using Windows.UI.Xaml;
+﻿using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using Xamarin.Forms.Platform.UWP;
+using UWPApp = Windows.UI.Xaml.Application;
+using UWPControlTemplate = Windows.UI.Xaml.Controls.ControlTemplate;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -15,6 +14,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		public FormsGridView()
 		{
+			Template = (UWPControlTemplate)UWPApp.Current.Resources["FormsListViewTemplate"];
+
 			// TODO hartez 2018/06/06 09:52:16 Do we need to clean this up? If so, where?	
 			RegisterPropertyChangedCallback(ItemsPanelProperty, ItemsPanelChanged);
 			Loaded += OnLoaded;
@@ -47,13 +48,13 @@ namespace Xamarin.Forms.Platform.UWP
 		public void UseHorizontalItemsPanel()
 		{
 			ItemsPanel =
-				(ItemsPanelTemplate)Windows.UI.Xaml.Application.Current.Resources["HorizontalGridItemsPanel"];
+				(ItemsPanelTemplate)UWPApp.Current.Resources["HorizontalGridItemsPanel"];
 		}
 
 		public void UseVerticalItemsPanel()
 		{
 			ItemsPanel =
-				(ItemsPanelTemplate)Windows.UI.Xaml.Application.Current.Resources["VerticalGridItemsPanel"];
+				(ItemsPanelTemplate)UWPApp.Current.Resources["VerticalGridItemsPanel"];
 		}
 
 		void FindItemsWrapGrid()

--- a/Xamarin.Forms.Platform.UAP/CollectionView/FormsListView.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/FormsListView.cs
@@ -1,5 +1,7 @@
 ﻿using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
+using UWPApp = Windows.UI.Xaml.Application;
+using UWPControlTemplate = Windows.UI.Xaml.Controls.ControlTemplate;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -7,6 +9,11 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		ContentControl _emptyViewContentControl;
 		FrameworkElement _emptyView;
+
+		public FormsListView()
+		{
+			Template = (UWPControlTemplate)UWPApp.Current.Resources["FormsListViewTemplate"];
+		}
 
 		public Visibility EmptyViewVisibility
 		{

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
@@ -49,44 +49,11 @@
         </Setter>
     </Style>
 
-    <Style TargetType="local:FormsListView">
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="TabNavigation" Value="Once" />
-        <Setter Property="IsSwipeEnabled" Value="True" />
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
-        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Enabled" />
-        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="True" />
-        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
-        <Setter Property="UseSystemFocusVisuals" Value="True" />
-        <Setter Property="ItemContainerTransitions">
-            <Setter.Value>
-                <TransitionCollection>
-                    <AddDeleteThemeTransition />
-                    <ContentThemeTransition />
-                    <ReorderThemeTransition />
-                    <EntranceThemeTransition IsStaggeringEnabled="False" />
-                </TransitionCollection>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <ItemsStackPanel Orientation="Vertical" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="local:FormsListView">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
-                        <Grid>
-                            <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"></ContentControl>
-                            <ScrollViewer x:Name="ScrollViewer" 
+    <ControlTemplate x:Key="FormsListViewTemplate" TargetType="local:FormsListView">
+        <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
+            <Grid>
+                <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"></ContentControl>
+                <ScrollViewer x:Name="ScrollViewer" 
                                 TabNavigation="{TemplateBinding TabNavigation}"
                                 HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
                                 HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
@@ -100,61 +67,23 @@
                                 IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                                 BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
                                 AutomationProperties.AccessibilityView="Raw">
-                                <ItemsPresenter Header="{TemplateBinding Header}"
+                    <ItemsPresenter Header="{TemplateBinding Header}"
                                     HeaderTemplate="{TemplateBinding HeaderTemplate}"
                                     HeaderTransitions="{TemplateBinding HeaderTransitions}"
                                     Footer="{TemplateBinding Footer}"
                                     FooterTemplate="{TemplateBinding FooterTemplate}"
                                     FooterTransitions="{TemplateBinding FooterTransitions}"
                                     Padding="{TemplateBinding Padding}" />
-                            </ScrollViewer>
-                        </Grid>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+    </ControlTemplate>
 
-    <Style TargetType="local:FormsGridView">
-        <Setter Property="Padding" Value="0,0,0,10" />
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="TabNavigation" Value="Once" />
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
-        <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Auto" />
-        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
-        <Setter Property="ScrollViewer.VerticalScrollMode" Value="Enabled" />
-        <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="True" />
-        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
-        <Setter Property="IsSwipeEnabled" Value="True" />
-        <Setter Property="UseSystemFocusVisuals" Value="True" />
-        <Setter Property="FocusVisualMargin" Value="-2" />
-        <Setter Property="ItemContainerTransitions">
-            <Setter.Value>
-                <TransitionCollection>
-                    <AddDeleteThemeTransition />
-                    <ContentThemeTransition />
-                    <ReorderThemeTransition />
-                    <EntranceThemeTransition IsStaggeringEnabled="False" />
-                </TransitionCollection>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="ItemsPanel">
-            <Setter.Value>
-                <ItemsPanelTemplate>
-                    <ItemsWrapGrid Orientation="Horizontal" />
-                </ItemsPanelTemplate>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate TargetType="local:FormsGridView">
-                    <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
-                        <Grid>
-                            <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"></ContentControl>
-                            <ScrollViewer x:Name="ScrollViewer"
+    <ControlTemplate x:Key="FormsGridViewTemplate" TargetType="local:FormsGridView">
+        <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
+            <Grid>
+                <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"></ContentControl>
+                <ScrollViewer x:Name="ScrollViewer"
                                 TabNavigation="{TemplateBinding TabNavigation}"
                                 HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
                                 HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
@@ -168,33 +97,24 @@
                                 IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
                                 BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
                                 AutomationProperties.AccessibilityView="Raw">
-                                <ItemsPresenter Header="{TemplateBinding Header}"
+                    <ItemsPresenter Header="{TemplateBinding Header}"
                                     HeaderTemplate="{TemplateBinding HeaderTemplate}"
                                     HeaderTransitions="{TemplateBinding HeaderTransitions}"
                                     Footer="{TemplateBinding Footer}"
                                     FooterTemplate="{TemplateBinding FooterTemplate}"
                                     FooterTransitions="{TemplateBinding FooterTransitions}"
                                     Padding="{TemplateBinding Padding}" />
-                            </ScrollViewer>
-                        </Grid>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
-    </Style>
+                </ScrollViewer>
+            </Grid>
+        </Border>
+    </ControlTemplate>
 
-    <Style x:Key="HorizontalCarouselListStyle" TargetType="ListView">
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="TabNavigation" Value="Once" />
+    <Style x:Key="HorizontalCarouselListStyle" TargetType="local:FormsListView">
         <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Hidden" />
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Disabled" />
         <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Auto" />
-        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
         <Setter Property="ScrollViewer.VerticalScrollMode" Value="Disabled" />
         <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
-        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
         <Setter Property="HorizontalContentAlignment" Value="Stretch" />
         <Setter Property="SelectionMode" Value="None" />
         <Setter Property="ItemContainerStyle">
@@ -205,70 +125,12 @@
                 </Style>
             </Setter.Value>
         </Setter>
-        <Setter Property="ItemContainerTransitions">
-            <Setter.Value>
-                <TransitionCollection>
-                    <AddDeleteThemeTransition />
-                    <ContentThemeTransition />
-                    <ReorderThemeTransition />
-                    <EntranceThemeTransition IsStaggeringEnabled="False" />
-                </TransitionCollection>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate 
-                    TargetType="ListView">
-                    <Border
-                        BorderBrush="{TemplateBinding BorderBrush}"
-					    Background="{TemplateBinding Background}"
-					    BorderThickness="{TemplateBinding BorderThickness}">
-                        <ScrollViewer 
-                            x:Name="ScrollViewer"
-						    TabNavigation="{TemplateBinding TabNavigation}"
-						    HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-						    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-						    IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
-						    VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-						    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-						    IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
-						    IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-						    IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-						    ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-						    IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-						    BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
-						    AutomationProperties.AccessibilityView="Raw"
-						    HorizontalSnapPointsType="Mandatory"
-						    HorizontalSnapPointsAlignment="Center"
-                            VerticalSnapPointsType="None"
-                            VerticalSnapPointsAlignment="Center">
-                            <ItemsPresenter HorizontalAlignment="Stretch"
-                                Header="{TemplateBinding Header}"
-							    HeaderTemplate="{TemplateBinding HeaderTemplate}"
-							    HeaderTransitions="{TemplateBinding HeaderTransitions}"
-							    Footer="{TemplateBinding Footer}"
-							    FooterTemplate="{TemplateBinding FooterTemplate}"
-							    FooterTransitions="{TemplateBinding FooterTransitions}"
-							    Padding="{TemplateBinding Padding}" />
-                        </ScrollViewer>
-                    </Border>
-                </ControlTemplate>
-            </Setter.Value>
-        </Setter>
     </Style>
 
-    <Style x:Key="VerticalCarouselListStyle" TargetType="ListView">
-        <Setter Property="IsTabStop" Value="False" />
-        <Setter Property="TabNavigation" Value="Once" />
-        <Setter Property="ScrollViewer.HorizontalScrollBarVisibility" Value="Disabled" />
+    <Style x:Key="VerticalCarouselListStyle" TargetType="local:FormsListView">
         <Setter Property="ScrollViewer.VerticalScrollBarVisibility" Value="Hidden" />
-        <Setter Property="ScrollViewer.HorizontalScrollMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsHorizontalRailEnabled" Value="False" />
         <Setter Property="ScrollViewer.VerticalScrollMode" Value="Auto" />
         <Setter Property="ScrollViewer.IsVerticalRailEnabled" Value="False" />
-        <Setter Property="ScrollViewer.ZoomMode" Value="Disabled" />
-        <Setter Property="ScrollViewer.IsDeferredScrollingEnabled" Value="False" />
-        <Setter Property="ScrollViewer.BringIntoViewOnFocusChange" Value="True" />
         <Setter Property="SelectionMode" Value="None" />
         <Setter Property="ItemContainerStyle">
             <Setter.Value>
@@ -276,56 +138,6 @@
                     <Setter Property="VerticalContentAlignment" Value="Stretch" />
                     <Setter Property="VerticalAlignment" Value="Stretch" />
                 </Style>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="ItemContainerTransitions">
-            <Setter.Value>
-                <TransitionCollection>
-                    <AddDeleteThemeTransition />
-                    <ContentThemeTransition />
-                    <ReorderThemeTransition />
-                    <EntranceThemeTransition IsStaggeringEnabled="False" />
-                </TransitionCollection>
-            </Setter.Value>
-        </Setter>
-        <Setter Property="Template">
-            <Setter.Value>
-                <ControlTemplate 
-                    TargetType="ListView">
-                    <Border
-                        BorderBrush="{TemplateBinding BorderBrush}"
-					    Background="{TemplateBinding Background}"
-					    BorderThickness="{TemplateBinding BorderThickness}">
-                        <ScrollViewer 
-                            x:Name="ScrollViewer"
-						    TabNavigation="{TemplateBinding TabNavigation}"
-						    HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
-						    HorizontalScrollBarVisibility="{TemplateBinding ScrollViewer.HorizontalScrollBarVisibility}"
-						    IsHorizontalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsHorizontalScrollChainingEnabled}"
-						    VerticalScrollMode="{TemplateBinding ScrollViewer.VerticalScrollMode}"
-						    VerticalScrollBarVisibility="{TemplateBinding ScrollViewer.VerticalScrollBarVisibility}"
-						    IsVerticalScrollChainingEnabled="{TemplateBinding ScrollViewer.IsVerticalScrollChainingEnabled}"
-						    IsHorizontalRailEnabled="{TemplateBinding ScrollViewer.IsHorizontalRailEnabled}"
-						    IsVerticalRailEnabled="{TemplateBinding ScrollViewer.IsVerticalRailEnabled}"
-						    ZoomMode="{TemplateBinding ScrollViewer.ZoomMode}"
-						    IsDeferredScrollingEnabled="{TemplateBinding ScrollViewer.IsDeferredScrollingEnabled}"
-						    BringIntoViewOnFocusChange="{TemplateBinding ScrollViewer.BringIntoViewOnFocusChange}"
-						    AutomationProperties.AccessibilityView="Raw"
-						    HorizontalSnapPointsType="None"
-						    HorizontalSnapPointsAlignment="Center"
-                            VerticalSnapPointsType="Mandatory"
-                            VerticalSnapPointsAlignment="Center">
-                            <ItemsPresenter
-                                Header="{TemplateBinding Header}"
-							    HeaderTemplate="{TemplateBinding HeaderTemplate}"
-							    HeaderTransitions="{TemplateBinding HeaderTransitions}"
-							    Footer="{TemplateBinding Footer}"
-							    FooterTemplate="{TemplateBinding FooterTemplate}"
-							    FooterTransitions="{TemplateBinding FooterTransitions}"
-							    Padding="{TemplateBinding Padding}" />
-                        </ScrollViewer>
-                    </Border>
-                </ControlTemplate>
             </Setter.Value>
         </Setter>
     </Style>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
@@ -27,9 +27,9 @@ namespace Xamarin.Forms.Platform.UWP
 			base.TearDownOldElement(oldElement);
 		}
 
-		protected override void SetUpNewElement(ItemsView newElement, bool setUpProperties)
+		protected override void SetUpNewElement(ItemsView newElement)
 		{
-			base.SetUpNewElement(newElement, setUpProperties);
+			base.SetUpNewElement(newElement);
 
 			if (newElement == null)
 			{

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -12,11 +12,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected override IItemsLayout Layout { get => _structuredItemsView.ItemsLayout; }
 
-		protected override void SetUpNewElement(ItemsView newElement, bool setUpProperties)
+		protected override void SetUpNewElement(ItemsView newElement)
 		{
 			_structuredItemsView = newElement as StructuredItemsView;
 
-			base.SetUpNewElement(newElement, setUpProperties);
+			base.SetUpNewElement(newElement);
 
 			if (newElement == null)
 			{


### PR DESCRIPTION
### Description of Change ###

The CarouselView on UWP does not display in the EmptyView when it's empty. These changes make the EmptyView work.

### Issues Resolved ### 

- EmptyView does not show in UWP CarouselView
- #7717 

### API Changes ###

 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Control Gallery, navigate to CarouselView Gallery -> CarouselView (Items) and tap the "Clear Items" button. The empty view (which says "This is the empty view") should display. Adding an item should make the empty view disappear.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
