### PR TITLE
Keep tab image collapsed if no datasource is available

### DIFF
--- a/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TabbedPageRenderer.cs
@@ -443,7 +443,7 @@ namespace Xamarin.Forms.Platform.UWP
 						// Update icon image.
 						if (tabBarImage.GetValue(FrameworkElement.NameProperty).ToString() == TabBarHeaderImageName)
 						{
-							if (headerIconsEnabled)
+							if (headerIconsEnabled && tabBarImage.DataContext != null)
 							{
 								if (Element.IsSet(Specifics.HeaderIconsSizeProperty))
 								{


### PR DESCRIPTION
### Description of Change ###

With the introduction of page icon images inside UWP tabs, the code will not check if an actual data source for the image is given.
So the labels of the tabs are pushed down even if this is not needed...

### Issues Resolved ### 

- fixes #6757

### API Changes ###

Changed:
 - object TabbedPageRenderer => Added DataContext check
 
### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Tabbar labels are again centered if no image is above them.

### Before/After Screenshots ### 

![Screenshot 2019-10-16 at 23 47 32](https://user-images.githubusercontent.com/351693/66961649-6ea73a00-f06f-11e9-96ad-fc704059c8a2.png)
![Screenshot 2019-10-16 at 23 44 55](https://user-images.githubusercontent.com/351693/66961648-6e0ea380-f06f-11e9-9124-5225372760dd.png)

### Testing Procedure ###

Run the Controls gallery app before the PR, click SwapRoot - TabbedPage
Run the same procedure again after the PR to see visual change

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
