### PR TITLE
[Android] Use v7 support libs for DrawableWrapper

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
@@ -15,6 +15,7 @@ using AColor = Android.Graphics.Color;
 using AView = Android.Views.View;
 using LP = Android.Views.ViewGroup.LayoutParams;
 using AImageButton = Android.Widget.ImageButton;
+using ASupportDrawable = Android.Support.V7.Graphics.Drawable;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -207,8 +208,7 @@ namespace Xamarin.Forms.Platform.Android
 			_textBlock.Threshold = 1;
 			_textBlock.Adapter = new ShellSearchViewAdapter(SearchHandler, _shellContext);
 			_textBlock.ItemClick += OnTextBlockItemClicked;
-			if (Forms.IsMarshmallowOrNewer)
-				_textBlock.SetDropDownBackgroundDrawable(new ClipDrawableWrapper(_textBlock.DropDownBackground));
+			_textBlock.SetDropDownBackgroundDrawable(new ClipDrawableWrapper(_textBlock.DropDownBackground));
 
 			// A note on accessibility. The _textBlocks hint is what android defaults to reading in the screen
 			// reader. Therefore, we do not need to set something else.
@@ -367,7 +367,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		class ClipDrawableWrapper : DrawableWrapper
+		class ClipDrawableWrapper : ASupportDrawable.DrawableWrapper
 		{
 			public ClipDrawableWrapper(Drawable dr) : base(dr)
 			{


### PR DESCRIPTION
### Description of Change ###
In my hacktoberfest-y mood, I grabbed #6291, but was surprised when I could not reproduce it. Digging deeper, I saw that its symptoms were resolved by #6198, and #6291 was actually a duplicate of #6197.

Rather than checking the API level and skipping functionality on older platforms, I thought it would be better to change the implementation to use the v7 support package version of `DrawableWrapper`, which would allow this functionality to be used by all relevant api levels.

### Issues Resolved ### 
- fixes #6291 

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
API levels < 23 will now able to take advantage of `ClipDrawableWrapper` / `SetDropDownBackgroundDrawable` in Shell search views.

### Testing Procedure ###
- Launch the Shell store in the Gallery on a device with api < 23.
- Observe a continued lack of crashing.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
