### PR TITLE
Ignore empty cache and don't cache invalid stream

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
+++ b/Xamarin.Forms.Xaml.UnitTests/Xamarin.Forms.Xaml.UnitTests.csproj
@@ -20,7 +20,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit" Version="2.6.4" />
-    <PackageReference Include="Microsoft.Build.Locator" Version="1.0.31" />
+    <PackageReference Include="Microsoft.Build.Locator" Version="1.2.6" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Core.UnitTests\MockPlatformServices.cs">


### PR DESCRIPTION
### Description of Change ###
- If the stream returned from the HttpClient is invalid the code was still creating an empty cache file which would cause subsequent calls to just use an empty file for the image instead of retrying to stream
- If the cached file is empty then don't use it and just retry the remote stream. 

### Issues Resolved ### 
- fixes #7751

### Platforms Affected ###
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
- Download the nuget
- Run this sample https://docs.microsoft.com/en-us/samples/xamarin/xamarin-forms-samples/workingwithimages/ against 4.1.0.709244 which will load an invalid image into cache
- now rerun the sample with the nuget that's part of this sample
- the image should now load

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
