### PR TITLE
GH-5606 Remove the EditorBrowser attribute from Device.cs

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -56,7 +56,6 @@ namespace Xamarin.Forms
 
 		public static string RuntimePlatform => PlatformServices.RuntimePlatform;
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static DeviceInfo Info
 		{
 			get
@@ -78,7 +77,6 @@ namespace Xamarin.Forms
 			get { return PlatformServices.IsInvokeRequired; }
 		}
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IPlatformServices PlatformServices
 		{
 			get


### PR DESCRIPTION
### Description of Change ###

Removed the EditorBrowser from `Xamarin.Forms.Core.Device.cs`

### Issues Resolved ### 
 

- fixes #5606

### API Changes ###
None.

 Removed:
```csharp
[EditorBrowsable(EditorBrowsableState.Never)]
public static IPlatformServices PlatformServices {get; set;}
```

```csharp
[EditorBrowsable(EditorBrowsableState.Never)]
public static DeviceInfo Info {get; set;}
```


### Platforms Affected ### 

- Core/XAML (all platforms)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
