### PR TITLE
[macOS] Add padding to Button

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using AppKit;
+using CoreGraphics;
 using Foundation;
 
 namespace Xamarin.Forms.Platform.MacOS
@@ -20,6 +21,30 @@ namespace Xamarin.Forms.Platform.MacOS
 				base.MouseDown(theEvent);
 
 				Released?.Invoke();
+			}
+
+			private nfloat _leftPadding;
+			private nfloat _topPadding;
+			private nfloat _rightPadding;
+			private nfloat _bottomPadding;
+
+			internal void UpdatePadding(Thickness padding)
+			{
+				_leftPadding = (nfloat)padding.Left;
+				_topPadding = (nfloat)padding.Top;
+				_rightPadding = (nfloat)padding.Right;
+				_bottomPadding = (nfloat)padding.Bottom;
+
+				InvalidateIntrinsicContentSize();
+			}
+
+			public override CGSize IntrinsicContentSize
+			{
+				get
+				{
+					var baseSize = base.IntrinsicContentSize;
+					return new CGSize(baseSize.Width + _leftPadding + _rightPadding, baseSize.Height + _topPadding + _bottomPadding);
+				}
 			}
 		}
 
@@ -59,6 +84,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateFont();
 				UpdateBorder();
 				UpdateImage();
+				UpdatePadding();
 			}
 		}
 
@@ -78,6 +104,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateBackgroundVisibility();
 			else if (e.PropertyName == Button.ImageSourceProperty.PropertyName)
 				UpdateImage();
+			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
+				UpdatePadding();
 		}
 
 		void OnButtonActivated(object sender, EventArgs eventArgs)
@@ -139,6 +167,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.Font.ToNSFont(), foregroundColor: color.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = NSTextAlignment.Center });
 				Control.AttributedTitle = textWithColor;
 			}
+		}
+
+		void UpdatePadding()
+		{
+			(Control as FormsNSButton)?.UpdatePadding(Element.Padding);
 		}
 
 		void HandleButtonPressed()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -44,10 +44,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				Released?.Invoke();
 			}
 
-			private nfloat _leftPadding;
-			private nfloat _topPadding;
-			private nfloat _rightPadding;
-			private nfloat _bottomPadding;
+			nfloat _leftPadding;
+			nfloat _topPadding;
+			nfloat _rightPadding;
+			nfloat _bottomPadding;
 
 			internal void UpdatePadding(Thickness padding)
 			{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -10,6 +10,27 @@ namespace Xamarin.Forms.Platform.MacOS
 	{
 		class FormsNSButton : NSButton
 		{
+			class FormsNSButtonCell : NSButtonCell
+			{
+				public override CGRect DrawTitle(NSAttributedString title, CGRect frame, NSView controlView)
+				{
+					if (controlView is FormsNSButton button)
+					{
+						var paddedFrame = new CGRect(frame.X + button._leftPadding,
+							frame.Y + button._topPadding,
+							frame.Width - button._leftPadding - button._rightPadding,
+							frame.Height - button._topPadding - button._bottomPadding);
+						return base.DrawTitle(title, paddedFrame, controlView);
+					}
+					return base.DrawTitle(title, frame, controlView);
+				}
+			}
+
+			public FormsNSButton()
+			{
+				Cell = new FormsNSButtonCell();
+			}
+
 			public event Action Pressed;
 
 			public event Action Released;


### PR DESCRIPTION
### Description of Change ###

Add support for `Padding` on `Button`. 

Overrides `IntrinsicContentSize` property on `FormsNSButton`. Adds `FormsNSButtonCell` with an overridden `DrawTitle` method. 

This does not do anything with `Button.Image`. Comparing macOS to iOS, there seems to be quite a lot of other functionality missing still, especially to do with images.

### Issues Resolved ### 

- fixes #7851 

### API Changes ###
 
 None public

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

Previously ignored padding on macOS buttons will now do something.

### Before/After Screenshots ### 
Before:

<img width="1136" alt="Before" src="https://user-images.githubusercontent.com/33512073/66300042-4b58ee00-e8fd-11e9-86ba-2524e7cb0dff.png">

After:

<img width="1136" alt="macOS-button-padding-after" src="https://user-images.githubusercontent.com/475450/66545883-95c3b000-eb33-11e9-91c7-f61b8eef24ae.png">

### Testing Procedure ###

View the control gallery for Button and Button Layout

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
