### PR TITLE
Make UpdateCancelButton virtual

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/CustomSearchBarRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/CustomSearchBarRenderer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS.CustomRenderers;
+using Xamarin.Forms.Platform.iOS;
+
+// REMARK: Test renderer to validate that Virtual UpdateCancelButton works
+
+//[assembly: ExportRenderer(typeof(SearchBar), typeof(CustomSearchBarRenderer))]
+//namespace Xamarin.Forms.ControlGallery.iOS.CustomRenderers
+//{
+//	public class CustomSearchBarRenderer : SearchBarRenderer
+//	{
+//		public override void UpdateCancelButton()
+//		{
+//			base.UpdateCancelButton();			
+//			Control.ShowsCancelButton = false;
+//		}
+//	}
+//}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -127,6 +127,7 @@
     <Compile Include="CustomRenderers\CustomRenderer.cs" />
     <Compile Include="CustomRenderers\RoundedLabelRenderer.cs" />
     <Compile Include="ApiLabelRenderer.cs" />
+    <Compile Include="CustomRenderers\CustomSearchBarRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -228,7 +228,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_textField.VerticalAlignment = Element.VerticalTextAlignment.ToNativeTextAlignment();
 		}
 
-		void UpdateCancelButton()
+		public virtual void UpdateCancelButton()
 		{
 			Control.ShowsCancelButton = !string.IsNullOrEmpty(Control.Text);
 


### PR DESCRIPTION
### Description of Change ###

Reopening https://github.com/xamarin/Xamarin.Forms/pull/846

**Note still not sure if this is the right way to go, how will developers now notice this is the way to override the behaviour? Normally you would do stuff in the OnElementChanged method for custom renderers**

### Issues Resolved ### 

Cancel button can appear unwanted on iOS

### API Changes ###

Changed:
 - object SearchBarRenderer => UpdateCancelButton is now Virtual

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Open the ControlGallery app on iOS simulator. Type text in the middle search bar. Notice the cancel button will appear.
Uncomment the CustomSearchBarRenderer in the ControlGallery.iOS part and now when typing in the search bar will no longer show the cancel button.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
