### PR TITLE
Propagate bindingcontext in menu

### DIFF
--- a/Xamarin.Forms.Core/Menu.cs
+++ b/Xamarin.Forms.Core/Menu.cs
@@ -91,5 +91,21 @@ namespace Xamarin.Forms
 		{
 			return _menus.GetEnumerator();
 		}
+
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			if (Count > 0)
+			{
+				for (var i = 0; i < Count; i++)
+				{
+					SetInheritedBindingContext(_menus[i], BindingContext);
+
+					for (var j = 0; j < _menus[i].Count; j++)
+						SetInheritedBindingContext(_menus[i][j], BindingContext);
+				}
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Extensions/NSMenuExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/NSMenuExtensions.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Forms.Platform.macOS.Extensions
 					var subMenuItem = item.ToNSMenuItem(menuItemCreator: menuItemCreator);
 					GetAccelerators(subMenuItem, item);
 					subMenu.AddItem(subMenuItem);
+					item.BindingContext = menus.BindingContext;
 					item.PropertyChanged += (sender, e) => (sender as MenuItem)?.UpdateNSMenuItem(subMenuItem, new string[] { e.PropertyName });
 				}
 				if (!nsMenu.Items.Contains(menuItem))

--- a/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
+++ b/Xamarin.Forms.Platform.MacOS/FormsApplicationDelegate.cs
@@ -111,6 +111,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void MainMenuOnPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
+			if (e != null && e.PropertyName.Equals(Menu.BindingContextProperty.PropertyName))
+				return;
+
 			var nsMenu = NSApplication.SharedApplication.MainMenu;
 			if (nsMenu == null)
 			{
@@ -125,6 +128,9 @@ namespace Xamarin.Forms.Platform.MacOS
 		protected virtual void SetupMainAppMenu(NSMenu nativeMenu)
 		{
 			var menu = Element.GetMenu(_application);
+
+			menu.BindingContext = _application.BindingContext;
+
 			menu.ToNSMenu(nativeMenu, NativeMenuItemCreator);
 		}
 


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

Propagate the `BindingContext` to the menuitems when the `BindingContext` changes for the menu

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #1637

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- MacOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Bindings start working on menu items on MacOS

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
