### PR TITLE
Invalidate layout on ViewCell if Measurements change

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var cell = new DataTemplate (typeof(CustomCell));
 
-			var listView = new ListView {
+			var listView = new ListView(ListViewCachingStrategy.RecycleElement) {
 				ItemsSource = presidents,
 				ItemTemplate = cell,
 				RowHeight = 200

--- a/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using UIKit;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -10,6 +11,7 @@ namespace Xamarin.Forms.Platform.iOS
 		static readonly BindableProperty RealCellProperty = BindableProperty.CreateAttached("RealCell", typeof(UITableViewCell), typeof(Cell), null);
 
 		EventHandler _onForceUpdateSizeRequested;
+		PropertyChangedEventHandler _onPropertyChangedEventHandler;
 
 		public virtual UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
@@ -89,7 +91,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected void WireUpForceUpdateSizeRequested(ICellController cell, UITableViewCell nativeCell, UITableView tableView)
 		{
+			var inpc = cell as INotifyPropertyChanged;
 			cell.ForceUpdateSizeRequested -= _onForceUpdateSizeRequested;
+
+			if (inpc != null)
+				inpc.PropertyChanged -= _onPropertyChangedEventHandler;
 
 			_onForceUpdateSizeRequested = (sender, e) =>
 			{
@@ -98,7 +104,30 @@ namespace Xamarin.Forms.Platform.iOS
 					tableView.ReloadRows(new[] { index }, UITableViewRowAnimation.None);
 			};
 
+			_onPropertyChangedEventHandler = (sender, e) =>
+			{
+				if(e.PropertyName == "RealCell" && sender is BindableObject bo && GetRealCell(bo) == null)
+				{
+					if(sender is ICellController icc)
+						icc.ForceUpdateSizeRequested -= _onForceUpdateSizeRequested;
+
+					if (sender is INotifyPropertyChanged notifyPropertyChanged)
+						notifyPropertyChanged.PropertyChanged -= _onPropertyChangedEventHandler;
+
+					_onForceUpdateSizeRequested = null;
+					_onPropertyChangedEventHandler = null;
+				}
+			};
+
 			cell.ForceUpdateSizeRequested += _onForceUpdateSizeRequested;
+			if (inpc != null)
+				inpc.PropertyChanged += _onPropertyChangedEventHandler;
+
+		}
+
+		void Ncp_PropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			System.Diagnostics.Debug.WriteLine($"{e.PropertyName}");
 		}
 
 		internal static UITableViewCell GetRealCell(BindableObject cell)

--- a/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellTableViewCell.cs
@@ -108,6 +108,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_cell != null)
 				{
 					_cell.PropertyChanged -= HandlePropertyChanged;
+					CellRenderer.SetRealCell(_cell, null);
 				}
 				_cell = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/ViewCellRenderer.cs
@@ -9,6 +9,10 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class ViewCellRenderer : CellRenderer
 	{
+		public ViewCellRenderer()
+		{
+		}
+
 		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
 		{
 			Performance.Start(out string reference);
@@ -141,6 +145,8 @@ namespace Xamarin.Forms.Platform.iOS
 					if (_viewCell != null)
 					{
 						_viewCell.PropertyChanged -= ViewCellPropertyChanged;
+						_viewCell.View.MeasureInvalidated -= OnMeasureInvalidated;
+						SetRealCell(_viewCell, null);
 					}
 					_viewCell = null;
 				}
@@ -170,6 +176,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Device.BeginInvokeOnMainThread(oldCell.SendDisappearing);
 					oldCell.PropertyChanged -= ViewCellPropertyChanged;
+					oldCell.View.MeasureInvalidated -= OnMeasureInvalidated;
 				}
 
 				_viewCell = cell;
@@ -201,9 +208,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 				Platform.SetRenderer(_viewCell.View, renderer);
 				UpdateIsEnabled(_viewCell.IsEnabled);
+				_viewCell.View.MeasureInvalidated += OnMeasureInvalidated;
 				Performance.Stop(reference);
 			}
 
+			void OnMeasureInvalidated(object sender, EventArgs e)
+			{
+				SetNeedsLayout();
+			}
+
+			
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
After the ViewCell has already renderered if the measure of the contents has changed then the ViewCell needs to Invalidate its layout so its view can remeasure. In this case the Image would layout empty with zero width. Once it was loaded it wouldn't cause the UITableCell layout to invalidate so the containing frame would still have a width of zero.

I also added some code to unhook some events on dispose to avoid circular reference memory leak issues

### Issues Resolved ### 
- fixes #6773 

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- run Issue2354 as all the presidents should load. Scroll the ListView and you they will continue to load

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
