### PR TITLE
Fix 7181 | [Bug] Cannot update ToolbarItem text and icon

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7181.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7181.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7181, "[Bug] Cannot update ToolbarItem text and icon", PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue7181 : TestShell
+	{
+		const string ToolbarBtn = "Toolbar button";
+		const string DefaultToolbarItemText = "Toolbar test";
+		const string AfterClickToolbarItemText = "Button Clicked";
+		const string SetToolbarIconBtn = "Set toolbar icon button";
+
+		int _clicks = 0;
+		ToolbarItem _toolbarItem;
+
+		protected override void Init()
+		{
+			var page = CreateContentPage("Test page");
+
+			_toolbarItem = new ToolbarItem(DefaultToolbarItemText, string.Empty, OnToolbarClicked)
+			{
+				AutomationId = ToolbarBtn
+			};
+
+			page.ToolbarItems.Add(_toolbarItem);
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label
+					{
+						Text = "You should be able to change toolbar text"
+					},
+					new Button
+					{
+						AutomationId = SetToolbarIconBtn,
+						Text = "Click to change toolbarIcon",
+						Command = new Command(()=> _toolbarItem.IconImageSource = "coffee.png" )
+					}
+				}
+			};
+		}
+
+		private void OnToolbarClicked() =>
+			_toolbarItem.Text = $"{AfterClickToolbarItemText} {_clicks++}";
+
+#if UITEST
+		[Test]
+		public void ShellToolbarItemTests()
+		{
+			var count = 0;
+			var toolbarButton = RunningApp.WaitForElement(ToolbarBtn);
+			Assert.AreEqual(toolbarButton[0].Text, DefaultToolbarItemText);
+
+			for (int i = 0; i < 5; i++)
+			{
+				RunningApp.Tap(ToolbarBtn);
+
+				toolbarButton = RunningApp.WaitForElement(ToolbarBtn);
+				Assert.AreEqual($"{AfterClickToolbarItemText} {count++}", toolbarButton[0].Text);
+			}
+
+			RunningApp.Tap(SetToolbarIconBtn);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7181.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7181.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Controls.Issues
 		private void OnToolbarClicked() =>
 			_toolbarItem.Text = $"{AfterClickToolbarItemText} {_clicks++}";
 
-#if UITEST
+#if UITEST && __ANDROID__
 		[Test]
 		public void ShellToolbarItemTests()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -35,6 +35,7 @@
       <DependentUpon>Issue7048.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7181.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7581.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7621.xaml.cs">

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -141,6 +141,13 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (_backButtonBehavior != null)
 					_backButtonBehavior.PropertyChanged -= OnBackButtonBehaviorChanged;
+
+				if(Page?.ToolbarItems?.Count > 0)
+				{
+					foreach (var item in Page.ToolbarItems)
+						item.PropertyChanged -= OnToolbarItemPropertyChanged;
+				}
+
 				((IShellController)_shellContext?.Shell)?.RemoveFlyoutBehaviorObserver(this);
 
 				UpdateTitleView(_shellContext.AndroidContext, _toolbar, null);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -152,7 +152,7 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.SearchConfirmed -= OnSearchConfirmed;
 					_searchView.Dispose();
 				}
-        
+
 				_drawerToggle?.Dispose();
 			}
 
@@ -316,14 +316,14 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var customIcon = await context.GetFormsDrawableAsync(image);
 
-				if(customIcon != null)
+				if (customIcon != null)
 					icon = new FlyoutIconDrawerDrawable(context, tintColor, customIcon, text);
 			}
 
 			if (!String.IsNullOrWhiteSpace(text) && icon == null)
 				icon = new FlyoutIconDrawerDrawable(context, tintColor, icon, text);
 
-			if(icon == null)
+			if (icon == null)
 			{
 				icon = new DrawerArrowDrawable(context.GetThemedContext());
 				icon.SetColorFilter(tintColor.ToAndroid(), PorterDuff.Mode.SrcAtop);
@@ -336,10 +336,10 @@ namespace Xamarin.Forms.Platform.Android
 				_drawerToggle.DrawerIndicatorEnabled = false;
 				toolbar.NavigationIcon = icon;
 			}
-			else if(_flyoutBehavior == FlyoutBehavior.Flyout)
+			else if (_flyoutBehavior == FlyoutBehavior.Flyout)
 			{
 				_drawerToggle.DrawerIndicatorEnabled = isEnabled;
-				if(isEnabled)
+				if (isEnabled)
 				{
 					_drawerToggle.DrawerArrowDrawable = icon;
 					toolbar.NavigationIcon = null;
@@ -372,7 +372,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				toolbar.NavigationContentDescription = shell.FlyoutIcon.AutomationId;
 			}
-			else if(toolbar.SetNavigationContentDescription(_shellContext.Shell.FlyoutIcon) == null)
+			else if (toolbar.SetNavigationContentDescription(_shellContext.Shell.FlyoutIcon) == null)
 			{
 				toolbar.SetNavigationContentDescription(R.String.Ok);
 			}
@@ -427,7 +427,7 @@ namespace Xamarin.Forms.Platform.Android
 					_titleViewContainer = null;
 				}
 			}
-			else if(_titleViewContainer == null)
+			else if (_titleViewContainer == null)
 			{
 				_titleViewContainer = new ContainerView(context, titleView);
 				_titleViewContainer.MatchHeight = _titleViewContainer.MatchWidth = true;
@@ -454,6 +454,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			foreach (var item in page.ToolbarItems)
 			{
+				item.PropertyChanged -= OnToolbarItemPropertyChanged;
+				item.PropertyChanged += OnToolbarItemPropertyChanged;
+
 				using (var title = new Java.Lang.String(item.Text))
 				{
 					var menuitem = menu.Add(title);
@@ -466,11 +469,11 @@ namespace Xamarin.Forms.Platform.Android
 						menuitem.SetShowAsAction(ShowAsAction.Always);
 
 					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
-					
-					if(TintColor != Color.Default)
+
+					if (TintColor != Color.Default)
 					{
 						var view = toolbar.FindViewById(menuitem.ItemId);
-						if (view is ATextView  textView)
+						if (view is ATextView textView)
 							textView.SetTextColor(TintColor.ToAndroid());
 					}
 
@@ -536,6 +539,14 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			menu.Dispose();
+		}
+
+		void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == MenuItem.TextProperty.PropertyName)
+				UpdateToolbarItems();
+			if (e.PropertyName == MenuItem.IconImageSourceProperty.PropertyName)
+				UpdateToolbarItems();
 		}
 
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)


### PR DESCRIPTION
### Description of Change ###

I've created `ShellToolbarTracker.OnToolbarItemPropertyChanged` to get changes from `ToolbarItem.PropertyChanged` and update view

### Issues Resolved ### 

- fixes #7181

### API Changes ###
 
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
ToolbarItem Text and Icons will be updated, when a new value set, on a shell page.

### Before/After Screenshots ### 

- Before

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67623849-72ba2100-f800-11e9-9977-8413b88c41af.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

- After 

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67623754-641f3a00-f7ff-11e9-81f7-f09637ad20b4.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>


### Testing Procedure ###
1. Created Shell application with ContentPage
2. Set OnClicked events of the ToolbarItem, to change the Text property
3. Toolbaritem Text will change

> Or just run the Issue7181 test from ControlGallery

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
