### PR TITLE
Let UICollectionViewCell handle state itself

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -82,9 +82,9 @@ namespace Xamarin.Forms.Platform.iOS
 			headerCell.Label.SetNeedsDisplay();
 
 			if (selectedItems.Length > 0 && selectedItems[0].Row == indexPath.Row)
-				headerCell.Label.TextColor = _selectedColor.ToUIColor();
+				headerCell.Label.TextColor = headerCell.SelectedColor = _selectedColor.ToUIColor();
 			else
-				headerCell.Label.TextColor = _unselectedColor.ToUIColor();
+				headerCell.Label.TextColor = headerCell.UnSelectedColor = _unselectedColor.ToUIColor();
 
 			return headerCell;
 		}
@@ -96,21 +96,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ItemDeselected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
-			var cell = (ShellSectionHeaderCell)CollectionView.CellForItem(indexPath);
-			cell.Label.TextColor = _unselectedColor.ToUIColor();
 		}
 
 		public override void ItemSelected(UICollectionView collectionView, NSIndexPath indexPath)
 		{
 			var row = indexPath.Row;
-
 			var item = ShellSection.Items[row];
-
 			if (item != ShellSection.CurrentItem)
 				ShellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, item);
-
-			var cell = (ShellSectionHeaderCell)CollectionView.CellForItem(indexPath);
-			cell.Label.TextColor = _selectedColor.ToUIColor();
 		}
 
 		public override nint NumberOfSections(UICollectionView collectionView)
@@ -229,6 +222,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public class ShellSectionHeaderCell : UICollectionViewCell
 		{
+			public UIColor SelectedColor { get; set; }
+			public UIColor UnSelectedColor { get; set; }
+
+			public override bool Selected
+			{
+				get => base.Selected;
+				set
+				{
+					base.Selected = value;
+					Label.TextColor = value ? SelectedColor : UnSelectedColor;
+				}
+			}
+
 			[Export("initWithFrame:")]
 			public ShellSectionHeaderCell(CGRect frame) : base(frame)
 			{


### PR DESCRIPTION
Fixes #7416


### Description of Change ###

Moved selecting and deselecting UI apparel code from UICollectionView to UICollectionViewCell.

Original version tried to get hold of the selected and deselected cell inside the UICollectionView. But cells that are 'off screen' will not be returned with the GetCellForItem(indexpath) method ( cfr UIKit docs ).
Hence, better to override the Selected property of the cell itself and update UI properties there.

### API Changes ###
Changed:
 - ShellSectionRootHeader

### Platforms Affected ### 
- iOS

### Testing Procedure ###
Open the Control Gallery app in the Xamarin.Forms repo, move to the Shell Store root page.
Add multiple top bar items so that several are off screen.
Scroll to the right and select the last one, scroll back to the left and select the first one.
Current version will crash with NULL ref exception in the Deselected method ( but even with null check there you can even get NULL ref exception in Selected method ).

Fix will correctly change the cell UI and not crash on null ref.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
