### PR TITLE
[Android] Make sure we use the right Context

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -10,6 +10,7 @@ using Android.Text;
 using Android.Text.Method;
 using Android.Util;
 using Android.Widget;
+using Android.Views;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
@@ -60,7 +61,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override SearchView CreateNativeControl()
 		{
-			return new SearchView(Context);
+			var context = (Context as ContextThemeWrapper).BaseContext ?? Context;
+			return new SearchView(context);
 		}
 
 		protected override void OnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)


### PR DESCRIPTION
Fix a regression caused by #8090 , still checking if this would be a issue in more places.
Basically everything that will be expecting a Context that s inside the ScrollViewer will have check if it's a themewrapper, the is special worrying if people want to grab the activity. 

### Description of Change ###

Check we pass the right context not the wrapper to the underlying controls. 
I m still investigating if other controls will suffer from the same when inside the ScrollView

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes broken API19 tests on master

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
You should be able to visit the SearchBar gallery

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
