### PR TITLE
[Android, Shell] Don't double dispose the more sheet

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8145.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8145.cs
@@ -1,0 +1,94 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Controls;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shell)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8145, "Shell System.ObjectDisposedException: 'Cannot access a disposed object. Object name: 'Android.Support.Design.Widget.BottomSheetDialog'.'", PlatformAffected.Android)]
+	public class Issue8145 : TestShell
+	{
+		string _titleElement = "Connect";
+		protected override void Init()
+		{
+			Title = "Shell";
+			Items.Add(new FlyoutItem
+			{
+				Title = _titleElement,
+				Items = {
+					new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},new Tab {
+							Title = "notme",
+							Items = {
+										new ContentPage { Title = "notme",  Content = new Label  { Text = "Click More, then choose the target. If it does not crash, this test has passed." } }
+									}
+						},
+					new Tab { 
+							Title = "target",
+							Items = {
+										new ContentPage { Title = "Target",  Content = new Label  { Text = "Success" } }
+									}
+						}
+				}
+			});
+		}
+
+#if UITEST
+#if !(__ANDROID__ || __IOS__)
+		[Ignore("Shell test is only supported on Android and iOS")]
+#endif
+		[Test]
+		public void Issue8145ShellToolbarDisposedException()
+		{
+			RunningApp.WaitForElement("More");
+			RunningApp.Tap("More");
+			RunningApp.WaitForElement("target");
+			RunningApp.Tap("target");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,9 +22,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
-    </Compile> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" /> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" /> 
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7048.xaml.cs">
       <DependentUpon>Issue7048.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -632,6 +632,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)MultipleClipToBounds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6994.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7371.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8145.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 			_bottomView.SetBackgroundColor(Color.White.ToAndroid());
 			_bottomView.SetOnNavigationItemSelectedListener(this);
 
-			if(ShellItem == null)
+			if (ShellItem == null)
 				throw new ArgumentException("Active Shell Item not set. Have you added any Shell Items to your Shell?", nameof(ShellItem));
 
 			HookEvents(ShellItem);
@@ -81,7 +81,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void Destroy()
 		{
-			if(ShellItem != null)
+			if (ShellItem != null)
 				UnhookEvents(ShellItem);
 
 			((IShellController)ShellContext?.Shell)?.RemoveAppearanceObserver(this);
@@ -280,8 +280,9 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			ChangeSection(shellSection);
 
-			dialog.Dismiss();
-			dialog.Dispose();
+			dialog.Dismiss(); //should trigger OnMoreSheetDismissed, which will clean up the dialog
+			if (dialog != _bottomSheetDialog) //should never be true, but just in case, prevent a leak
+				dialog.Dispose();
 		}
 
 		protected virtual void OnMoreSheetDismissed(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

#7768 added additional disposal of Shell elements. However, the `BottomSheetDialog` created for the `More` menu was already being disposed, and after these changes, we were attempting to dispose it twice, causing an ObjectDispsoedException.

### Issues Resolved ### 

- fixes #8145

### API Changes ###

 
 None

### Platforms Affected ### 

- Android


### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test is provided.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
