### PR TITLE
Fix iOS crash when group type is not an IList

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewGroupTypeIssue.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewGroupTypeIssue.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 5882300, "Crash if group type is not IList",
+		PlatformAffected.iOS)]
+	public class CollectionViewGroupTypeIssue : TestNavigationPage
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+#if APP
+			FlagTestHelpers.SetCollectionViewTestFlag();
+			PushAsync(TestPage());
+#endif
+		}
+
+		ContentPage TestPage()
+		{
+			var page = new ContentPage();
+
+			var success = new Label { Text = Success };
+
+			var data = new List<string> { "eins", "zwei", "drei" };
+
+			var cv = new CollectionView
+			{
+				ItemsSource = data,
+				IsGrouped = true
+			};
+
+			var layout = new StackLayout { Children = { success, cv } };
+
+			page.Content = layout;
+
+			return page;
+		}
+
+#if UITEST
+		[Test]
+		public void NonIListGroupTypeShouldNotCrash()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">
       <DependentUpon>Issue1455.xaml</DependentUpon>
@@ -1417,7 +1418,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
       <DependentUpon>Issue7789.xaml</DependentUpon>
     </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">      
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">


### PR DESCRIPTION
### Description of Change ###

Grouped CollectionView on iOS is doing a direct cast to IList in a couple of places where it shouldn't be. These changes fix that, preventing crashes under certain view model conditions.

### Issues Resolved ### 
- crashes when group types are not IList

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated test.

### PR Checklist ###
- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
