### PR TITLE
Convert HSL(A) with Double from InvariantString

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -276,6 +276,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(Color.Blue, converter.ConvertFromInvariantString("hsl(240,100%, 50%)"));
 			Assert.AreEqual(Color.Blue, converter.ConvertFromInvariantString("hsl(240,110%, 50%)"));
 			Assert.AreEqual(Color.Blue.MultiplyAlpha(.8), converter.ConvertFromInvariantString("hsla(240,100%, 50%, .8)"));
+			Assert.AreEqual(Color.FromHsla(0.66916666666666669, 1, 0.5), converter.ConvertFromInvariantString("hsl(240.9,100%, 50%)"));
 			Assert.AreEqual(Color.Default, converter.ConvertFromInvariantString("Color.Default"));
 			Assert.AreEqual(Color.Accent, converter.ConvertFromInvariantString("Accent"));
 			var hotpink = Color.FromHex("#FF69B4");

--- a/Xamarin.Forms.Core/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Core/ColorTypeConverter.cs
@@ -251,7 +251,7 @@ namespace Xamarin.Forms
 				maxValue = 100;
 				elem = elem.Substring(0, elem.Length - 1);
 			}
-			return (double)(int.Parse(elem, NumberStyles.Number, CultureInfo.InvariantCulture).Clamp(0, maxValue)) / maxValue;
+			return double.Parse(elem, NumberStyles.Number, CultureInfo.InvariantCulture).Clamp(0, maxValue) / maxValue;
 		}
 
 		static double ParseOpacity(string elem)


### PR DESCRIPTION
### Description of Change ###

Fix bug  #8113 and provide changes in Unit Tests where reproduce the bug.

### Issues Resolved ### 

- fixes #8113 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

N/A

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run Unit Tests before and after changes in `ColorTypeConverter`

### PR Checklist ###
- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
