### PR TITLE
Fix issue 6878 | [Bug] ShellItem.Items.Clear() crashes when the ShellItem has bottom tabs

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
+using System.ComponentModel;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6878,
+		"ShellItem.Items.Clear() crashes when the ShellItem has bottom tabs", PlatformAffected.All)]
+
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue6878 : TestShell
+	{
+		const string ExceptionMessage = "😢 oh no! An exception as throw...";
+		const string ClearShellItems = "ClearShellItems";
+		const string StatusLabel = "StatusLabel";
+
+		StackLayout _stackContent;
+
+		protected override void Init()
+		{
+			_stackContent = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = StatusLabel,
+						Text = "Everything is fine 😎"
+					}
+				}
+			};
+
+			_stackContent.Children.Add(BuildClearButton());
+			CreateContentPage().Content = _stackContent;
+
+			CurrentItem = Items.Last();
+
+			AddBottomTab("bottom 1");
+			AddBottomTab("bottom 2");
+			Shell.SetBackgroundColor(this, Color.BlueViolet);
+		}
+
+		Button BuildClearButton()
+		{
+			return new Button()
+			{
+				Text = "Click to clear ShellItem.Items",
+				Command = new Command(() =>
+				{
+					try
+					{
+						Items.Last().Items.Clear();
+					}
+					catch (NotSupportedException)
+					{
+						Items.Clear();
+						CreateContentPage().Content = _stackContent;
+						((Label)_stackContent.Children[0]).Text = ExceptionMessage;
+						CurrentItem = Items.Last();
+					}
+				}),
+				AutomationId = ClearShellItems
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void ShellItemItemsClearTests()
+		{
+			RunningApp.WaitForElement(StatusLabel);
+			RunningApp.Tap(ClearShellItems);
+
+			var label = RunningApp.WaitForElement(StatusLabel)[0];
+			Assert.AreEqual(label.Text, ExceptionMessage);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
@@ -28,9 +28,11 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class Issue6878 : TestShell
 	{
-		const string ExceptionMessage = "😢 oh no! An exception as throw...";
 		const string ClearShellItems = "ClearShellItems";
 		const string StatusLabel = "StatusLabel";
+		const string StatusLabelText = "Everything is fine 😎";
+		const string TopTab = "Top Tab";
+		const string PostClearTopTab = "Post clear Top Tab";
 
 		StackLayout _stackContent;
 
@@ -43,18 +45,18 @@ namespace Xamarin.Forms.Controls.Issues
 					new Label()
 					{
 						AutomationId = StatusLabel,
-						Text = "Everything is fine 😎"
+						Text = StatusLabelText
 					}
 				}
 			};
 
 			_stackContent.Children.Add(BuildClearButton());
-			CreateContentPage().Content = _stackContent;
+			AddTopTab(TopTab).Content = _stackContent;
 
 			CurrentItem = Items.Last();
 
-			AddBottomTab("bottom 1");
-			AddBottomTab("bottom 2");
+			AddTopTab(TopTab);
+			AddBottomTab("Bottom tab");
 			Shell.SetBackgroundColor(this, Color.BlueViolet);
 		}
 
@@ -65,17 +67,12 @@ namespace Xamarin.Forms.Controls.Issues
 				Text = "Click to clear ShellItem.Items",
 				Command = new Command(() =>
 				{
-					try
-					{
-						Items.Last().Items.Clear();
-					}
-					catch (NotSupportedException)
-					{
-						Items.Clear();
-						CreateContentPage().Content = _stackContent;
-						((Label)_stackContent.Children[0]).Text = ExceptionMessage;
-						CurrentItem = Items.Last();
-					}
+					Items[0].Items.Clear();
+					Items.Clear();
+					AddTopTab(TopTab).Content = _stackContent;
+					CurrentItem = Items.Last();
+
+					AddTopTab(PostClearTopTab);
 				}),
 				AutomationId = ClearShellItems
 			};
@@ -89,7 +86,8 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(ClearShellItems);
 
 			var label = RunningApp.WaitForElement(StatusLabel)[0];
-			Assert.AreEqual(label.Text, ExceptionMessage);
+			Assert.AreEqual(label.Text, StatusLabelText);
+			RunningApp.Tap(PostClearTopTab);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -38,6 +38,7 @@
       <DependentUpon>Issue7048.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)Issue6878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7581.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7361.cs" />

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -226,10 +226,6 @@ namespace Xamarin.Forms
 
 		void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if ((e.Action == NotifyCollectionChangedAction.Reset ||
-				e.Action == NotifyCollectionChangedAction.Remove) && Items.Count == 0)
-				throw new NotSupportedException("the ShellItem.Items must have at least one item.");
-
 			if (e.NewItems != null)
 			{
 				foreach (Element element in e.NewItems)

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -226,6 +226,10 @@ namespace Xamarin.Forms
 
 		void ItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if ((e.Action == NotifyCollectionChangedAction.Reset ||
+				e.Action == NotifyCollectionChangedAction.Remove) && Items.Count == 0)
+				throw new NotSupportedException("the ShellItem.Items must have at least one item.");
+
 			if (e.NewItems != null)
 			{
 				foreach (Element element in e.NewItems)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
@@ -87,6 +87,9 @@ namespace Xamarin.Forms.Platform.Android
 				index = Math.Min(index, menu.Size() - 1);
 
 				var child = menuView.GetChildAt(index);
+				if (child == null)
+					return;
+
 				var touchPoint = new Point(child.Left + (child.Right - child.Left) / 2, child.Top + (child.Bottom - child.Top) / 2);
 
 				bottomView.SetBackground(new ColorChangeRevealDrawable(lastColor, newColor, touchPoint));


### PR DESCRIPTION
### Description of Change ###

I followed another PR (#8079) feedback and create a null check to avoid NullException for `ShellBottomNavViewAppearanceTracker.SetBackgroundColor`

### Issues Resolved ### 

- fixes #6878 

### API Changes ###
Changed:
 - void ShellBottomNavViewAppearanceTracker.SetBackgroundColor
	- added this validation:

```C#
	var child = menuView.GetChildAt(index);

	if (child == null)
		return;
```
 
### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
1. Create a ShellItem in that contains tabs and set background-color
2. In code, call Items.Clear() on your ShellItem.
3. No exceptions at this point

- Or just run 6878 issue at Control Galery:

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67534473-a97b2480-f6a4-11e9-99db-889cb99abb8f.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
