### PR TITLE
[X] resolve indexers on generic types

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetPropertiesVisitor.cs
@@ -500,15 +500,15 @@ namespace Xamarin.Forms.Build.Tasks
 					if (int.TryParse(indexArg, out _))
 						indexer = previousPartTypeRef.GetProperty(pd => pd.Name == indexerName
 																	 && pd.GetMethod != null
-																	 && TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType, module.ImportReference(("mscorlib", "System", "Int32")))
+																	 && TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(previousPartTypeRef), module.ImportReference(("mscorlib", "System", "Int32")))
 																	 && pd.GetMethod.IsPublic, out indexerDeclTypeRef);
 					indexer = indexer ?? previousPartTypeRef.GetProperty(pd => pd.Name == indexerName
 																			&& pd.GetMethod != null
-																			&& TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType, module.ImportReference(("mscorlib", "System", "String")))
+																			&& TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(previousPartTypeRef), module.ImportReference(("mscorlib", "System", "String")))
 																			&& pd.GetMethod.IsPublic, out indexerDeclTypeRef);
 					indexer = indexer ?? previousPartTypeRef.GetProperty(pd => pd.Name == indexerName
 																			&& pd.GetMethod != null
-																			&& TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType, module.ImportReference(("mscorlib", "System", "String")))
+																			&& TypeRefComparer.Default.Equals(pd.GetMethod.Parameters[0].ParameterType.ResolveGenericParameters(previousPartTypeRef), module.ImportReference(("mscorlib", "System", "Object")))
 																			&& pd.GetMethod.IsPublic, out indexerDeclTypeRef);
 
 					properties.Add((indexer, indexerDeclTypeRef, indexArg));

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh8221.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh8221.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh8221"
+        x:DataType="local:Gh8221VM">
+    <StackLayout>
+        <Label Text="{Binding Data[EntryOne]}" x:Name="entryone"/>
+        <Label Text="{Binding Data[EntryTwo]}" x:Name="entrytwo"/>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh8221.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh8221.xaml.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public class Gh8221VM
+	{
+		public Dictionary<string, string> Data { get; set; } = new Dictionary<string, string> { { "EntryOne", "One" }, { "EntryTwo", "Two" } };
+	}
+
+	public partial class Gh8221 : ContentPage
+	{
+		public Gh8221() => InitializeComponent();
+		public Gh8221(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void BindingWithMultipleIndexers([Values(false, true)]bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					MockCompiler.Compile(typeof(Gh8221));
+				var layout = new Gh8221(useCompiledXaml) { BindingContext = new Gh8221VM() };
+				Assert.That(layout.entryone.Text, Is.EqualTo("One"));
+				Assert.That(layout.entrytwo.Text, Is.EqualTo("Two"));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

The lovely #7837 is trying to be smarter at identifying which indexer to invoke,
by checking the parametertype. Of course, it wasn't tested on generic types...

So this is definitely a regression, I apologize for it.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8221

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
