### PR TITLE
[iOS] Fix iOS ScrollToAsync not completing when scrolling to current location

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ScrollGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ScrollGallery.cs
@@ -34,9 +34,11 @@ namespace Xamarin.Forms.Controls
 			var btn8 = new Button { Text = "Toggle Orientation" };
 			var btn9 = new Button { Text = "Default Scroll Bar Visibility" };
 
+			var labelStack = new StackLayout { Orientation = StackOrientation.Horizontal };
 			var label = new Label { Text = string.Format ("X: {0}, Y: {1}", 0, 0) };
+			var scrollStatusLabel = new Label { Text = string.Empty };
 			
-			root.Children.Add (label);
+			root.Children.Add (labelStack);
 			root.Children.Add (btnStack);
 			root.Children.Add (btnStack1);
 
@@ -49,6 +51,9 @@ namespace Xamarin.Forms.Controls
 
 			btnStack1.Children.Add (btn);
 			btnStack1.Children.Add (btn4);
+
+			labelStack.Children.Add(label);
+			labelStack.Children.Add(scrollStatusLabel);
 
 			Grid.SetRow (btnStack, 1);
 			Grid.SetRow (btnStack1, 2);
@@ -73,6 +78,7 @@ namespace Xamarin.Forms.Controls
 			};
 
 			btn.Clicked += async (object sender, EventArgs e) => {
+				scrollStatusLabel.Text = "scrolling";
 				switch (orientation) {
 					case ScrollOrientation.Horizontal:
 						await _scrollview.ScrollToAsync (100, 0, true);
@@ -84,6 +90,7 @@ namespace Xamarin.Forms.Controls
 						await _scrollview.ScrollToAsync (100, 100, true);
 						break;
 				}
+				scrollStatusLabel.Text = "completed";
 			};
 			btn4.Clicked += async (object sender, EventArgs e) => {
 				switch (orientation) {

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ScrollViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ScrollViewUITests.cs
@@ -56,6 +56,16 @@ namespace Xamarin.Forms.Core.UITests
 		}
 
 		[Test]
+		[Description("ScrollTo Y = 100")]
+		public void ScrollToYTwice()
+		{
+			App.Tap(c => c.Marked("Scroll to 100"));
+			App.WaitForElement("completed");
+			App.Tap(c => c.Marked("Scroll to 100"));
+			App.WaitForElement("completed");
+		}
+
+		[Test]
 		[Description ("ScrollTo Y = 100 no animation")]
 		public void ScrollToYNoAnim ()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -260,8 +260,10 @@ namespace Xamarin.Forms.Platform.iOS
 				_requestedScroll = e;
 				return;
 			}
+
+			PointF newOffset = PointF.Empty;
 			if (e.Mode == ScrollToMode.Position)
-				SetContentOffset(new PointF((nfloat)e.ScrollX, (nfloat)e.ScrollY), e.ShouldAnimate);
+				newOffset = new PointF((nfloat)e.ScrollX, (nfloat)e.ScrollY);
 			else
 			{
 				var positionOnScroll = ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
@@ -272,17 +274,20 @@ namespace Xamarin.Forms.Platform.iOS
 				switch (ScrollView.Orientation)
 				{
 					case ScrollOrientation.Horizontal:
-						SetContentOffset(new PointF((nfloat)positionOnScroll.X, ContentOffset.Y), e.ShouldAnimate);
+						newOffset = new PointF((nfloat)positionOnScroll.X, ContentOffset.Y);
 						break;
 					case ScrollOrientation.Vertical:
-						SetContentOffset(new PointF(ContentOffset.X, (nfloat)positionOnScroll.Y), e.ShouldAnimate);
+						newOffset = new PointF(ContentOffset.X, (nfloat)positionOnScroll.Y);
 						break;
 					case ScrollOrientation.Both:
-						SetContentOffset(new PointF((nfloat)positionOnScroll.X, (nfloat)positionOnScroll.Y), e.ShouldAnimate);
+						newOffset = new PointF((nfloat)positionOnScroll.X, (nfloat)positionOnScroll.Y);
 						break;
 				}
 			}
-			if (!e.ShouldAnimate)
+			var sameOffset = newOffset == ContentOffset;
+			SetContentOffset(newOffset, e.ShouldAnimate);
+
+			if (!e.ShouldAnimate || sameOffset)
 				ScrollView.SendScrollFinished();
 		}
 


### PR DESCRIPTION
### Description of Change ###

If `OnScrollToRequested` would call `SetContentOffset` with the current `ContentOffset`, call `SendScrollFinished` immediately (the same behavior as scrolling without animation).

### Issues Resolved ### 
- fixes #7972
### API Changes ###

 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I added a label to `ScrollGallery` that says "scrolling" when scrolling starts and "completed" when it finished. Previously, when pressing the scroll button twice it would not change back to "completed".

**I also added a simple UITest testing this but haven't been able to actually run it.**

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
