### PR TITLE
Add VSM Setter TargetName

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateManagerGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateManagerGallery.cs
@@ -15,7 +15,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
 					GalleryBuilder.NavButton("OnIdiom Example", () => new OnIdiomExample(), Navigation),
 					GalleryBuilder.NavButton("Validation Example", () => new ValidationExample(), Navigation),
 					GalleryBuilder.NavButton("Code (No XAML) Example", () => new CodeOnlyExample(), Navigation),
-					GalleryBuilder.NavButton("VisualStates directly on Elements", () => new VisualStatesDirectlyOnElements(), Navigation)
+					GalleryBuilder.NavButton("VisualStates directly on Elements", () => new VisualStatesDirectlyOnElements(), Navigation),
+					GalleryBuilder.NavButton("VisualStateManager Setter Target", () => new VisualStateSetterTarget(), Navigation)
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries.VisualStateSetterTarget"
+			Title="VisualStateManager Setter Targets">
+    <ContentPage.Content>
+        <StackLayout>
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="ColorStates">
+                    <VisualState x:Name="Normal" />
+                    <VisualState x:Name="Invalid">
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor" Value="Azure"/>
+                            <Setter Target="ALabel.TextColor" Property="BackgroundColor" Value="Red"/>
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+
+            <Label x:Name="ALabel" Text="This is a label" HorizontalTextAlignment="Start" HorizontalOptions="Start" />         
+
+            <Label x:Name="CurrentState"></Label>
+
+            <Button x:Name="ToggleValid" Text="Toggle Validity State" Clicked="ToggleValid_OnClicked"></Button>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml
@@ -3,21 +3,29 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              x:Class="Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries.VisualStateSetterTarget"
 			Title="VisualStateManager Setter Targets">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style TargetType="Label">
+                <Setter Property="TextColor" Value="Green" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
     <ContentPage.Content>
-        <StackLayout>
+        <StackLayout x:Name="TheStack">
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="ColorStates">
                     <VisualState x:Name="Normal" />
                     <VisualState x:Name="Invalid">
                         <VisualState.Setters>
                             <Setter Property="BackgroundColor" Value="Azure"/>
-                            <Setter Target="ALabel.TextColor" Property="BackgroundColor" Value="Red"/>
+                            <Setter TargetName="ALabel" Property="Label.TextColor" Value="Red"/>
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
             </VisualStateManager.VisualStateGroups>
 
-            <Label x:Name="ALabel" Text="This is a label" HorizontalTextAlignment="Start" HorizontalOptions="Start" />         
+            <Label x:Name="ALabel" Text="This is a (styled) label" HorizontalTextAlignment="Start" HorizontalOptions="Start" />
 
             <Label x:Name="CurrentState"></Label>
 

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml.cs
@@ -30,8 +30,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
 				_currentColorState = "Normal";
 			}
 
-			CurrentState.Text = $"{_currentColorState}";
-			VisualStateManager.GoToState(ALabel, _currentColorState);
+			CurrentState.Text = $"Current state: {_currentColorState}";
+			VisualStateManager.GoToState(TheStack, _currentColorState);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/VisualStateSetterTarget.xaml.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class VisualStateSetterTarget : ContentPage
+	{
+		string _currentColorState = "Normal";
+
+		public VisualStateSetterTarget()
+		{
+			InitializeComponent ();
+		}
+
+		void ToggleValid_OnClicked(object sender, EventArgs e)
+		{
+			if (_currentColorState == "Normal")
+			{
+				_currentColorState = "Invalid";
+			}
+			else
+			{
+				_currentColorState = "Normal";
+			}
+
+			CurrentState.Text = $"{_currentColorState}";
+			VisualStateManager.GoToState(ALabel, _currentColorState);
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -307,7 +307,8 @@ namespace Xamarin.Forms.Core.UnitTests
 							Setters =
 							{
 								new Setter { Property = View.MarginBottomProperty, Value = targetMargin },
-								new Setter { TargetName = "Label2", Property = View.MarginTopProperty, Value = targetMargin }
+								new Setter { Target = "Label2", Property = View.MarginTopProperty, Value = targetMargin },
+								new Setter { Target = label2, Property = View.MarginLeftProperty, Value = targetMargin }
 							}
 						}
 					}
@@ -318,9 +319,11 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(label1.Margin.Top, Is.EqualTo(defaultMargin));
 			Assert.That(label1.Margin.Bottom, Is.EqualTo(targetMargin));
+			Assert.That(label1.Margin.Left, Is.EqualTo(defaultMargin));
 
 			Assert.That(label2.Margin.Top, Is.EqualTo(targetMargin));
 			Assert.That(label2.Margin.Bottom, Is.EqualTo(defaultMargin));
+			Assert.That(label2.Margin.Left, Is.EqualTo(targetMargin));
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -307,8 +307,7 @@ namespace Xamarin.Forms.Core.UnitTests
 							Setters =
 							{
 								new Setter { Property = View.MarginBottomProperty, Value = targetMargin },
-								new Setter { Target = "Label2", Property = View.MarginTopProperty, Value = targetMargin },
-								new Setter { Target = label2, Property = View.MarginLeftProperty, Value = targetMargin }
+								new Setter { TargetName = "Label2", Property = View.MarginTopProperty, Value = targetMargin }
 							}
 						}
 					}
@@ -323,7 +322,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(label2.Margin.Top, Is.EqualTo(targetMargin));
 			Assert.That(label2.Margin.Bottom, Is.EqualTo(defaultMargin));
-			Assert.That(label2.Margin.Left, Is.EqualTo(targetMargin));
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Linq;
 using NUnit.Framework;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -288,6 +289,11 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var label1 = new Label();
 			var label2 = new Label();
+			INameScope nameScope = new NameScope();
+			NameScope.SetNameScope(label1, nameScope);
+			nameScope.RegisterName("Label1", label1);
+			NameScope.SetNameScope(label2, nameScope);
+			nameScope.RegisterName("Label2", label2);
 
 			var list = new VisualStateGroupList
 			{
@@ -301,7 +307,7 @@ namespace Xamarin.Forms.Core.UnitTests
 							Setters =
 							{
 								new Setter { Property = View.MarginBottomProperty, Value = targetMargin },
-								new Setter { Target = label2, Property = View.MarginTopProperty, Value = targetMargin }
+								new Setter { TargetName = "Label2", Property = View.MarginTopProperty, Value = targetMargin }
 							}
 						}
 					}

--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -281,6 +281,43 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void VisualElementGoesToCorrectStateWhenSetterHasTarget()
+		{
+			double defaultMargin = default(double);
+			double targetMargin = 1.5;
+
+			var label1 = new Label();
+			var label2 = new Label();
+
+			var list = new VisualStateGroupList
+			{
+				new VisualStateGroup
+				{
+					States =
+					{
+						new VisualState
+						{
+							Name = NormalStateName,
+							Setters =
+							{
+								new Setter { Property = View.MarginBottomProperty, Value = targetMargin },
+								new Setter { Target = label2, Property = View.MarginTopProperty, Value = targetMargin }
+							}
+						}
+					}
+				}
+			};
+
+			VisualStateManager.SetVisualStateGroups(label1, list);
+
+			Assert.That(label1.Margin.Top, Is.EqualTo(defaultMargin));
+			Assert.That(label1.Margin.Bottom, Is.EqualTo(targetMargin));
+
+			Assert.That(label2.Margin.Top, Is.EqualTo(targetMargin));
+			Assert.That(label2.Margin.Bottom, Is.EqualTo(defaultMargin));
+		}
+
+		[Test]
 		public void CanRemoveAStateAndAddANewStateWithTheSameName()
 		{
 			var stateGroups = new VisualStateGroupList();

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -14,17 +14,6 @@ namespace Xamarin.Forms
 	{
 		readonly ConditionalWeakTable<BindableObject, object> _originalValues = new ConditionalWeakTable<BindableObject, object>();
 
-		/// <summary>
-		///		Set the target for the property to be changed.  Can be a <c>x:Reference</c> to a <see cref="BindableObject"/>
-		///		or the Name of an object in the attached scope.
-		/// </summary>
-		/// <example>
-		/// The following example shows the two ways of targeting a named object.
-		/// <code>
-		///		<Setter Target="{x:Reference TargetLabel1}" Property="Label.TextColor" Value="#94b0b7" />
-		///		<Setter Target="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
-		/// </code>
-		/// </example>
 		public object Target { get; set; }
 
 		public BindableProperty Property { get; set; }

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -48,11 +48,15 @@ namespace Xamarin.Forms
 			return this;
 		}
 
-		internal void Apply(BindableObject scope, bool fromStyle = false)
+		internal void Apply(BindableObject target, bool fromStyle = false)
 		{
-			var targetObject = FindTargetObject(scope, TargetName);
-			if (targetObject == null)
-				throw new ArgumentNullException(nameof(targetObject));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+
+			var targetObject = target;
+
+			if (!string.IsNullOrEmpty(TargetName) && target is Element element)
+				targetObject = element.FindByName(TargetName) as BindableObject ?? throw new ArgumentNullException(nameof(targetObject));
+
 			if (Property == null)
 				return;
 
@@ -77,11 +81,15 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal void UnApply(BindableObject scope, bool fromStyle = false)
+		internal void UnApply(BindableObject target, bool fromStyle = false)
 		{
-			var targetObject = FindTargetObject(scope, TargetName);
-			if (targetObject == null)
-				throw new ArgumentNullException(nameof(targetObject));
+			if (target == null) throw new ArgumentNullException(nameof(target));
+
+			var targetObject = target;
+
+			if (!string.IsNullOrEmpty(TargetName) && target is Element element)
+				targetObject = element.FindByName(TargetName) as BindableObject ?? throw new ArgumentNullException(nameof(targetObject));
+
 			if (Property == null)
 				return;
 
@@ -101,20 +109,6 @@ namespace Xamarin.Forms
 			}
 			else
 				targetObject.ClearValue(Property);
-		}
-
-		BindableObject FindTargetObject(BindableObject scope, string targetName)
-		{
-			if (scope == null || string.IsNullOrEmpty(TargetName))
-				return scope;
-
-			if (scope is Element element)
-			{
-				if (element.FindByName(targetName) is BindableObject targetObject)
-					return targetObject;
-			}
-
-			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Forms
 	{
 		readonly ConditionalWeakTable<BindableObject, object> _originalValues = new ConditionalWeakTable<BindableObject, object>();
 
+		public BindableObject Target { get; set; }
+
 		public BindableProperty Property { get; set; }
 
 		public object Value { get; set; }
@@ -29,7 +31,10 @@ namespace Xamarin.Forms
 				{
 					MemberInfo minfo = null;
 					try {
-						minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+						if (Target != null)
+							minfo = Target.GetType().GetRuntimeProperty(Property.PropertyName);
+						else
+							minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
 					} catch (AmbiguousMatchException e) {
 						throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", serviceProvider, innerException: e);
 					}
@@ -47,8 +52,9 @@ namespace Xamarin.Forms
 			return this;
 		}
 
-		internal void Apply(BindableObject target, bool fromStyle = false)
+		internal void Apply(BindableObject bindableObject, bool fromStyle = false)
 		{
+			var target = Target ?? bindableObject;
 			if (target == null)
 				throw new ArgumentNullException(nameof(target));
 			if (Property == null)
@@ -76,8 +82,9 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal void UnApply(BindableObject target, bool fromStyle = false)
+		internal void UnApply(BindableObject bindableObject, bool fromStyle = false)
 		{
+			var target = Target ?? bindableObject;
 			if (target == null)
 				throw new ArgumentNullException(nameof(target));
 			if (Property == null)

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Runtime.CompilerServices;
-using System.Xml;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml;
 
@@ -14,7 +13,7 @@ namespace Xamarin.Forms
 	{
 		readonly ConditionalWeakTable<BindableObject, object> _originalValues = new ConditionalWeakTable<BindableObject, object>();
 
-		public object Target { get; set; }
+		public string TargetName { get; set; }
 
 		public BindableProperty Property { get; set; }
 
@@ -51,7 +50,7 @@ namespace Xamarin.Forms
 
 		internal void Apply(BindableObject scope, bool fromStyle = false)
 		{
-			var targetObject = FindTargetObject(scope, Target);
+			var targetObject = FindTargetObject(scope, TargetName);
 			if (targetObject == null)
 				throw new ArgumentNullException(nameof(targetObject));
 			if (Property == null)
@@ -80,7 +79,7 @@ namespace Xamarin.Forms
 
 		internal void UnApply(BindableObject scope, bool fromStyle = false)
 		{
-			var targetObject = FindTargetObject(scope, Target);
+			var targetObject = FindTargetObject(scope, TargetName);
 			if (targetObject == null)
 				throw new ArgumentNullException(nameof(targetObject));
 			if (Property == null)
@@ -104,15 +103,12 @@ namespace Xamarin.Forms
 				targetObject.ClearValue(Property);
 		}
 
-		BindableObject FindTargetObject(BindableObject scope, object target)
+		BindableObject FindTargetObject(BindableObject scope, string targetName)
 		{
-			if (scope == null || target == null)
+			if (scope == null || string.IsNullOrEmpty(TargetName))
 				return scope;
 
-			if (target is BindableObject bindableObject)
-				return bindableObject;
-
-			if (scope is Element element && target is string targetName)
+			if (scope is Element element)
 			{
 				if (element.FindByName(targetName) is BindableObject targetObject)
 					return targetObject;

--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -14,8 +14,6 @@ namespace Xamarin.Forms
 	{
 		readonly ConditionalWeakTable<BindableObject, object> _originalValues = new ConditionalWeakTable<BindableObject, object>();
 
-		public BindableObject Target { get; set; }
-
 		public string TargetName { get; set; }
 
 		public BindableProperty Property { get; set; }
@@ -33,10 +31,7 @@ namespace Xamarin.Forms
 				{
 					MemberInfo minfo = null;
 					try {
-						if (Target != null)
-							minfo = Target.GetType().GetRuntimeProperty(Property.PropertyName);
-						else
-							minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+						minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
 					} catch (AmbiguousMatchException e) {
 						throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", serviceProvider, innerException: e);
 					}
@@ -56,7 +51,7 @@ namespace Xamarin.Forms
 
 		internal void Apply(BindableObject bindableObject, bool fromStyle = false)
 		{
-			var target = FindTargetObject(bindableObject, Target, TargetName);
+			var target = FindTargetObject(bindableObject, TargetName);
 			if (target == null)
 				throw new ArgumentNullException(nameof(target));
 			if (Property == null)
@@ -85,7 +80,7 @@ namespace Xamarin.Forms
 
 		internal void UnApply(BindableObject bindableObject, bool fromStyle = false)
 		{
-			var target = FindTargetObject(bindableObject, Target, TargetName);
+			var target = FindTargetObject(bindableObject, TargetName);
 			if (target == null)
 				throw new ArgumentNullException(nameof(target));
 			if (Property == null)
@@ -109,23 +104,18 @@ namespace Xamarin.Forms
 				target.ClearValue(Property);
 		}
 
-		BindableObject FindTargetObject(BindableObject root, BindableObject target, string targetName)
+		BindableObject FindTargetObject(BindableObject root, string targetName)
 		{
-			root = target ?? root;
-			if (root == null)
-				return null;
-			if (!string.IsNullOrWhiteSpace(targetName))
-			{
-				if (root is Element element)
-				{
-					if (element.FindByName(TargetName) is BindableObject locatedTarget)
-						return locatedTarget;
-				}
+			if (root == null || string.IsNullOrWhiteSpace(targetName))
+				return root;
 
-				return null;
+			if (root is Element element)
+			{
+				if (element.FindByName(targetName) is BindableObject locatedTarget)
+					return locatedTarget;
 			}
 
-			return root;
+			return null;
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -76,7 +76,7 @@
 		<VisualStateGroup Name="ColorStates">
 			<VisualState Name="Red">
 				<VisualState.Setters>
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#340002" />
+					<Setter TargetName="TargetLabel1" Property="Label.BackgroundColor" Value="#340002" />
 					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#920e0c" />
 					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Red" />
 				</VisualState.Setters>
@@ -84,7 +84,7 @@
 
 			<VisualState Name="Blue">
 				<VisualState.Setters>
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#4a707a" />
+					<Setter TargetName="TargetLabel1" Property="Label.BackgroundColor" Value="#4a707a" />
 					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
 					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Blue" />
 				</VisualState.Setters>

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -76,17 +76,17 @@
 		<VisualStateGroup Name="ColorStates">
 			<VisualState Name="Red">
 				<VisualState.Setters>
-					<Setter TargetName="TargetLabel1" Property="Label.BackgroundColor" Value="#340002" />
-					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#920e0c" />
-					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Red" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#340002" />
+					<Setter Target="TargetLabel1" Property="Label.TextColor" Value="#920e0c" />
+					<Setter Target="TargetLabel1" Property="Label.Text" Value="Red" />
 				</VisualState.Setters>
 			</VisualState>
 
 			<VisualState Name="Blue">
 				<VisualState.Setters>
-					<Setter TargetName="TargetLabel1" Property="Label.BackgroundColor" Value="#4a707a" />
-					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
-					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Blue" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#4a707a" />
+					<Setter Target="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
+					<Setter Target="TargetLabel1" Property="Label.Text" Value="Blue" />
 				</VisualState.Setters>
 			</VisualState>
 		</VisualStateGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -76,17 +76,15 @@
 		<VisualStateGroup Name="ColorStates">
 			<VisualState Name="Red">
 				<VisualState.Setters>
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#340002" />
-					<Setter Target="TargetLabel1" Property="Label.TextColor" Value="#920e0c" />
-					<Setter Target="TargetLabel1" Property="Label.Text" Value="Red" />
+					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#920e0c" />
+					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Red" />
 				</VisualState.Setters>
 			</VisualState>
 
 			<VisualState Name="Blue">
 				<VisualState.Setters>
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#4a707a" />
-					<Setter Target="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
-					<Setter Target="TargetLabel1" Property="Label.Text" Value="Blue" />
+					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
+					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Blue" />
 				</VisualState.Setters>
 			</VisualState>
 		</VisualStateGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -77,16 +77,16 @@
 			<VisualState Name="Red">
 				<VisualState.Setters>
 					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#340002" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.TextColor" Value="#920e0c" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.Text" Value="Red" />
+					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#920e0c" />
+					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Red" />
 				</VisualState.Setters>
 			</VisualState>
 
 			<VisualState Name="Blue">
 				<VisualState.Setters>
 					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#4a707a" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.TextColor" Value="#94b0b7" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="Label.Text" Value="Blue" />
+					<Setter TargetName="TargetLabel1" Property="Label.TextColor" Value="#94b0b7" />
+					<Setter TargetName="TargetLabel1" Property="Label.Text" Value="Blue" />
 				</VisualState.Setters>
 			</VisualState>
 		</VisualStateGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -9,24 +9,24 @@
 			<Style TargetType="Entry" x:Key="CustomDisabledState">
 				<Setter Property="VisualStateManager.VisualStateGroups">
 					<VisualStateGroupList>
-						<VisualStateGroup x:Name="CommonStates">
-							<VisualState x:Name="Normal" />
-							<VisualState x:Name="Disabled">
+						<VisualStateGroup Name="CommonStates">
+							<VisualState Name="Normal" />
+							<VisualState Name="Disabled">
 								<VisualState.Setters>
 									<Setter Property="TextColor" Value="Gray" />
 									<Setter Property="PlaceholderColor" Value="LightGray" />
 								</VisualState.Setters>
 							</VisualState>
 						</VisualStateGroup>
-						<VisualStateGroup x:Name="Other">
-							<VisualState x:Name="Fake">
+						<VisualStateGroup Name="Other">
+							<VisualState Name="Fake">
 								<VisualState.Setters>
 									<Setter Property="TextColor" Value="Gray" />
 									<Setter Property="PlaceholderColor" Value="LightGray" />
 								</VisualState.Setters>
 							</VisualState>
 						</VisualStateGroup>
-						<VisualStateGroup x:Name="Extra">
+						<VisualStateGroup Name="Extra">
 						</VisualStateGroup>
 					</VisualStateGroupList>
 				</Setter>
@@ -35,9 +35,9 @@
 			<Style TargetType="Entry" x:Key="OtherStyle">
 				<Setter Property="VisualStateManager.VisualStateGroups">
 					<VisualStateGroupList>
-						<VisualStateGroup x:Name="CommonStates">
-							<VisualState x:Name="Normal" />
-							<VisualState x:Name="Disabled">
+						<VisualStateGroup Name="CommonStates">
+							<VisualState Name="Normal" />
+							<VisualState Name="Disabled">
 								<VisualState.Setters>
 									<Setter Property="TextColor" Value="Default" />
 									<Setter Property="PlaceholderColor" Value="Default" />
@@ -72,30 +72,50 @@
 		</ResourceDictionary>
 	</ContentPage.Resources>
 
+	<VisualStateManager.VisualStateGroups>
+		<VisualStateGroup Name="ColorStates">
+			<VisualState Name="Red">
+				<VisualState.Setters>
+					<Setter Target="{x:Reference TargetLabel1}" Property="BackgroundColor" Value="#340002" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="TextColor" Value="#920e0c" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Text" Value="Red" />
+				</VisualState.Setters>
+			</VisualState>
+
+			<VisualState Name="Blue">
+				<VisualState.Setters>
+					<Setter Target="{x:Reference TargetLabel1}" Property="BackgroundColor" Value="#4a707a" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="TextColor" Value="#94b0b7" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Text" Value="Blue" />
+				</VisualState.Setters>
+			</VisualState>
+		</VisualStateGroup>
+	</VisualStateManager.VisualStateGroups>
+
 	<StackLayout>
 		<Entry x:Name="Entry0" />
 		<Entry x:Name="Entry1" Style="{StaticResource CustomDisabledState}" />
 
 		<Entry x:Name="Entry2">
 			<VisualStateManager.VisualStateGroups>
-				<VisualStateGroup x:Name="CommonStates">
-					<VisualState x:Name="Normal" />
-					<VisualState x:Name="Disabled">
+				<VisualStateGroup Name="CommonStates">
+					<VisualState Name="Normal" />
+					<VisualState Name="Disabled">
 						<VisualState.Setters>
 							<Setter Property="TextColor" Value="Gray" />
 							<Setter Property="PlaceholderColor" Value="LightGray" />
 						</VisualState.Setters>
 					</VisualState>
 				</VisualStateGroup>
-				<VisualStateGroup x:Name="Other">
-					<VisualState x:Name="Fake" />
+				<VisualStateGroup Name="Other">
+					<VisualState Name="Fake" />
 				</VisualStateGroup>
 			</VisualStateManager.VisualStateGroups>
 		</Entry>
 
 		<Entry x:Name="Entry3">
 			<VisualStateManager.VisualStateGroups>
-				<VisualStateGroup x:Name="Empty" />
+				<VisualStateGroup Name="Empty" />
 			</VisualStateManager.VisualStateGroups>
 		</Entry>
 		
@@ -108,16 +128,16 @@
 			and VisualState names on different VisualElements -->
 		<Entry x:Name="Entry5">
 			<VisualStateManager.VisualStateGroups>
-				<VisualStateGroup x:Name="CommonStates">
-					<VisualState x:Name="Normal" />
+				<VisualStateGroup Name="CommonStates">
+					<VisualState Name="Normal" />
 				</VisualStateGroup>
 			</VisualStateManager.VisualStateGroups>
 		</Entry>
 		
 		<Entry x:Name="Button1">
 			<VisualStateManager.VisualStateGroups>
-				<VisualStateGroup x:Name="CommonStates">
-					<VisualState x:Name="Normal">
+				<VisualStateGroup Name="CommonStates">
+					<VisualState Name="Normal">
 						<VisualState.Setters>
 							<Setter Property="BackgroundColor" Value="Lime" />
 						</VisualState.Setters>
@@ -125,6 +145,8 @@
 				</VisualStateGroup>
 			</VisualStateManager.VisualStateGroups>
 		</Entry>
+
+		<Label x:Name="TargetLabel1" Style="{StaticResource ErrorLabel}"></Label>
 
 	</StackLayout>
 

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml
@@ -76,17 +76,17 @@
 		<VisualStateGroup Name="ColorStates">
 			<VisualState Name="Red">
 				<VisualState.Setters>
-					<Setter Target="{x:Reference TargetLabel1}" Property="BackgroundColor" Value="#340002" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="TextColor" Value="#920e0c" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="Text" Value="Red" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#340002" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.TextColor" Value="#920e0c" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.Text" Value="Red" />
 				</VisualState.Setters>
 			</VisualState>
 
 			<VisualState Name="Blue">
 				<VisualState.Setters>
-					<Setter Target="{x:Reference TargetLabel1}" Property="BackgroundColor" Value="#4a707a" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="TextColor" Value="#94b0b7" />
-					<Setter Target="{x:Reference TargetLabel1}" Property="Text" Value="Blue" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.BackgroundColor" Value="#4a707a" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.TextColor" Value="#94b0b7" />
+					<Setter Target="{x:Reference TargetLabel1}" Property="Label.Text" Value="Blue" />
 				</VisualState.Setters>
 			</VisualState>
 		</VisualStateGroup>

--- a/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/VisualStateManagerTests.xaml.cs
@@ -181,6 +181,24 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 				Assert.That(button.BackgroundColor, Is.EqualTo(Color.Lime));
 			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void TargetedVisualElementGoesToCorrectState(bool useCompiledXaml)
+			{
+				var layout = new VisualStateManagerTests(useCompiledXaml);
+
+				var label1 = layout.TargetLabel1;
+
+				VisualStateManager.GoToState(layout, "Red");
+
+				Assert.That(label1.Text, Is.EqualTo("Red"));
+
+				VisualStateManager.GoToState(layout, "Blue");
+
+				Assert.That(label1.Text, Is.EqualTo("Blue"));
+
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Adds the ability to target a child object by name for a Setter for visual state management or styles.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4924 
- closes #5034
- closes #5622

### API Changes ###

Added:
 - `public string TargetName { get; set; }`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

I've added a core gallery page `VisualStateSetterTarget.xaml` which has a button to toggle the VSM state of the `StackLayout`. When it's pressed, the `ALabel` is also triggered because of it's reference through `TargetName`.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
