### PR TITLE
[UWP] Fix crash on Switch Renderer when a custom renderer provides Color objects instead of Brush

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomSwitchRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomSwitchRenderer.cs
@@ -1,0 +1,70 @@
+﻿using System.ComponentModel;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.UWP;
+using WResourceDictionary = Windows.UI.Xaml.ResourceDictionary;
+
+[assembly: ExportRenderer(typeof(CustomSwitch), typeof(CustomSwitchRenderer))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	// Used in Issue7253.cs
+	public class CustomSwitchRenderer : SwitchRenderer
+	{
+		protected CustomSwitch CustomSwitch => Element as CustomSwitch;
+
+		protected CustomSwitchStyle CustomStyle { get; set; }
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement == null)
+				return;
+
+			Control.OnContent = null;
+			Control.OffContent = null;
+			CustomStyle = new CustomSwitchStyle();
+			Control.Resources = CustomStyle;
+
+			OnElementPropertyChanged(this, new PropertyChangedEventArgs(nameof(CustomSwitch.CustomColor)));
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			switch (e.PropertyName)
+			{
+				case nameof(CustomSwitch.CustomColor):
+					CustomStyle.ToggleSwitchStrokeOn(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchStrokeOff(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchKnobFillOn(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchKnobFillOff(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchStrokeOnPointerOver(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchStrokeOffPointerOver(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchKnobFillOffPointerOver(CustomSwitch.CustomColor.ToUwpColor());
+					CustomStyle.ToggleSwitchKnobFillOnPointerOver(CustomSwitch.CustomColor.ToUwpColor());
+					break;
+			}
+
+			base.OnElementPropertyChanged(sender, e);
+		}
+
+		protected class CustomSwitchStyle : WResourceDictionary
+		{
+			public void ToggleSwitchStrokeOn(Windows.UI.Color c) => this["ToggleSwitchStrokeOn"] = c;
+			public void ToggleSwitchStrokeOff(Windows.UI.Color c) => this["ToggleSwitchStrokeOff"] = c;
+			public void ToggleSwitchKnobFillOn(Windows.UI.Color c) => this["ToggleSwitchKnobFillOn"] = c;
+			public void ToggleSwitchKnobFillOff(Windows.UI.Color c) => this["ToggleSwitchKnobFillOff"] = c;
+			public void ToggleSwitchStrokeOnPointerOver(Windows.UI.Color c) => this["ToggleSwitchStrokeOnPointerOver"] = c;
+			public void ToggleSwitchStrokeOffPointerOver(Windows.UI.Color c) => this["ToggleSwitchStrokeOffPointerOver"] = c;
+			public void ToggleSwitchKnobFillOffPointerOver(Windows.UI.Color c) => this["ToggleSwitchKnobFillOffPointerOver"] = c;
+			public void ToggleSwitchKnobFillOnPointerOver(Windows.UI.Color c) => this["ToggleSwitchKnobFillOnPointerOver"] = c;
+
+		}
+	}
+
+	public static class ColorHelper
+	{
+		public static Windows.UI.Color ToUwpColor(this Color xColor) =>
+			Windows.UI.Color.FromArgb((byte)(xColor.A * 255), (byte)(xColor.R * 255), (byte)(xColor.G * 255), (byte)(xColor.B * 255));
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -121,6 +121,7 @@
   <ItemGroup>
     <Compile Include="AttachedStateEffectRenderer.cs" />
     <Compile Include="BorderEffect.cs" />
+    <Compile Include="CustomSwitchRenderer.cs" />
     <Compile Include="DisposePageRenderer.cs" />
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
     <Compile Include="RegistrarValidationService.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7253.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7253.cs
@@ -1,0 +1,60 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7253, "[UWP] Switch custom Renderer using custom colors throws exception", PlatformAffected.UWP)]
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	public class Issue7253 : TestContentPage
+	{
+		public Issue7253()
+		{
+			Title = "Issue 7253";
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				Padding = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				Text = "If the custom Switch below is rendering without problems, the test passes."
+			};
+
+			var customSwitch = new CustomSwitch
+			{
+				CustomColor = Color.Red
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(customSwitch);
+
+			Content = layout;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class CustomSwitch : Switch
+	{
+		public static readonly BindableProperty CustomColorProperty = 
+			BindableProperty.Create(nameof(CustomColor), typeof(Color), typeof(CustomSwitch), Color.Black);
+
+		public Color CustomColor
+		{
+			get => (Color)GetValue(CustomColorProperty);
+			set => SetValue(CustomColorProperty, value);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -143,7 +143,9 @@ namespace Xamarin.Forms.Platform.UWP
 						 Storyboard.GetTargetProperty(t) == "Fill")
 				.KeyFrames.First();
 
-			if (_originalThumbOnBrush == nul (frame.Value is Windows.UI.Color color)
+			if (_originalThumbOnBrush == null)
+			{
+				if (frame.Value is Windows.UI.Color color)
 					_originalOnColorBrush = new SolidColorBrush(color);
 
 				if (frame.Value is Brush brush)

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -131,6 +131,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 
 			var grid = Control.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>();
+
 			if (grid == null)
 				return;
 
@@ -142,23 +143,29 @@ namespace Xamarin.Forms.Platform.UWP
 						 Storyboard.GetTargetProperty(t) == "Fill")
 				.KeyFrames.First();
 
-			if (_originalThumbOnBrush == null)
-				_originalThumbOnBrush = (Brush)frame.Value;
+			if (_originalThumbOnBrush == nul (frame.Value is Windows.UI.Color color)
+					_originalOnColorBrush = new SolidColorBrush(color);
+
+				if (frame.Value is Brush brush)
+					_originalThumbOnBrush = brush;
+			}
 
 			if (!Element.ThumbColor.IsDefault)
-				frame.Value = new SolidColorBrush(Element.ThumbColor.ToWindowsColor())
-				{
-					Opacity = _originalThumbOnBrush.Opacity
-				};
+			{
+				var brush = Element.ThumbColor.ToBrush();
+				brush.Opacity = _originalThumbOnBrush.Opacity;
+				frame.Value = brush;
+			}
 			else
 				frame.Value = _originalThumbOnBrush;
 
 			var thumb = (Ellipse)grid.FindName("SwitchKnobOn");
+
 			if (_originalThumbOnBrush == null)
 				_originalThumbOnBrush = thumb.Fill;
 
 			if (!Element.ThumbColor.IsDefault)
-				thumb.Fill = new SolidColorBrush(Element.ThumbColor.ToWindowsColor());
+				thumb.Fill = Element.ThumbColor.ToBrush();
 			else
 				thumb.Fill = _originalThumbOnBrush;
 		}


### PR DESCRIPTION
### Description of Change ###

Fix crash on Switch Renderer when a custom renderer provides Color objects instead of Brush to customize the Switch colors.
Some versions ago we introduced the option to customize the ThumbColor: https://github.com/xamarin/Xamarin.Forms/commit/a21caa53899a541a2763b769af811019a94195e8
It was expected to use a Brush (explicit cast) and in this case, a Color was used in the custom renderer (see #7253). Applied changes to allow the use of Color and/or Brush without problems.

### Issues Resolved ### 

- fixes #7253 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7253. If a custom Switch is rendered without problems, the test passes.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
