### PR TITLE
[iOS] Make ItemsViewLayout implementations accessible

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
@@ -4,7 +4,7 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal class CarouselViewLayout : ItemsViewLayout
+	public class CarouselViewLayout : ItemsViewLayout
 	{
 		readonly CarouselView _carouselView;
 		readonly ItemsLayout _itemsLayout;
@@ -13,11 +13,6 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_carouselView = carouselView;
 			_itemsLayout = itemsLayout;
-		}
-
-		public override bool ShouldInvalidateLayout(UICollectionViewLayoutAttributes preferredAttributes, UICollectionViewLayoutAttributes originalAttributes)
-		{
-			return base.ShouldInvalidateLayout(preferredAttributes, originalAttributes);
 		}
 
 		public override bool ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -6,7 +6,7 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal class GridViewLayout : ItemsViewLayout
+	public class GridViewLayout : ItemsViewLayout
 	{
 		readonly GridItemsLayout _itemsLayout;
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected UICollectionViewDelegateFlowLayout Delegator { get; set; }
 
-		public ItemsViewController(TItemsView itemsView, ItemsViewLayout layout) : base(layout)
+		protected ItemsViewController(TItemsView itemsView, ItemsViewLayout layout) : base(layout)
 		{
 			ItemsView = itemsView;
 			ItemsViewLayout = layout;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListViewLayout.cs
@@ -3,7 +3,7 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal class ListViewLayout : ItemsViewLayout
+	public class ListViewLayout : ItemsViewLayout
 	{
 		public ListViewLayout(LinearItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy) : base(itemsLayout, itemSizingStrategy)
 		{


### PR DESCRIPTION
### Description of Change ###

There is no way to inherit from the existing `ItemsViewLayout` implementations, so custom renderers are forced to derive from `ItemsViewLayout` directly. Also changed the accessibility of the constructor for `ItemsViewController`.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
