### PR TITLE
[Android] Fix RecyclerView offsets upon items source change

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7993.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7993.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue7993">
+    
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+
+        <StackLayout Grid.Row="0" Orientation="Vertical" Spacing="5" BackgroundColor="Beige">
+            <Label LineBreakMode="WordWrap" Text="Scroll down into the list to increase vertical offset. Click NewItemsSource to reset items source. Verify that vertical offset becomes zero." HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+            <Label x:Name="Label1" Text="VerticalOffset: 0" HorizontalTextAlignment="Center"/>
+            <Button Text="NewItemsSource" Clicked="NewItemsSourceClicked" HorizontalOptions="Center"/>
+        </StackLayout>
+
+        <CollectionView Grid.Row="1" AutomationId="CollectionView7993" ItemsSource="{Binding Items}" Scrolled="CollectionView_OnScrolled">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical" ItemSpacing="5"/>
+            </CollectionView.ItemsLayout>
+            
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid BackgroundColor="#F1F1F1">
+                        <Label Text="{Binding Text}" Margin="10" HorizontalTextAlignment="Center" VerticalTextAlignment="Center"/>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7993.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7993.xaml.cs
@@ -1,0 +1,112 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+
+#if UITEST && __ANDROID__
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Linq;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST && __ANDROID__
+	[Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7993, "[Bug] CollectionView.Scrolled event offset isn't correctly reset when items change", PlatformAffected.Android)]
+	public partial class Issue7993 : TestContentPage
+	{
+#if APP
+		public Issue7993()
+		{
+			Device.SetFlags(new List<string> { CollectionView.CollectionViewExperimental });
+
+			InitializeComponent();
+
+			BindingContext = new ViewModel7993();
+		}
+
+		void CollectionView_OnScrolled(object sender, ItemsViewScrolledEventArgs e)
+		{
+			Label1.Text = "VerticalOffset: " + e.VerticalOffset;
+		}
+
+		void NewItemsSourceClicked(object sender, EventArgs e)
+		{
+			BindingContext = new ViewModel7993();
+		}
+#endif
+
+		protected override void Init()
+		{
+
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void CollectionViewVerticalOffset()
+		{
+			var colView = RunningApp.WaitForElement("CollectionView7993")[0];
+
+			RunningApp.WaitForElement(x => x.Marked("VerticalOffset: 0"));
+
+			AppResult[] lastCellResults = null;
+
+			RunningApp.QueryUntilPresent(() =>
+			{
+				RunningApp.DragCoordinates(colView.Rect.CenterX, colView.Rect.Y + colView.Rect.Height - 50, colView.Rect.CenterX, colView.Rect.Y + 5);
+
+				lastCellResults = RunningApp.Query("19");
+
+				return lastCellResults;
+			}, 20, 1);
+
+			Assert.IsTrue(lastCellResults?.Any() ?? false);
+
+			RunningApp.Tap(x => x.Marked("NewItemsSource"));
+			RunningApp.WaitForElement(x => x.Marked("VerticalOffset: 0"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModel7993
+	{
+		public ObservableCollection<Model7993> Items { get; set; }
+
+		public ViewModel7993()
+		{
+			var collection = new ObservableCollection<Model7993>();
+
+			for (var i = 0; i < 20; i++)
+			{
+				collection.Add(new Model7993()
+				{
+					Text = i.ToString()
+				});
+			}
+
+			Items = collection;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Model7993
+	{
+		public string Text { get; set; }
+
+		public Model7993()
+		{
+			
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -75,6 +75,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7943.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7993.xaml.cs">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7865.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
@@ -1425,7 +1428,7 @@
     <Compile Update="$(MSBuildThisFileDirectory)Issue7357.xaml.cs">
       <DependentUpon>Issue7357.xaml</DependentUpon>
     </Compile>
-   <Compile Update="$(MSBuildThisFileDirectory)Issue7792.xaml.cs">
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7792.xaml.cs">
       <DependentUpon>Issue7792.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7789.xaml.cs">
@@ -1457,6 +1460,9 @@
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7943.xaml.cs">
       <DependentUpon>Issue7943.xaml</DependentUpon>
+    </Compile>
+    <Compile Update="$(MSBuildThisFileDirectory)Issue7993.xaml.cs">
+      <DependentUpon>Issue7993.xaml</DependentUpon>
     </Compile>
     <Compile Update="$(MSBuildThisFileDirectory)Issue7865.xaml.cs">
       <DependentUpon>Issue7865.xaml</DependentUpon>
@@ -1548,6 +1554,12 @@
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7943.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7993.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -266,6 +266,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateItemsUpdatingScrollMode();
 
 			UpdateEmptyView();
+			AddOrUpdateScrollListener();
 		}
 
 		protected virtual TAdapter CreateAdapter()
@@ -334,8 +335,7 @@ namespace Xamarin.Forms.Platform.Android
 			// Listen for ScrollTo requests
 			ItemsView.ScrollToRequested += ScrollToRequested;
 
-			_recyclerViewScrollListener = CreateScrollListener();
-			AddOnScrollListener(_recyclerViewScrollListener);
+			AddOrUpdateScrollListener();
 		}
 
 		protected virtual RecyclerViewScrollListener<TItemsView, TItemsViewSource> CreateScrollListener()
@@ -391,12 +391,7 @@ namespace Xamarin.Forms.Platform.Android
 			// Stop listening for ScrollTo requests
 			oldElement.ScrollToRequested -= ScrollToRequested;
 
-			if (_recyclerViewScrollListener != null)
-			{
-				_recyclerViewScrollListener.Dispose();
-				ClearOnScrollListeners();
-				_recyclerViewScrollListener = null;
-			}
+			RemoveScrollListener();
 
 			if (ItemsViewAdapter != null)
 			{
@@ -651,6 +646,24 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				ScrollHelper.UndoNextScrollAdjustment();
 			}
+		}
+
+		void AddOrUpdateScrollListener()
+		{
+			RemoveScrollListener();
+
+			_recyclerViewScrollListener = CreateScrollListener();
+			AddOnScrollListener(_recyclerViewScrollListener);
+		}
+
+		void RemoveScrollListener()
+		{
+			if (_recyclerViewScrollListener == null)
+				return;
+
+			_recyclerViewScrollListener.Dispose();
+			ClearOnScrollListeners();
+			_recyclerViewScrollListener = null;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR disposes and resets the existing scroll listener on `RecyclerView` upon items source change so that we no longer report the previous horizontal/vertical offsets.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7993

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
