### PR TITLE
[Tizen] fix picker focus issue in Tizen TV

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
@@ -9,6 +9,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		public event EventHandler TextBlockFocused;
 		public event EventHandler TextBlockUnfocused;
 
+		public event EventHandler LayoutFocused;
+		public event EventHandler LayoutUnfocused;
+
 		public bool IsTextBlockFocused => _isTexstBlockFocused;
 
 		ELayout _editfieldLayout;
@@ -91,14 +94,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			return _editfieldLayout;
 		}
 
-		protected ELayout EditfieldLayout
-		{
-			get
-			{
-				return _editfieldLayout;
-			}
-		}
-
 		protected virtual ELayout CreateEditFieldLayout(EvasObject parent)
 		{
 			var layout = new ELayout(parent);
@@ -108,11 +103,13 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				SetFocusOnTextBlock(false);
 				layout.SignalEmit("elm,state,unfocused", "");
+				LayoutUnfocused?.Invoke(this, EventArgs.Empty);
 			};
 			layout.Focused += (s, e) =>
 			{
 				AllowFocus(false);
 				layout.SignalEmit("elm,state,focused", "");
+				LayoutFocused?.Invoke(this, EventArgs.Empty);
 			};
 
 			layout.KeyDown += (s, e) =>

--- a/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
@@ -30,6 +30,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (Control != null)
 				{
 					Control.TextBlockFocused -= OnTextBlockFocused;
+					if (Device.Idiom == TargetIdiom.TV)
+					{
+						Control.LayoutFocused -= OnLayoutFocused;
+						Control.LayoutUnfocused -= OnLayoutUnfocused;
+					}
 					CleanView();
 				}
 			}
@@ -46,7 +51,15 @@ namespace Xamarin.Forms.Platform.Tizen
 					InputPanelShowByOnDemand = true,
 				};
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
+				entry.HorizontalTextAlignment = Native.TextAlignment.Center;
 				entry.TextBlockFocused += OnTextBlockFocused;
+
+				if (Device.Idiom == TargetIdiom.TV)
+				{
+					entry.LayoutFocused += OnLayoutFocused;
+					entry.LayoutUnfocused += OnLayoutUnfocused;
+				}
+
 				SetNativeControl(entry);
 			}
 			base.OnElementChanged(e);
@@ -86,6 +99,16 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateTitleColor()
 		{
 			Control.PlaceholderColor = Element.TitleColor.ToNative();
+		}
+
+		void OnLayoutFocused(object sender, EventArgs e)
+		{
+			Control.FontSize = Control.FontSize * 1.5;
+		}
+
+		void OnLayoutUnfocused(object sender, EventArgs e)
+		{
+			Control.FontSize = Control.FontSize / 1.5;
 		}
 
 		void OnTextBlockFocused(object sender, EventArgs e)


### PR DESCRIPTION
<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->
This PR is to fix below issues ocurred on Tizen TV.
 - Text is not shown
 - There is no changes and effects when the picker has focus

Since these issues are caused by the difference of UI between TV and mobile, this changes will be applied on TV profile only.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
- None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The text will grow when the picker has focus.


### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

- Before
![tv_issue](https://user-images.githubusercontent.com/20968023/66022740-e29ef980-e529-11e9-96ae-1d985f635a47.jpg)


- After
![tv_picker](https://user-images.githubusercontent.com/20968023/66022763-f34f6f80-e529-11e9-95b0-fed6bd869935.gif)



### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
