### PR TITLE
Use FontSizeConverter for FontImageSource.Size property

### DIFF
--- a/Xamarin.Forms.Core/FontImageSource.cs
+++ b/Xamarin.Forms.Core/FontImageSource.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms
 
 		public override bool IsEmpty => string.IsNullOrEmpty(Glyph);
 
+		[TypeConverter(typeof(FontSizeConverter))]
 		public double Size { get => (double)GetValue(SizeProperty); set => SetValue(SizeProperty, value); }
 		public static readonly BindableProperty SizeProperty = CreateBindableProperty(nameof(Size), 30d);
 


### PR DESCRIPTION
### Description of Change ###

Allows to use named font size for `FontImageSource.Size` property

### Issues Resolved ### 

- fixes #7664

### API Changes ###

None

Added:

None

Changed:

- Add `FontSizeConverter` attribute to `Size` property of `FontImagesource`
 
 Removed:

None
 
### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

N/A

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
