### PR TITLE
[Android] Fix Switch Thumb wrong color

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -45,6 +45,7 @@ using Xamarin.Forms.Controls.Issues;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
 [assembly: ExportRenderer(typeof(ShellGestures.TouchTestView), typeof(ShellGesturesTouchTestViewRenderer))]
+[assembly: ExportRenderer(typeof(Issue7249Switch), typeof(Issue7249SwitchRenderer))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY

--- a/Xamarin.Forms.ControlGallery.Android/Issue7249SwitchRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Issue7249SwitchRenderer.cs
@@ -1,0 +1,66 @@
+﻿using Android.Content;
+using Android.Graphics;
+using Android.OS;
+using Xamarin.Forms.Platform.Android;
+using Xamarin.Forms.Controls.Issues;
+using static Android.Widget.CompoundButton;
+
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class Issue7249SwitchRenderer : SwitchRenderer
+	{
+		Issue7249Switch _view;
+
+		public Issue7249SwitchRenderer(Context context) : base(context)
+		{
+
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Switch> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.OldElement != null || e.NewElement == null)
+				return;
+
+			_view = (Issue7249Switch)Element;
+
+			if (Build.VERSION.SdkInt >= BuildVersionCodes.JellyBean)
+			{
+				if (Control != null)
+				{
+					if (Control.Checked)
+					{
+						Control.TrackDrawable.SetColorFilter(_view.SwitchOnColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+					}
+					else
+					{
+						Control.TrackDrawable.SetColorFilter(_view.SwitchOffColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+					}
+
+					Control.ThumbDrawable.SetColorFilter(_view.SwitchThumbColor.ToAndroid(), PorterDuff.Mode.Multiply);
+
+					Control.CheckedChange += OnCheckedChange;
+				}
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			Control.CheckedChange -= OnCheckedChange;
+			base.Dispose(disposing);
+		}
+
+		void OnCheckedChange(object sender, CheckedChangeEventArgs e)
+		{
+			if (Control.Checked)
+			{
+				Control.TrackDrawable.SetColorFilter(_view.SwitchOnColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+			}
+			else
+			{
+				Control.TrackDrawable.SetColorFilter(_view.SwitchOffColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -120,6 +120,7 @@
       <Link>GalleryPages\AdvancedOpenGLGallery.cs</Link>
     </Compile>
     <Compile Include="ApiLabelRenderer.cs" />
+    <Compile Include="Issue7249SwitchRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7249.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7249.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7249, "(Android) Wrong color on Slider", PlatformAffected.Android)]
+	public class Issue7249 : TestContentPage
+	{
+		public Issue7249()
+		{
+			Title = "Issue 7249";
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				Padding = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				Text = "Toggle the first Switch and verify that the color of the Thumb is equal to the Thumb color of the second Switch."
+			};
+
+			var switch1 = new Switch
+			{
+				HorizontalOptions = LayoutOptions.Start,
+				IsToggled = false
+			};
+
+			var switch2 = new Switch
+			{
+				HorizontalOptions = LayoutOptions.Start,
+				IsToggled = true
+			};
+
+			var instructions2 = new Label
+			{
+				Text = "The Switch below uses a Custom Renderer to validate that can override colors using a Custom Renderer."
+			};
+
+			var customSwitch = new Issue7249Switch
+			{
+				SwitchOffColor = Color.Red,
+				SwitchOnColor = Color.Green,
+				SwitchThumbColor = Color.Yellow,
+				HorizontalOptions = LayoutOptions.Start,
+				IsToggled = false
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(switch1);
+			layout.Children.Add(switch2);
+			layout.Children.Add(instructions2);
+			layout.Children.Add(customSwitch);
+
+			Content = layout;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7249Switch : Switch
+	{
+		public static readonly BindableProperty SwitchOffColorProperty =
+		  BindableProperty.Create(nameof(SwitchOffColor),
+			  typeof(Color), typeof(CustomSwitch),
+			  Color.Default);
+
+		public Color SwitchOffColor
+		{
+			get { return (Color)GetValue(SwitchOffColorProperty); }
+			set { SetValue(SwitchOffColorProperty, value); }
+		}
+
+		public static readonly BindableProperty SwitchOnColorProperty =
+		  BindableProperty.Create(nameof(SwitchOnColor),
+			  typeof(Color), typeof(CustomSwitch),
+			  Color.Default);
+
+		public Color SwitchOnColor
+		{
+			get { return (Color)GetValue(SwitchOnColorProperty); }
+			set { SetValue(SwitchOnColorProperty, value); }
+		}
+
+		public static readonly BindableProperty SwitchThumbColorProperty =
+		  BindableProperty.Create(nameof(SwitchThumbColor),
+			  typeof(Color), typeof(CustomSwitch),
+			  Color.Default);
+
+		public Color SwitchThumbColor
+		{
+			get { return (Color)GetValue(SwitchThumbColorProperty); }
+			set { SetValue(SwitchThumbColorProperty, value); }
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1143,6 +1143,7 @@
       <DependentUpon>Issue7886.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7249.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		bool _disposed;
 		Drawable _defaultTrackDrawable;
 		string _defaultContentDescription;
-		ColorFilter _defaultThumbColorFilter;
+		bool _changedThumbColor;
 
 		public SwitchRenderer(Context context) : base(context)
 		{
@@ -91,7 +91,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					aswitch.SetOnCheckedChangeListener(this);
 					SetNativeControl(aswitch);
 					_defaultTrackDrawable = aswitch.TrackDrawable;
-					_defaultThumbColorFilter = Control.ThumbDrawable.GetColorFilter();
 				}
 				else
 					UpdateEnabled(); // Normally set by SetNativeControl, but not when the Control is reused.
@@ -140,7 +139,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (Element == null)
 				return;
 
-			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter, PorterDuff.Mode.Multiply);
+			if (Element.ThumbColor != Color.Default)
+			{
+				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor.ToAndroid(), PorterDuff.Mode.Multiply);
+				_changedThumbColor = true;
+			}
+			else
+			{
+				if (_changedThumbColor)
+				{
+					Control.ThumbDrawable?.ClearColorFilter();
+					_changedThumbColor = false;
+				}
+			}
 		}
 
 		void HandleToggled(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 	public class SwitchRenderer : ViewRenderer<Switch, ASwitch>, CompoundButton.IOnCheckedChangeListener
 	{
 		Drawable _defaultTrackDrawable;
-		ColorFilter _defaultThumbColorFilter;
+		bool _changedThumbColor;
 
 		public SwitchRenderer(Context context) : base(context)
 		{
@@ -84,7 +84,6 @@ namespace Xamarin.Forms.Platform.Android
 					aswitch.SetOnCheckedChangeListener(this);
 					SetNativeControl(aswitch);
 					_defaultTrackDrawable = Control.TrackDrawable;					
-					_defaultThumbColorFilter = Control.ThumbDrawable.GetColorFilter();
 				}
 				else
 				{
@@ -138,7 +137,19 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element == null)
 				return;
 
-			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, _defaultThumbColorFilter, PorterDuff.Mode.Multiply);
+			if (Element.ThumbColor != Color.Default)
+			{
+				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor.ToAndroid(), PorterDuff.Mode.Multiply);
+				_changedThumbColor = true;
+			}
+			else
+			{
+				if (_changedThumbColor)
+				{
+					Control.ThumbDrawable?.ClearColorFilter();
+					_changedThumbColor = false;
+				}
+			}
 		}
 
 		void HandleToggled(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

Fix **Switch Thumb wrong color on Android**. We introduce an option to change the ThumbColor here https://github.com/xamarin/Xamarin.Forms/pull/6798
We save in a variable the color of the Thumb https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs#L87 and use it if ThumbColor is not set https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs#L141
The problem is that the default Thumb color is different if the switch is Checked or not (white or pink respectively). Applied changes to set the color of the ThumbColor only when it is not Color.Default. 

### Issues Resolved ### 

- fixes #7249

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![7249-before](https://user-images.githubusercontent.com/6755973/66043982-d9f5f580-e520-11e9-9d35-48d0123f8574.gif)

#### After
![7249-after](https://user-images.githubusercontent.com/6755973/66043271-06107700-e51f-11e9-9da0-772c3366eed8.gif)

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
