### PR TITLE
iOS13 Fix Modal lifecycle

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7878.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -8,43 +10,77 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 7878, "Page not popped on iOS 13 FormSheet swipe down", PlatformAffected.iOS)]
 	public class Issue7878 : TestContentPage
 	{
-		ContentPage _modalPage;
-
 		protected override void Init()
 		{
+			var label = new Label
+			{
+				Text = "Both modals should behave the same. With the FormSheet when swiping down the modal should be dismissed properly. And for both modals the Appearing event on this page should be called. If so, this tests succeeded."
+			};
+
+			var modalButtonFormSheet = new Button
+			{
+				Text = "Show Modal FormSheet"
+			};
+
+			modalButtonFormSheet.Clicked += Button_Clicked_FormSheet;
+
 			var modalButton = new Button
 			{
-				Text = "Modal me",
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
+				Text = "Show Modal Full Screen"
 			};
 
 			modalButton.Clicked += Button_Clicked;
 
-			Content = modalButton;
-
-			_modalPage = new ContentPage();
-
-			var button = new Button
+			var stackLayout = new StackLayout
 			{
-				Text = "Pressing this raises the popped event, swiping down as well!",
 				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
+				VerticalOptions = LayoutOptions.Center,
+				Children = {
+					modalButton, modalButtonFormSheet
+				}
 			};
 
-			button.Clicked += (o, a) =>
-			{
-				Navigation.PopModalAsync();
-			};
+			Content = stackLayout;
+		}
 
-			_modalPage.Content = button;
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			DisplayAlert("I have appeared!", "👋", "OK");
 		}
 
 		void Button_Clicked(object sender, EventArgs e)
 		{
-			var navigationPage = new NavigationPage(_modalPage);
-			PlatformConfiguration.iOSSpecific.Page.SetModalPresentationStyle(navigationPage.On<PlatformConfiguration.iOS>(), PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet);
-			Navigation.PushModalAsync(navigationPage);
+			Navigation.PushModalAsync(new ModalPage(false));
+		}
+
+		void Button_Clicked_FormSheet(object sender, EventArgs e)
+		{
+			Navigation.PushModalAsync(new ModalPage(true));
+		}
+
+		class ModalPage : ContentPage
+		{
+			public ModalPage(bool isFormSheet)
+			{
+				if (isFormSheet)
+					On<iOS>().SetModalPresentationStyle(UIModalPresentationStyle.FormSheet);
+
+				var button = new Button
+				{
+					Text = "Pressing this raises the popped event, swiping down as well!",
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center
+				};
+
+				button.Clicked += (o, a) =>
+				{
+					Navigation.PopModalAsync();
+				};
+
+				Content = button;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7878.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7878, "Page not popped on iOS 13 FormSheet swipe down", PlatformAffected.iOS)]
+	public class Issue7878 : TestContentPage
+	{
+		ContentPage _modalPage;
+
+		protected override void Init()
+		{
+			var modalButton = new Button
+			{
+				Text = "Modal me",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			modalButton.Clicked += Button_Clicked;
+
+			Content = modalButton;
+
+			_modalPage = new ContentPage();
+
+			var button = new Button
+			{
+				Text = "Pressing this raises the popped event, swiping down doesn't",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			button.Clicked += (o, a) =>
+			{
+				Navigation.PopModalAsync();
+			};
+
+			_modalPage.Content = button;
+		}
+
+		void Button_Clicked(System.Object sender, System.EventArgs e)
+		{
+			var navigationPage = new NavigationPage(_modalPage);
+			Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page.SetModalPresentationStyle(navigationPage.On<Xamarin.Forms.PlatformConfiguration.iOS>(), Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet);
+			Navigation.PushModalAsync(navigationPage);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7878.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var button = new Button
 			{
-				Text = "Pressing this raises the popped event, swiping down doesn't",
+				Text = "Pressing this raises the popped event, swiping down as well!",
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center
 			};
@@ -40,10 +40,10 @@ namespace Xamarin.Forms.Controls.Issues
 			_modalPage.Content = button;
 		}
 
-		void Button_Clicked(System.Object sender, System.EventArgs e)
+		void Button_Clicked(object sender, EventArgs e)
 		{
 			var navigationPage = new NavigationPage(_modalPage);
-			Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page.SetModalPresentationStyle(navigationPage.On<Xamarin.Forms.PlatformConfiguration.iOS>(), Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet);
+			PlatformConfiguration.iOSSpecific.Page.SetModalPresentationStyle(navigationPage.On<PlatformConfiguration.iOS>(), PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FormSheet);
 			Navigation.PushModalAsync(navigationPage);
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1727,12 +1727,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4459.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7789.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1233,6 +1233,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7283.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1658.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5395.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6663.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8004.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7886.xaml.cs">
@@ -1721,6 +1722,30 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5354.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4459.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7758.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7789.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7865.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1733,12 +1733,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7758.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7789.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
@@ -1767,17 +1761,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7789.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7817.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7865.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UIModalPresentationStyle.cs
@@ -3,6 +3,7 @@
 	public enum UIModalPresentationStyle
 	{
 		FullScreen,
-		FormSheet
+		FormSheet,
+		Automatic
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -84,6 +84,10 @@ namespace Xamarin.Forms.Platform.iOS
 					return UIModalPresentationStyle.FormSheet;
 				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FullScreen:
 					return UIModalPresentationStyle.FullScreen;
+#if __XCODE11__
+				case PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.Automatic:
+					return UIModalPresentationStyle.Automatic;
+#endif
 				default:
 					throw new ArgumentOutOfRangeException(nameof(style));
 			}

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -19,10 +19,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (elementConfiguration?.On<PlatformConfiguration.iOS>()?.ModalPresentationStyle() is PlatformConfiguration.iOSSpecific.UIModalPresentationStyle style)
 			{
 				var result = style.ToNativeModalPresentationStyle();
+#if __XCODE11__
 				if (!Forms.IsiOS13OrNewer && result == UIKit.UIModalPresentationStyle.Automatic)
 				{
 					result = UIKit.UIModalPresentationStyle.FullScreen;
 				}
+#endif
 
 				ModalPresentationStyle = result;
 			}
@@ -33,17 +35,18 @@ namespace Xamarin.Forms.Platform.iOS
 			AddChildViewController(modal.ViewController);
 
 			modal.ViewController.DidMoveToParentViewController(this);
-
+#if __XCODE11__
 			if (Forms.IsiOS13OrNewer)
 				PresentationController.Delegate = this;
+#endif
 		}
-
+#if __XCODE11__
 		[Export("presentationControllerDidDismiss:")]
 		public async void DidDismiss(UIPresentationController presentationController)
 		{
 			await Application.Current.NavigationProxy.PopModalAsync(false);
 		}
-
+#endif
 		public override void DismissViewController(bool animated, Action completionHandler)
 		{
 			if (PresentedViewController == null)

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -44,7 +44,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (Forms.IsiOS13OrNewer)
 				PresentationController.Delegate = new PresentationControllerDelegate(DismissModalAsync);
-
 		}
 
 		async Task DismissModalAsync()

--- a/Xamarin.Forms.Platform.iOS/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/PageExtensions.cs
@@ -1,5 +1,6 @@
 using System;
 using UIKit;
+using System.Linq;
 
 namespace Xamarin.Forms
 {
@@ -38,6 +39,18 @@ namespace Xamarin.Forms.Platform.iOS
 		public static UIViewController CreateViewController(this ContentPage page)
 		{
 			return Xamarin.Forms.PageExtensions.CreateViewController(page);
+		}
+
+		internal static Page GetCurrentPage(this Page currentPage)
+		{
+			if (currentPage.NavigationProxy.ModalStack.LastOrDefault() is Page modal)
+				return modal;
+			else if (currentPage is MasterDetailPage mdp)
+				return GetCurrentPage(mdp.Detail);
+			else if (currentPage is IPageContainer<Page> pc)
+				return GetCurrentPage(pc.CurrentPage);
+			else
+				return currentPage;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -176,15 +176,19 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
+				// While the above IsiOS13OrNewer will always be false if __XCODE11__ is true
+				// the UIModalPresentationStyle.Automatic is the only Xcode 11 API
+				// for readability I decided to only take this part out
+#if __XCODE11__
 				if (presentationStyle == UIKit.UIModalPresentationStyle.Automatic)
 					shouldFire = false;
-				else if (presentationStyle == UIKit.UIModalPresentationStyle.FullScreen)
+#endif
+				if (presentationStyle == UIKit.UIModalPresentationStyle.FullScreen)
 					shouldFire = false; // This is mainly for backwards compatibility
 			}
 
 			if (_appeared && shouldFire)
 				Page.GetCurrentPage()?.SendDisappearing();
-
 
 			_modals.Add(modal);
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -8,6 +8,7 @@ using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
 using RectangleF = CoreGraphics.CGRect;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -126,6 +127,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			modal.DisposeModalAndChildRenderers();
 
+			if (!IsModalPresentedFullScreen(modal))
+				Page.GetCurrentPage()?.SendAppearing();
+
 			return modal;
 		}
 
@@ -157,6 +161,30 @@ namespace Xamarin.Forms.Platform.iOS
 		Task INavigation.PushModalAsync(Page modal, bool animated)
 		{
 			EndEditing();
+
+
+			var elementConfiguration = modal as IElementConfiguration<Page>;
+
+			var presentationStyle = elementConfiguration?.On<PlatformConfiguration.iOS>()?.ModalPresentationStyle().ToNativeModalPresentationStyle();
+
+			bool shouldFire = true;
+
+			if (Forms.IsiOS13OrNewer)
+			{
+				if (presentationStyle == UIKit.UIModalPresentationStyle.FullScreen)
+					shouldFire = false; // This is mainly for backwards compatibility
+			}
+			else
+			{
+				if (presentationStyle == UIKit.UIModalPresentationStyle.Automatic)
+					shouldFire = false;
+				else if (presentationStyle == UIKit.UIModalPresentationStyle.FullScreen)
+					shouldFire = false; // This is mainly for backwards compatibility
+			}
+
+			if (_appeared && shouldFire)
+				Page.GetCurrentPage()?.SendDisappearing();
+
 
 			_modals.Add(modal);
 
@@ -612,6 +640,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 				PresentActionSheet(arguments);
 			});
+		}
+
+		static bool IsModalPresentedFullScreen(Page modal)
+		{
+			var elementConfiguration = modal as IElementConfiguration<Page>;
+			var presentationStyle = elementConfiguration?.On<PlatformConfiguration.iOS>()?.ModalPresentationStyle();
+			return presentationStyle != null && presentationStyle == PlatformConfiguration.iOSSpecific.UIModalPresentationStyle.FullScreen;
 		}
 
 		internal void UnsubscribeFromAlertsAndActionsSheets()

--- a/build.cake
+++ b/build.cake
@@ -137,7 +137,6 @@ Task("provision-androidsdk")
     .Does(async () =>
     {
         Information ("ANDROID_HOME: {0}", ANDROID_HOME);
-        Information ("androidSDK: {0}", androidSDK);
 
         if(androidSdkManagerInstalls.Length > 0)
         {

--- a/build.cake
+++ b/build.cake
@@ -137,6 +137,7 @@ Task("provision-androidsdk")
     .Does(async () =>
     {
         Information ("ANDROID_HOME: {0}", ANDROID_HOME);
+        Information ("androidSDK: {0}", androidSDK);
 
         if(androidSdkManagerInstalls.Length > 0)
         {


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7878 
- related #7145 & #7172
- fixes #9307

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Modals presented as a `FormSheet` can now be swiped down and this will trigger the popped event for a modal within Xamarin.Forms. Because of that, the app continues to behave as intended instead of getting stuck because of the modal still being on the navigation stack.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
