### PR TITLE
[MacOS] FIx against NRE on disposing Entry renderer

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -240,11 +240,17 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateAlignment()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			Control.Alignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
 		}
 
 		void UpdateColor()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			var textColor = Element.TextColor;
 
 			if (textColor.IsDefault || !Element.IsEnabled)
@@ -263,11 +269,17 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateFont()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			Control.Font = Element.ToNSFont();
 		}
 
 		void UpdatePlaceholder()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			var formatted = (FormattedString)Element.Placeholder;
 
 			if (formatted == null)
@@ -285,11 +297,16 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void SetAccessibilityLabel()
 		{
+			if (IsElementOrControlEmpty)
+				return;
 			Control.AccessibilityLabel = (string)Element?.GetValue(AutomationProperties.NameProperty) ?? Control.PlaceholderAttributedString?.Value;
 		}
 
 		void UpdateText()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			// ReSharper disable once RedundantCheckBeforeAssignment
 			if (Control.StringValue != Element.Text)
 				Control.StringValue = Element.Text ?? string.Empty;
@@ -297,6 +314,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateMaxLength()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			var currentControlText = Control?.StringValue;
 
 			if (currentControlText.Length > Element?.MaxLength)
@@ -306,6 +326,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateIsReadOnly()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			Control.Editable = !Element.IsReadOnly;
 			if (Element.IsReadOnly && Control.Window?.FirstResponder == Control.CurrentEditor)
 				Control.Window?.MakeFirstResponder(null);

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -445,6 +445,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextHtml()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			string text = Element.Text ?? string.Empty;
 
 #if __MOBILE__
@@ -574,6 +577,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdatePadding()
 		{
+			if (IsElementOrControlEmpty)
+				return;
+
 			if (Element.Padding.IsEmpty)
 				return;
 


### PR DESCRIPTION
Sometimes when disposing the EntryRender on macOS SetAccessibilityLabel was throwing a NRE 
### Description of Change ###

Check if Element or Control are null before update

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- none

### API Changes ###

 None

### Platforms Affected ### 

- macOS
### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
