### PR TITLE
[iOS] Fixed crash displaying strings in CarouselView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"  
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7789">
+    <ContentPage.Content>
+    <StackLayout Margin="10">
+        <CarouselView>
+            <CarouselView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Baboon</x:String>
+                    <x:String>Capuchin Monkey</x:String>
+                    <x:String>Blue Monkey</x:String>
+                    <x:String>Squirrel Monkey</x:String>
+                    <x:String>Golden Lion Tamarin</x:String>
+                    <x:String>Howler Monkey</x:String>
+                    <x:String>Japanese Macaque</x:String>
+                    <x:String>Mandrill</x:String>
+                    <x:String>Proboscis Monkey</x:String>
+                    <x:String>Red-shanked Douc</x:String>
+                    <x:String>Gray-shanked Douc</x:String>
+                    <x:String>Golden Snub-nosed Monkey</x:String>
+                    <x:String>Black Snub-nosed Monkey</x:String>
+                    <x:String>Tonkin Snub-nosed Monkey</x:String>
+                    <x:String>Thomas's Langur</x:String>
+                    <x:String>Purple-faced Langur</x:String>
+                    <x:String>Gelada</x:String>
+                </x:Array>
+            </CarouselView.ItemsSource>
+        </CarouselView>
+    </StackLayout> 
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml
@@ -8,7 +8,10 @@
              x:Class="Xamarin.Forms.Controls.Issues.Issue7789">
     <ContentPage.Content>
     <StackLayout Margin="10">
-        <CarouselView>
+        <Label
+            Text="If the CarouselView below is rendered without problems, the test passes."/>
+        <CarouselView
+            BackgroundColor="GreenYellow">
             <CarouselView.ItemsSource>
                 <x:Array Type="{x:Type x:String}">
                     <x:String>Baboon</x:String>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7789, "CarouselView crash when displaying strings", PlatformAffected.iOS)]
+	public partial class Issue7789 : TestContentPage
+	{
+		public Issue7789()
+		{
+#if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1406,10 +1406,10 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\Projects\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7789.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
       <DependentUpon>Issue7789.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -58,6 +58,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1403,6 +1406,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
+    <Compile Update="C:\Projects\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7789.xaml.cs">
+      <DependentUpon>Issue7789.xaml</DependentUpon>
+    </Compile>
     <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
@@ -1475,6 +1481,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7593.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7789.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void RegisterViewTypes()
 		{
 			CollectionView.RegisterClassForCell(typeof(CarouselTemplatedCell), CarouselTemplatedCell.ReuseId);
+			base.RegisterViewTypes();
 		}
 
 		internal void TearDown()


### PR DESCRIPTION
### Description of Change ###

 Fixed **crash** displaying strings in **CarouselView**. Example:

```
 <StackLayout Margin="10">
        <CarouselView>
            <CarouselView.ItemsSource>
                <x:Array Type="{x:Type x:String}">
                    <x:String>Baboon</x:String>
                    <x:String>Capuchin Monkey</x:String>
                    <x:String>Blue Monkey</x:String>
                </x:Array>
            </CarouselView.ItemsSource>
        </CarouselView>
</StackLayout> 
```
The crash was on `DequeueReusableCell` because with the CarouselView we was registering the cell used with template in the Carousel https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs#L62. However, without template (Example: using strings) the cell expected was not registered: https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs#L253

### Issues Resolved ### 

- fixes #7789 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7789. If the CarouselView is rendered (without any error), the test passes.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
