### PR TITLE
[iOS] Fixed error updating dynamically the NumberOfSideItems in CarouselView.

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
 
-			if (changedProperty.Is(CarouselView.PeekAreaInsetsProperty))
+			if (changedProperty.IsOneOf(CarouselView.PeekAreaInsetsProperty, CarouselView.NumberOfSideItemsProperty))
 			{
 				(CarouselViewController.Layout as CarouselViewLayout).UpdateConstraints(Frame.Size);
 				CarouselViewController.Layout.InvalidateLayout();


### PR DESCRIPTION
### Description of Change ###

Fixed error updating dynamically the **NumberOfSideItems** in CarouselView.
Testing for another Issue I have detected this issue!.

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
#### Before
![sideitems-before](https://user-images.githubusercontent.com/6755973/66139922-860f0d80-e601-11e9-9c94-27b7b725dd1a.gif)

#### After
![sideitems-after](https://user-images.githubusercontent.com/6755973/66139920-84454a00-e601-11e9-8944-251f16484c0d.gif)

### Testing Procedure ###
Launch CarouselView Core Gallery samples. Then, modify the NumberOfSideItems and check if the Carousel updates correctly.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
