### PR TITLE
[iOS] Fix scroll to does not scroll to end

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2271.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2271.cs
@@ -1,0 +1,102 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2271, "ScrollToAsync not working on iOS", PlatformAffected.iOS)]
+	public class Issue2271 : TestNavigationPage
+	{
+		public class LandingPage : ContentPage
+		{ 
+			StackLayout layout;
+			Button addAtEndAndScrollToEnd, addAtStartAndScrollToStart, scrollToStart, scrollToEnd;
+			ScrollView scrollView;
+
+			public LandingPage()
+			{
+				layout = new StackLayout();
+				for (var i = 0; i < 100; i++)
+				{
+					layout.Children.Add(new Label { Text = $"This is a button {layout.Children.Count}" });
+				}
+
+				addAtEndAndScrollToEnd = new Button { Text = "Add Item and scroll to bottom" };
+				addAtStartAndScrollToStart = new Button { Text = "Add item at beginning and move to beginning" };
+				scrollToStart = new Button { Text = "Scroll to first" };
+				scrollToEnd = new Button { Text = "Scroll to last" };
+				scrollView = new ScrollView { Content = layout };
+
+				Content = new StackLayout
+				{
+					Children =
+					{
+						scrollView,
+						addAtEndAndScrollToEnd,
+						addAtStartAndScrollToStart,
+						scrollToStart,
+						scrollToEnd
+					}
+				};
+
+				addAtEndAndScrollToEnd.Clicked += AddItem_Clicked;
+				addAtStartAndScrollToStart.Clicked += AddItemAtBegging_Clicked;
+				scrollToEnd.Clicked += ScrollToEnd_Clicked;
+				scrollToStart.Clicked += ScrollToStart_Clicked;
+			}
+
+			private async void ScrollToStart_Clicked(object sender, EventArgs e)
+			{
+				await scrollView.ScrollToAsync(layout.Children.First(), ScrollToPosition.Start, false);
+			}
+
+			private async void ScrollToEnd_Clicked(object sender, EventArgs e)
+			{
+				await scrollView.ScrollToAsync(layout.Children.Last(), ScrollToPosition.End, false);
+			}
+
+			private async void AddItem_Clicked(object sender, EventArgs e)
+			{
+				Label lastButton = null;
+				for (int i = 0; i < 10; ++i)
+				{
+					lastButton = new Label
+					{
+						Text = $"Insert nr {layout.Children.Count}"
+					};
+					layout.Children.Add(lastButton);
+				}
+
+				await scrollView.ScrollToAsync(lastButton, ScrollToPosition.End, false);
+			}
+
+			private async void AddItemAtBegging_Clicked(object sender, EventArgs e)
+			{
+				Label lastButton = null;
+				for (int i = 0; i < 10; ++i)
+				{
+					lastButton = new Label
+					{
+						Text = $"Insert nr {layout.Children.Count}"
+					};
+					layout.Children.Insert(0, lastButton);
+				} 
+
+				await scrollView.ScrollToAsync(lastButton, ScrollToPosition.Start, false);
+			}
+		}
+
+		protected override void Init()
+		{
+			var page = new LandingPage();
+			Navigation.PushAsync(page);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2271.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2271.cs
@@ -52,17 +52,17 @@ namespace Xamarin.Forms.Controls.Issues
 				scrollToStart.Clicked += ScrollToStart_Clicked;
 			}
 
-			private async void ScrollToStart_Clicked(object sender, EventArgs e)
+			async void ScrollToStart_Clicked(object sender, EventArgs e)
 			{
 				await scrollView.ScrollToAsync(layout.Children.First(), ScrollToPosition.Start, false);
 			}
 
-			private async void ScrollToEnd_Clicked(object sender, EventArgs e)
+			async void ScrollToEnd_Clicked(object sender, EventArgs e)
 			{
 				await scrollView.ScrollToAsync(layout.Children.Last(), ScrollToPosition.End, false);
 			}
 
-			private async void AddItem_Clicked(object sender, EventArgs e)
+			async void AddItem_Clicked(object sender, EventArgs e)
 			{
 				Label lastButton = null;
 				for (int i = 0; i < 10; ++i)
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Controls.Issues
 				await scrollView.ScrollToAsync(lastButton, ScrollToPosition.End, false);
 			}
 
-			private async void AddItemAtBegging_Clicked(object sender, EventArgs e)
+			async void AddItemAtBegging_Clicked(object sender, EventArgs e)
 			{
 				Label lastButton = null;
 				for (int i = 0; i < 10; ++i)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7825.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2271.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -267,9 +267,8 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				var positionOnScroll = ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
-
-				positionOnScroll.X = positionOnScroll.X.Clamp(0, ContentSize.Width - Bounds.Size.Width);
-				positionOnScroll.Y = positionOnScroll.Y.Clamp(0, ContentSize.Height - Bounds.Size.Height);
+				positionOnScroll.X = positionOnScroll.X.Clamp(0, ContentSize.Width);
+				positionOnScroll.Y = positionOnScroll.Y.Clamp(0, ContentSize.Height);
 
 				switch (ScrollView.Orientation)
 				{


### PR DESCRIPTION
### Description of Change ###

ScrollView.ScrollToAsync now correctly scrolls to the end on iOS.

### Issues Resolved ### 

- fixes #2271

### API Changes ###

 None

### Platforms Affected ### 

- iOS 

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added issue 2271 to control gallery

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
