### PR TITLE
Store references to local variable so it's not collected

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/AnimatableKeyTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AnimatableKeyTests.cs
@@ -65,7 +65,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			var dict = new Dictionary<AnimatableKey, object> { { key1, new object () } };
 
 			Assert.Throws<ArgumentException> (() => {
-				dict.Add (key2, new object ());
+				var closureKey1 = key1;
+				var closureKey2 = key1;
+				var closureAnimatable = animatable;
+
+				dict.Add(key2, new object());
 			});
 		}
 	}

--- a/Xamarin.Forms.Core.UnitTests/ImageButtonUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/ImageButtonUnitTest.cs
@@ -194,7 +194,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			var source = new StreamImageSource();
 			var image = new ImageButton { Source = source };
 			bool fired = false;
-			image.MeasureInvalidated += (sender, e) => fired = true;
+			EventHandler eventHandler = (sender, e) => fired = true;
+			image.MeasureInvalidated += eventHandler;
 			Assert.Null(source.Stream);
 			source.Stream = token => Task.FromResult<Stream>(null);
 			Assert.NotNull(source.Stream);


### PR DESCRIPTION
### Description of Change ###

Occasionally these UI Tests are failing and my current working theory is that it's due to the usage of WeakReferences.  

For the AnimatableKey I'm thinking once it switches to the lambda those keys go out of scope and the weakreference is occasionally collected.


### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- I'm up to about 6 runs of this on CI and they haven't failed yet 🤞 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
