### PR TITLE
Fix double refresh issue with RefreshView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7803.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7803.xaml
@@ -1,0 +1,35 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue7803">
+    
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+
+        <StackLayout Grid.Row="0" Orientation="Vertical" Spacing="5">
+            <Label LineBreakMode="WordWrap" Text="Pull to refresh and verify that the last item shows 19. If not, the test has failed." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+            <Label LineBreakMode="WordWrap" Text="{Binding Text}" HorizontalTextAlignment="Center"/>
+        </StackLayout>
+
+        <RefreshView Grid.Row="1" IsRefreshing="{Binding IsRefreshing}" Command="{Binding RefreshCommand}">
+            <CollectionView AutomationId="CollectionView7803" ItemsSource="{Binding Items}">
+                <CollectionView.ItemsLayout>
+                    <LinearItemsLayout Orientation="Vertical" ItemSpacing="5"/>
+                </CollectionView.ItemsLayout>
+                
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid HeightRequest="100" BackgroundColor="Beige">
+                            <Label Text="{Binding Position}" HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </RefreshView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7803.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7803.xaml.cs
@@ -1,0 +1,170 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using System.ComponentModel;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Linq;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7803, "[Bug] CarouselView/RefreshView pull to refresh command firing twice on a single pull", PlatformAffected.All)]
+	public partial class Issue7803 : TestContentPage
+	{
+#if APP
+		public Issue7803()
+		{
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+
+			InitializeComponent();
+
+			BindingContext = new ViewModel7803();
+		}
+#endif
+
+		protected override void Init()
+		{
+
+		}
+
+#if UITEST
+		[Test]
+		public void DelayedIsRefreshingAndCommandTest_SwipeDown()
+		{
+			var collectionView = RunningApp.WaitForElement(q => q.Marked("CollectionView7803"))[0];
+
+			RunningApp.Pan(new Drag(collectionView.Rect, Drag.Direction.TopToBottom, Drag.DragLength.Medium));
+
+			RunningApp.WaitForElement(q => q.Marked("Count: 20"));
+
+			AppResult[] lastCellResults = null;
+
+			RunningApp.QueryUntilPresent(() =>
+			{
+				RunningApp.DragCoordinates(collectionView.Rect.CenterX, collectionView.Rect.Y + collectionView.Rect.Height - 50, collectionView.Rect.CenterX, collectionView.Rect.Y + 5);
+
+				lastCellResults = RunningApp.Query("19");
+
+				return lastCellResults;
+			}, 10, 1);
+
+			Assert.IsTrue(lastCellResults?.Any() ?? false);
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModel7803 : INotifyPropertyChanged
+	{
+		public ObservableCollection<Model7803> Items { get; set; } = new ObservableCollection<Model7803>();
+
+		private bool _isRefreshing;
+
+		public bool IsRefreshing
+		{
+			get
+			{
+				return _isRefreshing;
+			}
+			set
+			{
+				_isRefreshing = value;
+
+				OnPropertyChanged("IsRefreshing");
+			}
+		}
+
+		private string _text;
+
+		public string Text
+		{
+			get
+			{
+				return _text;
+			}
+			set
+			{
+				_text = value;
+
+				OnPropertyChanged("Text");
+			}
+		}
+
+		public Command RefreshCommand { get; set; }
+
+		public ViewModel7803()
+		{
+			PopulateItems();
+
+			RefreshCommand = new Command(async () =>
+			{
+				IsRefreshing = true;
+
+				await Task.Delay(2000);
+				PopulateItems();
+
+				IsRefreshing = false;
+			});
+		}
+
+		void PopulateItems()
+		{
+			var count = Items.Count;
+
+			for (var i = count; i < count + 10; i++)
+				Items.Add(new Model7803() { Position = i });
+
+			Text = "Count: " + Items.Count;
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged(string name)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Model7803 : INotifyPropertyChanged
+	{
+		private int _position;
+
+		public int Position
+		{
+			get
+			{
+				return _position;
+			}
+			set
+			{
+				_position = value;
+
+				OnPropertyChanged("Position");
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged(string name)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7803.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7803.xaml.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Pan(new Drag(collectionView.Rect, Drag.Direction.TopToBottom, Drag.DragLength.Medium));
 
 			RunningApp.WaitForElement(q => q.Marked("Count: 20"));
+			RunningApp.WaitForNoElement(q => q.Marked("Count: 30"));
 
 			AppResult[] lastCellResults = null;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -58,6 +58,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7803.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1416,6 +1419,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
       <DependentUpon>Issue7593.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7803.xaml.cs">
+      <DependentUpon>Issue7803.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1455.xaml">
@@ -1473,6 +1479,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7593.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7803.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -49,15 +49,19 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			set
 			{
-				_refreshing = value;
+				// Allow RefreshView.IsRefreshing to sync up with Refreshing
+				if (RefreshView != null && RefreshView.IsRefreshing != value)
+				{
+					RefreshView.IsRefreshing = value;
+					return;
+				}
 
-				if (RefreshView != null && RefreshView.IsRefreshing != _refreshing)
-					RefreshView.IsRefreshing = _refreshing;
+				_refreshing = value;
 
 				base.Refreshing = _refreshing;
 
-				if (base.Refreshing && Element is RefreshView refreshView && refreshView.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
-					refreshView.Command.Execute(refreshView?.CommandParameter);
+				if (base.Refreshing && RefreshView != null && RefreshView.Command != null && RefreshView.Command.CanExecute(RefreshView?.CommandParameter))
+					RefreshView.Command.Execute(RefreshView?.CommandParameter);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -49,19 +49,12 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			set
 			{
-				// Allow RefreshView.IsRefreshing to sync up with Refreshing
-				if (RefreshView != null && RefreshView.IsRefreshing != value)
-				{
-					RefreshView.SetValueFromRenderer(RefreshView.IsRefreshingProperty, value);
-					return;
-				}
-
 				_refreshing = value;
 
 				base.Refreshing = _refreshing;
 
-				if (base.Refreshing && RefreshView != null && RefreshView.Command != null && RefreshView.Command.CanExecute(RefreshView?.CommandParameter))
-					RefreshView.Command.Execute(RefreshView?.CommandParameter);
+				if (base.Refreshing && RefreshView?.Command != null && RefreshView.Command.CanExecute(RefreshView.CommandParameter))
+					RefreshView.Command.Execute(RefreshView.CommandParameter);
 			}
 		}
 
@@ -190,7 +183,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void OnRefresh()
 		{
-			Refreshing = true;
+			// Allow IsRefreshing to fire the refresh command
+			if (!RefreshView.IsRefreshing)
+				RefreshView.SetValueFromRenderer(RefreshView.IsRefreshingProperty, true);
+			else
+				UpdateIsRefreshing();
 		}
 
 		void HandlePropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Forms.Platform.Android
 				// Allow RefreshView.IsRefreshing to sync up with Refreshing
 				if (RefreshView != null && RefreshView.IsRefreshing != value)
 				{
-					RefreshView.IsRefreshing = value;
+					RefreshView.SetValueFromRenderer(RefreshView.IsRefreshingProperty, value);
 					return;
 				}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -31,8 +31,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var refreshView = Element;
 
-					if (refreshView?.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
-						refreshView.Command.Execute(refreshView?.CommandParameter);
+					if (refreshView?.Command != null && refreshView.Command.CanExecute(refreshView.CommandParameter))
+						refreshView.Command.Execute(refreshView.CommandParameter);
 				}
 				else
 					_refreshControl.EndRefreshing();

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -23,22 +23,15 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			set
 			{
-				var refreshView = Element;
-
-				// Allow refreshView.IsRefreshing to sync up with Refreshing
-				if (refreshView != null && refreshView.IsRefreshing != value)
-				{
-					refreshView.SetValueFromRenderer(RefreshView.IsRefreshingProperty, value);
-					return;
-				}
-
 				_isRefreshing = value;
 
 				if (_isRefreshing)
 				{
 					_refreshControl.BeginRefreshing();
 
-					if (refreshView != null && refreshView.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
+					var refreshView = Element;
+
+					if (refreshView?.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
 						refreshView.Command.Execute(refreshView?.CommandParameter);
 				}
 				else
@@ -218,7 +211,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnRefresh(object sender, EventArgs e)
 		{
-			IsRefreshing = true;
+			var refreshView = Element;
+
+			// Allow IsRefreshing to fire the refresh command
+			if (!refreshView.IsRefreshing)
+				refreshView.SetValueFromRenderer(RefreshView.IsRefreshingProperty, true);
+			else
+				UpdateIsRefreshing();
 		}
 
 		void IEffectControlProvider.RegisterEffect(Effect effect)

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -17,19 +17,28 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public bool IsRefreshing
 		{
-			get { return _isRefreshing; }
+			get
+			{
+				return _isRefreshing;
+			}
 			set
 			{
-				_isRefreshing = value;
+				var refreshView = Element;
 
-				if (Element != null && Element.IsRefreshing != _isRefreshing)
-					Element.IsRefreshing = _isRefreshing;
+				// Allow refreshView.IsRefreshing to sync up with Refreshing
+				if (refreshView != null && refreshView.IsRefreshing != value)
+				{
+					refreshView.IsRefreshing = value;
+					return;
+				}
+
+				_isRefreshing = value;
 
 				if (_isRefreshing)
 				{
 					_refreshControl.BeginRefreshing();
 
-					if (Element is RefreshView refreshView && refreshView.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
+					if (refreshView != null && refreshView.Command != null && refreshView.Command.CanExecute(refreshView?.CommandParameter))
 						refreshView.Command.Execute(refreshView?.CommandParameter);
 				}
 				else

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 				// Allow refreshView.IsRefreshing to sync up with Refreshing
 				if (refreshView != null && refreshView.IsRefreshing != value)
 				{
-					refreshView.IsRefreshing = value;
+					refreshView.SetValueFromRenderer(RefreshView.IsRefreshingProperty, value);
 					return;
 				}
 


### PR DESCRIPTION
### Description of Change ###

If you refresh a RefreshView and add a time delay beforehand (through Task.Delay or network latency), then previously we ended up calling the refresh command twice. This PR fixes the issue. Also added a UI test.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7803

### Testing Procedure ###
Pull to refresh and make sure that the count shows 20 instead of 30.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
