### PR TITLE
[Build] Remove windows Hosted image reference

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
   parameters:
     name: android_legacy
     displayName: Build Android [Legacy Renderers]
-    vmImage: $(macOSVmImage)
+    vmImage: $(winVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -70,7 +70,7 @@ jobs:
   parameters:
     name: android_preappcompact
     displayName: Build Android [Pre-AppCompat]
-    vmImage: $(macOSVmImage)
+    vmImage: $(winVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -80,7 +80,7 @@ jobs:
   parameters:
     name: android_fast
     displayName: Build Android [Fast Renderers]
-    vmImage: $(macOSVmImage)
+    vmImage: $(winVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,6 @@ variables:
   value: 5.0.2
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
-- name: winVmImage
-  value: Hosted VS2017
   
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,6 +15,8 @@ variables:
   value: 5.0.2
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
+- name: DOTNET_VERSION
+  value: 3.0.100
   
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,7 +60,7 @@ jobs:
   parameters:
     name: android_legacy
     displayName: Build Android [Legacy Renderers]
-    vmImage: $(winVmImage)
+    vmImage: $(macOSVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -70,7 +70,7 @@ jobs:
   parameters:
     name: android_preappcompact
     displayName: Build Android [Pre-AppCompat]
-    vmImage: $(winVmImage)
+    vmImage: $(macOSVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG FORMS_APPLICATION_ACTIVITY APP" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -80,7 +80,7 @@ jobs:
   parameters:
     name: android_fast
     displayName: Build Android [Fast Renderers]
-    vmImage: $(winVmImage)
+    vmImage: $(macOSVmImage)
     targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
     androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:DefineConstants="TRACE DEBUG TEST_EXPERIMENTAL_RENDERERS APP" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
     buildConfiguration: $(DefaultBuildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,8 +15,6 @@ variables:
   value: 5.0.2
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
-- name: DOTNET_VERSION
-  value: 3.0.100
   
 resources:
   repositories:

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -15,10 +15,10 @@ string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/je
 
 if (IsMac)
 {
-	Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
+	Item (XreItem.Xcode_11_1_0).XcodeSelect ();
 
-  if(!String.IsNullOrEmpty(monoSDK_macos))
-    Item ("Mono", monoVersion)
+  	if(!String.IsNullOrEmpty(monoSDK_macos))
+    	Item ("Mono", monoVersion)
       .Source (_ => monoSDK_macos);
 
 	if(!String.IsNullOrEmpty(androidSDK_macos))

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -17,7 +17,7 @@ var channel = Env("CHANNEL") ?? "Stable";
 var windowsChannel = Env("WIN_CHANNEL") ?? "VisualStudio.16.Stable"; 
 
 
-if (channel == "VS16Stable")
+if (channel == "VS16Stable" || channel == "Stable")
 {
 	windowsChannel = "VisualStudio.16.Stable";
 }
@@ -32,6 +32,7 @@ if (channel == "Preview")
 	windowsChannel = "VisualStudio.16.Preview";
 }
 
+Console.WriteLine($"{channel} , win - {windowsChannel}");
 
 if (IsMac)
 {
@@ -42,11 +43,6 @@ else
 {
 	XamarinChannel(windowsChannel); 
 }
-
-
-
-Console.WriteLine(channel);
-
 
 Item(XreItem.Java_OpenJDK_1_8_0_25);
 AndroidSdk ().ApiLevel((AndroidApiLevel)29);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -13,19 +13,40 @@ string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVer
 string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
+var channel = Env("CHANNEL") ?? "Stable";
+var windowsChannel = Env("WIN_CHANNEL") ?? "VisualStudio.16.Stable"; 
+
+
+if (channel == "VS16Stable")
+{
+	windowsChannel = "VisualStudio.16.Stable";
+}
+
+if (channel == "VS15Stable")
+{
+	windowsChannel = "VisualStudio.15.Stable";
+}
+
+if (channel == "Preview")
+{
+	windowsChannel = "VisualStudio.16.Preview";
+}
+
+
 if (IsMac)
 {
 	Item (XreItem.Xcode_11_1_0).XcodeSelect ();
+	XamarinChannel(channel); 
 }
 else
 {
-	
+	XamarinChannel(windowsChannel); 
 }
 
-var channel = Env("CHANNEL") ?? "Stable";
+
 
 Console.WriteLine(channel);
-XamarinChannel(channel); 
+
 
 Item(XreItem.Java_OpenJDK_1_8_0_25);
 AndroidSdk ().ApiLevel((AndroidApiLevel)29);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -16,55 +16,16 @@ string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/je
 if (IsMac)
 {
 	Item (XreItem.Xcode_11_1_0).XcodeSelect ();
-
-  	if(!String.IsNullOrEmpty(monoSDK_macos))
-    	Item ("Mono", monoVersion)
-      .Source (_ => monoSDK_macos);
-
-	if(!String.IsNullOrEmpty(androidSDK_macos))
-		Item ("Xamarin.Android", "10.0.0.43")
-      .Source (_ => androidSDK_macos);
-
-	if(!String.IsNullOrEmpty(iOSSDK_macos))
-		Item ("Xamarin.iOS", "13.2.0.42")
-      .Source (_ => iOSSDK_macos);
-
-	if(!String.IsNullOrEmpty(macSDK_macos))
-		Item ("Xamarin.Mac", "6.2.0.42")
-      .Source (_ => macSDK_macos);
-    
-	ForceJavaCleanup();
-
-    var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
-    if (!string.IsNullOrEmpty(dotnetVersion))
-	  {
-		// VSTS installs into a non-default location. Let's hardcode it here because why not.
-		var vstsBaseInstallPath = Path.Combine (Environment.GetEnvironmentVariable ("HOME"), ".dotnet", "sdk");
-		var vstsInstallPath = Path.Combine (vstsBaseInstallPath, dotnetVersion);
-		var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
-		if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
-			ln (defaultInstallLocation, vstsInstallPath);
-	  }
 }
 else
 {
-	if(!String.IsNullOrEmpty(androidSDK_windows))
-		Item ("Xamarin.Android", "10.0.0.43")
-      .Source (_ => androidSDK_windows);
-
-	if(!String.IsNullOrEmpty(iOSSDK_windows))
-		Item ("Xamarin.iOS", "13.2.0.42")
-      .Source (_ => iOSSDK_windows);
-
-	if(!String.IsNullOrEmpty(macSDK_windows))
-		Item ("Xamarin.Mac", "6.2.0.42")
-      .Source (_ => macSDK_windows);
-
-	if(!String.IsNullOrEmpty(monoSDK_windows))
-    Item ("Mono", monoVersion)
-      .Source (_ => monoSDK_windows);
-
+	
 }
+
+var channel = Env("CHANNEL") ?? "Stable";
+
+Console.WriteLine(channel);
+XamarinChannel(channel); 
 
 Item(XreItem.Java_OpenJDK_1_8_0_25);
 AndroidSdk ().ApiLevel((AndroidApiLevel)29);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -28,8 +28,8 @@ else
 	XamarinChannel(windowsChannel); 
 }
 
-Item(XreItem.Java_OpenJDK_1_8_0_25);
-AndroidSdk ().ApiLevel((AndroidApiLevel)29);
+//Item(XreItem.Java_OpenJDK_1_8_0_25);
+//AndroidSdk ().ApiLevel((AndroidApiLevel)29);
 
 void ln (string source, string destination)
 {

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -14,23 +14,7 @@ string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/je
 string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
 
 var channel = Env("CHANNEL") ?? "Stable";
-var windowsChannel = Env("WIN_CHANNEL") ?? "VisualStudio.16.Stable"; 
-
-
-if (channel == "VS16Stable" || channel == "Stable")
-{
-	windowsChannel = "VisualStudio.16.Stable";
-}
-
-if (channel == "VS15Stable")
-{
-	windowsChannel = "VisualStudio.15.Stable";
-}
-
-if (channel == "Preview")
-{
-	windowsChannel = "VisualStudio.16.Preview";
-}
+var windowsChannel = Env("WIN_CHANNEL") ?? "VisualStudio.15.Release"; 
 
 Console.WriteLine($"{channel} , win - {windowsChannel}");
 

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -36,7 +36,7 @@ jobs:
       
       - task: Bash@3
         displayName: 'Cake Provision'
-        condition: eq(variables['provisioning'], 'false')
+        condition: eq(variables['provisioningCake'], 'true')
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -41,11 +41,11 @@ jobs:
           targetType: 'filePath'
           filePath: 'build.sh'
           arguments: --target provision
-          
-      - task: DotNetCoreInstaller@0
-        displayName: 'Install .net core $(DOTNET_VERSION)'
-        condition: ne(variables['DOTNET_VERSION'], '')  
+
+      - task: UseDotNet@2
+        condition: ne(variables['DOTNET_VERSION'], '')
         inputs:
+          packageType: 'sdk'
           version: $(DOTNET_VERSION)
 
       - script: |

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -10,7 +10,7 @@ steps:
       
   - task: Bash@3
     displayName: 'Cake Provision'
-    condition: eq(variables['provisioning'], 'false')
+    condition: eq(variables['provisioningCake'], 'true')
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -16,10 +16,10 @@ steps:
       filePath: 'build.sh'
       arguments: --target provision
   
-  - task: DotNetCoreInstaller@0
-    displayName: 'Install .net core $(DOTNET_VERSION)'
+  - task: UseDotNet@2
     condition: ne(variables['DOTNET_VERSION'], '')
     inputs:
+      packageType: 'sdk'
       version: $(DOTNET_VERSION)
 
   - script: |

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -35,7 +35,7 @@ jobs:
     steps:
     - script: build.cmd -Target provision
       displayName: 'Cake Provision'
-      condition: eq(variables['provisioning'], 'false')
+      condition: eq(variables['provisioningCake'], 'true')
   
     - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provisionator'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -36,7 +36,7 @@ jobs:
     - script: build.cmd -Target provision
       displayName: 'Cake Provision'
       condition: eq(variables['provisioningCake'], 'true')
-  
+
     - task: xamops.azdevex.provisionator-task.provisionator@1
       displayName: 'Provisionator'
       condition: eq(variables['provisioning'], 'true')
@@ -51,7 +51,7 @@ jobs:
         version: $(DOTNET_VERSION)
 
     - script: |
-        dotnet new globaljson --sdk-version $(DOTNET_VERSION)
+        dotnet new globaljson --sdk-version $(DOTNET_VERSION) --force
       displayName: 'Add globaljson file'
       condition: ne(variables['DOTNET_VERSION'], '')
 
@@ -60,7 +60,7 @@ jobs:
       condition: ne(variables['NUGET_VERSION'], '')
       inputs:
         versionSpec: $(NUGET_VERSION)
-          
+
     - task: NuGetCommand@2
       displayName: 'NuGet restore ${{ parameters.slnPath }}'
       inputs:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -44,10 +44,10 @@ jobs:
         provisioning_script: ${{ parameters.provisionatorPath }}
         provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
 
-    - task: DotNetCoreInstaller@0
-      displayName: "Install .net core $(DOTNET_VERSION)"
+    - task: UseDotNet@2
       condition: ne(variables['DOTNET_VERSION'], '')
       inputs:
+        packageType: 'sdk'
         version: $(DOTNET_VERSION)
 
     - script: |


### PR DESCRIPTION
Update yaml pipeline, remove reference to windows hosted 2017, that will be set by the pipeline at queue time 


### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
