### PR TITLE
[Bug] WPF ListViewRenderer fails on item tapped with empty item source #7995

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ListPage.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ListPage.cs
@@ -15,9 +15,15 @@ namespace Xamarin.Forms.Controls
 		public ListPage ()
 		{
 			_listScreen = new ListScreen ();
+			var clearItemsButton = new Button { Text = "Clear items" };
+			clearItemsButton.Clicked += delegate
+			{
+				_listScreen.View.ItemsSource = new List<int>();
+			};
 			Content = new StackLayout {
 				Children = {
 					new Label {Text = "Foo"},
+					clearItemsButton,
 					_listScreen.View
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/ListPage.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ListPage.cs
@@ -20,10 +20,16 @@ namespace Xamarin.Forms.Controls
 			{
 				_listScreen.View.ItemsSource = new List<int>();
 			};
+            var resetItemsSourceButton = new Button { Text = "Set ItemsSource = null" };
+			resetItemsSourceButton.Clicked += delegate
+			{
+				_listScreen.View.ItemsSource = null;
+			};
 			Content = new StackLayout {
 				Children = {
 					new Label {Text = "Foo"},
 					clearItemsButton,
+					resetItemsSourceButton,
 					_listScreen.View
 				}
 			};

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -448,7 +448,14 @@ namespace Xamarin.Forms
 
 			cell?.OnTapped();
 
-			ItemTapped?.Invoke(this, new ItemTappedEventArgs(ItemsSource.Cast<object>().ElementAt(groupIndex), cell?.BindingContext, TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
+			var itemSource = ItemsSource.Cast<object>().ToList();
+			object tappedGroup = null;
+			if (itemSource.Count > groupIndex)
+			{
+				tappedGroup = itemSource.ElementAt(groupIndex);
+			}
+
+			ItemTapped?.Invoke(this, new ItemTappedEventArgs(tappedGroup, cell?.BindingContext, TemplatedItems.GetGlobalIndexOfItem(cell?.BindingContext)));
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -448,9 +448,9 @@ namespace Xamarin.Forms
 
 			cell?.OnTapped();
 
-			var itemSource = ItemsSource.Cast<object>().ToList();
+			var itemSource = ItemsSource?.Cast<object>().ToList();
 			object tappedGroup = null;
-			if (itemSource.Count > groupIndex)
+			if (itemSource?.Count > groupIndex)
 			{
 				tappedGroup = itemSource.ElementAt(groupIndex);
 			}


### PR DESCRIPTION
[Bug] WPF ListViewRenderer fails on item tapped with empty item source #7995

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7995 

### API Changes ###

Changed:
 - ListView.NotifyRowTapped - check ItemsSource contains search index
 
### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP
- WPF
- GTK

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Execute ControlGallery WPF, open ListView Gallery - Legacy ->Press Clear items -> MouseClick on ListView

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
