### PR TITLE
Fix shell to correctly pick visible item when currently active Shell Item is removed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8008.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8008.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8008, "Removing Shell Item can cause Shell to try and set a MenuItem as the default visible item")]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue8008 : TestShell
+	{
+		ShellItem item1;
+		protected override void Init()
+		{
+			item1 = AddContentPage();
+
+			Items.Add(new MenuShellItem(new MenuItem()
+			{
+				Text = "Menu Item",
+				Command = new Command(() =>
+				{
+					throw new Exception("I shouldn't execute after removing an item");
+				})
+			}));
+
+			AddContentPage(new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "If you are reading this then this test has passed",
+							AutomationId = "Success"
+						}
+					}
+				}
+			});
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				this.Items.Remove(item1);
+			});
+
+		}
+
+#if UITEST
+		[Test]
+		public void RemovingShellItemCorrectlyPicksNextValidShellItemAsVisibleShellItem()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8008.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6640.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7329.cs" />

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -783,7 +783,7 @@ namespace Xamarin.Forms
 		{
 			base.OnChildAdded(child);
 
-			if (child is ShellItem shellItem && CurrentItem == null && !(child is MenuShellItem))
+			if (child is ShellItem shellItem && CurrentItem == null && ValidDefaultShellItem(child))
 			{
 				((IShellController)this).OnFlyoutItemSelected(shellItem);
 			}
@@ -793,11 +793,21 @@ namespace Xamarin.Forms
 		{
 			base.OnChildRemoved(child);
 
-			if (child == CurrentItem && Items.Count > 0)
+			if (child == CurrentItem)
 			{
-				((IShellController)this).OnFlyoutItemSelected(Items[0]);
+				for (var i = 0; i < Items.Count; i++)
+				{
+					var item = Items[i];
+					if (ValidDefaultShellItem(item))
+					{
+						((IShellController)this).OnFlyoutItemSelected(item);
+						break;
+					}
+				}
 			}
 		}
+
+		bool ValidDefaultShellItem(Element child) => !(child is MenuShellItem);
 
 		internal override IEnumerable<Element> ChildrenNotDrawnByThisElement
 		{


### PR DESCRIPTION
### Description of Change ###
If the visible shell item is removed then correctly pick the next visible shell item

This also fixes a Hot Reload issue with Shell


### Issues Resolved ### 
- fixes #8008
- https://devdiv.visualstudio.com/DevDiv/_queries/edit/964986/?triage=true

### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- Tests are automated

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
