### PR TITLE
[UWP] CarouselView fixes

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -23,9 +23,6 @@ namespace Xamarin.Forms.Platform.UWP
 		protected override IItemsLayout Layout => CarouselView?.ItemsLayout;
 		UWPDataTemplate CarouselItemsViewTemplate => (UWPDataTemplate)UWPApp.Current.Resources["CarouselItemsViewDefaultTemplate"];
 
-		double _itemWidth;
-		double _itemHeight;
-
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs changedProperty)
 		{
 			base.OnElementPropertyChanged(sender, changedProperty);
@@ -101,7 +98,7 @@ namespace Xamarin.Forms.Platform.UWP
 			return new CollectionViewSource
 			{
 				Source = TemplatedItemSourceFactory.Create(Element.ItemsSource, Element.ItemTemplate, Element, 
-					_itemHeight, _itemWidth, GetItemSpacing()),
+					GetItemHeight(), GetItemWidth(), GetItemSpacing()),
 				IsSourceGrouped = false
 			};
 		}
@@ -147,9 +144,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnListSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
 		{
-			_itemHeight = GetItemHeight();
-			_itemWidth = GetItemWidth();
 			UpdateItemsSource();
+			UpdateSnapPointsType();
+			UpdateSnapPointsAlignment();
 		}
 
 		void OnScrollViewChanging(object sender, ScrollViewerViewChangingEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Doing rebase at https://github.com/xamarin/Xamarin.Forms/pull/7590 I have noticed that some CarouselVIew properties does not work on UWP:
- NumberOfSideItems
- PeekAreaInsets
- Snap

The regression was possibly introduced in https://github.com/xamarin/Xamarin.Forms/commit/f524502aeee444be12c17e25bf103e0d358763b4#diff-49b633c124c929ea2ab8b63dca84ca3d

This PR fixes this issues.

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
#### Before
![cv-uwp-issues-before](https://user-images.githubusercontent.com/6755973/66575251-e65bfd00-eb75-11e9-81f7-a62a33694222.gif)
#### After
![cv-uwp-issues-after](https://user-images.githubusercontent.com/6755973/66575246-e52ad000-eb75-11e9-99d4-deff90c21f89.gif)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
