### PR TITLE
Move CollectionView UWP implementation to generics

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -21,6 +21,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		CarouselView CarouselView => Element;
 		protected override IItemsLayout Layout => CarouselView?.ItemsLayout;
+		LinearItemsLayout CarouselItemsLayout => CarouselView?.ItemsLayout;
+
 		UWPDataTemplate CarouselItemsViewTemplate => (UWPDataTemplate)UWPApp.Current.Resources["CarouselItemsViewDefaultTemplate"];
 
 		double _itemWidth;
@@ -42,9 +44,9 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateIsBounceEnabled();
 		}
 
-		protected override void HandleLayoutPropertyChange(PropertyChangedEventArgs property)
+		protected override void HandleLayoutPropertyChanged(PropertyChangedEventArgs property)
 		{
-			if (property.IsOneOf(LinearItemsLayout.ItemSpacingProperty, GridItemsLayout.HorizontalItemSpacingProperty, GridItemsLayout.VerticalItemSpacingProperty))
+			if (property.IsOneOf(LinearItemsLayout.ItemSpacingProperty))
 				UpdateItemSpacing();
 			else if (property.Is(ItemsLayout.SnapPointsTypeProperty))
 				UpdateSnapPointsType();
@@ -108,19 +110,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected override ListViewBase SelectListViewBase()
 		{
-			ListViewBase listView = null;
-
-			switch (Layout)
-			{
-				case LinearItemsLayout listItemsLayout:
-					listView = CreateCarouselListLayout(listItemsLayout.Orientation);
-					break;
-			}
-
-			if (listView == null)
-			{
-				listView = new FormsListView();
-			}
+			ListViewBase listView = CreateCarouselListLayout(CarouselItemsLayout.Orientation);
 
 			FindScrollViewer(listView);
 
@@ -174,13 +164,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 			ListViewBase.IsSwipeEnabled = CarouselView.IsSwipeEnabled;
 
-			switch (Layout)
+			switch (CarouselItemsLayout.Orientation)
 			{
-				case LinearItemsLayout listItemsLayout when listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal:
+				case ItemsLayoutOrientation.Horizontal:
 					ScrollViewer.SetHorizontalScrollMode(ListViewBase, CarouselView.IsSwipeEnabled ? ScrollMode.Auto : ScrollMode.Disabled);
 					ScrollViewer.SetHorizontalScrollBarVisibility(ListViewBase, CarouselView.IsSwipeEnabled ? WScrollBarVisibility.Auto : WScrollBarVisibility.Disabled);
 					break;
-				case LinearItemsLayout listItemsLayout when listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical:
+				case ItemsLayoutOrientation.Vertical:
 					ScrollViewer.SetVerticalScrollMode(ListViewBase, CarouselView.IsSwipeEnabled ? ScrollMode.Auto : ScrollMode.Disabled);
 					ScrollViewer.SetVerticalScrollBarVisibility(ListViewBase, CarouselView.IsSwipeEnabled ? WScrollBarVisibility.Auto : WScrollBarVisibility.Disabled);
 					break;
@@ -197,15 +187,12 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			UpdateItemsSource();
 
-			if (Layout is LinearItemsLayout listItemsLayout)
-			{
-				var itemSpacing = listItemsLayout.ItemSpacing;
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
-					_scrollViewer.Padding = new Windows.UI.Xaml.Thickness(0, 0, itemSpacing, 0);
+			var itemSpacing = CarouselItemsLayout.ItemSpacing;
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+				_scrollViewer.Padding = new Windows.UI.Xaml.Thickness(0, 0, itemSpacing, 0);
 
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
-					_scrollViewer.Padding = new Windows.UI.Xaml.Thickness(0, 0, 0, itemSpacing);
-			}
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
+				_scrollViewer.Padding = new Windows.UI.Xaml.Thickness(0, 0, 0, itemSpacing);
 		}
 
 		void UpdateSnapPointsType()
@@ -213,14 +200,11 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_scrollViewer == null)
 				return;
 
-			if (Layout is LinearItemsLayout listItemsLayout)
-			{
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
-					_scrollViewer.HorizontalSnapPointsType = GetWindowsSnapPointsType(listItemsLayout.SnapPointsType);
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+				_scrollViewer.HorizontalSnapPointsType = GetWindowsSnapPointsType(CarouselItemsLayout.SnapPointsType);
 
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
-					_scrollViewer.VerticalSnapPointsType = GetWindowsSnapPointsType(listItemsLayout.SnapPointsType);
-			}
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
+				_scrollViewer.VerticalSnapPointsType = GetWindowsSnapPointsType(CarouselItemsLayout.SnapPointsType);
 		}
 
 		void UpdateSnapPointsAlignment()
@@ -228,14 +212,11 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_scrollViewer == null)
 				return;
 
-			if (Layout is LinearItemsLayout listItemsLayout)
-			{
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
-					_scrollViewer.HorizontalSnapPointsAlignment = GetWindowsSnapPointsAlignment(listItemsLayout.SnapPointsAlignment);
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+				_scrollViewer.HorizontalSnapPointsAlignment = GetWindowsSnapPointsAlignment(CarouselItemsLayout.SnapPointsAlignment);
 
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
-					_scrollViewer.VerticalSnapPointsAlignment = GetWindowsSnapPointsAlignment(listItemsLayout.SnapPointsAlignment);
-			}
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
+				_scrollViewer.VerticalSnapPointsAlignment = GetWindowsSnapPointsAlignment(CarouselItemsLayout.SnapPointsAlignment);
 		}
 
 		ListViewBase CreateCarouselListLayout(ItemsLayoutOrientation layoutOrientation)
@@ -265,10 +246,10 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			var itemWidth = ActualWidth;
 
-			if (Layout is LinearItemsLayout listItemsLayout && listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
 			{
 				var numberOfVisibleItems = CarouselView.NumberOfSideItems * 2 + 1;
-				itemWidth = (ActualWidth - CarouselView.PeekAreaInsets.Left - CarouselView.PeekAreaInsets.Right - listItemsLayout.ItemSpacing) / numberOfVisibleItems;
+				itemWidth = (ActualWidth - CarouselView.PeekAreaInsets.Left - CarouselView.PeekAreaInsets.Right - CarouselItemsLayout.ItemSpacing) / numberOfVisibleItems;
 			}
 
 			return Math.Max(itemWidth, 0);
@@ -278,10 +259,10 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			var itemHeight = ActualHeight;
 
-			if (Layout is LinearItemsLayout listItemsLayout && listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
 			{
 				var numberOfVisibleItems = CarouselView.NumberOfSideItems * 2 + 1;
-				itemHeight = (ActualHeight - CarouselView.PeekAreaInsets.Top - CarouselView.PeekAreaInsets.Bottom - listItemsLayout.ItemSpacing) / numberOfVisibleItems;
+				itemHeight = (ActualHeight - CarouselView.PeekAreaInsets.Top - CarouselView.PeekAreaInsets.Bottom - CarouselItemsLayout.ItemSpacing) / numberOfVisibleItems;
 			}
 
 			return Math.Max(itemHeight, 0);
@@ -289,16 +270,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 		Thickness GetItemSpacing()
 		{
-			if (Layout is LinearItemsLayout listItemsLayout)
-			{
-				var itemSpacing = listItemsLayout.ItemSpacing;
+			var itemSpacing = CarouselItemsLayout.ItemSpacing;
 
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
-					return new Thickness(itemSpacing, 0, 0, 0);
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
+				return new Thickness(itemSpacing, 0, 0, 0);
 
-				if (listItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
-					return new Thickness(0, itemSpacing, 0, 0);
-			}
+			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
+				return new Thickness(0, itemSpacing, 0, 0);
 
 			return new Thickness(0);
 		}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -11,7 +11,7 @@ using WSnapPointsAlignment = Windows.UI.Xaml.Controls.Primitives.SnapPointsAlign
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class CarouselViewRenderer : ItemsViewRenderer
+	public class CarouselViewRenderer : ItemsViewRenderer<CarouselView>
 	{
 		ScrollViewer _scrollViewer;
 		public CarouselViewRenderer()
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.UWP
 			CollectionView.VerifyCollectionViewFlagEnabled(nameof(CarouselView));
 		}
 
-		CarouselView CarouselView => (CarouselView)Element;
+		CarouselView CarouselView => Element;
 		protected override IItemsLayout Layout => CarouselView?.ItemsLayout;
 		UWPDataTemplate CarouselItemsViewTemplate => (UWPDataTemplate)UWPApp.Current.Resources["CarouselItemsViewDefaultTemplate"];
 
@@ -30,9 +30,9 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
 
-			if (changedProperty.IsOneOf(ItemsView.ItemsSourceProperty, CarouselView.NumberOfSideItemsProperty, LinearItemsLayout.ItemSpacingProperty))
+			if (changedProperty.IsOneOf(CarouselView.ItemsSourceProperty, CarouselView.NumberOfSideItemsProperty, LinearItemsLayout.ItemSpacingProperty))
 				UpdateItemsSource();
-			else if (changedProperty.Is(ItemsView.ItemTemplateProperty))
+			else if (changedProperty.Is(CarouselView.ItemTemplateProperty))
 				UpdateItemTemplate();
 			else if (changedProperty.Is(CarouselView.PeekAreaInsetsProperty))
 				UpdatePeekAreaInsets();

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CollectionViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CollectionViewRenderer.cs
@@ -14,7 +14,7 @@ using Xamarin.Forms.Platform.UAP;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class CollectionViewRenderer : GroupableItemsViewRenderer
+	public class CollectionViewRenderer : GroupableItemsViewRenderer<GroupableItemsView>
 	{
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/GroupableItemsViewRenderer.cs
@@ -4,22 +4,9 @@ using Windows.UI.Xaml.Data;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class GroupableItemsViewRenderer : SelectableItemsViewRenderer
+	public class GroupableItemsViewRenderer<TItemsView> : SelectableItemsViewRenderer<TItemsView>
+		where TItemsView : GroupableItemsView
 	{
-		GroupableItemsView _groupableItemsView;
-
-		protected override void SetUpNewElement(ItemsView newElement)
-		{
-			_groupableItemsView = Element as GroupableItemsView;
-			base.SetUpNewElement(newElement);
-		}
-
-		protected override void TearDownOldElement(ItemsView oldElement)
-		{
-			base.TearDownOldElement(oldElement);
-			_groupableItemsView = null;
-		}
-
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs changedProperty)
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
@@ -33,7 +20,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected override CollectionViewSource CreateCollectionViewSource()
 		{
-			if (_groupableItemsView != null && _groupableItemsView.IsGrouped)
+			if (ItemsView != null && ItemsView.IsGrouped)
 			{
 				var itemTemplate = Element.ItemTemplate;
 				var itemsSource = Element.ItemsSource;
@@ -41,7 +28,7 @@ namespace Xamarin.Forms.Platform.UWP
 				return new CollectionViewSource
 				{
 					Source = TemplatedItemSourceFactory.CreateGrouped(itemsSource, itemTemplate,
-					_groupableItemsView.GroupHeaderTemplate, _groupableItemsView.GroupFooterTemplate, Element),
+					ItemsView.GroupHeaderTemplate, ItemsView.GroupFooterTemplate, Element),
 					IsSourceGrouped = true,
 					ItemsPath = new Windows.UI.Xaml.PropertyPath(nameof(GroupTemplateContext.Items))
 				};

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -11,7 +11,8 @@ using System.Collections.Specialized;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public abstract class ItemsViewRenderer : ViewRenderer<ItemsView, ListViewBase>
+	public abstract class ItemsViewRenderer<TItemsView> : ViewRenderer<TItemsView, ListViewBase>
+		where TItemsView : ItemsView
 	{
 		protected CollectionViewSource CollectionViewSource;
 
@@ -25,9 +26,10 @@ namespace Xamarin.Forms.Platform.UWP
 		FrameworkElement _emptyView;
 		View _formsEmptyView;
 
+		protected TItemsView ItemsView => Element;
 		protected ItemsControl ItemsControl { get; private set; }
 
-		protected override void OnElementChanged(ElementChangedEventArgs<ItemsView> args)
+		protected override void OnElementChanged(ElementChangedEventArgs<TItemsView> args)
 		{
 			base.OnElementChanged(args);
 			TearDownOldElement(args.OldElement);
@@ -38,23 +40,24 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
 
-			if (changedProperty.Is(ItemsView.ItemsSourceProperty))
+			if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemsSourceProperty))
 			{
 				UpdateItemsSource();
 			}
-			else if (changedProperty.Is(ItemsView.ItemTemplateProperty))
+			else if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemTemplateProperty))
 			{
 				UpdateItemTemplate();
 			}
-			else if (changedProperty.Is(ItemsView.HorizontalScrollBarVisibilityProperty))
+			else if (changedProperty.Is(Xamarin.Forms.ItemsView.HorizontalScrollBarVisibilityProperty))
 			{
 				UpdateHorizontalScrollBarVisibility();
 			}
-			else if (changedProperty.Is(ItemsView.VerticalScrollBarVisibilityProperty))
+			else if (changedProperty.Is(Xamarin.Forms.ItemsView.VerticalScrollBarVisibilityProperty))
 			{
 				UpdateVerticalScrollBarVisibility();
 			}
-			else if (changedProperty.IsOneOf(ItemsView.EmptyViewProperty, ItemsView.EmptyViewTemplateProperty))
+			else if (changedProperty.IsOneOf(Xamarin.Forms.ItemsView.EmptyViewProperty, 
+				Xamarin.Forms.ItemsView.EmptyViewTemplateProperty))
 			{
 				UpdateEmptyView();
 			}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		protected abstract ListViewBase SelectListViewBase();
-		protected abstract void HandleLayoutPropertyChange(PropertyChangedEventArgs property);
+		protected abstract void HandleLayoutPropertyChanged(PropertyChangedEventArgs property);
 		protected abstract IItemsLayout Layout { get; }
 
 		protected virtual void UpdateItemsSource()
@@ -162,7 +162,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void LayoutPropertyChanged(object sender, PropertyChangedEventArgs property)
 		{
-			HandleLayoutPropertyChange(property);
+			HandleLayoutPropertyChanged(property);
 		}
 
 		protected virtual void SetUpNewElement(ItemsView newElement)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
@@ -5,9 +5,9 @@ using UWPListViewSelectionMode = Windows.UI.Xaml.Controls.ListViewSelectionMode;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class SelectableItemsViewRenderer : StructuredItemsViewRenderer
+	public class SelectableItemsViewRenderer<TItemsView> : StructuredItemsViewRenderer<TItemsView>
+		where TItemsView : SelectableItemsView
 	{
-		SelectableItemsView _selectableItemsView;
 		bool _ignoreNativeSelectionChange;
 
 		protected override void TearDownOldElement(ItemsView oldElement)
@@ -19,9 +19,9 @@ namespace Xamarin.Forms.Platform.UWP
 				oldListViewBase.SelectionChanged -= OnNativeSelectionChanged;
 			}
 
-			if (_selectableItemsView != null)
+			if (ItemsView != null)
 			{
-				_selectableItemsView.SelectionChanged -= OnSelectionChanged;
+				ItemsView.SelectionChanged -= OnSelectionChanged;
 			}
 
 			base.TearDownOldElement(oldElement);
@@ -36,11 +36,9 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 
-			_selectableItemsView = newElement as SelectableItemsView;
-
-			if (_selectableItemsView != null)
+			if (ItemsView != null)
 			{
-				_selectableItemsView.SelectionChanged += OnSelectionChanged;
+				ItemsView.SelectionChanged += OnSelectionChanged;
 			}
 
 			var newListViewBase = ListViewBase;
@@ -50,7 +48,7 @@ namespace Xamarin.Forms.Platform.UWP
 				newListViewBase.SetBinding(ListViewBase.SelectionModeProperty,
 						new Windows.UI.Xaml.Data.Binding
 						{
-							Source = _selectableItemsView,
+							Source = ItemsView,
 							Path = new Windows.UI.Xaml.PropertyPath("SelectionMode"),
 							Converter = new SelectionModeConvert(),
 							Mode = Windows.UI.Xaml.Data.BindingMode.TwoWay
@@ -80,9 +78,9 @@ namespace Xamarin.Forms.Platform.UWP
 				case UWPListViewSelectionMode.None:
 					break;
 				case UWPListViewSelectionMode.Single:
-					if (_selectableItemsView != null)
+					if (ItemsView != null)
 					{
-						if (_selectableItemsView.SelectedItem == null)
+						if (ItemsView.SelectedItem == null)
 						{
 							ListViewBase.SelectedItem = null;
 						}
@@ -93,11 +91,11 @@ namespace Xamarin.Forms.Platform.UWP
 								{
 									if (item is ItemTemplateContext itemPair)
 									{
-										return itemPair.Item == _selectableItemsView.SelectedItem;
+										return itemPair.Item == ItemsView.SelectedItem;
 									}
 									else
 									{
-										return item == _selectableItemsView.SelectedItem;
+										return item == ItemsView.SelectedItem;
 									}
 								});
 						}
@@ -108,11 +106,11 @@ namespace Xamarin.Forms.Platform.UWP
 					ListViewBase.SelectedItems.Clear();
 					foreach (var nativeItem in ListViewBase.Items)
 					{
-						if (nativeItem is ItemTemplateContext itemPair && _selectableItemsView.SelectedItems.Contains(itemPair.Item))
+						if (nativeItem is ItemTemplateContext itemPair && ItemsView.SelectedItems.Contains(itemPair.Item))
 						{
 							ListViewBase.SelectedItems.Add(nativeItem);
 						}
-						else if (_selectableItemsView.SelectedItems.Contains(nativeItem))
+						else if (ItemsView.SelectedItems.Contains(nativeItem))
 						{
 							ListViewBase.SelectedItems.Add(nativeItem);
 						}
@@ -155,7 +153,7 @@ namespace Xamarin.Forms.Platform.UWP
 					case UWPListViewSelectionMode.Multiple:
 						selectableItemsView.SelectionChanged -= OnSelectionChanged;
 
-						_selectableItemsView.SelectedItems.Clear();
+						ItemsView.SelectedItems.Clear();
 						var selectedItems =
 							ListViewBase.SelectedItems
 								.Select(a =>
@@ -167,7 +165,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 						foreach (var item in selectedItems)
 						{
-							_selectableItemsView.SelectedItems.Add(item);
+							ItemsView.SelectedItems.Add(item);
 						}
 
 						selectableItemsView.SelectionChanged += OnSelectionChanged;

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -4,18 +4,16 @@ using UWPApp = Windows.UI.Xaml.Application;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class StructuredItemsViewRenderer : ItemsViewRenderer
+	public class StructuredItemsViewRenderer<TItemsView> : ItemsViewRenderer<TItemsView>
+		where TItemsView : StructuredItemsView
 	{
-		StructuredItemsView _structuredItemsView;
 		View _currentHeader;
 		View _currentFooter;
 
-		protected override IItemsLayout Layout { get => _structuredItemsView.ItemsLayout; }
+		protected override IItemsLayout Layout { get => ItemsView?.ItemsLayout; }
 
 		protected override void SetUpNewElement(ItemsView newElement)
 		{
-			_structuredItemsView = newElement as StructuredItemsView;
-
 			base.SetUpNewElement(newElement);
 
 			if (newElement == null)
@@ -69,7 +67,7 @@ namespace Xamarin.Forms.Platform.UWP
 				_currentHeader = null;
 			}
 
-			var header = _structuredItemsView.Header;
+			var header = ItemsView.Header;
 
 			switch (header)
 			{
@@ -90,7 +88,7 @@ namespace Xamarin.Forms.Platform.UWP
 					break;
 
 				default:
-					var headerTemplate = _structuredItemsView.HeaderTemplate;
+					var headerTemplate = ItemsView.HeaderTemplate;
 					if (headerTemplate != null)
 					{
 						ListViewBase.HeaderTemplate = ItemsViewTemplate;
@@ -118,7 +116,7 @@ namespace Xamarin.Forms.Platform.UWP
 				_currentFooter = null;
 			}
 
-			var footer = _structuredItemsView.Footer;
+			var footer = ItemsView.Footer;
 
 			switch (footer)
 			{
@@ -139,7 +137,7 @@ namespace Xamarin.Forms.Platform.UWP
 					break;
 
 				default:
-					var footerTemplate = _structuredItemsView.FooterTemplate;
+					var footerTemplate = ItemsView.FooterTemplate;
 					if (footerTemplate != null)
 					{
 						ListViewBase.FooterTemplate = ItemsViewTemplate;

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -152,7 +152,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		protected override void HandleLayoutPropertyChange(PropertyChangedEventArgs property)
+		protected override void HandleLayoutPropertyChanged(PropertyChangedEventArgs property)
 		{
 			if (property.Is(GridItemsLayout.SpanProperty))
 			{


### PR DESCRIPTION
### Description of Change ###

The UWP implementation for CollectionView has some awkward casts and unnecessary local typed references to maintain that can be done more cleanly with generics. These changes clean up the code.

### Issues Resolved ### 
None, just makes the code easier to maintain.

### API Changes ###
None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
