### PR TITLE
Make iOS FrameRenderer.SetupLayer virtual

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.iOS
 				SetupLayer();
 		}
 
-		void SetupLayer()
+		public virtual void SetupLayer()
 		{
 			float cornerRadius = Element.CornerRadius;
 


### PR DESCRIPTION
### Description of Change ###

iOS FrameRenderer.SetupLayer is now made virtual so users have more control over it

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7667

### API Changes ###

Changed:
 - private void FrameRenderer.SetupLayer()  => public virtual FrameRenderer.SetupLayer()

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None, but allows users to override the behavior

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
- [x] Trying to covertly get a Hacktoberfest shirt