### PR TITLE
Fix Bug 7823 - Frame corner radius.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7823.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7823.cs
@@ -1,32 +1,80 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest.Queries;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 7823, "[Bug] Frame corner radius.", PlatformAffected.Android)]
-	public sealed class Issue7823 : TestContentPage
+	[Issue(IssueTracker.Github, 7823, "[Bug] Frame corner radius.", PlatformAffected.All)]
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	public class Issue7823 : TestContentPage
 	{
+		const string GetClipToOutline = "getClipToOutline";
+		const string GetClipChildren = "getClipChildren";
+		const string GetClipBounds = "getClipBounds";
+		const string SecondaryFrame = "Secondary Frame";
+		const string RootFrame = "Root Frame";
+		const string BoxView = "Box View";
+
 		protected override void Init()
 		{
-			Content = new Frame
+			Content = new StackLayout()
 			{
-				CornerRadius = 5,
-				BackgroundColor = Color.Red,
-				Padding = 10,
-				Content = new Frame
+				Children =
 				{
-					CornerRadius = 10,
-					BackgroundColor = Color.Blue,
-					Padding = 0,
-					Content = new BoxView
+					new ApiLabel(),
+					new Frame
 					{
-						BackgroundColor = Color.Green,
-						WidthRequest = 100,
-						HeightRequest = 100
+						AutomationId = RootFrame,
+						CornerRadius = 5,
+						BackgroundColor = Color.Red,
+						Padding = 10,
+						Content = new Frame
+						{
+							AutomationId = SecondaryFrame,
+							CornerRadius = 10,
+							BackgroundColor = Color.Blue,
+							Padding = 0,
+							Content = new BoxView
+							{
+								AutomationId = BoxView,
+								BackgroundColor = Color.Green,
+								WidthRequest = 100,
+								HeightRequest = 100
+							}
+						}
 					}
 				}
 			};
 		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		[UiTest(typeof(Frame))]
+		public void Issue7823TestIsClippedIssue()
+		{
+			RunningApp.WaitForElement(RootFrame);
+			var clipChildrenValue = RunningApp.InvokeFromElement<bool>(SecondaryFrame, GetClipChildren)[0];
+
+			if (RunningApp.IsApiHigherThan(17))
+			{
+				var clipBoundsRec = RunningApp.InvokeFromElement<object>(RootFrame, GetClipBounds)[0];
+				Assert.IsTrue(clipBoundsRec.ToString().Contains("\"empty\": false"));
+				Assert.IsFalse(clipChildrenValue);
+			}
+			else
+			{
+				Assert.IsTrue(clipChildrenValue);
+			}
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7823.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7823.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7823, "[Bug] Frame corner radius.", PlatformAffected.Android)]
+	public sealed class Issue7823 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new Frame
+			{
+				CornerRadius = 5,
+				BackgroundColor = Color.Red,
+				Padding = 10,
+				Content = new Frame
+				{
+					CornerRadius = 10,
+					BackgroundColor = Color.Blue,
+					Padding = 0,
+					Content = new BoxView
+					{
+						BackgroundColor = Color.Green,
+						WidthRequest = 100,
+						HeightRequest = 100
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -68,6 +68,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7823.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1417,7 +1418,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
       <DependentUpon>Issue7789.xaml</DependentUpon>
     </Compile>
-    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">      
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7519Xaml.xaml.cs">
       <DependentUpon>Issue7519Xaml.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7817.xaml.cs">

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -43,6 +43,9 @@ namespace Xamarin.UITest
 			return true;
 		}
 
+		public static TResult[] InvokeFromElement<TResult>(this IApp app, string element, string methodName) =>
+			app.Query(c => c.Marked(element).Invoke(methodName).Value<TResult>());
+
 #if __IOS__
 		public static void SendAppToBackground(this IApp app, TimeSpan timeSpan)
 		{

--- a/Xamarin.Forms.Core/Frame.cs
+++ b/Xamarin.Forms.Core/Frame.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty HasShadowProperty = BindableProperty.Create("HasShadow", typeof(bool), typeof(Frame), true);
 
 		public static readonly BindableProperty CornerRadiusProperty = BindableProperty.Create(nameof(CornerRadius), typeof(float), typeof(Frame), -1.0f,
-									validateValue: (bindable, value) => ((float)value) == -1.0f || ((float)value) >= 0f);
+									validateValue: (bindable, value) => ((float)value) == -1.0f || ((float)value) >= 0f, propertyChanged: OnCornerRadiusChanged);
 
 		readonly Lazy<PlatformConfigurationRegistry<Frame>> _platformConfigurationRegistry;
 
@@ -87,5 +87,11 @@ namespace Xamarin.Forms
 		bool IBorderElement.IsBorderColorSet() => IsSet(BorderColorProperty);
 
 		bool IBorderElement.IsBorderWidthSet() => false;
+
+		static void OnCornerRadiusChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is Frame frame)
+				frame.IsClippedToBounds |= (float)newValue > 0f;
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
I created changed event, on "CornerRadiusProperty", to set "IsClippedToBounds" to true when radius is greater than 0.

### Issues Resolved ### 
- fixes #7823 

### API Changes ###
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

Frame will cut corners of child elements, when corner radius greater than 0 and padding equals 0. 

### Before/After Screenshots ### 

- Before

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/32664004/66212973-88d43600-e6c7-11e9-839a-356f0ac7bbc4.jpg" alt="before screenshot" style="max-width:100%;"/>
	</kbd>
</p>

- After
<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/66707670-789d0600-ed1a-11e9-8efa-41490395b4a0.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### Testing Procedure ###

1. Create frame with any corner radius and NOT ZERO padding.
1. Create one more frame as a child of the first with any corner radius and ZERO padding.
1. Into the second frame insert boxview(can be any view)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
