### PR TITLE
Fix 4459 - Update UWP BoxViewRenderer to fully support corner radius

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
@@ -8,6 +8,7 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using Xamarin.Forms.ControlGallery.WindowsUniversal;
 using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.UAP;
 using Xamarin.Forms.Platform.UWP;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.Bugzilla42602.TextBoxView), typeof(Xamarin.Forms.ControlGallery.WindowsUniversal.TextBoxViewRenderer))]
@@ -119,7 +120,9 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 	}
 
 
+#pragma warning disable 618
 	public class TextBoxViewRenderer : BoxViewRenderer
+#pragma warning restore 618
 	{
 		Canvas m_Canvas;
 

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
@@ -8,7 +8,6 @@ using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Shapes;
 using Xamarin.Forms.ControlGallery.WindowsUniversal;
 using Xamarin.Forms.Controls.Issues;
-using Xamarin.Forms.Platform.UAP;
 using Xamarin.Forms.Platform.UWP;
 
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.Bugzilla42602.TextBoxView), typeof(Xamarin.Forms.ControlGallery.WindowsUniversal.TextBoxViewRenderer))]

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/CustomRenderers.cs
@@ -119,9 +119,7 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 	}
 
 
-#pragma warning disable 618
-	public class TextBoxViewRenderer : BoxViewRenderer
-#pragma warning restore 618
+	public class TextBoxViewRenderer : BoxViewBorderRenderer
 	{
 		Canvas m_Canvas;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
@@ -29,7 +29,7 @@
                 <Entry x:Name="BottomLeft" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
             </StackLayout>
 
-            <issues:Issue4459BoxView x:Name="BoxView" BackgroundColor="#CC3300"
+            <BoxView x:Name="BoxView" BackgroundColor="#CC3300"
                      WidthRequest="200"
                      HeightRequest="100"
                      CornerRadius="10,0,0,10"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
@@ -1,0 +1,38 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue4459">
+    <ContentPage.Content>
+        <StackLayout>
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Top Left"></Label>
+                <Entry x:Name="TopLeft" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
+            </StackLayout>
+
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Top Right"></Label>
+                <Entry x:Name="TopRight" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
+            </StackLayout>
+
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Bottom Right"></Label>
+                <Entry x:Name="BottomRight" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
+            </StackLayout>
+
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Bottom Left"></Label>
+                <Entry x:Name="BottomLeft" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
+            </StackLayout>
+
+            <BoxView x:Name="BoxView" BackgroundColor="#CC3300"
+                     WidthRequest="200"
+                     HeightRequest="100"
+                     CornerRadius="10,0,0,10"
+                     Margin="50"
+            />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
@@ -3,10 +3,12 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues;assembly=Xamarin.Forms.Controls"
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.Issues.Issue4459">
     <ContentPage.Content>
         <StackLayout>
+            <Label>Enter a corner radius for each corner and the box view below should update.</Label>
             <StackLayout Orientation="Horizontal">
                 <Label Text="Top Left"></Label>
                 <Entry x:Name="TopLeft" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
@@ -27,7 +29,7 @@
                 <Entry x:Name="BottomLeft" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
             </StackLayout>
 
-            <BoxView x:Name="BoxView" BackgroundColor="#CC3300"
+            <issues:Issue4459BoxView x:Name="BoxView" BackgroundColor="#CC3300"
                      WidthRequest="200"
                      HeightRequest="100"
                      CornerRadius="10,0,0,10"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
@@ -20,9 +20,4 @@ namespace Xamarin.Forms.Controls.Issues
 			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
 		}
 	}
-
-	public class Issue4459BoxView : BoxView
-	{
-
-	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
@@ -20,8 +20,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 		void InputView_OnTextChanged(object sender, TextChangedEventArgs e)
 		{
+#if APP
 			BoxView.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
 			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
+#endif
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
@@ -6,12 +6,16 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 4459, "[UWP] BoxView CornerRadius doesn't work", PlatformAffected.UWP)]
+#if APP
 	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
 	public partial class Issue4459 : ContentPage
 	{
 		public Issue4459()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 
 		void InputView_OnTextChanged(object sender, TextChangedEventArgs e)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
@@ -1,0 +1,23 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4459, "[UWP] BoxView CornerRadius doesn't work", PlatformAffected.UWP)]
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class Issue4459 : ContentPage
+	{
+		public Issue4459()
+		{
+			InitializeComponent();
+		}
+
+		void InputView_OnTextChanged(object sender, TextChangedEventArgs e)
+		{
+			BoxView.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
+			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
@@ -20,4 +20,9 @@ namespace Xamarin.Forms.Controls.Issues
 			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
 		}
 	}
+
+	public class Issue4459BoxView : BoxView
+	{
+
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -23,6 +23,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8207.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6362.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7505.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4459.xaml.cs">
+      <DependentUpon>Issue4459.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">
       <DependentUpon>Issue1455.xaml</DependentUpon>
@@ -1694,6 +1698,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue5354.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4459.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
@@ -3,9 +3,8 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Shapes;
-using Xamarin.Forms.Platform.UWP;
 
-namespace Xamarin.Forms.Platform.UAP
+namespace Xamarin.Forms.Platform.UWP
 {
 	public class BoxViewBorderRenderer : ViewRenderer<BoxView, Border>
 	{

--- a/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform.UWP;
 
 namespace Xamarin.Forms.Platform.UAP
 {
-	class BoxViewRenderer2 : ViewRenderer<BoxView, Border>
+	public class BoxViewBorderRenderer : ViewRenderer<BoxView, Border>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)
 		{

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Shapes;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	[Obsolete("Replaced with BoxViewRenderer2")]
+	[Obsolete("BoxViewRenderer is obsolete as of version 4.X. Please use BoxViewBorderRenderer instead.")]
 	public class BoxViewRenderer : ViewRenderer<BoxView, Windows.UI.Xaml.Shapes.Rectangle>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 
-		private void SetCornerRadius(CornerRadius cornerRadius)
+		void SetCornerRadius(CornerRadius cornerRadius)
 		{
 			Control.CornerRadius = new Windows.UI.Xaml.CornerRadius(cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft);
 		}

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Shapes;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	[Obsolete("BoxViewRenderer is obsolete as of version 4.X. Please use BoxViewBorderRenderer instead.")]
+	[Obsolete("BoxViewRenderer is obsolete as of version 4.X. Please use BoxViewBorderRenderer instead.", false)]
 	public class BoxViewRenderer : ViewRenderer<BoxView, Windows.UI.Xaml.Shapes.Rectangle>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
@@ -1,11 +1,12 @@
 ﻿using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Shapes;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	public class BoxViewRenderer : ViewRenderer<BoxView, Windows.UI.Xaml.Shapes.Rectangle>
+	public class BoxViewRenderer : ViewRenderer<BoxView, Border>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)
 		{
@@ -15,7 +16,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (Control == null)
 				{
-					var rect = new Windows.UI.Xaml.Shapes.Rectangle
+					var rect = new Border
 					{
 						DataContext = Element
 					};
@@ -48,10 +49,22 @@ namespace Xamarin.Forms.Platform.UWP
 			return new FrameworkElementAutomationPeer(Control);
 		}
 
+		protected override void UpdateBackgroundColor()
+		{
+			//background color change must be handled separately
+			//because the background would protrude through the border if the corners are rounded
+			//as the background would be applied to the renderer's FrameworkElement
+			Color backgroundColor = Element.BackgroundColor;
+			if (Control != null)
+			{
+				Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
+			}
+		}
+
+
 		private void SetCornerRadius(CornerRadius cornerRadius)
 		{
-			Control.RadiusX = cornerRadius.TopLeft;
-			Control.RadiusY = cornerRadius.BottomRight;
+			Control.CornerRadius = new Windows.UI.Xaml.CornerRadius(cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
@@ -1,10 +1,12 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
 using Windows.UI.Xaml.Shapes;
 
 namespace Xamarin.Forms.Platform.UWP
 {
+	[Obsolete("Replaced with BoxViewRenderer2")]
 	public class BoxViewRenderer : ViewRenderer<BoxView, Windows.UI.Xaml.Shapes.Rectangle>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Shapes;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	[Obsolete("BoxViewRenderer is obsolete as of version 4.X. Please use BoxViewBorderRenderer instead.", false)]
+	[Obsolete("BoxViewRenderer is obsolete as of version 4.6.0. Please use BoxViewBorderRenderer instead.", false)]
 	public class BoxViewRenderer : ViewRenderer<BoxView, Windows.UI.Xaml.Shapes.Rectangle>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)

--- a/Xamarin.Forms.Platform.UAP/BoxViewRenderer2.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewRenderer2.cs
@@ -1,11 +1,13 @@
 ﻿using System.ComponentModel;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
+using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Shapes;
+using Xamarin.Forms.Platform.UWP;
 
-namespace Xamarin.Forms.Platform.UWP
+namespace Xamarin.Forms.Platform.UAP
 {
-	public class BoxViewRenderer : ViewRenderer<BoxView, Windows.UI.Xaml.Shapes.Rectangle>
+	class BoxViewRenderer2 : ViewRenderer<BoxView, Border>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)
 		{
@@ -15,7 +17,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (Control == null)
 				{
-					var rect = new Windows.UI.Xaml.Shapes.Rectangle
+					var rect = new Border
 					{
 						DataContext = Element
 					};
@@ -48,10 +50,20 @@ namespace Xamarin.Forms.Platform.UWP
 			return new FrameworkElementAutomationPeer(Control);
 		}
 
-		private void SetCornerRadius(CornerRadius cornerRadius)
+		protected override void UpdateBackgroundColor()
 		{
-			Control.RadiusX = cornerRadius.TopLeft;
-			Control.RadiusY = cornerRadius.BottomRight;
+			//background color change must be handled separately
+			//because the background would protrude through the border if the corners are rounded
+			//as the background would be applied to the renderer's FrameworkElement
+			if (Control == null)
+				return;
+			Color backgroundColor = Element.BackgroundColor;
+			Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
+		}
+
+		void SetCornerRadius(CornerRadius cornerRadius)
+		{
+			Control.CornerRadius = new Windows.UI.Xaml.CornerRadius(cornerRadius.TopLeft, cornerRadius.TopRight, cornerRadius.BottomRight, cornerRadius.BottomLeft);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
@@ -7,7 +7,9 @@ using Xamarin.Forms.Platform.UWP;
 // Views
 
 [assembly: ExportRenderer(typeof(Layout), typeof(LayoutRenderer))]
+#pragma warning disable CS0618 // Type or member is obsolete
 [assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer))]
+#pragma warning restore CS0618 // Type or member is obsolete
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(ImageButton), typeof(ImageButtonRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]

--- a/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform.UWP;
 // Views
 
 [assembly: ExportRenderer(typeof(Layout), typeof(LayoutRenderer))]
-[assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer))]
+[assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer2))]
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(ImageButton), typeof(ImageButtonRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]

--- a/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Platform.UWP;
 // Views
 
 [assembly: ExportRenderer(typeof(Layout), typeof(LayoutRenderer))]
-[assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer2))]
+[assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer))]
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(ImageButton), typeof(ImageButtonRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]

--- a/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.UAP/Properties/AssemblyInfo.cs
@@ -7,9 +7,7 @@ using Xamarin.Forms.Platform.UWP;
 // Views
 
 [assembly: ExportRenderer(typeof(Layout), typeof(LayoutRenderer))]
-#pragma warning disable CS0618 // Type or member is obsolete
-[assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer))]
-#pragma warning restore CS0618 // Type or member is obsolete
+[assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewBorderRenderer))]
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
 [assembly: ExportRenderer(typeof(ImageButton), typeof(ImageButtonRenderer))]
 [assembly: ExportRenderer(typeof(Label), typeof(LabelRenderer))]


### PR DESCRIPTION
### Fixes #4459  ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

Xamarin forms BoxView supports individual corner radius settings but the UWP BoxViewRenderer was using the Rectangle class as it's native control which does not.  This PR changes BoxViewRenderer to use the UWP Border class instead, which fully supports a unique radius for each corner.

In researching the various ways in UWP to support this, switching to border control seemed the simplest and least likely solution to cause regressions.  Other solutions I found was to us a clipping rectangle, but that seemed like it would have the same issue of only a radius setting shared on all corners.  There was also a solution that used a brush to achieve this effect, but also seemed more complicated then needed.

My only concern with switching to border is if there would be any performance impact over rectangle.  So far I've not been able to find any documentation.  Considering how simple the shapes are and given UWP is a desktop platform, I don't believe there will be a performance issue.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4459

### API Changes ###
<!-- List all API changes here (or just put None), example:
None

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Updates the UWP BoxRenderer to use Border instead of Rectangle.  Since Rectangle has no way to individually control corner radius, switch the renderer to use Border.  Used the FrameRenderer as a reference to correctly apply the background with the corner radius.

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
