### PR TITLE
[iOS] [macOS] Fix HTML string encoding

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/LabelCoreGalleryPage.cs
@@ -237,14 +237,14 @@ namespace Xamarin.Forms.Controls
 				}
 			);
 			
-			var htmlLabelContainer = new ViewContainer<Label>(Test.Label.TextType,
+			var htmlLabelContainer = new ViewContainer<Label>(Test.Label.HtmlTextType,
 				new Label
 				{
 					Text = "<h1>Hello world!</h1>",
 					TextType = TextType.Html
 				});
 
-			var htmlLabelMultipleLinesContainer = new ViewContainer<Label>(Test.Label.TextType,
+			var htmlLabelMultipleLinesContainer = new ViewContainer<Label>(Test.Label.HtmlTextTypeMultipleLines,
 				new Label
 				{
 					Text = "<h1>Hello world!</h1><p>Lorem <strong>ipsum</strong> bla di bla <i>blabla</i> blablabl&nbsp;ablabla & blablablablabl ablabl ablablabl ablablabla blablablablablablab lablablabla blablab lablablabla blablabl ablablablab lablabla blab lablablabla blablab lablabla blablablablab lablabla blablab lablablabl ablablabla blablablablablabla blablabla</p>",
@@ -259,6 +259,14 @@ namespace Xamarin.Forms.Controls
 				
 			};
 
+			var htmlLabelProperties = new ViewContainer<Label>(Test.Label.HtmlTextLabelProperties, new Label
+			{
+				Text = "<h1>End aligned. Green. ä</h1>",
+				TextType = TextType.Html,
+				HorizontalTextAlignment = TextAlignment.Center,
+				TextColor = Color.Green,
+			});
+
 			var gestureRecognizer = new TapGestureRecognizer();
 
 			gestureRecognizer.Tapped += (s, a) =>
@@ -268,7 +276,7 @@ namespace Xamarin.Forms.Controls
 
 			toggleLabel.GestureRecognizers.Add(gestureRecognizer);
 
-			var toggleHtmlPlainTextLabelContainer = new ViewContainer<Label>(Test.Label.TextType,
+			var toggleHtmlPlainTextLabelContainer = new ViewContainer<Label>(Test.Label.TextTypeToggle,
 				toggleLabel);
 
 			Add (namedSizeMediumBoldContainer);
@@ -308,6 +316,7 @@ namespace Xamarin.Forms.Controls
 			Add(paddingContainer);
 			Add (htmlLabelContainer);
 			Add (htmlLabelMultipleLinesContainer);
+			Add (htmlLabelProperties);
 			Add (toggleHtmlPlainTextLabelContainer);
 		}
 	}

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -640,7 +640,10 @@ namespace Xamarin.Forms.CustomAttributes
 			VerticalTextAlignmentCenter,
 			VerticalTextAlignmentEnd,
 			MaxLines,
-			TextType
+			HtmlTextType,
+			HtmlTextTypeMultipleLines,
+			HtmlTextLabelProperties,
+			TextTypeToggle,
 		}
 
 		public enum MasterDetailPage

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -453,7 +453,8 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 			var attr = new NSAttributedStringDocumentAttributes
 			{
-				DocumentType = NSDocumentType.HTML
+				DocumentType = NSDocumentType.HTML,
+				StringEncoding = NSStringEncoding.UTF8
 			};
 
 			NSError nsError = null;
@@ -463,7 +464,8 @@ namespace Xamarin.Forms.Platform.MacOS
 #else
 			var attr = new NSAttributedStringDocumentAttributes
 			{
-				DocumentType = NSDocumentType.HTML
+				DocumentType = NSDocumentType.HTML,
+				StringEncoding = NSStringEncoding.UTF8
 			};
 
 			var htmlData = new NSMutableData();

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -450,30 +450,28 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			string text = Element.Text ?? string.Empty;
 
+			var attr = GetNSAttributedStringDocumentAttributes();
 #if __MOBILE__
-			var attr = new NSAttributedStringDocumentAttributes
-			{
-				DocumentType = NSDocumentType.HTML,
-				StringEncoding = NSStringEncoding.UTF8
-			};
 
 			NSError nsError = null;
 
 			Control.AttributedText = new NSAttributedString(text, attr, ref nsError);
-
 #else
-			var attr = new NSAttributedStringDocumentAttributes
-			{
-				DocumentType = NSDocumentType.HTML,
-				StringEncoding = NSStringEncoding.UTF8
-			};
-
 			var htmlData = new NSMutableData();
 			htmlData.SetData(text);
 
 			Control.AttributedStringValue = new NSAttributedString(htmlData, attr, out _);
 #endif
 			_perfectSizeValid = false;
+		}
+
+		protected virtual NSAttributedStringDocumentAttributes GetNSAttributedStringDocumentAttributes()
+		{
+			return new NSAttributedStringDocumentAttributes
+			{
+				DocumentType = NSDocumentType.HTML,
+				StringEncoding = NSStringEncoding.UTF8
+			};
 		}
 
 		void UpdateFont()


### PR DESCRIPTION
### Description of Change ###

Specify explicit StringEncoding when creating attributed text from HTML on iOS and macOS.
Also updated the control gallery to demonstrate the other iOS HTML bugs.

### Issues Resolved ### 

- fixes #8156 

### API Changes ###

 None

### Platforms Affected ### 

- iOS
- macOS

### Behavioral/Visual Changes ###

Text outside the ASCII range, assumed to be UTF-8 will now display correctly.

### Before/After Screenshots ### 

![image](https://user-images.githubusercontent.com/475450/67642691-65875a00-f906-11e9-86b2-cc9d3bfe0a5c.png)


### Testing Procedure ###

Control gallery label page.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
