### PR TITLE
[Core] Fixed SnapPointsType discrepancy in CarouselView

### DIFF
--- a/Xamarin.Forms.Core/Items/LinearItemsLayout.cs
+++ b/Xamarin.Forms.Core/Items/LinearItemsLayout.cs
@@ -13,7 +13,8 @@ namespace Xamarin.Forms
 
 		internal static readonly LinearItemsLayout CarouselDefault = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
 		{
-			SnapPointsAlignment = SnapPointsAlignment.Center, SnapPointsType = SnapPointsType.Mandatory
+			SnapPointsType = SnapPointsType.MandatorySingle,
+			SnapPointsAlignment = SnapPointsAlignment.Center
 		};
 
 		public static readonly BindableProperty ItemSpacingProperty =


### PR DESCRIPTION
### Description of Change ###

Fixed SnapPointsType discrepancy between CarouselView and LinearItemsLayout.
Also renamed ListItemsLayout to LinearItemsLayout.

### Issues Resolved ### 

- fixes #7876

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Launch Core Gallery and test any CarouselView sample to verify that the snap continues working. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
