### PR TITLE
Fix 6307 |  [Bug] [Shell] [Android] Setting BackButtonBehavior IsEnabled to False causes an exception when loading page

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6307.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6307.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 					new Label()
 					{
 						AutomationId = StatusLabel,
-						Text = "You must be able to navigate between pages 😎"
+						Text = "You should be able to navigate between pages 😎"
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6307.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6307.cs
@@ -1,0 +1,109 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6307,
+	"Setting BackButtonBehavior IsEnabled to False causes an exception when loading page", PlatformAffected.Android)]
+
+#if UITEST
+	[Category(UITestCategories.Shell)]
+#endif
+	public class Issue6307 : TestShell
+	{
+		const string StatusLabel = "StatusLabel";
+
+		protected override void Init()
+		{
+			var page = CreateContentPage();
+			Shell.SetBackgroundColor(this, Color.Green);
+
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = StatusLabel,
+						Text = "You must be able to navigate between pages 😎"
+					}
+				}
+			};
+
+			CurrentItem = Items.Last();
+
+			AddTopTab("Tab 1");
+			AddTopTab("Tab 2");
+			AddTopTab("Tab 3");
+
+			foreach (var item in Items[0].Items[0].Items)
+			{
+				Shell.SetBackButtonBehavior((ContentPage)item.Content, new BackButtonBehavior() { IsEnabled = false });
+			}
+		}
+
+		#region Use Base.AddTopTab in 4.3+
+
+		void AddTopTab(string title)
+		{
+			var page = CreateContentPage();
+			if (Items.Count == 0)
+			{
+				var item = AddContentPage<ShellItem, ShellSection>(page);
+				item.Items[0].Items[0].Title = title ?? page.Title;
+				return;
+			}
+
+			Items[0].Items[0].Items.Add(new ShellContent()
+			{
+				Title = title ?? page.Title,
+				Content = page,
+				AutomationId = title
+			});
+		}
+
+		TShellItem AddContentPage<TShellItem, TShellSection>(ContentPage contentPage = null)
+			where TShellItem : ShellItem
+			where TShellSection : ShellSection
+		{
+			contentPage = contentPage ?? new ContentPage();
+			TShellItem item = Activator.CreateInstance<TShellItem>();
+			item.Title = contentPage.Title;
+			TShellSection shellSection = Activator.CreateInstance<TShellSection>();
+			Items.Add(item);
+			item.Items.Add(shellSection);
+
+			shellSection.Items.Add(new ShellContent()
+			{
+				Content = contentPage
+			});
+
+			return item;
+		}
+
+		#endregion
+
+#if UITEST
+		[Test]
+		public void ShellBackButtonDisabledTests()
+		{
+			var tab1 = "Tab 1";
+			RunningApp.WaitForElement(tab1);
+			RunningApp.Tap(tab1);
+			RunningApp.Tap("Tab 2");
+			RunningApp.Tap("Tab 3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -9,6 +9,7 @@
     <Import_RootNamespace>Xamarin.Forms.Controls.Issues</Import_RootNamespace>
   </PropertyGroup>
   <ItemGroup>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6307.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6458.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6258.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3150.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -328,6 +328,9 @@ namespace Xamarin.Forms.Platform.Android
 				(icon as DrawerArrowDrawable).Progress = 1;
 			}
 
+			if (icon == null)
+				return;
+
 			var iconState = icon.GetConstantState();
 			if (iconState != null)
 			{


### PR DESCRIPTION
### Description of Change ###
I've created a simple null check at line 331 in ShellToolbarTracker.cs

### Issues Resolved ### 

- fixes #6307 

### API Changes ###
 
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

Not throw an exception when navigating between pages

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Create an app using Shell
2. Add the following lines to one of one detail page
    <Shell.BackButtonBehavior >
        <BackButtonBehavior IsEnabled="False" />
    </Shell.BackButtonBehavior>
3. Run the app and attempt to navigate to the page

> Or simply run Issue6307 test from gallery

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67255050-7cd1cd80-f456-11e9-8d27-82b0062f8f61.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
