### PR TITLE
Fix issue 6388 | [CollectionView] Error when using ListItemsLayout in XAML

### DIFF
--- a/Xamarin.Forms.Core/Items/LinearItemsLayout.cs
+++ b/Xamarin.Forms.Core/Items/LinearItemsLayout.cs
@@ -4,6 +4,10 @@ namespace Xamarin.Forms
 {
 	public class LinearItemsLayout : ItemsLayout
 	{
+		public LinearItemsLayout() : this(ItemsLayoutOrientation.Vertical)
+		{
+		}
+
 		public LinearItemsLayout([Parameter("Orientation")] ItemsLayoutOrientation orientation) : base(orientation)
 		{
 		}


### PR DESCRIPTION
### Description of Change ###
I've created a parameterless constructor for `LinearItemsLayout`


### Issues Resolved ### 
- fixes #6388

### API Changes ###
Added:
 - LinearItemsLayout.ctor without parameters 

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
- Before

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67444576-1678b680-f5e0-11e9-8a04-673b9e1347ff.png" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

-After

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67444616-37d9a280-f5e0-11e9-9a3f-03398292ffb8.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### Testing Procedure ###
1. Create a new Xamarin.Forms project
2. Add these lines to MainPage.xaml:
```XAML
<CollectionView>
  <CollectionView.ItemsLayout>
    <ListItemsLayout SnapPointsAlignment="Center" SnapPointsType="Mandatory">
      <x:Arguments>
        <ItemsLayoutOrientation>Horizontal</ItemsLayoutOrientation>
      </x:Arguments>
    </ListItemsLayout>
  </CollectionView.ItemsLayout>
</CollectionView>
```
### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
