### PR TITLE
[Android, iOS] Fixed CarouselView ScrollTo (by object) not working issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml
@@ -8,6 +8,8 @@
              x:Class="Xamarin.Forms.Controls.Issues.Issue7798">
     <ContentPage.Content>
   <StackLayout Margin="20">
+      <Label
+          Text="Press the Button below and verify that the Carousel scroll position moves to monkey 9 (Proboscis Monkey)."/>
         <StackLayout Orientation="Horizontal"
                      HorizontalOptions="Center">
             <Label Text="Animate scroll: "
@@ -15,7 +17,7 @@
             <Switch x:Name="animateSwitch"
                     IsToggled="true" />
         </StackLayout>
-        <Button Text="Scroll to item 6"
+        <Button Text="Scroll to monkey 9 (Proboscis Monkey)"
                 Clicked="OnButtonClicked" />
         <CarouselView x:Name="carouselView"
                       ItemsSource="{Binding Monkeys}"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7798">
+    <ContentPage.Content>
+  <StackLayout Margin="20">
+        <StackLayout Orientation="Horizontal"
+                     HorizontalOptions="Center">
+            <Label Text="Animate scroll: "
+                   VerticalTextAlignment="Center" />
+            <Switch x:Name="animateSwitch"
+                    IsToggled="true" />
+        </StackLayout>
+        <Button Text="Scroll to item 6"
+                Clicked="OnButtonClicked" />
+        <CarouselView x:Name="carouselView"
+                      ItemsSource="{Binding Monkeys}"
+                      Scrolled="OnCarouselViewScrolled">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout>
+                        <Frame HasShadow="True"
+                               BorderColor="DarkGray"
+                               CornerRadius="5"
+                               Margin="20"
+                               HeightRequest="300"
+                               HorizontalOptions="Center"
+                               VerticalOptions="CenterAndExpand">
+                            <StackLayout>
+                                <Label Text="{Binding Name}" 
+                                       FontAttributes="Bold"
+                                       FontSize="Large"
+                                       HorizontalOptions="Center"
+                                       VerticalOptions="Center" />
+                                <Image Source="{Binding ImageUrl}" 
+                                       Aspect="AspectFill"
+                                       HeightRequest="150"
+                                       WidthRequest="150"
+                                       HorizontalOptions="Center" />
+                                <Label Text="{Binding Location}"
+                                       HorizontalOptions="Center" />
+                                <Label Text="{Binding Details}"
+                                       FontAttributes="Italic"
+                                       HorizontalOptions="Center"
+                                       MaxLines="5"
+                                       LineBreakMode="TailTruncation" />
+                            </StackLayout>
+                        </Frame>
+                    </StackLayout>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+    </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 #if APP
 			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			Title = "Issue 7798";
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7798()
 		{
 #if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7798.xaml.cs
@@ -1,0 +1,223 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Diagnostics;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7798, "[iOS] CarouselView ScrollTo (by object) not working", PlatformAffected.iOS)]
+	public partial class Issue7798 : TestContentPage
+	{
+		public Issue7798()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			BindingContext = new Issue7798ViewModel();
+		}
+
+		void OnButtonClicked(object sender, EventArgs e)
+		{
+			var viewModel = BindingContext as Issue7798ViewModel;
+			var monkey = viewModel.Monkeys.FirstOrDefault(m => m.Name == "Proboscis Monkey");
+			carouselView.ScrollTo(monkey, position: ScrollToPosition.MakeVisible, animate: animateSwitch.IsToggled);
+		}
+
+		void OnCarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
+		{
+			Debug.WriteLine("HorizontalDelta: " + e.HorizontalDelta);
+			Debug.WriteLine("VerticalDelta: " + e.VerticalDelta);
+			Debug.WriteLine("HorizontalOffset: " + e.HorizontalOffset);
+			Debug.WriteLine("VerticalOffset: " + e.VerticalOffset);
+			Debug.WriteLine("FirstVisibleItemIndex: " + e.FirstVisibleItemIndex);
+			Debug.WriteLine("CenterItemIndex: " + e.CenterItemIndex);
+			Debug.WriteLine("LastVisibleItemIndex: " + e.LastVisibleItemIndex);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7798Model
+	{
+		public string Name { get; set; }
+		public string Location { get; set; }
+		public string Details { get; set; }
+		public string ImageUrl { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7798ViewModel : BindableObject
+	{
+		readonly IList<Issue7798Model> _source;
+
+		public ObservableCollection<Issue7798Model> Monkeys { get; private set; }
+
+		public Issue7798ViewModel()
+		{
+			_source = new List<Issue7798Model>();
+			CreateMonkeyCollection();
+		}
+
+		void CreateMonkeyCollection()
+		{
+			_source.Add(new Issue7798Model
+			{
+				Name = "Baboon",
+				Location = "Africa & Asia",
+				Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Capuchin Monkey",
+				Location = "Central & South America",
+				Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Blue Monkey",
+				Location = "Central and East Africa",
+				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Squirrel Monkey",
+				Location = "Central & South America",
+				Details = "The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Saimiri_sciureus-1_Luc_Viatour.jpg/220px-Saimiri_sciureus-1_Luc_Viatour.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Golden Lion Tamarin",
+				Location = "Brazil",
+				Details = "The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Golden_lion_tamarin_portrait3.jpg/220px-Golden_lion_tamarin_portrait3.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Howler Monkey",
+				Location = "South America",
+				Details = "Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Alouatta_guariba.jpg/200px-Alouatta_guariba.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Japanese Macaque",
+				Location = "Japan",
+				Details = "The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each year.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Macaca_fuscata_fuscata1.jpg/220px-Macaca_fuscata_fuscata1.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Mandrill",
+				Location = "Southern Cameroon, Gabon, and Congo",
+				Details = "The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandrill_at_san_francisco_zoo.jpg/220px-Mandrill_at_san_francisco_zoo.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Proboscis Monkey",
+				Location = "Borneo",
+				Details = "The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Proboscis_Monkey_in_Borneo.jpg/250px-Proboscis_Monkey_in_Borneo.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Red-shanked Douc",
+				Location = "Vietnam, Laos",
+				Details = "The red-shanked douc is a species of Old World monkey, among the most colourful of all primates. This monkey is sometimes called the \"costumed ape\" for its extravagant appearance. From its knees to its ankles it sports maroon-red \"stockings\", and it appears to wear white forearm length gloves. Its attire is finished with black hands and feet. The golden face is framed by a white ruff, which is considerably fluffier in males. The eyelids are a soft powder blue. The tail is white with a triangle of white hair at the base. Males of all ages have a white spot on both sides of the corners of the rump patch, and red and white genitals.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Portrait_of_a_Douc.jpg/159px-Portrait_of_a_Douc.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Gray-shanked Douc",
+				Location = "Vietnam",
+				Details = "The gray-shanked douc langur is a douc species native to the Vietnamese provinces of Quảng Nam, Quảng Ngãi, Bình Định, Kon Tum, and Gia Lai. The total population is estimated at 550 to 700 individuals. In 2016, Dr Benjamin Rawson, Country Director of Fauna & Flora International - Vietnam Programme, announced a discovery of an additional population of more than 500 individuals found in Central Vietnam, bringing the total population up to approximately 1000 individuals.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Cuc.Phuong.Primate.Rehab.center.jpg/320px-Cuc.Phuong.Primate.Rehab.center.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Golden Snub-nosed Monkey",
+				Location = "China",
+				Details = "The golden snub-nosed monkey is an Old World monkey in the Colobinae subfamily. It is endemic to a small area in temperate, mountainous forests of central and Southwest China. They inhabit these mountainous forests of Southwestern China at elevations of 1,500-3,400 m above sea level. The Chinese name is Sichuan golden hair monkey. It is also widely referred to as the Sichuan snub-nosed monkey. Of the three species of snub-nosed monkeys in China, the golden snub-nosed monkey is the most widely distributed throughout China.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg/165px-Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Black Snub-nosed Monkey",
+				Location = "China",
+				Details = "The black snub-nosed monkey, also known as the Yunnan snub-nosed monkey, is an endangered species of primate in the family Cercopithecidae. It is endemic to China, where it is known to the locals as the Yunnan golden hair monkey and the black golden hair monkey. It is threatened by habitat loss. It was named after Bishop Félix Biet.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/RhinopitecusBieti.jpg/320px-RhinopitecusBieti.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Tonkin Snub-nosed Monkey",
+				Location = "Vietnam",
+				Details = "The Tonkin snub-nosed monkey or Dollman's snub-nosed monkey is a slender-bodied arboreal Old World monkey, endemic to northern Vietnam. It is a black and white monkey with a pink nose and lips and blue patches round the eyes. It is found at altitudes of 200 to 1,200 m (700 to 3,900 ft) on fragmentary patches of forest on craggy limestone areas. First described in 1912, the monkey was rediscovered in 1990 but is exceedingly rare. In 2008, fewer than 250 individuals were thought to exist, and the species was the subject of intense conservation effort. The main threats faced by these monkeys is habitat loss and hunting, and the International Union for Conservation of Nature has rated the species as \"critically endangered\".",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg/320px-Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Thomas's Langur",
+				Location = "Indonesia",
+				Details = "Thomas's langur is a species of primate in the family Cercopithecidae. It is endemic to North Sumatra, Indonesia. Its natural habitat is subtropical or tropical dry forests. It is threatened by habitat loss. Its native names are reungkah in Acehnese and kedih in Alas.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Purple-faced Langur",
+				Location = "Sri Lanka",
+				Details = "The purple-faced langur, also known as the purple-faced leaf monkey, is a species of Old World monkey that is endemic to Sri Lanka. The animal is a long-tailed arboreal species, identified by a mostly brown appearance, dark face (with paler lower face) and a very shy nature. The species was once highly prevalent, found in suburban Colombo and the \"wet zone\" villages (areas with high temperatures and high humidity throughout the year, whilst rain deluges occur during the monsoon seasons), but rapid urbanization has led to a significant decrease in the population level of the monkeys.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
+			});
+
+			_source.Add(new Issue7798Model
+			{
+				Name = "Gelada",
+				Location = "Ethiopia",
+				Details = "The gelada, sometimes called the bleeding-heart monkey or the gelada baboon, is a species of Old World monkey found only in the Ethiopian Highlands, with large populations in the Semien Mountains. Theropithecus is derived from the Greek root words for \"beast-ape.\" Like its close relatives the baboons, it is largely terrestrial, spending much of its time foraging in grasslands.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Gelada-Pavian.jpg/320px-Gelada-Pavian.jpg"
+			});
+
+			Monkeys = new ObservableCollection<Issue7798Model>(_source);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -58,6 +58,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7798.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1401,6 +1404,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
+    <Compile Update="C:\Projects\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7798.xaml.cs">
+      <DependentUpon>Issue7798.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
@@ -1473,6 +1479,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7593.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7798.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -165,6 +165,9 @@ namespace Xamarin.Forms
 			set => SetValue(ItemsLayoutProperty, value);
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool IsScrolling { get; set; }
+
 		public event EventHandler<CurrentItemChangedEventArgs> CurrentItemChanged;
 		public event EventHandler<PositionChangedEventArgs> PositionChanged;
 
@@ -214,8 +217,8 @@ namespace Xamarin.Forms
 
 			carousel.PositionChanged?.Invoke(carousel, args);
 
-			//user is interacting with the carousel we don't need to scroll to item 
-			if (!carousel.IsDragging)
+			// If the user is interacting with the Carousel or the Carousel is doing ScrollTo, we don't need to scroll to item.
+			if (!carousel.IsDragging && !carousel.IsScrolling)
 				carousel.ScrollTo(args.CurrentPosition, position: ScrollToPosition.Center, animate: carousel.IsScrollAnimated);
 
 			carousel.OnPositionChanged(args);
@@ -258,6 +261,12 @@ namespace Xamarin.Forms
 		public void SetIsDragging(bool value)
 		{
 			SetValue(IsDraggingPropertyKey, value);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SetIsScrolling(bool value)
+		{
+			IsScrolling = value;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -85,6 +85,11 @@ namespace Xamarin.Forms.Platform.Android
 				else
 					Carousel.SetIsDragging(false);
 			}
+
+			if (state == ScrollStateIdle)
+				Carousel.SetIsScrolling(false);
+			else
+				Carousel.SetIsScrolling(true);
 		}
 
 		protected override ItemDecoration CreateSpacingDecoration(IItemsLayout itemsLayout)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -155,11 +155,13 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnScrollViewChanging(object sender, ScrollViewerViewChangingEventArgs e)
 		{
 			CarouselView.SetIsDragging(true);
+			CarouselView.SetIsScrolling(true);
 		}
 
 		void OnScrollViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
 		{
 			CarouselView.SetIsDragging(e.IsIntermediate);
+			CarouselView.SetIsScrolling(e.IsIntermediate);
 		}
 
 		void UpdatePeekAreaInsets()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -1,8 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using CoreGraphics;
-using Foundation;
+﻿using Foundation;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -60,6 +56,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void RegisterViewTypes()
 		{
 			CollectionView.RegisterClassForCell(typeof(CarouselTemplatedCell), CarouselTemplatedCell.ReuseId);
+			base.RegisterViewTypes();
 		}
 
 		internal void TearDown()
@@ -74,6 +71,11 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void DraggingEnded(UIScrollView scrollView, bool willDecelerate)
 		{
 			_carouselView.SetIsDragging(false);
+		}
+
+		internal void UpdateIsScrolling(bool isScrolling)
+		{
+			_carouselView.IsScrolling = isScrolling;
 		}
 
 		void UpdateInitialPosition()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.iOS
 			};
 
 			ItemsViewController.ItemsView.SendScrolled(itemsViewScrolledEventArgs);
-			CarouselViewController?.DraggingStarted(scrollView);
+			CarouselViewController?.UpdateIsScrolling(true);
 
 			_previousHorizontalOffset = (float)contentOffsetX;
 			_previousVerticalOffset = (float)contentOffsetY;
@@ -170,7 +170,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ScrollAnimationEnded(UIScrollView scrollView)
 		{
 			GroupableItemsViewController?.HandleScrollAnimationEnded();
-			CarouselViewController?.DraggingEnded(scrollView, false);
+			CarouselViewController?.UpdateIsScrolling(false);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -67,6 +67,7 @@ namespace Xamarin.Forms.Platform.iOS
 			};
 
 			ItemsViewController.ItemsView.SendScrolled(itemsViewScrolledEventArgs);
+			CarouselViewController?.DraggingStarted(scrollView);
 
 			_previousHorizontalOffset = (float)contentOffsetX;
 			_previousVerticalOffset = (float)contentOffsetY;
@@ -169,6 +170,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ScrollAnimationEnded(UIScrollView scrollView)
 		{
 			GroupableItemsViewController?.HandleScrollAnimationEnded();
+			CarouselViewController?.DraggingEnded(scrollView, false);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Fixed CarouselView ScrollTo (by object) not working issue.

### Issues Resolved ### 

- fixes #7798 and #7801

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue7798-before](https://user-images.githubusercontent.com/6755973/66327994-12843d80-e92c-11e9-8dbf-45b0a0de4214.gif)

#### After

Android
![issue7798-after-droid](https://user-images.githubusercontent.com/6755973/66327143-9a694800-e92a-11e9-8555-3717911e8b46.gif)

iOS
![issue7798-after-ios](https://user-images.githubusercontent.com/6755973/66327129-976e5780-e92a-11e9-8f62-718d5998598e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7798. Press the Button and check if the Carousel navigate to the 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
