### PR TITLE
Cleanup material controls character spacing interactions

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialPickerRenderer.cs
@@ -50,9 +50,10 @@ namespace Xamarin.Forms.Material.Android
 		{
 			_textInputLayout.SetHint(Element.Title, Element);
 		}
+
 		protected override void UpdateTitleColor() => ApplyTheme();
 		protected override void UpdateTextColor() => ApplyTheme();
-		protected virtual void ApplyTheme() => _textInputLayout?.ApplyTheme(Element.TextColor, Color.Default);
+		protected virtual void ApplyTheme() => _textInputLayout?.ApplyTheme(Element.TextColor, Element.TitleColor);
 
 		AView ITabStop.TabStop => EditText;
 	}

--- a/Xamarin.Forms.Material.iOS/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialEntryRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using CoreGraphics;
+using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS;
 

--- a/Xamarin.Forms.Material.iOS/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialEntryRenderer.cs
@@ -12,9 +12,9 @@ namespace Xamarin.Forms.Material.iOS
 		protected override void UpdateColor() => Control?.UpdateTextColor(this);
 		protected virtual void ApplyTheme() => Control?.ApplyTheme(this);
 		protected override void UpdatePlaceholder() => Control?.UpdatePlaceholder(this);
-		protected override void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString)
+		protected override void UpdateAttributedPlaceholder(NSAttributedString nsAttributedString)
 		{
-			// Attributed place holders don't currently work with Material Text Fields
+			// AttributedPlaceholder doesn't currently work with Material
 			// once/if it does start working it will be handled inside MaterialTextManager	
 		}
 

--- a/Xamarin.Forms.Material.iOS/MaterialEntryRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialEntryRenderer.cs
@@ -11,6 +11,11 @@ namespace Xamarin.Forms.Material.iOS
 		protected override void UpdateColor() => Control?.UpdateTextColor(this);
 		protected virtual void ApplyTheme() => Control?.ApplyTheme(this);
 		protected override void UpdatePlaceholder() => Control?.UpdatePlaceholder(this);
+		protected override void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString)
+		{
+			// Attributed place holders don't currently work with Material Text Fields
+			// once/if it does start working it will be handled inside MaterialTextManager	
+		}
 
 		protected override void UpdateFont()
 		{

--- a/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Foundation;
 using UIKit;
 using Xamarin.Forms.Platform.iOS;
 
@@ -19,6 +20,18 @@ namespace Xamarin.Forms.Material.iOS
 		protected virtual void ApplyTheme() => Control?.ApplyTheme(this);
 		protected internal override void UpdatePlaceholder() => Control?.UpdatePlaceholder(this);
 
+		protected override void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString)
+		{
+			// Attributed place holders don't currently work with Material Text Fields
+			// once/if it does start working it will be handled inside MaterialTextManager	
+		}
+
+		protected override void UpdateCharacterSpacing()
+		{
+			base.UpdateCharacterSpacing();
+			Control?.UpdatePlaceholder(this);
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			base.OnElementChanged(e);
@@ -30,8 +43,8 @@ namespace Xamarin.Forms.Material.iOS
 			}
 		}
 
-		string IMaterialEntryRenderer.Placeholder => string.Empty;
-		Color IMaterialEntryRenderer.PlaceholderColor => Color.Default;
+		string IMaterialEntryRenderer.Placeholder => Element?.Title;
+		Color IMaterialEntryRenderer.PlaceholderColor => Element.TitleColor;
 		Color IMaterialEntryRenderer.TextColor => Element?.TextColor ?? Color.Default;
 		Color IMaterialEntryRenderer.BackgroundColor => Element?.BackgroundColor ?? Color.Default;
 	}

--- a/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
@@ -20,9 +20,9 @@ namespace Xamarin.Forms.Material.iOS
 		protected virtual void ApplyTheme() => Control?.ApplyTheme(this);
 		protected internal override void UpdatePlaceholder() => Control?.UpdatePlaceholder(this);
 
-		protected override void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString)
+		protected override void UpdateAttributedPlaceholder(NSAttributedString nSAttributedString)
 		{
-			// Attributed place holders don't currently work with Material Text Fields
+			// AttributedPlaceholder doesn't currently work with Material
 			// once/if it does start working it will be handled inside MaterialTextManager	
 		}
 
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Material.iOS
 		}
 
 		string IMaterialEntryRenderer.Placeholder => Element?.Title;
-		Color IMaterialEntryRenderer.PlaceholderColor => Element.TitleColor;
+		Color IMaterialEntryRenderer.PlaceholderColor => Element?.TitleColor ?? Color.Default;
 		Color IMaterialEntryRenderer.TextColor => Element?.TextColor ?? Color.Default;
 		Color IMaterialEntryRenderer.BackgroundColor => Element?.BackgroundColor ?? Color.Default;
 	}

--- a/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialPickerRenderer.cs
@@ -26,12 +26,6 @@ namespace Xamarin.Forms.Material.iOS
 			// once/if it does start working it will be handled inside MaterialTextManager	
 		}
 
-		protected override void UpdateCharacterSpacing()
-		{
-			base.UpdateCharacterSpacing();
-			Control?.UpdatePlaceholder(this);
-		}
-
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			base.OnElementChanged(e);

--- a/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Material.iOS
 		public static void UpdatePlaceholder(IMaterialTextField textField, IMaterialEntryRenderer element)
 		{
 			var placeholderText = element.Placeholder ?? String.Empty;
-			//textField.ActiveTextInputController.PlaceholderText = placeholderText;
+			textField.ActiveTextInputController.PlaceholderText = placeholderText;
 			ApplyTheme(textField, element);
 
 			var previous = textField.ActiveTextInputController.FloatingPlaceholderScale;

--- a/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Material.iOS
 		public static void UpdatePlaceholder(IMaterialTextField textField, IMaterialEntryRenderer element)
 		{
 			var placeholderText = element.Placeholder ?? String.Empty;
-			textField.ActiveTextInputController.PlaceholderText = placeholderText;
+			//textField.ActiveTextInputController.PlaceholderText = placeholderText;
 			ApplyTheme(textField, element);
 
 			var previous = textField.ActiveTextInputController.FloatingPlaceholderScale;

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -343,17 +343,19 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_useLegacyColorManagement)
 			{
 				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
-				Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
+				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
 			}
 			else
 			{
 				// Using VSM color management; take whatever is in Element.PlaceholderColor
 				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
-				Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
+				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
 			}
 
-			Control.AttributedPlaceholder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
+			UpdateAttributedPlaceHolder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing));
 		}
+		protected virtual void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString) =>
+			Control.AttributedPlaceholder = nSAttributedString;
 
 		void UpdateText()
 		{
@@ -372,7 +374,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var placeHolder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 
 			if (placeHolder != null)
-				Control.AttributedPlaceholder = placeHolder;
+				UpdateAttributedPlaceHolder(placeHolder);
 		}
 
 		void UpdateMaxLength()

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -343,19 +343,19 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_useLegacyColorManagement)
 			{
 				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
-				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
+				UpdateAttributedPlaceholder(formatted.ToAttributed(Element, color));
 			}
 			else
 			{
 				// Using VSM color management; take whatever is in Element.PlaceholderColor
 				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
-				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
+				UpdateAttributedPlaceholder(formatted.ToAttributed(Element, color));
 			}
 
-			UpdateAttributedPlaceHolder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing));
+			UpdateAttributedPlaceholder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing));
 		}
-		protected virtual void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString) =>
-			Control.AttributedPlaceholder = nSAttributedString;
+		protected virtual void UpdateAttributedPlaceholder(NSAttributedString nsAttributedString) =>
+			Control.AttributedPlaceholder = nsAttributedString;
 
 		void UpdateText()
 		{
@@ -374,7 +374,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var placeHolder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 
 			if (placeHolder != null)
-				UpdateAttributedPlaceHolder(placeHolder);
+				UpdateAttributedPlaceholder(placeHolder);
 		}
 
 		void UpdateMaxLength()

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var placeHolder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing);
 
 			if (placeHolder != null)
-				UpdateAttributedPlaceHolder(placeHolder);
+				UpdateAttributedPlaceholder(placeHolder);
 		}
 
         protected internal virtual void UpdateFont()
@@ -196,20 +196,20 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_useLegacyColorManagement)
 			{
 				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
-				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
+				UpdateAttributedPlaceholder(formatted.ToAttributed(Element, color));
 			}
 			else
 			{
 				// Using VSM color management; take whatever is in Element.PlaceholderColor
 				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
-				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
+				UpdateAttributedPlaceholder(formatted.ToAttributed(Element, color));
 			}
 
-			UpdateAttributedPlaceHolder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing));
+			UpdateAttributedPlaceholder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing));
 		}
 
-		protected virtual void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString) => 
-			Control.AttributedPlaceholder = nSAttributedString;
+		protected virtual void UpdateAttributedPlaceholder(NSAttributedString nsAttributedString) => 
+			Control.AttributedPlaceholder = nsAttributedString;
 
 		void UpdatePicker()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateCharacterSpacing();
 		}
 
-        protected void UpdateCharacterSpacing()
+        protected virtual void UpdateCharacterSpacing()
         {
 			var textAttr = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
 
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var placeHolder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing);
 
 			if (placeHolder != null)
-				Control.AttributedPlaceholder = placeHolder;
+				UpdateAttributedPlaceHolder(placeHolder);
 		}
 
         protected internal virtual void UpdateFont()
@@ -196,18 +196,20 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_useLegacyColorManagement)
 			{
 				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
-				Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
+				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
 			}
 			else
 			{
 				// Using VSM color management; take whatever is in Element.PlaceholderColor
 				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
-				Control.AttributedPlaceholder = formatted.ToAttributed(Element, color);
+				UpdateAttributedPlaceHolder(formatted.ToAttributed(Element, color));
 			}
 
-			Control.AttributedPlaceholder = Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing);
+			UpdateAttributedPlaceHolder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Title, Element.CharacterSpacing));
 		}
 
+		protected virtual void UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString) => 
+			Control.AttributedPlaceholder = nSAttributedString;
 
 		void UpdatePicker()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -165,7 +165,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateCharacterSpacing();
 		}
 
-        protected virtual void UpdateCharacterSpacing()
+        protected void UpdateCharacterSpacing()
         {
 			var textAttr = Control.AttributedText.AddCharacterSpacing(Control.Text, Element.CharacterSpacing);
 


### PR DESCRIPTION
### Description of Change ###

Character spacing PR started using the title for the placeholder on picker which we originally weren't going to do but at this point I think it's fine. It's what users will expect if they switch to material

Unfortunately (AFAICT) character spacing doesn't work with place holders on the material controls. I poked iOS a bit and couldn't get it to work. I'm hoping once we update material components on android/ios then maybe it'll work?

- Since we're now using Title I replaced the APIs needed for TitleColor
- I added an override for *UpdateAttributedPlaceHolder* on iOS so that the Material implementations can control this field. It's confusing having the non material control set this. If AttributedPlaceHolder start working for material than the Material control can be updated to handle it


### API Changes ###
Added: iOS only
 - EntryRendererBase.UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString)
 - PickerRendererBase.UpdateAttributedPlaceHolder(NSAttributedString nSAttributedString)

### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
- make sure character spacing still works and that picker obeys title color for placeholder color

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
