### PR TITLE
Fixing issue #4941 (and 1722 for UWP). Adding a test in UWP Navigatio…

### DIFF
--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -170,6 +170,10 @@ namespace Xamarin.Forms.Platform.UWP
 			NavigationPage oldElement = Element;
 			Element = (NavigationPage)element;
 
+			if (Element != null && Element.CurrentPage is null)
+				throw new InvalidOperationException(
+					"NavigationPage must have a root Page before being used. Either call PushAsync with a valid Page, or pass a Page to the constructor before usage.");
+
 			if (oldElement != null)
 			{
 				oldElement.PushRequested -= OnPushRequested;


### PR DESCRIPTION
Fixing issue #4941 (and #1722 for UWP). Adding a test in UWP NavigationPageRenderer.SetElement, to check if the supplied NavigationPage Element has a CurrentPage. If not, an InvalidOperationException is thrown. (Otherwise a NullReferenceException would be thrown at a later point.)

### Description of Change ###

Adding a test in the UWP NavigationPageRenderer to check if the supplied element, a NavigationPage, has a CurrentPage. If it has not, an InvalidOperationException is thrown.

### Issues Resolved ### 

- fixes #4941

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None, except if an exception is now caught, that would have been missed before (when a NullReferenceException would have been thrown at a later point), or vice versa.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

In Debug Mode go to the WindowsUniversal ControlGallery, to test G1722. Entering this the program will crash, but the exception thrown will be InvalidOperationException, not a NullReferenceException as before the fix.

Note: I realize this is not the most automation friendly procedure, but as the Issue references this particular test, and it not passing in this manner, it seemed most prudent. (Also, this is my first PR / contribution, so I hope you'll forgive me if I'm not to familiar with the proper way to do things…)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
