### PR TITLE
[Android] Fix crash changing the Application MainPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7283.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7283.cs
@@ -1,0 +1,59 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7283, "[Android] Crash changing the Application MainPage",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public class Issue7283 : TestContentPage
+	{
+		public Issue7283()
+		{
+			Title = "Issue 7283";
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				Padding = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				Text = "Press the Button below. If navigate without any errors, the test has passed."
+			};
+
+			var navigateButton = new Button
+			{
+				Text = "Navigate"
+			};
+
+			navigateButton.Clicked += async (sender, e) =>
+			{
+				navigateButton.IsEnabled = false;
+
+				await Task.Delay(2000);
+				var navigation = new NavigationPage();
+				Application.Current.MainPage = navigation;
+				await Application.Current.MainPage.Navigation.PushAsync(new ContentPage { Title = "Did I crash?" });
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(navigateButton);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1030,6 +1030,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7582.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7563.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6127.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7283.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -1027,7 +1027,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (!textColor.IsDefault)
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
-			bar.Title = currentPage != null ? currentPage.Title : string.Empty;
+			bar.Title = currentPage?.Title : string.Empty;
 
 			UpdateTitleIcon();
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -1027,7 +1027,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (!textColor.IsDefault)
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
-			bar.Title = currentPage?.Title : string.Empty;
+			bar.Title = currentPage?.Title ?? string.Empty;
 
 			UpdateTitleIcon();
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -643,7 +643,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (_masterDetailPage == null)
 			{
-				_masterDetailPage = PageController.InternalChildren[0] as MasterDetailPage;
+				if (PageController.InternalChildren.Count > 0)
+					_masterDetailPage = PageController.InternalChildren[0] as MasterDetailPage;
+
 				if (_masterDetailPage == null)
 					return;
 			}
@@ -1025,7 +1027,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (!textColor.IsDefault)
 				bar.SetTitleTextColor(textColor.ToAndroid().ToArgb());
 
-			bar.Title = currentPage.Title ?? "";
+			bar.Title = currentPage != null ? currentPage.Title : string.Empty;
 
 			UpdateTitleIcon();
 
@@ -1035,6 +1037,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void UpdateTitleIcon()
 		{
 			Page currentPage = Element.CurrentPage;
+
+			if (currentPage == null)
+				return;
+
 			ImageSource source = NavigationPage.GetTitleIconImageSource(currentPage);
 
 			if (source == null || source.IsEmpty)
@@ -1072,6 +1078,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				return;
 
 			Page currentPage = Element.CurrentPage;
+
+			if (currentPage == null)
+				return;
+
 			VisualElement titleView = NavigationPage.GetTitleView(currentPage);
 			if (_titleViewRenderer != null)
 			{


### PR DESCRIPTION
### Description of Change ###

Fix an exception (crash) changing the Application MainPage.

_NOTE: I will include the commit where we changed this behavior here. The same was working on 4.1 and it stopped working from 4.2._

### Issues Resolved ### 

- fixes #7283

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
```
{System.ArgumentOutOfRangeException: Index was out of range. Must be non-negative and less than the size of the collection.
Parameter name: index
at System.Collections.Generic.List1[T].get_Item (System.Int32 index) [0x00009] in <ff07eae8184a40a08e79049bbcb31a0e>:0 at System.Collections.ObjectModel.Collection1[T].get_Item (System.Int32 index) [0x00000] in :0
at Xamarin.Forms.Platform.Android.AppCompat.NavigationPageRenderer.RegisterToolbar () [0x0004b] in D:\a\1\s\Xamarin.Forms.Platform.Android\AppCompat\NavigationPageRenderer.cs:646
at Xamarin.Forms.Platform.Android.AppCompat.NavigationPageRenderer.OnAttachedToWindow () [0x0001f] in D:\a\1\s\Xamarin.Forms.Platform.Android\AppCompat\NavigationPageRenderer.cs:299
at Android.Views.View.n_OnAttachedToWindow (System.IntPtr jnienv, System.IntPtr native__this) [0x00009] in :0
at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.25(intptr,intptr)}
```

#### After
![7283](https://user-images.githubusercontent.com/6755973/66042478-d3fe1580-e51c-11e9-83b8-1de52ac03333.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7283. Press the "Navigate" Button. If can navigate to a new Page without any crash or exception, the test passes.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
