### PR TITLE
[iOS] Add UpdateMode platform-specific to DatePicker and TimePicker

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PickerGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PickerGallery.cs
@@ -21,30 +21,32 @@ namespace Xamarin.Forms.Controls
 		public UpdateMode UpdateMode
 		{
 			get => (UpdateMode)GetValue(UpdateModeProperty);
-			set => SetValue(UpdateModeProperty, value); 
+			set => SetValue(UpdateModeProperty, value);
 		}
 
-		#endregion 
+		#endregion
 
 
-		public PickerGallery ()
+		public PickerGallery()
 		{
-			var picker = new Picker {Title="Dismiss in one sec", Items =  {"John", "Paul", "George", "Ringo"}};
-			picker.Focused += async (object sender, FocusEventArgs e) => {
-				await Task.Delay (1000);
-				picker.Unfocus ();
+			var picker = new Picker { Title = "Dismiss in one sec", Items = { "John", "Paul", "George", "Ringo" } };
+			picker.Focused += async (object sender, FocusEventArgs e) =>
+			{
+				await Task.Delay(1000);
+				picker.Unfocus();
 			};
 
-			Label testLabel = new Label { Text = "", AutomationId="test", ClassId="test" };
+			Label testLabel = new Label { Text = "", AutomationId = "test", ClassId = "test" };
 
 			Picker p1 = new Picker
 			{
 				BindingContext = this,
-				Title = "Pick a number", 
+				Title = "Pick a number",
 				Items = { "0", "1", "2", "3", "4", "5", "6" }
 			};
 			p1.SetBinding(PlatformConfiguration.iOSSpecific.Picker.UpdateModeProperty, UpdateModeProperty.PropertyName);
-			p1.SelectedIndexChanged += (sender, e) => {
+			p1.SelectedIndexChanged += (sender, e) =>
+			{
 				testLabel.Text = "Selected Index Changed";
 			};
 			p1.SetAutomationPropertiesName("Title picker");
@@ -61,11 +63,13 @@ namespace Xamarin.Forms.Controls
 				Title = "Update Mode",
 				EnumType = typeof(UpdateMode)
 			};
-			updateModePicker.SetBinding(Picker.SelectedItemProperty, UpdateModeProperty.PropertyName, mode:BindingMode.TwoWay);
+			updateModePicker.SetBinding(Picker.SelectedItemProperty, UpdateModeProperty.PropertyName, mode: BindingMode.TwoWay);
 
-			Content = new ScrollView { 
-				Content = new StackLayout {
-					Padding = new Thickness (20, 20),
+			Content = new ScrollView
+			{
+				Content = new StackLayout
+				{
+					Padding = new Thickness(20, 20),
 					Children = {
 						new DatePicker (),
 						new TimePicker (),

--- a/Xamarin.Forms.Controls/GalleryPages/PickerGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PickerGallery.cs
@@ -3,11 +3,30 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Controls
 {
 	public class PickerGallery : ContentPage
 	{
+		#region UpdateMode
+
+		public static readonly BindableProperty UpdateModeProperty = BindableProperty.Create(
+			nameof(UpdateMode),
+			typeof(UpdateMode),
+			typeof(PickerGallery),
+			default(UpdateMode));
+
+		public UpdateMode UpdateMode
+		{
+			get => (UpdateMode)GetValue(UpdateModeProperty);
+			set => SetValue(UpdateModeProperty, value); 
+		}
+
+		#endregion 
+
+
 		public PickerGallery ()
 		{
 			var picker = new Picker {Title="Dismiss in one sec", Items =  {"John", "Paul", "George", "Ringo"}};
@@ -18,11 +37,31 @@ namespace Xamarin.Forms.Controls
 
 			Label testLabel = new Label { Text = "", AutomationId="test", ClassId="test" };
 
-			Picker p1 = new Picker { Title = "Pick a number", Items = { "0", "1", "2", "3", "4", "5", "6" }};
+			Picker p1 = new Picker
+			{
+				BindingContext = this,
+				Title = "Pick a number", 
+				Items = { "0", "1", "2", "3", "4", "5", "6" }
+			};
+			p1.SetBinding(PlatformConfiguration.iOSSpecific.Picker.UpdateModeProperty, UpdateModeProperty.PropertyName);
 			p1.SelectedIndexChanged += (sender, e) => {
 				testLabel.Text = "Selected Index Changed";
 			};
 			p1.SetAutomationPropertiesName("Title picker");
+
+			DatePicker datePicker = new DatePicker { BindingContext = this };
+			datePicker.SetBinding(PlatformConfiguration.iOSSpecific.DatePicker.UpdateModeProperty, UpdateModeProperty.PropertyName);
+
+			TimePicker timePicker = new TimePicker { BindingContext = this };
+			timePicker.SetBinding(PlatformConfiguration.iOSSpecific.TimePicker.UpdateModeProperty, UpdateModeProperty.PropertyName);
+
+			Picker updateModePicker = new EnumPicker
+			{
+				BindingContext = this,
+				Title = "Update Mode",
+				EnumType = typeof(UpdateMode)
+			};
+			updateModePicker.SetBinding(Picker.SelectedItemProperty, UpdateModeProperty.PropertyName, mode:BindingMode.TwoWay);
 
 			Content = new ScrollView { 
 				Content = new StackLayout {
@@ -37,7 +76,10 @@ namespace Xamarin.Forms.Controls
 						new Picker {Title = "Pick", Items =  {"Jason Smith", "Rui Marinho", "Eric Maupin", "Chris King"}, HorizontalOptions = LayoutOptions.CenterAndExpand},
 						picker,
 						testLabel,
-						p1
+						updateModePicker,
+						p1,
+						datePicker,
+						timePicker
 					}
 				}
 			};

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
 {
-    using FormsElement = Xamarin.Forms.DatePicker;
+	using FormsElement = Xamarin.Forms.DatePicker;
 
 	public static class DatePicker
 	{

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/DatePicker.cs
@@ -1,0 +1,34 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+    using FormsElement = Xamarin.Forms.DatePicker;
+
+	public static class DatePicker
+	{
+		public static readonly BindableProperty UpdateModeProperty = BindableProperty.Create(
+			nameof(UpdateMode),
+			typeof(UpdateMode),
+			typeof(DatePicker),
+			default(UpdateMode));
+
+		public static UpdateMode GetUpdateMode(BindableObject element)
+		{
+			return (UpdateMode)element.GetValue(UpdateModeProperty);
+		}
+
+		public static void SetUpdateMode(BindableObject element, UpdateMode value)
+		{
+			element.SetValue(UpdateModeProperty, value);
+		}
+
+		public static UpdateMode UpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetUpdateMode(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
+		{
+			SetUpdateMode(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/TimePicker.cs
@@ -1,0 +1,34 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Xamarin.Forms.TimePicker;
+
+	public static class TimePicker
+	{
+		public static readonly BindableProperty UpdateModeProperty = BindableProperty.Create(
+			nameof(UpdateMode),
+			typeof(UpdateMode),
+			typeof(TimePicker),
+			default(UpdateMode));
+
+		public static UpdateMode GetUpdateMode(BindableObject element)
+		{
+			return (UpdateMode)element.GetValue(UpdateModeProperty);
+		}
+
+		public static void SetUpdateMode(BindableObject element, UpdateMode value)
+		{
+			element.SetValue(UpdateModeProperty, value);
+		}
+
+		public static UpdateMode UpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetUpdateMode(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetUpdateMode(this IPlatformElementConfiguration<iOS, FormsElement> config, UpdateMode value)
+		{
+			SetUpdateMode(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				entry.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
 				entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
-				
+
 				entry.InputAssistantItem.LeadingBarButtonGroups = null;
 				entry.InputAssistantItem.TrailingBarButtonGroups = null;
 
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
 			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName ||
-			         e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
+					 e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
 			{
 				UpdateFont();
 			}
@@ -160,7 +160,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			(Control as UITextField).UpdateTextAlignment(Element);
 		}
-		
+
 		protected internal virtual void UpdateFont()
 		{
 			Control.Font = Element.ToUIFont();

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -123,11 +123,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HandleValueChanged(object sender, EventArgs e)
 		{
-			ElementController?.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
+			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.Immediately)
+			{
+				ElementController?.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
+			}
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
+			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.WhenFinished)
+			{
+				ElementController.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
+			}
+
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -64,7 +64,11 @@ namespace Xamarin.Forms.Platform.iOS
 				var width = UIScreen.MainScreen.Bounds.Width;
 				var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
 				var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
-				var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) => entry.ResignFirstResponder());
+				var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) =>
+				{
+					UpdateElementDate();
+					entry.ResignFirstResponder();
+				});
 
 				toolbar.SetItems(new[] { spacer, doneButton }, false);
 
@@ -125,17 +129,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.Immediately)
 			{
-				ElementController?.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
+				UpdateElementDate();
 			}
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
-			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.WhenFinished)
-			{
-				ElementController.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
-			}
-
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 
@@ -150,6 +149,11 @@ namespace Xamarin.Forms.Platform.iOS
 				_picker.SetDate(Element.Date.ToNSDate(), animate);
 
 			Control.Text = Element.Date.ToString(Element.Format);
+		}
+
+		void UpdateElementDate()
+		{
+			ElementController.SetValueFromRenderer(DatePicker.DateProperty, _picker.Date.ToDateTime().Date);
 		}
 
 		void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					entry.InputView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
 					entry.InputAccessoryView.AutoresizingMask = UIViewAutoresizing.FlexibleHeight;
-					
+
 					entry.InputAssistantItem.LeadingBarButtonGroups = null;
 					entry.InputAssistantItem.TrailingBarButtonGroups = null;
 
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (e.PropertyName == TimePicker.CharacterSpacingProperty.PropertyName)
 				UpdateCharacterSpacing();
 			else if (e.PropertyName == TimePicker.FontAttributesProperty.PropertyName ||
-			         e.PropertyName == TimePicker.FontFamilyProperty.PropertyName || e.PropertyName == TimePicker.FontSizeProperty.PropertyName)
+					 e.PropertyName == TimePicker.FontFamilyProperty.PropertyName || e.PropertyName == TimePicker.FontSizeProperty.PropertyName)
 				UpdateFont();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -73,7 +73,11 @@ namespace Xamarin.Forms.Platform.iOS
 					var width = UIScreen.MainScreen.Bounds.Width;
 					var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
 					var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);
-					var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) => entry.ResignFirstResponder());
+					var doneButton = new UIBarButtonItem(UIBarButtonSystemItem.Done, (o, a) =>
+					{
+						UpdateElementTime();
+						entry.ResignFirstResponder();
+					});
 
 					toolbar.SetItems(new[] { spacer, doneButton }, false);
 
@@ -129,11 +133,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
-			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.WhenFinished)
-			{
-				ElementController.SetValueFromRenderer(TimePicker.TimeProperty, _picker.Date.ToDateTime() - new DateTime(1, 1, 1));
-			}
-
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 
@@ -146,7 +145,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.Immediately)
 			{
-				ElementController.SetValueFromRenderer(TimePicker.TimeProperty, _picker.Date.ToDateTime() - new DateTime(1, 1, 1));
+				UpdateElementTime();
 			}
 		}
 
@@ -186,6 +185,11 @@ namespace Xamarin.Forms.Platform.iOS
 			_picker.Date = new DateTime(1, 1, 1).Add(Element.Time).ToNSDate();
 			Control.Text = DateTime.Today.Add(Element.Time).ToString(Element.Format);
 			Element.InvalidateMeasureNonVirtual(Internals.InvalidationTrigger.MeasureChanged);
+		}
+
+		void UpdateElementTime()
+		{
+			ElementController.SetValueFromRenderer(TimePicker.TimeProperty, _picker.Date.ToDateTime() - new DateTime(1, 1, 1));
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using Foundation;
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -128,6 +129,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
+			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.WhenFinished)
+			{
+				ElementController.SetValueFromRenderer(TimePicker.TimeProperty, _picker.Date.ToDateTime() - new DateTime(1, 1, 1));
+			}
+
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 
@@ -138,7 +144,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnValueChanged(object sender, EventArgs e)
 		{
-			ElementController.SetValueFromRenderer(TimePicker.TimeProperty, _picker.Date.ToDateTime() - new DateTime(1, 1, 1));
+			if (Element.OnThisPlatform().UpdateMode() == UpdateMode.Immediately)
+			{
+				ElementController.SetValueFromRenderer(TimePicker.TimeProperty, _picker.Date.ToDateTime() - new DateTime(1, 1, 1));
+			}
 		}
 
 		void UpdateFlowDirection()


### PR DESCRIPTION
### Description of Change ###

Add iOS-specific to UpdateMode enum from Picker to DatePicker and TimePicker.

### Issues Resolved ### 

Didn't see any GitHub issues, but some related forum threads:
- https://forums.xamarin.com/discussion/93521/what-is-date-picker-behaviour-in-xamarin-forms
- https://forums.xamarin.com/discussion/98832/add-cancel-button-to-ios-datepicker-and-timepicker-only-change-the-value-when-done-is-clicked
- https://forums.xamarin.com/discussion/94666/cant-detect-ok-button-press-on-datepicker

### API Changes ###

Added:
 - `Xamarin.Forms.PlatformConfiguration.iOSSpecific.DatePicker` class
 - `Xamarin.Forms.PlatformConfiguration.iOSSpecific.TimePicker` class

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###

When UpdateMode is set to WhenFinished, the Date/Time property will be set when the user closes the picker with the Done button rather than as they scroll.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Use the Picker Gallery - Legacy page in the Control Gallery app. Setting the UpdateMode from the picker 4th from the bottom will affect the Picker, DatePicker, and TimePicker below it.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
