### PR TITLE
Ordering children while adding

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8129.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8129.cs
@@ -1,0 +1,176 @@
+﻿using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.RefreshView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8129, "[Bug] Adding children to iOS VisualElementPackager has O(N^2) performance and thrashes the native layer", PlatformAffected.iOS)]
+	public class Issue8129 : TestContentPage
+	{
+		RefreshView _refreshView;
+		Command _refreshCommand;
+
+		public Issue8129()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Refresh View with too many elements (2000) Tests";
+			var scrollViewContent = new StackLayout();
+
+			Enumerable
+				.Range(0, 2000)
+				.Select(_ => new Label() { HeightRequest = 200, Text = $"Pull me down to refresh me - {_}" })
+				.ForEach(x => scrollViewContent.Children.Add(x));
+
+
+			bool canExecute = true;
+			_refreshCommand = new Command(async (parameter) =>
+			{
+				if (!_refreshView.IsRefreshing)
+				{
+					throw new Exception("IsRefreshing should be true when command executes");
+				}
+
+				if (parameter != null && !(bool)parameter)
+				{
+					throw new Exception("Refresh command incorrectly firing with disabled parameter");
+				}
+
+				await Task.Delay(2000);
+				_refreshView.IsRefreshing = false;
+			}, (object parameter) =>
+			{
+				return parameter != null && canExecute && (bool)parameter;
+			});
+
+			_refreshView = new RefreshView()
+			{
+				Content = new ScrollView()
+				{
+					HeightRequest = 2000,
+					BackgroundColor = Color.Green,
+					Content = scrollViewContent,
+					AutomationId = "LayoutContainer"
+				},
+				Command = _refreshCommand,
+				CommandParameter = true
+			};
+
+			var isRefreshingLabel = new Label();
+
+			var label = new Label { BindingContext = _refreshView };
+			isRefreshingLabel.SetBinding(Label.TextProperty, new Binding("IsRefreshing", stringFormat: "IsRefreshing: {0}", source: _refreshView));
+
+			var commandEnabledLabel = new Label { BindingContext = _refreshView };
+			commandEnabledLabel.SetBinding(Label.TextProperty, new Binding("IsEnabled", stringFormat: "IsEnabled: {0}", source: _refreshView));
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					isRefreshingLabel,
+					commandEnabledLabel,
+					new Button()
+					{
+						Text = "Toggle Refresh",
+						Command = new Command(() =>
+						{
+							_refreshView.IsRefreshing = !_refreshView.IsRefreshing;
+						})
+					},
+					new Button()
+					{
+						Text = "Toggle Can Execute",
+						Command = new Command(() =>
+						{
+							canExecute = !canExecute;
+							_refreshCommand.ChangeCanExecute();
+						}),
+						AutomationId = "ToggleCanExecute"
+					},
+					new Button()
+					{
+						Text = "Toggle Can Execute Parameter",
+						Command = new Command(() =>
+						{
+							_refreshView.CommandParameter = !((bool)_refreshView.CommandParameter);
+							_refreshCommand.ChangeCanExecute();
+						}),
+						AutomationId = "ToggleCanExecuteParameter"
+					},
+					new Button()
+					{
+						Text = "Toggle Command Being Set",
+						Command = new Command(() =>
+						{
+							if(_refreshView.Command != null)
+								_refreshView.Command = null;
+							else
+								_refreshView.Command = _refreshCommand;
+						}),
+						AutomationId = "ToggleCommandBeingSet"
+					},
+					_refreshView
+				}
+			};
+		}
+#if UITEST
+		[Test]
+		public void IsRefreshingAndCommandTest()
+		{
+			RunningApp.Tap(q => q.Button("Toggle Refresh"));
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: True"));
+			RunningApp.Screenshot("Refreshing");
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
+			RunningApp.Screenshot("Refreshed");
+		}
+
+		[Test]
+		public void IsRefreshingAndCommandTest_SwipeDown()
+		{
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
+
+			TriggerRefresh();
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: True"));
+			RunningApp.Screenshot("Refreshing");
+			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
+			RunningApp.Screenshot("Refreshed");
+		}
+
+		[Test]
+		public void RefreshDisablesWithCommand()
+		{
+			RunningApp.WaitForElement("IsRefreshing: False");
+			RunningApp.Tap("ToggleCanExecute");
+			RunningApp.WaitForElement("IsEnabled: False");
+			TriggerRefresh();
+
+			var results = RunningApp.Query("IsRefreshing: True");
+			Assert.AreEqual(0, results.Length);
+			results = RunningApp.Query("IsRefreshing: True");
+			Assert.AreEqual(0, results.Length);
+		}
+
+		void TriggerRefresh()
+		{
+			var container = RunningApp.WaitForElement("LayoutContainer")[0];
+			RunningApp.Pan(new Drag(container.Rect, Drag.Direction.TopToBottom, Drag.DragLength.Medium));
+
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8129.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8129.cs
@@ -12,17 +12,10 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-#if UITEST
-	[Category(UITestCategories.RefreshView)]
-#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 8129, "[Bug] Adding children to iOS VisualElementPackager has O(N^2) performance and thrashes the native layer", PlatformAffected.iOS)]
 	public class Issue8129 : TestContentPage
 	{
-		public Issue8129()
-		{
-		}
-
 		protected override void Init()
 		{
 			Title = "Page with too many elements (2000) Tests";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1749,6 +1749,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13616.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13670.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8129.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -46,7 +46,23 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				var child = ElementController.LogicalChildren[i] as VisualElement;
 				if (child != null)
+				{
 					OnChildAdded(child);
+
+					if (!CompressedLayout.GetIsHeadless(child))
+					{
+						var childRenderer = Platform.GetRenderer(child);
+
+						if (childRenderer == null)
+							continue;
+
+						var nativeControl = childRenderer.NativeView;
+#if __MOBILE__
+						Renderer.NativeView.BringSubviewToFront(nativeControl);
+#endif
+						nativeControl.Layer.ZPosition = i * 1000;
+					}
+				}
 			}
 		}
 		
@@ -120,8 +136,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				if (Renderer.ViewController != null && viewRenderer.ViewController != null)
 					Renderer.ViewController.AddChildViewController(viewRenderer.ViewController);
-
-				EnsureChildrenOrder();
 			}
 
 			Performance.Stop(reference);

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -143,12 +143,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			viewRenderer.Dispose();
 		}
 
-		void EnsureChildrenOrder()
+		void EnsureChildrenOrder(VisualElement element = null)
 		{
 			if (ElementController.LogicalChildren.Count == 0)
 				return;
 
-			for (var z = 0; z < ElementController.LogicalChildren.Count; z++)
+			var effectedChildIndex = 0;
+			if (element != null)
+				effectedChildIndex = ElementController.LogicalChildren.IndexOf(element);
+
+			for (var z = effectedChildIndex; z < ElementController.LogicalChildren.Count; z++)
 			{
 				var child = ElementController.LogicalChildren[z] as VisualElement;
 				if (child == null)
@@ -182,7 +186,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (view != null)
 			{
 				OnChildAdded(view);
-				OrderElement(view, ElementController.LogicalChildren.IndexOf(view));
+				EnsureChildrenOrder(view);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -170,7 +170,11 @@ namespace Xamarin.Forms.Platform.MacOS
 			var childRenderer = Platform.GetRenderer(element);
 
 			if (childRenderer == null)
+			{
+				Performance.Stop(reference);
+
 				return;
+			}
 
 			var nativeControl = childRenderer.NativeView;
 #if __MOBILE__

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -165,7 +165,11 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			Performance.Start(out string reference);
 			if (CompressedLayout.GetIsHeadless(element))
+			{
+				Performance.Stop(reference);
+
 				return;
+			}
 
 			var childRenderer = Platform.GetRenderer(element);
 

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using Xamarin.Forms.Internals;
 
 #if __MOBILE__
@@ -158,6 +159,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void OrderElement(VisualElement element, int order)
 		{
+			Performance.Start(out string reference);
 			if (CompressedLayout.GetIsHeadless(element))
 				return;
 
@@ -171,13 +173,17 @@ namespace Xamarin.Forms.Platform.MacOS
 			Renderer.NativeView.BringSubviewToFront(nativeControl);
 #endif
 			nativeControl.Layer.ZPosition = order * 1000;
+			Performance.Stop(reference);
 		}
 
 		void OnChildAdded(object sender, ElementEventArgs e)
 		{
 			var view = e.Element as VisualElement;
 			if (view != null)
+			{
 				OnChildAdded(view);
+				OrderElement(view, ElementController.LogicalChildren.IndexOf(view));
+			}
 		}
 
 		void OnChildRemoved(object sender, ElementEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -48,20 +48,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (child != null)
 				{
 					OnChildAdded(child);
-
-					if (!CompressedLayout.GetIsHeadless(child))
-					{
-						var childRenderer = Platform.GetRenderer(child);
-
-						if (childRenderer == null)
-							continue;
-
-						var nativeControl = childRenderer.NativeView;
-#if __MOBILE__
-						Renderer.NativeView.BringSubviewToFront(nativeControl);
-#endif
-						nativeControl.Layer.ZPosition = i * 1000;
-					}
+					OrderElement(child, i);
 				}
 			}
 		}
@@ -165,17 +152,25 @@ namespace Xamarin.Forms.Platform.MacOS
 				var child = ElementController.LogicalChildren[z] as VisualElement;
 				if (child == null)
 					continue;
-				var childRenderer = Platform.GetRenderer(child);
-
-				if (childRenderer == null)
-					continue;
-
-				var nativeControl = childRenderer.NativeView;
-#if __MOBILE__
-				Renderer.NativeView.BringSubviewToFront(nativeControl);
-#endif
-				nativeControl.Layer.ZPosition = z * 1000;
+				OrderElement(child, z);
 			}
+		}
+
+		void OrderElement(VisualElement element, int order)
+		{
+			if (CompressedLayout.GetIsHeadless(element))
+				return;
+
+			var childRenderer = Platform.GetRenderer(element);
+
+			if (childRenderer == null)
+				return;
+
+			var nativeControl = childRenderer.NativeView;
+#if __MOBILE__
+			Renderer.NativeView.BringSubviewToFront(nativeControl);
+#endif
+			nativeControl.Layer.ZPosition = order * 1000;
 		}
 
 		void OnChildAdded(object sender, ElementEventArgs e)


### PR DESCRIPTION
### Description of Change ###
Orders (Z ordering) the child soon after adding it to the view, reducing the complexity from N^2 to N
### Issues Resolved ###
- fixes #8129 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Followed the same repro that was reported in the bug.
Added 2000 elements to a Stack View
Test Cases -> G8129
Should not lock the UI considerably.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
