### PR TITLE
Fixed 5680 - [Enhancement] Added method to force value coercion

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5680.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5680.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:local="clr-namespace:Xamarin.Forms.Controls" x:Class="Xamarin.Forms.Controls.Issues.Issue5680" x:Name="page1">
+    <StackLayout Padding="0,20,0,0" BindingContext="{x:Reference page1}">
+        <Label Text="Bindable Property CoerceValue Callback Demo" FontAttributes="Bold" HorizontalOptions="Center" />
+        <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+            <Label Text="Maximum angle:" />
+            <Entry Text="{Binding MaximumAngle}" WidthRequest="50" />
+        </StackLayout>
+        <StackLayout Orientation="Horizontal" HorizontalOptions="Center">
+            <Label Text="Rotation angle:" />
+            <Entry Text="{Binding Angle}" WidthRequest="50" />
+        </StackLayout>
+        <Label x:Name="CoerceResult" FontAttributes="Bold" HorizontalOptions="Center"/>
+        <Image Source="test.jpg" Rotation="{Binding Angle}" VerticalOptions="CenterAndExpand" WidthRequest="300" HeightRequest="300" />
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5680.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5680.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5680, "[Enhancement] Add method to force value coercion")]
+	public partial class Issue5680 : TestContentPage
+    {
+		
+		public Issue5680()
+        {
+            InitializeComponent();
+        }
+
+		protected override void Init()
+		{
+
+		}
+
+		public static readonly BindableProperty AngleProperty = BindableProperty.Create("Angle", typeof(double), typeof(Issue5680), 0.0, coerceValue: CoerceAngle);
+		public static readonly BindableProperty MaximumAngleProperty = BindableProperty.Create("MaximumAngle", typeof(double), typeof(Issue5680), 360.0, propertyChanged: ForceCoerceValue);
+
+		public double Angle
+		{
+			get { return (double)GetValue(AngleProperty); }
+			set { SetValue(AngleProperty, value); }
+		}
+
+		public double MaximumAngle
+		{
+			get { return (double)GetValue(MaximumAngleProperty); }
+			set { SetValue(MaximumAngleProperty, value); }
+		}
+
+		static object CoerceAngle(BindableObject bindable, object value)
+		{
+			var homePage = bindable as Issue5680;
+			double input = (double)value;
+
+			if (input > homePage.MaximumAngle)
+			{
+				input = homePage.MaximumAngle;
+			}
+			return input;
+		}
+
+		static void ForceCoerceValue(BindableObject bindable, object oldValue, object newValue)
+		{
+			bindable.CoerceValue(AngleProperty);
+		}
+	}
+}

--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -530,6 +530,36 @@ namespace Xamarin.Forms
 			context.Binding = null;
 		}
 
+		public void CoerceValue(BindableProperty property) => CoerceValue(property, checkAccess: true);
+
+		public void CoerceValue(BindablePropertyKey propertyKey)
+		{
+			if (propertyKey == null)
+				throw new ArgumentNullException(nameof(propertyKey));
+
+			CoerceValue(propertyKey.BindableProperty, checkAccess: false);
+		}
+
+		void CoerceValue(BindableProperty property, bool checkAccess)
+		{
+			if (property == null)
+				throw new ArgumentNullException(nameof(property));
+
+			if (checkAccess && property.IsReadOnly)
+				throw new InvalidOperationException($"The BindableProperty \"{property.PropertyName}\" is readonly.");
+
+			BindablePropertyContext bpcontext = GetContext(property);
+			if (bpcontext == null)
+				return;
+
+			object currentValue = bpcontext.Value;
+
+			if (property.ValidateValue != null && !property.ValidateValue(this, currentValue))
+				throw new ArgumentException($"Value is an invalid value for {property.PropertyName}", nameof(currentValue));
+
+			property.CoerceValue?.Invoke(this, currentValue);
+		}
+
 		[Flags]
 		enum BindableContextAttributes
 		{


### PR DESCRIPTION
### Description of Change ###

As requested in the issue, Added a new method `CoerceValue` to `BindableObject` which when called, it would force coerce the current value of the property if a coerceCallback is set on the property.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5680 

### API Changes ###

Added:
Below methods are added to `BindableObject.cs` of Xamarin.Forms.Core library:
```
public void CoerceValue(BindableProperty property) => CoerceValue(property, checkAccess: true);

public void CoerceValue(BindablePropertyKey propertyKey)
{
	if (propertyKey == null)
		throw new ArgumentNullException(nameof(propertyKey));

	CoerceValue(propertyKey.BindableProperty, checkAccess: false);
}

void CoerceValue(BindableProperty property, bool checkAccess)
{
	if (property == null)
		throw new ArgumentNullException(nameof(property));

	if (checkAccess && property.IsReadOnly)
		throw new InvalidOperationException($"The BindableProperty \"{property.PropertyName}\" is readonly.");

	BindablePropertyContext bpcontext = GetContext(property);
	if (bpcontext == null)
		return;

	object currentValue = bpcontext.Value;

	if (property.ValidateValue != null && !property.ValidateValue(this, currentValue))
		throw new ArgumentException($"Value is an invalid value for {property.PropertyName}", nameof(currentValue));

	property.CoerceValue?.Invoke(this, currentValue);
}
```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->
![image](https://user-images.githubusercontent.com/17450941/67145064-62072980-f29b-11e9-88b6-051ed8cbe842.png)


- Just run Issue5680.xaml from Control Gallery and for force coercion, try changing the value of 'Maximum angle' which will force call the Coerce method on 'Angle' (or Rotation angle) property.

Please note, As there was no sample reproduction attached, I have added the above sample testcase from Xamarin.Forms Samples (CoerceValueCallback) to reproduce it. It isn't a best testcase (which may be required to perfectly test it).

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
