### PR TITLE
Shell android dispose

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6640.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6640.cs
@@ -1,0 +1,95 @@
+using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6640, "[Android] Crash when app go background", PlatformAffected.Android)]
+	public class Issue6640 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout
+			{
+				Children =
+				{
+					new Button
+					{
+						AutomationId = "GoToShell",
+						Text = "Click the button",
+						Command = new Command(() =>
+						{
+							Application.Current.MainPage = new MasterPageShell();
+						})
+					}
+				}
+			};
+		}
+
+		[Preserve(AllMembers = true)]
+		public class MasterPageShell : TestShell
+		{
+			protected override void Init()
+			{
+				FlyoutHeader = new FlyoutHeader();
+				Items.Add(new FlyoutItem
+				{
+					Title = "Issue 6640",
+					Items =
+					{
+						new ShellSection
+						{
+							Items =
+							{
+								new ShellContent
+								{
+									Content = new ContentPage
+									{
+										Content = new StackLayout
+										{
+											Children =
+											{
+												new Button
+												{
+													AutomationId = "Logout",
+													Text = "Click the button",
+													Command = new Command(() =>
+													{
+														Application.Current.MainPage = new ContentPage
+														{
+															Content = new StackLayout
+															{
+																BackgroundColor = Color.White,
+																Children =
+																{
+																	new Label
+																	{
+																		Text = $"Press Back Arrow to send application to background and wait few seconds.{Environment.NewLine}Application must not crash." 
+																	}
+																}
+															}
+														};
+													})
+												}
+											}
+										}
+									}
+								}
+							}
+						}
+					}
+				});
+			}
+		}
+
+		[Preserve(AllMembers = true)]
+		public class FlyoutHeader : TestContentPage
+		{
+			protected override void Init()
+			{
+				Content = new Grid();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Controls.Issues
 			returnButton.Clicked += OnReturnTapped;
 			stackLayout.Children.Add(returnButton);
 
-			var tabTwoPage = new ContentPage { Content =  stackLayout };
+			var tabTwoPage = new ContentPage { Content = stackLayout };
 			tabOne.Items.Add(tabOnePage);
 			tabTwo.Items.Add(tabTwoPage);
 
@@ -86,7 +86,8 @@ namespace Xamarin.Forms.Controls.Issues
 						Items = { tabOne, tabTwo }
 					}
 			);
-			Items.Add(new FlyoutItem {
+			Items.Add(new FlyoutItem
+			{
 				Title = flyoutOtherTitle,
 				Items = { flyoutContent }
 			});
@@ -104,8 +105,8 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(insertAutomationId);
 			RunningApp.Tap(insertAutomationId);
 
-			TapInFlyout(flyoutOtherTitle);
-			TapInFlyout(flyoutMainTitle);
+			TapInFlyout(flyoutOtherTitle, timeoutMessage: flyoutOtherTitle);
+			TapInFlyout(flyoutMainTitle, timeoutMessage: flyoutMainTitle);
 
 			RunningApp.WaitForElement(returnAutomationId);
 			RunningApp.Tap(returnAutomationId);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -728,10 +728,10 @@ namespace Xamarin.Forms.Controls
 				AppSetup.EndIsolate();
 			}
 		}
-		public void ShowFlyout(string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, bool testForFlyoutIcon = true)
+		public void ShowFlyout(string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, bool testForFlyoutIcon = true, string timeoutMessage = null)
 		{			
 			if(testForFlyoutIcon)
-				RunningApp.WaitForElement(flyoutIcon);
+				RunningApp.WaitForElement(flyoutIcon, timeoutMessage);
 
 			if (usingSwipe)
 			{
@@ -745,10 +745,11 @@ namespace Xamarin.Forms.Controls
 		}
 
 
-		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false)
+		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null)
 		{
-			ShowFlyout(flyoutIcon, usingSwipe);
-			RunningApp.WaitForElement(text);
+			timeoutMessage = timeoutMessage ?? text;
+			ShowFlyout(flyoutIcon, usingSwipe, timeoutMessage: timeoutMessage);
+			RunningApp.WaitForElement(text, timeoutMessage);
 			RunningApp.Tap(text);
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6640.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7329.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7290.cs" />

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -352,7 +352,6 @@ namespace Xamarin.Forms
 
 			_navStack.Insert(index, page);
 			AddPage(page);
-			SendAppearanceChanged();
 
 			var args = new NavigationRequestedEventArgs(page, before, false)
 			{

--- a/Xamarin.Forms.Platform.Android/AppCompat/ShellFragmentContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ShellFragmentContainer.cs
@@ -4,6 +4,7 @@ using Android.Runtime;
 using Android.Views;
 using System;
 using LP = Android.Views.ViewGroup.LayoutParams;
+using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -18,10 +19,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			ShellContentTab = shellContent;
 		}
 
-		protected ShellFragmentContainer(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
-		{
-		}
-
 		public override Page Page => _page;
 
 		protected override PageContainer CreatePageContainer(Context context, IVisualElementRenderer child, bool inFragment)
@@ -32,7 +29,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			};
 		}
 
-		public override global::Android.Views.View OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
+		public override AView OnCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState)
 		{
 			_page = ((IShellContentController)ShellContentTab).GetOrCreateContent();
 			return base.OnCreateView(inflater, container, savedInstanceState);

--- a/Xamarin.Forms.Platform.Android/Extensions/FragmentManagerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/FragmentManagerExtensions.cs
@@ -17,6 +17,11 @@ namespace Xamarin.Forms.Platform.Android
 			return fragmentTransaction.Add(containerViewId, fragment);
 		}
 
+		public static FragmentTransaction ReplaceEx(this FragmentTransaction fragmentTransaction, int containerViewId, Fragment fragment)
+		{
+			return fragmentTransaction.Replace(containerViewId, fragment);
+		}
+
 		public static FragmentTransaction HideEx(this FragmentTransaction fragmentTransaction, Fragment fragment)
 		{
 			return fragmentTransaction.Hide(fragment);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Android
 		ShellItem _shellItem;
 		ColorStateList _defaultList;
 		bool _disposed;
-		Color _lastColor = Color.Default;
+		ColorStateList _colorStateList;
 
 		public ShellBottomNavViewAppearanceTracker(IShellContext shellContext, ShellItem shellItem)
 		{
@@ -42,7 +42,6 @@ namespace Xamarin.Forms.Platform.Android
 			var unselectedColor = controller.EffectiveTabBarUnselectedColor;
 			var titleColor = controller.EffectiveTabBarTitleColor;
 
-
 			if (_defaultList == null)
 			{
 #if __ANDROID_28__
@@ -52,41 +51,45 @@ namespace Xamarin.Forms.Platform.Android
 #endif
 			}
 
-			var colorStateList = MakeColorStateList(titleColor, disabledColor, unselectedColor);
-			bottomView.ItemTextColor = colorStateList;
-			bottomView.ItemIconTintList = colorStateList;
-
-			colorStateList.Dispose();
+			_colorStateList = MakeColorStateList(titleColor, disabledColor, unselectedColor);
+			bottomView.ItemTextColor = _colorStateList;
+			bottomView.ItemIconTintList = _colorStateList;
 
 			SetBackgroundColor(bottomView, backgroundColor);
 		}
 
 		protected virtual void SetBackgroundColor(BottomNavigationView bottomView, Color color)
 		{
-			if (_lastColor.IsDefault)
-				_lastColor = color;
+			var menuView = bottomView.GetChildAt(0) as BottomNavigationMenuView;
+			var oldBackground = bottomView.Background;
+			var colorDrawable = oldBackground as ColorDrawable;
+			var colorChangeRevealDrawable = oldBackground as ColorChangeRevealDrawable;
+			AColor lastColor = colorChangeRevealDrawable?.EndColor ?? colorDrawable?.Color ?? Color.Default.ToAndroid();
+			var newColor = color.ToAndroid();
 
-			using (var menuView = bottomView.GetChildAt(0) as BottomNavigationMenuView)
+			if (menuView == null)
 			{
-				if (menuView == null)
+				if (colorDrawable != null && lastColor == newColor)
+					return;
+
+				if (lastColor != color.ToAndroid() || colorDrawable == null)
 				{
 					bottomView.SetBackground(new ColorDrawable(color.ToAndroid()));
 				}
-				else
-				{
-					var index = _shellItem.Items.IndexOf(_shellItem.CurrentItem);
-					using (var menu = bottomView.Menu)
-						index = Math.Min(index, menu.Size() - 1);
+			}
+			else
+			{
+				if (colorChangeRevealDrawable != null && lastColor == newColor)
+					return;
 
-					using (var child = menuView.GetChildAt(index))
-					{
-						var touchPoint = new Point(child.Left + (child.Right - child.Left) / 2, child.Top + (child.Bottom - child.Top) / 2);
+				var index = _shellItem.Items.IndexOf(_shellItem.CurrentItem);
+				var menu = bottomView.Menu;
+				index = Math.Min(index, menu.Size() - 1);
 
-						bottomView.Background?.Dispose();
-						bottomView.SetBackground(new ColorChangeRevealDrawable(_lastColor.ToAndroid(), color.ToAndroid(), touchPoint));
-						_lastColor = color;
-					}
-				}
+				var child = menuView.GetChildAt(index);
+				var touchPoint = new Point(child.Left + (child.Right - child.Left) / 2, child.Top + (child.Bottom - child.Top) / 2);
+
+				bottomView.SetBackground(new ColorChangeRevealDrawable(lastColor, newColor, touchPoint));
 			}
 		}
 
@@ -135,20 +138,23 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposed)
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
 			{
-				if (disposing)
-				{
-					_defaultList?.Dispose();
-				}
+				_defaultList?.Dispose();
+				_colorStateList?.Dispose();
 
 				_shellItem = null;
 				_shellContext = null;
 				_defaultList = null;
-				_disposed = true;
+				_colorStateList = null;
 			}
 		}
 
-#endregion IDisposable
+		#endregion IDisposable
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -167,7 +167,6 @@ namespace Xamarin.Forms.Platform.Android
 			_toolbar = null;
 			_root = null;
 			_renderer = null;
-			_page = null;
 			_shellContent = null;
 		}
 
@@ -177,8 +176,11 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			_disposed = true;
-			if(disposing)
+			if (disposing)
+			{
 				Destroy();
+				_page = null;
+			}
 
 			base.Dispose(disposing);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -54,6 +54,7 @@ namespace Xamarin.Forms.Platform.Android
 		ShellContent _shellContent;
 		Toolbar _toolbar;
 		IShellToolbarTracker _toolbarTracker;
+		bool _disposed;
 
 		public ShellContentFragment(IShellContext shellContext, ShellContent shellContent)
 		{
@@ -137,32 +138,57 @@ namespace Xamarin.Forms.Platform.Android
 			return _root;
 		}
 
-		// Use OnDestroy instead of OnDestroyView because OnDestroyView will be
-		// called before the animation completes. This causes tons of tiny issues.
-		public override void OnDestroy()
+		void Destroy()
 		{
-			base.OnDestroy();
-
-			_shellPageContainer.RemoveAllViews();
-			_renderer?.Dispose();
-			_root?.Dispose();
-			_toolbarTracker.Dispose();
-			_appearanceTracker.Dispose();
-
-			((IShellController)_shellContext.Shell).RemoveAppearanceObserver(this);
+			((IShellController)_shellContext.Shell).RemoveAppearanceObserver(this);			
 
 			if (_shellContent != null)
 			{
 				((IShellContentController)_shellContent).RecyclePage(_page);
 				_page.ClearValue(Platform.RendererProperty);
-				_page = null;
 			}
 
+			if (_shellPageContainer != null)
+			{
+				_shellPageContainer.RemoveAllViews();
+
+				if (_root is ViewGroup vg)
+					vg.RemoveView(_shellPageContainer);
+			}
+
+			_renderer?.Dispose();
+			_root?.Dispose();
+			_toolbarTracker?.Dispose();
+			_appearanceTracker?.Dispose();
+
+
 			_appearanceTracker = null;
-			_toolbar = null;
 			_toolbarTracker = null;
+			_toolbar = null;
 			_root = null;
 			_renderer = null;
+			_page = null;
+			_shellContent = null;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+			if(disposing)
+				Destroy();
+
+			base.Dispose(disposing);
+		}
+
+		// Use OnDestroy instead of OnDestroyView because OnDestroyView will be
+		// called before the animation completes. This causes tons of tiny issues.
+		public override void OnDestroy()
+		{
+			base.OnDestroy();
+			Destroy();
 		}
 
 		protected virtual void ResetAppearance() => _appearanceTracker.ResetAppearance(_toolbar, _toolbarTracker);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -146,6 +146,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				((IShellContentController)_shellContent).RecyclePage(_page);
 				_page.ClearValue(Platform.RendererProperty);
+				_page = null;
 			}
 
 			if (_shellPageContainer != null)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Forms.Platform.Android
 		IShellFlyoutContentRenderer _flyoutContent;
 		int _flyoutWidth;
 		int _currentLockMode;
+		bool _disposed;
 
 		public ShellFlyoutRenderer(IShellContext shellContext, Context context) : base(context)
 		{
@@ -169,6 +170,29 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				SetScrimColor(behavior == FlyoutBehavior.Locked ? Color.Transparent.ToAndroid() : (int)DefaultScrimColor);
 			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				Shell.PropertyChanged -= OnShellPropertyChanged;
+
+				RemoveDrawerListener(this);
+				((IShellController)_shellContext.Shell).RemoveFlyoutBehaviorObserver(this);
+
+				RemoveView(_content);
+				RemoveView(_flyoutContent.AndroidView);
+
+				_flyoutContent.Dispose();
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -299,14 +299,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 			}
 
-			public HeaderContainer(Context context, IAttributeSet attribs) : base(context, attribs)
-			{
-			}
-
-			public HeaderContainer(Context context, IAttributeSet attribs, int defStyleAttr) : base(context, attribs, defStyleAttr)
-			{
-			}
-
 			protected override void LayoutView(double x, double y, double width, double height)
 			{
 				var context = Context;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -1,6 +1,5 @@
 ﻿using Android.Content;
 using Android.Graphics.Drawables;
-using Android.Runtime;
 using Android.Support.Design.Widget;
 using Android.Support.V7.Widget;
 using Android.Util;
@@ -23,18 +22,21 @@ namespace Xamarin.Forms.Platform.Android
 
 		#endregion IShellFlyoutContentRenderer
 
-        IShellContext _shellContext;
-        bool _disposed;
-        HeaderContainer _headerView;
-        ViewGroup _rootView;
-        Drawable _defaultBackgroundColor;
+		IShellContext _shellContext;
+		bool _disposed;
+		HeaderContainer _headerView;
+		ViewGroup _rootView;
+		Drawable _defaultBackgroundColor;
 		ImageView _bgImage;
-        View _flyoutHeader;
-        int _actionBarHeight;
+		AppBarLayout _appBar;
+		RecyclerView _recycler;
+		ShellFlyoutRecyclerAdapter _adapter;
+		View _flyoutHeader;
+		int _actionBarHeight;
 
-        public ShellFlyoutTemplatedContentRenderer(IShellContext shellContext)
-        {
-            _shellContext = shellContext;
+		public ShellFlyoutTemplatedContentRenderer(IShellContext shellContext)
+		{
+			_shellContext = shellContext;
 
 			LoadView(shellContext);
 		}
@@ -51,17 +53,19 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			var coordinator = LayoutInflater.FromContext(context).Inflate(Resource.Layout.FlyoutContent, null);
-			var recycler = coordinator.FindViewById<RecyclerView>(Resource.Id.flyoutcontent_recycler);
-			var appBar = coordinator.FindViewById<AppBarLayout>(Resource.Id.flyoutcontent_appbar);
+
+			_recycler = coordinator.FindViewById<RecyclerView>(Resource.Id.flyoutcontent_recycler);
+
+			_appBar = coordinator.FindViewById<AppBarLayout>(Resource.Id.flyoutcontent_appbar);
 
 			_rootView = coordinator as ViewGroup;
 
-			appBar.AddOnOffsetChangedListener(this);
+			_appBar.AddOnOffsetChangedListener(this);
 
 			_actionBarHeight = (int)context.ToPixels(56);
 
 			_flyoutHeader = ((IShellController)shellContext.Shell).FlyoutHeader;
-			if(_flyoutHeader != null)
+			if (_flyoutHeader != null)
 				_flyoutHeader.MeasureInvalidated += OnFlyoutHeaderMeasureInvalidated;
 
 			_headerView = new HeaderContainer(context, _flyoutHeader)
@@ -73,13 +77,12 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				ScrollFlags = AppBarLayout.LayoutParams.ScrollFlagScroll
 			};
-			appBar.AddView(_headerView);
+			_appBar.AddView(_headerView);
 
-			var adapter = new ShellFlyoutRecyclerAdapter(shellContext, OnElementSelected);
-			recycler.SetPadding(0, (int)context.ToPixels(20), 0, 0);
-			recycler.SetClipToPadding(false);
-			recycler.SetLayoutManager(new LinearLayoutManager(context, (int)Orientation.Vertical, false));
-			recycler.SetAdapter(adapter);
+			_adapter = new ShellFlyoutRecyclerAdapter(shellContext, OnElementSelected);
+			_recycler.SetClipToPadding(false);
+			_recycler.SetLayoutManager(new LinearLayoutManager(context, (int)Orientation.Vertical, false));
+			_recycler.SetAdapter(_adapter);
 
 			var metrics = context.Resources.DisplayMetrics;
 			var width = Math.Min(metrics.WidthPixels, metrics.HeightPixels);
@@ -102,14 +105,14 @@ namespace Xamarin.Forms.Platform.Android
 			};
 
 			UpdateFlyoutHeaderBehavior();
-            _shellContext.Shell.PropertyChanged += OnShellPropertyChanged;
+			_shellContext.Shell.PropertyChanged += OnShellPropertyChanged;
 
-            UpdateFlyoutBackground();
-        }
+			UpdateFlyoutBackground();
+		}
 
 		void OnFlyoutHeaderMeasureInvalidated(object sender, EventArgs e)
 		{
-			if(_headerView != null)
+			if (_headerView != null)
 				UpdateFlyoutHeaderBehavior();
 		}
 
@@ -118,8 +121,8 @@ namespace Xamarin.Forms.Platform.Android
 			((IShellController)_shellContext.Shell).OnFlyoutItemSelected(element);
 		}
 
-        protected virtual void OnShellPropertyChanged(object sender, PropertyChangedEventArgs e)
-        {
+		protected virtual void OnShellPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
 			if (e.PropertyName == Shell.FlyoutHeaderBehaviorProperty.PropertyName)
 				UpdateFlyoutHeaderBehavior();
 			else if (e.IsOneOf(
@@ -127,7 +130,7 @@ namespace Xamarin.Forms.Platform.Android
 				Shell.FlyoutBackgroundImageProperty,
 				Shell.FlyoutBackgroundImageAspectProperty))
 				UpdateFlyoutBackground();
-        }
+		}
 
 		protected virtual void UpdateFlyoutBackground()
 		{
@@ -179,7 +182,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_rootView.IndexOfChild(_bgImage) == -1)
 				{
-					if(_bgImage.SetElevation(float.MinValue))
+					if (_bgImage.SetElevation(float.MinValue))
 						_rootView.AddView(_bgImage);
 					else
 						_rootView.AddView(_bgImage, 0);
@@ -191,10 +194,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var context = _shellContext.AndroidContext;
 
-			Thickness margin = default(Thickness);
-
-			if (_flyoutHeader != null)
-				margin = _flyoutHeader.Margin;
+			var margin = _flyoutHeader?.Margin ?? default(Thickness);
 
 			var minimumHeight = Convert.ToInt32(_actionBarHeight + context.ToPixels(margin.Top) - context.ToPixels(margin.Bottom));
 			_headerView.SetMinimumHeight(minimumHeight);
@@ -245,31 +245,49 @@ namespace Xamarin.Forms.Platform.Android
 			_headerView.SetPadding(0, -verticalOffset, 0, 0);
 		}
 
-        protected override void Dispose(bool disposing)
-        {
-            if (!_disposed)
-            {
-                if (disposing)
-                {
-                    _shellContext.Shell.PropertyChanged -= OnShellPropertyChanged;
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
 
-                    if (_flyoutHeader != null)
-                        _flyoutHeader.MeasureInvalidated += OnFlyoutHeaderMeasureInvalidated;
+			_disposed = true;
 
-                    _headerView.Dispose();
-                    _rootView.Dispose();
-                    _defaultBackgroundColor?.Dispose();
-					_bgImage?.Dispose();
+			if (disposing)
+			{
+				_shellContext.Shell.PropertyChanged -= OnShellPropertyChanged;
+
+				if (_flyoutHeader != null)
+					_flyoutHeader.MeasureInvalidated -= OnFlyoutHeaderMeasureInvalidated;
+
+				if (_appBar != null)
+				{
+					_appBar.RemoveOnOffsetChangedListener(this);
+					_appBar.RemoveView(_headerView);
 				}
 
-                _flyoutHeader = null;
-                _defaultBackgroundColor = null;
-				_bgImage = null;
+				if (_recycler != null)
+				{
+					_recycler.SetLayoutManager(null);
+					_recycler.SetAdapter(null);
+					_recycler.Dispose();
+				}
+
+				_adapter?.Dispose();
+				_headerView.Dispose();
+				_rootView.Dispose();
+				_defaultBackgroundColor?.Dispose();
+				_bgImage?.Dispose();
+
+				_flyoutHeader = null;
 				_rootView = null;
-                _headerView = null;
-                _shellContext = null;
-                _disposed = true;
-            }
+				_headerView = null;
+				_shellContext = null;
+				_appBar = null;
+				_recycler = null;
+				_adapter = null;
+				_defaultBackgroundColor = null;
+				_bgImage = null;
+			}
 
 			base.Dispose(disposing);
 		}
@@ -286,10 +304,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			public HeaderContainer(Context context, IAttributeSet attribs, int defStyleAttr) : base(context, attribs, defStyleAttr)
-			{
-			}
-
-			protected HeaderContainer(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
 			{
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFragmentPagerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFragmentPagerAdapter.cs
@@ -64,14 +64,19 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
-			if (disposing && !_disposed)
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
 			{
 				((INotifyCollectionChanged)_shellSection.Items).CollectionChanged -= OnItemsCollectionChanged;
-				_shellSection = null;
-				_disposed = true;
 
+				_shellSection = null;
 			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -48,6 +48,8 @@ namespace Xamarin.Forms.Platform.Android
 		FrameLayout _navigationArea;
 		AView _outerLayout;
 		IShellBottomNavViewAppearanceTracker _appearanceTracker;
+		BottomSheetDialog _bottomSheetDialog;
+		bool _disposed;
 
 		public ShellItemRenderer(IShellContext shellContext) : base(shellContext)
 		{
@@ -76,29 +78,55 @@ namespace Xamarin.Forms.Platform.Android
 			return _outerLayout;
 		}
 
-		// Use OnDestory become OnDestroyView may fire before events are completed.
-		public override void OnDestroy()
+
+		void Destroy()
 		{
-			UnhookEvents(ShellItem);
+			if(ShellItem != null)
+				UnhookEvents(ShellItem);
+
+			((IShellController)ShellContext.Shell).RemoveAppearanceObserver(this);
+
+			if (_bottomSheetDialog != null)
+			{
+				_bottomSheetDialog.DismissEvent -= OnMoreSheetDismissed;
+				_bottomSheetDialog?.Dispose();
+				_bottomSheetDialog = null;
+			}
+
+			_navigationArea?.Dispose();
+			_appearanceTracker?.Dispose();
+			_outerLayout?.Dispose();
+
 			if (_bottomView != null)
 			{
 				_bottomView?.SetOnNavigationItemSelectedListener(null);
 				_bottomView?.Background?.Dispose();
 				_bottomView?.Dispose();
-				_bottomView = null;
-
-				_navigationArea?.Dispose();
-				_navigationArea = null;
-
-				_appearanceTracker?.Dispose();
-				_appearanceTracker = null;
-
-				_outerLayout?.Dispose();
-				_outerLayout = null;
 			}
 
-			((IShellController)ShellContext.Shell).RemoveAppearanceObserver(this);
+			_bottomView = null;
+			_navigationArea = null;
+			_appearanceTracker = null;
+			_outerLayout = null;
 
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+			if(disposing)
+				Destroy();
+
+			base.Dispose(disposing);
+		}
+
+		// Use OnDestory become OnDestroyView may fire before events are completed.
+		public override void OnDestroy()
+		{
+			Destroy();
 			base.OnDestroy();
 		}
 
@@ -228,9 +256,9 @@ namespace Xamarin.Forms.Platform.Android
 			var id = item.ItemId;
 			if (id == MoreTabId)
 			{
-				var bottomSheetDialog = CreateMoreBottomSheet(OnMoreItemSelected);
-				bottomSheetDialog.Show();
-				bottomSheetDialog.DismissEvent += OnMoreSheetDismissed;
+				_bottomSheetDialog = CreateMoreBottomSheet(OnMoreItemSelected);
+				_bottomSheetDialog.Show();
+				_bottomSheetDialog.DismissEvent += OnMoreSheetDismissed;
 			}
 			else
 			{
@@ -256,7 +284,17 @@ namespace Xamarin.Forms.Platform.Android
 			dialog.Dispose();
 		}
 
-		protected virtual void OnMoreSheetDismissed(object sender, EventArgs e) => OnShellSectionChanged();
+		protected virtual void OnMoreSheetDismissed(object sender, EventArgs e)
+		{
+			OnShellSectionChanged();
+
+			if (_bottomSheetDialog != null)
+			{
+				_bottomSheetDialog.DismissEvent -= OnMoreSheetDismissed;
+				_bottomSheetDialog.Dispose();
+				_bottomSheetDialog = null;
+			}
+		}
 
 		protected override void OnShellItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			_disposed = true;
-			if(disposing)
+			if (disposing)
 				Destroy();
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 		IShellObservableFragment _currentFragment;
 		ShellSection _shellSection;
 		Page _displayedPage;
+		bool _disposed;
 
 		protected ShellItemRendererBase(IShellContext shellContext)
 		{
@@ -82,18 +83,39 @@ namespace Xamarin.Forms.Platform.Android
 			return ShellContext.CreateFragmentForPage(page);
 		}
 
-		public override void OnDestroy()
+		void Destroy()
 		{
-			base.OnDestroy();
-
 			foreach (var item in _fragmentMap)
+			{
+				RemoveFragment(item.Value.Fragment);
 				item.Value.Fragment.Dispose();
+			}
+
 			_fragmentMap.Clear();
 
 			ShellSection = null;
 			DisplayedPage = null;
 
 			Destroyed?.Invoke(this, EventArgs.Empty);
+		}
+
+		public override void OnDestroy()
+		{
+			Destroy();
+			base.OnDestroy();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if(disposing)
+				Destroy();
+
+			base.Dispose(disposing);
 		}
 
 		protected abstract ViewGroup GetNavigationTarget();
@@ -158,7 +180,7 @@ namespace Xamarin.Forms.Platform.Android
 					// We need to handle this after we know what the target is
 					// because we might accidentally remove an already added target.
 					// Then there would be two transactions in a row, one removing and one adding
-					// the same fragement and things get really screwy when you do that.
+					// the same fragment and things get really screwy when you do that.
 					break;
 
 				default:
@@ -200,11 +222,11 @@ namespace Xamarin.Forms.Platform.Android
 					trackFragment = target;
 
 					if (_currentFragment != null)
-						t.Hide(_currentFragment.Fragment);
+						t.HideEx(_currentFragment.Fragment);
 
 					if (!target.Fragment.IsAdded)
-						t.Add(GetNavigationTarget().Id, target.Fragment);
-					t.Show(target.Fragment);
+						t.AddEx(GetNavigationTarget().Id, target.Fragment);
+					t.ShowEx(target.Fragment);
 					break;
 
 				case ShellNavigationSource.Pop:
@@ -213,10 +235,10 @@ namespace Xamarin.Forms.Platform.Android
 					trackFragment = _currentFragment;
 
 					if (_currentFragment != null)
-						t.Remove(_currentFragment.Fragment);
+						t.RemoveEx(_currentFragment.Fragment);
 
 					if (!target.Fragment.IsAdded)
-						t.Add(GetNavigationTarget().Id, target.Fragment);
+						t.AddEx(GetNavigationTarget().Id, target.Fragment);
 					t.Show(target.Fragment);
 					break;
 			}
@@ -237,7 +259,7 @@ namespace Xamarin.Forms.Platform.Android
 				result.TrySetResult(true);
 			}
 
-			t.CommitAllowingStateLoss();
+			t.CommitAllowingStateLossEx();
 
 			_currentFragment = target;
 
@@ -346,7 +368,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void RemoveAllButCurrent(Fragment skip)
 		{
-			var trans = ChildFragmentManager.BeginTransaction();
+			var trans = ChildFragmentManager.BeginTransactionEx();
 			foreach (var kvp in _fragmentMap)
 			{
 				var f = kvp.Value.Fragment;
@@ -354,7 +376,7 @@ namespace Xamarin.Forms.Platform.Android
 					continue;
 				trans.Remove(f);
 			};
-			trans.CommitAllowingStateLoss();
+			trans.CommitAllowingStateLossEx();
 		}
 
 		void RemoveAllPushedPages(ShellSection shellSection, bool keepCurrent)
@@ -362,7 +384,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (shellSection.Stack.Count <= 1 || (keepCurrent && shellSection.Stack.Count == 2))
 				return;
 
-			var t = ChildFragmentManager.BeginTransaction();
+			var t = ChildFragmentManager.BeginTransactionEx();
 
 			foreach (var kvp in _fragmentMap.ToList())
 			{
@@ -374,17 +396,17 @@ namespace Xamarin.Forms.Platform.Android
 				if (keepCurrent && kvp.Value.Fragment == _currentFragment)
 					continue;
 
-				t.Remove(kvp.Value.Fragment);
+				t.RemoveEx(kvp.Value.Fragment);
 			}
 
-			t.CommitAllowingStateLoss();
+			t.CommitAllowingStateLossEx();
 		}
 
 		void RemoveFragment(Fragment fragment)
 		{
-			var t = ChildFragmentManager.BeginTransaction();
-			t.Remove(fragment);
-			t.CommitAllowingStateLoss();
+			var t = ChildFragmentManager.BeginTransactionEx();
+			t.RemoveEx(fragment);
+			t.CommitAllowingStateLossEx();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
@@ -101,8 +101,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnDestroy()
 		{
-			Destroy();
 			base.OnDestroy();
+			Destroy();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -112,7 +112,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			_disposed = true;
 
-			if(disposing)
+			if (disposing)
 				Destroy();
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
@@ -246,10 +246,10 @@ namespace Xamarin.Forms.Platform.Android
 			FragmentTransaction transaction = manager.BeginTransaction();
 
 			if (animate)
-				transaction.SetTransition((int)global::Android.App.FragmentTransit.EnterMask);
+				transaction.SetTransitionEx((int)global::Android.App.FragmentTransit.EnterMask);
 
-			transaction.Replace(_frameLayout.Id, fragment);
-			transaction.CommitAllowingStateLoss();
+			transaction.ReplaceEx(_frameLayout.Id, fragment);
+			transaction.CommitAllowingStateLossEx();
 
 			void OnDestroyed (object sender, EventArgs args)
 			{
@@ -332,15 +332,17 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var bounds = Bounds;
 
-				var paint = new Paint();
+				using (var paint = new Paint())
+				{
 
-				paint.Color = _color;
+					paint.Color = _color;
 
-				canvas.DrawRect(new Rect(0, 0, bounds.Right, _topSize), paint);
+					canvas.DrawRect(new Rect(0, 0, bounds.Right, _topSize), paint);
 
-				canvas.DrawRect(new Rect(0, bounds.Bottom - _bottomSize, bounds.Right, bounds.Bottom), paint);
+					canvas.DrawRect(new Rect(0, bounds.Bottom - _bottomSize, bounds.Right, bounds.Bottom), paint);
 
-				paint.Dispose();
+					paint.Dispose();
+				}
 			}
 
 			public override void SetAlpha(int alpha)
@@ -361,20 +363,37 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposed)
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
 			{
-				if (disposing)
+				if (_currentRenderer != null && _currentRenderer.Fragment.IsAlive())
 				{
-					Element.PropertyChanged -= OnElementPropertyChanged;
-					Element.SizeChanged -= OnElementSizeChanged;
+					FragmentTransaction transaction = FragmentManager.BeginTransaction();
+					transaction.RemoveEx(_currentRenderer.Fragment);
+					transaction.CommitAllowingStateLossEx();
+					FragmentManager.ExecutePendingTransactionsEx();
 				}
 
-				Element = null;
-				// TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
-				// TODO: set large fields to null.
+				Element.PropertyChanged -= OnElementPropertyChanged;
+				Element.SizeChanged -= OnElementSizeChanged;
+				((IShellController)Element).RemoveAppearanceObserver(this);
 
-				_disposed = true;
+				// This cast is necessary because IShellFlyoutRenderer doesn't implement IDisposable
+				(_flyoutRenderer as IDisposable)?.Dispose();
+
+				_currentRenderer.Dispose();
+				_currentRenderer = null;
 			}
+
+			Element = null;
+			// TODO: free unmanaged resources (unmanaged objects) and override a finalizer below.
+			// TODO: set large fields to null.
+
+			_disposed = true;
 		}
 
 		#endregion IDisposable

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
@@ -123,20 +123,18 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
+			if (_disposed)
+				return;
 
 			if (disposing)
 			{
 				_disposed = true;
 
-				_searchHandlerAppearanceTracker?.Dispose();
 				SearchHandler.PropertyChanged -= OnSearchHandlerPropertyChanged;
 
 				_textBlock.ItemClick -= OnTextBlockItemClicked;
 				_textBlock.RemoveTextChangedListener(this);
 				_textBlock.SetOnEditorActionListener(null);
-				_textBlock.Adapter.Dispose();
-				_textBlock.Adapter = null;
 				_textBlock.DropDownBackground.Dispose();
 				_textBlock.SetDropDownBackgroundDrawable(null);
 
@@ -144,6 +142,9 @@ namespace Xamarin.Forms.Platform.Android
 				_clearPlaceholderButton.Click -= OnClearPlaceholderButtonClicked;
 				_searchButton.Click -= OnSearchButtonClicked;
 
+				_textBlock.Adapter.Dispose();
+				_textBlock.Adapter = null;
+				_searchHandlerAppearanceTracker?.Dispose();
 				_textBlock.Dispose();
 				_clearButton.Dispose();
 				_searchButton.Dispose();
@@ -160,6 +161,8 @@ namespace Xamarin.Forms.Platform.Android
 			_searchHandlerAppearanceTracker = null;
 
 			SearchHandler = null;
+
+			base.Dispose(disposing);
 		}
 
 		protected virtual void LoadView(SearchHandler searchHandler)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSearchViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSearchViewAdapter.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 		Filter _filter;
 		IReadOnlyList<object> _emptyList = new List<object>();
 		IReadOnlyList<object> ListProxy => SearchController.ListProxy ?? _emptyList;
+		bool _disposed;
 
 		public ShellSearchViewAdapter(SearchHandler searchHandler, IShellContext shellContext)
 		{
@@ -30,19 +31,24 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
+			if (_disposed)
+				return;
+
+			_disposed = true;
 
 			if (disposing)
 			{
 				SearchController.ListProxyChanged -= OnListPropxyChanged;
 				_searchHandler.PropertyChanged -= OnSearchHandlerPropertyChanged;
-				_filter.Dispose();
+				_filter?.Dispose();
 			}
 
 			_filter = null;
 			_shellContext = null;
 			_searchHandler = null;
 			_defaultTemplate = null;
+
+			base.Dispose(disposing);
 		}
 		
 		public Filter Filter => _filter ?? (_filter = new CustomFilter(this));

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellTabLayoutAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellTabLayoutAppearanceTracker.cs
@@ -37,8 +37,7 @@ namespace Xamarin.Forms.Platform.Android
 			var unselectedArgb = unselected.ToAndroid(ShellRenderer.DefaultUnselectedColor).ToArgb();
 
 			tabLayout.SetTabTextColors(unselectedArgb, titleArgb);
-			using (var colorDrawable = new ColorDrawable(background.ToAndroid(ShellRenderer.DefaultBackgroundColor)))
-				tabLayout.SetBackground(colorDrawable);
+			tabLayout.SetBackground(new ColorDrawable(background.ToAndroid(ShellRenderer.DefaultBackgroundColor)));
 			tabLayout.SetSelectedTabIndicatorColor(foreground.ToAndroid(ShellRenderer.DefaultForegroundColor));
 		}
 
@@ -51,15 +50,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposed)
-			{
-				if (disposing)
-				{
-				}
+			if (_disposed)
+				return;
 
-				_shellContext = null;
-				_disposed = true;
-			}
+			_disposed = true;
+			_shellContext = null;
 		}
 
 		#endregion IDisposable

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarAppearanceTracker.cs
@@ -47,13 +47,14 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!_disposed)
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
 			{
-				if (disposing)
-				{
-				}
 				_shellContext = null;
-				_disposed = true;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -128,8 +128,6 @@ namespace Xamarin.Forms.Platform.Android
 				else
 					_shellContext.Shell.FlyoutIsPresented = !_shellContext.Shell.FlyoutIsPresented;
 			}
-
-			v.Dispose();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -137,11 +135,16 @@ namespace Xamarin.Forms.Platform.Android
 			if (_disposed)
 				return;
 
+			_disposed = true;
+
 			if (disposing)
 			{
+				if (_backButtonBehavior != null)
+					_backButtonBehavior.PropertyChanged -= OnBackButtonBehaviorChanged;
+				((IShellController)_shellContext.Shell).RemoveFlyoutBehaviorObserver(this);
+
 				UpdateTitleView(_shellContext.AndroidContext, _toolbar, null);
 
-				_drawerToggle?.Dispose();
 				if (_searchView != null)
 				{
 					_searchView.View.RemoveFromParent();
@@ -150,10 +153,7 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.Dispose();
 				}
 
-				((IShellController)_shellContext.Shell).RemoveFlyoutBehaviorObserver(this);
-
-				if (_backButtonBehavior != null)
-					_backButtonBehavior.PropertyChanged -= OnBackButtonBehaviorChanged;
+				_drawerToggle?.Dispose();
 			}
 
 			_backButtonBehavior = null;
@@ -164,7 +164,6 @@ namespace Xamarin.Forms.Platform.Android
 			Page = null;
 			_toolbar = null;
 			_drawerLayout = null;
-			_disposed = true;
 			base.Dispose(disposing);
 		}
 


### PR DESCRIPTION
### Description of Change ###
This PR takes a set of the changes from this PR https://github.com/xamarin/Xamarin.Forms/pull/6715 but in a slightly more subtle way plus it maintains the OnDestroy calls.

If we merge this version of the  PR then if we feel the other PR still has valid changes than we can rebase that one against master. I'd feel more comfortable with those changes living in master instead of just being pushed to 4.2.0. This PR also only has breaking changes with the removal of some constructors

I tested this PR with Xaminals and I'm not able to reproduce the back button bug


### Issues Resolved ### 
- fixes #6640
- closes #6715

### Platforms Affected ### 
- Android


### Testing Procedure ###
- use these nugets with xaminals and see if you can cause a dispose exception
- Run the control gallery and try to cause a dispose exception by swapping out the Shell Page or hitting back button until it exits CG

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
