### PR TITLE
[macOS] Implement slider min/max/thumb color

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
-		private void UpdateMaximumTrackColor()
+		void UpdateMaximumTrackColor()
 		{
 			// Cell could be overwritten with an other custom cell
 			if (Control.Cell is FormsSliderCell sliderCell)
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
-		private void UpdateMinimumTrackColor()
+		void UpdateMinimumTrackColor()
 		{
 			// Cell could be overwritten with an other custom cell
 			if (Control.Cell is FormsSliderCell sliderCell)
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
-		private void UpdateThumbColor()
+		void UpdateThumbColor()
 		{
 			// Cell could be overwritten with an other custom cell
 			if (Control.Cell is FormsSliderCell sliderCell)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
@@ -2,10 +2,11 @@
 using AppKit;
 using System.ComponentModel;
 using CoreGraphics;
+using Xamarin.Forms.Platform.macOS.Controls;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	public class XFSliderCell : NSSliderCell
+	internal class FormsSliderCell : NSSliderCell
 	{
 		public Color MinimumTrackColor { get; set; }
 
@@ -77,9 +78,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				if (Control == null)
 				{
-					SetNativeControl(new NSSlider());
+					SetNativeControl(new FormsNSSlider());
 					Control.Activated += OnControlActivated;
-					Control.Cell = new XFSliderCell();
+					Control.Cell = new FormsSliderCell();
 				}
 
 				UpdateMaximum();
@@ -116,7 +117,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		private void UpdateMaximumTrackColor()
 		{
 			// Cell could be overwritten with an other custom cell
-			if (Control.Cell is XFSliderCell sliderCell)
+			if (Control.Cell is FormsSliderCell sliderCell)
 			{
 				sliderCell.MaximumTrackColor = Element.MaximumTrackColor;
 			}
@@ -125,7 +126,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		private void UpdateMinimumTrackColor()
 		{
 			// Cell could be overwritten with an other custom cell
-			if (Control.Cell is XFSliderCell sliderCell)
+			if (Control.Cell is FormsSliderCell sliderCell)
 			{
 				sliderCell.MinimumTrackColor = Element.MinimumTrackColor;
 			}
@@ -134,7 +135,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		private void UpdateThumbColor()
 		{
 			// Cell could be overwritten with an other custom cell
-			if (Control.Cell is XFSliderCell sliderCell)
+			if (Control.Cell is FormsSliderCell sliderCell)
 			{
 				sliderCell.ThumbColor = Element.ThumbColor;
 			}


### PR DESCRIPTION
### Description of Change ###

Adds implementation for `MinimumTrackColorProperty`, `MaximumTrackColorProperty` and `ThumbColorProperty` for macOS.

### Issues Resolved ### 

Missing platform implementation

### API Changes ###

 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

macOS now reflects values of this property or uses the default value if a color is default.

### Before/After Screenshots ### 
Default:
<img width="665" alt="grafik" src="https://user-images.githubusercontent.com/11095003/67147911-ac87a680-f299-11e9-9686-bad4ae7651e7.png">
Thumb color set:
<img width="672" alt="grafik" src="https://user-images.githubusercontent.com/11095003/67147913-b9a49580-f299-11e9-86e1-b8910591c52c.png">
Min color set:
<img width="676" alt="grafik" src="https://user-images.githubusercontent.com/11095003/67147917-c75a1b00-f299-11e9-8c14-d06f32a7382b.png">
Max color set:
<img width="675" alt="grafik" src="https://user-images.githubusercontent.com/11095003/67147920-ce812900-f299-11e9-880d-c4231f483108.png">
 
### Testing Procedure ###

Slider control in control gallery

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
