### PR TITLE
[Bug] ContentPage.ControlTemplate gets not rendered in Wpf (#7671)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7671.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7671.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7671">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="Welcome to Xamarin.Forms!"
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+        </StackLayout>
+    </ContentPage.Content>
+    <ContentPage.ControlTemplate>
+        <ControlTemplate>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="60" />
+                    <RowDefinition />
+                    <RowDefinition Height="60" />
+                </Grid.RowDefinitions>
+
+                <Frame Grid.Row="0" BackgroundColor="Green">
+                    <Label Text="I am the template." />
+                </Frame>
+                <ContentPresenter Grid.Row="1" />
+                <Frame Grid.Row="2" BackgroundColor="Red">
+                    <Label Text="I am the template." />
+                </Frame>
+            </Grid>
+        </ControlTemplate>
+    </ContentPage.ControlTemplate>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7671.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7671.xaml.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 7671, "Check ControlTemplate rendering", PlatformAffected.WPF)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue7671 : ContentPage
+	{
+		public Issue7671()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7671.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7671.xaml.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Xamarin.Forms;
-using Xamarin.Forms.CustomAttributes;
+﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
@@ -13,12 +6,16 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.None, 7671, "Check ControlTemplate rendering", PlatformAffected.WPF)]
+#if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
 	public partial class Issue7671 : ContentPage
 	{
 		public Issue7671()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -2728,7 +2728,6 @@
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
-</Project>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7671.xaml">
       <SubType>Designer</SubType>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -287,6 +287,14 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7671.xaml.cs">
+      <DependentUpon>Issue7671.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7671.xaml.cs">
+      <DependentUpon>Issue7671.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7700.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
       <SubType>Code</SubType>
@@ -2712,6 +2720,19 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8263.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7671.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+</Project>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7671.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -291,10 +291,6 @@
       <DependentUpon>Issue7671.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-    <Compile Include="$(MSBuildThisFileDirectory)Issue7671.xaml.cs">
-      <DependentUpon>Issue7671.xaml</DependentUpon>
-      <SubType>Code</SubType>
-    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7700.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
       <SubType>Code</SubType>
@@ -2720,12 +2716,6 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8263.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7671.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.WPF/Controls/FormsContentPage.cs
+++ b/Xamarin.Forms.Platform.WPF/Controls/FormsContentPage.cs
@@ -1,10 +1,18 @@
-﻿namespace Xamarin.Forms.Platform.WPF.Controls
+﻿using System;
+using System.Windows;
+using WpfSize = System.Windows.Size;
+
+namespace Xamarin.Forms.Platform.WPF.Controls
 {
 	public class FormsContentPage : FormsPage
 	{
 		public FormsContentPage()
 		{
-			this.DefaultStyleKey = typeof(FormsContentPage);
+		}
+
+		static FormsContentPage()
+		{
+			DefaultStyleKeyProperty.OverrideMetadata(typeof(FormsContentPage), new FrameworkPropertyMetadata(typeof(FormsContentPage)));
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/FormsContentLoader.cs
+++ b/Xamarin.Forms.Platform.WPF/FormsContentLoader.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Windows;
@@ -57,7 +58,7 @@ namespace Xamarin.Forms.Platform.WPF
 			var contentPage = visualElement as ContentPage;
 			if (contentPage?.ControlTemplate != null)
 			{
-				contentPage.Content?.Layout(actualRect);
+				(contentPage.LogicalChildren.OfType<VisualElement>().FirstOrDefault() ?? contentPage.Content)?.Layout(actualRect);
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.WPF/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/PageRenderer.cs
@@ -1,47 +1,47 @@
 ﻿using System.ComponentModel;
+using System.Linq;
 using Xamarin.Forms.Platform.WPF.Controls;
 
 namespace Xamarin.Forms.Platform.WPF
 {
 	public class PageRenderer : VisualPageRenderer<Page, FormsContentPage>
 	{
-		VisualElement _currentView;
+		VisualElement _currentView = null;
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
 		{
 			if (e.NewElement != null)
 			{
-				if (Control == null) // construct and SetNativeControl and suscribe control event
-				{
+				if (Control == null)
 					SetNativeControl(new FormsContentPage());
-				}
 
-				// Update control property 
 				UpdateContent();
 			}
-
 			base.OnElementChanged(e);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-
-			if (e.PropertyName == ContentPage.ContentProperty.PropertyName)
+			
+			if (e.PropertyName == ContentPage.ContentProperty.PropertyName
+				|| e.PropertyName == TemplatedPage.ControlTemplateProperty.PropertyName)
+			{
 				UpdateContent();
+			}
 		}
 
 		void UpdateContent()
 		{
-			ContentPage page = Element as ContentPage;
-			if (page != null)
+			if (Element is ContentPage page)
 			{
-				if (_currentView != null)
+				if (_currentView != null) // destroy current view
 				{
-					_currentView.Cleanup(); // cleanup old view
+					_currentView?.Cleanup();
+					_currentView = null;
 				}
 
-				_currentView = page.Content;
+				_currentView = page.LogicalChildren.OfType<VisualElement>().FirstOrDefault() ?? page.Content;
 				Control.Content = _currentView != null ? Platform.GetOrCreateRenderer(_currentView).GetNativeElement() : null;
 			}
 		}


### PR DESCRIPTION
### Description of Change ###
`PageRenderer` renderes the first child instead of the `Content`.

Sorry, I destroyed the branch #7672.

### Issues Resolved ### 
- fixes #7671

### API Changes ###
 None

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###
ControlTemplate gets rendered in wpf.

### Before/After Screenshots ### 

Before:
![PageRendererBefore](https://user-images.githubusercontent.com/9724420/65603918-d43f6380-dfa6-11e9-8a8f-6daa2bfa2ebe.png)
After:
![PageRendererAfter](https://user-images.githubusercontent.com/9724420/65603915-d43f6380-dfa6-11e9-8540-43706d68e349.png)

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
