### PR TITLE
Fix Bug 7396 - Shell: Setting Shell.BackgroundColor overrides all colors of TabBar

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7396.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7396.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 		PlatformAffected.Android)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
 #endif
 	public class Issue7396 : TestShell
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7396.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7396.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7396, "Setting Shell.BackgroundColor overrides all colors of TabBar",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue7396 : TestShell
+	{
+		const string CreateTopTabButton = "CreateTopTabButton";
+		const string CreateBottomTabButton = "CreateBottomTabButton";
+		const string ChangeShellColorButton = "ChangeShellBackgroundColorButton";
+
+		protected override void Init()
+		{
+			var page = CreateContentPage();
+			page.Title = "Main";
+			page.Content = CreateEntryInsetView();
+
+			CurrentItem = Items.Last();
+		}
+
+		View CreateEntryInsetView()
+		{
+			var random = new Random();
+			ScrollView view = null;
+			view = new ScrollView()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+						{
+							new Button()
+							{
+								Text = "Top Tab",
+								AutomationId = CreateTopTabButton,
+								Command = new Command(() => AddTopTab("top"))
+							},
+							new Button()
+							{
+								Text = "Bottom Tab",
+								AutomationId = CreateBottomTabButton,
+								Command = new Command(() => AddBottomTab("bottom", "coffee.png"))
+							},
+							new Button()
+							{
+								Text = "Random Shell Background Color",
+								AutomationId = ChangeShellColorButton,
+								Command = new Command(() =>
+									Shell.SetBackgroundColor(this, Color.FromRgb(random.Next(0,255), random.Next(0,255), random.Next(0,255))))
+							},
+						}
+				}
+			};
+
+			return view;
+		}
+
+#if UITEST && __ANDROID__
+
+		[Test]
+		public void BottomTabColorTest()
+		{
+			//7396 Issue | Shell: Setting Shell.BackgroundColor overrides all colors of TabBar
+			RunningApp.WaitForElement(CreateBottomTabButton);
+			RunningApp.Tap(CreateBottomTabButton);
+			RunningApp.Tap(CreateBottomTabButton);
+			RunningApp.Tap(ChangeShellColorButton);
+			RunningApp.Screenshot("I should see a bottom tabbar icon");
+			Assert.Inconclusive("Check that bottom tabbar icon is visible");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -30,6 +30,9 @@ namespace Xamarin.Forms.Controls.Issues
 		const string EntryTest = nameof(EntryTest);
 		const string EntryToClick = "EntryToClick";
 		const string EntryToClick2 = "EntryToClick2";
+		const string CreateTopTabButton = "CreateTopTabButton";
+		const string CreateBottomTabButton = "CreateBottomTabButton";
+		const string ChangeShellColorButton = "ChangeShellBackgroundColorButton";
 		const string EntrySuccess = "EntrySuccess";
 		const string ResetKeyboard = "Hide Keyboard";
 		const string Reset = "Reset";
@@ -147,7 +150,7 @@ namespace Xamarin.Forms.Controls.Issues
 			PropertyChangedEventHandler propertyChangedEventHandler = null;
 			propertyChangedEventHandler = (sender, args) =>
 			{
-				if(args.PropertyName == PlatformConfiguration.iOSSpecific.Page.SafeAreaInsetsProperty.PropertyName)
+				if (args.PropertyName == PlatformConfiguration.iOSSpecific.Page.SafeAreaInsetsProperty.PropertyName)
 				{
 					if (page.On<iOS>().SafeAreaInsets().Top > 0)
 					{
@@ -257,6 +260,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		View CreateEntryInsetView()
 		{
+			var random = new Random();
 			ScrollView view = null;
 			view = new ScrollView()
 			{
@@ -286,8 +290,25 @@ namespace Xamarin.Forms.Controls.Issues
 								Text = ResetKeyboard
 
 							},
-							new Button(){ Text = "Top Tab", Command = new Command(() => AddTopTab("top"))},
-							new Button(){ Text = "Bottom Tab", Command = new Command(() => AddBottomTab("bottom"))},
+							new Button()
+							{
+								Text = "Top Tab",
+								AutomationId = CreateTopTabButton,
+								Command = new Command(() => AddTopTab("top"))
+							},
+							new Button()
+							{
+								Text = "Bottom Tab",
+								AutomationId = CreateBottomTabButton,
+								Command = new Command(() => AddBottomTab("bottom", "coffee.png"))
+							},
+							new Button()
+							{
+								Text = "Random Shell Background Color",
+								AutomationId = ChangeShellColorButton,
+								Command = new Command(() =>
+									Shell.SetBackgroundColor(this, Color.FromRgb(random.Next(0,255), random.Next(0,255), random.Next(0,255))))
+							},
 							new Entry()
 							{
 								AutomationId = EntryToClick2
@@ -391,6 +412,22 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.AreEqual(1, somePadding.Length);
 
 			Assert.Greater(somePadding[0].Rect.Y, zeroPadding[0].Rect.Y);
+		}
+		
+#endif
+
+#if UITEST && __ANDROID__
+
+		[Test]
+		public void BottomTabColorTest()
+		{
+			//7396 Issue | Shell: Setting Shell.BackgroundColor overrides all colors of TabBar
+			RunningApp.Tap(EntryTest);
+			RunningApp.WaitForElement(EntrySuccess);
+			RunningApp.Tap(CreateBottomTabButton);
+			RunningApp.Tap(ChangeShellColorButton);
+			RunningApp.Screenshot("I should see a bottom tabbar icon");
+			Assert.Inconclusive("Check that bottom tabbar icon is visible");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string EntryToClick2 = "EntryToClick2";
 		const string CreateTopTabButton = "CreateTopTabButton";
 		const string CreateBottomTabButton = "CreateBottomTabButton";
-		const string ChangeShellColorButton = "ChangeShellBackgroundColorButton";
+		
 		const string EntrySuccess = "EntrySuccess";
 		const string ResetKeyboard = "Hide Keyboard";
 		const string Reset = "Reset";
@@ -260,7 +260,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		View CreateEntryInsetView()
 		{
-			var random = new Random();
 			ScrollView view = null;
 			view = new ScrollView()
 			{
@@ -300,14 +299,7 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								Text = "Bottom Tab",
 								AutomationId = CreateBottomTabButton,
-								Command = new Command(() => AddBottomTab("bottom", "coffee.png"))
-							},
-							new Button()
-							{
-								Text = "Random Shell Background Color",
-								AutomationId = ChangeShellColorButton,
-								Command = new Command(() =>
-									Shell.SetBackgroundColor(this, Color.FromRgb(random.Next(0,255), random.Next(0,255), random.Next(0,255))))
+								Command = new Command(() => AddBottomTab("bottom"))
 							},
 							new Entry()
 							{
@@ -414,21 +406,6 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.Greater(somePadding[0].Rect.Y, zeroPadding[0].Rect.Y);
 		}
 		
-#endif
-
-#if UITEST && __ANDROID__
-
-		[Test]
-		public void BottomTabColorTest()
-		{
-			//7396 Issue | Shell: Setting Shell.BackgroundColor overrides all colors of TabBar
-			RunningApp.Tap(EntryTest);
-			RunningApp.WaitForElement(EntrySuccess);
-			RunningApp.Tap(CreateBottomTabButton);
-			RunningApp.Tap(ChangeShellColorButton);
-			RunningApp.Screenshot("I should see a bottom tabbar icon");
-			Assert.Inconclusive("Check that bottom tabbar icon is visible");
-		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Controls
 				// then initializing the app causes a "NUnit.Framework.InconclusiveException" with the exception-
 				// message "App did not start for some reason. System.Argument.Exception: 1 is not supported code page.
 				// Parameter name: codepage."
-				if(System.Threading.Thread.CurrentThread.CurrentCulture != System.Globalization.CultureInfo.InvariantCulture)
+				if (System.Threading.Thread.CurrentThread.CurrentCulture != System.Globalization.CultureInfo.InvariantCulture)
 					System.Threading.Thread.CurrentThread.CurrentCulture = System.Globalization.CultureInfo.InvariantCulture;
 
 				runningApp = InitializeApp();
@@ -602,17 +602,17 @@ namespace Xamarin.Forms.Controls
 #endif
 		}
 
-		public ContentPage AddTopTab(string title)
+		public ContentPage AddTopTab(string title, string icon = null)
 		{
 			var page = new ContentPage();
-			AddTopTab(page, title);
+			AddTopTab(page, title, icon);
 			return page;
 		}
 
 
-		public void AddTopTab(ContentPage page, string title = null)
+		public void AddTopTab(ContentPage page, string title = null, string icon = null)
 		{
-			if(Items.Count == 0)
+			if (Items.Count == 0)
 			{
 				var item = AddContentPage(page);
 				item.Items[0].Items[0].Title = title ?? page.Title;
@@ -622,16 +622,20 @@ namespace Xamarin.Forms.Controls
 			Items[0].Items[0].Items.Add(new ShellContent()
 			{
 				Title = title ?? page.Title,
-				Content = page
+				Content = page,
+				Icon = icon
 			});
 		}
 
-		public ContentPage AddBottomTab(string title)
+		public ContentPage AddBottomTab(string title, string icon = null)
 		{
-
 			ContentPage page = new ContentPage();
 			Items[0].Items.Add(new ShellSection()
 			{
+				AutomationId = title,
+				Route = title,
+				Title = title,
+				Icon = icon,
 				Items =
 				{
 					new ShellContent()
@@ -670,7 +674,7 @@ namespace Xamarin.Forms.Controls
 			return item;
 		}
 
-		public ContentPage CreateContentPage(string shellItemTitle = null) 
+		public ContentPage CreateContentPage(string shellItemTitle = null)
 			=> CreateContentPage<ShellItem, ShellSection>(shellItemTitle);
 
 		public ContentPage CreateContentPage<TShellItem, TShellSection>(string shellItemTitle = null)
@@ -743,10 +747,10 @@ namespace Xamarin.Forms.Controls
 				AppSetup.EndIsolate();
 			}
 		}
-		public void ShowFlyout(string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, bool testForFlyoutIcon = true, string timeoutMessage = null)
-		{			
-			if(testForFlyoutIcon)
-				RunningApp.WaitForElement(flyoutIcon, timeoutMessage);
+		public void ShowFlyout(string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, bool testForFlyoutIcon = true)
+		{
+			if (testForFlyoutIcon)
+				RunningApp.WaitForElement(flyoutIcon);
 
 			if (usingSwipe)
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -767,7 +767,7 @@ namespace Xamarin.Forms.Controls
 		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null)
 		{
 			timeoutMessage = timeoutMessage ?? text;
-			ShowFlyout(flyoutIcon, usingSwipe, timeoutMessage: timeoutMessage);
+			ShowFlyout(flyoutIcon, usingSwipe);
 			RunningApp.WaitForElement(text, timeoutMessage);
 			RunningApp.Tap(text);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6476.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7825.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
@@ -45,9 +45,10 @@ namespace Xamarin.Forms.Platform.Android
 			if (_defaultList == null)
 			{
 #if __ANDROID_28__
-				_defaultList = bottomView.ItemTextColor ?? MakeColorStateList(titleColor.ToAndroid().ToArgb(), disabledColor.ToAndroid().ToArgb(), unselectedColor.ToAndroid().ToArgb());
+				_defaultList = bottomView.ItemTextColor ?? bottomView.ItemIconTintList
+					?? MakeColorStateList(titleColor.ToAndroid().ToArgb(), disabledColor.ToAndroid().ToArgb(), unselectedColor.ToAndroid().ToArgb());
 #else
-				_defaultList = bottomView.ItemTextColor;
+				_defaultList = bottomView.ItemTextColor ?? bottomView.ItemIconTintList;
 #endif
 			}
 
@@ -95,12 +96,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		ColorStateList MakeColorStateList(Color titleColor, Color disabledColor, Color unselectedColor)
 		{
-			var states = new int[][] {
-				new int[] { -R.Attribute.StateEnabled },
-				new int[] {R.Attribute.StateChecked },
-				new int[] { }
-			};
-
 			var disabledInt = disabledColor.IsDefault ?
 				_defaultList.GetColorForState(new[] { -R.Attribute.StateEnabled }, AColor.Gray) :
 				disabledColor.ToAndroid().ToArgb();


### PR DESCRIPTION
### Description of Change ###

Fixes #7396 where tabbar icon/text color was changed when change shell backgroundcolor property

### Issues Resolved ### 

- fixes #7396 

### API Changes ###

 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Bottom tabbar icon/text color dont change when shell brackground is setted

### Before/After Screenshots ### 

- Before
<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/66704094-8a1ce880-ecef-11e9-9d89-6bd124c22d91.gif" alt="before screenshot" style="max-width:100%;"/>
	</kbd>
</p>

- After

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/66704108-a6208a00-ecef-11e9-9c6c-3712fe650ae3.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### Testing Procedure ###

- Run the issues project, go to "ShellInsets" and click on "Entry Inset" button.
- Add a bottom tab
- Click on "Random Shell Background Color" button

### PR Checklist ###
- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
