### PR TITLE
Fix Flyout behavior so it propagates from templated Content Page once it's created

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellAppearanceChange.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellAppearanceChange.cs
@@ -1,0 +1,95 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell AppearanceChange",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public class ShellAppearanceChangeTests : TestShell
+	{
+		protected override void Init()
+		{
+			AddContentPage(GetContentPage(Color.Red));
+		}
+
+		ContentPage GetContentPage(Color color)
+		{
+			var stackLayout = new StackLayout()
+			{
+				Children =
+				{
+					new Label() { Text = $"I should have a {color} background"},
+					new Button()
+					{
+						Text = "Push Purple Page",
+						Command = new Command(() =>
+						{
+							var contentPage = GetContentPage(Color.Purple);
+							Navigation.PushAsync(contentPage);
+						}),
+					},				
+				}
+			};
+
+			if (Navigation?.NavigationStack != null)
+			{
+				stackLayout.Children.Add(new Button()
+				{
+					Text = "Insert Orange Page Before Current Page",
+					Command = new Command(() =>
+					{
+						var contentPage = GetContentPage(Color.Orange);
+						Navigation.InsertPageBefore(contentPage, Navigation.NavigationStack.Last());
+					}),
+				});
+
+				stackLayout.Children.Add(new Button()
+				{
+					Text = "Pop Page",
+					Command = new Command(() =>
+					{
+						Navigation.PopAsync();
+					}),
+				});
+
+				stackLayout.Children.Add(new Button()
+				{
+					Text = "Remove Current Page",
+					Command = new Command(() =>
+					{
+						Navigation.RemovePage(Navigation.NavigationStack.Last());
+					}),
+				});
+
+				stackLayout.Children.Add(new Button()
+				{
+					Text = "Pop To Root",
+					Command = new Command(() =>
+					{
+						Navigation.PopToRootAsync();
+					}),
+				});
+			}
+
+			var page = new ContentPage()
+			{
+				Title = color.ToString(),
+				Content = stackLayout
+			};
+
+			Shell.SetBackgroundColor(page, color);
+			return page;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -145,6 +145,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(EnableFlyoutBehavior);
 			ShowFlyout(usingSwipe: true);
 			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.Tap(FlyoutItem);
 
 			// Flyout Icon is not visible but you can still swipe open
 			RunningApp.Tap(DisableFlyoutBehavior);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -57,14 +57,6 @@ namespace Xamarin.Forms.Controls.Issues
 					{
 						new Button()
 						{
-							Text = "Push Page",
-							Command = new Command(() =>
-							{
-								Navigation.PushAsync(new ContentPage());
-							}),
-						},
-						new Button()
-						{
 							Text = "Enable Flyout Behavior",
 							Command = new Command(() =>
 							{
@@ -137,21 +129,21 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(EnableFlyoutBehavior);
 
 			// Starting shell out as disabled correctly disables flyout
-			RunningApp.WaitForNoElement(FlyoutIconAutomationId);
+			RunningApp.WaitForNoElement(FlyoutIconAutomationId, "Flyout Icon Visible on Startup");
 			ShowFlyout(usingSwipe: true, testForFlyoutIcon: false);
-			RunningApp.WaitForNoElement(FlyoutItem);
+			RunningApp.WaitForNoElement(FlyoutItem, "Flyout Visible on Startup");
 
 			// Enable Flyout Test
 			RunningApp.Tap(EnableFlyoutBehavior);
 			ShowFlyout(usingSwipe: true);
-			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.WaitForElement(FlyoutItem, "Flyout Not Visible after Enabled");
 			RunningApp.Tap(FlyoutItem);
 
 			// Flyout Icon is not visible but you can still swipe open
 			RunningApp.Tap(DisableFlyoutBehavior);
-			RunningApp.WaitForNoElement(FlyoutIconAutomationId);
+			RunningApp.WaitForNoElement(FlyoutIconAutomationId, "Flyout Icon Visible after being Disabled");
 			ShowFlyout(usingSwipe: true, testForFlyoutIcon: false);
-			RunningApp.WaitForNoElement(FlyoutItem);
+			RunningApp.WaitForNoElement(FlyoutItem, "Flyout Visible after being Disabled");
 
 
 			// enable flyout and make sure disabling back button behavior doesn't hide icon
@@ -159,34 +151,34 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(FlyoutIconAutomationId);
 			RunningApp.Tap(DisableBackButtonBehavior);
 			ShowFlyout(usingSwipe: true);
-			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.WaitForElement(FlyoutItem, "Flyout swipe not working after Disabling Back Button Behavior");
 			RunningApp.Tap(FlyoutItem);
 
 			// make sure you can still open flyout via code
 			RunningApp.Tap(EnableFlyoutBehavior);
 			RunningApp.Tap(EnableBackButtonBehavior);
 			RunningApp.Tap(OpenFlyout);
-			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.WaitForElement(FlyoutItem, "Flyout not opening via code");
 			RunningApp.Tap(FlyoutItem);
 
 			// make sure you can still open flyout via code if flyout behavior is disabled
 			RunningApp.Tap(DisableFlyoutBehavior);
 			RunningApp.Tap(EnableBackButtonBehavior);
 			RunningApp.Tap(OpenFlyout);
-			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.WaitForElement(FlyoutItem, "Flyout not opening via code when flyout behavior disabled");
 			RunningApp.Tap(FlyoutItem);
 
 			// make sure you can still open flyout via code if back button behavior is disabled
 			RunningApp.Tap(EnableFlyoutBehavior);
 			RunningApp.Tap(DisableBackButtonBehavior);
 			RunningApp.Tap(OpenFlyout);
-			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.WaitForElement(FlyoutItem, "Flyout not opening via code when back button behavior is disabled");
 			RunningApp.Tap(FlyoutItem);
 
 			// FlyoutLocked ensure that the flyout and buttons are still visible
 			RunningApp.Tap(EnableBackButtonBehavior);
 			RunningApp.Tap(LockFlyoutBehavior);
-			RunningApp.WaitForElement(title);
+			RunningApp.WaitForElement(title, "Flyout Locked hiding content");
 			RunningApp.Tap(EnableFlyoutBehavior);
 
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		BackButtonBehavior _behavior;
 		const string title = "Basic Test";
+		const string FlyoutItem = "Flyout Item";
 		const string EnableFlyoutBehavior = "EnableFlyoutBehavior";
 		const string DisableFlyoutBehavior = "DisableFlyoutBehavior";
 		const string LockFlyoutBehavior = "LockFlyoutBehavior";
@@ -41,7 +42,8 @@ namespace Xamarin.Forms.Controls.Issues
 			_behavior = new BackButtonBehavior();
 			var page = GetContentPage(title);
 			Shell.SetBackButtonBehavior(page, _behavior);
-			AddContentPage(page).Title = title;
+			AddContentPage(page).Title = FlyoutItem;
+			Shell.SetFlyoutBehavior(this.CurrentItem, FlyoutBehavior.Disabled);
 		}
 
 		ContentPage GetContentPage(string title)
@@ -53,6 +55,14 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					Children =
 					{
+						new Button()
+						{
+							Text = "Push Page",
+							Command = new Command(() =>
+							{
+								Navigation.PushAsync(new ContentPage());
+							}),
+						},
 						new Button()
 						{
 							Text = "Enable Flyout Behavior",
@@ -125,14 +135,22 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			// Flyout is visible
 			RunningApp.WaitForElement(EnableFlyoutBehavior);
-			RunningApp.WaitForElement(FlyoutIconAutomationId);
+
+			// Starting shell out as disabled correctly disables flyout
+			RunningApp.WaitForNoElement(FlyoutIconAutomationId);
+			ShowFlyout(usingSwipe: true, testForFlyoutIcon: false);
+			RunningApp.WaitForNoElement(FlyoutItem);
+
+			// Enable Flyout Test
+			RunningApp.Tap(EnableFlyoutBehavior);
+			ShowFlyout(usingSwipe: true);
+			RunningApp.WaitForElement(FlyoutItem);
 
 			// Flyout Icon is not visible but you can still swipe open
 			RunningApp.Tap(DisableFlyoutBehavior);
 			RunningApp.WaitForNoElement(FlyoutIconAutomationId);
 			ShowFlyout(usingSwipe: true, testForFlyoutIcon: false);
-			RunningApp.WaitForElement(title);
-			RunningApp.Tap(title);
+			RunningApp.WaitForNoElement(FlyoutItem);
 
 
 			// enable flyout and make sure disabling back button behavior doesn't hide icon
@@ -140,29 +158,29 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement(FlyoutIconAutomationId);
 			RunningApp.Tap(DisableBackButtonBehavior);
 			ShowFlyout(usingSwipe: true);
-			RunningApp.WaitForElement(title);
-			RunningApp.Tap(title);
+			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.Tap(FlyoutItem);
 
 			// make sure you can still open flyout via code
 			RunningApp.Tap(EnableFlyoutBehavior);
 			RunningApp.Tap(EnableBackButtonBehavior);
 			RunningApp.Tap(OpenFlyout);
-			RunningApp.WaitForElement(title);
-			RunningApp.Tap(title);
+			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.Tap(FlyoutItem);
 
 			// make sure you can still open flyout via code if flyout behavior is disabled
 			RunningApp.Tap(DisableFlyoutBehavior);
 			RunningApp.Tap(EnableBackButtonBehavior);
 			RunningApp.Tap(OpenFlyout);
-			RunningApp.WaitForElement(title);
-			RunningApp.Tap(title);
+			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.Tap(FlyoutItem);
 
 			// make sure you can still open flyout via code if back button behavior is disabled
 			RunningApp.Tap(EnableFlyoutBehavior);
 			RunningApp.Tap(DisableBackButtonBehavior);
 			RunningApp.Tap(OpenFlyout);
-			RunningApp.WaitForElement(title);
-			RunningApp.Tap(title);
+			RunningApp.WaitForElement(FlyoutItem);
+			RunningApp.Tap(FlyoutItem);
 
 			// FlyoutLocked ensure that the flyout and buttons are still visible
 			RunningApp.Tap(EnableBackButtonBehavior);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBehavior.cs
@@ -53,6 +53,8 @@ namespace Xamarin.Forms.Controls.Issues
 				Title = title,
 				Content = new StackLayout()
 				{
+					VerticalOptions = LayoutOptions.FillAndExpand,
+					BackgroundColor = Color.Red,
 					Children =
 					{
 						new Button()
@@ -84,6 +86,10 @@ namespace Xamarin.Forms.Controls.Issues
 							}),
 							AutomationId = LockFlyoutBehavior
 						},
+						new StackLayout()
+						{
+							VerticalOptions = LayoutOptions.CenterAndExpand
+						},
 						new Button()
 						{
 							Text = "Open Flyout",
@@ -91,7 +97,8 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								this.FlyoutIsPresented = true;
 							}),
-							AutomationId = OpenFlyout
+							AutomationId = OpenFlyout,
+							VerticalOptions = LayoutOptions.End
 						},
 						new Button()
 						{
@@ -100,7 +107,8 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								_behavior.IsEnabled = true;
 							}),
-							AutomationId = EnableBackButtonBehavior
+							AutomationId = EnableBackButtonBehavior,	
+							VerticalOptions = LayoutOptions.End
 
 						},
 						new Button()
@@ -110,7 +118,8 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								_behavior.IsEnabled = false;
 							}),
-							AutomationId = DisableBackButtonBehavior
+							AutomationId = DisableBackButtonBehavior,
+							VerticalOptions = LayoutOptions.End
 						}
 					}
 				}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -636,7 +636,7 @@ namespace Xamarin.Forms.Controls
 				{
 					new ShellContent()
 					{
-						Content = page,
+						ContentTemplate = new DataTemplate(() => page),
 						Title = title
 					}
 				}
@@ -659,7 +659,7 @@ namespace Xamarin.Forms.Controls
 						{
 							new ShellContent()
 							{
-								Content = page
+								ContentTemplate = new DataTemplate(() => page),
 							}
 						}
 					}
@@ -687,7 +687,7 @@ namespace Xamarin.Forms.Controls
 
 			shellSection.Items.Add(new ShellContent()
 			{
-				Content = page
+				ContentTemplate = new DataTemplate(() => page)
 			});
 
 			item.Items.Add(shellSection);
@@ -712,7 +712,7 @@ namespace Xamarin.Forms.Controls
 
 			shellSection.Items.Add(new ShellContent()
 			{
-				Content = contentPage
+				ContentTemplate = new DataTemplate(() => contentPage)
 			});
 
 			return item;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -98,6 +98,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7339.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellAppearanceChange.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7128.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellGestures.cs" />
@@ -1587,12 +1588,6 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7803.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7048.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1589,5 +1589,11 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+  </ItemGroup>  
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7048.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/Shell/IShellSectionController.cs
+++ b/Xamarin.Forms.Core/Shell/IShellSectionController.cs
@@ -22,5 +22,7 @@ namespace Xamarin.Forms
 		void SendInsetChanged(Thickness inset, double tabThickness);
 
 		void SendPopped();
+		void SendPopping(Page page);
+		void SendPopped(Page page);
 	}
 }

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -206,7 +206,11 @@ namespace Xamarin.Forms
 		void IShellController.AddFlyoutBehaviorObserver(IFlyoutBehaviorObserver observer)
 		{
 			_flyoutBehaviorObservers.Add(observer);
-			observer.OnFlyoutBehaviorChanged(GetEffectiveFlyoutBehavior());
+
+			// We need to wait until the visible page has been created before we try to calculate
+			// the flyout behavior
+			if(GetVisiblePage() != null)
+				observer.OnFlyoutBehaviorChanged(GetEffectiveFlyoutBehavior());
 		}
 
 		void IShellController.AppearanceChanged(Element source, bool appearanceSet)
@@ -1029,7 +1033,7 @@ namespace Xamarin.Forms
 
 		void NotifyFlyoutBehaviorObservers()
 		{
-			if (CurrentItem == null)
+			if (CurrentItem == null || GetVisiblePage() == null)
 				return;
 
 			var behavior = GetEffectiveFlyoutBehavior();

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1130,11 +1130,11 @@ namespace Xamarin.Forms
 		{
 			readonly Shell _shell;
 
-			NavigationProxy SectionProxy => _shell.CurrentItem.CurrentItem.NavigationProxy;
+			NavigationProxy SectionProxy => _shell.CurrentItem?.CurrentItem?.NavigationProxy;
 
 			public NavigationImpl(Shell shell) => _shell = shell;
 
-			protected override IReadOnlyList<Page> GetNavigationStack() => SectionProxy.NavigationStack;
+			protected override IReadOnlyList<Page> GetNavigationStack() => SectionProxy?.NavigationStack;
 
 			protected override void OnInsertPageBefore(Page page, Page before) => SectionProxy.InsertPageBefore(page, before);
 

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -62,11 +62,6 @@ namespace Xamarin.Forms
 				ContentCache = result;
 			}
 
-			if (result != null && result.Parent != this)
-			{
-				OnChildAdded(result);
-			}
-
 			if (result == null)
 				throw new InvalidOperationException($"No Content found for {nameof(ShellContent)}, Title:{Title}, Route {Route}");
 
@@ -122,6 +117,11 @@ namespace Xamarin.Forms
 			set
 			{
 				_contentCache = value;
+				if (value != null && value.Parent != this)
+				{
+					OnChildAdded(value);
+				}
+
 				if (Parent != null)
 					((ShellSection)Parent).UpdateDisplayedPage();
 			}
@@ -162,8 +162,6 @@ namespace Xamarin.Forms
 				{
 					shellContent._logicalChildren.Add((Element)newValue);
 					shellContent.ContentCache = newElement;
-					// parent new item
-					shellContent.OnChildAdded(newElement);
 				}
 				else if(newValue != null)
 				{

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -266,8 +266,6 @@ namespace Xamarin.Forms
 				Shell.ApplyQueryAttributes(content, queryData, isLast);
 				await OnPushAsync(content, i == routes.Count - 1 && animate);
 			}
-
-			SendAppearanceChanged();
 		}
 
 		internal void SendStructureChanged()
@@ -295,6 +293,7 @@ namespace Xamarin.Forms
 			}
 
 			PresentedPageAppearing();
+			SendAppearanceChanged();
 		}
 
 		protected override void OnChildAdded(Element child)
@@ -392,7 +391,6 @@ namespace Xamarin.Forms
 			_navStack.Remove(page);
 			PresentedPageAppearing();
 
-			SendAppearanceChanged();
 			_navigationRequested?.Invoke(this, args);
 			if (args.Task != null)
 				await args.Task;
@@ -429,7 +427,6 @@ namespace Xamarin.Forms
 			_navigationRequested?.Invoke(this, args);
 			var oldStack = _navStack;
 			_navStack = new List<Page> { null };
-			SendAppearanceChanged();
 
 			if (args.Task != null)
 				await args.Task;
@@ -469,7 +466,6 @@ namespace Xamarin.Forms
 			_navStack.Add(page);
 			PresentedPageAppearing();
 			AddPage(page);
-			SendAppearanceChanged();
 			_navigationRequested?.Invoke(this, args);
 
 			SendUpdateCurrentState(ShellNavigationSource.Push);
@@ -506,7 +502,6 @@ namespace Xamarin.Forms
 			if(currentPage)
 				PresentedPageAppearing();
 
-			SendAppearanceChanged();
 			RemovePage(page);
 			var args = new NavigationRequestedEventArgs(page, false)
 			{

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -281,6 +281,7 @@ namespace Xamarin.Forms
 		internal void UpdateDisplayedPage()
 		{
 			var stack = Stack;
+			var previousPage = DisplayedPage;
 			if (stack.Count > 1)
 			{
 				DisplayedPage = stack[stack.Count - 1];
@@ -292,8 +293,11 @@ namespace Xamarin.Forms
 					DisplayedPage = currentItem.Page;
 			}
 
-			PresentedPageAppearing();
-			SendAppearanceChanged();
+			if (previousPage != DisplayedPage)
+			{
+				PresentedPageAppearing();
+				SendAppearanceChanged();
+			}
 		}
 
 		protected override void OnChildAdded(Element child)

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -131,6 +131,24 @@ namespace Xamarin.Forms
 			SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
+		void IShellSectionController.SendPopping(Page page)
+		{
+			if (_navStack.Count <= 1)
+				throw new Exception("Nav Stack consistency error");
+
+			_navStack.Remove(page);
+			SendAppearanceChanged();
+		}
+
+		void IShellSectionController.SendPopped(Page page)
+		{
+			if(_navStack.Contains(page))
+				_navStack.Remove(page);
+
+			RemovePage(page);
+			SendUpdateCurrentState(ShellNavigationSource.Pop);
+		}
+
 		#endregion IShellSectionController
 
 		#region IPropertyPropagationController

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -398,10 +398,14 @@ namespace Xamarin.Forms.Platform.iOS
 				throw new ArgumentNullException(nameof(popTask));
 			}
 
+			var poppedPage = _shellSection.Stack[_shellSection.Stack.Count - 1];
+
+			// this is used to setup appearance changes based on the incoming page
+			((IShellSectionController)_shellSection).SendPopping(poppedPage);
+
 			await popTask;
 
-			var poppedPage = _shellSection.Stack[_shellSection.Stack.Count - 1];
-			((IShellSectionController)_shellSection).SendPopped();
+			((IShellSectionController)_shellSection).SendPopped(poppedPage);
 			DisposePage(poppedPage);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Flyout Behavior was being calculated before the Content Page was realized so any attached properties on the Content Page were ignored. This change centralizes SendAppearanceChange calls as well so it's being called from a more correct place opposed to just trying to guess everywhere it should be called

### Issues Resolved ### 

- fixes #7985

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- Flyout behavior is automated but you can run UI test and make sure it works as you expect
- I also added a manual Appearance change test you can use to verify appearance changes propagate correctly

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
