### PR TITLE
[Android/iOS] Fixed ItemsUpdatingScrollMode on CarouselView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml
@@ -9,7 +9,12 @@
              x:Class="Xamarin.Forms.Controls.Issues.Issue7817">
     <ContentPage.Content>
     <StackLayout Margin="20">
-         <StackLayout Orientation="Horizontal"
+        <Grid
+            BackgroundColor="Yellow">
+            <Label
+                Text="A new item is added to the Carousel every 2 seconds. Change ItemsUpdatingScrollMode by selecting KeepLastItemInView in the Picker and verify that the behavior changes. The CarouselView must move the scroll to the latest item added."/>
+        </Grid>
+        <StackLayout Orientation="Horizontal"
                       HorizontalOptions="Center">
                 <Label Text="UpdatingScrollMode: "
                        VerticalTextAlignment="Center" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml
@@ -8,57 +8,70 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.Issues.Issue7817">
     <ContentPage.Content>
-    <StackLayout Margin="20">
+    <Grid
+        Margin="12">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
         <Grid
+            Grid.Row="0"
             BackgroundColor="Yellow">
             <Label
-                Text="A new item is added to the Carousel every 2 seconds. Change ItemsUpdatingScrollMode by selecting KeepLastItemInView in the Picker and verify that the behavior changes. The CarouselView must move the scroll to the latest item added."/>
+                LineBreakMode="WordWrap"
+                Text="Change ItemsUpdatingScrollMode by selecting KeepLastItemInView in the Picker and verify that the behavior changes. The CarouselView must move the scroll to the latest item added."/>
         </Grid>
-        <StackLayout Orientation="Horizontal"
-                      HorizontalOptions="Center">
-                <Label Text="UpdatingScrollMode: "
-                       VerticalTextAlignment="Center" />
-                <local:EnumPicker x:Name="enumPicker"
-                                  EnumType="{x:Type ItemsUpdatingScrollMode}"
-                                  SelectedIndex="0"
-                                  SelectedIndexChanged="OnItemsUpdatingScrollModeChanged" />
+        <StackLayout
+            Grid.Row="1"
+            Orientation="Horizontal"
+            HorizontalOptions="Center">
+            <Label
+                Text="UpdatingScrollMode: "
+                VerticalTextAlignment="Center" />
+            <local:EnumPicker x:Name="enumPicker"
+                              EnumType="{x:Type ItemsUpdatingScrollMode}"
+                              SelectedIndex="0"
+                              SelectedIndexChanged="OnItemsUpdatingScrollModeChanged" />
          </StackLayout>
-        <CarouselView x:Name="carouselView"
-                      ItemsSource="{Binding Monkeys}">
-        <CarouselView.ItemTemplate>
-            <DataTemplate>
-                <StackLayout>
-                    <Frame HasShadow="True"
-                           BorderColor="DarkGray"
-                           CornerRadius="5"
-                           Margin="20"
-                           HeightRequest="300"
-                           HorizontalOptions="Center"
-                           VerticalOptions="CenterAndExpand">
-                        <StackLayout>
-                            <Label Text="{Binding Name}" 
-                                    FontAttributes="Bold"
-                                    FontSize="Large"
-                                    HorizontalOptions="Center"
-                                    VerticalOptions="Center" />
-                            <Image Source="{Binding ImageUrl}" 
-                                    Aspect="AspectFill"
-                                    HeightRequest="150"
-                                    WidthRequest="150"
-                                    HorizontalOptions="Center" />
-                            <Label Text="{Binding Location}"
-                                    HorizontalOptions="Center" />
-                            <Label Text="{Binding Details}"
-                                    FontAttributes="Italic"
-                                    HorizontalOptions="Center"
-                                    MaxLines="5"
-                                    LineBreakMode="TailTruncation" />
-                        </StackLayout>
-                    </Frame>
-                </StackLayout>
-            </DataTemplate>
-        </CarouselView.ItemTemplate>
+        <CarouselView
+            Grid.Row="2"
+            x:Name="carouselView"
+            ItemsSource="{Binding Monkeys}">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout>
+                        <Frame HasShadow="True"
+                               BorderColor="DarkGray"
+                               CornerRadius="5"
+                               Margin="20"
+                               HeightRequest="300"
+                               HorizontalOptions="Center"
+                               VerticalOptions="CenterAndExpand">
+                            <StackLayout>
+                                <Label Text="{Binding Name}" 
+                                        FontAttributes="Bold"
+                                        FontSize="Large"
+                                        HorizontalOptions="Center"
+                                        VerticalOptions="Center" />
+                                <Image Source="{Binding ImageUrl}" 
+                                        Aspect="AspectFill"
+                                        HeightRequest="150"
+                                        WidthRequest="150"
+                                        HorizontalOptions="Center" />
+                                <Label Text="{Binding Location}"
+                                        HorizontalOptions="Center" />
+                                <Label Text="{Binding Details}"
+                                        FontAttributes="Italic"
+                                        HorizontalOptions="Center"
+                                        MaxLines="5"
+                                        LineBreakMode="TailTruncation" />
+                            </StackLayout>
+                        </Frame>
+                    </StackLayout>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
         </CarouselView>
-    </StackLayout>
+    </Grid>
     </ContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"  
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7817">
+    <ContentPage.Content>
+    <StackLayout Margin="20">
+         <StackLayout Orientation="Horizontal"
+                      HorizontalOptions="Center">
+                <Label Text="UpdatingScrollMode: "
+                       VerticalTextAlignment="Center" />
+                <local:EnumPicker x:Name="enumPicker"
+                                  EnumType="{x:Type ItemsUpdatingScrollMode}"
+                                  SelectedIndex="0"
+                                  SelectedIndexChanged="OnItemsUpdatingScrollModeChanged" />
+         </StackLayout>
+        <CarouselView x:Name="carouselView"
+                      ItemsSource="{Binding Monkeys}">
+        <CarouselView.ItemTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <Frame HasShadow="True"
+                           BorderColor="DarkGray"
+                           CornerRadius="5"
+                           Margin="20"
+                           HeightRequest="300"
+                           HorizontalOptions="Center"
+                           VerticalOptions="CenterAndExpand">
+                        <StackLayout>
+                            <Label Text="{Binding Name}" 
+                                    FontAttributes="Bold"
+                                    FontSize="Large"
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center" />
+                            <Image Source="{Binding ImageUrl}" 
+                                    Aspect="AspectFill"
+                                    HeightRequest="150"
+                                    WidthRequest="150"
+                                    HorizontalOptions="Center" />
+                            <Label Text="{Binding Location}"
+                                    HorizontalOptions="Center" />
+                            <Label Text="{Binding Details}"
+                                    FontAttributes="Italic"
+                                    HorizontalOptions="Center"
+                                    MaxLines="5"
+                                    LineBreakMode="TailTruncation" />
+                        </StackLayout>
+                    </Frame>
+                </StackLayout>
+            </DataTemplate>
+        </CarouselView.ItemTemplate>
+        </CarouselView>
+    </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Reflection;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CarouselView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7817, "[Android/iOS] Changing ItemsUpdatingScrollMode has no effect on CarouselView")]
+	public partial class Issue7817 : TestContentPage
+	{
+		public Issue7817()
+		{
+#if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			Title = "Issue 7817";
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			BindingContext = new Issue7817ViewModel();
+		}
+
+		void OnItemsUpdatingScrollModeChanged(object sender, EventArgs e)
+		{
+			carouselView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)(sender as EnumPicker).SelectedItem;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class EnumPicker : Picker
+	{
+		public static readonly BindableProperty EnumTypeProperty = BindableProperty.Create(nameof(EnumType), typeof(Type), typeof(EnumPicker),
+			propertyChanged: (bindable, oldValue, newValue) =>
+			{
+				var picker = (EnumPicker)bindable;
+
+				if (oldValue != null)
+				{
+					picker.ItemsSource = null;
+				}
+				if (newValue != null)
+				{
+					if (!((Type)newValue).GetTypeInfo().IsEnum)
+						throw new ArgumentException("EnumPicker: EnumType property must be enumeration type");
+
+					picker.ItemsSource = Enum.GetValues((Type)newValue);
+				}
+			});
+
+		public Type EnumType
+		{
+			set => SetValue(EnumTypeProperty, value);
+			get => (Type)GetValue(EnumTypeProperty);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7817Model
+	{
+		public int Index { get; set; }
+		public string Name { get; set; }
+		public string Location { get; set; }
+		public string Details { get; set; }
+		public string ImageUrl { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7817ViewModel : BindableObject
+	{
+		public Issue7817ViewModel()
+		{
+			CreateCollection();
+		}
+
+		public ObservableCollection<Issue7817Model> Monkeys { get; private set; } = new ObservableCollection<Issue7817Model>();
+
+		void CreateCollection()
+		{
+			Monkeys.Add(new Issue7817Model
+			{
+				Index = 0,
+				Name = "Baboon",
+				Location = "Africa & Asia",
+				Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
+			});
+
+			Monkeys.Add(new Issue7817Model
+			{
+				Index = 1,
+				Name = "Capuchin Monkey",
+				Location = "Central & South America",
+				Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
+			});
+
+			Monkeys.Add(new Issue7817Model
+			{
+				Index = 2,
+				Name = "Blue Monkey",
+				Location = "Central and East Africa",
+				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
 using System.Reflection;
 
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
@@ -43,7 +43,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 		void OnItemsUpdatingScrollModeChanged(object sender, EventArgs e)
 		{
+#if APP
 			carouselView.ItemsUpdatingScrollMode = (ItemsUpdatingScrollMode)(sender as EnumPicker).SelectedItem;
+#endif
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.ObjectModel;
 using System.Collections.Generic;
+using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
@@ -34,9 +35,10 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 		}
 
-		protected override void Init()
+		protected override async void Init()
 		{
 			BindingContext = new Issue7817ViewModel();
+			await ((Issue7817ViewModel)BindingContext).CreateCollectionAsync();
 		}
 
 		void OnItemsUpdatingScrollModeChanged(object sender, EventArgs e)
@@ -86,14 +88,9 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public class Issue7817ViewModel : BindableObject
 	{
-		public Issue7817ViewModel()
-		{
-			CreateCollection();
-		}
-
 		public ObservableCollection<Issue7817Model> Monkeys { get; private set; } = new ObservableCollection<Issue7817Model>();
 
-		void CreateCollection()
+		public async Task CreateCollectionAsync()
 		{
 			Monkeys.Add(new Issue7817Model
 			{
@@ -104,6 +101,8 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
 			});
 
+			await Task.Delay(2000);
+
 			Monkeys.Add(new Issue7817Model
 			{
 				Index = 1,
@@ -113,6 +112,8 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
 			});
 
+			await Task.Delay(2000);
+
 			Monkeys.Add(new Issue7817Model
 			{
 				Index = 2,
@@ -120,6 +121,37 @@ namespace Xamarin.Forms.Controls.Issues
 				Location = "Central and East Africa",
 				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
+			});
+
+			Monkeys.Add(new Issue7817Model
+			{
+				Index = 3,
+				Name = "Thomas's Langur",
+				Location = "Indonesia",
+				Details = "Thomas's langur is a species of primate in the family Cercopithecidae. It is endemic to North Sumatra, Indonesia. Its natural habitat is subtropical or tropical dry forests. It is threatened by habitat loss. Its native names are reungkah in Acehnese and kedih in Alas.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
+			});
+
+			await Task.Delay(2000);
+
+			Monkeys.Add(new Issue7817Model
+			{
+				Index = 4,
+				Name = "Purple-faced Langur",
+				Location = "Sri Lanka",
+				Details = "The purple-faced langur, also known as the purple-faced leaf monkey, is a species of Old World monkey that is endemic to Sri Lanka. The animal is a long-tailed arboreal species, identified by a mostly brown appearance, dark face (with paler lower face) and a very shy nature. The species was once highly prevalent, found in suburban Colombo and the \"wet zone\" villages (areas with high temperatures and high humidity throughout the year, whilst rain deluges occur during the monsoon seasons), but rapid urbanization has led to a significant decrease in the population level of the monkeys.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
+			});
+
+			await Task.Delay(2000);
+
+			Monkeys.Add(new Issue7817Model
+			{
+				Index = 5,
+				Name = "Gelada",
+				Location = "Ethiopia",
+				Details = "The gelada, sometimes called the bleeding-heart monkey or the gelada baboon, is a species of Old World monkey found only in the Ethiopian Highlands, with large populations in the Semien Mountains. Theropithecus is derived from the Greek root words for \"beast-ape.\" Like its close relatives the baboons, it is largely terrestrial, spending much of its time foraging in grasslands.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Gelada-Pavian.jpg/320px-Gelada-Pavian.jpg"
 			});
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
@@ -90,6 +90,8 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public class Issue7817ViewModel : BindableObject
 	{
+		const int AddItemDelay = 2000;
+
 		public ObservableCollection<Issue7817Model> Monkeys { get; private set; } = new ObservableCollection<Issue7817Model>();
 
 		public async Task CreateCollectionAsync()
@@ -103,7 +105,7 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
 			});
 
-			await Task.Delay(2000);
+			await Task.Delay(AddItemDelay);
 
 			Monkeys.Add(new Issue7817Model
 			{
@@ -114,7 +116,7 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
 			});
 
-			await Task.Delay(2000);
+			await Task.Delay(AddItemDelay);
 
 			Monkeys.Add(new Issue7817Model
 			{
@@ -134,7 +136,7 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
 			});
 
-			await Task.Delay(2000);
+			await Task.Delay(AddItemDelay);
 
 			Monkeys.Add(new Issue7817Model
 			{
@@ -145,7 +147,7 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
 			});
 
-			await Task.Delay(2000);
+			await Task.Delay(AddItemDelay);
 
 			Monkeys.Add(new Issue7817Model
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+c<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>
@@ -56,6 +56,9 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7593.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
@@ -1403,7 +1406,10 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
-    <Compile Update="C:\Users\hartez\Documents\Xamarin\Xamarin.Forms\Xamarin.Forms.Controls.Issues\Xamarin.Forms.Controls.Issues.Shared\Issue7519Xaml.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">
+      <DependentUpon>Issue7817.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
@@ -1475,6 +1481,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7593.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7817.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1,4 +1,4 @@
-c<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <MSBuildAllProjects>$(MSBuildAllProjects);$(MSBuildThisFileFullPath)</MSBuildAllProjects>

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -64,6 +64,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateIsBounceEnabled();
 			else if (changedProperty.Is(LinearItemsLayout.ItemSpacingProperty))
 				UpdateItemSpacing();
+			else if (changedProperty.Is(ItemsView.ItemsUpdatingScrollModeProperty))
+				UpdateItemsUpdatingScrollMode();
 		}
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -54,9 +54,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs changedProperty)
 		{
-			if (changedProperty.Is(ItemsView.ItemsSourceProperty))
-				UpdateItemsSource();
-			else if (changedProperty.Is(CarouselView.PeekAreaInsetsProperty))
+			base.OnElementPropertyChanged(sender, changedProperty);
+   
+			if (changedProperty.Is(CarouselView.PeekAreaInsetsProperty))
 				UpdatePeekAreaInsets();
 			else if (changedProperty.Is(CarouselView.IsSwipeEnabledProperty))
 				UpdateIsSwipeEnabled();
@@ -64,8 +64,6 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateIsBounceEnabled();
 			else if (changedProperty.Is(LinearItemsLayout.ItemSpacingProperty))
 				UpdateItemSpacing();
-			else if (changedProperty.Is(ItemsView.ItemsUpdatingScrollModeProperty))
-				UpdateItemsUpdatingScrollMode();
 		}
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -484,7 +484,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (ItemsUpdatingScrollMode == ItemsUpdatingScrollMode.KeepLastItemInView)
 			{
-				ForceScrollToLastItem(CollectionView);
+				ForceScrollToLastItem(CollectionView, _itemsLayout);
 			}
 		}
 
@@ -551,7 +551,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return false;
 		}
 
-		static void ForceScrollToLastItem(UICollectionView collectionView)
+		static void ForceScrollToLastItem(UICollectionView collectionView, ItemsLayout itemsLayout)
 		{
 			var sections = (int)collectionView.NumberOfSections();
 
@@ -566,7 +566,12 @@ namespace Xamarin.Forms.Platform.iOS
 				if (itemCount > 0)
 				{
 					var lastIndexPath = NSIndexPath.FromItemSection(itemCount - 1, section);
-					collectionView.ScrollToItem(lastIndexPath, UICollectionViewScrollPosition.Bottom, true);
+
+					if (itemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
+						collectionView.ScrollToItem(lastIndexPath, UICollectionViewScrollPosition.Bottom, true);
+					else
+						collectionView.ScrollToItem(lastIndexPath, UICollectionViewScrollPosition.Right, true);
+
 					return;
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

Fixed **ItemsUpdatingScrollMode** property on **CarouselView**. 

### Issues Resolved ### 

- fixes #7817

### API Changes ###

 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue7817-before](https://user-images.githubusercontent.com/6755973/66397147-7dd91880-e9db-11e9-9ff2-080a5127be90.gif)

#### After
![issue7817-after](https://user-images.githubusercontent.com/6755973/66397383-ff30ab00-e9db-11e9-939f-d7dfdaf15367.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7817. Change `ItemsUpdatingScrollMode` using the Picker and check if the Carousel scroll behavior changed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
