### PR TITLE
IOS Linker fixes inside Xamarin.Forms

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -65,12 +65,6 @@
     <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
     <AndroidEnableMultiDex>true</AndroidEnableMultiDex>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(CI)' == 'True' ">
-    <AndroidLinkMode>Full</AndroidLinkMode>
-    <AndroidUseSharedRuntime>False</AndroidUseSharedRuntime>
-    <EmbedAssembliesIntoApk>True</EmbedAssembliesIntoApk>
-    <AndroidSupportedAbis>armeabi-v7a,x86</AndroidSupportedAbis>
-  </PropertyGroup>
   <ItemGroup>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Mono.Android" />

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -96,6 +96,9 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
+  <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
+    <MtouchLink>Full</MtouchLink>
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
     <AppExtensionDebugBundleId />
   </PropertyGroup>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -65,7 +65,7 @@
     <MtouchDebug>True</MtouchDebug>
     <CodesignEntitlements>
     </CodesignEntitlements>
-    <MtouchLink>SdkOnly</MtouchLink>
+    <MtouchLink>Full</MtouchLink>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchExtraArgs />
     <MtouchFastDev>False</MtouchFastDev>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -65,7 +65,7 @@
     <MtouchDebug>True</MtouchDebug>
     <CodesignEntitlements>
     </CodesignEntitlements>
-    <MtouchLink>Full</MtouchLink>
+    <MtouchLink>SdkOnly</MtouchLink>
     <MtouchProfiling>False</MtouchProfiling>
     <MtouchExtraArgs />
     <MtouchFastDev>False</MtouchFastDev>

--- a/Xamarin.Forms.Core/Internals/LinkerSafeAttribute.cs
+++ b/Xamarin.Forms.Core/Internals/LinkerSafeAttribute.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.ComponentModel;
+
+namespace Xamarin.Forms.Internals
+{
+	[AttributeUsage(AttributeTargets.All)]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public sealed class LinkerSafeAttribute : Attribute
+	{
+		public LinkerSafeAttribute()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Foundation;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -6,6 +7,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		CarouselView CarouselView => Element;
 
+		[Preserve(Conditional = true)]
 		public CarouselViewRenderer()
 		{
 			CarouselView.VerifyCarouselViewFlagEnabled(nameof(CarouselViewRenderer));

--- a/Xamarin.Forms.Platform.iOS/LinkerSafeAttribute.cs
+++ b/Xamarin.Forms.Platform.iOS/LinkerSafeAttribute.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms.Internals
 {
 	[AttributeUsage(AttributeTargets.All)]
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public sealed class LinkerSafeAttribute : Attribute
+	class LinkerSafeAttribute : Attribute
 	{
 		public LinkerSafeAttribute()
 		{

--- a/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.iOS/Properties/AssemblyInfo.cs
@@ -59,4 +59,4 @@ using UIKit;
 [assembly: Xamarin.Forms.Dependency(typeof(Deserializer))]
 [assembly: Xamarin.Forms.Dependency(typeof(ResourcesProvider))]
 [assembly: ResolutionGroupName("Xamarin")]
-[assembly: Preserve]
+[assembly: LinkerSafe]

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -8,6 +8,7 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using Specifics = Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using SizeF = CoreGraphics.CGSize;
+using PreserveAttribute = Foundation.PreserveAttribute;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -35,6 +36,7 @@ namespace Xamarin.Forms.Platform.iOS
 		IImageVisualElementRenderer IButtonLayoutRenderer.ImageVisualElementRenderer => this;
 		nfloat IButtonLayoutRenderer.MinimumHeight => _minimumButtonHeight;
 
+		[Preserve(Conditional = true)]
 		public ButtonRenderer()
 		{
 			BorderElementManager.Init(this);

--- a/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 		VisualElementTracker _tracker;
 		Page _previousPage;
 
+		[Preserve(Conditional = true)]
 		public CarouselPageRenderer()
 		{
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/CheckBoxRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/CheckBoxRenderer.cs
@@ -1,9 +1,11 @@
 ﻿using System;
+using Foundation;
 
 namespace Xamarin.Forms.Platform.iOS
 {
 	public class CheckBoxRenderer : CheckBoxRendererBase<FormsCheckBox>
 	{
+		[Preserve(Conditional = true)]
 		public CheckBoxRenderer()
 		{
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		UILabel _placeholderLabel;
 
+		[Preserve(Conditional = true)]
 		public EditorRenderer()
 		{
 			Frame = new RectangleF(0, 20, 320, 40);

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class EntryRenderer : EntryRendererBase<UITextField>
 	{
+		[Preserve(Conditional = true)]
 		public EntryRenderer()
 		{
 			Frame = new RectangleF(0, 20, 320, 40);

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Drawing;
 using CoreAnimation;
 using CoreGraphics;
+using Foundation;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -88,12 +89,14 @@ namespace Xamarin.Forms.Platform.iOS
 			base.LayoutSubviews();
 		}
 
+		[Preserve(Conditional = true)]
 		class ShadowView : UIView
 		{
 			CALayer _shadowee;
 			CGRect _previousBounds;
 			CGRect _previousFrame;
 
+			[Preserve(Conditional = true)]
 			public ShadowView(CALayer shadowee)
 			{
 				_shadowee = shadowee;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly nfloat _minimumButtonHeight = 44; // Apple docs
 
 
+		[Preserve(Conditional = true)]
 		public ImageButtonRenderer() : base()
 		{
 			ButtonElementManager.Init(this);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -8,6 +8,7 @@ using Foundation;
 using UIKit;
 using Xamarin.Forms.Internals;
 using RectangleF = CoreGraphics.CGRect;
+using PreserveAttribute = Foundation.PreserveAttribute;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -32,6 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		bool _isDisposed;
 
+		[Preserve(Conditional = true)]
 		public ImageRenderer() : base()
 		{
 			ImageElementManager.Init(this);

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms.Platform.iOS
 		UIImage _defaultNavBarShadowImage;
 		UIImage _defaultNavBarBackImage;
 
+		[Preserve(Conditional = true)]
 		public NavigationRenderer() : base(typeof(FormsNavigationBar), null)
 		{
 			MessagingCenter.Subscribe<IVisualElementRenderer>(this, UpdateToolbarButtons, sender =>

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 		Thickness _userPadding = default(Thickness);
 		bool _userOverriddenSafeArea = false;
 
+		[Preserve(Conditional = true)]
 		public PageRenderer()
 		{
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 		Page Page => Element as Page;
 
 
+		[Preserve(Conditional = true)]
 		public PhoneMasterDetailRenderer()
 		{
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return true;
 			}
 
-			if (view is UIWebView)
+			if (view is WkWebViewRenderer)
 			{
 				return true;
 			}
@@ -155,7 +155,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return true;
 			}
 
-			if (view is UIWebView webView)
+			if (view is WkWebViewRenderer webView)
 			{
 				webView.ScrollView.InsertSubview(_refreshControl, index);
 				return true;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _checkedForRtlScroll = false;
 		bool _previousLTR = true;
 
+		[Preserve(Conditional = true)]
 		public ScrollViewRenderer() : base(RectangleF.Empty)
 		{
 			ScrollAnimationEnded += HandleScrollAnimationEnded;

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -7,6 +7,7 @@ using ObjCRuntime;
 using UIKit;
 using WebKit;
 using Xamarin.Forms.Internals;
+using PreserveAttribute = Foundation.PreserveAttribute;
 using Uri = System.Uri;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -20,10 +21,15 @@ namespace Xamarin.Forms.Platform.iOS
 #pragma warning disable 0414
 		VisualElementTracker _tracker;
 #pragma warning restore 0414
+
+
+		[Preserve(Conditional = true)]
 		public WkWebViewRenderer() : base(RectangleF.Empty, new WKWebViewConfiguration())
 		{
 		}
 
+
+		[Preserve(Conditional = true)]
 		public WkWebViewRenderer(WKWebViewConfiguration config) : base(RectangleF.Empty, config)
 		{
 		}

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -165,6 +165,7 @@
     <Compile Include="Extensions\VisualElementExtensions.cs" />
     <Compile Include="Flags.cs" />
     <Compile Include="IOSDeviceInfo.cs" />
+    <Compile Include="LinkerSafeAttribute.cs" />
     <Compile Include="ModalWrapper.cs" />
     <Compile Include="Renderers\FormsCAKeyFrameAnimation.cs" />
     <Compile Include="Renderers\FormsCheckBox.cs" />


### PR DESCRIPTION
### Description of Change ###
- Removes the Preserve Attribute from the Xamarin.Forms SDK
- Removing the Preserve Attribute will have little to no effect until this change https://github.com/xamarin/xamarin-macios/pull/7165 makes it into Xamarin.iOS SDK
- Ironically the *RenderWith* attribute causes all the renderers to not link out. I've ran this branch against the UI tests and all the UI Tests pass with this change. We'll want to test this change against the Forms Samples and really basic projects to make sure full linking doesn't break those projects. 
- Add Linker Safe Attribute so that (Assembly-level attributed used to inform MonoTouch's linker that this assembly can be safely linked, regardless of the system linker settings.)

This won't really cause anything to get linked out of the forms platform dll but it sets up the library so that some day maybe it can. It also let's us start testing this against our UI tests and master nightlies to make sure everything still works

### Issues Resolved ### 
- Partially fixes #7323


### Platforms Affected ### 
- iOS

### Testing Procedure ###
- pull down the nuget, installed the Xamarin.ios sdk here https://github.com/xamarin/xamarin-macios/pull/7165  turn on full linking, and make sure projects all still run

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
