### PR TITLE
Fix WPF Entry initial TextColor ignored when typing

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8148.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8148.cs
@@ -1,0 +1,22 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8148, "WPF Entry initial TextColor ignored when typing", PlatformAffected.WPF)]
+	public class Issue8148 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label() { Text = "Start typing - text should be red immediately as you typing" },
+					new Entry { TextColor = Color.Red },
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -34,6 +34,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6945.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7313.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5500.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8148.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8008.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6640.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7556.cs" />

--- a/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
@@ -144,17 +144,14 @@ namespace Xamarin.Forms.Platform.WPF
 			Entry entry = Element;
 			if (entry != null)
 			{
-				if (!IsNullOrEmpty(entry.Text))
-				{
-					if (!entry.TextColor.IsDefault)
-						Control.Foreground = entry.TextColor.ToBrush();
-					else
-						Control.Foreground = (Brush)WControl.ForegroundProperty.GetMetadata(typeof(FormsTextBox)).DefaultValue;
+				if (!entry.TextColor.IsDefault)
+					Control.Foreground = entry.TextColor.ToBrush();
+				else
+					Control.Foreground = (Brush)WControl.ForegroundProperty.GetMetadata(typeof(FormsTextBox)).DefaultValue;
 
-					// Force the PhoneTextBox control to do some internal bookkeeping
-					// so the colors change immediately and remain changed when the control gets focus
-					Control.OnApplyTemplate();
-				}
+				// Force the PhoneTextBox control to do some internal bookkeeping
+				// so the colors change immediately and remain changed when the control gets focus
+				Control.OnApplyTemplate();
 			}
 			else
 				Control.Foreground = (Brush)WControl.ForegroundProperty.GetMetadata(typeof(FormsTextBox)).DefaultValue;


### PR DESCRIPTION
### Description of Change ###
Foreground color was applied only if initial entry text is not empty.

Now foreground applies independently from text.

### Issues Resolved ### 

- fixes #8148 

### API Changes ### 
 None

### Platforms Affected ### 
- WPF
### Behavioral/Visual Changes ###

Native TextBox Foreground color equals to Entry TextColor immediately as you start typing.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
