### PR TITLE
Fix 6048 | [Bug] OnPlatform doesnt work with Comma separated values

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6048.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6048.xaml
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.TestPages.Issue6048">
+    <ContentPage.Content>
+        <StackLayout Padding="{OnPlatform iOS=0,30,0,0, Default=0}">
+            <Label Text="Welcome to Xamarin.Forms!"
+                VerticalOptions="CenterAndExpand" 
+                HorizontalOptions="CenterAndExpand" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6048.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6048.xaml.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms.CustomAttributes;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues.TestPages
+{
+
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6048, "OnPlatform padding", PlatformAffected.All, NavigationBehavior.PushAsync)]
+	public partial class Issue6048 : ContentPage
+	{
+		const string DialogTitle = "Oooops... 😥";
+		const string ConfirmButton = "OK";
+#if APP
+
+        public Issue6048()
+        {
+			try
+			{
+				InitializeComponent();
+			}
+			catch (FormatException ex)
+			{
+				DisplayAlert(DialogTitle, "An exception was throw", ConfirmButton);
+			}
+        }
+#endif
+
+#if UITEST
+		[SetUp]
+		public void Setup()
+		{
+			AppSetup.BeginIsolate();
+			AppSetup.NavigateToIssue(GetType(), AppSetup.RunningApp);
+		}
+
+		[Test]
+		public void OnPlatformPaddingTests()
+		{
+			var app = AppSetup.RunningApp;
+			var dialog = app.WaitForElement(DialogTitle)[0];
+
+			Assert.AreEqual("alertTitle", dialog.Id);
+
+			app.Tap(ConfirmButton);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,9 +22,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <SubType>Code</SubType>
-    </Compile> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" /> 
-    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" /> 
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5868.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7048.xaml.cs">
       <DependentUpon>Issue7048.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -632,6 +632,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)MultipleClipToBounds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6994.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7371.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6048.xaml.cs">
+      <DependentUpon>Issue6048.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -1591,6 +1595,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7048.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6048.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
@@ -14,53 +14,62 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 		class MockElementNode : IElementNode, IValueNode, IXmlLineInfo
 		{
-			public bool HasLineInfo () { return false; }
+			public bool HasLineInfo() { return false; }
 
-			public int LineNumber {
+			public int LineNumber
+			{
 				get { return -1; }
 			}
 
-			public int LinePosition {
+			public int LinePosition
+			{
 				get { return -1; }
 			}
 
 
-			public IXmlNamespaceResolver NamespaceResolver {
-				get {
-					throw new NotImplementedException ();
+			public IXmlNamespaceResolver NamespaceResolver
+			{
+				get
+				{
+					throw new NotImplementedException();
 				}
 			}
 
-			public object Value {get;set;}
+			public object Value { get; set; }
 			public Dictionary<XmlName, INode> Properties { get; set; }
 
 			public List<XmlName> SkipProperties { get; set; }
 
 			public NameScopeRef NameScopeRef => throw new NotImplementedException();
 
-			public XmlType XmlType {
+			public XmlType XmlType
+			{
 				get;
 				set;
 			}
 
-			public string NamespaceURI {
-				get {
-					throw new NotImplementedException ();
+			public string NamespaceURI
+			{
+				get
+				{
+					throw new NotImplementedException();
 				}
 			}
 
-			public INode Parent {
-				get {
-					throw new NotImplementedException ();
+			public INode Parent
+			{
+				get
+				{
+					throw new NotImplementedException();
 				}
-				set { throw new NotImplementedException (); }
+				set { throw new NotImplementedException(); }
 			}
-				
+
 			public List<INode> CollectionItems { get; set; }
 
-			public void Accept (IXamlNodeVisitor visitor, INode parentNode)
+			public void Accept(IXamlNodeVisitor visitor, INode parentNode)
 			{
-				throw new NotImplementedException ();
+				throw new NotImplementedException();
 			}
 
 
@@ -73,95 +82,103 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[SetUp]
-		public override void Setup ()
+		public override void Setup()
 		{
-			base.Setup ();
-			var nsManager = new XmlNamespaceManager (new NameTable ());
-			nsManager.AddNamespace ("local", "clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests");
-			nsManager.AddNamespace ("x", "http://schemas.microsoft.com/winfx/2009/xaml");
-			typeResolver = new Internals.XamlTypeResolver (nsManager, XamlParser.GetElementType, Assembly.GetCallingAssembly ());
+			base.Setup();
+			var nsManager = new XmlNamespaceManager(new NameTable());
+			nsManager.AddNamespace("local", "clr-namespace:Xamarin.Forms.Xaml.UnitTests;assembly=Xamarin.Forms.Xaml.UnitTests");
+			nsManager.AddNamespace("x", "http://schemas.microsoft.com/winfx/2009/xaml");
+			typeResolver = new Internals.XamlTypeResolver(nsManager, XamlParser.GetElementType, Assembly.GetCallingAssembly());
 		}
 
 		[Test]
-		public void BindingOnSelf ()
+		public void BindingOnSelf()
 		{
 			var bindingString = "{Binding}";
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual (Binding.SelfPath, ((Binding)binding).Path);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual(Binding.SelfPath, ((Binding)binding).Path);
 		}
 
 		[Test]
-		public void BindingWithImplicitPath ()
+		public void BindingWithImplicitPath()
 		{
 			var bindingString = "{Binding Foo}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
 		}
 
 		[Test]
-		public void BindingWithPath ()
+		public void BindingWithPath()
 		{
 			var bindingString = "{Binding Path=Foo}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
 		}
 
 		[Test]
-		public void BindingWithComposedPath ()
+		public void BindingWithComposedPath()
 		{
 			var bindingString = "{Binding Path=Foo.Bar}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo.Bar", ((Binding)binding).Path);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo.Bar", ((Binding)binding).Path);
 		}
 
 		[Test]
-		public void BindingWithImplicitComposedPath ()
+		public void BindingWithImplicitComposedPath()
 		{
 			var bindingString = "{Binding Path=Foo.Bar}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo.Bar", ((Binding)binding).Path);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo.Bar", ((Binding)binding).Path);
 		}
 
 		class MockValueProvider : IProvideParentValues, IProvideValueTarget
 		{
-			public MockValueProvider (string key, object resource)
+			public MockValueProvider(string key, object resource)
 			{
 				var rd = new ResourceDictionary {
 					{key, resource}
 				};
 
-				ve = new VisualElement {
+				ve = new VisualElement
+				{
 					Resources = rd,
 				};
 			}
 
 
 			VisualElement ve;
-			public IEnumerable<object> ParentObjects {
-				get {
+			public IEnumerable<object> ParentObjects
+			{
+				get
+				{
 					yield return ve;
 				}
 			}
@@ -172,148 +189,158 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		}
 
 		[Test]
-		public void BindingWithImplicitPathAndConverter ()
+		public void BindingWithImplicitPathAndConverter()
 		{
 			var bindingString = "{Binding Foo, Converter={StaticResource Bar}}";
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
-				IProvideValueTarget = new MockValueProvider ("Bar", new ReverseConverter()),
+				IProvideValueTarget = new MockValueProvider("Bar", new ReverseConverter()),
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.NotNull (((Binding)binding).Converter);
-			Assert.That (((Binding)binding).Converter, Is.InstanceOf<ReverseConverter> ());
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.NotNull(((Binding)binding).Converter);
+			Assert.That(((Binding)binding).Converter, Is.InstanceOf<ReverseConverter>());
 		}
 
 		[Test]
-		public void BindingWithPathAndConverter ()
+		public void BindingWithPathAndConverter()
 		{
 			var bindingString = "{Binding Path=Foo, Converter={StaticResource Bar}}";
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
-				IProvideValueTarget = new MockValueProvider ("Bar", new ReverseConverter()),
+				IProvideValueTarget = new MockValueProvider("Bar", new ReverseConverter()),
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.NotNull (((Binding)binding).Converter);
-			Assert.That (((Binding)binding).Converter, Is.InstanceOf<ReverseConverter> ());
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.NotNull(((Binding)binding).Converter);
+			Assert.That(((Binding)binding).Converter, Is.InstanceOf<ReverseConverter>());
 		}
 
 
 		[Test]
-		public void TestBindingMode ()
+		public void TestBindingMode()
 		{
 			var bindingString = "{Binding Foo, Mode=TwoWay}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.AreEqual (BindingMode.TwoWay, ((Binding)binding).Mode);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.AreEqual(BindingMode.TwoWay, ((Binding)binding).Mode);
 		}
 
 		[Test]
-		public void BindingStringFormat ()
+		public void BindingStringFormat()
 		{
 			var bindingString = "{Binding Foo, StringFormat=Bar}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.AreEqual ("Bar", ((Binding)binding).StringFormat);		
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.AreEqual("Bar", ((Binding)binding).StringFormat);
 		}
 
 		[Test]
-		public void BindingStringFormatWithEscapes ()
+		public void BindingStringFormatWithEscapes()
 		{
 			var bindingString = "{Binding Foo, StringFormat='{}Hello {0}'}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.AreEqual ("Hello {0}", ((Binding)binding).StringFormat);		
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.AreEqual("Hello {0}", ((Binding)binding).StringFormat);
 		}
 
 		[Test]
-		public void BindingStringFormatWithoutEscaping ()
+		public void BindingStringFormatWithoutEscaping()
 		{
 			var bindingString = "{Binding Foo, StringFormat='{0,20}'}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.AreEqual ("{0,20}", ((Binding)binding).StringFormat);
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.AreEqual("{0,20}", ((Binding)binding).StringFormat);
 		}
 
 		[Test]
-		public void BindingStringFormatNumeric ()
+		public void BindingStringFormatNumeric()
 		{
 			var bindingString = "{Binding Foo, StringFormat=P2}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.AreEqual ("P2", ((Binding)binding).StringFormat);	
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.AreEqual("P2", ((Binding)binding).StringFormat);
 		}
 
 		[Test]
-		public void BindingConverterParameter ()
+		public void BindingConverterParameter()
 		{
 			var bindingString = "{Binding Foo, ConverterParameter='Bar'}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo", ((Binding)binding).Path);
-			Assert.AreEqual ("Bar", ((Binding)binding).ConverterParameter);	
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo", ((Binding)binding).Path);
+			Assert.AreEqual("Bar", ((Binding)binding).ConverterParameter);
 		}
 
 		[Test]
-		public void BindingsCompleteString ()
+		public void BindingsCompleteString()
 		{
 			var bindingString = "{Binding Path=Foo.Bar, StringFormat='{}Qux, {0}', Converter={StaticResource Baz}, Mode=OneWayToSource}";
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
-				IProvideValueTarget = new MockValueProvider ("Baz", new ReverseConverter()),
+				IProvideValueTarget = new MockValueProvider("Baz", new ReverseConverter()),
 			});
 
-			Assert.That (binding, Is.InstanceOf<Binding> ());
-			Assert.AreEqual ("Foo.Bar", ((Binding)binding).Path);
-			Assert.NotNull (((Binding)binding).Converter);
-			Assert.That (((Binding)binding).Converter, Is.InstanceOf<ReverseConverter> ());
-			Assert.AreEqual (BindingMode.OneWayToSource, ((Binding)binding).Mode);
-			Assert.AreEqual ("Qux, {0}", ((Binding)binding).StringFormat);	
+			Assert.That(binding, Is.InstanceOf<Binding>());
+			Assert.AreEqual("Foo.Bar", ((Binding)binding).Path);
+			Assert.NotNull(((Binding)binding).Converter);
+			Assert.That(((Binding)binding).Converter, Is.InstanceOf<ReverseConverter>());
+			Assert.AreEqual(BindingMode.OneWayToSource, ((Binding)binding).Mode);
+			Assert.AreEqual("Qux, {0}", ((Binding)binding).StringFormat);
 		}
 
 		[Test]
-		public void BindingWithStaticConverter ()
+		public void BindingWithStaticConverter()
 		{
 			var bindingString = "{Binding Converter={x:Static local:ReverseConverter.Instance}}";
 
-			var binding = (new MarkupExtensionParser ()).ParseExpression (ref bindingString, new Internals.XamlServiceProvider (null, null) {
+			var binding = (new MarkupExtensionParser()).ParseExpression(ref bindingString, new Internals.XamlServiceProvider(null, null)
+			{
 				IXamlTypeResolver = typeResolver,
 			}) as Binding;
-				
-			Assert.NotNull (binding);
+
+			Assert.NotNull(binding);
 			Assert.AreEqual(".", binding.Path);
-			Assert.That (binding.Converter, Is.TypeOf<ReverseConverter> ());
+			Assert.That(binding.Converter, Is.TypeOf<ReverseConverter>());
 		}
 
 		public int FontSize { get; set; }
@@ -353,6 +380,33 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			Assert.AreEqual(expected, actual);
 		}
 
+		public Thickness Padding { get; }
+
+		
+		[TestCase("{OnPlatform iOS=20, 8,20,12, Default=30}", Device.iOS)]
+		[TestCase("{OnPlatform Android=20,3, 5,2, iOS=25}", Device.Android)]
+		[TestCase("{OnPlatform UWP=20 ,6,20,12, Android=30}", Device.UWP)]
+		[TestCase("{OnPlatform Android=20 ,a6,20,12, Default=30}", Device.Android)]
+		public void OnPlatformExtensionException(string markup, string platform)
+		{
+			var services = new MockPlatformServices
+			{
+				RuntimePlatform = platform
+			};
+
+			Device.PlatformServices = services;
+			Assert.That(() => {
+				var result = (new MarkupExtensionParser()).ParseExpression(ref markup, new Internals.XamlServiceProvider(null, null)
+				{
+					IXamlTypeResolver = typeResolver,
+					IProvideValueTarget = new MockValueProvider("foo", new object())
+					{
+						TargetProperty = GetType().GetProperty(nameof(Padding))
+					}
+				});
+			}, Throws.TypeOf<FormatException>());
+		}
+
 		[TestCase("{OnIdiom Phone=23, Tablet=25, Default=20}", TargetIdiom.Phone, 23)]
 		[TestCase("{OnIdiom Phone=23, Tablet=25, Default=20}", TargetIdiom.Tablet, 25)]
 		[TestCase("{OnIdiom 20, Phone=23, Tablet=25}", TargetIdiom.Desktop, 20)]
@@ -363,7 +417,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		public void OnIdiomExtension(string markup, TargetIdiom idiom, int expected)
 		{
 			Device.SetIdiom(idiom);
-			var actual =  (new MarkupExtensionParser()).ParseExpression(ref markup, new Internals.XamlServiceProvider(null, null)
+			var actual = (new MarkupExtensionParser()).ParseExpression(ref markup, new Internals.XamlServiceProvider(null, null)
 			{
 				IXamlTypeResolver = typeResolver,
 				IProvideValueTarget = new MockValueProvider("foo", new object())

--- a/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
@@ -32,6 +32,7 @@
 //
 
 using System;
+using System.Linq;
 using System.Text;
 
 namespace Xamarin.Forms.Xaml
@@ -137,7 +138,13 @@ namespace Xamarin.Forms.Xaml
 				str_value = value as string;
 			}
 			else
+			{
 				str_value = GetNextPiece(ref remaining, out next);
+				var nextProp = remaining.Split(',').FirstOrDefault() ?? string.Empty;
+
+				if (next == ',' && !nextProp.Contains("="))
+					throw new FormatException("Expression can not contains multiple values without quotes");
+			}
 
 			SetPropertyValue(prop, str_value, value, serviceProvider);
 		}


### PR DESCRIPTION
### Description of Change ###

I've created a validation for markup expressions that check if the next property is a number.

### Issues Resolved ### 

- fixes #6048 

### API Changes ###
 
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

- Before
<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67626704-96439280-f825-11e9-9b12-9fa33241d28c.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

- After

<p align="center">
	<kbd>
		<img src="https://user-images.githubusercontent.com/19656249/67626665-fc7be580-f824-11e9-8374-9ae50bb50ccf.gif" alt="image" style="max-width:100%;"/>
	</kbd>
</p>

### Testing Procedure ###
- Define padding on anything like Padding="{OnPlatform iOS=0,30,0,0, Default=0}"

> Or simply run the issue6048 test from controlgallery

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
