### PR TITLE
fix for Issue 7772- Device.Idiom return TV for Android TV devices

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Forms
 			//this doesn't seem to work
 			using (var value = new TypedValue())
 			{
-				if (context.Theme.ResolveAttribute(Resource.Attribute.TextSize, value, true)) 
+				if (context.Theme.ResolveAttribute(Resource.Attribute.TextSize, value, true))
 				{
 					size = value.Data;
 				}
@@ -321,9 +321,29 @@ namespace Xamarin.Forms
 			}
 
 			Profile.FramePartition("Epilog");
-			// This could change as a result of a config change, so we need to check it every time
-			int minWidthDp = activity.Resources.Configuration.SmallestScreenWidthDp;
-			Device.SetIdiom(minWidthDp >= TabletCrossover ? TargetIdiom.Tablet : TargetIdiom.Phone);
+
+			var currentIdiom = TargetIdiom.Unsupported;
+
+			// first try UIModeManager
+			using (var uiModeManager = UiModeManager.FromContext(ApplicationContext))
+			{
+				try
+				{
+					var uiMode = uiModeManager?.CurrentModeType ?? UiMode.TypeUndefined;
+					currentIdiom = DetectIdiom(uiMode);
+				}
+				catch (Exception ex)
+				{
+					System.Diagnostics.Debug.WriteLine($"Unable to detect using UiModeManager: {ex.Message}");
+				}
+			}
+
+			if (TargetIdiom.Unsupported == currentIdiom)
+			{
+				// This could change as a result of a config change, so we need to check it every time
+				int minWidthDp = activity.Resources.Configuration.SmallestScreenWidthDp;
+				Device.SetIdiom(minWidthDp >= TabletCrossover ? TargetIdiom.Tablet : TargetIdiom.Phone);
+			}
 
 			if (SdkInt >= BuildVersionCodes.JellyBeanMr1)
 				Device.SetFlowDirection(activity.Resources.Configuration.LayoutDirection.ToFlowDirection());
@@ -333,6 +353,22 @@ namespace Xamarin.Forms
 
 			IsInitialized = true;
 			Profile.FrameEnd();
+		}
+
+		static TargetIdiom DetectIdiom(UiMode uiMode)
+		{
+			var returnValue = TargetIdiom.Unsupported;
+			if (uiMode.HasFlag(UiMode.TypeNormal))
+				returnValue = TargetIdiom.Unsupported;
+			else if (uiMode.HasFlag(UiMode.TypeTelevision))
+				returnValue = TargetIdiom.TV;
+			else if (uiMode.HasFlag(UiMode.TypeDesk))
+				returnValue = TargetIdiom.Desktop;
+			else if (SdkInt >= BuildVersionCodes.KitkatWatch && uiMode.HasFlag(UiMode.TypeWatch))
+				returnValue = TargetIdiom.Watch;
+
+			Device.SetIdiom(returnValue);
+			return returnValue;
 		}
 
 		static IReadOnlyList<string> s_flags;
@@ -666,7 +702,7 @@ namespace Xamarin.Forms
 
 			public async Task<Stream> GetStreamAsync(Uri uri, CancellationToken cancellationToken)
 			{
-				using (var client = new HttpClient())				
+				using (var client = new HttpClient())
 				{
 					HttpResponseMessage response = await client.GetAsync(uri, cancellationToken).ConfigureAwait(false);
 					if (!response.IsSuccessStatusCode)
@@ -675,9 +711,9 @@ namespace Xamarin.Forms
 						return null;
 					}
 
-					// the HttpResponseMessage needs to be disposed of after the calling code is done with the stream 
+					// the HttpResponseMessage needs to be disposed of after the calling code is done with the stream
 					// otherwise the stream may get disposed before the caller can use it
-					return new StreamWrapper(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), response);					
+					return new StreamWrapper(await response.Content.ReadAsStreamAsync().ConfigureAwait(false), response);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

Fix for Issue #7772 [based on code from Essentials](https://github.com/xamarin/Essentials/blob/07cb1f3b728593f0c46529d0f3cb0b3586bac565/Xamarin.Essentials/DeviceInfo/DeviceInfo.android.cs#L29)

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7772 

### API Changes ###

Device.Idiom return TV for Android TV devices


### Platforms Affected ### 

- Android


### Behavioral/Visual Changes ###


Not applicable

### Testing Procedure ###

build nugets for my change, updated the demo app from #7772 with local nugets, compiled the app and ran it on Fire TV 4k Stick, Android phone and Android tablet. Now Device.Idiom return TV for Android TV devices like Xamarin.Essentials

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
