### PR TITLE
Add IsReadOnly to Switch

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
@@ -43,9 +43,16 @@ namespace Xamarin.Forms.Controls
 			thumbColorContainer.ContainerLayout.Children.Add(changeThumbColorButton);
 			thumbColorContainer.ContainerLayout.Children.Add(clearThumbColorButton);
 
+			var isReadOnlyContainer = new StateViewContainer<Switch>(Test.Switch.IsReadOnly, new Switch());
+			isReadOnlyContainer.StateChangeButton.Command = new Command(() =>
+			{
+				isReadOnlyContainer.View.IsReadOnly = !isReadOnlyContainer.View.IsReadOnly;
+			});
+
 			Add(isToggledContainer);
 			Add(onColorContainer);
 			Add(thumbColorContainer);
+			Add(isReadOnlyContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Switch.cs
+++ b/Xamarin.Forms.Core/Switch.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Switch), Color.Default);
 
+		public static readonly BindableProperty IsReadOnlyProperty = BindableProperty.Create(nameof(IsReadOnly), typeof(bool), typeof(Switch), false);
+
 		public Color OnColor
 		{
 			get { return (Color)GetValue(OnColorProperty); }
@@ -27,6 +29,12 @@ namespace Xamarin.Forms
 		{
 			get { return (Color)GetValue(ThumbColorProperty); }
 			set { SetValue(ThumbColorProperty, value); }
+		}
+
+		public bool IsReadOnly
+		{
+			get { return (bool)GetValue(IsReadOnlyProperty); }
+			set { SetValue(IsReadOnlyProperty, value); }
 		}
 
 		readonly Lazy<PlatformConfigurationRegistry<Switch>> _platformConfigurationRegistry;

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -738,7 +738,8 @@ namespace Xamarin.Forms.CustomAttributes
 		{
 			IsToggled,
 			OnColor,
-			ThumbColor
+			ThumbColor,
+			IsReadOnly
 		}
 
 		public enum CheckBox

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -33,7 +33,17 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void CompoundButton.IOnCheckedChangeListener.OnCheckedChanged(CompoundButton buttonView, bool isChecked)
 		{
-			((IViewController)Element).SetValueFromRenderer(Switch.IsToggledProperty, isChecked);
+			if (Element.IsReadOnly)
+			{
+				if (Element.IsToggled != Control.Checked)
+				{
+					Control.Toggle();
+				}
+			}
+			else
+			{
+				((IViewController)Element).SetValueFromRenderer(Switch.IsToggledProperty, isChecked);
+			}
 			UpdateOnColor();
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -28,7 +28,17 @@ namespace Xamarin.Forms.Platform.Android
 
 		void CompoundButton.IOnCheckedChangeListener.OnCheckedChanged(CompoundButton buttonView, bool isChecked)
 		{
-			((IViewController)Element).SetValueFromRenderer(Switch.IsToggledProperty, isChecked);
+			if (Element.IsReadOnly)
+			{
+				if (Element.IsToggled != Control.Checked)
+				{
+					Control.Toggle();
+				}
+			}
+			else
+			{
+				((IViewController)Element).SetValueFromRenderer(Switch.IsToggledProperty, isChecked);
+			}
 			UpdateOnColor();
 		}
 

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -65,7 +65,17 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnNativeToggled(object sender, RoutedEventArgs routedEventArgs)
 		{
-			((IElementController)Element).SetValueFromRenderer(Switch.IsToggledProperty, Control.IsOn);
+			if (Element.IsReadOnly)
+			{
+				if (Element.IsToggled != Control.IsOn)
+				{
+					Control.IsOn = !Control.IsOn;
+				}
+			}
+			else
+			{
+				((IElementController)Element).SetValueFromRenderer(Switch.IsToggledProperty, Control.IsOn);
+			}
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Platform.iOS
 				e.NewElement.Toggled += OnElementToggled;
 				UpdateOnColor();
 				UpdateThumbColor();
+				UpdateIsReadonly();
 			}
 
 			base.OnElementChanged(e);
@@ -62,6 +63,14 @@ namespace Xamarin.Forms.Platform.iOS
 			Control.ThumbTintColor = thumbColor.IsDefault ? _defaultThumbColor : thumbColor.ToUIColor();
 		}
 
+		void UpdateIsReadonly()
+		{
+			if (Element == null)
+				return;
+
+			Control.UserInteractionEnabled = !Element.IsReadOnly;
+		}
+
 		void OnControlValueChanged(object sender, EventArgs e)
 		{
 			((IElementController)Element).SetValueFromRenderer(Switch.IsToggledProperty, Control.On);
@@ -80,6 +89,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateOnColor();
 			if (e.PropertyName == Switch.ThumbColorProperty.PropertyName)
 				UpdateThumbColor();
+			if (e.PropertyName == Switch.IsReadOnlyProperty.PropertyName)
+				UpdateIsReadonly();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Add IsReadOnly property to the Switch.

This allows for focusing the control by keyboard navigation, as the Entry ReadOnly does, but not changing the value.

Both Android and UWP give a bit of visual when that happens, but never visibly toggle state.

### Issues Resolved ### 

- fixes #6953

### API Changes ###
Added:
 - bool Switch.IsReadOnly { get; set; } //Bindable Property


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
Default of IsReadOnly is false. No changes without setting the property.

When set, the Switch still appears enabled, but toggling does not occur.

### Before/After Screenshots ### 

Not applicable, looks the same as always

### Testing Procedure ###
Go the Switch Gallery page in the Control Gallery. Scroll to the IsReadOnly option.

Try and toggle the switch, push the Change Readonly button, try and toggle the switch.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
