### PR TITLE
Fixed 8211 - Handled NullRef in Shell if incorrectly-configured

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -813,25 +813,5 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsFalse(GetItems(shell).Contains(item1));
 			Assert.IsTrue(GetItems(shell).Contains(item2));
 		}
-
-		[Test]
-		public async Task FailWhenNoShellContentProvided()
-		{
-			var shell = new Shell();
-			var tabBar = new TabBar();
-			var tab = new Tab();
-			tabBar.Items.Add(tab);
-			shell.Items.Add(tabBar);
-			Assert.Catch(typeof(InvalidOperationException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
-		}
-
-		[Test]
-		public async Task FailWhenNoShellContentOrTabProvided()
-		{
-			var shell = new Shell();
-			var tabBar = new TabBar();
-			shell.Items.Add(tabBar);
-			Assert.Catch(typeof(InvalidOperationException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
-		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -813,5 +813,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsFalse(GetItems(shell).Contains(item1));
 			Assert.IsTrue(GetItems(shell).Contains(item2));
 		}
+
+		[Test]
+		public async Task FailWhenNoShellContentProvided()
+		{
+			var shell = new Shell();
+			var tabBar = new TabBar();
+			var tab = new Tab();
+			tabBar.Items.Add(tab);
+			shell.Items.Add(tabBar);
+			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
+		}
+
+		[Test]
+		public async Task FailWhenNoShellContentOrTabProvided()
+		{
+			var shell = new Shell();
+			var tabBar = new TabBar();
+			shell.Items.Add(tabBar);
+			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -822,7 +822,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var tab = new Tab();
 			tabBar.Items.Add(tab);
 			shell.Items.Add(tabBar);
-			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
+			Assert.Catch(typeof(InvalidOperationException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
 		}
 
 		[Test]
@@ -831,7 +831,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var shell = new Shell();
 			var tabBar = new TabBar();
 			shell.Items.Add(tabBar);
-			Assert.Catch(typeof(ArgumentException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
+			Assert.Catch(typeof(InvalidOperationException), () => Routing.RegisterRoute(string.Empty, typeof(ContentPage)));
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -70,6 +70,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (ShellItem == null)
 				throw new ArgumentException("Active Shell Item not set. Have you added any Shell Items to your Shell?", nameof(ShellItem));
 
+			if (ShellItem.CurrentItem == null)
+				throw new ArgumentException("Active Shell Content not set. Have you added any Shell Content to your Shell?", nameof(ShellSection));
+
 			HookEvents(ShellItem);
 			SetupMenu();
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -68,10 +68,10 @@ namespace Xamarin.Forms.Platform.Android
 			_bottomView.SetOnNavigationItemSelectedListener(this);
 
 			if (ShellItem == null)
-				throw new ArgumentException("Active Shell Item not set. Have you added any Shell Items to your Shell?", nameof(ShellItem));
+				throw new InvalidOperationException("Active Shell Item not set. Have you added any Shell Items to your Shell?");
 
 			if (ShellItem.CurrentItem == null)
-				throw new ArgumentException("Active Shell Content not set. Have you added any Shell Content to your Shell?", nameof(ShellSection));
+				throw new InvalidOperationException($"No content not found for active {ShellItem}. Title: {ShellItem.Title}. Route: {ShellItem.Route}.");
 
 			HookEvents(ShellItem);
 			SetupMenu();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.Android
 				throw new InvalidOperationException("Active Shell Item not set. Have you added any Shell Items to your Shell?");
 
 			if (ShellItem.CurrentItem == null)
-				throw new InvalidOperationException($"No content not found for active {ShellItem}. Title: {ShellItem.Title}. Route: {ShellItem.Route}.");
+				throw new InvalidOperationException($"Content not found for active {ShellItem}. Title: {ShellItem.Title}. Route: {ShellItem.Route}.");
 
 			HookEvents(ShellItem);
 			SetupMenu();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Platform.Android
 				return null;
 
 			if (shellSection.CurrentItem == null)
-				throw new InvalidOperationException($"No content found for active {shellSection}. Title: {shellSection.Title}. Route: {shellSection.Route}.");
+				throw new InvalidOperationException($"Content not found for active {shellSection}. Title: {shellSection.Title}. Route: {shellSection.Route}.");
 
 			var root = inflater.Inflate(Resource.Layout.RootLayout, null).JavaCast<CoordinatorLayout>();
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -131,8 +131,9 @@ namespace Xamarin.Forms.Platform.Android
 			var shellSection = ShellSection;
 			if (shellSection == null)
 				return null;
+
 			if (shellSection.CurrentItem == null)
-				throw new ArgumentException("Active Shell Content not set. Have you added any Shell Content to your Shell?", nameof(ShellSection));
+				throw new InvalidOperationException($"No content found for active {shellSection}. Title: {shellSection.Title}. Route: {shellSection.Route}.");
 
 			var root = inflater.Inflate(Resource.Layout.RootLayout, null).JavaCast<CoordinatorLayout>();
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -131,6 +131,8 @@ namespace Xamarin.Forms.Platform.Android
 			var shellSection = ShellSection;
 			if (shellSection == null)
 				return null;
+			if (shellSection.CurrentItem == null)
+				throw new ArgumentException("Active Shell Content not set. Have you added any Shell Content to your Shell?", nameof(ShellSection));
 
 			var root = inflater.Inflate(Resource.Layout.RootLayout, null).JavaCast<CoordinatorLayout>();
 

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
@@ -302,10 +302,10 @@ namespace Xamarin.Forms.Platform.UWP
 		void SwitchSection(ShellNavigationSource source, ShellSection section, Page page, bool animate = true)
 		{
 			if (section == null)
-				throw new InvalidOperationException($"No content not found for active {ShellItem} - {ShellItem.Title}.");
+				throw new InvalidOperationException($"Content not found for active {ShellItem} - {ShellItem.Title}.");
 
 			if (section.CurrentItem == null)
-				throw new InvalidOperationException($"No content found for active {section} - {section.Title}.");
+				throw new InvalidOperationException($"Content not found for active {section} - {section.Title}.");
 
 			SectionRenderer.NavigateToShellSection(source, section, animate);
 		}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
@@ -97,7 +97,15 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			UnhookEvents(ShellItem);
 			ShellItem = newItem;
+
+			if (newItem.CurrentItem == null)
+				throw new InvalidOperationException($"No content not found for active {newItem}. Title: {newItem.Title}. Route: {newItem.Route}.");
+
 			ShellSection = newItem.CurrentItem;
+
+			if (ShellSection.CurrentItem == null)
+				throw new InvalidOperationException($"No content found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
+
 			HookEvents(newItem);
 		}
 
@@ -293,6 +301,12 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void SwitchSection(ShellNavigationSource source, ShellSection section, Page page, bool animate = true)
 		{
+			if (section == null)
+				throw new InvalidOperationException($"No content not found for active {ShellItem} - {ShellItem.Title}.");
+
+			if (section.CurrentItem == null)
+				throw new InvalidOperationException($"No content found for active {section} - {section.Title}.");
+
 			SectionRenderer.NavigateToShellSection(source, section, animate);
 		}
 

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
@@ -99,12 +99,12 @@ namespace Xamarin.Forms.Platform.UWP
 			ShellItem = newItem;
 
 			if (newItem.CurrentItem == null)
-				throw new InvalidOperationException($"No content not found for active {newItem}. Title: {newItem.Title}. Route: {newItem.Route}.");
+				throw new InvalidOperationException($"Content not found for active {newItem}. Title: {newItem.Title}. Route: {newItem.Route}.");
 
 			ShellSection = newItem.CurrentItem;
 
 			if (ShellSection.CurrentItem == null)
-				throw new InvalidOperationException($"No content found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
+				throw new InvalidOperationException($"Content not found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
 
 			HookEvents(newItem);
 		}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -24,28 +24,28 @@ namespace Xamarin.Forms.Platform.UWP
 			IsSettingsVisible = false;
 			AlwaysShowHeader = false;
 			PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.Top;
-			ItemInvoked += MenuItemInvoked;
+			ItemInvoked += OnMenuItemInvoked;
 
 			AutoSuggestBox = new Windows.UI.Xaml.Controls.AutoSuggestBox() { Width = 300 };
-			AutoSuggestBox.TextChanged += SearchBox_TextChanged;
-			AutoSuggestBox.QuerySubmitted += SearchBox_QuerySubmitted;
-			AutoSuggestBox.SuggestionChosen += SearchBox_SuggestionChosen;
+			AutoSuggestBox.TextChanged += OnSearchBoxTextChanged;
+			AutoSuggestBox.QuerySubmitted += OnSearchBoxQuerySubmitted;
+			AutoSuggestBox.SuggestionChosen += OnSearchBoxSuggestionChosen;
 
 			Frame = new Windows.UI.Xaml.Controls.Frame();
 			Content = Frame;
-			this.SizeChanged += ShellSectionRenderer_SizeChanged;
+			this.SizeChanged += OnShellSectionRendererSizeChanged;
 			Resources["NavigationViewTopPaneBackground"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultBackgroundColor);
 			Resources["TopNavigationViewItemForeground"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultForegroundColor);
 			Resources["TopNavigationViewItemForegroundSelected"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultForegroundColor);
 			Resources["NavigationViewSelectionIndicatorForeground"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultForegroundColor);
 		}
 
-		void ShellSectionRenderer_SizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
+		void OnShellSectionRendererSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
 		{
 			Page.ContainerArea = new Rectangle(0, 0, e.NewSize.Width, e.NewSize.Height);
 		}
 
-		void MenuItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
+		void OnMenuItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)
 		{
 			var shellContent = args.InvokedItemContainer?.DataContext as ShellContent;
 			var shellItem = ShellSection.RealParent as ShellItem;
@@ -105,6 +105,7 @@ namespace Xamarin.Forms.Platform.UWP
 				Page.PropertyChanged -= OnPagePropertyChanged;
 				((IShellContentController)CurrentContent).RecyclePage(Page);
 			}
+
 			CurrentContent = shellContent;
 			if (shellContent != null)
 			{
@@ -228,18 +229,18 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		void SearchBox_TextChanged(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs args)
+		void OnSearchBoxTextChanged(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxTextChangedEventArgs args)
 		{
 			if (args.Reason != Windows.UI.Xaml.Controls.AutoSuggestionBoxTextChangeReason.ProgrammaticChange)
 				_currentSearchHandler.Query = sender.Text;
 		}
 
-		void SearchBox_SuggestionChosen(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxSuggestionChosenEventArgs args)
+		void OnSearchBoxSuggestionChosen(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxSuggestionChosenEventArgs args)
 		{
 			((ISearchHandlerController)_currentSearchHandler).ItemSelected(args.SelectedItem);
 		}
 
-		void SearchBox_QuerySubmitted(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxQuerySubmittedEventArgs args)
+		void OnSearchBoxQuerySubmitted(Windows.UI.Xaml.Controls.AutoSuggestBox sender, Windows.UI.Xaml.Controls.AutoSuggestBoxQuerySubmittedEventArgs args)
 		{
 			((ISearchHandlerController)_currentSearchHandler).QueryConfirmed();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -228,6 +228,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CreateTabRenderers()
 		{
+			if(ShellItem.CurrentItem == null)
+				throw new InvalidOperationException($"No content not found for active {ShellItem}. Title: {ShellItem.Title}. Route: {ShellItem.Route}.");
+
 			var items = ShellItemController.GetItems();
 			var count = items.Count;
 			int maxTabs = 5; // fetch this a better way

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -229,7 +229,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void CreateTabRenderers()
 		{
 			if(ShellItem.CurrentItem == null)
-				throw new InvalidOperationException($"No content not found for active {ShellItem}. Title: {ShellItem.Title}. Route: {ShellItem.Route}.");
+				throw new InvalidOperationException($"Content not found for active {ShellItem}. Title: {ShellItem.Title}. Route: {ShellItem.Route}.");
 
 			var items = ShellItemController.GetItems();
 			var count = items.Count;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -53,6 +53,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLoad()
 		{
+			if (ShellSection.CurrentItem == null)
+				throw new InvalidOperationException($"No content found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
+
 			base.ViewDidLoad();
 
 			_containerArea = new UIView();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidLoad()
 		{
 			if (ShellSection.CurrentItem == null)
-				throw new InvalidOperationException($"No content found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
+				throw new InvalidOperationException($"Content not found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
 
 			base.ViewDidLoad();
 


### PR DESCRIPTION
### Description of Change ###

As mentioned in the issue #8211, Handled Null Reference exceptions in Shell if incorrectly-configured.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8211

### API Changes ###

Changed:
- `ShellSectionRenderer.cs` : Added below condition to handle Null Ref if no Shell Content provided [first usecase]:
```
if (shellSection.CurrentItem == null)
	throw new ArgumentException("Active Shell Content not set. Have you added any Shell Content to your Shell?", nameof(ShellSection));
```
 - `ShellItemRenderer.cs` : Added below condition to handle Null Ref if no Shell Content provided (this will also handle if no tab provided [second usecase]):
 ```
if (ShellItem.CurrentItem == null)
	throw new ArgumentException("Active Shell Content not set. Have you added any Shell Content to your Shell?", nameof(ShellSection));
```

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- I've added below Unit Test cases in existing ShellTests.cs for both cases:
`FailWhenNoShellContentProvided()`
`FailWhenNoShellContentOrTabProvided()` 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
