### PR TITLE
BindableLayout allow use ViewCell

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml
@@ -18,9 +18,20 @@
 				<Label Text="{Binding }" />
 			</Frame>
 		</DataTemplate>
+		<!-- Template for ViewCell items -->
+		<DataTemplate x:Key="MyViewCellCharTemplate">
+			<ViewCell>
+				<Frame Padding="10"
+					   BackgroundColor="DodgerBlue">
+					<Label Text="{Binding }" />
+				</Frame>
+			</ViewCell>
+		   
+		</DataTemplate>
 		<local:BindableLayoutItemTemplateSelector x:Key="ItemTemplateSelector"
 												  IntTemplate="{StaticResource MyIntTemplate}"
-												  CharTemplate="{StaticResource MyCharTemplate}" />
+												  CharTemplate="{StaticResource MyCharTemplate}"
+												  ViewCellTemplate="{StaticResource MyViewCellCharTemplate}"/>
 	</ContentPage.Resources>
 	<Grid RowSpacing="0">
 		<Grid.RowDefinitions>

--- a/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/BindableLayoutGalleryPage.xaml.cs
@@ -70,10 +70,21 @@ namespace Xamarin.Forms.Controls.GalleryPages
 	{
 		public DataTemplate IntTemplate { get; set; }
 		public DataTemplate CharTemplate { get; set; }
+		public DataTemplate ViewCellTemplate { get; set; }
+
+		bool _viewCell;
 
 		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
 		{
-			return item is int ? IntTemplate : CharTemplate;
+			if(item is int)
+				return IntTemplate;
+
+			_viewCell = !_viewCell;
+
+			if (!_viewCell)
+				return CharTemplate;
+
+			return ViewCellTemplate;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/BindableLayout.cs
+++ b/Xamarin.Forms.Core/BindableLayout.cs
@@ -188,14 +188,26 @@ namespace Xamarin.Forms
 		{
 			if (dataTemplate != null)
 			{
-				var view = (View)dataTemplate.CreateContent();
+				var content = dataTemplate.CreateContent();
+				View view;
+				switch(content)
+				{
+					case View v:
+						view = v;
+						break;
+					case ViewCell viewCell:
+						view = viewCell.View;
+						break;
+					default:
+						view = new Label { Text = item?.ToString() };
+						break;
+				}
+
 				view.BindingContext = item;
 				return view;
 			}
-			else
-			{
-				return new Label() { Text = item?.ToString() };
-			}
+
+			return new Label { Text = item?.ToString() };
 		}
 
 		void ItemsSourceCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###
It would be nice to have the opportunity to use ViewCell in a DataTemplate in Bindable Layout.
In this case, you can change to choose which container to use. ListView or StakLayout for example.

``` xaml
<DataTemplate x:Key="MyViewCellCharTemplate">
    <ViewCell>
        <Frame Padding="10" BackgroundColor="DodgerBlue">
	      <Label Text="{Binding }" />
	</Frame>
    </ViewCell>
</DataTemplate>
```

### Issues Resolved ### 

- fixes #8268

### API Changes ###
 None

### Platforms Affected ### 
- Core/XAML (all platforms)
### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
1. Open Controll Gallery
2. Select BindableLayout Gallery - Legacy
3. Press Replase button
4. Check different colors for background.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
