### PR TITLE
Remove requirement for CollectionView Experimental flag

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBindingErrors.xaml.cs
@@ -26,8 +26,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public CollectionViewBindingErrors()
 		{
 #if APP
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			var listener = new CountBindingErrors(BindingErrorCount);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewGroupTypeIssue.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewGroupTypeIssue.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			PushAsync(TestPage());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewHeaderFooterString.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewHeaderFooterString.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterString());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewHeaderFooterTemplate.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewHeaderFooterTemplate.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterTemplate());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewHeaderFooterView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewHeaderFooterView.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterView());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsSourceTypes.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewItemsSourceTypes.cs
@@ -23,9 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-#if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-#endif
 			Content = new StackLayout()
 			{
 				Children =

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FlagTestHelpers.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FlagTestHelpers.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { flag });
 		}
 
-		public static void SetCollectionViewTestFlag()
+		public static void SetCarouselViewTestFlag()
 		{
 			SetTestFlag("CollectionView_Experimental");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
@@ -36,8 +36,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		public Github5623()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			BindingContext = new ViewModel5623();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5354.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5354.xaml.cs
@@ -30,8 +30,6 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 		public Issue5354()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			BindingContext = new ViewModel5354();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5535.cs
@@ -23,8 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewSwapGallery());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5765.cs
@@ -23,8 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(CreateRoot());
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5949.cs
@@ -26,7 +26,6 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			Appearing += Issue5949Appearing;
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6609.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6609.cs
@@ -23,8 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.SelectionGalleries.SelectionChangedCommandParameter());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6644.xaml.cs
@@ -14,7 +14,6 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 		public Issue6644()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 			InitializeComponent();
 			cv.ItemsSource = new ObservableCollection<int>(Enumerable.Range(0, 10).ToList());
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6963.cs
@@ -23,8 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.SelectionGalleries.SelectionSynchronization());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7102.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7102.cs
@@ -23,8 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			PushAsync(new GalleryPages.CollectionViewGalleries.ObservableCodeCollectionViewGallery(grid: false));
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7128.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7128.cs
@@ -23,7 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			PushAsync(CreateRoot());
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7338.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			PushAsync(CreateRoot());
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7357.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7357.xaml.cs
@@ -34,8 +34,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		public Issue7357()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			(CollectionView7357.ItemsLayout as LinearItemsLayout).ItemSpacing = 5;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7512.xaml.cs
@@ -30,8 +30,6 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 		public Issue7512()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			BindingContext = new ViewModel7512();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7519.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7519.cs
@@ -23,7 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			PushAsync(new Issue7519Xaml());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7593.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7593.xaml.cs
@@ -32,8 +32,6 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 		public Issue7593()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			BindingContext = new ViewModel7593();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7621.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7621.xaml.cs
@@ -32,8 +32,6 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 		public Issue7621()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			BindingContext = new ViewModel7621();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7758.xaml.cs
@@ -11,8 +11,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7758()
 		{
 #if APP
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7789.xaml.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7789()
 		{
 #if APP
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7792.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7792.xaml.cs
@@ -18,7 +18,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7792()
 		{
 #if APP
- 			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 			InitializeComponent();
 #endif
 			BindingContext = new Issue7792ViewModel();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7817.xaml.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7817()
 		{
 #if APP
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
 			Title = "Issue 7817";
 			InitializeComponent();
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7865.xaml.cs
@@ -26,7 +26,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7865()
 		{
 #if APP
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 			Title = "Issue 7865";
 			InitializeComponent();
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml.cs
@@ -26,7 +26,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue7943()
 		{
 #if APP
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
 			Title = "Issue 7943";
 			InitializeComponent();
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/NestedCollectionViews.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/NestedCollectionViews.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			PushAsync(new GalleryPages.CollectionViewGalleries.NestedGalleries.NestedCollectionViewGallery());
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollToGroup.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ScrollToGroup.cs
@@ -23,7 +23,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
 			PushAsync(new GalleryPages.CollectionViewGalleries.ScrollToGalleries.ScrollToGroup());
 #endif
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -14,8 +14,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var button = new Button
 			{
-				Text = "Enable CollectionView",
-				AutomationId = "EnableCollectionView"
+				Text = "Enable CarouselView",
+				AutomationId = "EnableCarouselView"
 			};
 			button.Clicked += ButtonClicked;
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			button.TextColor = Color.Black;
 			button.IsEnabled = false;
 
-			Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental });
+			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		{
 			var button = sender as Button;
 
-			button.Text = "CollectionView Enabled!";
+			button.Text = "CarouselView Enabled!";
 			button.TextColor = Color.Black;
 			button.IsEnabled = false;
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -14,20 +14,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 	{
 		public CollectionViewGallery()
 		{
-			var button = new Button
-			{
-				Text = "Enable CollectionView",
-				AutomationId = "EnableCollectionView"
-			};
-			button.Clicked += ButtonClicked;
-
 			Content = new ScrollView
 			{
 				Content = new StackLayout
 				{
 					Children =
 					{
-						button,
 						GalleryBuilder.NavButton("Default Text Galleries", () => new DefaultTextGallery(), Navigation),
 						GalleryBuilder.NavButton("DataTemplate Galleries", () => new DataTemplateGallery(), Navigation),
 						GalleryBuilder.NavButton("Observable Collection Galleries", () => new ObservableCollectionGallery(), Navigation),
@@ -46,17 +38,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 					}
 				}
 			};
-		}
-
-		void ButtonClicked(object sender, System.EventArgs e)
-		{
-			var button = sender as Button;
-
-			button.Text = "CollectionView Enabled!";
-			button.TextColor = Color.Black;
-			button.IsEnabled = false;
-
-			Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
 			{
 				Children =
 				{
-					new Button { Text ="Enable CollectionView", AutomationId = "EnableCollectionView", Command = new Command(() => Device.SetFlags(new[] { ExperimentalFlags.CollectionViewExperimental })) },
 					GalleryBuilder.NavButton("Refresh Layout Gallery", () => new RefreshLayoutGallery(), Navigation),
 					GalleryBuilder.NavButton("Refresh ScrollView Gallery", () => new RefreshScrollViewGallery(), Navigation),
 					GalleryBuilder.NavButton("Refresh ListView Gallery", () => new RefreshListViewGallery(), Navigation),

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -14,9 +14,10 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			App.NavigateToGallery(GalleryQueries.CollectionViewGallery);
 
+			App.WaitForElement(_carouselViewGalleries);
+			App.Tap(_carouselViewGalleries);
 			App.WaitForElement(_enableControl);
 			App.Tap(_enableControl);
-			App.Tap(_carouselViewGalleries);
 		}
 
 		[TestCase("CarouselView (Code, Horizontal)")]

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -7,15 +7,15 @@ namespace Xamarin.Forms.Core.UITests
 	[Category(UITestCategories.CarouselView)]
 	internal class CarouselViewUITests : BaseTestFixture
 	{
-		string _enableCollectionView = "Enable CollectionView";
+		string _enableControl = "Enable CarouselView";
 		string _carouselViewGalleries = "CarouselView Galleries";
 
 		protected override void NavigateToGallery()
 		{
 			App.NavigateToGallery(GalleryQueries.CollectionViewGallery);
 
-			App.WaitForElement(_enableCollectionView);
-			App.Tap(_enableCollectionView);
+			App.WaitForElement(_enableControl);
+			App.Tap(_enableControl);
 			App.Tap(_carouselViewGalleries);
 		}
 

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
@@ -6,7 +6,6 @@ namespace Xamarin.Forms.Core.UITests
 	internal class CollectionViewUITests : BaseTestFixture
 	{
 		string _collectionViewId = "collectionview";
-		string _enableCollectionView = "Enable CollectionView";
 		string _btnUpdate = "Update";
 		string _entryUpdate = "entryUpdate";
 		string _entryInsert = "entryInsert";
@@ -170,8 +169,6 @@ namespace Xamarin.Forms.Core.UITests
 		void VisitInitialGallery(string collectionTestName)
 		{
 			var galeryName = $"{collectionTestName} Galleries";
-			App.WaitForElement(t => t.Marked(_enableCollectionView));
-			App.Tap(t => t.Marked(_enableCollectionView));
 
 			App.WaitForElement(t => t.Marked(galeryName));
 			App.Tap(t => t.Marked(galeryName));

--- a/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[SetUp]
 		public override void Setup()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
 			base.Setup();
 			var mockDeviceInfo = new TestDeviceInfo();
 			Device.Info = mockDeviceInfo;

--- a/Xamarin.Forms.Core.UnitTests/ItemsViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ItemsViewTests.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[SetUp]
 		public override void Setup()
 		{
-			Device.SetFlags(new List<string> {CollectionView.CollectionViewExperimental}); 
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental }); 
 			base.Setup();
 			var mockDeviceInfo = new TestDeviceInfo();
 			Device.Info = mockDeviceInfo;

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Forms
 {
 	internal static class ExperimentalFlags
 	{
-		internal const string CollectionViewExperimental = "CollectionView_Experimental";
 		internal const string ShellUWPExperimental = "Shell_UWP_Experimental";
+		internal const string CarouselViewExperimental = "CarouselView_Experimental";
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void VerifyFlagEnabled(

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms
 	{
 		internal const string ShellUWPExperimental = "Shell_UWP_Experimental";
 		internal const string CarouselViewExperimental = "CarouselView_Experimental";
+		internal const string CollectionViewExperimental = "CollectionView_Experimental";
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void VerifyFlagEnabled(

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -5,6 +5,7 @@ using System.ComponentModel;
 using System.Windows.Input;
 using Xamarin.Forms.Platform;
 using System.Linq;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -173,13 +174,22 @@ namespace Xamarin.Forms
 
 		public CarouselView()
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(constructorHint: nameof(CarouselView));
+			VerifyCarouselViewFlagEnabled(constructorHint: nameof(CarouselView));
 			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
 			{
 				SnapPointsType = SnapPointsType.MandatorySingle,
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
 			ItemSizingStrategy = ItemSizingStrategy.None;
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void VerifyCarouselViewFlagEnabled(
+			string constructorHint = null,
+			[CallerMemberName] string memberName = "")
+		{
+			ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CarouselViewExperimental, 
+				constructorHint, memberName);
 		}
 
 		protected virtual void OnPositionChanged(PositionChangedEventArgs args)

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -188,8 +188,17 @@ namespace Xamarin.Forms
 			string constructorHint = null,
 			[CallerMemberName] string memberName = "")
 		{
-			ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CarouselViewExperimental, 
-				constructorHint, memberName);
+			try
+			{
+				ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CarouselViewExperimental,
+					constructorHint, memberName);
+			}
+			catch (InvalidOperationException)
+			{
+				// We'll still honor the CollectionView_Experimental flag for CarouselView stuff
+				ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CollectionViewExperimental,
+					constructorHint, memberName);
+			}
 		}
 
 		protected virtual void OnPositionChanged(PositionChangedEventArgs args)

--- a/Xamarin.Forms.Core/Items/CollectionView.cs
+++ b/Xamarin.Forms.Core/Items/CollectionView.cs
@@ -12,19 +12,5 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_CollectionViewRenderer))]
 	public class CollectionView : GroupableItemsView
 	{
-		internal const string CollectionViewExperimental = "CollectionView_Experimental";
-
-		public CollectionView()
-		{
-			VerifyCollectionViewFlagEnabled(constructorHint: nameof(CollectionView));
-		}
-
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static void VerifyCollectionViewFlagEnabled(
-			string constructorHint = null,
-			[CallerMemberName] string memberName = "")
-		{
-			ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CollectionViewExperimental);
-		}
 	}
 }

--- a/Xamarin.Forms.Core/Items/ItemsLayout.cs
+++ b/Xamarin.Forms.Core/Items/ItemsLayout.cs
@@ -6,7 +6,6 @@
 
 		protected ItemsLayout([Parameter("Orientation")] ItemsLayoutOrientation orientation)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(constructorHint: nameof(ItemsLayout));
 			Orientation = orientation;
 		}
 

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -11,11 +11,6 @@ namespace Xamarin.Forms
 	{
 		List<Element> _logicalChildren = new List<Element>();
 
-		protected internal ItemsView()
-		{
-			CollectionView.VerifyCollectionViewFlagEnabled(constructorHint: nameof(ItemsView));
-		}
-
 		public static readonly BindableProperty EmptyViewProperty =
 			BindableProperty.Create(nameof(EmptyView), typeof(object), typeof(ItemsView), null);
 

--- a/Xamarin.Forms.Core/Items/ScrollToRequestEventArgs.cs
+++ b/Xamarin.Forms.Core/Items/ScrollToRequestEventArgs.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Forms
 		public ScrollToRequestEventArgs(int index, int groupIndex, 
 			ScrollToPosition scrollToPosition, bool isAnimated)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(ScrollToRequestEventArgs));
-
 			Mode = ScrollToMode.Position;
 
 			Index = index;
@@ -31,8 +29,6 @@ namespace Xamarin.Forms
 		public ScrollToRequestEventArgs(object item, object group, 
 			ScrollToPosition scrollToPosition, bool isAnimated)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(ScrollToRequestEventArgs));
-
 			Mode = ScrollToMode.Element;
 
 			Item = item;

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Views;
-using FormsCollectionView = Xamarin.Forms.CollectionView;
+using FormsCarouselView = Xamarin.Forms.CarouselView;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public CarouselViewRenderer(Context context) : base(context)
 		{
-			FormsCollectionView.VerifyCollectionViewFlagEnabled(nameof(CarouselViewRenderer));
+			FormsCarouselView.VerifyCarouselViewFlagEnabled(nameof(CarouselViewRenderer));
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -43,7 +43,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public EmptyViewAdapter(ItemsView itemsView)
 		{
-			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(EmptyViewAdapter));
 			ItemsView = itemsView;
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal ItemsViewAdapter(TItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
-			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewAdapter<TItemsView, TItemsViewSource>));
-
 			ItemsView = itemsView ?? throw new ArgumentNullException(nameof(itemsView));
 
 			UpdateUsingItemTemplate();

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -42,8 +42,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public ItemsViewRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.collectionViewStyle))
 		{
-			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewRenderer<TItemsView, TAdapter, TItemsViewSource>));
-
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 			_effectControlProvider = new EffectControlProvider(this);
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/PositionalSmoothScroller.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/PositionalSmoothScroller.cs
@@ -9,7 +9,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public PositionalSmoothScroller(Context context, ScrollToPosition scrollToPosition) : base(context)
 		{
-			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(PositionalSmoothScroller));
 			_scrollToPosition = scrollToPosition;
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/SnapManager.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SnapManager.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public SnapManager(IItemsLayout itemsLayout, RecyclerView recyclerView)
 		{
-			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(SnapManager));
 			_itemsLayout = itemsLayout;
 			_recyclerView = recyclerView;
 		}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.UWP
 		ScrollViewer _scrollViewer;
 		public CarouselViewRenderer()
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(CarouselView));
+			CarouselView.VerifyCarouselViewFlagEnabled(nameof(CarouselView));
 		}
 
 		CarouselView CarouselView => Element;

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
@@ -13,7 +13,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 		public ItemContentControl()
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemContentControl));
 			DefaultStyleKey = typeof(ItemContentControl);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public CarouselViewRenderer()
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(CarouselViewRenderer));
+			CarouselView.VerifyCarouselViewFlagEnabled(nameof(CarouselViewRenderer));
 		}
 
 		protected override CarouselViewController CreateController(CarouselView newElement, ItemsViewLayout layout)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/DefaultCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/DefaultCell.cs
@@ -14,8 +14,6 @@ namespace Xamarin.Forms.Platform.iOS
 		[Export("initWithFrame:")]
 		protected DefaultCell(CGRect frame) : base(frame)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(DefaultCell));
-
 			Label = new UILabel(frame)
 			{
 				TextColor = UIColor.Black,

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewCell.cs
@@ -10,7 +10,6 @@ namespace Xamarin.Forms.Platform.iOS
 		[Export("initWithFrame:")]
 		protected ItemsViewCell(CGRect frame) : base(frame)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewCell));
 			ContentView.BackgroundColor = UIColor.Clear;
 
 			var selectedBackgroundView = new UIView

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -20,8 +20,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected ItemsViewLayout(ItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy)
 		{
-			Xamarin.Forms.CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewLayout));
-
 			ItemSizingStrategy = itemSizingStrategy;
 
 			_itemsLayout = itemsLayout;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -15,10 +15,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected TItemsView ItemsView => Element;
 
-		public ItemsViewRenderer()
-		{
-			CollectionView.VerifyCollectionViewFlagEnabled(nameof(ItemsViewRenderer<TItemsView, TViewController>));
-		}
+
 
 		public override UIViewController ViewController => Controller;
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ScrollToPositionExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ScrollToPositionExtensions.cs
@@ -7,8 +7,6 @@ namespace Xamarin.Forms.Platform.iOS
 		public static UICollectionViewScrollPosition ToCollectionViewScrollPosition(this ScrollToPosition scrollToPosition, 
 			UICollectionViewScrollDirection scrollDirection = UICollectionViewScrollDirection.Vertical, bool isLtr = false)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled();
-
 			if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
 			{
 				return scrollToPosition.ToHorizontalCollectionViewScrollPosition(isLtr);
@@ -19,8 +17,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public static UICollectionViewScrollPosition ToHorizontalCollectionViewScrollPosition(this ScrollToPosition scrollToPosition, bool isLtr)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled();
-
 			switch (scrollToPosition)
 			{
 				case ScrollToPosition.MakeVisible:
@@ -37,8 +33,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public static UICollectionViewScrollPosition ToVerticalCollectionViewScrollPosition(this ScrollToPosition scrollToPosition)
 		{
-			CollectionView.VerifyCollectionViewFlagEnabled();
-
 			switch (scrollToPosition)
 			{
 				case ScrollToPosition.MakeVisible:


### PR DESCRIPTION
### Description of Change ###

Removes requirement for CollectionView_Experimental flag; adds CarouselView_Experimental flag requirement.

### Issues Resolved ### 
None

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
