### PR TITLE
Change build type on AndroidManifest.XML inside  ControlGallery

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -219,9 +219,7 @@
     </AndroidResource>
   </ItemGroup>
   <ItemGroup>
-    <TransformFile Include="Properties\AndroidManifest.xml">
-      <SubType>Designer</SubType>
-    </TransformFile>
+    <None Include="Properties\AndroidManifest.xml" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\error.xml" />


### PR DESCRIPTION
### Description of Change ###
Currently AndroidManifest.xml is set to *TransformFile* but that's not correct. If you create any new android projects you'll see it's just set to *None*

Having it set to *TransformFile* is causing issues with VS 16.3 and opening the file. 

### Platforms Affected ### 
- Android


### Testing Procedure ###
- make sure the gallery runs and settings inside AndroidManifest file are being used

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
