### PR TITLE
In Android : Reverse layout only when default layout direction is the…

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/EdgeSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EdgeSnapHelper.cs
@@ -1,5 +1,6 @@
 using Android.Support.V7.Widget;
 using AView = Android.Views.View;
+using ALayoutDirection = Android.Views.LayoutDirection;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -13,8 +14,11 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		protected static bool IsLayoutReversed(RecyclerView.LayoutManager layoutManager)
-		{
-			if (layoutManager is LinearLayoutManager linearLayoutManager)
+        {
+            if (layoutManager.LayoutDirection == (int)(ALayoutDirection.Rtl))
+                return true;
+
+            if (layoutManager is LinearLayoutManager linearLayoutManager)
 			{
 				return linearLayoutManager.ReverseLayout;
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/EdgeSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EdgeSnapHelper.cs
@@ -14,11 +14,11 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		protected static bool IsLayoutReversed(RecyclerView.LayoutManager layoutManager)
-        {
-            if (layoutManager.LayoutDirection == (int)(ALayoutDirection.Rtl))
-                return true;
+		{
+			if (layoutManager.LayoutDirection == (int)(ALayoutDirection.Rtl))
+				return true;
 
-            if (layoutManager is LinearLayoutManager linearLayoutManager)
+			if (layoutManager is LinearLayoutManager linearLayoutManager)
 			{
 				return linearLayoutManager.ReverseLayout;
 			}
@@ -26,13 +26,13 @@ namespace Xamarin.Forms.Platform.Android
 			return false;
 		}
 
-		protected int[] CalculateDistanceToFinalSnap(RecyclerView.LayoutManager layoutManager, AView targetView, 
+		protected int[] CalculateDistanceToFinalSnap(RecyclerView.LayoutManager layoutManager, AView targetView,
 			int direction = 1)
 		{
 			var orientationHelper = CreateOrientationHelper(layoutManager);
 			var isHorizontal = layoutManager.CanScrollHorizontally();
 			var rtl = isHorizontal && IsLayoutReversed(layoutManager);
-			
+
 			var size = orientationHelper.GetDecoratedMeasurement(targetView);
 
 			var hiddenPortion = size - VisiblePortion(targetView, orientationHelper, rtl);
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.Android
 			var size = orientationHelper.GetDecoratedMeasurement(view);
 
 			var portionInViewPort = VisiblePortion(view, orientationHelper, reversed && isHorizontal);
-			
+
 			// Is the first visible view at least halfway on screen?
 			return portionInViewPort >= size / 2;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -539,19 +539,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				return;
 			}
-
-			var effectiveFlowDirection = ((IVisualElementController)Element).EffectiveFlowDirection;
-
-			if (effectiveFlowDirection.IsRightToLeft()
-				&& Context.GetActivity().Window.DecorView.LayoutDirection == LayoutDirection.Ltr)
-			{
-				linearLayoutManager.ReverseLayout = true;
-			}
-			else if (effectiveFlowDirection.IsLeftToRight()
-				&& Context.GetActivity().Window.DecorView.LayoutDirection == LayoutDirection.Rtl)
-			{
-				linearLayoutManager.ReverseLayout = false;
-			}
 		}
 
 		protected virtual int DetermineTargetPosition(ScrollToRequestEventArgs args)

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -542,11 +542,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			var effectiveFlowDirection = ((IVisualElementController)Element).EffectiveFlowDirection;
 
-			if (effectiveFlowDirection.IsRightToLeft())
+			if (effectiveFlowDirection.IsRightToLeft()
+				&& Context.GetActivity().Window.DecorView.LayoutDirection == LayoutDirection.Ltr)
 			{
 				linearLayoutManager.ReverseLayout = true;
 			}
-			else if (effectiveFlowDirection.IsLeftToRight())
+			else if (effectiveFlowDirection.IsLeftToRight()
+				&& Context.GetActivity().Window.DecorView.LayoutDirection == LayoutDirection.Rtl)
 			{
 				linearLayoutManager.ReverseLayout = false;
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
@@ -1,5 +1,6 @@
 using Android.Support.V7.Widget;
 using AView = Android.Views.View;
+using ALayoutDirection = Android.Views.LayoutDirection;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -16,8 +17,11 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		protected static bool IsLayoutReversed(RecyclerView.LayoutManager layoutManager)
-		{
-			if (layoutManager is LinearLayoutManager linearLayoutManager)
+        {
+            if (layoutManager.LayoutDirection == (int)(ALayoutDirection.Rtl))
+                return true;
+
+            if (layoutManager is LinearLayoutManager linearLayoutManager)
 			{
 				return linearLayoutManager.ReverseLayout;
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
@@ -17,11 +17,11 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		protected static bool IsLayoutReversed(RecyclerView.LayoutManager layoutManager)
-        {
-            if (layoutManager.LayoutDirection == (int)(ALayoutDirection.Rtl))
-                return true;
+		{
+			if (layoutManager.LayoutDirection == (int)(ALayoutDirection.Rtl))
+				return true;
 
-            if (layoutManager is LinearLayoutManager linearLayoutManager)
+			if (layoutManager is LinearLayoutManager linearLayoutManager)
 			{
 				return linearLayoutManager.ReverseLayout;
 			}


### PR DESCRIPTION
… opposite of the user settings (#7397)

### Description of Change ###

Android: If CollectionView.FlowDirection=RightToLeft , the change will make sure to display the CollectionView in the correct direction (right-to-left) regardless of the application direction settings defined in AndroidManifest and MainActivity.

### Issues Resolved ### 

- fixes #7397 

### API Changes ###
 
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

The change will force CollectionView to display direction RightToLeft even when application default direction is Rtl in AndroidManifest and MainActivity which currently does not.

### Before/After Screenshots ### 

Before the change, if I set the default direction of the application to right-to-left in AndroidManifest and MainActivity, everything will change direction to right to left including Shell controls but CollectionView will display left-to-right even though its FlowDirection is set to RightToLeft.
Before the change:
![image](https://user-images.githubusercontent.com/12378171/66173615-b387a580-e659-11e9-9567-3d51f0f5a52b.png)
After the change
![image](https://user-images.githubusercontent.com/12378171/66173835-debec480-e65a-11e9-9785-a90c32efbd7a.png)


### Testing Procedure ###

1- in AndroidManifest.xml , add the attribute `android:supportsRtl="true"` to `application` node.
2- in MainActivity.cs , add `Window.DecorView.LayoutDirection = LayoutDirection.Rtl;` to `OnCreate` 
3- in your xaml page add the following property to your CollectionView `FlowDirection=RightToLeft`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
