### PR TITLE
Add extension methods for ScaleXTo and ScaleYTo

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
@@ -23,6 +23,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
+			var label = new Label
+			{
+				Text = "Click the button below to animate the BoxView using individual ScaleXTo and ScaleYTo extension methods.",
+				TextColor = Color.Black
+			};
+
 			var button = new Button
 			{
 				AutomationId = AnimateBoxView,
@@ -42,23 +48,14 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.Center
 			};
 
-			var anotherBoxView = new BoxView
-			{
-				BackgroundColor = Color.Red,
-				WidthRequest = 200,
-				HeightRequest = 100,
-				Scale = 1,
-				Opacity = 0.5,
-				HorizontalOptions = LayoutOptions.Center
-			};
-
 			var grid = new Grid();
 
-			Grid.SetRow(anotherBoxView, 1);
+			Grid.SetRow(label, 0);
+			Grid.SetRow(_boxView, 1);
 			Grid.SetRow(button, 2);
-					   
+
+			grid.Children.Add(label);
 			grid.Children.Add(_boxView);
-			grid.Children.Add(anotherBoxView);
 			grid.Children.Add(button);
 
 			Content = grid;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
@@ -1,0 +1,87 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Animation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8004, "Add a ScaleXTo and ScaleYTo animation extension method", PlatformAffected.All)]
+	public class Issue8004 : TestContentPage
+	{
+		BoxView _boxView;
+		const string AnimateBoxView = "AnimateBoxView";
+
+		protected override void Init()
+		{
+			var button = new Button
+			{
+				AutomationId = AnimateBoxView,
+				Text = "Animate BoxView",
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				VerticalOptions = LayoutOptions.EndAndExpand
+			};
+
+			button.Clicked += AnimateButton_Clicked;
+
+			_boxView = new BoxView
+			{
+				BackgroundColor = Color.Blue,
+				WidthRequest = 200,
+				HeightRequest = 100,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var anotherBoxView = new BoxView
+			{
+				BackgroundColor = Color.Red,
+				WidthRequest = 200,
+				HeightRequest = 100,
+				Scale = 1,
+				Opacity = 0.5,
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var grid = new Grid();
+
+			Grid.SetRow(anotherBoxView, 1);
+			Grid.SetRow(button, 2);
+					   
+			grid.Children.Add(_boxView);
+			grid.Children.Add(anotherBoxView);
+			grid.Children.Add(button);
+
+			Content = grid;
+		}
+
+		void AnimateButton_Clicked(object sender, EventArgs e)
+		{
+			_boxView.ScaleYTo(2, 250, Easing.CubicInOut);
+			_boxView.ScaleXTo(1.5, 400, Easing.BounceOut);
+		}
+
+#if UITEST
+		[Test]
+		public async Task AnimateScaleOfBoxView()
+		{
+			RunningApp.WaitForElement(AnimateBoxView);
+			RunningApp.Tap(AnimateBoxView);
+
+			await Task.Delay(500);
+
+			Assert.AreEqual(_boxView.ScaleX, 1.5);
+			Assert.AreEqual(_boxView.ScaleY, 2);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Controls
 			}
 
 			// Running on the simulator
-			//var app = ConfigureApp.iOS
+			// var app = ConfigureApp.iOS
 			//				  .PreferIdeSettings()
 			//		  		  .AppBundle("../../../Xamarin.Forms.ControlGallery.iOS/bin/iPhoneSimulator/Debug/XamarinFormsControlGalleryiOS.app")
 			//				  .Debug()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1087,6 +1087,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6127.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7283.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5395.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8004.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/ViewExtensions.cs
+++ b/Xamarin.Forms.Core/ViewExtensions.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Forms
 			view.AbortAnimation(nameof(RotateYTo));
 			view.AbortAnimation(nameof(RotateXTo));
 			view.AbortAnimation(nameof(ScaleTo));
+			view.AbortAnimation(nameof(ScaleXTo));
+			view.AbortAnimation(nameof(ScaleYTo));
 			view.AbortAnimation(nameof(FadeTo));
 		}
 
@@ -114,6 +116,22 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException(nameof(view));
 
 			return AnimateTo(view, view.Scale, scale, nameof(ScaleTo), (v, value) => v.Scale = value, length, easing);
+		}
+
+		public static Task<bool> ScaleXTo(this VisualElement view, double scale, uint length = 250, Easing easing = null)
+		{
+			if (view == null)
+				throw new ArgumentNullException(nameof(view));
+
+			return AnimateTo(view, view.ScaleX, scale, nameof(ScaleXTo), (v, value) => v.ScaleX = value, length, easing);
+		}
+
+		public static Task<bool> ScaleYTo(this VisualElement view, double scale, uint length = 250, Easing easing = null)
+		{
+			if (view == null)
+				throw new ArgumentNullException(nameof(view));
+
+			return AnimateTo(view, view.ScaleY, scale, nameof(ScaleYTo), (v, value) => v.ScaleY = value, length, easing);
 		}
 
 		public static Task<bool> TranslateTo(this VisualElement view, double x, double y, uint length = 250, Easing easing = null)


### PR DESCRIPTION
### Description of Change ###

- Added `ScaleXTo` extension method for VisualElement
- Added `ScaleYTo` extension method for VisualElement

### Issues Resolved ### 

- fixes #8004

### API Changes ###
Added:
 - public static Task<bool> ScaleXTo(this VisualElement view, double scale, uint length = 250, Easing easing = null)
 - public static Task<bool> ScaleYTo(this VisualElement view, double scale, uint length = 250, Easing easing = null)

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added #8004 in the gallery app. Click the button at the bottom and it should animate the blue box view in both the X-axis and Y-axis using a different kind of animation for each axis.

### PR Checklist ###

- [X] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
