### PR TITLE
[macOS] Fix GestureRecognizer on ListView Item not working

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1658.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1658.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1658, "[macOS] GestureRecognizer on ListView Item not working",
+		PlatformAffected.macOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue1658 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			var page = new ContentPage();
+
+			PushAsync(page);
+
+			page.Content = new ListView()
+			{
+				ItemsSource = new [] {"1"},
+				ItemTemplate = new DataTemplate(() =>
+				{
+					ViewCell cells = new ViewCell();
+
+					cells.ContextActions.Add(new MenuItem()
+					{
+						IconImageSource = "coffee.png",
+						AutomationId = "coffee.png"
+					});
+
+					var box = new BoxView {
+						WidthRequest = 30,
+						HeightRequest = 30,
+						Color = Color.Red,
+						AutomationId = "ColorBox"
+					};
+
+					var gr = new TapGestureRecognizer();
+					gr.Command = new Command(() => {
+						box.Color = box.Color == Color.Red ? Color.Yellow : Color.Red;
+					});
+					box.GestureRecognizers.Add(gr);
+					cells.View = new StackLayout()
+					{
+						Orientation = StackOrientation.Horizontal,
+						Children =
+						{
+							new Label()
+							{
+								Text = "Right click on any item within viewcell (including this label) should trigger context action on this row and you should see a coffee cup. Tap on colored box should change box color",
+								AutomationId = "ListViewItem"
+							},
+							box
+						}
+					};
+
+					return cells;
+				})
+			};
+		}
+
+#if UITEST && __MACOS__
+		[Test]
+		public void ContextActionsIconImageSource()
+		{
+			RunningApp.ActivateContextMenu("ListViewItem");
+			RunningApp.WaitForElement("coffee.png");
+			RunningApp.DismissContextMenu();
+
+			RunningApp.WaitForElement("ColorBox");
+			RunningApp.Screenshot("Box should be red");
+			RunningApp.Tap("ColorBox");
+			RunningApp.Screenshot("Box should be yellow");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1221,6 +1221,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6491.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6127.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7283.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue1658.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5395.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6663.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8004.cs" />

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Platform.MacOS
 		static readonly CGColor s_defaultHeaderViewsBackground = NSColor.LightGray.CGColor;
 		Cell _cell;
 		readonly NSTableViewCellStyle _style;
-		NSView _contexActionsTrackingView;
 
 		public Action<object, PropertyChangedEventArgs> PropertyChanged;
 
@@ -105,13 +104,6 @@ namespace Xamarin.Forms.Platform.MacOS
 			TextLabel?.CenterTextVertically(new CGRect(imageWidth + padding, availableHeight - labelHeights, labelWidth,
 				labelHeights));
 
-			var topNSView = Subviews.LastOrDefault();
-			if (_contexActionsTrackingView != topNSView)
-			{
-				_contexActionsTrackingView.RemoveFromSuperview();
-				_contexActionsTrackingView.Frame = Frame;
-				AddSubview(_contexActionsTrackingView, NSWindowOrderingMode.Above, Subviews.LastOrDefault());
-			}
 			base.Layout();
 		}
 
@@ -176,17 +168,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					AddSubview(AccessoryView = accessoryView);
 				}
 			}
-			AddSubview(_contexActionsTrackingView = new TrackingClickNSView());
 		}
-	}
-
-	class TrackingClickNSView : NSView
-	{
-		internal TrackingClickNSView()
-		{
-			AutoresizingMask = NSViewResizingMask.WidthSizable | NSViewResizingMask.HeightSizable;
-		}
-
 		public override void RightMouseDown(NSEvent theEvent)
 		{
 			HandleContextActions(theEvent);
@@ -196,7 +178,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void HandleContextActions(NSEvent theEvent)
 		{
-			var contextActionCell = (Superview as INativeElementView).Element as Cell;
+			var contextActionCell = this.Element as Cell;
 			var contextActionsCount = contextActionCell.ContextActions.Count;
 			if (contextActionsCount > 0)
 			{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
@@ -472,6 +472,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (clickedRow != -1)
 					(Source as ListViewDataSource)?.OnRowClicked();
 			}
+
+			public override bool ValidateProposedFirstResponder(NSResponder responder, NSEvent forEvent)
+			{
+				return true;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -130,10 +130,14 @@ namespace Xamarin.Forms.Platform.MacOS
 				var eventTracker = weakEventTracker.Target as EventTracker;
 				var view = eventTracker?._renderer?.Element as View;
 
+				var handled = false;
 				if (tapGestureRecognizer != null && view != null)
+				{
 					tapGestureRecognizer.SendTapped(view);
+					handled = true;
+				}
 
-				return false;
+				return handled;
 			});
 		}
 
@@ -166,11 +170,17 @@ namespace Xamarin.Forms.Platform.MacOS
 				var nativeRecognizer = gesturerecognizer as NSClickGestureRecognizer;
 				var recognizers = childGestures?.GetChildGesturesFor<TapGestureRecognizer>(x => x.NumberOfTapsRequired == (int)nativeRecognizer.NumberOfClicksRequired);
 
-					foreach (var item in recognizers)
-						if (item == tapGestureRecognizer && view != null)
-							tapGestureRecognizer.SendTapped(view);
+				var handled = false;
+				foreach (var item in recognizers)
+				{
+					if (item == tapGestureRecognizer && view != null)
+					{
+						tapGestureRecognizer.SendTapped(view);
+						handled = true;
+					}
+				}
 						
-				return false;
+				return handled;
 			});
 		}
 #else


### PR DESCRIPTION
### Description of Change ###
CellNSView was adding invisible TrackingClickNSView above all nested views to handle RightMouseDown and context actions. This prevented other gestures to work on Views inside ListItem.
This logic was moved to CellNsView itself.

Also NSGestureProbe now stops propagating event if it was handled by 
tapGestureRecognizer. Otherwise tap events was handled twice - by tapGestureRecognizer and ListView.ItemSelected.

### Issues Resolved ### 

- fixes #1658

### API Changes ###

 None

### Platforms Affected ### 
MacOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)