### PR TITLE
Fixed issue setting Position in CarouselView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml
@@ -1,0 +1,14 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"  
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7865">
+    <ContentPage.Content>
+        <StackLayout>
+     
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml
@@ -9,11 +9,15 @@
     <ContentPage.Content>
          <Grid>
              <Grid.RowDefinitions>
+                 <RowDefinition Height="Auto"/>
                  <RowDefinition Height="*"/>
                  <RowDefinition Height="100"/>
              </Grid.RowDefinitions>
-             <CarouselView
+             <Label
                  Grid.Row="0"
+                 Text="Changing the selected item in the CollectionView at the bottom must update the CarouselView position correctly (match)."/>
+             <CarouselView
+                 Grid.Row="1"
                  x:Name="ItemsCarousel"
                  ItemsSource="{Binding Monkeys}"
                  PositionChanged="OnPositionChanged">
@@ -57,7 +61,7 @@
                      </CarouselView.ItemTemplate>
              </CarouselView>
              <CollectionView
-                 Grid.Row="1"
+                 Grid.Row="2"
                  x:Name="IndicatorView"
                  Margin="0,6"
                  HorizontalOptions="Center"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml
@@ -7,8 +7,103 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.Issues.Issue7865">
     <ContentPage.Content>
-        <StackLayout>
-     
-        </StackLayout>
+         <Grid>
+             <Grid.RowDefinitions>
+                 <RowDefinition Height="*"/>
+                 <RowDefinition Height="100"/>
+             </Grid.RowDefinitions>
+             <CarouselView
+                 Grid.Row="0"
+                 x:Name="ItemsCarousel"
+                 ItemsSource="{Binding Monkeys}"
+                 PositionChanged="OnPositionChanged">
+                     <CarouselView.ItemTemplate>
+                         <DataTemplate>
+                             <StackLayout>
+                                 <Frame
+                                     HasShadow="True"
+                                     BorderColor="DarkGray"
+                                     CornerRadius="6"
+                                     Margin="12"
+                                     HeightRequest="350"
+                                     HorizontalOptions="Center"
+                                     VerticalOptions="CenterAndExpand">
+                                    <StackLayout>
+                                        <Label Text="{Binding Index}" 
+                                                FontAttributes="Bold"
+                                                FontSize="Small"
+                                                HorizontalOptions="Center" />
+                                        <Label Text="{Binding Name}" 
+                                                FontAttributes="Bold"
+                                                FontSize="Large"
+                                                HorizontalOptions="Center"
+                                                VerticalOptions="Center" />
+                                        <Image Source="{Binding ImageUrl}" 
+                                                Aspect="AspectFill"
+                                                HeightRequest="150"
+                                                WidthRequest="150"
+                                                HorizontalOptions="Center" />
+                                        <Label Text="{Binding Location}"
+                                                HorizontalOptions="Center" />
+                                        <Label Text="{Binding Details}"
+                                                FontAttributes="Italic"
+                                                HorizontalOptions="Center"
+                                                MaxLines="5"
+                                                LineBreakMode="TailTruncation" />
+                                    </StackLayout>
+                                 </Frame>
+                             </StackLayout>
+                         </DataTemplate>
+                     </CarouselView.ItemTemplate>
+             </CarouselView>
+             <CollectionView
+                 Grid.Row="1"
+                 x:Name="IndicatorView"
+                 Margin="0,6"
+                 HorizontalOptions="Center"
+                 VerticalOptions="Center"
+                 SelectionMode="Single"
+                 SelectionChanged="IndicatorSelectionChanged"
+                 ItemsSource="{Binding Monkeys}">
+                 <CollectionView.Resources>
+                     <Style TargetType="Grid">
+                        <Setter Property="VisualStateManager.VisualStateGroups">
+                            <VisualStateGroupList>
+                                <VisualStateGroup x:Name="CommonStates">
+                                    <VisualState x:Name="Normal" />
+                                    <VisualState x:Name="Selected">
+                                        <VisualState.Setters>
+                                            <Setter Property="BackgroundColor"
+                                                    Value="LightSkyBlue" />
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateGroupList>
+                        </Setter>
+                     </Style>
+                 </CollectionView.Resources>
+                 <CollectionView.ItemsLayout>
+                     <LinearItemsLayout
+                         Orientation="Horizontal"
+                         ItemSpacing="8"/>
+                 </CollectionView.ItemsLayout>
+                 <CollectionView.ItemTemplate>
+                     <DataTemplate>
+                         <Grid
+                             BackgroundColor="Red"
+                             HeightRequest="36"
+                             WidthRequest="36"
+                             VerticalOptions="Start"
+                             HorizontalOptions="Start">
+                             <Label
+                                 TextColor="White"
+                                 Text="{Binding Index}"
+                                 HorizontalOptions="Center"
+                                 VerticalOptions="Center"/>
+                         </Grid>
+                     </DataTemplate>
+                 </CollectionView.ItemTemplate>
+             </CollectionView>
+        </Grid>
     </ContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
@@ -1,0 +1,37 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CarouselView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7865, "[iOS] CarouselView setting Position has dif behavior than ScrollTo")]
+	public partial class Issue7865 : TestContentPage
+	{
+		public Issue7865()
+		{
+#if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			Title = "Issue 7865";
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using Xamarin.Forms.Internals;
 using Xamarin.Forms.CustomAttributes;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
 
 #if UITEST
 using Xamarin.UITest;
@@ -17,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 7865, "[iOS] CarouselView setting Position has dif behavior than ScrollTo")]
+	[Issue(IssueTracker.Github, 7865, "[iOS] CarouselView setting Position has dif behavior than ScrollTo", PlatformAffected.iOS)]
 	public partial class Issue7865 : TestContentPage
 	{
 		public Issue7865()
@@ -31,7 +34,91 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-		
+			BindingContext = new Issue7865ViewModel();
+		}
+
+		public void OnPositionChanged(object sender, PositionChangedEventArgs args)
+		{
+			IndicatorView.SelectionChanged -= IndicatorSelectionChanged;
+			IndicatorView.SelectedItem = (BindingContext as Issue7865ViewModel).Monkeys[args.CurrentPosition];
+			IndicatorView.SelectionChanged += IndicatorSelectionChanged;
+
+		}
+
+		public void IndicatorSelectionChanged(object sender, SelectionChangedEventArgs args)
+		{
+			ItemsCarousel.PositionChanged -= OnPositionChanged;
+			ItemsCarousel.Position = (BindingContext as Issue7865ViewModel).Monkeys.IndexOf(args.CurrentSelection[0] as Issue7865Model);
+			ItemsCarousel.PositionChanged += OnPositionChanged;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7865Model
+	{
+		public int Index { get; set; }
+		public string Name { get; set; }
+		public string Location { get; set; }
+		public string Details { get; set; }
+		public string ImageUrl { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue7865ViewModel : BindableObject
+	{
+		public Issue7865ViewModel()
+		{
+			CreateItems();
+		}
+
+		public ObservableCollection<Issue7865Model> Monkeys { get; private set; } = new ObservableCollection<Issue7865Model>();
+
+		public void CreateItems()
+		{
+			Monkeys.Add(new Issue7865Model
+			{
+				Index = 0,
+				Name = "Baboon",
+				Location = "Africa & Asia",
+				Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
+			});
+
+			Monkeys.Add(new Issue7865Model
+			{
+				Index = 1,
+				Name = "Capuchin Monkey",
+				Location = "Central & South America",
+				Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
+			});
+   
+			Monkeys.Add(new Issue7865Model
+			{
+				Index = 2,
+				Name = "Blue Monkey",
+				Location = "Central and East Africa",
+				Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
+				ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
+			});
+
+			Monkeys.Add(new Issue7865Model
+			{
+				Index = 3,
+				Name = "Thomas's Langur",
+				Location = "Indonesia",
+				Details = "Thomas's langur is a species of primate in the family Cercopithecidae. It is endemic to North Sumatra, Indonesia. Its natural habitat is subtropical or tropical dry forests. It is threatened by habitat loss. Its native names are reungkah in Acehnese and kedih in Alas.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
+			});
+
+			Monkeys.Add(new Issue7865Model
+			{
+				Index = 4,
+				Name = "Purple-faced Langur",
+				Location = "Sri Lanka",
+				Details = "The purple-faced langur, also known as the purple-faced leaf monkey, is a species of Old World monkey that is endemic to Sri Lanka. The animal is a long-tailed arboreal species, identified by a mostly brown appearance, dark face (with paler lower face) and a very shy nature. The species was once highly prevalent, found in suburban Colombo and the \"wet zone\" villages (areas with high temperatures and high humidity throughout the year, whilst rain deluges occur during the monsoon seasons), but rapid urbanization has led to a significant decrease in the population level of the monkeys.",
+				ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
+			});
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
@@ -39,17 +39,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 		public void OnPositionChanged(object sender, PositionChangedEventArgs args)
 		{
-			IndicatorView.SelectionChanged -= IndicatorSelectionChanged;
 			IndicatorView.SelectedItem = (BindingContext as Issue7865ViewModel).Monkeys[args.CurrentPosition];
-			IndicatorView.SelectionChanged += IndicatorSelectionChanged;
-
 		}
 
 		public void IndicatorSelectionChanged(object sender, SelectionChangedEventArgs args)
-		{
-			ItemsCarousel.PositionChanged -= OnPositionChanged;
+		{		
 			ItemsCarousel.Position = (BindingContext as Issue7865ViewModel).Monkeys.IndexOf(args.CurrentSelection[0] as Issue7865Model);
-			ItemsCarousel.PositionChanged += OnPositionChanged;
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -64,6 +64,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7865.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1431,6 +1434,9 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
       <DependentUpon>Issue7758.xaml</DependentUpon>
     </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7865.xaml.cs">
+      <DependentUpon>Issue7865.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1455.xaml">
@@ -1500,6 +1506,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7789.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7865.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -165,6 +165,9 @@ namespace Xamarin.Forms
 			set => SetValue(ItemsLayoutProperty, value);
 		}
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool IsScrolling { get; set; }
+
 		public event EventHandler<CurrentItemChangedEventArgs> CurrentItemChanged;
 		public event EventHandler<PositionChangedEventArgs> PositionChanged;
 
@@ -214,8 +217,8 @@ namespace Xamarin.Forms
 
 			carousel.PositionChanged?.Invoke(carousel, args);
 
-			//user is interacting with the carousel we don't need to scroll to item 
-			if (!carousel.IsDragging)
+			// If the user is interacting with the Carousel or the Carousel is doing ScrollTo, we don't need to scroll to item.
+			if (!carousel.IsDragging && !carousel.IsScrolling)
 				carousel.ScrollTo(args.CurrentPosition, position: ScrollToPosition.Center, animate: carousel.IsScrollAnimated);
 
 			carousel.OnPositionChanged(args);

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -85,6 +85,8 @@ namespace Xamarin.Forms.Platform.Android
 				else
 					Carousel.SetIsDragging(false);
 			}
+
+			Carousel.IsScrolling = state != ScrollStateIdle;
 		}
 
 		protected override ItemDecoration CreateSpacingDecoration(IItemsLayout itemsLayout)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -155,11 +155,13 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnScrollViewChanging(object sender, ScrollViewerViewChangingEventArgs e)
 		{
 			CarouselView.SetIsDragging(true);
+			CarouselView.IsScrolling = true;
 		}
 
 		void OnScrollViewChanged(object sender, ScrollViewerViewChangedEventArgs e)
 		{
 			CarouselView.SetIsDragging(e.IsIntermediate);
+			CarouselView.IsScrolling = e.IsIntermediate;
 		}
 
 		void UpdatePeekAreaInsets()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -77,6 +77,11 @@ namespace Xamarin.Forms.Platform.iOS
 			_carouselView.SetIsDragging(false);
 		}
 
+		internal void UpdateIsScrolling(bool isScrolling)
+		{
+			_carouselView.IsScrolling = isScrolling;
+		}
+
 		void UpdateInitialPosition()
 		{
 			if (_carouselView.Position != 0)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -172,5 +172,10 @@ namespace Xamarin.Forms.Platform.iOS
 			GroupableItemsViewController?.HandleScrollAnimationEnded();
 			CarouselViewController?.UpdateIsScrolling(false);
 		}
+
+		public override void DecelerationEnded(UIScrollView scrollView)
+		{
+			CarouselViewController?.UpdateIsScrolling(false);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/UICollectionViewDelegator.cs
@@ -67,6 +67,7 @@ namespace Xamarin.Forms.Platform.iOS
 			};
 
 			ItemsViewController.ItemsView.SendScrolled(itemsViewScrolledEventArgs);
+			CarouselViewController?.UpdateIsScrolling(true);
 
 			_previousHorizontalOffset = (float)contentOffsetX;
 			_previousVerticalOffset = (float)contentOffsetY;
@@ -169,6 +170,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ScrollAnimationEnded(UIScrollView scrollView)
 		{
 			GroupableItemsViewController?.HandleScrollAnimationEnded();
+			CarouselViewController?.UpdateIsScrolling(false);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Fixed issue setting **Position** in **CarouselView**. Sometimes only updated the position by 1 whereas.

NOTE: The fix is the same as the one applied in https://github.com/xamarin/Xamarin.Forms/pull/7857

### Issues Resolved ### 

- fixes #7865

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue7865-before](https://user-images.githubusercontent.com/6755973/66494578-2c528b80-eab8-11e9-9c1c-6faccf649816.gif)
#### After
![issue7865-after](https://user-images.githubusercontent.com/6755973/66494581-2d83b880-eab8-11e9-982a-2370ebd76985.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7865. Press any item from the bottom CollectionView. The Carousel must change the position to the selected position.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
