### PR TITLE
[UWP] Delay RequestRefresh until RefreshControl Loaded

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8186.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8186.cs
@@ -1,0 +1,80 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8186, "[UWP] Setting IsRefreshing from OnAppearing on RefreshView crashes UWP",
+		PlatformAffected.UWP)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.RefreshView)]
+#endif
+	public class Issue8186 : TestNavigationPage
+	{
+		RefreshView _refreshView;
+		protected override void Init()
+		{
+			_refreshView = new RefreshView()
+			{
+				Content = new ScrollView()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "If you are reading this and see a refresh circle test has succeeded",
+								AutomationId = "Success"
+							},
+							new Button()
+							{
+								Text = "Push Page then return to this page.",
+								Command = new Command(() =>
+								{
+									Navigation.PushAsync(new ContentPage()
+									{
+										Content = new Button()
+										{
+											Text = "Pop Page",
+											AutomationId = "PopPage",
+											Command = new Command(()=> Navigation.PopAsync())
+										}
+									});
+								}),
+								AutomationId = "PushPage"
+							}
+						}
+					}
+				}
+			};
+
+			var page = new ContentPage() { Content = _refreshView };
+			page.Appearing += (_, __) => _refreshView.IsRefreshing = true;
+			page.Disappearing += (_, __) => _refreshView.IsRefreshing = false;
+			PushAsync(page);
+		}
+
+#if UITEST
+		[Test]
+		public void SetIsRefreshingToTrueInOnAppearingDoesntCrash()
+		{
+			RunningApp.WaitForElement("Success");
+			RunningApp.Tap("PushPage");
+			RunningApp.Tap("PopPage");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -19,12 +19,13 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterTemplate.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8186.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
-    </Compile> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" /> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" /> 
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <SubType>Code</SubType>


### PR DESCRIPTION
### Description of Change ###

Calling RequestRefresh before RefreshControl is part of the visual tree throws an exception. I tested updating to 2.2 of WinU, which got rid of the exception but the visualization still didn't quite work correctly.  It wasn't enough to just trigger it after Loaded either so I Queue it up on the UI thread

### Issues Resolved ### 
- fixes #8186

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- Automated test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
