### PR TITLE
Validate on Date part only

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
@@ -174,5 +174,14 @@ namespace Xamarin.Forms.Core.UnitTests
 			datePicker.SetValue (DatePicker.DateProperty, nullableDateTime);
 			Assert.AreEqual (dateTime, datePicker.Date);
 		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/5784
+		public void SetMaxAndMinDateTimeToNow()
+		{
+			var datePicker = new DatePicker();
+			datePicker.SetValue(DatePicker.MaximumDateProperty, DateTime.Now);
+			Assert.DoesNotThrow(() => datePicker.SetValue(DatePicker.MinimumDateProperty, DateTime.Now));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -154,12 +154,12 @@ namespace Xamarin.Forms
 
 		static bool ValidateMaximumDate(BindableObject bindable, object value)
 		{
-			return (DateTime)value >= ((DatePicker)bindable).MinimumDate;
+			return ((DateTime)value).Date >= ((DatePicker)bindable).MinimumDate;
 		}
 
 		static bool ValidateMinimumDate(BindableObject bindable, object value)
 		{
-			return (DateTime)value <= ((DatePicker)bindable).MaximumDate;
+			return ((DateTime)value).Date <= ((DatePicker)bindable).MaximumDate;
 		}
 
 		public IPlatformElementConfiguration<T, DatePicker> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -154,12 +154,12 @@ namespace Xamarin.Forms
 
 		static bool ValidateMaximumDate(BindableObject bindable, object value)
 		{
-			return ((DateTime)value).Date >= ((DatePicker)bindable).MinimumDate;
+			return ((DateTime)value).Date >= ((DatePicker)bindable).MinimumDate.Date;
 		}
 
 		static bool ValidateMinimumDate(BindableObject bindable, object value)
 		{
-			return ((DateTime)value).Date <= ((DatePicker)bindable).MaximumDate;
+			return ((DateTime)value).Date <= ((DatePicker)bindable).MaximumDate.Date;
 		}
 
 		public IPlatformElementConfiguration<T, DatePicker> On<T>() where T : IConfigPlatform


### PR DESCRIPTION
### Description of Change ###

When setting min and maxdate on a date picker to DateTime.Now we get an exception on the value binding of the min date. Due to the fact that the whole DateTime part was being validated.
Since the coerce part of the DatePicker will revert to only the Date part of the given DateTime value, it's best to also convert to only Date in the Validate methods of the DatePicker.

### Issues Resolved ### 

- fixes #5784

### API Changes ###
Changed:
 - return (DateTime)value >= ((DatePicker)bindable).MinimumDate;
 - return ((DateTime)value).Date >= ((DatePicker)bindable).MinimumDate;

- return (DateTime)value <= ((DatePicker)bindable).MaximumDate;
- return ((DateTime)value).Date <= ((DatePicker)bindable).MaximumDate;

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<img width="1440" alt="Screenshot 2019-10-01 at 22 05 19" src="https://user-images.githubusercontent.com/351693/65996948-b9825880-e498-11e9-84a7-a3db55093138.png">
<img width="1440" alt="Screenshot 2019-10-01 at 22 06 14" src="https://user-images.githubusercontent.com/351693/65996950-ba1aef00-e498-11e9-8855-66de3fea4f19.png">

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
