### PR TITLE
[macOs] implements Frame CornerRadius

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/FrameCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/FrameCoreGalleryPage.cs
@@ -23,14 +23,19 @@ namespace Xamarin.Forms.Controls
 
 			var hasShadowContainer = new StateViewContainer<Frame> (Test.Frame.HasShadow, new Frame { HasShadow = true });
 			var outlineColorContainer = new StateViewContainer<Frame> (Test.Frame.OutlineColor, new Frame { BorderColor = Color.Teal, });
-			var viewContainer = new StateViewContainer<Frame> (Test.Frame.OutlineColor, new Frame {
+			var viewContainer = new StateViewContainer<Frame> (Test.Frame.Content, new Frame {
 				BorderColor = Color.Teal,
 				Content = new Label { Text = "I am a frame" }
+			});
+			var cornerRadiusContainer = new StateViewContainer<Frame>(Test.Frame.CornerRadius, new Frame {
+				BorderColor = Color.Teal,
+				CornerRadius = 25
 			});
 
 			Add (hasShadowContainer);
 			Add (outlineColorContainer);
 			Add (viewContainer);
+			Add (cornerRadiusContainer);
 		}
 	}
 }

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -549,7 +549,9 @@ namespace Xamarin.Forms.CustomAttributes
 		public enum Frame
 		{
 			OutlineColor,
-			HasShadow
+			HasShadow,
+			Content,
+			CornerRadius
 		}
 
 		public enum Image

--- a/Xamarin.Forms.Platform.MacOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/FrameRenderer.cs
@@ -20,13 +20,20 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
 			    e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||
-				e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName)
+				e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
+				e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName)
 				SetupLayer();
 		}
 
 		void SetupLayer()
 		{
-			Layer.CornerRadius = 5;
+			float cornerRadius = Element.CornerRadius;
+
+			if (cornerRadius == -1f)
+				cornerRadius = 5f; // default corner radius
+
+			Layer.CornerRadius = cornerRadius;
+
 			if (Element.BackgroundColor == Color.Default)
 				Layer.BackgroundColor = NSColor.White.CGColor;
 			else


### PR DESCRIPTION
### Description of Change ###
- Implements Frame CornerRadius for macOS, currently CornerRadius always set to 5
- Adds CornerRadius property to FrameCoreGalleryPage
### API Changes ###
 
 None

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
- CornerRadius works

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->
Before
![Screenshot 2019-10-23 at 14 20 41](https://user-images.githubusercontent.com/33512073/67387941-7f403e80-f5a0-11e9-9d53-741f0f3971d3.png)
After
![Screenshot 2019-10-23 at 14 19 17](https://user-images.githubusercontent.com/33512073/67387951-82d3c580-f5a0-11e9-9a4e-dc03273fd955.png)


### Testing Procedure ###
open FrameCoreGalleryPage

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
