### PR TITLE
build.cake: more readable way of using an enum

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -302,11 +302,9 @@ RunTarget(target);
 
 MSBuildSettings GetMSBuildSettings()
 {
-    var msbuildSettings =  new MSBuildSettings();
-
-    msbuildSettings.PlatformTarget = PlatformTarget.MSIL;
-    msbuildSettings.MSBuildPlatform = (Cake.Common.Tools.MSBuild.MSBuildPlatform)1;
-    msbuildSettings.Configuration = configuration;
-    return msbuildSettings;
-
+    return new MSBuildSettings {
+        PlatformTarget = PlatformTarget.MSIL,
+        MSBuildPlatform = (Cake.Common.Tools.MSBuild.MSBuildPlatform)1,
+        Configuration = configuration,
+    };
 }

--- a/build.cake
+++ b/build.cake
@@ -304,7 +304,7 @@ MSBuildSettings GetMSBuildSettings()
 {
     return new MSBuildSettings {
         PlatformTarget = PlatformTarget.MSIL,
-        MSBuildPlatform = (Cake.Common.Tools.MSBuild.MSBuildPlatform)1,
+        MSBuildPlatform = Cake.Common.Tools.MSBuild.MSBuildPlatform.x86,
         Configuration = configuration,
     };
 }


### PR DESCRIPTION
I had to look up what "1" meant in the documentation!
(https://cakebuild.net/api/Cake.Common.Tools.MSBuild/MSBuildPlatform/)