### PR TITLE
[macOS] Visual glitch when exiting the full screen with ScrollViewer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4854.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4854.cs
@@ -1,0 +1,42 @@
+﻿using System;
+using System.Linq.Expressions;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4854, "[macOS] Visual glitch when exiting the full screen with ScrollViewer", PlatformAffected.macOS)]
+	public class Issue4854 : TestContentPage
+	{
+
+		protected override void Init()
+		{
+			var gMain = new Grid { BackgroundColor = Color.LightBlue };
+			gMain.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+			gMain.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+			var label = new Label
+			{
+				Text = "Enter full screen and exit and see the artifacts on the screen.",
+				FontSize = 14
+			};
+			var sl = new StackLayout { HorizontalOptions = LayoutOptions.Center, WidthRequest = 300, Padding = new Thickness(15) };
+			sl.Children.Add(label);
+			gMain.Children.Add(sl);
+
+			var button = new Button { Text = "Test", BackgroundColor = Color.Gray, HorizontalOptions = LayoutOptions.Center };
+			var g = new Grid { BackgroundColor = Color.LightGray, Padding = new Thickness(20) };
+			g.Children.Add(button);
+			Grid.SetRow(g, 1);
+			gMain.Children.Add(g);
+
+			Content = new ScrollView { Content = gMain, BackgroundColor = Color.LightGreen };
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1079,6 +1079,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4356.cs">
       <DependentUpon>Issue4356.xaml</DependentUpon>
     </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)Issue4854.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5951.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github6021.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5132.cs" />

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -255,7 +255,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (ContentView == null || ScrollView == null || ScrollView.Content == null)
 				return false;
 
-			if (Math.Abs(ScrollView.ScrollY) < 0.001 && Math.Abs(ScrollView.ScrollX) < 0.001 && ScrollView.Content.Height > ScrollView.Height)
+			if (Math.Abs(ScrollView.ScrollY) < 0.001 && Math.Abs(ScrollView.ScrollX) < 0.001 && ScrollView.Content.Height >= ScrollView.Height)
 			{
 				ContentView.ScrollToPoint(new CoreGraphics.CGPoint(0, 0));
 				return true;
@@ -270,12 +270,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (ScrollView == null)
 				return;
 
-			if (ScrollView.ContentSize.Height >= ScrollView.Height)
+			var height = ScrollView.Height;
+			var contentHeightOverflow = ScrollView.ContentSize.Height - height;
+			if (contentHeightOverflow >= 0)
 			{
-				CoreGraphics.CGPoint location = ContentView.DocumentVisibleRect().Location;
-
-				if (location.Y > -1 && ScrollView.Height >= 0)
-					ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, ScrollView.ContentSize.Height - ScrollView.Height - location.Y));
+				if (height >= 0)
+				{
+					var location = ContentView.DocumentVisibleRect().Location;
+					if (location.Y > -1)
+						ScrollView.SetScrolledPosition(Math.Max(0, location.X), Math.Max(0, contentHeightOverflow - location.Y));
+				}
 			}
 			else
 				ResetNativeNonScroll();


### PR DESCRIPTION
<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

Calculation of Y offset in ScrollViewer is improved. Now visual glitch when exiting the full screen with ScrollViewer is gone.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4854

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- macOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The app returns to the previous state when exiting the full screen.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Manual tests included in Xamarin.Forms.Controls.Issues: Issue4854

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
