### PR TITLE
[iOS] Alternative proposal for PR 7794

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
@@ -25,9 +25,11 @@
             <RowDefinition/>
             <RowDefinition Height="Auto"/>
         </Grid.RowDefinitions>
-        <Grid Grid.Row="0" BackgroundColor="Black" HeightRequest="50">
-            <Label Text="If the red line is between Item 3 and Item 4, the test has passed." TextColor="White"/>
+        
+        <Grid Grid.Row="0" BackgroundColor="Black" Padding="10">
+            <Label Text="If the red line is not between Item 3 and Item 4, the test has failed. Change device orientation to landscape. If the red line is not between Item 3 and Item 4, the test has failed. If there is a visible white background during orientation change, the test has failed." TextColor="White"/>
         </Grid>
+        
         <CollectionView Grid.Row="1">
             <CollectionView.EmptyView>
                 <ContentView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="Beige">
@@ -42,7 +44,9 @@
                 </ContentView>
             </CollectionView.EmptyView>
         </CollectionView>
+        
         <Grid Grid.Row="2" BackgroundColor="Black" HeightRequest="50"/>
-        <Grid Grid.Row="0" Grid.RowSpan="3" BackgroundColor="Red" HeightRequest="5" VerticalOptions="Center"/>
+        
+        <Grid Grid.Row="1" BackgroundColor="Red" HeightRequest="5" VerticalOptions="Center"/>
     </Grid>
 </controls:TestContentPage> 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage  
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue7758">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="StackLayout" x:Key="StackLayoutStyle">
+                <Setter Property="Orientation" Value="Vertical"/>
+                <Setter Property="HorizontalOptions" Value="Center"/>
+                <Setter Property="VerticalOptions" Value="Center"/>
+                <Setter Property="Padding" Value="20, 0"/>
+                <Setter Property="Spacing" Value="10"/>
+                <Setter Property="BackgroundColor" Value="Wheat"/>
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <Grid RowSpacing="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+            <RowDefinition Height="Auto"/>
+        </Grid.RowDefinitions>
+        <Grid Grid.Row="0" BackgroundColor="Black" HeightRequest="50">
+            <Label Text="If the red line is between Item 3 and Item 4, the test has passed." TextColor="White"/>
+        </Grid>
+        <CollectionView Grid.Row="1">
+            <CollectionView.EmptyView>
+                <ContentView HorizontalOptions="FillAndExpand" VerticalOptions="FillAndExpand" BackgroundColor="Beige">
+                    <StackLayout Style="{x:StaticResource StackLayoutStyle}">
+                        <Label Text="Text1" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
+                        <Label Text="Text2" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
+                        <Label Text="Text3" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
+                        <Label Text="Text4" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
+                        <Label Text="Text5" HorizontalTextAlignment="Center" FontAttributes="Bold" FontSize="14.5"/>
+                        <Label Text="Text6" HorizontalTextAlignment="Center" TextColor="#636571" FontSize="14.5"/>
+                    </StackLayout>
+                </ContentView>
+            </CollectionView.EmptyView>
+        </CollectionView>
+        <Grid Grid.Row="2" BackgroundColor="Black" HeightRequest="50"/>
+        <Grid Grid.Row="0" Grid.RowSpan="3" BackgroundColor="Red" HeightRequest="5" VerticalOptions="Center"/>
+    </Grid>
+</controls:TestContentPage> 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -1,0 +1,22 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 7758, "[iOS] EmptyView is not rendered in screen center", PlatformAffected.iOS)]
+    public partial class Issue7758 : TestContentPage
+    {
+        public Issue7758()
+        {
+#if APP
+			InitializeComponent();
+#endif
+        }
+
+        protected override void Init()
+        {
+
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -10,11 +10,13 @@ namespace Xamarin.Forms.Controls.Issues
         public Issue7758()
         {
 #if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+
 			InitializeComponent();
 #endif
-        }
+		}
 
-        protected override void Init()
+		protected override void Init()
         {
 
         }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Xamarin.Forms.CustomAttributes;
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.Issues
@@ -18,7 +19,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
         {
-
+			
         }
     }
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -18,8 +18,8 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		protected override void Init()
-        {
-			
-        }
+		{
+
+		}
     }
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 7758, "[iOS] EmptyView is not rendered in screen center", PlatformAffected.iOS)]
 	public partial class Issue7758 : TestContentPage
 	{
-        public Issue7758()
+		public Issue7758()
 		{
 #if APP
 			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -4,12 +4,12 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-    [Preserve(AllMembers = true)]
-    [Issue(IssueTracker.Github, 7758, "[iOS] EmptyView is not rendered in screen center", PlatformAffected.iOS)]
-    public partial class Issue7758 : TestContentPage
-    {
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7758, "[iOS] EmptyView is not rendered in screen center", PlatformAffected.iOS)]
+	public partial class Issue7758 : TestContentPage
+	{
         public Issue7758()
-        {
+		{
 #if APP
 			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -55,6 +55,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -1416,6 +1419,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
       <DependentUpon>Issue7593.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
+      <DependentUpon>Issue7758.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1455.xaml">
@@ -1473,6 +1479,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7593.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7758.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (wasEmpty != _isEmpty)
 			{
-				UpdateEmptyView();
+				UpdateEmptyViewVisibility(_isEmpty);
 			}
 
 			if (wasEmpty && !_isEmpty)
@@ -127,6 +127,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewDidLoad();
 			AutomaticallyAdjustsScrollViewInsets = false;
 			RegisterViewTypes();
+			UpdateEmptyView();
 		}
 
 		public override void ViewWillLayoutSubviews()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -127,7 +127,6 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewDidLoad();
 			AutomaticallyAdjustsScrollViewInsets = false;
 			RegisterViewTypes();
-			UpdateEmptyView();
 		}
 
 		public override void ViewWillLayoutSubviews()
@@ -141,7 +140,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!_initialConstraintsSet)
 			{
 				ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
+				UpdateEmptyView();
 				_initialConstraintsSet = true;
+			}
+			else
+			{
+				ResizeEmptyView();
 			}
 		}
 
@@ -266,6 +270,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// If the empty view is being displayed, we might need to update it
 			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+		}
+
+		void ResizeEmptyView()
+		{
+			if (_emptyUIView != null)
+				_emptyUIView.Frame = CollectionView.Frame;
+
+			if (_emptyViewFormsElement != null)
+				_emptyViewFormsElement.Layout(CollectionView.Frame.ToRectangle());
 		}
 
 		protected void UpdateSubview(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (wasEmpty != _isEmpty)
 			{
-				UpdateEmptyViewVisibility(_isEmpty);
+				UpdateEmptyView();
 			}
 
 			if (wasEmpty && !_isEmpty)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -97,7 +97,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			SetNativeControl(ItemsViewController.View);
 			ItemsViewController.CollectionView.BackgroundColor = UIColor.Clear;
-			ItemsViewController.UpdateEmptyView();
 			UpdateHorizontalScrollBarVisibility();
 			UpdateVerticalScrollBarVisibility();
 


### PR DESCRIPTION
#7794 attempts to use the `CollectionView` frame for properly laying out the empty view. However, the comment in the same block of code mentions `_emptyUIView` is measured properly, which is not the case. 

I have noticed that when `ItemsViewController.UpdateEmptyView()` is called in `ItemsViewRenderer`, `CollectionView` is sized to have the entire screen dimensions. A second call to `UpdateEmptyView()` which happens in ItemsViewController -> NumberOfSections -> CheckForEmptySource uses the correct dimensions.

I moved `UpdateEmptyView()` call into `ViewDidLoad` which fixed the issue.

fixes #7251 and #7758