### PR TITLE
[Android] Activity restarts with resolution change, page UI doesnt change

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/ChangeDensityButtonRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ChangeDensityButtonRenderer.cs
@@ -26,12 +26,13 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
 		{
-			Element.Clicked -= ChangeDensityClicked;
-			Element.Clicked += ChangeDensityClicked;
 			base.OnElementChanged(e);
+
+			if(Element.Command == null)
+				Element.Command = new Command(ChangeDensityClicked);
 		}
 
-		private void ChangeDensityClicked(object sender, EventArgs e)
+		private void ChangeDensityClicked()
 		{
 			using (var metrics = Context.Resources.DisplayMetrics)
 			{

--- a/Xamarin.Forms.ControlGallery.Android/ChangeDensityButtonRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ChangeDensityButtonRenderer.cs
@@ -1,18 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-using Android.App;
-using Android.Content;
-using Android.OS;
-using Android.Runtime;
+﻿using Android.Content;
 using Android.Util;
-using Android.Views;
-using Android.Widget;
 using Xamarin.Forms;
-using Xamarin.Forms.Controls;
 using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls;
 using Xamarin.Forms.Platform.Android;
 
 [assembly: ExportRenderer(typeof(ChangeDensityButton), typeof(ChangeDensityButtonRenderer))]
@@ -20,6 +10,18 @@ namespace Xamarin.Forms.ControlGallery.Android
 {
 	public class ChangeDensityButtonRenderer : Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer
 	{
+		private DisplayMetricsDensity _previousDensityDpi;
+
+		private int? _previousHeightPixels;
+		private int? _previousWidthPixels;
+
+		private float? _previousScaledDensity;
+		private float? _previousDensity;
+		private float? _previousXdpi;
+		private float? _previousYDpi;
+
+		private bool restoreDensity;
+
 		public ChangeDensityButtonRenderer(Context context) : base(context)
 		{
 		}
@@ -32,20 +34,37 @@ namespace Xamarin.Forms.ControlGallery.Android
 				Element.Command = new Command(ChangeDensityClicked);
 		}
 
-		private void ChangeDensityClicked()
+		void ChangeDensityClicked()
 		{
 			using (var metrics = Context.Resources.DisplayMetrics)
 			{
-				metrics.Density = 1.5f;
-				metrics.DensityDpi = DisplayMetricsDensity.D260;
-				metrics.HeightPixels = 1104;
-				metrics.WidthPixels = 1920;
-				metrics.ScaledDensity = 1.5f;
-				metrics.Xdpi = 254.0f;
-				metrics.Ydpi = 254.0f;
+				BackupMetricsParameters(metrics);
+
+				metrics.Density = restoreDensity ? _previousDensity.Value : 1.5f;
+				metrics.DensityDpi = restoreDensity ? _previousDensityDpi : DisplayMetricsDensity.D260;
+				metrics.HeightPixels = restoreDensity ? _previousHeightPixels.Value : 1104;
+				metrics.WidthPixels = restoreDensity ? _previousWidthPixels.Value : 1920;
+				metrics.ScaledDensity = restoreDensity ? _previousScaledDensity.Value : 1.5f;
+				metrics.Xdpi =  restoreDensity ? _previousXdpi.Value : 254.0f;
+				metrics.Ydpi = restoreDensity ? _previousYDpi.Value : 254.0f;
 
 				Context.Resources.DisplayMetrics.SetTo(metrics);
+				restoreDensity = !restoreDensity;
 			}
+		}
+
+		void BackupMetricsParameters(DisplayMetrics metrics)
+		{
+			if (_previousDensity.HasValue)
+				return;
+
+			_previousDensity = metrics.Density;
+			_previousDensityDpi = metrics.DensityDpi;
+			_previousHeightPixels = metrics.HeightPixels;
+			_previousWidthPixels = metrics.WidthPixels;
+			_previousScaledDensity = metrics.ScaledDensity;
+			_previousXdpi = metrics.Xdpi;
+			_previousYDpi = metrics.Ydpi;
 		}
 	}
 }

--- a/Xamarin.Forms.ControlGallery.Android/ChangeDensityButtonRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/ChangeDensityButtonRenderer.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Util;
+using Android.Views;
+using Android.Widget;
+using Xamarin.Forms;
+using Xamarin.Forms.Controls;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(ChangeDensityButton), typeof(ChangeDensityButtonRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class ChangeDensityButtonRenderer : Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer
+	{
+		public ChangeDensityButtonRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
+		{
+			Element.Clicked -= ChangeDensityClicked;
+			Element.Clicked += ChangeDensityClicked;
+			base.OnElementChanged(e);
+		}
+
+		private void ChangeDensityClicked(object sender, EventArgs e)
+		{
+			using (var metrics = Context.Resources.DisplayMetrics)
+			{
+				metrics.Density = 1.5f;
+				metrics.DensityDpi = DisplayMetricsDensity.D260;
+				metrics.HeightPixels = 1104;
+				metrics.WidthPixels = 1920;
+				metrics.ScaledDensity = 1.5f;
+				metrics.Xdpi = 254.0f;
+				metrics.Ydpi = 254.0f;
+
+				Context.Resources.DisplayMetrics.SetTo(metrics);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/DensityLabelRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/DensityLabelRenderer.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using Android.Content;
+using Android.OS;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(DensityLabel), typeof(DensityLabelRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class DensityLabelRenderer : Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer
+	{
+		public DensityLabelRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			((DensityLabel)Element).GetCurrentDensityValue = new Command(GetCurrentDensityValueCommandExecute);
+
+			GetCurrentDensityValueCommandExecute();
+			base.OnElementChanged(e);
+		}
+
+		void GetCurrentDensityValueCommandExecute()
+		{
+			using (var metrics = Context.Resources.DisplayMetrics)
+				Element.Text = metrics.Density.ToString();
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -99,6 +99,8 @@
     <Compile Include="BrokenNativeControl.cs" />
     <Compile Include="CacheService.cs" />
     <Compile Include="DrawableExtensions.cs" />
+    <Compile Include="ChangeDensityButtonRenderer.cs" />
+    <Compile Include="DensityLabelRenderer.cs" />
     <Compile Include="FormsApplicationActivity.cs" />
     <Compile Include="DisposeLabelRenderer.cs" />
     <Compile Include="DisposePageRenderer.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/ChangeDensityButton.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/ChangeDensityButton.cs
@@ -1,0 +1,11 @@
+﻿namespace Xamarin.Forms.Controls
+{
+	public class ChangeDensityButton : Button
+	{
+		public ChangeDensityButton()
+		{
+			AutomationId = "ChangeDensityButton";
+			Text = "Click to change current density";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/DensityLabel.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/DensityLabel.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Xamarin.Forms.Controls
+{
+	public class DensityLabel : Label
+	{
+		public DensityLabel() =>
+			AutomationId = "DensityLabel";
+
+		public void RefreshValue() =>
+			GetCurrentDensityValue?.Execute(null);
+
+		public ICommand GetCurrentDensityValue { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7239.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7239.cs
@@ -49,11 +49,25 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue7239TestDensityChangeIssue()
 		{
 			RunningApp.WaitForElement(RefreshButton);
+			var startDensityValue = RunningApp.GetScreenDensity();
+
+			UpdateCurrentDensity();
+			ValidateCurrentDensity(1.5f);
+
+			UpdateCurrentDensity();
+			ValidateCurrentDensity(startDensityValue);
+		}
+
+		void UpdateCurrentDensity()
+		{
 			RunningApp.Tap(ChangeDensityButton);
 			RunningApp.Tap(RefreshButton);
+		}
 
-			var finalDensity = RunningApp.GetScreenDensity();
-			Assert.AreEqual(1.5f, finalDensity);
+		void ValidateCurrentDensity(float expectedValue)
+		{
+			var currentDensityValue = RunningApp.GetScreenDensity();
+			Assert.AreEqual(expectedValue, currentDensityValue);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7239.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7239.cs
@@ -1,0 +1,60 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest.Queries;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7239, "[Bug] Activity restarts with resolution change, page UI doesnt change", PlatformAffected.Android)]
+#if UITEST
+	[Category(UITestCategories.Page)]
+#endif
+	public class Issue7239 : TestContentPage
+	{
+		const string RefreshButton = "RefreshButton";
+		const string ChangeDensityButton = "ChangeDensityButton";
+
+		protected override void Init()
+		{
+			var densityLabel = new DensityLabel()
+			{
+				FontSize = 80
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					densityLabel,
+					new ChangeDensityButton(),
+					new Button()
+					{
+						AutomationId = RefreshButton,
+						Text = "Click to refresh",
+						Command = new Command(()=> densityLabel?.RefreshValue())
+					}
+				}
+			};
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		[UiTest(typeof(Page))]
+		public void Issue7239TestDensityChangeIssue()
+		{
+			RunningApp.WaitForElement(RefreshButton);
+			RunningApp.Tap(ChangeDensityButton);
+			RunningApp.Tap(RefreshButton);
+
+			var finalDensity = RunningApp.GetScreenDensity();
+			Assert.AreEqual(1.5f, finalDensity);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -41,6 +41,8 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\ChangeDensityButton.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\DensityLabel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">
       <DependentUpon>Issue1455.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -91,6 +93,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7181.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5367.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7239.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7581.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7361.cs" />
@@ -1500,7 +1503,6 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
-    <Folder Include="$(MSBuildThisFileDirectory)Controls\" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2858.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -97,6 +97,9 @@ namespace Xamarin.UITest
 		public static TResult[] InvokeFromElement<TResult>(this IApp app, string element, string methodName) =>
 			app.Query(c => c.Marked(element).Invoke(methodName).Value<TResult>());
 
+		public static float GetScreenDensity(this IApp app, string apiLabelId = "DensityLabel") =>
+			Convert.ToSingle(app.WaitForElement(apiLabelId)[0].ReadText().Replace(",", "."));
+
 #if __IOS__
 		public static void SendAppToBackground(this IApp app, TimeSpan timeSpan)
 		{

--- a/Xamarin.Forms.Platform.Android/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ContextExtensions.cs
@@ -86,9 +86,6 @@ namespace Xamarin.Forms.Platform.Android
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		static void SetupMetrics(Context context)
 		{
-			if (s_displayDensity != float.MinValue)
-				return;
-
 			using (DisplayMetrics metrics = context.Resources.DisplayMetrics)
 				s_displayDensity = metrics.Density;
 		}

--- a/Xamarin.Forms.Platform.Android/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ContextExtensions.cs
@@ -86,8 +86,7 @@ namespace Xamarin.Forms.Platform.Android
 		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		static void SetupMetrics(Context context)
 		{
-			using (DisplayMetrics metrics = context.Resources.DisplayMetrics)
-				s_displayDensity = metrics.Density;
+			s_displayDensity = context.Resources.DisplayMetrics.Density;
 		}
 
 		public static AActivity GetActivity(this Context context)


### PR DESCRIPTION
### Description of Change ###
I`ve removed validation from density cache

### Issues Resolved ### 
- fixes #7239

### API Changes ###
  
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
If android density  change, application will use this new value

### Before/After Screenshots ### 

- Before

None

- After
<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/66721978-bf543400-edde-11e9-8400-37925e7d8837.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### Testing Procedure ###
1- open xamarin forms app
2- put app in background and go to settings
3- search for device resolution option
4- change it to other resolution and open the app from background
5- check the page resolution

> Or run a Issue 7239 on Xamarin Gallery

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
