### PR TITLE
Fix typo in RefreshViewRenderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _isDisposed;
 		bool _isRefreshing;
 		bool _usingLargeTitles;
-		nfloat _origininalY;
+		nfloat _originalY;
 		nfloat _refreshControlHeight;
 		UIView _refreshControlParent;
 		UIRefreshControl _refreshControl;
@@ -112,9 +112,9 @@ namespace Xamarin.Forms.Platform.iOS
 					return true;
 
 				if (refreshing)
-					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _origininalY - _refreshControlHeight), true);
+					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY - _refreshControlHeight), true);
 				else
-					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _origininalY), true);
+					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY), true);
 
 				return true;
 			}
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				scrollView.AlwaysBounceVertical = true;
 
-				_origininalY = scrollView.ContentOffset.Y;
+				_originalY = scrollView.ContentOffset.Y;
 				_refreshControlHeight = _refreshControl.Frame.Size.Height;
 
 				return true;


### PR DESCRIPTION
Just a lil typo fix. `_origininalY` -> `_originalY`