### PR TITLE
Disable XamlC task for VS Live Unit Testing

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -106,7 +106,7 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True' ">
+	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True' And '$(BuildingForLiveUnitTesting)' != 'True' ">
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -109,7 +109,7 @@
 	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True'">
     <PropertyGroup>
       <ValidateOnlyValue>$(XFXamlCValidateOnly)</ValidateOnlyValue>
-      <ValidateOnlyValue Condition="'$(BuildingForLiveUnitTesting)' != 'True' ">True</ValidateOnlyValue>
+      <ValidateOnlyValue Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</ValidateOnlyValue>
     </PropertyGroup>
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -107,17 +107,17 @@
 	</PropertyGroup>
 
 	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True'">
-    <PropertyGroup>
-      <ValidateOnlyValue>$(XFXamlCValidateOnly)</ValidateOnlyValue>
-      <ValidateOnlyValue Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</ValidateOnlyValue>
-    </PropertyGroup>
+	    <PropertyGroup>
+		<_XFXamlCValidateOnly>$(XFXamlCValidateOnly)</_XFXamlCValidateOnly>
+		<_XFXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_XFXamlCValidateOnly>
+	    </PropertyGroup>
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
 			OptimizeIL = "true"
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"
-			ValidateOnly = "$(ValidateOnlyValue)"
+			ValidateOnly = "$(_XFXamlCValidateOnly)"
 			KeepXamlResources = "$(XFKeepXamlResources)" />
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -106,14 +106,18 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True' And '$(BuildingForLiveUnitTesting)' != 'True' ">
+	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True'">
+    <PropertyGroup>
+      <ValidateOnlyValue>$(XFXamlCValidateOnly)</ValidateOnlyValue>
+      <ValidateOnlyValue Condition="'$(BuildingForLiveUnitTesting)' != 'True' ">True</ValidateOnlyValue>
+    </PropertyGroup>
 		<XamlCTask
 			Assembly = "$(IntermediateOutputPath)$(TargetFileName)"
 			ReferencePath = "@(ReferencePath)"
 			OptimizeIL = "true"
 			DebugSymbols = "$(DebugSymbols)"
 			DebugType = "$(DebugType)"
-			ValidateOnly = "$(XFXamlCValidateOnly)"
+			ValidateOnly = "$(ValidateOnlyValue)"
 			KeepXamlResources = "$(XFKeepXamlResources)" />
 		<Touch Files="$(IntermediateOutputPath)XamlC.stamp" AlwaysCreate="True" />
 		<ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Add a condition that prevents the execution of the XamlC task when a build is performed for the Live Unit Testing feature of Visual Studio.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7862

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
