### PR TITLE
Set correct MinWidth for CheckBox style

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7048.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7048.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue7048">
+    <ContentPage.Content>
+        <StackLayout VerticalOptions="Center">
+            <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+                <CheckBox BackgroundColor="Silver"/>
+                <Label Text="CheckBox" VerticalOptions="Center" />
+            </StackLayout>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7048.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7048.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if APP
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7048, "[Bug][UWP] CheckBox Has Incosistent Paddings",
+		PlatformAffected.UWP)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Issue7048 : ContentPage
+    {
+        public Issue7048()
+        {
+            InitializeComponent();
+        }
+    }
+#endif
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -25,6 +25,10 @@
     </Compile> 
     <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" /> 
     <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" /> 
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7048.xaml.cs">
+      <DependentUpon>Issue7048.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <SubType>Code</SubType>
@@ -1581,6 +1585,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7803.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7048.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/FormsCheckBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsCheckBoxStyle.xaml
@@ -14,7 +14,7 @@
         <Setter Property="VerticalContentAlignment" Value="Top"/>
         <Setter Property="FontFamily" Value="{ThemeResource ContentControlThemeFontFamily}"/>
         <Setter Property="FontSize" Value="{ThemeResource ControlContentThemeFontSize}"/>
-        <Setter Property="MinWidth" Value="120"/>
+        <Setter Property="MinWidth" Value="32"/>
         <Setter Property="MinHeight" Value="32"/>
         <Setter Property="UseSystemFocusVisuals" Value="True"/>
         <Setter Property="FocusVisualMargin" Value="-7,-3,-7,-3"/>


### PR DESCRIPTION
Fixes #7048 

### Description of Change ###

Default MinWidth value for CheckBox was defined as 120 in the CheckBox style on UWP.
Best we set this to the same value as MinHeight, so now both are 32.

### Issues Resolved ### 

- fixes #7048

### API Changes ###

Changed:
 - object FormsCheckBoxStyle.xaml MinWidth property 120 => 32

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Right padding will be gone.

None

### Before/After Screenshots ### 

<img width="964" alt="Screenshot (5)" src="https://user-images.githubusercontent.com/351693/66716215-90809280-edcb-11e9-99bc-680ed3473bee.png">
<img width="961" alt="Screenshot (4)" src="https://user-images.githubusercontent.com/351693/66716214-8fe7fc00-edcb-11e9-9fa9-1ee9c48b9e76.png">

### Testing Procedure ###

Added Issue7048 to Xamarin Controls test app

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
