### PR TITLE
Fix image aspect settings MacOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7949.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7949.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7949, "Aspect settings not working on MacOS", PlatformAffected.macOS)]
+	public class Issue7949 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var grid = new Grid
+			{
+				BackgroundColor = Color.Yellow
+			};
+
+			grid.RowDefinitions.Add(new RowDefinition
+			{
+				Height = GridLength.Star
+			});
+
+			grid.RowDefinitions.Add(new RowDefinition
+			{
+				Height = GridLength.Star
+			});
+
+			grid.ColumnDefinitions.Add(new ColumnDefinition
+			{
+				Width = GridLength.Star
+			});
+
+			grid.ColumnDefinitions.Add(new ColumnDefinition
+			{
+				Width = GridLength.Star
+			});
+
+			var image0 = new Image
+			{
+				Source = "photo.jpg",
+				Aspect = Aspect.AspectFill,
+				BackgroundColor = Color.Red,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var image1 = new Image
+			{
+				Source = "photo.jpg",
+				Aspect = Aspect.AspectFit,
+				BackgroundColor = Color.Green,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var image2 = new Image
+			{
+				Source = "photo.jpg",
+				Aspect = Aspect.Fill,
+				BackgroundColor = Color.Blue,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			grid.Children.Add(image0, 0, 0);
+			grid.Children.Add(image1, 1, 0);
+			grid.Children.Add(image2, 0, 1);
+
+			Content = grid;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7949.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7949.cs
@@ -1,6 +1,13 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -8,6 +15,9 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 7949, "Aspect settings not working on MacOS", PlatformAffected.macOS)]
 	public class Issue7949 : TestContentPage
 	{
+		readonly Aspect[] _aspectSettings = { Aspect.AspectFit, Aspect.AspectFill, Aspect.Fill };
+		const string CycleButtonAutomationId = "CycleAspectsThingaMejiggy";
+
 		protected override void Init()
 		{
 			var grid = new Grid
@@ -62,11 +72,64 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.FillAndExpand
 			};
 
+			var stack = new StackLayout();
+
+			var image3 = new Image
+			{
+				Source = "photo.jpg",
+				Aspect = Aspect.AspectFit,
+				BackgroundColor = Color.Blue,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			var button = new Button
+			{
+				AutomationId = CycleButtonAutomationId,
+				Text = "Cycle"
+			};
+
+			button.Clicked += (o, a) =>
+			{
+				var i = _aspectSettings.IndexOf(image3.Aspect) + 1;
+
+				if (i == _aspectSettings.Length)
+					i = 0;
+
+				image3.Aspect = _aspectSettings[i];
+			};
+
+			stack.Children.Add(image3);
+			stack.Children.Add(button);
+
 			grid.Children.Add(image0, 0, 0);
 			grid.Children.Add(image1, 1, 0);
 			grid.Children.Add(image2, 0, 1);
+			grid.Children.Add(stack, 1, 1);
 
 			Content = grid;
 		}
+
+#if UITEST
+		[Test]
+		[UiTest (typeof(Image))]
+		public async Task Issue852TestsEntriesClickable()
+		{
+			RunningApp.WaitForElement (CycleButtonAutomationId);
+			RunningApp.Screenshot("All aspects should show properly, lower right should show AspectFit");
+
+			RunningApp.Tap(CycleButtonAutomationId);
+			await Task.Delay(1000);
+			RunningApp.Screenshot("Lower right should show AspectFill");
+
+			RunningApp.Tap(CycleButtonAutomationId);
+			await Task.Delay(1000);
+			RunningApp.Screenshot("Lower right should show Fill");
+
+			RunningApp.Tap(CycleButtonAutomationId);
+			await Task.Delay(1000);
+			RunningApp.Screenshot("Lower right should show AspectFit");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1098,6 +1098,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7283.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5395.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7949.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1500,7 +1501,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7593.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
@@ -85,8 +85,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 
 				case Aspect.AspectFill:
-					// TODO: There is no AspectFill...
-
+					// No built in aspect fill on the NSImageView directly, it is there on the layer so go through there
+					if (Control.Image != null)
+					{
+						Control.Layer = new CALayer();
+						Control.Layer.ContentsGravity = CALayer.GravityResizeAspectFill;
+						Control.Layer.Contents = Control.Image.CGImage;
+						Control.WantsLayer = true;
+					}
 					break;
 				case Aspect.AspectFit:
 					Control.ImageScaling = NSImageScale.ProportionallyDown;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageElementManager.cs
@@ -80,6 +80,21 @@ namespace Xamarin.Forms.Platform.MacOS
 			Control.ContentMode = imageElement.Aspect.ToUIViewContentMode();
 #else
 			Control.Layer.ContentsGravity = imageElement.Aspect.ToNSViewContentMode();
+
+			switch (imageElement.Aspect)
+			{
+
+				case Aspect.AspectFill:
+					// TODO: There is no AspectFill...
+
+					break;
+				case Aspect.AspectFit:
+					Control.ImageScaling = NSImageScale.ProportionallyDown;
+					break;
+				case Aspect.Fill:
+					Control.ImageScaling = NSImageScale.AxesIndependently;
+					break;
+			}
 #endif
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix the different aspect settings for `Image` on MacOS.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fix #7949

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- MacOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Make the different image aspect settings work again for MacOS. Seems working is broken after a big refactoring.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before

![image](https://user-images.githubusercontent.com/939291/66752146-06026680-ee91-11e9-8c9d-167e1a337095.png)

After

![image](https://user-images.githubusercontent.com/939291/66752155-11ee2880-ee91-11e9-95bb-d7089e99333d.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Added a issue7949 page to the gallery app. If all images show a different aspect setting, it worked!

I've added a box in the lower right with a "cycle" button that lets you change the aspect to see if they all work and if they work when changed at runtime.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
