### PR TITLE
.create-nuget.sh and .create-stubs.sh files

### DIFF
--- a/.create-nuget.sh
+++ b/.create-nuget.sh
@@ -7,7 +7,7 @@
 
 CONSOLE_PREFIX="-- SCRIPT MESSAGE:"
 CONFIG=Debug
-NUGET_EXE=caketools/nuget.exe
+NUGET_EXE=nuget.exe
 
 # Download NuGet if it does not exist.
 if [ ! -f "$NUGET_EXE" ]; then

--- a/.create-nuget.sh
+++ b/.create-nuget.sh
@@ -1,0 +1,115 @@
+ #!/bin/bash 
+
+# This is not our official nuget build script.
+# This is used as a quick and dirty way create nuget packages used to test user issue reproductions.
+# This is updated as XF developers use it to test reproductions. As such, it may not always work.
+# This is not ideal, but it's better than nothing, and it usually works fine.
+
+CONSOLE_PREFIX="-- SCRIPT MESSAGE:"
+CONFIG=Debug
+NUGET_EXE=caketools/nuget.exe
+
+# Check if Homebrew is installed
+if [[ $(command -v brew) == "" ]]; then
+    echo "${CONSOLE_PREFIX} Installing Homebrew"
+    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
+else
+    echo "${CONSOLE_PREFIX} Updating Homebrew"
+    brew update
+fi
+
+# Check if Wine is installed
+if brew cask ls --versions wine-stable > /dev/null; then
+  echo "${CONSOLE_PREFIX} Wine package is installed."
+else
+  echo "${CONSOLE_PREFIX} Wine package is not installed."
+  echo "${CONSOLE_PREFIX} In order to install Wine we're also need to install Xquartz."
+  echo "${CONSOLE_PREFIX} The installing proccess may require to ask your password"
+  brew cask install xquartz
+  brew cask install wine-stable
+fi
+
+# Download NuGet if it does not exist.
+if [ ! -f "$NUGET_EXE" ]; then
+    echo "${CONSOLE_PREFIX} Downloading NuGet..."
+    curl -Lsfo "$NUGET_EXE" https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+    if [ $? -ne 0 ]; then
+        echo "${CONSOLE_PREFIX} An error occurred while downloading nuget.exe."
+        exit 1
+    fi
+fi
+
+case $1 in
+  "droid")
+    sh .create-stubs.sh $CONFIG
+    wine $NUGET_EXE restore .xamarin.forms.android.nuget.sln
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 /p:CreateAllAndroidTargets=true .xamarin.forms.android.nuget.sln
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 /p:CreateAllAndroidTargets=true .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 /p:CreateAllAndroidTargets=true .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1
+    ;;
+  "rdroid")
+    CONFIG=Release
+    wine $NUGET_EXE restore .xamarin.forms.android.nuget.sln
+    msbuild /v:m /p:configuration=release /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln
+    msbuild /v:m /p:configuration=release /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
+    msbuild /v:m /p:configuration=release /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1
+    ;;
+  "adroid")
+    ./create-nuget.sh droid
+    ./create-nuget.sh rdroid
+    exit 1
+    ;;
+  "pdroid")
+    CONFIG=Release
+    msbuild /v:m /p:configuration=release /p:platform="anyCpu" /p:WarningLevel=0 Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+    msbuild /v:m /p:configuration=release /p:platform="anyCpu" /p:WarningLevel=0 Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
+    msbuild /v:m /p:configuration=release /p:platform="anyCpu" /p:WarningLevel=0 Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj /p:AndroidTargetFrameworkVersion=v8.1
+    ;;
+  "pddroid")
+    CONFIG=Debug
+    msbuild /v:m /p:configuration=debug /p:platform="anyCpu" /p:WarningLevel=0 Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+    msbuild /v:m /p:configuration=debug /p:platform="anyCpu" /p:WarningLevel=0 Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
+    msbuild /v:m /p:configuration=debug /p:platform="anyCpu" /p:WarningLevel=0 Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj /p:AndroidTargetFrameworkVersion=v8.1
+    ;;
+  "ios")
+    CONFIG=Debug
+    sh .create-stubs.sh $CONFIG
+    wine $NUGET_EXE restore .xamarin.forms.ios.nuget.sln
+    msbuild /v:m /p:platform="any cpu" .xamarin.forms.ios.nuget.sln
+    ;;
+  "droidios")
+    CONFIG=Debug
+    sh .create-stubs.sh $CONFIG
+    wine $NUGET_EXE restore .xamarin.forms.android.nuget.sln
+    wine $NUGET_EXE restore .xamarin.forms.ios.nuget.sln
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln
+    msbuild /v:m /p:platform="any cpu" .xamarin.forms.ios.nuget.sln
+    ;;
+  "all")
+    CONFIG=Debug
+    sh .create-stubs.sh $CONFIG
+    wine $NUGET_EXE restore .xamarin.forms.nuget.sln
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln
+    ;;
+  "rall")
+    CONFIG=Release
+    sh .create-stubs.sh $CONFIG
+    wine $NUGET_EXE restore .xamarin.forms.nuget.sln
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln /p:configuration=release
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln /p:configuration=release /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln /p:configuration=release /p:AndroidTargetFrameworkVersion=v8.1
+    ;;
+  *)
+    CONFIG=Debug
+    sh .create-stubs.sh $CONFIG
+    wine $NUGET_EXE restore .xamarin.forms.nuget.sln
+    msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln
+    ;;
+esac
+
+DEBUG_VERSION=0
+wine $NUGET_EXE pack .nuspec/Xamarin.Forms.nuspec -properties configuration=$CONFIG\;platform=anycpu -Version 9.9.$DEBUG_VERSION
+if [ ! -n $CREATE_MAP_NUGET ]; then
+  # Requires building x86, x64, AMD
+  wine $NUGET_EXE pack .nuspec/Xamarin.Forms.Maps.nuspec -properties configuration=$CONFIG\;platform=anycpu -Version 9.9.$DEBUG_VERSION
+fi

--- a/.create-nuget.sh
+++ b/.create-nuget.sh
@@ -9,26 +9,6 @@ CONSOLE_PREFIX="-- SCRIPT MESSAGE:"
 CONFIG=Debug
 NUGET_EXE=caketools/nuget.exe
 
-# Check if Homebrew is installed
-if [[ $(command -v brew) == "" ]]; then
-    echo "${CONSOLE_PREFIX} Installing Homebrew"
-    /usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
-else
-    echo "${CONSOLE_PREFIX} Updating Homebrew"
-    brew update
-fi
-
-# Check if Wine is installed
-if brew cask ls --versions wine-stable > /dev/null; then
-  echo "${CONSOLE_PREFIX} Wine package is installed."
-else
-  echo "${CONSOLE_PREFIX} Wine package is not installed."
-  echo "${CONSOLE_PREFIX} In order to install Wine we're also need to install Xquartz."
-  echo "${CONSOLE_PREFIX} The installing proccess may require to ask your password"
-  brew cask install xquartz
-  brew cask install wine-stable
-fi
-
 # Download NuGet if it does not exist.
 if [ ! -f "$NUGET_EXE" ]; then
     echo "${CONSOLE_PREFIX} Downloading NuGet..."
@@ -42,14 +22,14 @@ fi
 case $1 in
   "droid")
     sh .create-stubs.sh $CONFIG
-    wine $NUGET_EXE restore .xamarin.forms.android.nuget.sln
+    msbuild /t:restore restore .xamarin.forms.android.nuget.sln
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 /p:CreateAllAndroidTargets=true .xamarin.forms.android.nuget.sln
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 /p:CreateAllAndroidTargets=true .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 /p:CreateAllAndroidTargets=true .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1
     ;;
   "rdroid")
     CONFIG=Release
-    wine $NUGET_EXE restore .xamarin.forms.android.nuget.sln
+    msbuild /t:restore .xamarin.forms.android.nuget.sln
     msbuild /v:m /p:configuration=release /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln
     msbuild /v:m /p:configuration=release /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
     msbuild /v:m /p:configuration=release /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln /p:AndroidTargetFrameworkVersion=v8.1
@@ -74,27 +54,27 @@ case $1 in
   "ios")
     CONFIG=Debug
     sh .create-stubs.sh $CONFIG
-    wine $NUGET_EXE restore .xamarin.forms.ios.nuget.sln
+    msbuild /t:restore .xamarin.forms.ios.nuget.sln
     msbuild /v:m /p:platform="any cpu" .xamarin.forms.ios.nuget.sln
     ;;
   "droidios")
     CONFIG=Debug
     sh .create-stubs.sh $CONFIG
-    wine $NUGET_EXE restore .xamarin.forms.android.nuget.sln
-    wine $NUGET_EXE restore .xamarin.forms.ios.nuget.sln
+    msbuild /t:restore .xamarin.forms.android.nuget.sln
+    msbuild /t:restore .xamarin.forms.ios.nuget.sln
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.android.nuget.sln
     msbuild /v:m /p:platform="any cpu" .xamarin.forms.ios.nuget.sln
     ;;
   "all")
     CONFIG=Debug
     sh .create-stubs.sh $CONFIG
-    wine $NUGET_EXE restore .xamarin.forms.nuget.sln
+    msbuild /t:restore .xamarin.forms.nuget.sln
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln
     ;;
   "rall")
     CONFIG=Release
     sh .create-stubs.sh $CONFIG
-    wine $NUGET_EXE restore .xamarin.forms.nuget.sln
+    msbuild /t:restore .xamarin.forms.nuget.sln
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln /p:configuration=release
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln /p:configuration=release /p:AndroidTargetFrameworkVersion=v8.1 /t:Restore
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln /p:configuration=release /p:AndroidTargetFrameworkVersion=v8.1
@@ -102,14 +82,14 @@ case $1 in
   *)
     CONFIG=Debug
     sh .create-stubs.sh $CONFIG
-    wine $NUGET_EXE restore .xamarin.forms.nuget.sln
+    msbuild /t:restore .xamarin.forms.nuget.sln
     msbuild /v:m /p:platform="any cpu" /p:WarningLevel=0 .xamarin.forms.nuget.sln
     ;;
 esac
 
 DEBUG_VERSION=0
-wine $NUGET_EXE pack .nuspec/Xamarin.Forms.nuspec -properties configuration=$CONFIG\;platform=anycpu -Version 9.9.$DEBUG_VERSION
+mono $NUGET_EXE pack .nuspec/Xamarin.Forms.nuspec -properties configuration=$CONFIG\;platform=anycpu -Version 9.9.$DEBUG_VERSION
 if [ ! -n $CREATE_MAP_NUGET ]; then
   # Requires building x86, x64, AMD
-  wine $NUGET_EXE pack .nuspec/Xamarin.Forms.Maps.nuspec -properties configuration=$CONFIG\;platform=anycpu -Version 9.9.$DEBUG_VERSION
+  mono $NUGET_EXE pack .nuspec/Xamarin.Forms.Maps.nuspec -properties configuration=$CONFIG\;platform=anycpu -Version 9.9.$DEBUG_VERSION
 fi

--- a/.create-stubs.sh
+++ b/.create-stubs.sh
@@ -1,0 +1,165 @@
+# This is not our official nuget build script.
+# This is used as a quick and dirty way create nuget packages used to test user issue reproductions.
+# This is updated as XF developers use it to test reproductions. As such, it may not always work.
+# This is not ideal, but it's better than nothing, and it usually works fine.
+
+CONFIG=$1
+CONSOLE_PREFIX="-- SCRIPT MESSAGE:"
+
+mkdir -p Xamarin.Forms.Platform.MacOS/bin/$CONFIG/
+mkdir -p Xamarin.Forms.Platform.Tizen/bin/$CONFIG/tizen40/
+mkdir -p Xamarin.Forms.Maps.Tizen/bin/$CONFIG/Tizen40
+mkdir -p Xamarin.Forms.Maps.MacOS/bin/$CONFIG
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/
+mkdir -p Xamarin.Forms.Platform.ios/bin/$CONFIG/
+mkdir -p Stubs/Xamarin.Forms.Platform.iOS/bin/iPhone/$CONFIG/
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ar
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ca
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/cs
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/da
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/de
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/el
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/es
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/fi
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/fr
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/he
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/hi
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/hr
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/hu
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/id
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/it
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ja
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ko
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ms
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/nb
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/nl
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/pl
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/pt-BR
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/pt
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ro
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/ru
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/sk
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/sv
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/th
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/tr
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/uk
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/vi
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/zh-Hans
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/zh-Hant
+mkdir -p Xamarin.Forms.Platform.iOS/bin/$CONFIG/zh-HK
+
+
+
+mkdir -p Xamarin.Forms.Platform.Android/bin/$CONFIG
+echo foo > Xamarin.Forms.Platform.Android/bin/$CONFIG/Xamarin.Forms.Platform.Android.dll
+
+mkdir -p Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$CONFIG
+echo foo > Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$CONFIG/FormsViewGroup.dll
+
+mkdir -p Stubs/Xamarin.Forms.Platform.Android/bin/$CONFIG
+echo foo > Stubs/Xamarin.Forms.Platform.Android/bin/$CONFIG/Xamarin.Forms.Platform.dll
+
+
+
+mkdir -p Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid90
+echo foo > Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid90/Xamarin.Forms.Platform.Android.dll
+
+mkdir -p Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$CONFIG/MonoAndroid90
+echo foo > Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$CONFIG/MonoAndroid90/FormsViewGroup.dll
+
+mkdir -p Stubs/Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid90
+echo foo > Stubs/Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid90/Xamarin.Forms.Platform.dll
+
+
+mkdir -p Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid81
+echo foo > Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid81/Xamarin.Forms.Platform.Android.dll
+
+mkdir -p Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$CONFIG/MonoAndroid81
+echo foo > Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$CONFIG/MonoAndroid81/FormsViewGroup.dll
+
+mkdir -p Stubs/Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid81
+echo foo > Stubs/Xamarin.Forms.Platform.Android/bin/$CONFIG/MonoAndroid81/Xamarin.Forms.Platform.dll
+
+
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ar/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ca/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/cs/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/da/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/de/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/el/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/es/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/fi/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/fr/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/he/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/hi/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/hr/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/hu/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/id/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/it/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ja/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ko/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ms/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/nb/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/nl/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/pl/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/pt-BR/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/pt/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ro/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/ru/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/sk/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/sv/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/th/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/tr/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/uk/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/vi/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/zh-Hans/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/zh-Hant/Xamarin.Forms.Platform.iOS.resources.dll
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/zh-HK/Xamarin.Forms.Platform.iOS.resources.dll
+
+echo foo > Xamarin.Forms.Platform.iOS/bin/$CONFIG/Xamarin.Forms.Platform.iOS.dll
+echo foo > Stubs/Xamarin.Forms.Platform.iOS/bin/iPhone/$CONFIG/Xamarin.Forms.Platform.dll
+
+echo foo > Xamarin.Forms.Platform.MacOS/bin/$CONFIG/Xamarin.forms.Platform.macOS.dll
+echo foo > Xamarin.Forms.Platform.MacOS/bin/$CONFIG/Xamarin.forms.Platform.dll
+echo foo > Xamarin.Forms.Maps.MacOS/bin/$CONFIG/Xamarin.Forms.Maps.macOS.dll
+
+mkdir -p Stubs/Xamarin.Forms.Platform.Tizen/bin/$CONFIG/tizen40
+echo foo > Stubs/Xamarin.Forms.Platform.Tizen/bin/$CONFIG/tizen40/Xamarin.Forms.Platform.dll
+echo foo > Xamarin.Forms.Maps.Tizen/bin/$CONFIG/Tizen40/Xamarin.Forms.Maps.Tizen.dll
+
+mkdir -p Xamarin.Forms.Platform.Tizen/bin/$CONFIG/tizen40
+echo foo > Xamarin.Forms.Platform.Tizen/bin/$CONFIG/tizen40/Xamarin.forms.Platform.tizen.dll
+echo foo > Xamarin.Forms.Platform.Tizen/bin/$CONFIG/tizen40/Xamarin.forms.Platform.dll
+
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Xamarin.Forms.Platform.UAP.dll
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Xamarin.Forms.Platform.UAP.pri
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Xamarin.Forms.Platform.UAP.xr.xml
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/FormsProgressBarStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/FormsFlyout.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/FormsCommandBarStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Resources.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/FormsTextBoxStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/AutoSuggestStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/SliderStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/MasterDetailControlStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/PageControlStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/TabbedPageStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/FormsEmbeddedPageWrapper.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/StepperControl.xbf
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/FormsCheckBoxStyle.xbf
+
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/Microsoft.UI.Xaml
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/Microsoft.UI.Xaml/DensityStyles
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Microsoft.UI.Xaml/DensityStyles/Compact.xbf
+
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/Shell
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Shell/ShellStyles.xbf
+
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/CollectionView/
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/CollectionView/ItemsViewStyles.xbf
+
+mkdir -p Xamarin.Forms.Platform.UAP/bin/$CONFIG/Items
+echo foo > Xamarin.Forms.Platform.UAP/bin/$CONFIG/Items/ItemsViewStyles.xbf
+
+echo "${CONSOLE_PREFIX} All necessary directories and files have been created."


### PR DESCRIPTION
### Description of Change ###

Long story short, I wanted to debug XF and see a behavior in one specific place but, unfortunately, I didn't see clear instructions how I can do that. I saw files .create-nuget.bat and .create-stubs.bat that allow to assemble nuget packages that I can use in 'raw' debugging purposes. These files are a .bat files but I don't have any Windows machine. So, I've decided to make a replicas of those files but for bash (macOS). I've tried it on "ios" and "droid" profiles and it seems working.

### Issues Resolved ### 

No issues are resolved

### API Changes ###

 None

### Platforms Affected ### 

None

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In order to test the result of scripts you could input `sh .create-nuget.sh ios` in Terminal and wait for Xamarin.Forms.9.9.X.nupkg file in root folder of the project. After that you may create a new XF project in vs4mac and replace exsisting XF packages in Core and iOS projects on your own.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
