### PR TITLE
Fix issue 6878 | [Bug] ShellItem.Items.Clear() crashes when the ShellItem has bottom tabs

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
+using System.ComponentModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6878,
+		"ShellItem.Items.Clear() crashes when the ShellItem has bottom tabs", PlatformAffected.All)]
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue6878 : TestShell
+	{
+		const string ExceptionMessage = "😢 oh no! An exception as throw...";
+		const string ClearShellItems = "ClearShellItems";
+		const string StatusLabel = "StatusLabel";
+
+		StackLayout _stackContent;
+
+		protected override void Init()
+		{
+			_stackContent = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = StatusLabel,
+						Text = "Everything is fine 😎"
+					}
+				}
+			};
+
+			_stackContent.Children.Add(BuildClearButton());
+			CreateContentPage().Content = _stackContent;
+
+			CurrentItem = Items.Last();
+
+			AddBottomTab("bottom 1");
+			AddBottomTab("bottom 2");
+			Shell.SetBackgroundColor(this, Color.BlueViolet);
+		}
+
+		Button BuildClearButton()
+		{
+			return new Button()
+			{
+				Text = "Click to clear ShellItem.Items",
+				Command = new Command(() =>
+				{
+					try
+					{
+						Items.Last().Items.Clear();
+					}
+					catch (NotSupportedException)
+					{
+						Items.Clear();
+						CreateContentPage().Content = _stackContent;
+						((Label)_stackContent.Children[0]).Text = ExceptionMessage;
+						CurrentItem = Items.Last();
+					}
+				}),
+				AutomationId = ClearShellItems
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void ShellItemItemsClearTests()
+		{
+			RunningApp.WaitForElement(StatusLabel);
+			RunningApp.Tap(ClearShellItems);
+
+			var label = RunningApp.WaitForElement(StatusLabel)[0];
+			Assert.AreEqual(label.Text, ExceptionMessage);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,9 +22,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
-    </Compile> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" /> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" /> 
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -226,6 +226,10 @@ namespace Xamarin.Forms
 
 		void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if ((e.Action == NotifyCollectionChangedAction.Reset ||
+				e.Action == NotifyCollectionChangedAction.Remove) && Items.Count == 0)
+				throw new NotSupportedException("the ShellItem.Items must have at least one item.");
+
 			if (e.NewItems != null)
 			{
 				foreach (Element element in e.NewItems)


### PR DESCRIPTION
### Description of Change ###

I followed @PureWeen suggestion, that's I agree, to just throw an exception that clear isn't supported for ShellItem
I tried to avoid exceptions, but Shell get lost and some navigations throw`s other exceptions

### Issues Resolved ### 

- fixes #6878 

### API Changes ###
Changed:
 - void ShellItem.ItemsCollectionChanged
	- added this validation:

```C#
if ((e.Action == NotifyCollectionChangedAction.Reset ||
	e.Action == NotifyCollectionChangedAction.Remove) && Items.Count == 0)
	throw new NotSupportedException("the ShellItem.Items must have at least one item.");
```
 
### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
1. Create a ShellItem in that contains tabs and set background-color
2. In code, call Items.Clear() on your ShellItem.
3. A NotSupportedException will occur 

- Or just run 6878 issue at Control Galery:

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67064337-91555380-f140-11e9-96ad-1a516ff0d9a3.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
