### PR TITLE
[UWP] Null HeaderTemplate and Header if no Title is provided on Picker.

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Controls
 		protected override void Build(StackLayout stackLayout)
 		{
 			base.Build(stackLayout);
-			var itemsContainer = new ViewContainer<Picker>(Test.Picker.Items, new Picker() { Title = "Title of picker" });
+			var itemsContainer = new ViewContainer<Picker>(Test.Picker.Items, new Picker());
 			itemsContainer.View.Items.Add("Item 1");
 			itemsContainer.View.Items.Add("Item 2");
 			itemsContainer.View.Items.Add("Item 3");

--- a/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/PickerCoreGalleryPage.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Controls
 		protected override void Build(StackLayout stackLayout)
 		{
 			base.Build(stackLayout);
-			var itemsContainer = new ViewContainer<Picker>(Test.Picker.Items, new Picker());
+			var itemsContainer = new ViewContainer<Picker>(Test.Picker.Items, new Picker() { Title = "Title of picker" });
 			itemsContainer.View.Items.Add("Item 1");
 			itemsContainer.View.Items.Add("Item 2");
 			itemsContainer.View.Items.Add("Item 3");

--- a/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/PickerRenderer.cs
@@ -216,6 +216,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateTitle()
 		{
+			Control.Header = null;
+			Control.HeaderTemplate = string.IsNullOrEmpty(Element.Title) ? null : (Windows.UI.Xaml.DataTemplate)Windows.UI.Xaml.Application.Current.Resources["ComboBoxHeader"];
 			Control.DataContext = Element;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

While using a Picker control without a Title provided, on UWP you would still get an empty Header above the dropdown of the Picker. Rendering empty space.

### Issues Resolved ### 

- fixes #8150

### API Changes ###
Changed:
 - object PickerRenderer => Remove code in reference to Header property of UWP ComboBox
 - object PickerRenderer => Changed UpdateTitle method

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

No longer empty space above Picker control on UWP.

### Before/After Screenshots ### 

Before - no title
![Screenshot 2019-10-22 at 23 18 32](https://user-images.githubusercontent.com/351693/67334588-b2dc8380-f522-11e9-9a22-936fcb6c10bd.png)

Before - with title
![Screenshot 2019-10-22 at 23 18 46](https://user-images.githubusercontent.com/351693/67334589-b2dc8380-f522-11e9-999e-7829a9bed03d.png)

After - no title
![Screenshot 2019-10-22 at 23 22 31](https://user-images.githubusercontent.com/351693/67334718-e7503f80-f522-11e9-960c-ae89641babd4.png)

After - with title
![Screenshot 2019-10-22 at 23 22 44](https://user-images.githubusercontent.com/351693/67334719-e7503f80-f522-11e9-9aa7-190f8e2350ec.png)

### Testing Procedure ###

Open Controls Gallery app on UWP, go to Picker Gallery, now see that no empty space is rendered above picker.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
