### PR TITLE
[X] binding find the right indexer

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -495,7 +495,22 @@ namespace Xamarin.Forms.Build.Tasks
 				if (indexArg != null) {
 					var defaultMemberAttribute = previousPartTypeRef.GetCustomAttribute(module, ("mscorlib", "System.Reflection", "DefaultMemberAttribute"));
 					var indexerName = defaultMemberAttribute?.ConstructorArguments?.FirstOrDefault().Value as string ?? "Item";
-					var indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName && pd.GetMethod != null && pd.GetMethod.IsPublic, out var indexerDeclTypeRef);
+					PropertyDefinition indexer = null;
+					TypeReference indexerDeclTypeRef = null;
+					if (int.TryParse(indexArg, out _))
+						indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName
+																	 && pd.GetMethod != null
+																	 && TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType, module.ImportReference(("mscorlib", "System", "Int32")))
+																	 && pd.GetMethod.IsPublic, out indexerDeclTypeRef);
+					indexer = indexer ?? previousPartTypeRef.GetProperty(pd => pd.Name == indexerName
+																			&& pd.GetMethod != null
+																			&& TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType, module.ImportReference(("mscorlib", "System", "String")))
+																			&& pd.GetMethod.IsPublic, out indexerDeclTypeRef);
+					indexer = indexer ?? previousPartTypeRef.GetProperty(pd => pd.Name == indexerName
+																			&& pd.GetMethod != null
+																			&& TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType, module.ImportReference(("mscorlib", "System", "String")))
+																			&& pd.GetMethod.IsPublic, out indexerDeclTypeRef);
+
 					properties.Add((indexer, indexerDeclTypeRef, indexArg));
 					var indexType = indexer.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(indexerDeclTypeRef);
 					if (!TypeRefComparer.Default.Equals(indexType, module.TypeSystem.String) && !TypeRefComparer.Default.Equals(indexType, module.TypeSystem.Int32))

--- a/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/TypeReferenceExtensions.cs
@@ -11,11 +11,9 @@ namespace Xamarin.Forms.Build.Tasks
 	{
 		static string GetAssembly(TypeReference typeRef)
 		{
-			var md = typeRef.Scope as ModuleDefinition;
-			if (md != null)
+			if (typeRef.Scope is ModuleDefinition md)
 				return md.Assembly.FullName;
-			var anr = typeRef.Scope as AssemblyNameReference;
-			if (anr != null)
+			if (typeRef.Scope is AssemblyNameReference anr)
 				return anr.FullName;
 			throw new ArgumentOutOfRangeException(nameof(typeRef));
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7837.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7837.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh7837">
+    <ContentPage.BindingContext>
+        <local:Gh7837VM />
+    </ContentPage.BindingContext>
+    <StackLayout>
+        <Label x:Name="label0" Text="{Binding .[42]}" />
+        <Label x:Name="label1" Text="{Binding .[foo]}" />
+        <Label x:Name="label2" Text="{Binding .[42]}" x:DataType="local:Gh7837VM" />
+        <Label x:Name="label3" Text="{Binding .[foo]}" x:DataType="local:Gh7837VM" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7837.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh7837.xaml.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh7837VMBase //using a base class to test #2131
+	{
+		public string this[int index] => "";
+		public string this[string index] => "";
+	}
+
+	public class Gh7837VM : Gh7837VMBase
+	{
+		public new string this[int index] => index == 42 ? "forty-two" : "dull number";
+		public new string this[string index] => index.ToUpper();
+	}
+
+	public partial class Gh7837 : ContentPage
+	{
+		public Gh7837() => InitializeComponent();
+		public Gh7837(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void BindingWithMultipleIndexers([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Gh7837));
+				var layout = new Gh7837(useCompiledXaml);
+				Assert.That(layout.label0.Text, Is.EqualTo("forty-two"));
+				Assert.That(layout.label1.Text, Is.EqualTo("FOO"));
+				Assert.That(layout.label2.Text, Is.EqualTo("forty-two"));
+				Assert.That(layout.label3.Text, Is.EqualTo("FOO"));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/MockCompiler.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MockCompiler.cs
@@ -35,8 +35,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				BuildEngine = new MSBuild.UnitTests.DummyBuildEngine()
 			};
 
-			IList<Exception> exceptions;
-			if (xamlc.Execute(out exceptions) || exceptions == null || !exceptions.Any()) {
+			if (xamlc.Execute(out IList<Exception> exceptions) || exceptions == null || !exceptions.Any()) {
 				methdoDefinition = xamlc.InitCompForType;
 				return;
 			}


### PR DESCRIPTION
### Description of Change ###

supports having multiple indexers on a bound source, try to invoke the right one.

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7837

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
