### PR TITLE
Add Application.LogWarningsListener

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -38,6 +38,9 @@ namespace Xamarin.Forms
 				if (CurrentLogListener != null && Log.Listeners.Contains(CurrentLogListener))
 					Log.Listeners.Remove(CurrentLogListener);
 
+				if (value == null)
+					return;
+
 				CurrentLogWarningListener = value;
 				CurrentLogListener = new DelegateLogListener((category, message) => CurrentLogWarningListener.Invoke((category, message)));
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -26,6 +26,25 @@ namespace Xamarin.Forms
 		[Obsolete("Assign the LogWarningsListener")]
 		public static bool LogWarningsToApplicationOutput { get; set; }
 
+		private static Action<(string Category, string Message)> CurrentLogWarningListener;
+		private static DelegateLogListener CurrentLogListener;
+
+		public static Action<(string Category, string Message)> LogWarningsListener
+		{
+			get => CurrentLogWarningListener;
+
+			set
+			{
+				if (CurrentLogListener != null && Log.Listeners.Contains(CurrentLogListener))
+					Log.Listeners.Remove(CurrentLogListener);
+
+				CurrentLogWarningListener = value;
+				CurrentLogListener = new DelegateLogListener((category, message) => CurrentLogWarningListener.Invoke((category, message)));
+
+				Log.Listeners.Add(CurrentLogListener);
+			}
+		}
+
 		public Application()
 		{
 			var f = false;


### PR DESCRIPTION
### Description of Change ###

Adds the `Application.LogWarningsListener` to be able to capture output from the internal XamForms logging

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8119

### API Changes ###

Added:
 - `static Action<(string Category, string Message)> Application.LogWarningsListener`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Hook into this new API by, for example, adding this line to your `App.xaml.cs`: 

`Application.LogWarningsListener = (warning) => Debug.WriteLine($"{warning.Category}: {warning.Message}");`

Now whenever a warning is raised from within Xamarin.Forms this will be outputted to the debug console. This happens when a binding could not be resolved. Add a binding to a property that does not exist, run the application and observe that you will be notified of the binding not working.

![image](https://user-images.githubusercontent.com/939291/67266353-56d91700-f4b0-11e9-9882-3e73d08bd2d6.png)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
