### PR TITLE
Anticipate calls into Android OS during startup

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -10,6 +10,7 @@ using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using System.Linq;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.ControlGallery.Android
 {
@@ -32,6 +33,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 	{
 		protected override void OnCreate(Bundle bundle)
 		{
+			Profile.Start();
+
 			ToolbarResource = Resource.Layout.Toolbar;
 			TabLayoutResource = Resource.Layout.Tabbar;
 
@@ -90,7 +93,12 @@ namespace Xamarin.Forms.ControlGallery.Android
 			}
 		}
 
-		
+		protected override void OnResume()
+		{
+			base.OnResume();
+			Profile.Stop();
+		}
+
 		[Export("IsPreAppCompat")]
 		public bool IsPreAppCompat()
 		{

--- a/Xamarin.Forms.Core/Profiler.cs
+++ b/Xamarin.Forms.Core/Profiler.cs
@@ -52,21 +52,21 @@ namespace Xamarin.Forms.Internals
 
 		public static void FrameBegin(
 			[CallerMemberName] string name = "",
-			string id = null,
 			[CallerLineNumber] int line = 0)
 		{
 			if (!Running)
 				return;
 
-			FrameBeginBody(name, id, line);
+			FrameBeginBody(name, null, line);
 		}
 
-		public static void FrameEnd()
+		public static void FrameEnd(
+			[CallerMemberName] string name = "")
 		{
 			if (!Running)
 				return;
 
-			FrameEndBody();
+			FrameEndBody(name);
 		}
 
 		public static void FramePartition(
@@ -90,9 +90,12 @@ namespace Xamarin.Forms.Internals
 			Stack.Push(new Profile(name, id, line));
 		}
 
-		static void FrameEndBody()
+		static void FrameEndBody(string name)
 		{
 			var profile = Stack.Pop();
+			if (profile._name != name)
+				throw new InvalidOperationException(
+					$"Expected to end frame '{profile._name}', not '{name}'.");
 			profile.Dispose();
 		}
 
@@ -104,7 +107,7 @@ namespace Xamarin.Forms.Internals
 			var name = profile._name;
 			profile.Dispose();
 
-			FrameBegin(name, id, line);
+			FrameBeginBody(name, id, line);
 		}
 
 		Profile(

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -331,7 +331,8 @@ namespace Xamarin.Forms.Internals
 			Profile.FramePartition("Reflect");
 			foreach (Assembly assembly in assemblies)
 			{
-				Profile.FrameBegin(assembly.GetName().Name);
+				var assemblyName = assembly.GetName().Name;
+				Profile.FrameBegin(assemblyName);
 
 				foreach (Type attrType in attrTypes)
 				{
@@ -370,7 +371,7 @@ namespace Xamarin.Forms.Internals
 				Array.Copy(effectAttributes, typedEffectAttributes, effectAttributes.Length);
 				RegisterEffects(resolutionName, typedEffectAttributes);
 
-				Profile.FrameEnd();
+				Profile.FrameEnd(assemblyName);
 			}
 
 			if ((flags & InitializationFlags.DisableCss) == 0)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -18,6 +18,7 @@ using AToolbar = Android.Support.V7.Widget.Toolbar;
 using AColor = Android.Graphics.Color;
 using ARelativeLayout = Android.Widget.RelativeLayout;
 using Xamarin.Forms.Internals;
+using System.Runtime.CompilerServices;
 
 #endregion
 
@@ -67,10 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = AndroidApplicationLifecycleState.Uninitialized;
 			_currentState = AndroidApplicationLifecycleState.Uninitialized;
 			PopupManager.Subscribe(this);
-
-			var anticipator = new Anticipator();
-			anticipator.AnticipateClassConstruction(typeof(Resource.Layout));
-			anticipator.AnticipateClassConstruction(typeof(Resource.Attribute));
+			RuntimeHelpers.RunClassConstructor(typeof(Anticipator).TypeHandle);
 		}
 
 		public event EventHandler ConfigurationChanged;

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms
 
 			Profile.FrameBegin("Assembly.GetCallingAssembly");
 			resourceAssembly = Assembly.GetCallingAssembly();
-			Profile.FrameEnd();
+			Profile.FrameEnd("Assembly.GetCallingAssembly");
 
 			Profile.FrameBegin();
 			SetupInit(activity, resourceAssembly, null);

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -53,7 +53,6 @@ namespace Xamarin.Forms
 
 		const int TabletCrossover = 600;
 
-		static BuildVersionCodes? s_sdkInt;
 		static bool? s_isLollipopOrNewer;
 		static bool? s_isMarshmallowOrNewer;
 		static bool? s_isNougatOrNewer;

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -72,13 +72,7 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static BuildVersionCodes SdkInt {
-			get {
-				if (!s_sdkInt.HasValue)
-					s_sdkInt = Build.VERSION.SdkInt;
-				return (BuildVersionCodes)s_sdkInt;
-			}
-		}
+		internal static BuildVersionCodes SdkInt => Anticipator.SdkInt;
 		internal static bool IsLollipopOrNewer
 		{
 			get

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -122,8 +122,6 @@ namespace Xamarin.Forms.Platform.Android
 			Profile.FramePartition("UpdateFlyoutBackground");
 			UpdateFlyoutBackground();
 
-			Profile.FrameEnd();
-
 			Profile.FramePartition(nameof(UpdateVerticalScrollMode));
 			UpdateVerticalScrollMode();
 			Profile.FrameEnd();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellRenderer.cs
@@ -353,7 +353,7 @@ namespace Xamarin.Forms.Platform.Android
 				decorView.SetBackground(split);
 			}
 
-			Profile.FrameEnd();
+			Profile.FrameEnd("UpdtStatBarClr");
 		}
 
 		class SplitDrawable : Drawable


### PR DESCRIPTION
### Description of Change ### 

Use a thread pool to anticipate calls into the Android OS that the UIThread will make during startup; Use a thread pool to thread to race ahead of the UIThread to place calls and cache results to remove that burden from the UIThread and thereby speedup startup.

Calling into the Android OS off the UIThread is a "gray" operation. We know not to modify the UI but what about getting the SDK version? The latter is likely ok and this change demonstrates how that type of call would be made. This anticipation is unlikely to speedup startup by an appreciable degree. That's not the point of the this PR. This PR is meant to demonstrate the pattern for future anticipations.

Doing any work off the UIThread at startup makes the startup code re-entrant. It would be a maintenance nightmare to make arbitrary startup code re-entrant. Doing so would require future developers to continually ask if the code they are working on is re-entrant and it may not be easy to discover if that's the case. To avoid this we isolate all re-entrant code in anticipator.cs and disallow scheduling arbitrary callback using the thread pool. 

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Just for reference:
![Screenshot_2019-10-25-15-08-33](https://user-images.githubusercontent.com/4120386/67607845-9d817800-f721-11e9-8f85-a654c9566d4f.png)


### Testing Procedure ###

Every UITests stresses startup optimizations. 

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
