### PR TITLE
GH-5612 Preventing NRE when disposing controls

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			UpdateAlignment();
 			UpdateMaxLength();
 			UpdateIsReadOnly();
-        }
+		}
 
 		void TextFieldFocusChanged(object sender, BoolEventArgs e)
 		{
@@ -285,6 +285,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void SetAccessibilityLabel()
 		{
+			if (_disposed || Control == null)
+				return;
+
 			Control.AccessibilityLabel = (string)Element?.GetValue(AutomationProperties.NameProperty) ?? Control.PlaceholderAttributedString?.Value;
 		}
 


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->
Added sanity checks. Checking if renderer is `_disposed` or `Control == null` before updating the accessibility label.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5612

### API Changes ###
 None

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Steps to Reproduce

- 1
  - Control Gallery
  - Accessibility
  - back button
  - **Should not crash**
- 2
  - Control Gallery
  - AutomationID Gallery
  - Test1
  - POP
  - **Should not crash**

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
