### PR TITLE
[iOS] fix Material button set backgroundcolor method

### DIFF
--- a/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
@@ -168,6 +168,9 @@ namespace Xamarin.Forms.Material.iOS
 					colorScheme.PrimaryColor = uiColor;
 					colorScheme.OnSurfaceColor = uiColor;
 				}
+
+				if (Control != null)
+					ApplyTheme();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixed material button background colour change issue.
We were updating the color scheme but ApplyTheme() was never called for the backgroundcolor.

### Issues Resolved ### 

- fixes #5747
- fixes #7002

### Platforms Affected ### 
- iOS

### After Screenshots ### 
![after](https://user-images.githubusercontent.com/9795917/67111278-354b0780-f1f2-11e9-9148-14e980336013.gif)



### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
