### PR TITLE
Fix 7361 - [UWP] Stepper buttons not becoming enabled again, when disabled more than once.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7361.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7361.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7361, "[UWP] Stepper display error when using Slider", PlatformAffected.UWP)]
+	public class Issue7361 : TestContentPage
+	{
+		Slider TheSlider;
+		Stepper TheStepper;
+		Label ValueLabel;
+
+		public Issue7361()
+		{
+			Title = "Issue 7361";
+		}
+
+		protected override void Init()
+		{
+			StackLayout layout = new StackLayout();
+			layout.Orientation = StackOrientation.Vertical;
+
+			var instructions = new Label
+			{
+				Margin = new Thickness(6),
+				Text = "Slide slider to max and min, check if Stepper +/- buttons becomes wrongly disabled permanently, after reaching ends."
+			};
+
+			StackLayout controlsLayout = new StackLayout();
+			controlsLayout.Orientation= StackOrientation.Horizontal;
+			controlsLayout.HorizontalOptions = LayoutOptions.FillAndExpand;
+
+			TheSlider = new Slider
+			{
+				Maximum = 100,
+				Minimum = 1,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				MinimumTrackColor = Color.LightPink,
+				MaximumTrackColor = Color.LightPink
+			};
+			controlsLayout.Children.Add(TheSlider);
+			
+			TheStepper = new Stepper
+			{
+				Maximum = 100,
+				Minimum = 1,
+				Increment = 1
+			};
+			controlsLayout.Children.Add(TheStepper);
+
+			StackLayout labelLayout = new StackLayout();
+			labelLayout.Orientation = StackOrientation.Horizontal;
+			labelLayout.HorizontalOptions = LayoutOptions.FillAndExpand;
+
+			Label valueHeaderLabel = new Label
+			{
+				Text = "Value:",
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label))
+			};
+			labelLayout.Children.Add(valueHeaderLabel);
+
+			ValueLabel = new Label
+			{
+				Text = "",
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label))
+			};
+			labelLayout.Children.Add(ValueLabel);
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(controlsLayout);
+			layout.Children.Add(labelLayout);
+
+			Content = layout;
+
+			TheSlider.Value = 50;
+			TheStepper.Value = 50;
+			TheSlider.ValueChanged += SliderChanged;
+			TheStepper.ValueChanged += StepperChanged;
+		}
+
+		private void SliderChanged(object sender, ValueChangedEventArgs e)
+		{
+			TheStepper.Value = e.NewValue;
+			ValueLabel.Text = e.NewValue.ToString();
+		}
+
+		private void StepperChanged(object sender, ValueChangedEventArgs e)
+		{
+			TheSlider.Value = e.NewValue;
+			ValueLabel.Text = e.NewValue.ToString();
+		}
+	}
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7361.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7361.cs
@@ -27,7 +27,8 @@ namespace Xamarin.Forms.Controls.Issues
 			var instructions = new Label
 			{
 				Margin = new Thickness(6),
-				Text = "Slide slider to max and min, check if Stepper +/- buttons becomes wrongly disabled permanently, after reaching ends."
+				Text = "Slide slider to the extreme Right and Left, check that the Stepper to the right's +/- buttons work as expected, " + 
+					   "becoming disabled at the Max and Min positions of the Slider, and then enabled again as the Slider moves towards the center."
 			};
 
 			StackLayout controlsLayout = new StackLayout();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,10 +22,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
-    </Compile> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" /> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" /> 
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7361.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.UAP/StepperControl.cs
+++ b/Xamarin.Forms.Platform.UAP/StepperControl.cs
@@ -223,17 +223,17 @@ namespace Xamarin.Forms.Platform.UWP
 			double increment = Increment;
 			if (_plus != null)
 			{
-				if (value + increment > Maximum)
+				if (value + increment > Maximum && _plusStateCache is null)
 					_plusStateCache = PseudoDisable(_plus);
-				else
+				else if (value + increment <= Maximum)
 					PsuedoEnable(_plus, ref _plusStateCache);
 			}
 
 			if (_minus != null)
 			{
-				if (value - increment < Minimum)
+				if (value - increment < Minimum && _minusStateCache is null)
 					_minusStateCache = PseudoDisable(_minus);
-				else
+				else if (value - increment >= Minimum)
 					PsuedoEnable(_minus, ref _minusStateCache);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

The UWP StepperControl maintains an internal state for whether the + and - buttons are disabled. But if a button is disabled more than once, a cache of the button's previous state is overwritten, and now holds the disabled state - and therefore never becomes properly disabled, when it should be reset to enabled. This change prevents the buttons from being disabled more than once.


### Issues Resolved ### 

- fixes #7361

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Steppers should now work as expected. (It also did in most use cases, already.)

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Go to Test Page 7361
Move Slider to theextreme right. Check that the Stepper + button become disabled.
Move Slider to Center. Check that the Stepper + button becomes enabled again.
Move Slider to Extreme left. Checkt that the Stepper - button becomes disabled.
Move Slider to Center. Check the the stepper - button becomes enabled again.


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
