### PR TITLE
[iOS] Fixed CollectionView EmptyView incorrect bounds issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage  
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue7758">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="StackLayout" x:Key="StackLayoutStyle">
+                <Setter Property="Orientation" Value="Vertical"/>
+                <Setter Property="HorizontalOptions" Value="Center"/>
+                <Setter Property="VerticalOptions" Value="Center"/>
+                <Setter Property="Padding" Value="20, 0"/>
+                <Setter Property="Spacing" Value="10"/>
+                <Setter Property="BackgroundColor" Value="Wheat"/>
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <Grid RowSpacing="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+
+        <Grid Grid.Row="0" BackgroundColor="Black" HeightRequest="50"/>
+
+        <CollectionView Grid.Row="1">
+            <CollectionView.EmptyView>
+                <ContentView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="Beige">
+                    <StackLayout Style="{x:StaticResource StackLayoutStyle}">
+                        <Label Text="Text1" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
+
+                        <Label Text="Text2" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
+
+                        <Label Text="Text3" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
+
+                        <Label Text="Text4" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
+
+                        <Label Text="Text5" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
+
+                        <Label Text="Text6" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
+                    </StackLayout>
+                </ContentView>
+            </CollectionView.EmptyView>
+        </CollectionView>
+
+        <Grid Grid.Row="2" BackgroundColor="Black" HeightRequest="50"/>
+
+        <Grid Grid.Row="0" Grid.RowSpan="3" BackgroundColor="Red" HeightRequest="5" VerticalOptions="Center"/>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
@@ -19,38 +19,30 @@
             </Style>
         </ResourceDictionary>
     </ContentPage.Resources>
-
     <Grid RowSpacing="0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"/>
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-
-        <Grid Grid.Row="0" BackgroundColor="Black" HeightRequest="50"/>
-
+        <Grid Grid.Row="0" BackgroundColor="Black" HeightRequest="50">
+            <Label Text="If the red line is between Item 3 and Item 4, the test has passed." TextColor="White"/>
+        </Grid>
         <CollectionView Grid.Row="1">
             <CollectionView.EmptyView>
                 <ContentView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="Beige">
                     <StackLayout Style="{x:StaticResource StackLayoutStyle}">
                         <Label Text="Text1" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
-
                         <Label Text="Text2" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
-
                         <Label Text="Text3" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
-
                         <Label Text="Text4" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
-
                         <Label Text="Text5" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
-
                         <Label Text="Text6" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
                     </StackLayout>
                 </ContentView>
             </CollectionView.EmptyView>
         </CollectionView>
-
         <Grid Grid.Row="2" BackgroundColor="Black" HeightRequest="50"/>
-
         <Grid Grid.Row="0" Grid.RowSpan="3" BackgroundColor="Red" HeightRequest="5" VerticalOptions="Center"/>
     </Grid>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -1,0 +1,22 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7758, "(iOS) EmptyView is not rendered in center", PlatformAffected.iOS)]
+	public partial class Issue7758 : TestContentPage
+	{
+		public Issue7758()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -54,6 +54,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1396,6 +1399,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
+    <Compile Update="C:\Projects\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7758.xaml.cs">
+      <DependentUpon>Issue7758.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
@@ -1461,6 +1467,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5354.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7758.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -141,9 +141,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
 				_initialConstraintsSet = true;
+				UpdateEmptyView();
 			}
 		}
-
+  
 		protected virtual UICollectionViewDelegator CreateDelegator()
 		{
 			return new UICollectionViewDelegator(ItemsViewLayout, this);
@@ -370,7 +371,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					// Now that the native empty view's frame is sized to the UICollectionView, we need to handle
 					// the Forms layout for its content
-					_emptyViewFormsElement.Layout(CollectionView.Frame.ToRectangle());
+					_emptyViewFormsElement.Layout(_emptyUIView.Frame.ToRectangle());
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -370,7 +370,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					// Now that the native empty view's frame is sized to the UICollectionView, we need to handle
 					// the Forms layout for its content
-					_emptyViewFormsElement.Layout(_emptyUIView.Frame.ToRectangle());
+					_emptyViewFormsElement.Layout(CollectionView.Frame.ToRectangle());
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -143,6 +143,8 @@ namespace Xamarin.Forms.Platform.iOS
 				_initialConstraintsSet = true;
 				UpdateEmptyView();
 			}
+   
+			UpdateEmptyViewLayout();
 		}
   
 		protected virtual UICollectionViewDelegator CreateDelegator()
@@ -266,6 +268,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// If the empty view is being displayed, we might need to update it
 			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+		}
+
+		internal void UpdateEmptyViewLayout()
+		{
+			if (_emptyUIView != null && _emptyViewFormsElement != null)
+				_emptyViewFormsElement.Layout(_emptyUIView.Frame.ToRectangle());
 		}
 
 		protected void UpdateSubview(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -97,7 +97,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			SetNativeControl(ItemsViewController.View);
 			ItemsViewController.CollectionView.BackgroundColor = UIColor.Clear;
-			ItemsViewController.UpdateEmptyView();
 			UpdateHorizontalScrollBarVisibility();
 			UpdateVerticalScrollBarVisibility();
 


### PR DESCRIPTION
### Description of Change ###

Fixed CollectionView **EmptyView** incorrect bounds issue.
_NOTE: This fix also affects to CarouselView._

### Issues Resolved ### 

- fixes #7251 and #7758

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="410" alt="7758-before" src="https://user-images.githubusercontent.com/6755973/66122864-17ba5300-e5e1-11e9-9704-fda8b38819d7.png">

#### After
<img width="413" alt="7758-after" src="https://user-images.githubusercontent.com/6755973/66122868-19841680-e5e1-11e9-9de5-21bfa05f46a8.png">

<img width="951" alt="Captura de pantalla 2019-10-04 a las 17 28 09" src="https://user-images.githubusercontent.com/6755973/66221383-24b57000-e6cf-11e9-93f9-eadf6d390ca6.png">

### Testing Procedure ###
Launch Core Gallery and open the Issue 7758. If the red line is between Item 3 and 4, the test passes.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
