### PR TITLE
Add ListViewHeaderItemMinHeight override in UWP resources.xaml

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/ListViewCoreGalleryPage.cs
@@ -97,10 +97,10 @@ namespace Xamarin.Forms.Controls
 		{
 			public HeaderCell()
 			{
-				Height = 60;
+				Height = 30;
 				var title = new Label
 				{
-					HeightRequest = 60,
+					HeightRequest = 30,
 					BackgroundColor = Color.Navy,
 					TextColor = Color.White
 				};
@@ -185,8 +185,13 @@ namespace Xamarin.Forms.Controls
 
 		protected override void InitializeElement(ListView element)
 		{
+			InitializeElementListView(element, 60);
+		}
+
+		private void InitializeElementListView(ListView element, int rowHeight)
+		{
 			element.HeightRequest = 350;
-			element.RowHeight = 60;
+			element.RowHeight = rowHeight;
 
 			var viewModel = new ListViewViewModel();
 			element.BindingContext = viewModel;
@@ -207,20 +212,20 @@ namespace Xamarin.Forms.Controls
 			var viewModel = new ListViewViewModel();
 
 			var groupDisplayBindingContainer = new ViewContainer<ListView>(Test.ListView.GroupDisplayBinding, new ListView());
-			InitializeElement(groupDisplayBindingContainer.View);
+			InitializeElementListView(groupDisplayBindingContainer.View, 0);
 			groupDisplayBindingContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			groupDisplayBindingContainer.View.IsGroupingEnabled = true;
 			groupDisplayBindingContainer.View.GroupDisplayBinding = new Binding("Key");
 
 
 			var groupHeaderTemplateContainer = new ViewContainer<ListView>(Test.ListView.GroupHeaderTemplate, new ListView());
-			InitializeElement(groupHeaderTemplateContainer.View);
+			InitializeElementListView(groupHeaderTemplateContainer.View, 0);
 			groupHeaderTemplateContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			groupHeaderTemplateContainer.View.IsGroupingEnabled = true;
 			groupHeaderTemplateContainer.View.GroupHeaderTemplate = new DataTemplate(typeof(HeaderCell));
 
 			var groupShortNameContainer = new ViewContainer<ListView>(Test.ListView.GroupShortNameBinding, new ListView());
-			InitializeElement(groupShortNameContainer.View);
+			InitializeElementListView(groupShortNameContainer.View, 0);
 			groupShortNameContainer.View.ItemsSource = viewModel.CategorizedEmployees;
 			groupShortNameContainer.View.IsGroupingEnabled = true;
 			groupShortNameContainer.View.GroupShortNameBinding = new Binding("Key");

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -4,21 +4,21 @@
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP"
 	x:Class="Xamarin.Forms.Platform.UWP.Resources">
 
-	<ResourceDictionary.MergedDictionaries>
-		<ResourceDictionary Source="FormsCommandBarStyle.xaml" />
-		<ResourceDictionary Source="PageControlStyle.xaml" />
-		<ResourceDictionary Source="FormsProgressBarStyle.xaml" />
-		<ResourceDictionary Source="FormsTextBoxStyle.xaml" />
-		<ResourceDictionary Source="FormsCheckBoxStyle.xaml" />
-		<ResourceDictionary Source="AutoSuggestStyle.xaml" />
-		<ResourceDictionary Source="MasterDetailControlStyle.xaml" />
-		<ResourceDictionary Source="TabbedPageStyle.xaml" />
-		<ResourceDictionary Source="SliderStyle.xaml" />
-		<ResourceDictionary Source="CollectionView/ItemsViewStyles.xaml" />
-	    <ResourceDictionary Source="Shell/ShellStyles.xaml" />
+    <ResourceDictionary.MergedDictionaries>
+        <ResourceDictionary Source="FormsCommandBarStyle.xaml" />
+        <ResourceDictionary Source="PageControlStyle.xaml" />
+        <ResourceDictionary Source="FormsProgressBarStyle.xaml" />
+        <ResourceDictionary Source="FormsTextBoxStyle.xaml" />
+        <ResourceDictionary Source="FormsCheckBoxStyle.xaml" />
+        <ResourceDictionary Source="AutoSuggestStyle.xaml" />
+        <ResourceDictionary Source="MasterDetailControlStyle.xaml" />
+        <ResourceDictionary Source="TabbedPageStyle.xaml" />
+        <ResourceDictionary Source="SliderStyle.xaml" />
+        <ResourceDictionary Source="CollectionView/ItemsViewStyles.xaml" />
+        <ResourceDictionary Source="Shell/ShellStyles.xaml" />
     </ResourceDictionary.MergedDictionaries>
-	
-	<uwp:CaseConverter x:Key="LowerConverter" ConvertToUpper="False" />
+
+    <uwp:CaseConverter x:Key="LowerConverter" ConvertToUpper="False" />
 	<uwp:CaseConverter x:Key="UpperConverter" ConvertToUpper="True" />
 	<uwp:HeightConverter x:Key="HeightConverter" />
 	<uwp:CollapseWhenEmptyConverter x:Key="CollapseWhenEmpty" />
@@ -34,8 +34,9 @@
 	<uwp:MasterBackgroundConverter x:Key="MasterBackgroundConverter" />
 	<uwp:ImageSourceIconElementConverter x:Key="ImageSourceIconElementConverter" />
 	<x:Double x:Key="TitleBarHeight">48</x:Double>
+    <x:Double x:Key="ListViewHeaderItemMinHeight">0</x:Double>
 
-	<DataTemplate x:Key="PushPinTemplate">
+    <DataTemplate x:Key="PushPinTemplate">
         <Path Data="M 50.7361,983.661 C 44.1895,983.661 38.8369,988.97 38.8369,995.517 39.8649,1003.3 45.246,1008.1 49.8547,1014.12 50.2838,1014.66 51.2336,1014.66 51.6619,1014.12 52.1384,1013.48 52.7575,1012.73 53.4248,1011.91 55.0322,1012.07 56.4727,1012.32 57.5676,1012.71 58.407,1013 59.06,1013.33 59.4192,1013.63 59.7784,1013.93 59.7716,1014.11 59.7716,1014.16 59.7716,1014.21 59.7716,1014.39 59.4192,1014.69 59.06,1014.99 58.407,1015.32 57.5676,1015.61 55.8888,1016.2 53.4519,1016.63 50.7361,1016.63 48.0204,1016.63 45.5399,1016.2 43.8611,1015.61 43.0218,1015.32 42.3695,1014.99 42.0103,1014.69 41.6504,1014.39 41.6135,1014.21 41.6135,1014.16 41.6135,1014.11 41.6511,1013.93 42.0103,1013.63 42.3695,1013.33 43.0218,1013 43.8611,1012.71 44.3158,1012.55 44.8455,1012.35 45.4039,1012.22 L 43.8611,1010.33 C 43.6124,1010.4 43.3441,1010.46 43.1119,1010.55 42.1005,1010.9 41.2318,1011.31 40.5555,1011.87 39.8799,1012.43 39.3216,1013.22 39.3216,1014.16 39.3216,1015.1 39.8799,1015.85 40.5555,1016.41 41.2318,1016.97 42.1005,1017.42 43.1119,1017.77 45.1356,1018.48 47.8025,1018.92 50.7362,1018.92 54.437,1018.81 57.9892,1018.36 60.8733,1016.41 62.5084,1014.79 62.0756,1013.4 60.8733,1011.87 60.1969,1011.31 59.3726,1010.9 58.3612,1010.55 57.4331,1010.22 56.3503,1009.94 55.1878,1009.75 56.1992,1008.51 57.2362,1007.18 58.2289,1005.79 60.5599,1002.51 62.5918,998.968 62.5918,995.517 62.5918,988.97 57.2836,983.661 50.7362,983.661 Z M 50.7361,989.655 C 47.571,989.655 44.9627,992.219 44.9627,995.385 44.9627,998.55 47.571,1001.16 50.7361,1001.16 53.902,1001.16 56.4659,998.55 56.4659,995.385 56.4659,992.219 53.902,989.655 50.7361,989.655 Z M 50.7361,991.947 C 52.6591,991.947 54.174,993.462 54.174,995.385 54.174,997.307 52.6591,998.866 50.7361,998.866 48.8139,998.866 47.2546,997.307 47.2546,995.385 47.2546,993.462 48.8139,991.947 50.7361,991.947 Z" Fill="#000000"  Height="74" Stretch="Fill" Margin="0" Width="50"/>
     </DataTemplate>
 

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -13,7 +13,7 @@
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>		
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -13,7 +13,7 @@
     <TargetPlatformIdentifier>UAP</TargetPlatformIdentifier>
     <TargetPlatformVersion>10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformMinVersion>10.0.16299.0</TargetPlatformMinVersion>
-    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>		
+    <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <MinimumVisualStudioVersion>14</MinimumVisualStudioVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{A5A43C5B-DE2A-4C0C-9213-0A381AF9435A};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>


### PR DESCRIPTION
### Description of Change ###

The default style template for ListViewHeaderItem in UWP has a MinHeight value pointing at ListViewHeaderItemMinHeight. This has a default value of 44 on UWP.
Meaning that if you want a grouped header in Xamarin Forms that is smaller that 44 in height you will still end up with 44! Causing extra white space that is not wanted.
You can override this value in the Resources.xaml. So now it is set to 0, that will force the header to be as heigh as defined in the height requests of the view.

**Note that the original issue was wrongly flagged and closed - after mentioning this it never got back out of triage**

### Issues Resolved ### 

- fixes #3959

### API Changes ###

Changed:
 - object Resources.xaml => added ListViewHeaderItemMinHeight

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Potentially grouped listviews in UWP will now have a smaller header.

### Before/After Screenshots ### 

<img width="1071" alt="Screenshot 2019-10-15 at 00 40 48" src="https://user-images.githubusercontent.com/351693/66787587-89997300-eee4-11e9-8203-efb92a2ea373.png">
<img width="1026" alt="Screenshot 2019-10-15 at 00 38 33" src="https://user-images.githubusercontent.com/351693/66787586-89997300-eee4-11e9-8780-eb05d57cd794.png">

### Testing Procedure ###

Run the gallery app and navigate to the ListView gallery. In that page open the GroupHeaderTemplate view.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
