### PR TITLE
In Android : Reverse layout only when default layout direction is the…

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -515,13 +515,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			var effectiveFlowDirection = ((IVisualElementController)Element).EffectiveFlowDirection;
 
-			if (effectiveFlowDirection.IsRightToLeft() && !linearLayoutManager.ReverseLayout)
+			if (effectiveFlowDirection.IsRightToLeft() && !linearLayoutManager.ReverseLayout && Context.GetActivity().Window.DecorView.LayoutDirection == LayoutDirection.Ltr)
 			{
 				linearLayoutManager.ReverseLayout = true;
-				return;
-			}
-
-			if (effectiveFlowDirection.IsLeftToRight() && linearLayoutManager.ReverseLayout)
+			} 
+			else if (effectiveFlowDirection.IsLeftToRight() && linearLayoutManager.ReverseLayout && Context.GetActivity().Window.DecorView.LayoutDirection == LayoutDirection.Rtl)
 			{
 				linearLayoutManager.ReverseLayout = false;
 			}


### PR DESCRIPTION
… opposite of the user settings (#7393)
### Description of Change ###
Android: If the user adds this line `android:supportsRtl="true"` to application node in AndroidManifest.xml and add `Window.DecorView.LayoutDirection = LayoutDirection.Rtl;` into MainActivity.cs , the CollectionView fails to display in the correct direction chosen by the user when setting the property FlowDirection.

### Issues Resolved ### 
- fixes #7397 

### API Changes ###
None
 
### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
When setting CollectionView.FlowDirection to RightToLeft and setting `Window.DecorView.LayoutDirection = LayoutDirection.Rtl` , the CollectionView will display from Right To Left

### Before/After Screenshots ### 

Before: the whole screen is display correctly from right-to-left but the CollectionView is left-to-right
![image](https://user-images.githubusercontent.com/12378171/66025065-372c7f80-e4fe-11e9-9a23-b5d94247cc58.png)

After: After the fix, the whole screen is displayed correctly from right-to-left including the CollectionView is also right-to-left
![image](https://user-images.githubusercontent.com/12378171/66024963-f9c7f200-e4fd-11e9-8d9d-d24ed9e0471d.png)


### Testing Procedure ###
Android:
1 - Add `android:supportsRtl="true"` to application node in AndroidManifest.xml.
2- add `Window.DecorView.LayoutDirection = LayoutDirection.Rtl;` in MainActivity.cs
3- Set CollectionView's property `ItemsLayout="HorizontalList"`
4- Set CollectionView's direction `FlowDirection="RightToLeft"`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
