### PR TITLE
Add missing null check on ItemsSource when IsGrouped is true

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8269.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8269.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8269, "[Bug] CollectionView exception when IsGrouped=true and null ItemSource", 
+		PlatformAffected.Android)]
+	public class Issue8269 : TestContentPage
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label { Text = "If this page has not crashed, the test is sucessful." };
+			var success = new Label { AutomationId = Success, Text = Success };
+
+			var cv = new CollectionView { ItemsSource = null, IsGrouped = true };
+
+			layout.Children.Add(success);
+			layout.Children.Add(instructions);
+			layout.Children.Add(cv);
+			
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void IsGroupedWithNullItemsSourceShouldNotCrash()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -96,6 +96,7 @@
       <DependentUpon>Issue7803.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8167.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8269.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
@@ -37,7 +37,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static IGroupableItemsViewSource Create(GroupableItemsView itemsView, RecyclerView.Adapter adapter)
 		{
-			if (itemsView.IsGrouped)
+			var source = itemsView.ItemsSource;
+
+			if (itemsView.IsGrouped && source != null)
 			{
 				return new ObservableGroupedSource(itemsView, new AdapterNotifier(adapter));
 			}


### PR DESCRIPTION
### Description of Change ###

Adds a missing null check before trying to create a grouped data source out of a null ItemsSource.

### Issues Resolved ### 
- fixes #8269

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
