### PR TITLE
Remove extra Profiler.FrameEnd()

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -10,6 +10,7 @@ using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using System.Linq;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.ControlGallery.Android
 {
@@ -32,6 +33,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 	{
 		protected override void OnCreate(Bundle bundle)
 		{
+			Profile.Start();
+
 			ToolbarResource = Resource.Layout.Toolbar;
 			TabLayoutResource = Resource.Layout.Tabbar;
 
@@ -90,7 +93,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 			}
 		}
 
-		
+		protected override void OnResume()
+		{
+			base.OnResume();
+			Profile.Stop();
+		}
+
 		[Export("IsPreAppCompat")]
 		public bool IsPreAppCompat()
 		{

--- a/Xamarin.Forms.Core/Profiler.cs
+++ b/Xamarin.Forms.Core/Profiler.cs
@@ -52,21 +52,21 @@ namespace Xamarin.Forms.Internals
 
 		public static void FrameBegin(
 			[CallerMemberName] string name = "",
-			string id = null,
 			[CallerLineNumber] int line = 0)
 		{
 			if (!Running)
 				return;
 
-			FrameBeginBody(name, id, line);
+			FrameBeginBody(name, null, line);
 		}
 
-		public static void FrameEnd()
+		public static void FrameEnd(
+			[CallerMemberName] string name = "")
 		{
 			if (!Running)
 				return;
 
-			FrameEndBody();
+			FrameEndBody(name);
 		}
 
 		public static void FramePartition(
@@ -90,9 +90,12 @@ namespace Xamarin.Forms.Internals
 			Stack.Push(new Profile(name, id, line));
 		}
 
-		static void FrameEndBody()
+		static void FrameEndBody(string name)
 		{
 			var profile = Stack.Pop();
+			if (profile._name != name)
+				throw new InvalidOperationException(
+					$"Expected to end frame '{profile._name}', not '{name}'.");
 			profile.Dispose();
 		}
 
@@ -104,7 +107,7 @@ namespace Xamarin.Forms.Internals
 			var name = profile._name;
 			profile.Dispose();
 
-			FrameBegin(name, id, line);
+			FrameBeginBody(name, id, line);
 		}
 
 		Profile(

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -331,7 +331,8 @@ namespace Xamarin.Forms.Internals
 			Profile.FramePartition("Reflect");
 			foreach (Assembly assembly in assemblies)
 			{
-				Profile.FrameBegin(assembly.GetName().Name);
+				var assemblyName = assembly.GetName().Name;
+				Profile.FrameBegin(assemblyName);
 
 				foreach (Type attrType in attrTypes)
 				{
@@ -370,7 +371,7 @@ namespace Xamarin.Forms.Internals
 				Array.Copy(effectAttributes, typedEffectAttributes, effectAttributes.Length);
 				RegisterEffects(resolutionName, typedEffectAttributes);
 
-				Profile.FrameEnd();
+				Profile.FrameEnd(assemblyName);
 			}
 
 			if ((flags & InitializationFlags.DisableCss) == 0)

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms
 
 			Profile.FrameBegin("Assembly.GetCallingAssembly");
 			resourceAssembly = Assembly.GetCallingAssembly();
-			Profile.FrameEnd();
+			Profile.FrameEnd("Assembly.GetCallingAssembly");
 
 			Profile.FrameBegin();
 			SetupInit(activity, resourceAssembly, null);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -122,8 +122,6 @@ namespace Xamarin.Forms.Platform.Android
 			Profile.FramePartition("UpdateFlyoutBackground");
 			UpdateFlyoutBackground();
 
-			Profile.FrameEnd();
-
 			Profile.FramePartition(nameof(UpdateVerticalScrollMode));
 			UpdateVerticalScrollMode();
 			Profile.FrameEnd();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
@@ -353,7 +353,7 @@ namespace Xamarin.Forms.Platform.Android
 				decorView.SetBackground(split);
 			}
 
-			Profile.FrameEnd();
+			Profile.FrameEnd("UpdtStatBarClr");
 		}
 
 		class SplitDrawable : Drawable


### PR DESCRIPTION
### Description of Change ###

The profiler depends on `Profiler.FrameBegin()` being paired with a single `Profiler.FrameEnd()`. This change removes an extra `Profiler.FrameEnd()`. The change also enables the profiler for the gallery which should prevent regressions. 

### API Changes ###

 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Testing Procedure ###
Every android gallery startup tests that the profiler calls are properly paired. 

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
