### PR TITLE
[Android] Remove duplicate statement in ObservableItemsSource

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ObservableGroupedSource.cs
@@ -35,11 +35,11 @@ namespace Xamarin.Forms.Platform.Android
 		public bool HasHeader { get; set; }
 		public bool HasFooter { get; set; }
 
-		public ObservableGroupedSource(GroupableItemsView groupableItemsView, ICollectionChangedNotifier adapter)
+		public ObservableGroupedSource(GroupableItemsView groupableItemsView, ICollectionChangedNotifier notifier)
 		{
 			var groupSource = groupableItemsView.ItemsSource;
 
-			_notifier = adapter;
+			_notifier = notifier;
 			_groupSource = groupSource as IList ?? new ListSource(groupSource);
 
 			if (_groupSource is INotifyCollectionChanged incc)

--- a/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
@@ -14,7 +14,6 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_itemsSource = itemSource;
 			_notifier = notifier;
-			_notifier = notifier;
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 


### PR DESCRIPTION
### Description of Change ###

`_notifier` was being assigned twice.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
