### PR TITLE
WKWebView opens target=_blank links

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1666.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1666.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var buttonD = new Button() { Text = "AEVAL", BackgroundColor = Color.LightBlue, AutomationId = "buttonD" };
 
 			var url = "https://www.microsoft.com/";
-			var html = $"<html><body><a href=\"{url}\">Link</a></body></html>";
+			var html = $"<html><body><a href=\"{url}\">Link</a><br /><a href=\"{url}\" target=\"_blank\">Link with target=_blank</a></body></html>";
 
 			var webView = new WkWebView()
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -249,6 +249,10 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					case WKNavigationType.LinkActivated:
 						navEvent = WebNavigationEvent.NewPage;
+
+						if (navigationAction.TargetFrame == null)
+							webView?.LoadRequest(navigationAction.Request);
+
 						break;
 					case WKNavigationType.FormSubmitted:
 						navEvent = WebNavigationEvent.NewPage;


### PR DESCRIPTION
### Description of Change ###

The `WKWebViewRenderer` was not following links that had the `target=_blank` attribute, this PR fixes that.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8028

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

In Issue1666 I've added a link with `target=_blank`. Before this fix, nothing would happen, now it opens the link like any other.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
