### PR TITLE
Occasionally clean up WeakReferences in Styles whose targets have been collected

### DIFF
--- a/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
+++ b/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
@@ -8,6 +8,9 @@ namespace Xamarin.Forms
 	{
 		readonly List<WeakReference> _associatedObjects = new List<WeakReference>();
 
+		const int CleanupTrigger = 128;
+		int _cleanupThreshold = CleanupTrigger;
+
 		public AttachedCollection()
 		{
 		}
@@ -64,6 +67,7 @@ namespace Xamarin.Forms
 			lock (_associatedObjects)
 			{
 				_associatedObjects.Add(new WeakReference(bindable));
+				CleanUpWeakReferences();
 			}
 			foreach (T item in this)
 				item.AttachTo(bindable);
@@ -122,6 +126,17 @@ namespace Xamarin.Forms
 					continue;
 				item.AttachTo(bindable);
 			}
+		}
+
+		void CleanUpWeakReferences()
+		{
+			if (_associatedObjects.Count < _cleanupThreshold)
+			{
+				return;
+			}
+
+			_associatedObjects.RemoveAll(t => !t.IsAlive);
+			_cleanupThreshold = _associatedObjects.Count + CleanupTrigger;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Style.cs
+++ b/Xamarin.Forms.Core/Style.cs
@@ -10,6 +10,9 @@ namespace Xamarin.Forms
 	{
 		internal const string StyleClassPrefix = "Xamarin.Forms.StyleClass.";
 
+		const int CleanupTrigger = 128;
+		int _cleanupThreshold = CleanupTrigger;
+
 		readonly BindableProperty _basedOnResourceProperty = BindableProperty.CreateAttached("BasedOnResource", typeof(Style), typeof(Style), default(Style),
 			propertyChanged: OnBasedOnResourceChanged);
 
@@ -93,6 +96,8 @@ namespace Xamarin.Forms
 			if (BaseResourceKey != null)
 				bindable.SetDynamicResource(_basedOnResourceProperty, BaseResourceKey);
 			ApplyCore(bindable, BasedOn ?? GetBasedOnResource(bindable));
+
+			CleanUpWeakReferences();
 		}
 
 		public Type TargetType { get; }
@@ -177,6 +182,17 @@ namespace Xamarin.Forms
 			if (value == null)
 				return true;
 			return value.TargetType.IsAssignableFrom(TargetType);
+		}
+
+		void CleanUpWeakReferences()
+		{
+			if (_targets.Count < _cleanupThreshold)
+			{
+				return;
+			}
+
+			_targets.RemoveAll(t => !t.TryGetTarget(out _));
+			_cleanupThreshold = _targets.Count + CleanupTrigger;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Styles use WeakReferences to track their targets so that the target BindableObjects can be garbage collected. However, the WeakReferences themselves are never removed from the Style; this means that long-lived Styles (e.g., application-wide styles) can accumulate WeakReferences for the entire lifetime of the application, eventually running out of memory.

These changes check the number of accumulated WeakReferences when a new reference is added; if the number of references is over a threshold, the list of references are scanned and references whose targets have already been collected are removed, allowing them to be garbage collected.

### Issues Resolved ### 
- WeakReference memory leak

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Run a Forms application which 
- uses a global Style 
- creates many BinableObjects which use that Style (e.g., scrolling forward and back in a CollectionView or ListView)

under a profiler and watch the WeakReference instance count. If the WeakReference count ever decreases, then this fix is working. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
