### PR TITLE
Change XamarinFormsVersionFile to a dot file so it's hidden

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,4 +69,4 @@ caketools/
 *.binlog
 .ionide/**
 /.nuspec
-XamarinFormsVersionFile.txt
+.XamarinFormsVersionFile.txt

--- a/Version.targets
+++ b/Version.targets
@@ -56,7 +56,7 @@
 
     <Message Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'" Importance="high" Text="##vso[build.addbuildtag]$(NightlyTag)"/>
     <ItemGroup>
-       <XamarinFormsVersionFile Include="../XamarinFormsVersionFile.txt"/>
+       <XamarinFormsVersionFile Include="../.XamarinFormsVersionFile.txt"/>
        <XamarinFormsVersionLine Include="$(PackageVersion)"/>
     </ItemGroup>
     

--- a/build.cake
+++ b/build.cake
@@ -174,7 +174,7 @@ Task("_NuGetPack")
     .Does(() =>
     {
         var nugetVersionFile = 
-            GetFiles("XamarinFormsVersionFile.txt");
+            GetFiles(".XamarinFormsVersionFile.txt");
         var nugetversion = FileReadText(nugetVersionFile.First());
 
         Information("Nuget Version: {0}", nugetversion);


### PR DESCRIPTION
### Description of Change ###

Change XamarinFormsVersionFile to a dot file so it's hidden. 

This file is only used by the CI processes and build scripts 

### Testing Procedure ###
Generate nugets from cake and make sure the *.XamarinFormsVersionFile* is generated but doesn't try to get added to SC.

Also make sure that nuget files are still generated with valid version numbers

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
