### PR TITLE
Set Continue On Error for task that creates version file in case of parallel builds

### DIFF
--- a/Version.targets
+++ b/Version.targets
@@ -59,7 +59,9 @@
        <XamarinFormsVersionFile Include="../XamarinFormsVersionFile.txt"/>
        <XamarinFormsVersionLine Include="$(PackageVersion)"/>
     </ItemGroup>
-    <WriteLinesToFile File="@(XamarinFormsVersionFile)" Lines="@(XamarinFormsVersionLine)" Overwrite="true" />
+    
+    <!-- Occasionally this throws an error from parallel builds writing to this file. It's fine if only one of them wins. -->
+    <WriteLinesToFile ContinueOnError="WarnAndContinue" File="@(XamarinFormsVersionFile)" Lines="@(XamarinFormsVersionLine)" Overwrite="true" />
     <Message Condition="$(CI)" Importance="high" Text="##vso[build.updatebuildnumber]$(PackageVersion)"/>
     <Message Condition="$(CI)" Importance="high" Text="##vso[task.setvariable variable=XamarinFormsPackageVersion;isOutput=true;]$(PackageVersion)"/>
   </Target>


### PR DESCRIPTION
### Description of Change ###

On windows when trying to rebuild the unit tests it occasionally fails with "process can't access file". I'm guessing this is from parallel builds writing to the file.  Only one process needs win the race to write the file.


### Testing Procedure ###
- make sure you can run unit tests
- make changes to core code and rebuild unit tests
- run *build.cmd -Target NugetPack* and make sure it creates Nugets with correct versions

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
