### PR TITLE
Fix Material Editor so TextChange delegate isn't removed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5500.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5500.cs
@@ -58,38 +58,24 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			Device.BeginInvokeOnMainThread(async () =>
-			{
-				GarbageCollectionHelper.Collect();
-				editor.Text = "First Test";
-				await Task.Delay(1);
-				if(editor.Text != entry.Text)
-				{
-					editor.Text = "Test has failed";
-					entry.Text = "Test has failed";
-					return;
-				}
-
-				entry.Text = "Second Test";
-				await Task.Delay(1);
-				if (editor.Text != entry.Text)
-				{
-					editor.Text = "Test has failed";
-					entry.Text = "Test has failed";
-					return;
-				}
-
-				await Task.Delay(1);
-				editor.Text = "Success";
-				entry.Text = "Success";
-			});
+			Device.BeginInvokeOnMainThread(GarbageCollectionHelper.Collect);
 		}
 
 #if UITEST
 		[Test]
 		public void VerifyEditorTextChangeEventsAreFiring()
 		{
-			RunningApp.WaitForElement("Success");
+			RunningApp.WaitForElement("EditorAutomationId");
+			RunningApp.EnterText("EditorAutomationId", "Test 1");
+
+			Assert.AreEqual("Test 1", RunningApp.WaitForElement("EditorAutomationId")[0].ReadText());
+			Assert.AreEqual("Test 1", RunningApp.WaitForElement("EntryAutomationId")[0].ReadText());
+
+			RunningApp.ClearText("EntryAutomationId");
+			RunningApp.EnterText("EntryAutomationId", "Test 2");
+
+			Assert.AreEqual("Test 2", RunningApp.WaitForElement("EditorAutomationId")[0].ReadText());
+			Assert.AreEqual("Test 2", RunningApp.WaitForElement("EntryAutomationId")[0].ReadText());
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5500.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5500.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5500, "[iOS] Editor with material visuals value binding not working on physical device",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Editor)]
+#endif
+	public class Issue5500 : TestContentPage
+	{
+		Editor editor;
+		Entry entry;
+
+		protected override void Init()
+		{
+			Visual = VisualMarker.Material;
+
+			editor = new Editor();
+			entry = new Entry();
+
+			editor.SetBinding(Editor.TextProperty, "Text");
+			editor.BindingContext = entry;
+			editor.Placeholder = "Editor";
+			editor.AutoSize = EditorAutoSizeOption.TextChanges;
+			editor.AutomationId = "EditorAutomationId";
+
+			entry.SetBinding(Entry.TextProperty, "Text");
+			entry.BindingContext = editor;
+			entry.Placeholder = "Entry";
+			entry.AutomationId = "EntryAutomationId";
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label(){ Text = "Typing into either text field should change the other field to match" },
+					entry, 
+					editor
+				}
+			};
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				GarbageCollectionHelper.Collect();
+				editor.Text = "First Test";
+				await Task.Delay(1);
+				if(editor.Text != entry.Text)
+				{
+					editor.Text = "Test has failed";
+					entry.Text = "Test has failed";
+					return;
+				}
+
+				entry.Text = "Second Test";
+				await Task.Delay(1);
+				if (editor.Text != entry.Text)
+				{
+					editor.Text = "Test has failed";
+					entry.Text = "Test has failed";
+					return;
+				}
+
+				await Task.Delay(1);
+				editor.Text = "Success";
+				entry.Text = "Success";
+			});
+		}
+
+#if UITEST
+		[Test]
+		public void VerifyEditorTextChangeEventsAreFiring()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5500.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6640.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7329.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -110,6 +110,8 @@ namespace Xamarin.Forms.Platform.iOS
 		where TControl : UIView
 	{
 		bool _disposed;
+		IUITextViewDelegate _pleaseDontCollectMeGarbageCollector;
+
 		IEditorController ElementController => Element;
 		protected abstract UITextView TextView { get; }
 
@@ -133,6 +135,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 
+			_pleaseDontCollectMeGarbageCollector = null;
 			base.Dispose(disposing);
 		}
 
@@ -167,6 +170,7 @@ namespace Xamarin.Forms.Platform.iOS
 				TextView.Started += OnStarted;
 				TextView.Ended += OnEnded;
 				TextView.ShouldChangeText += ShouldChangeText;
+				_pleaseDontCollectMeGarbageCollector = TextView.Delegate;
 			}
 
 			UpdateFont();


### PR DESCRIPTION
### Description of Change ###
After assigning events to the event handler tied to text changes store it to a local variable. If I don't do this then at some point the Delegate just gets nulled out on the material rendererers when launched to a device

### Issues Resolved ### 
- fixes #5500 


### Platforms Affected ### 
- iOS

### Testing Procedure ###
- Test included with instructions
- Also test Material Entry and that auto size based on text changes works

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
