### PR TITLE
[UWP] Fix crash setting the MainPage using the OnStart method

### DIFF
--- a/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs
@@ -48,7 +48,11 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnApplicationPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == "MainPage")
+			{
+				if (Platform == null)
+					RegisterWindow(_application.MainPage);
 				Platform.SetPage(_application.MainPage);
+			}
 		}
 
 		void OnApplicationResuming(object sender, object e)


### PR DESCRIPTION
### Description of Change ###

Fix a crash (NRE) setting the MainPage using the OnStart method on **UWP**.

Adding support to MultiWindow (#2432), changes were made to `WindowsBasePage`: https://github.com/xamarin/Xamarin.Forms/blob/7a9b54dae9605169f0417c168af2cd81f931b2a9/Xamarin.Forms.Platform.UAP/WindowsBasePage.cs

### Issues Resolved ### 

- fixes #7537

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Modify Core Gallery to set the MainPage in the OnStart method. If the sample starts without problems, the fix is valid.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
