### PR TITLE
Fixed 8176 - Shell BackButtonBehavior Inconsistencies & controlling FlyoutBehavior

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -112,7 +112,11 @@ namespace Xamarin.Forms.Controls.Issues
 					Command = new Command(ToggleIsEnabled),
 					AutomationId = ToggleIsEnabledId
 				});
-
+				layout.Children.Add(new Button()
+				{
+					Text = "Toggle Flyout Behavior",
+					Command = new Command(ToggleFlyoutBehavior),
+				});
 				layout.Children.Add(new Button()
 				{
 					Text = "Push Page",
@@ -177,6 +181,10 @@ namespace Xamarin.Forms.Controls.Issues
 			public void ToggleIsEnabled()
 			{
 				behavior.IsEnabled = !behavior.IsEnabled;
+			}
+			public void ToggleFlyoutBehavior()
+			{
+				Shell.Current.FlyoutBehavior = Shell.Current.FlyoutBehavior == FlyoutBehavior.Flyout ? FlyoutBehavior.Disabled : FlyoutBehavior.Flyout;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -333,19 +333,30 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (command != null || CanNavigateBack)
 			{
-				_drawerToggle.DrawerIndicatorEnabled = false;
-				toolbar.NavigationIcon = icon;
-			}
-			else if(_flyoutBehavior == FlyoutBehavior.Flyout)
-			{
-				_drawerToggle.DrawerIndicatorEnabled = isEnabled;
-				if(isEnabled)
+				if (isEnabled)
 				{
-					_drawerToggle.DrawerArrowDrawable = icon;
-					toolbar.NavigationIcon = null;
+					_drawerToggle.DrawerIndicatorEnabled = false;
+					toolbar.NavigationIcon = icon;
 				}
 				else
-					toolbar.NavigationIcon = icon;
+				{
+					if (_flyoutBehavior != FlyoutBehavior.Flyout) //if Disabled or Locked
+						_drawerToggle.DrawerIndicatorEnabled = false;
+					else
+						_drawerToggle.DrawerIndicatorEnabled = true;
+
+					if (_flyoutBehavior != FlyoutBehavior.Disabled)
+					{
+						_drawerToggle.DrawerArrowDrawable = icon;
+						toolbar.NavigationIcon = icon;
+					}
+				}
+			}
+			else if (_flyoutBehavior == FlyoutBehavior.Flyout)
+			{
+				_drawerToggle.DrawerIndicatorEnabled = true;
+				_drawerToggle.DrawerArrowDrawable = icon;
+				toolbar.NavigationIcon = null;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

As mentioned in the issue #8176 & #5219 (Possibly), I've noticed that `BackButtonBehavior` is not working as expected and it also overrides the `FlyoutBehavior` (tested with latest master branch).
As you can see in the attached 'Before' screenshot behavior, following are the issues:

-  On single Shell page (without navigation stack), when we set BackButtonBehavior `IsEnabled` to False, it disables the `FlyoutBehavior` too but hamburger icon exists (which is unexpected as BackButtonBehavior should not alter FlyoutBehavior at all).

- When a page is pushed to Navigation Stack of Shell (also described in issue #8176), when we set BackButtonBehavior `IsEnabled` to False, it displays the Back Button arrow but does nothing (which is not a good user experience as there should be a way to set the icon to the default hamburger icon used in the MasterDetail page of Shell).

As per my understanding (and more of proposal), the `BackButtonBehavior` should be applicable only on the pages pushed to Navigation Stack and should not alter the `FlyoutBehavior` at all. Also, if the `BackButtonBehavior` is disabled on the navigation pages, it should fallback to the FlyoutBehavior's current state  (i.e. it should display the default Flyout if it's enabled or hide if user has chosen it to be disabled) to maintain the user experience and keep things configurable. Let me know if it makes sense.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8176 
- related to #5219 (Possibly as BackButtonBehavior's `IsEnabled` alters FlyoutBehavior too)

### API Changes ###

Changed:
 - Following logic has been updated inside `UpdateLeftBarButtonItem` method of `ShellToolbarTracker.cs` to handle the inconsistencies of Shell `BackButtonBehavior` (for both single and navigation pages).
```
if (command != null || CanNavigateBack)
{
	if (isEnabled)
	{
		_drawerToggle.DrawerIndicatorEnabled = false;
		toolbar.NavigationIcon = icon;
	}
	else
	{
		if (_flyoutBehavior != FlyoutBehavior.Flyout) //if Disabled or Locked
			_drawerToggle.DrawerIndicatorEnabled = false;
		else
			_drawerToggle.DrawerIndicatorEnabled = true;

		if (_flyoutBehavior != FlyoutBehavior.Disabled)
		{
			_drawerToggle.DrawerArrowDrawable = icon;
			toolbar.NavigationIcon = icon;
		}
	}
}
else if (_flyoutBehavior == FlyoutBehavior.Flyout)
{
	_drawerToggle.DrawerIndicatorEnabled = true;
	_drawerToggle.DrawerArrowDrawable = icon;
	toolbar.NavigationIcon = null;
}
else
{
	_drawerToggle.DrawerIndicatorEnabled = false;
}
```


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

As described above, after this change BackButtonBehavior will work as expected on both single and navigation pages.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

**Before**:

![8176_before](https://user-images.githubusercontent.com/17450941/67633172-9352ab80-f8d2-11e9-90cb-8cbdaede1f3d.gif)

**After**:

![8176_after](https://user-images.githubusercontent.com/17450941/67633174-9cdc1380-f8d2-11e9-829e-c1880b3ef9e8.gif)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Just run `ShellBackButtonBehavior.cs` and `ShellFlyoutBehavior.cs` from Control Gallery as demonstrated in the above attached screen recordings.
- I've tested the following scenarios:

1. On single page of Shell, if BackButtonBehavior `IsEnabled` set to False, it will display default Flyout unless user has chosen it to be `FlyoutBehavior=Disabled`.
2. When a page is pushed to Navigation Stack, it will display Back button arrow by default (if default `BackButtonBehavior`).
3. If the BackButtonBehavior `IsEnabled` set to False on navigation page, it will display default Flyout unless user has chosen it to be `FlyoutBehavior=Disabled`.

As the above method is also responsible for overriding icons (with BackButtonBehavior), I've tested that it works as expected (overrides icons for both Flyout & Back button) but would like to propose that for Flyout, we should have separate properties to override icons and not use BackButtonBehavior to alter Flyout in any way. 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
