### PR TITLE
[Android] Use AppCompat AlertDialog

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
@@ -9,7 +9,7 @@
   <style name="MyTheme" parent="MyTheme.Base">
   </style>
   <!-- Base theme applied no matter what API -->
-  <style name="MyTheme.Base" parent="Theme.AppCompat.Light.DarkActionBar">
+  <style name="MyTheme.Base" parent="Theme.AppCompat.DayNight.DarkActionBar">
     <!--If you are using revision 22.1 please use just windowNoTitle. Without android:-->
     <item name="windowNoTitle">true</item>
     <!--We will be using the toolbar so no need to show ActionBar-->
@@ -27,12 +27,16 @@
     <item name="windowActionModeOverlay">true</item>
 
     <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
-		
+    <item name="android:alertDialogTheme">@style/DayNightDialogStyle</item>
 		<!--Uncomment to test exceptionally red button-->
 		<!--<item name="android:buttonStyle">@style/red_button_style</item>-->
   </style>
 
   <style name="AppCompatDialogStyle" parent="Theme.AppCompat.Light.Dialog">
+    <item name="colorAccent">#FF4081</item>
+  </style>
+
+  <style name="DayNightDialogStyle" parent="Theme.AppCompat.DayNight.Dialog.Alert">
     <item name="colorAccent">#FF4081</item>
   </style>
 

--- a/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Resources/values/styles.xml
@@ -27,7 +27,12 @@
     <item name="windowActionModeOverlay">true</item>
 
     <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+
+    <!-- Styles Android.App.AlertDialog -->
     <item name="android:alertDialogTheme">@style/DayNightDialogStyle</item>
+    <!-- Styles Android.Support.V7.App.AlertDialog -->
+    <item name="alertDialogTheme">@style/DayNightDialogStyle</item>
+
 		<!--Uncomment to test exceptionally red button-->
 		<!--<item name="android:buttonStyle">@style/red_button_style</item>-->
   </style>
@@ -37,7 +42,7 @@
   </style>
 
   <style name="DayNightDialogStyle" parent="Theme.AppCompat.DayNight.Dialog.Alert">
-    <item name="colorAccent">#FF4081</item>
+    <item name="colorAccent">#00FF21</item>
   </style>
 
   <style name="TestStyle" parent="@android:style/Theme.Holo.Light.DarkActionBar">    

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -7,6 +7,7 @@ using Android.Text;
 using Android.Views;
 using Android.Widget;
 using Xamarin.Forms.Internals;
+using AlertDialog = Android.Support.V7.App.AlertDialog;
 
 namespace Xamarin.Forms.Platform.Android
 {


### PR DESCRIPTION
### Description of Change ###

Change from using `Android.App.AlertDialog` to `Android.Support.V7.App.AlertDialog` when creating dialogs for `DisplayAlert`, `DisplayActionSheet`, and `DisplayPromptAsync`. 

Fixes display issues when using a custom alertDialogTheme in your Android app theme inheriting from DayNight while in dark mode.

### Issues Resolved ### 

- fixes #8029

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

If using a custom alertDialogTheme in your Android application theme, the item name should be changed from `android:alertDialogTheme` to `alertDialogTheme`.

### Before/After Screenshots ### 

Before:
![Screenshot_1571247120](https://user-images.githubusercontent.com/6132629/66943771-77692300-f011-11e9-9b84-716f26dcc274.png)

After:
![Screenshot_1571247316](https://user-images.githubusercontent.com/6132629/66943774-79cb7d00-f011-11e9-8625-689a253ea567.png)

### Testing Procedure ###

Run the DisplayAlert Gallery page in Control Gallery app in dark mode on a supported Android device.

Comment out this line to get before/after comparisons:
https://github.com/xamarin/Xamarin.Forms/blob/2dcdc319e13e8d77a1a4644ee76eb432c5be7007/Xamarin.Forms.Platform.Android/PopupManager.cs#L10

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
