### PR TITLE
Fix [WPF] Frame cornerRadius doesn't clip content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7825.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7825.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7825, "WPF Frame cornerRadius doesn't clip content", PlatformAffected.WPF)]
+	public class Issue7825 : ContentPage
+	{
+		public Issue7825()
+		{
+			var sl = new StackLayout { Padding = new Size(20, 20) };
+
+			var frame = new Frame {
+				Content = new BoxView() {
+					BackgroundColor = Color.Red
+				},
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+			frame.Padding = 0;
+			frame.CornerRadius = 50;
+
+			sl.Children.Add(frame);
+			Content = sl;
+		}
+	}
+}
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,6 +19,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7825.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.WPF/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/FrameRenderer.cs
@@ -6,12 +6,36 @@ using System.Text;
 using System.Threading.Tasks;
 using System.Windows;
 using System.Windows.Controls;
+using System.Windows.Data;
+using System.Windows.Media;
 
 namespace Xamarin.Forms.Platform.WPF
 {
 	public class FrameRenderer : ViewRenderer<Frame, Border>
 	{
 		VisualElement _currentView;
+		readonly Border _rounding;
+		readonly VisualBrush _mask;
+
+		public FrameRenderer()
+		{
+			_rounding = new Border();
+			_rounding.Background = Color.White.ToBrush();
+			_rounding.SnapsToDevicePixels = true;
+			var wb = new System.Windows.Data.Binding(nameof(Border.ActualWidth));
+			wb.RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
+			{
+				AncestorType = typeof(Border)
+			};
+			_rounding.SetBinding(Border.WidthProperty, wb);
+			var hb = new System.Windows.Data.Binding(nameof(Border.ActualHeight));
+			hb.RelativeSource = new RelativeSource(RelativeSourceMode.FindAncestor)
+			{
+				AncestorType = typeof(Border)
+			};
+			_rounding.SetBinding(Border.HeightProperty, hb);
+			_mask = new VisualBrush(_rounding);
+		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
 		{
@@ -56,6 +80,7 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 
 			_currentView = Element.Content;
+			Control.OpacityMask = _mask;
 			Control.Child = _currentView != null ? Platform.GetOrCreateRenderer(_currentView).GetNativeElement() : null;
 		}
 
@@ -76,6 +101,7 @@ namespace Xamarin.Forms.Platform.WPF
 		void UpdateCornerRadius()
 		{
 			Control.CornerRadius = new System.Windows.CornerRadius(Element.CornerRadius >= 0 ? Element.CornerRadius : 0);
+			_rounding.CornerRadius = Control.CornerRadius;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Adds opacity mask to clip nested content

### Issues Resolved ### 

- fixes #7825

### API Changes ###
 
 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Before 
![image](https://user-images.githubusercontent.com/33512073/66220456-b7f1a400-e6d5-11e9-92d3-d855eb905c3d.png)

After
![image](https://user-images.githubusercontent.com/33512073/66220491-cb047400-e6d5-11e9-988c-fa47e0840bd1.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
