### PR TITLE
[macOS] Add ImageButton to macOS

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Controls/FormsImageView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Controls/FormsImageView.cs
@@ -5,7 +5,7 @@ using CoreGraphics;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	internal class FormsNSImageView : NSImageView
+	public class FormsNSImageView : NSImageView, IImageView
 	{
 		bool _isOpaque;
 

--- a/Xamarin.Forms.Platform.MacOS/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.MacOS/Properties/AssemblyInfo.cs
@@ -21,6 +21,7 @@ using Xamarin.Forms.Platform.MacOS;
 [assembly: ExportRenderer(typeof(Entry), typeof(EntryRenderer))]
 [assembly: ExportRenderer(typeof(Frame), typeof(FrameRenderer))]
 [assembly: ExportRenderer(typeof(Image), typeof(ImageRenderer))]
+[assembly: ExportRenderer(typeof(ImageButton), typeof(ImageButtonRenderer))]
 [assembly: ExportRenderer(typeof(OpenGLView), typeof(OpenGLViewRenderer))]
 [assembly: ExportRenderer(typeof(Picker), typeof(PickerRenderer))]
 [assembly: ExportRenderer(typeof(ProgressBar), typeof(ProgressBarRenderer))]

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -8,8 +8,8 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public class ButtonRenderer : ViewRenderer<Button, NSButton>
 	{
-		class FormsNSButton : NSButton
-		{
+		public class FormsNSButton : NSButton, IImageView
+		{ 
 			class FormsNSButtonCell : NSButtonCell
 			{
 				public override CGRect DrawTitle(NSAttributedString title, CGRect frame, NSView controlView)
@@ -29,19 +29,18 @@ namespace Xamarin.Forms.Platform.MacOS
 			public FormsNSButton()
 			{
 				Cell = new FormsNSButtonCell();
-			}
+			} 
 
-			public event Action Pressed;
-
-			public event Action Released;
+			public event EventHandler Pressed; 
+			public event EventHandler Released;
 
 			public override void MouseDown(NSEvent theEvent)
 			{
-				Pressed?.Invoke();
+				Pressed?.Invoke(this, EventArgs.Empty);
 
 				base.MouseDown(theEvent);
 
-				Released?.Invoke();
+				Released?.Invoke(this, EventArgs.Empty);
 			}
 
 			nfloat _leftPadding;
@@ -189,18 +188,18 @@ namespace Xamarin.Forms.Platform.MacOS
 				Control.AttributedTitle = textWithColor;
 			}
 		}
-
+ 
 		void UpdatePadding()
 		{
 			(Control as FormsNSButton)?.UpdatePadding(Element.Padding);
 		}
-
-		void HandleButtonPressed()
+ 
+		void HandleButtonPressed(object sender, EventArgs args) 
 		{
 			Element?.SendPressed();
 		}
 
-		void HandleButtonReleased()
+		void HandleButtonReleased(object sender, EventArgs args)
 		{
 			Element?.SendReleased();
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ImageRenderer.cs
@@ -5,7 +5,7 @@ using AppKit;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	public class ImageRenderer : ViewRenderer<Image, NSImageView>, IImageVisualElementRenderer
+	public class ImageRenderer : ViewRenderer<Image, FormsNSImageView>, IImageVisualElementRenderer
 	{
 		bool _isDisposed;
 
@@ -91,6 +91,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		bool IImageVisualElementRenderer.IsDisposed => _isDisposed;
 
-		NSImageView IImageVisualElementRenderer.GetImage() => Control;
+		IImageView IImageVisualElementRenderer.GetImage() => Control;
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -219,6 +219,9 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\LabelRenderer.cs">
       <Link>Renderers\LabelRenderer.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\ImageButtonRenderer.cs">
+      <Link>Renderers\ImageButtonRenderer.cs</Link>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Platform.iOS\ResourcesProvider.cs">
       <Link>ResourcesProvider.cs</Link>
     </Compile>
@@ -244,6 +247,12 @@
     </Compile>
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\ImageElementManager.cs">
       <Link>Renderers\ImageElementManager.cs</Link>
+    </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\ButtonElementManager.cs">
+      <Link>Renderers\ButtonElementManager.cs</Link>
+    </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\BorderElementManager.cs">
+      <Link>Renderers\BorderElementManager.cs</Link>
     </Compile>
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Renderers\IImageVisualElementRenderer.cs">
       <Link>Renderers\IImageVisualElementRenderer.cs</Link>

--- a/Xamarin.Forms.Platform.iOS/Renderers/BorderElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/BorderElementManager.cs
@@ -1,8 +1,17 @@
 ﻿using System;
 using System.ComponentModel;
-using NativeView = UIKit.UIView;
 
+#if __MOBILE__
+using UIKit;
+using NativeView = UIKit.UIView;
 namespace Xamarin.Forms.Platform.iOS
+#else
+using AppKit;
+using CoreAnimation;
+using NativeView = AppKit.NSView;
+namespace Xamarin.Forms.Platform.MacOS
+#endif
+	 
 {
 	internal static class BorderElementManager
 	{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonElementManager.cs
@@ -1,17 +1,23 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
 
-using Foundation;
+#if __MOBILE__
 using UIKit;
-
+using NativeButton = UIKit.UIButton;
 namespace Xamarin.Forms.Platform.iOS
+#else
+using AppKit;
+using CoreAnimation;
+using NativeButton = Xamarin.Forms.Platform.MacOS.ButtonRenderer.FormsNSButton;
+namespace Xamarin.Forms.Platform.MacOS
+#endif
+
 {
 	internal static class ButtonElementManager
 	{
+#if __MOBILE__
 		static readonly UIControlState[] s_controlStates = { UIControlState.Normal, UIControlState.Highlighted, UIControlState.Disabled };
+#endif
 
 		public static void Init(IVisualNativeElementRenderer renderer)
 		{
@@ -22,8 +28,9 @@ namespace Xamarin.Forms.Platform.iOS
 		static void OnControlChanged(object sender, EventArgs e)
 		{
 			var renderer = (IVisualNativeElementRenderer)sender;
-			var control = (UIButton)renderer.Control;
+			var control = (NativeButton)renderer.Control;
 
+#if __MOBILE__
 			foreach (UIControlState uiControlState in s_controlStates)
 			{
 				control.SetTitleColor(UIButton.Appearance.TitleColor(uiControlState), uiControlState); // if new values are null, old values are preserved.
@@ -31,48 +38,48 @@ namespace Xamarin.Forms.Platform.iOS
 				control.SetBackgroundImage(UIButton.Appearance.BackgroundImageForState(uiControlState), uiControlState);
 			}
 
-
 			control.TouchUpInside -= TouchUpInside;
 			control.TouchDown -= TouchDown;
 			control.TouchUpInside += TouchUpInside;
 			control.TouchDown += TouchDown;
+#else
+			control.Released -= TouchUpInside;
+			control.Pressed -= TouchDown;
+			control.Released += TouchUpInside;
+			control.Pressed += TouchDown;
+#endif
 		}
+		 
 
 		static void TouchUpInside(object sender, EventArgs eventArgs)
 		{
-			var button = sender as UIButton;
+			var button = sender as NativeButton;
 			var renderer = button.Superview as IVisualNativeElementRenderer;
 			OnButtonTouchUpInside(renderer.Element as IButtonController);
 		}
 
 		static void TouchDown(object sender, EventArgs eventArgs)
 		{
-			var button = sender as UIButton;
+			var button = sender as NativeButton;
 			var renderer = button.Superview as IVisualNativeElementRenderer;
 			OnButtonTouchDown(renderer.Element as IButtonController);
 		}
 
 		public static void Dispose(IVisualNativeElementRenderer renderer)
 		{
-			var control = (UIButton)renderer.Control;
+			var control = (NativeButton)renderer.Control;
 			renderer.ElementPropertyChanged -= OnElementPropertyChanged;
+#if __MOBILE__
 			control.TouchUpInside -= TouchUpInside;
 			control.TouchDown -= TouchDown;
+#else
+			control.Released -= TouchUpInside;
+			control.Pressed -= TouchDown;
+#endif
 		}
 
 		static void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-		}
-
-
-		static void SetControlPropertiesFromProxy(UIButton control)
-		{
-			foreach (UIControlState uiControlState in s_controlStates)
-			{
-				control.SetTitleColor(UIButton.Appearance.TitleColor(uiControlState), uiControlState); // if new values are null, old values are preserved.
-				control.SetTitleShadowColor(UIButton.Appearance.TitleShadowColor(uiControlState), uiControlState);
-				control.SetBackgroundImage(UIButton.Appearance.BackgroundImageForState(uiControlState), uiControlState);
-			}
 		}
 
 		internal static void OnButtonTouchDown(IButtonController element)

--- a/Xamarin.Forms.Platform.iOS/Renderers/IImageVisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IImageVisualElementRenderer.cs
@@ -5,13 +5,24 @@ namespace Xamarin.Forms.Platform.iOS
 #else
 using NativeImageView = AppKit.NSImageView;
 using NativeImage = AppKit.NSImage;
+using CoreAnimation;
+
 namespace Xamarin.Forms.Platform.MacOS
 #endif
 {
+#if __MACOS__
+	public interface IImageView
+	{
+		NativeImage Image { get; set; }
+
+		CALayer Layer { get; set; } 
+	}
+#endif
+
 	public interface IImageVisualElementRenderer : IVisualNativeElementRenderer
 	{
 		void SetImage(NativeImage image);
 		bool IsDisposed { get; }
-		NativeImageView GetImage();
+		IImageView GetImage();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
@@ -158,7 +158,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			var elemValue = (string)Element?.GetValue(AutomationProperties.NameProperty);
 			if (string.IsNullOrWhiteSpace(elemValue) && Control?.AccessibilityLabel ==
 #if __MOBILE__
-				Control?.Title(UIControlState.Normal))
+				Control?.Title(UIControlState.Normal)
 #else
 				Control?.Title
 #endif


### PR DESCRIPTION
### Description of Change ###

Implements ImageButton on macOS.
Adds Button/BorderManager and adjusts internal views to be used across iOS/macOS internally.

### Issues Resolved ###  

- fixes #4792

### API Changes ### 

 None

### Platforms Affected ### 

-macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Sample for the working `ImageButton` next to the iOS sample.

<img width="1031" alt="grafik" src="https://user-images.githubusercontent.com/11095003/67167807-007bb380-f39e-11e9-9d88-d02c9ed33458.png">
With border color set:
<img width="1059" alt="grafik" src="https://user-images.githubusercontent.com/11095003/67167790-e6da6c00-f39d-11e9-9753-60a26d0f2e93.png">

### Testing Procedure ###

- Testable in the control gallery

### PR Checklist ### 

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
