### PR TITLE
[iOS] Prevent crash when adding item to source of CollectionView in tab

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
@@ -1,0 +1,89 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7700, "[Bug][iOS] If CollectionView in other Tab gets changed before it's displayed, it stays invisible",
+		PlatformAffected.iOS)]
+	public class Issue7700 : TestTabbedPage
+	{
+		ObservableCollection<string> _source = new ObservableCollection<string>(){ "one", "two", "three" };
+
+		const string Add = "Add";
+		const string Success = "Success";
+		const string Tab2 = "Tab2";
+
+		protected override void Init()
+		{
+#if APP
+			FlagTestHelpers.SetCollectionViewTestFlag();
+
+			Children.Add(FirstPage());
+			Children.Add(CollectionViewPage());
+#endif
+		}
+
+		ContentPage FirstPage()
+		{
+			var page = new ContentPage() { Title = "7700 First Page", Padding = 40 };
+
+			var button = new Button() { Text = Add, AutomationId = Add };
+
+			button.Clicked += AddButtonClicked;
+
+			page.Content = button;
+
+			return page;
+		}
+
+		private void AddButtonClicked(object sender, EventArgs e)
+		{
+			_source.Insert(0, Success);
+		}
+
+		ContentPage CollectionViewPage()
+		{
+			var cv = new CollectionView();
+
+			cv.ItemTemplate = new DataTemplate(() => {
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("."));
+				return label;
+			});
+
+			cv.ItemsSource = _source;
+
+			var page = new ContentPage() { Title = Tab2, Padding = 40 };
+
+			page.Content = cv;
+
+			return page;
+		}
+
+#if UITEST
+		[Test]
+		public void AddingItemToUnviewedCollectionViewShouldNotCrash()
+		{
+			RunningApp.WaitForElement(Go);
+			RunningApp.Tap(Go);	
+			RunningApp.Tap(Tab2);		
+
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
@@ -78,8 +78,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void AddingItemToUnviewedCollectionViewShouldNotCrash()
 		{
-			RunningApp.WaitForElement(Go);
-			RunningApp.Tap(Go);	
+			RunningApp.WaitForElement(Add);
+			RunningApp.Tap(Add);	
 			RunningApp.Tap(Tab2);		
 
 			RunningApp.WaitForElement(Success);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
@@ -46,8 +46,6 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			FlagTestHelpers.SetCollectionViewTestFlag();
-
 			Children.Add(FirstPage());
 			Children.Add(CollectionViewPage());
 			Children.Add(GroupedCollectionViewPage());

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
@@ -56,13 +56,15 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var page = new ContentPage() { Title = "7700 First Page", Padding = 40 };
 
+			var instructions = new Label { Text = $"Tap the button marked {Add1}. Then tap the button marked {Add2}. If the application does not crash, the test has passed." };
+
 			var button1 = new Button() { Text = "Add to List", AutomationId = Add1 };
 			button1.Clicked += Button1Clicked;
 
 			var button2 = new Button() { Text = "Add to Grouped List", AutomationId = Add2 };
 			button2.Clicked += Button2Clicked;
 
-			var layout = new StackLayout { Children = { button1, button2 } };
+			var layout = new StackLayout { Children = { instructions, button1, button2 } };
 
 			page.Content = layout;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
@@ -42,6 +42,8 @@ namespace Xamarin.Forms.Controls.Issues
 		const string Success = "Success";
 		const string Tab2 = "Tab2";
 		const string Tab3 = "Tab3";
+		const string Add1Label = "Add to List";
+		const string Add2Label = "Add to Grouped List";
 
 		protected override void Init()
 		{
@@ -56,12 +58,12 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var page = new ContentPage() { Title = "7700 First Page", Padding = 40 };
 
-			var instructions = new Label { Text = $"Tap the button marked {Add1}. Then tap the button marked {Add2}. If the application does not crash, the test has passed." };
+			var instructions = new Label { Text = $"Tap the button marked '{Add1Label}'. Then tap the button marked '{Add2Label}'. If the application does not crash, the test has passed." };
 
-			var button1 = new Button() { Text = "Add to List", AutomationId = Add1 };
+			var button1 = new Button() { Text = Add1Label, AutomationId = Add1 };
 			button1.Clicked += Button1Clicked;
 
-			var button2 = new Button() { Text = "Add to Grouped List", AutomationId = Add2 };
+			var button2 = new Button() { Text = Add2Label, AutomationId = Add2 };
 			button2.Clicked += Button2Clicked;
 
 			var layout = new StackLayout { Children = { instructions, button1, button2 } };

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7993.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7993.xaml.cs
@@ -28,8 +28,6 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 		public Issue7993()
 		{
-			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
-
 			InitializeComponent();
 
 			BindingContext = new ViewModel7993();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -59,6 +59,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7700.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -28,9 +28,9 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override IItemsViewSource CreateItemsViewSource()
 		{
 			// Use the BindableProperty here (instead of _isGroupingEnabled) because the cached value might not be set yet
-			if (GroupableItemsView.IsGrouped) 
+			if (ItemsView.IsGrouped) 
 			{
-				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, this);
+				return ItemsSourceFactory.CreateGrouped(ItemsView.ItemsSource, this);
 			}
 
 			return base.CreateItemsViewSource();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -28,9 +28,9 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override IItemsViewSource CreateItemsViewSource()
 		{
 			// Use the BindableProperty here (instead of _isGroupingEnabled) because the cached value might not be set yet
-			if (ItemsView.IsGrouped) 
+			if (GroupableItemsView.IsGrouped) 
 			{
-				return ItemsSourceFactory.CreateGrouped(ItemsView.ItemsSource, CollectionView);
+				return ItemsSourceFactory.CreateGrouped(GroupableItemsView.ItemsSource, this);
 			}
 
 			return base.CreateItemsViewSource();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
@@ -7,7 +7,7 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal static class ItemsSourceFactory
 	{
-		public static IItemsViewSource Create(IEnumerable itemsSource, UICollectionView collectionView)
+		public static IItemsViewSource Create(IEnumerable itemsSource, UICollectionViewController collectionViewController)
 		{
 			if (itemsSource == null)
 			{
@@ -17,21 +17,21 @@ namespace Xamarin.Forms.Platform.iOS
 			switch (itemsSource)
 			{
 				case INotifyCollectionChanged _:
-					return new ObservableItemsSource(itemsSource as IList, collectionView);
+					return new ObservableItemsSource(itemsSource as IList, collectionViewController);
 				case IEnumerable _:
 				default:
 					return new ListSource(itemsSource);
 			}
 		}
 
-		public static IItemsViewSource CreateGrouped(IEnumerable itemsSource, UICollectionView collectionView)
+		public static IItemsViewSource CreateGrouped(IEnumerable itemsSource, UICollectionViewController collectionViewController)
 		{
 			if (itemsSource == null)
 			{
 				return new EmptySource();
 			}
 
-			return new ObservableGroupedSource(itemsSource, collectionView);
+			return new ObservableGroupedSource(itemsSource, collectionViewController);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual IItemsViewSource CreateItemsViewSource()
 		{
-			return ItemsSourceFactory.Create(ItemsView.ItemsSource, CollectionView);
+			return ItemsSourceFactory.Create(ItemsView.ItemsSource, this);
 		}
 
 		public virtual void UpdateItemsSource()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		public int GroupCount => Count == 0 ? 0 : 1;
+		public int GroupCount => 1;
 
 		public int ItemCount => Count;
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -142,6 +142,13 @@ namespace Xamarin.Forms.Platform.iOS
 				// we'll just reload the data so the UICollectionView can get its internal state sorted out.
 				_collectionView.ReloadData();
 			}
+			else if (_collectionView.ContentSize.IsEmpty)
+			{
+				// The UICollectionView has never actually been displayed; possibly it's in a tab that's never been viewed
+				// At this point, trying to just insert the item will throw a layout error (which will crash on iOS 
+				// versions before 13). So instead we do a reload.
+				_collectionView.ReloadData();
+			}
 			else
 			{
 				_collectionView.PerformBatchUpdates(() =>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -8,21 +8,23 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	internal class ObservableItemsSource : IItemsViewSource
 	{
+		readonly UICollectionViewController _collectionViewController;
 		readonly UICollectionView _collectionView;
 		readonly bool _grouped;
 		readonly int _section;
 		readonly IList _itemsSource;
 		bool _disposed;
 
-		public ObservableItemsSource(IList itemSource, UICollectionView collectionView, int group = -1)
+		public ObservableItemsSource(IList itemSource, UICollectionViewController collectionViewController, int group = -1)
 		{
-			_collectionView = collectionView;
+			_collectionViewController = collectionViewController;
+			_collectionView = _collectionViewController.CollectionView;
 		
 			_section = group < 0 ? 0 : group;
 			_grouped = group >= 0;
 
 			_itemsSource = itemSource;
-
+			
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 
@@ -71,7 +73,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return NSIndexPath.Create(-1, -1);
 		}
 
-		public int GroupCount => _itemsSource.Count == 0 ? 0 : 1;
+		public int GroupCount => 1;
 
 		public int ItemCount => _itemsSource.Count;
 
@@ -130,38 +132,48 @@ namespace Xamarin.Forms.Platform.iOS
 			return result;
 		}
 
+		bool NotLoadedYet()
+		{
+			// If the UICollectionView hasn't actually been loaded, then calling InsertItems or DeleteItems is 
+			// going to crash or get in an unusable state; instead, ReloadData should be used
+			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
+		}
+
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
 			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _itemsSource.IndexOf(args.NewItems[0]);
 			var count = args.NewItems.Count;
 
-			if (!_grouped && _collectionView.NumberOfSections() != GroupCount && count > 0)
+			if (NotLoadedYet())
 			{
-				// Okay, we're going from completely empty to more than 0 items; this means we don't even
-				// have a section 0 yet. Inserting a section 0 manually results in an unexplained crash, so instead
-				// we'll just reload the data so the UICollectionView can get its internal state sorted out.
 				_collectionView.ReloadData();
+				return;
 			}
-			else if (_collectionView.ContentSize.IsEmpty)
+
+			if (!_grouped && _collectionView.NumberOfItemsInSection(_section) == 0)
 			{
-				// The UICollectionView has never actually been displayed; possibly it's in a tab that's never been viewed
-				// At this point, trying to just insert the item will throw a layout error (which will crash on iOS 
-				// versions before 13). So instead we do a reload.
+				// Okay, we're going from completely empty to more than 0 items; there's an iOS bug which apparently
+				// will just crash if we call InsertItems here, so we have to do ReloadData.
 				_collectionView.ReloadData();
+				return;
 			}
-			else
-			{
-				_collectionView.PerformBatchUpdates(() =>
+
+			_collectionView.PerformBatchUpdates(() =>
 				{
 					var indexes = CreateIndexesFrom(startIndex, count);
 					_collectionView.InsertItems(indexes);
 				}, null);
-			}
 		}
 
 		void Remove(NotifyCollectionChangedEventArgs args)
 		{
 			var startIndex = args.OldStartingIndex;
+
+			if (NotLoadedYet())
+			{
+				_collectionView.ReloadData();
+				return;
+			}
 
 			if (startIndex < 0)
 			{
@@ -170,20 +182,13 @@ namespace Xamarin.Forms.Platform.iOS
 				Reload();
 				return;
 			}
-	
+
 			// If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
 			var count = args.OldItems.Count;
 
 			_collectionView.PerformBatchUpdates(() =>
 			{
 				_collectionView.DeleteItems(CreateIndexesFrom(startIndex, count));
-
-				if (!_grouped && _collectionView.NumberOfSections() != GroupCount)
-				{
-					// We had a non-grouped list with items, and we're removing the last one;
-					// we also need to remove the group it was in
-					_collectionView.DeleteSections(new NSIndexSet(0));
-				}
 			}, null);
 		}
 


### PR DESCRIPTION
### Description of Change ###

If
- a CollectionView is on a tab that has never been displayed
- the CollectionView's `ItemsSource` implements `INotifyCollectionChanged`
- an item is added to that `ItemsSource`

on iOS 13 a layout error will be raised and the CollectionView will be left in a weird state. Pre-13, it'll just crash.

These changes detect that scenario and avoid the crash.

### Issues Resolved ### 
- fixes #7700

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated test.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
