### PR TITLE
Ellipsize Picker text on Android

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialPickerEditText.cs
+++ b/Xamarin.Forms.Material.Android/MaterialPickerEditText.cs
@@ -1,4 +1,8 @@
-﻿#if __ANDROID_28__
+﻿
+using Android.Support.V4.View;
+using Android.Text;
+using Java.Lang;
+#if __ANDROID_28__
 using System;
 using Android.Content;
 using Android.Graphics;
@@ -31,6 +35,24 @@ namespace Xamarin.Forms.Material.Android
 		{
 			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
 			PickerManager.OnFocusChanged(gainFocus, this, (IPopupTrigger)Parent.Parent);
+		}
+
+		public override void SetText(ICharSequence text, BufferType type)
+		{
+			if (ViewCompat.IsLaidOut(this) && text != null)
+			{
+				int textWidth = Width - CompoundPaddingLeft - CompoundPaddingRight;
+
+				string fullText = text.ToString();
+				string ellipsizedText = TextUtils.Ellipsize(fullText, Paint, textWidth, TextUtils.TruncateAt.End);
+
+				if (!string.IsNullOrEmpty(ellipsizedText))
+				{
+					text = new Java.Lang.String(ellipsizedText);
+				}
+			}
+
+			base.SetText(text, type);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerEditText.cs
@@ -2,8 +2,11 @@ using System;
 using Android.Content;
 using Android.Graphics;
 using Android.Runtime;
+using Android.Support.V4.View;
+using Android.Text;
 using Android.Views;
 using Android.Widget;
+using Java.Lang;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -31,6 +34,24 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnFocusChanged(gainFocus, direction, previouslyFocusedRect);
 			PickerManager.OnFocusChanged(gainFocus, this, this);
+		}
+
+		public override void SetText(ICharSequence text, BufferType type)
+		{
+			if (ViewCompat.IsLaidOut(this) && text != null)
+			{
+				int textWidth = Width - CompoundPaddingLeft - CompoundPaddingRight;
+
+				string fullText = text.ToString();
+				string ellipsizedText = TextUtils.Ellipsize(fullText, Paint, textWidth, TextUtils.TruncateAt.End);
+
+				if (!string.IsNullOrEmpty(ellipsizedText))
+				{
+					text = new Java.Lang.String(ellipsizedText);
+				}
+			}
+
+			base.SetText(text, type);
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

Ellipsize the text in the Picker on Android if it is too long.

### Issues Resolved ### 

- fixes #5703 

### API Changes ###

Added:
 - public override void PickerEditText.SetText(ICharSequence text, BufferType type)
 - public override void MaterialPickerEditText.SetText(ICharSequence text, BufferType type)

### Platforms Affected ### 

- Android
- Android Material

### Behavioral/Visual Changes ###

Text is ellipsized.

### Before/After Screenshots ### 
Before:
![Screenshot_1570648970](https://user-images.githubusercontent.com/6132629/66516160-11771b80-eaa6-11e9-8d27-639ae6212d77.png)

After:
![Screenshot_1570649138](https://user-images.githubusercontent.com/6132629/66516164-13d97580-eaa6-11e9-859f-be1b66983ca5.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Add a long string to the Items of a picker. Select that item.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
