### PR TITLE
Fix [macOS] navigation page doesn't hide previous page

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
@@ -9,7 +9,6 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			//BackgroundColor = Color.Yellow;
 			Navigation.PushAsync(new ContentPage
 			{
 				BackgroundColor = Color.Yellow,
@@ -19,30 +18,30 @@ namespace Xamarin.Forms.Controls.Issues
 						new Button
 						{
 							HorizontalOptions = LayoutOptions.Start,
-							Text = "btn1 - push page",
-							Command = new Command(async () => await Navigation.PushAsync(new Page2(),false))
+							Text = "push page",
+							Command = new Command(async () => await Navigation.PushAsync(new PageWithTransparency(),false))
 						},
-						new Button
+						new Label
 						{
 							HorizontalOptions = LayoutOptions.Center,
 							VerticalOptions = LayoutOptions.Center,
-							Text = "btn2 - should be invisible when tabbed page pushed",
-							Command = new Command(async () => await Navigation.PushAsync(new Page2(), false))
+							Text = "This text should be invisible after second page pushed",
 						}
 					}
 				},
 			});
 		}
-		class Page2:TabbedPage
+		class PageWithTransparency : ContentPage
 		{
-			public Page2()
+			public PageWithTransparency()
 			{
-				this.BackgroundColor = Color.Red.MultiplyAlpha(0.5);
-				this.Children.Add(new ContentPage
+				this.BackgroundColor = Color.Red.MultiplyAlpha(0.2);
+				Content = new Label
 				{
-					Title = "Tab1",
-					BackgroundColor = Color.Blue.MultiplyAlpha(0.2),
-				});
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.CenterAndExpand,
+					Text = "Text on second page",
+				};
 			}
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
@@ -19,21 +19,29 @@ namespace Xamarin.Forms.Controls.Issues
 						new Button
 						{
 							HorizontalOptions = LayoutOptions.Start,
-							Text = "push page",
+							Text = "btn1 - push page",
 							Command = new Command(async () => await Navigation.PushAsync(new Page2(),false))
-						}}
-				}
+						},
+						new Button
+						{
+							HorizontalOptions = LayoutOptions.Center,
+							VerticalOptions = LayoutOptions.Center,
+							Text = "btn2 - should be invisible when tabbed page pushed",
+							Command = new Command(async () => await Navigation.PushAsync(new Page2(), false))
+						}
+					}
+				},
 			});
 		}
 		class Page2:TabbedPage
 		{
 			public Page2()
 			{
-				this.BackgroundColor = Color.Red;
+				this.BackgroundColor = Color.Red.MultiplyAlpha(0.5);
 				this.Children.Add(new ContentPage
 				{
 					Title = "Tab1",
-					BackgroundColor = Color.Blue,
+					BackgroundColor = Color.Blue.MultiplyAlpha(0.2),
 				});
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
@@ -1,0 +1,41 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7898, "Null Reference Exception thrown when set FontFamily for label in Xamarin Forms macOS", PlatformAffected.macOS)]
+	public class Issue7898 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			//BackgroundColor = Color.Yellow;
+			Navigation.PushAsync(new ContentPage
+			{
+				BackgroundColor = Color.Yellow,
+				Content = new StackLayout()
+				{
+					Children = {
+						new Button
+						{
+							HorizontalOptions = LayoutOptions.Start,
+							Text = "push page",
+							Command = new Command(async () => await Navigation.PushAsync(new Page2(),false))
+						}}
+				}
+			});
+		}
+		class Page2:TabbedPage
+		{
+			public Page2()
+			{
+				this.BackgroundColor = Color.Red;
+				this.Children.Add(new ContentPage
+				{
+					Title = "Tab1",
+					BackgroundColor = Color.Blue,
+				});
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7898.cs
@@ -4,7 +4,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 7898, "Null Reference Exception thrown when set FontFamily for label in Xamarin Forms macOS", PlatformAffected.macOS)]
+	[Issue(IssueTracker.Github, 7898, "navigation page doesn't hide previous page", PlatformAffected.macOS)]
 	public class Issue7898 : TestNavigationPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1093,6 +1093,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6127.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7283.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5395.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">


### PR DESCRIPTION
### Description of Change ###

Added Show-Hide logic for previous page in NavigationPageRenderer

Issue happens when any page with transparency pushed to NavigationPage, because new page simply added to ViewController above previous.

### Issues Resolved ### 

- fixes #7898 

### API Changes ###
 
 None

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
Before
![Screenshot 2019-10-10 at 11 36 07](https://user-images.githubusercontent.com/33512073/66552721-830ca380-eb52-11e9-937a-3023813c06c5.png)

After
![Screenshot 2019-10-10 at 11 36 54](https://user-images.githubusercontent.com/33512073/66552732-856efd80-eb52-11e9-9b5a-f8298e28443d.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
