### PR TITLE
Don't force the Master page closed on disappear if it's set to always visible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31255.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31255.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Forms.Controls.Issues
 		#if UITEST
 		[Test]
 		[Ignore("Fails intermittently on TestCloud")]
-		public async void Bugzilla31255Test ()
+		public async Task Bugzilla31255Test ()
 		{
 			RunningApp.Screenshot ("I am at Bugzilla 31255");
 			await Task.Delay (5000);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31602.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31602.cs
@@ -7,7 +7,7 @@ using Xamarin.Forms.Internals;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
-using Xamarin.UITest.iOS;
+using Xamarin.UITest;
 using NUnit.Framework;
 #endif
 
@@ -113,12 +113,11 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla31602Test ()
 		{
-			var appAs = RunningApp as iOSApp;
-			if (appAs != null && appAs.Device.IsTablet) {
+			if (RunningApp.IsTablet()) {
 				RunningApp.Tap (q => q.Marked ("Sidemenu Opener"));
 				RunningApp.WaitForElement (q => q.Marked ("SideMenu"));
 				RunningApp.SetOrientationLandscape ();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32902.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32902.cs
@@ -111,19 +111,16 @@ namespace Xamarin.Forms.Controls.Issues
 
 		}
 
-#if UITEST
+#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla32902Test ()
 		{
-			var appIos = RunningApp as iOSApp;
-			if (appIos != null) {
-				if(appIos.Device.IsTablet)
-				{
-					RunningApp.Tap (q => q.Marked ("btnNext"));
-					RunningApp.Tap (q => q.Marked ("btnPushModal"));
-					RunningApp.Tap (q => q.Marked ("Master"));
-					RunningApp.Tap (q => q.Marked ("btnPop"));
-				}
+			if (RunningApp.IsTablet())
+			{
+				RunningApp.Tap (q => q.Marked ("btnNext"));
+				RunningApp.Tap (q => q.Marked ("btnPushModal"));
+				RunningApp.Tap (q => q.Marked ("Master"));
+				RunningApp.Tap (q => q.Marked ("btnPop"));
 			}
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
@@ -59,12 +59,11 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		#if UITEST
+		#if UITEST && __IOS__
 		[Test]
 		public void Bugzilla34632Test ()
 		{
-			var app = RunningApp as iOSApp;
-			if (app != null && app.Device.IsTablet) {
+			if (RunningApp.IsTablet()) {
 				RunningApp.SetOrientationPortrait ();
 				RunningApp.Tap (q => q.Marked ("btnModal"));
 				RunningApp.SetOrientationLandscape ();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34632.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 							IsPresented = false;
 						}
 					})
-				} 
+				}	
 			};
 
 			Detail = new NavigationPage (new ModalRotationIssue ());
@@ -71,7 +71,9 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.Tap (q => q.Marked ("btnModal"));
 				RunningApp.SetOrientationPortrait ();
 				RunningApp.Tap (q => q.Marked ("btnDismissModal"));
+				RunningApp.Tap("Main Page");
 				RunningApp.Tap (q => q.Marked ("btnMaster"));
+				RunningApp.WaitForNoElement("btnMaster");
 			}
 			else
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1461.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public static bool ShouldRunTest (IApp app)
 		{
-			return (app is iOSApp appAs && appAs.Device.IsTablet);
+			return app.IsTablet();
 		}
 	}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using Xamarin.UITest;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest.iOS;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
@@ -23,7 +24,19 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			Master = new ContentPage() { Title = "Master", BackgroundColor = Color.Blue };
+			Master = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children = 
+					{
+						new Label() { Margin = 20, Text = "Master Visible", TextColor = Color.White }
+					}
+				},
+				Title = "Master",
+				BackgroundColor = Color.Blue
+			};
+
 			Detail = new NavigationPage(new DetailsPage(this) { Title = "Details" });
 		}
 
@@ -46,15 +59,29 @@ namespace Xamarin.Forms.Controls.Issues
 						{
 							Text = "Click to rotate through MasterBehavior settings and test each one",
 							Command = new Command(OnChangeMasterBehavior)
+						},
+						new Button()
+						{
+							Text = "Push Modal Page When on Split MasterBehavior",
+							AutomationId = "PushModalPage",
+							Command = new Command(() =>
+							{
+								Navigation.PushModalAsync(new ContentPage(){
+									Content = new Button()
+									{
+										Text = "After popping this Page MasterBehavior should still be split",
+										AutomationId = "PopModalPage",
+										Command = new Command(() => Navigation.PopModalAsync())
+									}
+								});
+							})
 						}
 					}
 				};
-			}
 
-			protected override void OnAppearing()
-			{
-				base.OnAppearing();
-				OnChangeMasterBehavior();
+
+				MDP.MasterBehavior = MasterBehavior.Split;
+				lblThings.Text = MDP.MasterBehavior.ToString();
 			}
 
 			void OnChangeMasterBehavior()
@@ -70,5 +97,22 @@ namespace Xamarin.Forms.Controls.Issues
 				lblThings.Text = MDP.MasterBehavior.ToString();
 			}
 		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void MasterStillVisibleAfterPushingAndPoppingModalPage()
+		{
+			var appIos = RunningApp as iOSApp;
+			if (appIos == null || appIos.Device.IsTablet)
+				return;
+
+			RunningApp.SetOrientationLandscape();
+			RunningApp.WaitForElement("Split");
+			RunningApp.WaitForElement("Master Visible");
+			RunningApp.Tap("PushModalPage");
+			RunningApp.Tap("PopModalPage");
+			RunningApp.WaitForElement("Master Visible");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
@@ -102,8 +102,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void MasterStillVisibleAfterPushingAndPoppingModalPage()
 		{
-			var appIos = RunningApp as iOSApp;
-			if (appIos == null || appIos.Device.IsTablet)
+			if (!RunningApp.IsTablet())
 				return;
 
 			RunningApp.SetOrientationLandscape();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7556.cs
@@ -112,6 +112,13 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("PopModalPage");
 			RunningApp.WaitForElement("Master Visible");
 		}
+
+		[TearDown]
+		public override void TearDown() 
+		{
+			RunningApp.SetOrientationPortrait ();
+			base.TearDown();
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -447,6 +447,33 @@ namespace Xamarin.Forms.Controls
 		}
 
 #if __IOS__
+
+		public bool IsTablet
+		{
+			get
+			{
+				if (_app is iOSApp app)
+				{
+					return app.Device.IsTablet;
+				}
+
+				throw new Exception($"Invaliid app type: {_app}");
+			}
+		}
+
+		public bool IsPhone
+		{
+			get
+			{
+				if (_app is iOSApp app)
+				{
+					return app.Device.IsPhone;
+				}
+
+				throw new Exception($"Invaliid app type: {_app}");
+			}
+		}
+
 		public void SendAppToBackground(TimeSpan timeSpan)
 		{
 			if (_app is iOSApp app)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -81,6 +81,7 @@ namespace Xamarin.Forms.Controls
 			// Running on a device
 			var app = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
+				.DeviceIdentifier("17FAAFF3-7BC6-49C3-8D22-C68B7914774F")
 				.StartApp(Xamarin.UITest.Configuration.AppDataMode.DoNotClear);
 			int _iosVersion;
 			if (int.TryParse(app.Invoke("iOSVersion").ToString(), out _iosVersion))

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -81,7 +81,6 @@ namespace Xamarin.Forms.Controls
 			// Running on a device
 			var app = ConfigureApp.iOS.InstalledApp(AppPaths.BundleId).Debug()
 				//Uncomment to run from a specific iOS SIM, get the ID from XCode -> Devices
-				.DeviceIdentifier("17FAAFF3-7BC6-49C3-8D22-C68B7914774F")
 				.StartApp(Xamarin.UITest.Configuration.AppDataMode.DoNotClear);
 			int _iosVersion;
 			if (int.TryParse(app.Invoke("iOSVersion").ToString(), out _iosVersion))

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-UnevenListTests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-UnevenListTests.cs
@@ -31,8 +31,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		public static bool ShouldRunTest(IApp app)
 		{
-			var appAs = app as iOSApp;
-			return (appAs != null && appAs.Device.IsPhone);
+			return app.IsPhone();
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -43,6 +43,36 @@ namespace Xamarin.UITest
 			return true;
 		}
 
+		public static bool IsTablet(this IApp app)
+		{
+#if __IOS__
+			if (app is Xamarin.Forms.Controls.ScreenshotConditionalApp sca)
+			{
+				return sca.IsTablet;
+			}
+			else if (app is iOSApp iOSApp)
+			{
+				return iOSApp.Device.IsTablet;
+			}
+#endif
+			return false;
+		}
+
+		public static bool IsPhone(this IApp app)
+		{
+#if __IOS__
+			if (app is Xamarin.Forms.Controls.ScreenshotConditionalApp sca)
+			{
+				return sca.IsPhone;
+			}
+			else if (app is iOSApp iOSApp)
+			{
+				return iOSApp.Device.IsPhone;
+			}
+#endif
+			return true;
+		}
+
 #if __IOS__
 		public static void SendAppToBackground(this IApp app, TimeSpan timeSpan)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -255,7 +255,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillDisappear(bool animated)
 		{
-			if (_masterVisible)
+			if (_masterVisible && !MasterDetailPage.ShouldShowSplitMode)
 				PerformButtonSelector();
 
 			base.ViewWillDisappear(animated);

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -16,25 +16,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 	internal class EventedViewController : ChildViewController
 	{
-		public override void ViewWillAppear(bool animated)
-		{
-			base.ViewWillAppear(animated);
-
-			var eh = WillAppear;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
-		}
-
 		public override void ViewWillDisappear(bool animated)
 		{
 			base.ViewWillDisappear(animated);
 
-			var eh = WillDisappear;
-			if (eh != null)
-				eh(this, EventArgs.Empty);
+			WillDisappear?.Invoke(this, EventArgs.Empty);
 		}
 
-		public event EventHandler WillAppear;
+		public override void ViewDidAppear(bool animated)
+		{
+			base.ViewDidAppear(animated);
+
+			DidAppear?.Invoke(this, EventArgs.Empty);
+		}
+
+		public event EventHandler DidAppear;
 
 		public event EventHandler WillDisappear;
 	}
@@ -95,7 +91,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_masterController != null)
 				{
-					_masterController.WillAppear -= MasterControllerWillAppear;
+					_masterController.DidAppear -= MasterControllerWillAppear;
 					_masterController.WillDisappear -= MasterControllerWillDisappear;
 				}
 
@@ -131,7 +127,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UpdateControllers();
 
-			_masterController.WillAppear += MasterControllerWillAppear;
+			_masterController.DidAppear += MasterControllerWillAppear;
 			_masterController.WillDisappear += MasterControllerWillDisappear;
 
 			PresentsWithGesture = MasterDetailPage.IsGestureEnabled;
@@ -251,6 +247,9 @@ namespace Xamarin.Forms.Platform.iOS
 				MasterDetailPage.CanChangeIsPresented = true;
 
 			MasterDetailPage.UpdateMasterBehavior();
+
+			if(MasterDetailPage.CanChangeIsPresented && !MasterDetailPage.ShouldShowSplitMode)
+				ElementController.SetValueFromRenderer(MasterDetailPage.IsPresentedProperty, false);
 		}
 
 		public override void ViewWillDisappear(bool animated)


### PR DESCRIPTION
### Description of Change ###
- Don't force the Master page closed if it's a split view
- When the conversion was made to the ScreenShotConditionalApp on UITests. A lot of the tests that were testing for iOSApp weren't updated to account for this. 
- Now that *Bugzilla34632Test* is actually running it revealed an issue with rotating the iPad when on a Modal Page and set to SplitOnLandscape


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- Automated test added
- The following PR https://github.com/xamarin/Duplo/pull/3388 is where this code was introduced. The UI test that's part of that PR runs fine with this code. With that knowledge please perform whatever additional scenario testing you see fit to make sure this doesn't cause a regression

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
