### PR TITLE
Fix bug 7581 - UWP Map not moving to location when map hidden then shown

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7581.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7581.cs
@@ -1,0 +1,60 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Maps;
+
+namespace Xamarin.Forms.Controls.Issues
+{ 
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7581, "UWP Map not moving to location when map hidden then shown", PlatformAffected.UWP)]
+	public class Issue7581 : TestContentPage
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			var _map = new Map
+			{
+				HeightRequest = 100,
+				WidthRequest = 960,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				IsVisible = false
+			};
+
+			_map.MoveToRegion(MapSpan.FromCenterAndRadius(
+				new Position(-41.342112, 173.179948), Distance.FromMiles(1))); // Nelson NZ
+
+			var pos1 = new Position(-41.342112, 173.179948);
+			var pin1 = new Pin
+			{
+				Type = PinType.Place,
+				Position = pos1,
+				Label = "Test Pin 1",
+				Address = "15 Hunt Street, Nelson"
+			};
+			_map.Pins.Add(pin1);
+
+			var pos2 = new Position(-41.341861, 173.193816);
+			var pin2 = new Pin
+			{
+				Type = PinType.Place,
+				Position = pos2,
+				Label = "Test Pin 2",
+				Address = "29 William Street, Nelson"
+			};
+			_map.Pins.Add(pin2);
+
+			var toggleButton = new Button
+			{
+				Text = "Toggle Map Visibility"
+			};
+			toggleButton.Clicked += (sender, e) => { _map.IsVisible = !_map.IsVisible; };
+
+			var grid = new Grid();
+			grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Star) });
+			grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(50, GridUnitType.Absolute) });
+			grid.Children.Add(_map, 0, 0);
+			grid.Children.Add(toggleButton, 0, 1);
+
+			Content = grid;
+		} 
+	} 
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -24,6 +24,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7581.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -1417,7 +1418,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
       <DependentUpon>Issue7789.xaml</DependentUpon>
     </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">      
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">

--- a/Xamarin.Forms.Maps.UWP/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.UWP/MapRenderer.cs
@@ -35,11 +35,12 @@ namespace Xamarin.Forms.Maps.UWP
 
 				if (Control == null)
 				{
-					SetNativeControl(new MapControl());
+					SetNativeControl(new MapControl()); 
 					Control.MapServiceToken = FormsMaps.AuthenticationToken;
 					Control.ZoomLevelChanged += async (s, a) => await UpdateVisibleRegion();
 					Control.CenterChanged += async (s, a) => await UpdateVisibleRegion();
 					Control.MapTapped += OnMapTapped;
+					Control.LayoutUpdated += OnLayoutUpdated; 
 				}
 
 				MessagingCenter.Subscribe<Map, MapSpan>(this, "MapMoveToRegion", async (s, a) => await MoveToRegion(a), mapModel);
@@ -61,6 +62,17 @@ namespace Xamarin.Forms.Maps.UWP
 
 				await Control.Dispatcher.RunIdleAsync(async (i) => await MoveToRegion(mapModel.LastMoveToRegion, MapAnimationKind.None));
 				await UpdateIsShowingUser();
+			}
+		}
+
+		bool _isRegionUpdatePending;
+
+		async void OnLayoutUpdated(object sender, object e)
+		{
+			if (_isRegionUpdatePending)
+			{
+				// _isRegionUpdatePending is set to false when the update is successfull
+				await MoveToRegion(Element.LastMoveToRegion, MapAnimationKind.None);
 			}
 		}
 
@@ -93,6 +105,12 @@ namespace Xamarin.Forms.Maps.UWP
 				{
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnPinCollectionChanged;
 					((ObservableCollection<MapElement>)Element.MapElements).CollectionChanged -= OnMapElementCollectionChanged;
+				}
+
+				if (Control != null)
+				{
+					Control.LayoutUpdated -= OnLayoutUpdated;
+					Control.MapTapped -= OnMapTapped;
 				}
 			}
 
@@ -242,7 +260,7 @@ namespace Xamarin.Forms.Maps.UWP
 			{
 				return new Geopath(new[]
 				{
-					new BasicGeoposition(), 
+					new BasicGeoposition(),
 				});
 			}
 		}
@@ -375,7 +393,7 @@ namespace Xamarin.Forms.Maps.UWP
 				Longitude = span.Center.Longitude + span.LongitudeDegrees / 2
 			};
 			var boundingBox = new GeoboundingBox(nw, se);
-			await Control.TrySetViewBoundsAsync(boundingBox, null, animation);
+			_isRegionUpdatePending = !await Control.TrySetViewBoundsAsync(boundingBox, null, animation); 
 		}
 
 		async Task UpdateVisibleRegion()


### PR DESCRIPTION
### Description of Change ###

Fixes #7581 by applying the new region on the next layout cycle when the initial move failed.

### Issues Resolved ###  

- fixes #7581 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

@stevechadbourne provided a test case in the issue #7581 which I added to the control gallery issue list.

### PR Checklist ### 

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
