### PR TITLE
[macOS] Add character spacing to button and label

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml
@@ -2,7 +2,8 @@
 
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.Forms.Controls.GalleryPages.CharacterSpacingGallery">
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CharacterSpacingGallery"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls">
 
     <StackLayout>
         <Label>
@@ -16,6 +17,8 @@
         </Label>
         <Slider x:Name="slider" Minimum="-10" Maximum="10" Value="0" ValueChanged="Slider_OnValueChanged" MaximumTrackColor="Gray"
                 MinimumTrackColor="Gray"  Margin="20,0"/>
+        <controls:ColorPicker x:Name="textColorPicker" ColorPicked="ColorPicker_OnColorPicked" Title="Text color" />
+        <controls:ColorPicker x:Name="placeholderColorPicker" ColorPicked="ColorPicker_OnColorPicked" Title="Placeholder color" />
 
         <ScrollView>
             <StackLayout>

--- a/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CharacterSpacingGallery.xaml.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Forms.Controls.GalleryPages
 		public CharacterSpacingGallery()
 		{
 			InitializeComponent();
+			textColorPicker.InitWithColor(Color.Red);
+			placeholderColorPicker.InitWithColor(Color.BlueViolet);
 		}
 
 		void Slider_OnValueChanged(object sender, ValueChangedEventArgs e)
@@ -34,9 +36,37 @@ namespace Xamarin.Forms.Controls.GalleryPages
 			Span.CharacterSpacing = e.NewValue;
 		}
 
+		void ColorPicker_OnColorPicked(object sender, ColorPickedEventArgs e)
+		{
+			if (sender == textColorPicker)
+			{
+				Button.TextColor = e.Color;
+				DatePicker.TextColor = e.Color;
+				Editor.TextColor = e.Color;
+				Entry.TextColor = e.Color;
+				PlaceholderEntry.TextColor = e.Color;
+				PlaceholderEditor.TextColor = e.Color;
+				Label.TextColor = e.Color;
+				Picker.TextColor = e.Color;
+				SearchBar.TextColor = e.Color;
+				PlaceholderSearchBar.TextColor = e.Color;
+				TimePicker.TextColor = e.Color;
+				Span.TextColor = e.Color;
+			}
+			else
+			{
+				PlaceholderEntry.PlaceholderColor = e.Color;
+				PlaceholderEditor.PlaceholderColor = e.Color;
+				PlaceholderSearchBar.PlaceholderColor = e.Color;
+
+			}
+		}
+
 		void ResetButtonClicked(object sender, EventArgs e)
 		{
 			slider.Value = 0;
+			textColorPicker.InitWithColor(Color.Red);
+			placeholderColorPicker.InitWithColor(Color.BlueViolet);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Extensions/NSAttributedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/NSAttributedStringExtensions.cs
@@ -1,0 +1,53 @@
+﻿using AppKit;
+using Foundation;
+
+namespace Xamarin.Forms.Platform.MacOS
+{
+    internal static class NSAttributedStringExtensions
+    {
+        internal static NSMutableAttributedString AddCharacterSpacing(this NSMutableAttributedString attributedString, string text, double characterSpacing)
+        {
+            if (attributedString == null || attributedString.Length == 0)
+            {
+                attributedString = text == null ? new NSMutableAttributedString() : new NSMutableAttributedString(text);
+            }
+            else
+            {
+                attributedString = new NSMutableAttributedString(attributedString);
+            }
+
+            AddKerningAdjustment(attributedString, text, characterSpacing);
+
+            return attributedString;
+        }
+
+        internal static NSMutableAttributedString AddCharacterSpacing(this NSAttributedString attributedString, string text, double characterSpacing)
+        {
+            NSMutableAttributedString mutableAttributedString;
+            if (attributedString == null || attributedString.Length == 0)
+            {
+                mutableAttributedString = text == null ? new NSMutableAttributedString() : new NSMutableAttributedString(text);
+            }
+            else
+            {
+                mutableAttributedString = new NSMutableAttributedString(attributedString);
+            }
+
+            AddKerningAdjustment(mutableAttributedString, text, characterSpacing);
+
+            return mutableAttributedString;
+        }
+
+        internal static void AddKerningAdjustment(NSMutableAttributedString mutableAttributedString, string text, double characterSpacing)
+        {
+            if (!string.IsNullOrEmpty(text))
+            {
+                mutableAttributedString.AddAttribute
+                (
+                    NSStringAttributeKey.KerningAdjustment,
+                    NSObject.FromObject(characterSpacing), new NSRange(0, text.Length - 1)
+                );
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -102,6 +102,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				}
 
 				UpdateText();
+				UpdateCharacterSpacing();
 				UpdateFont();
 				UpdateBorder();
 				UpdateImage();
@@ -127,6 +128,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateImage();
 			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
 				UpdatePadding();
+			else if (e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
+				UpdateCharacterSpacing();
 		}
 
 		void OnButtonActivated(object sender, EventArgs eventArgs)
@@ -186,6 +189,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 			{
 				var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.Font.ToNSFont(), foregroundColor: color.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = NSTextAlignment.Center });
+				textWithColor.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
 				Control.AttributedTitle = textWithColor;
 			}
 		}
@@ -193,6 +197,11 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdatePadding()
 		{
 			(Control as FormsNSButton)?.UpdatePadding(Element.Padding);
+		}
+
+		void UpdateCharacterSpacing()
+		{
+			Control.AttributedTitle = Control.AttributedTitle.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
 		}
 
 		void HandleButtonPressed()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -189,7 +189,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 			{
 				var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.Font.ToNSFont(), foregroundColor: color.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = NSTextAlignment.Center });
-				textWithColor.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
+				textWithColor = textWithColor.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
 				Control.AttributedTitle = textWithColor;
 			}
 		}

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -253,6 +253,7 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Extensions\FontExtensions.Shared.cs">
       <Link>Extensions\FontExtensions.Shared.cs</Link>
     </Compile>
+    <Compile Include="Extensions\NSAttributedStringExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -277,12 +277,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				newAttributedText.RemoveAttribute(underlineStyleKey, range);
 			else
 				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
-
-#if __MOBILE__
+	
 			UpdateCharacterSpacing();
-#else
-			Control.AttributedStringValue = newAttributedText;
-#endif
 			_perfectSizeValid = false;
 		}
 
@@ -379,20 +375,24 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateCharacterSpacing()
 		{
-#if __MOBILE__
 			if (IsElementOrControlEmpty)
 				return;
 
 			if (Element?.TextType != TextType.Text)
 				return;
-
+#if __MOBILE__
 			var textAttr = Control.AttributedText.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
 
 			if (textAttr != null)
 				Control.AttributedText = textAttr;
-				
-			_perfectSizeValid = false;
+#else
+   			var textAttr = Control.AttributedStringValue.AddCharacterSpacing(Element.Text, Element.CharacterSpacing);
+
+			if (textAttr != null)
+				Control.AttributedStringValue = textAttr;
 #endif
+
+			_perfectSizeValid = false;
 		}
 
 		void UpdateText()

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -277,7 +277,10 @@ namespace Xamarin.Forms.Platform.MacOS
 				newAttributedText.RemoveAttribute(underlineStyleKey, range);
 			else
 				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
-	
+
+#if !__MOBILE__
+			Control.AttributedStringValue = newAttributedText;
+#endif
 			UpdateCharacterSpacing();
 			_perfectSizeValid = false;
 		}
@@ -510,7 +513,10 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 			Control.TextColor = textColor.ToUIColor(ColorExtensions.Black);
 #else
-			Control.TextColor = textColor.ToNSColor(ColorExtensions.Black);
+			var alignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
+			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });
+			textWithColor = textWithColor.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
+			Control.AttributedStringValue = textWithColor;
 #endif
 			UpdateLayout();
 		}


### PR DESCRIPTION
### Description of Change ###

Implements character spacing for button and label on macOS.

I had planned to add character spacing to everything, but encountered issues.

Doing the obvious straightforward thing for DatePicker and TimePicker did nothing.
Doing the obvious straightforward thing for Entry, Editor and SearchBar worked, until the value was edited, which reset the spacing.

Something more will need to be done, possibly with custom Cells.

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

Character spacing on macOS is now implemented for Button and Label.

### Before/After Screenshots ### 

![image](https://user-images.githubusercontent.com/475450/67517359-569c6f80-f69a-11e9-97e4-4f28a1426936.png)

### Testing Procedure ###
There is a character spacing gallery page. I added color pickers to change the text color and placeholder color (currently irrelevant) to make sure the spacing changes play nicely with color changes.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
