### PR TITLE
[Android] Fixed issue refreshing CollectionView using ScrollView inside DataTemplate

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8198.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8198.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.RefreshView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8198, "ScrollView at CollectionView at RefreshView always leads to Pull-To-Refresh", PlatformAffected.Android)]
+	public class Issue8198 : TestContentPage
+	{
+		RefreshView _refreshView;
+		Command _refreshCommand;
+
+		public Issue8198()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 8198";
+
+			var layout = new Grid();
+
+			_refreshCommand = new Command(async (parameter) =>
+			{
+				if (!_refreshView.IsRefreshing)
+				{
+					throw new Exception("IsRefreshing should be true when command executes");
+				}
+
+				if (parameter != null && !(bool)parameter)
+				{
+					throw new Exception("Refresh command incorrectly firing with disabled parameter");
+				}
+
+				await Task.Delay(2000);
+				_refreshView.IsRefreshing = false;
+			});
+
+			_refreshView = new RefreshView
+			{
+				Command = _refreshCommand
+   			};
+
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = GetDataTemplate(),
+				ItemsSource = new string[]
+				{
+					"Item 1",
+					"Item 2",
+					"Item 3",
+					"Item 4",
+					"Item 5",
+					"item 6",
+					"Item 7",
+					"Item 8",
+					"Item 9",
+					"Item 10",
+	 				"Item 11",
+					"item 12",
+					"Item 13",
+					"Item 14",
+					"Item 15",
+					"Item 16",
+					"Item 17",
+					"Item 18",
+					"Item 19",
+					"Item 20"
+				}
+			};
+
+			_refreshView.Content = collectionView;
+			layout.Children.Add(_refreshView);
+
+			Content = layout;
+		}
+
+		DataTemplate GetDataTemplate()
+		{
+			var template = new DataTemplate(() =>
+			{
+				var scroll = new ScrollView();
+				var grid = new Grid();
+				grid.RowDefinitions.Add(new RowDefinition() { Height = 40 });
+
+				var cell = new Label();
+				cell.SetBinding(Label.TextProperty, ".");
+				cell.FontSize = 20;
+				cell.BackgroundColor = Color.LightBlue;
+				grid.Children.Add(cell, 0, 0);
+
+				scroll.Content = grid;
+				return scroll;
+				//return grid;
+   			});
+			return template;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8198.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8198.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				BackgroundColor = Color.Black,
 				TextColor = Color.White,
-				Text = " Scroll the CollectionView to end and try to scroll up again. If the Refresh Indicator does not appear until it reaches the top, the test has passed."
+				Text = "Scroll the CollectionView to end, lift finger off screen, and then try to scroll up again. If the Refresh Indicator does not appear until it reaches the top, the test has passed."
 			};
 
 			_refreshCommand = new Command(async (parameter) =>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1131,6 +1131,7 @@
       <DependentUpon>Issue7886.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8198.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCarouselViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCarouselViewGallery.xaml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries.RefreshCarouselViewGallery"  
+             Title="CarouselView (Pull To Refresh)">
+    <ContentPage.Content>
+        <RefreshView
+            IsRefreshing="{Binding IsRefreshing}"
+            RefreshColor="Pink"
+            Command="{Binding RefreshCommand}"
+            HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <CarouselView
+                ItemsSource="{Binding Items}">
+                <CarouselView.ItemsLayout>
+                    <LinearItemsLayout
+                        Orientation="Horizontal"
+                        SnapPointsAlignment="Center"
+                        SnapPointsType="MandatorySingle"/>
+                </CarouselView.ItemsLayout>
+                <CarouselView.ItemTemplate>
+                    <DataTemplate>
+                        <ScrollView>
+                            <Grid>
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="*" />
+                                    <RowDefinition Height="Auto" />
+                                </Grid.RowDefinitions>
+                                <BoxView
+                                    Grid.Column="0"
+                                    Color="{Binding Color}"/>
+                                <Label
+                                    Grid.Column="1"
+                                    Text="{Binding Name}"
+                                    VerticalOptions="Center"
+                                    HeightRequest="48"/>
+                            </Grid>
+                        </ScrollView>
+                    </DataTemplate>
+                </CarouselView.ItemTemplate>
+            </CarouselView>
+        </RefreshView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCarouselViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCarouselViewGallery.xaml
@@ -30,10 +30,10 @@
                                     <RowDefinition Height="Auto" />
                                 </Grid.RowDefinitions>
                                 <BoxView
-                                    Grid.Column="0"
+                                    Grid.Row="0"
                                     Color="{Binding Color}"/>
                                 <Label
-                                    Grid.Column="1"
+                                    Grid.Row="1"
                                     Text="{Binding Name}"
                                     VerticalOptions="Center"
                                     HeightRequest="48"/>

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCarouselViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCarouselViewGallery.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public partial class RefreshCarouselViewGallery : ContentPage
+	{
+		public RefreshCarouselViewGallery()
+		{
+			InitializeComponent();
+            BindingContext = new RefreshViewModel();
+        }
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCollectionViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCollectionViewGallery.xaml
@@ -15,19 +15,21 @@
                 ItemsSource="{Binding Items}">
                 <CollectionView.ItemTemplate>
                      <DataTemplate>
-                        <Grid>
-                            <Grid.ColumnDefinitions>
-                                <ColumnDefinition Width="48" />
-                                <ColumnDefinition Width="*" />
-                            </Grid.ColumnDefinitions>
-                            <BoxView
-                                Grid.Column="0"
-                                Color="{Binding Color}"
-                                HeightRequest="48"/>
-                            <Label
-                                Grid.Column="1"
-                                Text="{Binding Name}"/>
-                        </Grid>
+                         <ScrollView>
+                             <Grid>
+                                 <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="48" />
+                                    <ColumnDefinition Width="*" />
+                                 </Grid.ColumnDefinitions>
+                                 <BoxView
+                                    Grid.Column="0"
+                                    Color="{Binding Color}"
+                                    HeightRequest="48"/>
+                                 <Label
+                                    Grid.Column="1"
+                                    Text="{Binding Name}"/>
+                             </Grid>
+                        </ScrollView>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshListViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshListViewGallery.xaml
@@ -25,19 +25,21 @@
                     <ListView.ItemTemplate>
                         <DataTemplate>
                             <ViewCell>
-                                <Grid>
-                                    <Grid.ColumnDefinitions>
-                                        <ColumnDefinition Width="48" />
-                                        <ColumnDefinition Width="*" />
-                                    </Grid.ColumnDefinitions>
-                                    <BoxView
-                                        Grid.Column="0"
-                                        Color="{Binding Color}"
-                                        HeightRequest="48"/>
-                                    <Label
-                                        Grid.Column="1"
-                                        Text="{Binding Name}"/>
-                                </Grid>
+                                <ScrollView>
+                                    <Grid>
+                                        <Grid.ColumnDefinitions>
+                                            <ColumnDefinition Width="48" />
+                                            <ColumnDefinition Width="*" />
+                                        </Grid.ColumnDefinitions>
+                                        <BoxView
+                                            Grid.Column="0"
+                                            Color="{Binding Color}"
+                                            HeightRequest="48"/>
+                                        <Label
+                                            Grid.Column="1"
+                                            Text="{Binding Name}"/>
+                                    </Grid>
+                                </ScrollView>
                             </ViewCell>
                         </DataTemplate>
                     </ListView.ItemTemplate>

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
@@ -11,16 +11,38 @@ namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
 		public RefreshViewGallery()
 		{
 			Title = "RefreshView Gallery";
+
+			var button = new Button
+			{
+				Text = "Enable CarouselView",
+				AutomationId = "EnableCarouselView"
+			};
+			button.Clicked += ButtonClicked;
+
 			Content = new StackLayout
 			{
 				Children =
 				{
+					button,
 					GalleryBuilder.NavButton("Refresh Layout Gallery", () => new RefreshLayoutGallery(), Navigation),
 					GalleryBuilder.NavButton("Refresh ScrollView Gallery", () => new RefreshScrollViewGallery(), Navigation),
 					GalleryBuilder.NavButton("Refresh ListView Gallery", () => new RefreshListViewGallery(), Navigation),
-					GalleryBuilder.NavButton("Refresh CollectionView Gallery", () => new RefreshCollectionViewGallery(), Navigation)
+					GalleryBuilder.NavButton("Refresh CollectionView Gallery", () => new RefreshCollectionViewGallery(), Navigation),
+					GalleryBuilder.NavButton("Refresh CarouselView Gallery", () => new RefreshCarouselViewGallery(), Navigation),
+					GalleryBuilder.NavButton("Refresh WebView Gallery", () => new RefreshWebViewGallery(), Navigation)
 				}
 			};
+		}
+
+		void ButtonClicked(object sender, System.EventArgs e)
+		{
+			var button = sender as Button;
+
+			button.Text = "CarouselView Enabled!";
+			button.TextColor = Color.Black;
+			button.IsEnabled = false;
+
+			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental });
 		}
 	}
 

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml
@@ -4,7 +4,8 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             x:Class="Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries.RefreshWebViewGallery">
+             x:Class="Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries.RefreshWebViewGallery"
+             Title="WebView (Pull To Refresh)">
     <ContentPage.Content>
         <RefreshView
             IsRefreshing="{Binding IsRefreshing}"

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries.RefreshWebViewGallery">
+    <ContentPage.Content>
+        <RefreshView
+            IsRefreshing="{Binding IsRefreshing}"
+            Command="{Binding RefreshCommand}"
+            HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <WebView
+                Source="{Binding Url}"/>
+        </RefreshView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Input;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public partial class RefreshWebViewGallery : ContentPage
+	{
+		public RefreshWebViewGallery()
+		{
+			InitializeComponent();
+			BindingContext = new RefreshWebViewGalleryViewModel();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class RefreshWebViewGalleryViewModel : BindableObject
+	{
+		const int RefreshDuration = 2;
+
+		readonly Random _random;
+		bool _isRefresing;
+		string _url;
+
+		public RefreshWebViewGalleryViewModel()
+		{
+			_random = new Random();
+			LoadUrl();
+		}
+
+		public bool IsRefreshing
+		{
+			get { return _isRefresing; }
+			set
+			{
+				_isRefresing = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public string Url
+		{
+			get { return _url; }
+			set
+			{
+				_url = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ICommand RefreshCommand => new Command(ExecuteRefresh);
+
+		void LoadUrl()
+		{
+			var urls = new List<string> { "https://microsoft.com", "https://dotnet.microsoft.com/apps/xamarin", "https://devblogs.microsoft.com/xamarin/" };
+			int index = _random.Next(urls.Count);
+			Url = urls[index];
+		}
+
+		void ExecuteRefresh()
+		{
+			IsRefreshing = true;
+
+			Device.StartTimer(TimeSpan.FromSeconds(RefreshDuration), () =>
+			{
+				LoadUrl();
+
+				IsRefreshing = false;
+
+				return false;
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshWebViewGallery.xaml.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
 
 		void LoadUrl()
 		{
-			var urls = new List<string> { "https://microsoft.com", "https://dotnet.microsoft.com/apps/xamarin", "https://devblogs.microsoft.com/xamarin/" };
+			var urls = new List<string> { "https://dotnet.microsoft.com/apps/xamarin", "https://devblogs.microsoft.com/xamarin/" };
 			int index = _random.Next(urls.Count);
 			Url = urls[index];
 		}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -86,6 +86,12 @@
     <EmbeddedResource Update="GalleryPages\MapWithItemsSourceGallery.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\RefreshViewGalleries\RefreshCarouselViewGallery.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\RefreshViewGalleries\RefreshWebViewGallery.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\TitleView.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -170,13 +170,13 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			if(view is RecyclerView recyclerView)
-				return recyclerView.ScrollY < 0;
+				return recyclerView.ComputeVerticalScrollOffset() > 0;
 
 			if (view is global::Android.Widget.ScrollView scrollview)
 				return scrollview.ScrollY < 0;
 
 			if (view is NestedScrollView nestedScrollView)
-				return nestedScrollView.ScrollY < 0;
+				return nestedScrollView.ComputeVerticalScrollOffset() > 0;
 
 			return true;
 		}


### PR DESCRIPTION
### Description of Change ###

Fixed issue refreshing CollectionView using ScrollView inside DataTemplate. Changed the validation to raise the refresh (the ScrollY is zero).

_NOTE: I have also added new samples related to RefreshView in CoreGallery. Tested the new samples and the same issue on iOS and is working fine._

### Issues Resolved ### 

- fixes #8198

### API Changes ###
 
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue8198-before](https://user-images.githubusercontent.com/6755973/67568186-d292c800-f72b-11e9-8ef8-5ceb54c0dfae.gif)

#### After
![issue8198-after](https://user-images.githubusercontent.com/6755973/67568187-d45c8b80-f72b-11e9-8d52-5ed86844562a.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 8198. Scroll the CollectionView to end and try to scroll up again. If the Refresh Indicator does not appear until it reaches the top, the test has passed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
