### PR TITLE
Fix bug 6957 Device.StartTimer() won't fire on WPF if it is executed on Non UI thread

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6957.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6957.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github,  6957, "Device.StartTimer() won't fire on WPF if it is executed on Non UI thread", PlatformAffected.WPF)]
+	public class Issue6957 : TestContentPage
+	{
+		ObservableCollection<string> _entries = new ObservableCollection<string>();
+
+		protected override void Init()
+		{ 
+			Device.BeginInvokeOnMainThread(()=> Device.StartTimer(TimeSpan.FromSeconds(2), () => Tick(false)));
+			Task.Run(() => Device.StartTimer(TimeSpan.FromSeconds(2), () => Tick(true)));
+			Content = new ListView
+			{
+				ItemsSource = _entries
+			};
+		}
+
+		bool Tick(bool fromOtherThread)
+		{
+			_entries.Add($"Tick from {(fromOtherThread ? "other thread" : "main thread")}");
+			return false; 
+		}
+	}
+}  

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -598,6 +598,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue5793.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6957.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6130.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.WPF
 		
 		public void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
-			var timer = new DispatcherTimer { Interval = interval };
+			var timer = new DispatcherTimer(DispatcherPriority.Background, System.Windows.Application.Current.Dispatcher) { Interval = interval };
 			timer.Start();
 			timer.Tick += (sender, args) =>
 			{


### PR DESCRIPTION
### Description of Change ###

Fixes issue #6957 "Device.StartTimer() won't fire on WPF if it is executed on Non UI thread" which was caused because the DispatcherTimer was invoked on a "dead" thread by using the current dispatcher instead. Read a bit more about the reason here: https://stackoverflow.com/a/8423977

### Issues Resolved ### 

- fixes #6957

### API Changes ###

 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ### 
None

### Before/After Screenshots ###  
Not applicable

### Testing Procedure ###

Added test case G6957 to control gallery which starts a timer from main and background thread.

### PR Checklist ### 

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
