### PR TITLE
Anticipate calls into Android OS during startup

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -18,6 +18,7 @@ using AToolbar = Android.Support.V7.Widget.Toolbar;
 using AColor = Android.Graphics.Color;
 using ARelativeLayout = Android.Widget.RelativeLayout;
 using Xamarin.Forms.Internals;
+using System.Runtime.CompilerServices;
 
 #endregion
 
@@ -67,10 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = AndroidApplicationLifecycleState.Uninitialized;
 			_currentState = AndroidApplicationLifecycleState.Uninitialized;
 			PopupManager.Subscribe(this);
-
-			var anticipator = new Anticipator();
-			anticipator.AnticipateClassConstruction(typeof(Resource.Layout));
-			anticipator.AnticipateClassConstruction(typeof(Resource.Attribute));
+			RuntimeHelpers.RunClassConstructor(typeof(Anticipator).TypeHandle);
 		}
 
 		public event EventHandler ConfigurationChanged;

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -53,7 +53,6 @@ namespace Xamarin.Forms
 
 		const int TabletCrossover = 600;
 
-		static BuildVersionCodes? s_sdkInt;
 		static bool? s_isLollipopOrNewer;
 		static bool? s_isMarshmallowOrNewer;
 		static bool? s_isNougatOrNewer;
@@ -72,13 +71,7 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static BuildVersionCodes SdkInt {
-			get {
-				if (!s_sdkInt.HasValue)
-					s_sdkInt = Build.VERSION.SdkInt;
-				return (BuildVersionCodes)s_sdkInt;
-			}
-		}
+		internal static BuildVersionCodes SdkInt => Anticipator.SdkInt;
 		internal static bool IsLollipopOrNewer
 		{
 			get


### PR DESCRIPTION
### Description of Change ### 

Use a thread pool to anticipate calls into the Android OS that the UIThread will make during startup; Use a thread pool thread to race ahead of the UIThread to place calls and cache results to remove that burden from the UIThread and thereby speedup startup.

Calling into the Android OS off the UIThread is a "gray" operation. We know to only modify the UI on the UIThread but what about getting the SDK version? The latter is likely ok and this change demonstrates how that type of call would be made. The particular anticipation in this PR is unlikely to speedup startup by an appreciable degree. That's not the point of the this PR. This PR is meant to demonstrate the pattern for future anticipations.

Doing any work off the UIThread at startup makes the startup code re-entrant. It would be a maintenance nightmare to make arbitrary startup code re-entrant. Doing so would require future developers to continually ask if the code they are working on is re-entrant and it may not be easy to discover if that's the case. To avoid this we isolate all re-entrant code in anticipator.cs and disallow scheduling arbitrary callback using the thread pool. 

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Just for reference:
![Screenshot_2019-10-25-15-08-33](https://user-images.githubusercontent.com/4120386/67607845-9d817800-f721-11e9-8f85-a654c9566d4f.png)


### Testing Procedure ###

Every UITests stresses startup optimizations. 

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
