### PR TITLE
With Shell ensure that ParentSet fires before OnAppearing

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
@@ -79,6 +79,56 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 
+		[TestCase(true)]
+		[TestCase(false)]
+		public void EnsureOnAppearingFiresAfterParentIsSet(bool templated)
+		{
+			Shell shell = new Shell();
+
+			ContentPage page = new ContentPage();
+
+			bool parentSet = false;
+			bool pageAppearing = false;
+			page.Appearing += (_, __) =>
+			{
+				if (page.Parent == null || !parentSet)
+					throw new Exception("Appearing firing before parent set is called");
+
+				pageAppearing = true;
+			};
+
+			page.ParentSet += (_, __) => parentSet = true;
+			shell.Items.Add(CreateShellItem(page, templated: templated));
+
+			var createdContent = (shell.Items[0].Items[0].Items[0] as IShellContentController).GetOrCreateContent();
+
+			Assert.IsTrue(pageAppearing);
+		}
+
+		[Test]
+		public async Task EnsureOnAppearingFiresForNavigatedToPage()
+		{
+			Routing.RegisterRoute("LifeCyclePage", typeof(LifeCyclePage));
+			Shell shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+			await shell.GoToAsync("LifeCyclePage");
+
+			var page = (LifeCyclePage)shell.GetVisiblePage();
+
+			Assert.IsTrue(page.Appearing);
+			Assert.IsTrue(page.ParentSet);
+		}
+
+		[Test]
+		public async Task EnsureOnAppearingFiresForPushedPage()
+		{
+			Shell shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+			shell.Navigation.PushAsync(new LifeCyclePage());
+			var page = (LifeCyclePage)shell.GetVisiblePage();
+			Assert.IsTrue(page.Appearing);
+			Assert.IsTrue(page.ParentSet);
+		}
 
 		[Test]
 		public async Task NavigatedFiresAfterContentIsCreatedWhenUsingTemplate()
@@ -327,7 +377,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 
 		[Test]
-		public async Task OnNavigatedOnlyFiresOnce()
+		public void OnNavigatedOnlyFiresOnce()
 		{
 			int navigated = 0;
 			Shell shell = new Shell();
@@ -374,6 +424,27 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.False(pageNotAppearingFired, "Incorrect Page Appearing Fired");
 		}
 
+		class LifeCyclePage : ContentPage
+		{
+			public bool Appearing;
+			public bool ParentSet;
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+
+				if (Parent == null)
+					throw new Exception("Parent is null");
+
+				Appearing = true;
+			}
+
+			protected override void OnParentSet()
+			{
+				base.OnParentSet();
+				ParentSet = true;
+			}
+		}
 
 		class ShellLifeCycleState
 		{

--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -50,11 +50,16 @@ namespace Xamarin.Forms.Core.UnitTests
 			}
 		}
 
-		protected ShellItem CreateShellItem(TemplatedPage page = null, bool asImplicit = false, string shellContentRoute = null, string shellSectionRoute = null, string shellItemRoute = null)
-		{
-			page = page ?? new ContentPage();
+		protected ShellItem CreateShellItem(
+			TemplatedPage page = null, 
+			bool asImplicit = false, 
+			string shellContentRoute = null, 
+			string shellSectionRoute = null, 
+			string shellItemRoute = null,
+			bool templated = false)
+		{			
 			ShellItem item = null;
-			var section = CreateShellSection(page, asImplicit, shellContentRoute, shellSectionRoute);
+			var section = CreateShellSection(page, asImplicit, shellContentRoute, shellSectionRoute, templated: templated);
 
 			if (!String.IsNullOrWhiteSpace(shellItemRoute))
 			{
@@ -73,9 +78,14 @@ namespace Xamarin.Forms.Core.UnitTests
 			return item;
 		}
 
-		protected ShellSection CreateShellSection(TemplatedPage page = null, bool asImplicit = false, string shellContentRoute = null, string shellSectionRoute = null)
+		protected ShellSection CreateShellSection(
+			TemplatedPage page = null, 
+			bool asImplicit = false, 
+			string shellContentRoute = null, 
+			string shellSectionRoute = null,
+			bool templated = false)
 		{
-			var content = CreateShellContent(page, asImplicit, shellContentRoute);
+			var content = CreateShellContent(page, asImplicit, shellContentRoute, templated: templated);
 
 			ShellSection section = null;
 
@@ -96,20 +106,28 @@ namespace Xamarin.Forms.Core.UnitTests
 			return section;
 		}
 
-		protected ShellContent CreateShellContent(TemplatedPage page = null, bool asImplicit = false, string shellContentRoute = null)
+		protected ShellContent CreateShellContent(TemplatedPage page = null, bool asImplicit = false, string shellContentRoute = null, bool templated = false)
 		{
-			page = page ?? new ContentPage();
 			ShellContent content = null;
 
-			if(!String.IsNullOrWhiteSpace(shellContentRoute))
+			if (!String.IsNullOrWhiteSpace(shellContentRoute))
 			{
-				content = new ShellContent() { Content = page };
+				if (templated)
+					content = new ShellContent() { ContentTemplate = new DataTemplate(() => page ?? new ContentPage()) };
+				else
+					content = new ShellContent() { Content = page ?? new ContentPage() };
+
 				content.Route = shellContentRoute;
 			}
 			else if (asImplicit)
 				content = (ShellContent)page;
 			else
-				content = new ShellContent() { Content = page };
+			{
+				if (templated)
+					content = new ShellContent() { ContentTemplate = new DataTemplate(() => page ?? new ContentPage()) };
+				else
+					content = new ShellContent() { Content = page ?? new ContentPage() };
+			}
 
 
 			return content;

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -103,7 +103,28 @@ namespace Xamarin.Forms
 				return;
 
 			base.SendAppearing();
-			((ContentCache ?? Content) as Page)?.SendAppearing();
+
+			SendPageAppearing((ContentCache ?? Content) as Page);
+		}
+
+		void SendPageAppearing(Page page)
+		{
+			if (page == null)
+				return;
+
+			if (page.Parent == null)
+			{
+				page.ParentSet += OnPresentedPageParentSet;
+				void OnPresentedPageParentSet(object sender, EventArgs e)
+				{
+					page.SendAppearing();
+					(sender as Page).ParentSet -= OnPresentedPageParentSet;
+				}
+			}
+			else
+			{
+				page.SendAppearing();
+			}
 		}
 
 		protected override void OnChildAdded(Element child)
@@ -112,7 +133,7 @@ namespace Xamarin.Forms
 			if (child is Page page && IsVisibleContent)
 			{
 				SendAppearing();
-				page.SendAppearing();
+				SendPageAppearing(page);
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -534,7 +534,24 @@ namespace Xamarin.Forms
 				if(_navStack.Count == 1)
 					CurrentItem?.SendAppearing();
 
-				sectionController.PresentedPage?.SendAppearing();
+				var presentedPage = sectionController.PresentedPage;
+				if (presentedPage != null)
+				{
+					if(presentedPage.Parent == null)
+					{
+						presentedPage.ParentSet += OnPresentedPageParentSet;
+
+						void OnPresentedPageParentSet(object sender, EventArgs e)
+						{
+							PresentedPageAppearing();
+							(sender as Page).ParentSet -= OnPresentedPageParentSet;
+						}
+					}
+					else
+					{
+						presentedPage.SendAppearing();
+					}
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
Certain execution paths would cause OnAppearing to fire before ParentSet. 

This makes adding behavior to OnAppearing difficult because you never know if the Parent is going to be set or not

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
ParentSet is now consistently fired before OnAppearing so there's a slight behavior change for scenarios where they were reversed

### Testing Procedure ###
- tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
