### PR TITLE
[Android] Fixed a crash on CollectionView changing ItemsSource

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml
@@ -7,20 +7,44 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.Issues.Issue7943">
     <ContentPage.Content>
-        <StackLayout>
-            <Button 
-                Text="Change Template"
-                Clicked="OnChangeTemplate"/>
-            <Button 
-                Text="Change ItemsSource" 
-                Clicked="OnChangeItemsSource"/>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid
+                Grid.Row="0"
+                BackgroundColor="Black">
+                <Label
+                    TextColor="White"
+                    Text="Press the buttons below to dynamically change the ItemTemplate and ItemsSource of the CollectionView. If change without problems, the test has passed."/>
+            </Grid>
+            <StackLayout
+                Grid.Row="1">
+                <Button
+                    Text="Change Template"
+                    Clicked="OnChangeTemplate"/>
+                <Button
+                    Text="Change ItemsSource" 
+                    Clicked="OnChangeItemsSource"/>
+                <Button
+                    Text="Clear ItemsSource" 
+                    Clicked="OnClearItemsSource"/>
+            </StackLayout>
             <CollectionView
+                Grid.Row="2"
                 x:Name="collectionView">
                 <CollectionView.EmptyView>
+                    <Grid
+                        BackgroundColor="GreenYellow">
                     <Label 
-                        Text="No data available"/>
+                        Text="No data available"
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"/>
+                    </Grid>
                 </CollectionView.EmptyView>
             </CollectionView>
-        </StackLayout>
+        </Grid>
     </ContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml
@@ -1,0 +1,26 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"     
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"  
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7943">
+    <ContentPage.Content>
+        <StackLayout>
+            <Button 
+                Text="Change Template"
+                Clicked="OnChangeTemplate"/>
+            <Button 
+                Text="Change ItemsSource" 
+                Clicked="OnChangeItemsSource"/>
+            <CollectionView
+                x:Name="collectionView">
+                <CollectionView.EmptyView>
+                    <Label 
+                        Text="No data available"/>
+                </CollectionView.EmptyView>
+            </CollectionView>
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml.cs
@@ -55,10 +55,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if APP
 		void OnChangeTemplate(object sender, EventArgs e)
-		{
+		{	
+			var random = new Random();
+
 			collectionView.ItemTemplate = new DataTemplate(() =>
 			{
 				var grid = new Grid();
+				grid.BackgroundColor = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255));
 				var lbl1 = new Label();
 				lbl1.SetBinding(Label.TextProperty, "Name");
 				grid.Children.Add(lbl1);
@@ -68,10 +71,14 @@ namespace Xamarin.Forms.Controls.Issues
 		void OnChangeItemsSource(object sender, EventArgs e)
 		{
 			collectionView.ItemsSource = new List<Issue7943Model> { new Issue7943Model("Paul", 35), new Issue7943Model("Lucy", 57) };
+		}		
+
+		void OnClearItemsSource(object sender, EventArgs e)
+		{
+			collectionView.ItemsSource = null;
 		}
-	}
 #endif
-	
+	}
 
 	[Preserve(AllMembers = true)]
 	class Issue7943Model

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7943.xaml.cs
@@ -1,0 +1,87 @@
+﻿using Xamarin.Forms.Xaml;
+using System;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7943, "[Android] Crashes if EmptyView defined and ItemsSource is changed after ItemTemplate is changed", PlatformAffected.Android)]
+	public partial class Issue7943 : TestContentPage
+	{
+		public Issue7943()
+		{
+#if APP
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+			Title = "Issue 7943";
+			InitializeComponent();
+
+			collectionView.ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid();
+				var lbl1 = new Label();
+				lbl1.SetBinding(Label.TextProperty, "Name");
+				grid.Children.Add(lbl1);
+				var lbl2 = new Label();
+				lbl2.SetBinding(Label.TextProperty, "Age");
+				lbl2.SetValue(Grid.ColumnProperty, 1);
+				grid.Children.Add(lbl2);
+
+				return grid;
+			});
+			collectionView.ItemsSource = new List<Issue7943Model> { new Issue7943Model("John", 41), new Issue7943Model("Jane", 24) };
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+
+#if APP
+		void OnChangeTemplate(object sender, EventArgs e)
+		{
+			collectionView.ItemTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid();
+				var lbl1 = new Label();
+				lbl1.SetBinding(Label.TextProperty, "Name");
+				grid.Children.Add(lbl1);
+				return grid;
+			});
+		}
+		void OnChangeItemsSource(object sender, EventArgs e)
+		{
+			collectionView.ItemsSource = new List<Issue7943Model> { new Issue7943Model("Paul", 35), new Issue7943Model("Lucy", 57) };
+		}
+	}
+#endif
+	
+
+	[Preserve(AllMembers = true)]
+	class Issue7943Model
+	{
+		public string Name { get; set; }
+		public int Age { get; set; }
+		public Issue7943Model(string name, int age)
+		{
+			Name = name;
+			Age = age;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -68,6 +68,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7943.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1417,7 +1420,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
       <DependentUpon>Issue7789.xaml</DependentUpon>
     </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">      
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">
@@ -1440,6 +1443,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7758.xaml.cs">
       <DependentUpon>Issue7758.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7943.xaml.cs">
+      <DependentUpon>Issue7943.xaml</DependentUpon>
     </Compile>
   </ItemGroup>
   <ItemGroup>
@@ -1516,6 +1522,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7817.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7943.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/CollectionView/DataChangeObserver.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/DataChangeObserver.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void Stop(Adapter adapter)
 		{
-			if (Observing && adapter != null)
+			if (Observing && adapter != null && adapter.HasObservers)
 			{
 				adapter.UnregisterAdapterDataObserver(this);
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -281,7 +281,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (GetAdapter() != _emptyViewAdapter)
 			{
+				_emptyCollectionObserver.Stop(oldItemViewAdapter);
+				_itemsUpdateScrollObserver.Stop(oldItemViewAdapter);
+	
 				SetAdapter(null);
+	
 				SwapAdapter(ItemsViewAdapter, true);
 			}
 


### PR DESCRIPTION
### Description of Change ###

Fixed a crash on CollectionView changing ItemsSource. 
When doing the swap of the Adapter I have added changes to not observe the old DataChangeObservers.

### Issues Resolved ### 

- fixes #7943

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
```
at Java.Interop.JniEnvironment+InstanceMethods.CallNonvirtualVoidMethod (Java.Interop.JniObjectReference instance, Java.Interop.JniObjectReference type, Java.Interop.JniMethodInfo method, Java.Interop.JniArgumentValue* args) [0x0008e] in :0
at Java.Interop.JniPeerMembers+JniInstanceMethods.InvokeVirtualVoidMethod (System.String encodedMember, Java.Interop.IJavaPeerable self, Java.Interop.JniArgumentValue* parameters) [0x0005d] in :0
at Android.Support.V7.Widget.RecyclerView+Adapter.UnregisterAdapterDataObserver (Android.Support.V7.Widget.RecyclerView+AdapterDataObserver observer) [0x00031] in <7d32f6ecea2f48a59f0d551b445680b3>:0
at Xamarin.Forms.Platform.Android.DataChangeObserver.Stop (Android.Support.V7.Widget.RecyclerView+Adapter adapter) [0x0000b] in D:\a\1\s\Xamarin.Forms.Platform.Android\CollectionView\DataChangeObserver.cs:33
at Xamarin.Forms.Platform.Android.ItemsViewRenderer3[TItemsView,TAdapter,TItemsViewSource].UpdateItemsSource () [0x00024] in D:\a\1\s\Xamarin.Forms.Platform.Android\CollectionView\ItemsViewRenderer.cs:260 at Xamarin.Forms.Platform.Android.ItemsViewRenderer3[TItemsView,TAdapter,TItemsViewSource].OnElementPropertyChanged (System.Object sender, System.ComponentModel.PropertyChangedEventArgs changedProperty) [0x00020] in D:\a\1\s\Xamarin.Forms.Platform.Android\CollectionView\ItemsViewRenderer.cs:214
at Xamarin.Forms.Platform.Android.StructuredItemsViewRenderer3[TItemsView,TAdapter,TItemsViewSource].OnElementPropertyChanged (System.Object sender, System.ComponentModel.PropertyChangedEventArgs changedProperty) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.Android\CollectionView\StructuredItemsViewRenderer.cs:19 at Xamarin.Forms.Platform.Android.SelectableItemsViewRenderer3[TItemsView,TAdapter,TItemsViewSource].OnElementPropertyChanged (System.Object sender, System.ComponentModel.PropertyChangedEventArgs changedProperty) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.Android\CollectionView\SelectableItemsViewRenderer.cs:18
at Xamarin.Forms.Platform.Android.GroupableItemsViewRenderer`3[TItemsView,TAdapter,TItemsViewSource].OnElementPropertyChanged (System.Object sender, System.ComponentModel.PropertyChangedEventArgs changedProperty) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.Android\CollectionView\GroupableItemsViewRenderer.cs:18
at (wrapper delegate-invoke) .invoke_void_object_PropertyChangedEventArgs(object,System.ComponentModel.PropertyChangedEventArgs)
at Xamarin.Forms.BindableObject.OnPropertyChanged (System.String propertyName) [0x00000] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:229
at Xamarin.Forms.Element.OnPropertyChanged (System.String propertyName) [0x00000] in D:\a\1\s\Xamarin.Forms.Core\Element.cs:350
at Xamarin.Forms.BindableObject.SetValueActual (Xamarin.Forms.BindableProperty property, Xamarin.Forms.BindableObject+BindablePropertyContext context, System.Object value, System.Boolean currentlyApplying, Xamarin.Forms.Internals.SetValueFlags attributes, System.Boolean silent) [0x00114] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:461
at Xamarin.Forms.BindableObject.SetValueCore (Xamarin.Forms.BindableProperty property, System.Object value, Xamarin.Forms.Internals.SetValueFlags attributes, Xamarin.Forms.BindableObject+SetValuePrivateFlags privateAttributes) [0x00173] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:397
at Xamarin.Forms.BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value, System.Boolean fromStyle, System.Boolean checkAccess) [0x00042] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:334
at Xamarin.Forms.BindableObject.SetValue (Xamarin.Forms.BindableProperty property, System.Object value) [0x00000] in D:\a\1\s\Xamarin.Forms.Core\BindableObject.cs:311
at Xamarin.Forms.ItemsView.set_ItemsSource (System.Collections.IEnumerable value) [0x00000] in D:\a\1\s\Xamarin.Forms.Core\Items\ItemsView.cs:43
at CollectionViewItemsSourceEmptyView.MainPage.Button_Clicked_ItemsSource (System.Object sender, System.EventArgs e) [0x00001] in /Users/jfversluis/Downloads/CollectionViewItemsSourceEmptyView/CollectionViewItemsSourceEmptyView/MainPage.xaml.cs:58
at Xamarin.Forms.Button.Xamarin.Forms.Internals.IButtonElement.PropagateUpClicked () [0x00000] in D:\a\1\s\Xamarin.Forms.Core\Button.cs:185
at Xamarin.Forms.ButtonElement.ElementClicked (Xamarin.Forms.VisualElement visualElement, Xamarin.Forms.Internals.IButtonElement ButtonElementManager) [0x0001f] in D:\a\1\s\Xamarin.Forms.Core\ButtonElement.cs:61
at Xamarin.Forms.Button.SendClicked () [0x00000] in D:\a\1\s\Xamarin.Forms.Core\Button.cs:171
at Xamarin.Forms.Platform.Android.ButtonElementManager.OnClick (Xamarin.Forms.VisualElement element, Xamarin.Forms.IButtonController buttonController, Android.Views.View v) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.Android\ButtonElementManager.cs:25
at Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer.Android.Views.View.IOnClickListener.OnClick (Android.Views.View v) [0x00000] in D:\a\1\s\Xamarin.Forms.Platform.Android\FastRenderers\ButtonRenderer.cs:71
at Android.Views.View+IOnClickListenerInvoker.n_OnClick_Landroid_view_View_ (System.IntPtr jnienv, System.IntPtr native__this, System.IntPtr native_v) [0x00011] in <4ed855fb65824da79e2edd6f6bb06c94>:0
at (wrapper dynamic-method) Android.Runtime.DynamicMethodNameCounter.41(intptr,intptr,intptr)
--- End of managed Java.Lang.IllegalStateException stack trace ---
java.lang.IllegalStateException: Observer crc643f46942d9dd1fff9.DataChangeObserver@1c09d95 was not registered.
at android.database.Observable.unregisterObserver(Observable.java:69)
at android.support.v7.widget.RecyclerView$Adapter.unregisterAdapterDataObserver(RecyclerView.java:7017)
at crc64ee486da937c010f4.ButtonRenderer.n_onClick(Native Method)
at crc64ee486da937c010f4.ButtonRenderer.onClick(ButtonRenderer.java:95)
at android.view.View.performClick(View.java:7140)
at android.view.View.performClickInternal(View.java:7117)
at android.view.View.access$3500(View.java:801)
at android.view.View$PerformClick.run(View.java:27351)
at android.os.Handler.handleCallback(Handler.java:883)
at android.os.Handler.dispatchMessage(Handler.java:100)
at android.os.Looper.loop(Looper.java:214)
at android.app.ActivityThread.main(ActivityThread.java:7356)
at java.lang.reflect.Method.invoke(Native Method)
at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:492)
at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:930)
```

#### After
![issue7943-after](https://user-images.githubusercontent.com/6755973/66649051-7446ef00-ec2d-11e9-86c5-56ea794b0e78.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 7943. Change the template, ItemsSource and clear items several times to validate that everything works as expected.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
