### PR TITLE
[iOS] Fix crash using an object that implements IEnumerable and INotifyCollectionChanged

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8200.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8200.cs
@@ -1,0 +1,169 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8200, "CollectionView on iOS assumes INotifyCollectionChanged is an IList", PlatformAffected.iOS)]
+	public class Issue8200 : TestContentPage
+	{
+		CollectionView _collectionView;
+
+		public Issue8200()
+		{
+			Title = "Issue 8200";
+			BindingContext = new Issue8200ViewModel();
+		}
+
+		protected override void Init()
+		{
+			var instructions = new Label
+			{
+				Text = "If you can see a CollectionView below with items, the test has passed."
+			};
+
+			var buttonsLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var addButton = new Button
+			{
+				Text = "Add Item"
+			};
+
+			addButton.SetBinding(Button.CommandProperty, "AddItemCommand");
+
+			buttonsLayout.Children.Add(addButton);
+
+			_collectionView = new CollectionView
+			{
+				BackgroundColor = Color.LightGreen,
+				ItemTemplate = CreateDataGridTemplate(),
+				SelectionMode = SelectionMode.None
+			};
+
+			_collectionView.SetBinding(ItemsView.ItemsSourceProperty, "Items");
+
+			var stack = new StackLayout();
+
+			stack.Children.Add(instructions);
+			stack.Children.Add(buttonsLayout);
+			stack.Children.Add(_collectionView);
+
+			Content = stack;
+		}
+
+		DataTemplate CreateDataGridTemplate()
+		{
+			var template = new DataTemplate(() =>
+			{
+				var grid = new Grid();
+				var cell = new Label();
+				cell.SetBinding(Label.TextProperty, "Text");
+				cell.FontSize = 20;
+				cell.BackgroundColor = Color.LightBlue;
+				grid.Children.Add(cell);
+
+				return grid;
+			});
+
+			return template;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8200Model
+	{
+		public string Text { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8200ViewModel : BindableObject
+	{
+		Issue8200Collection _items;
+
+		public Issue8200ViewModel()
+		{
+			LoadItems();
+		}
+
+		public Issue8200Collection Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ICommand AddItemCommand => new Command(AddItem);
+
+		void LoadItems()
+		{
+			Items = new Issue8200Collection();
+
+			for (int i = 0; i < 30; i++)
+			{
+				Items.AddNewItem(new Issue8200Model { Text = i.ToString() });
+			}
+		}
+
+		void AddItem()
+		{
+			var itemsCount = Items.Count();
+			Items.AddNewItem(new Issue8200Model { Text = itemsCount.ToString() });
+		}
+	}
+
+	public class Issue8200Collection : IEnumerable<Issue8200Model>, INotifyCollectionChanged
+	{
+		readonly List<Issue8200Model> _internalList = new List<Issue8200Model>();
+
+		public IEnumerable<Issue8200Model> GetItems()
+		{
+			foreach (var item in _internalList)
+			{
+				yield return item;
+			}
+		}
+
+		public IEnumerator<Issue8200Model> GetEnumerator()
+		{
+			return GetItems().GetEnumerator();
+		}
+
+		public void AddNewItem(Issue8200Model newItem)
+		{
+			int index = _internalList.Count;
+			_internalList.Add(newItem);
+			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, newItem, index));
+		}
+
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+		protected void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+		{
+			CollectionChanged?.Invoke(this, e);
+		}
+
+		IEnumerator IEnumerable.GetEnumerator()
+		{
+			return GetEnumerator();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1143,6 +1143,7 @@
       <DependentUpon>Issue7886.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8200.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsSourceFactory.cs
@@ -18,6 +18,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				case IList _ when itemsSource is INotifyCollectionChanged:
 					return new ObservableItemsSource(itemsSource as IList, notifier);
+				case IEnumerable _ when itemsSource is INotifyCollectionChanged:
+					return new ObservableItemsSource(itemsSource as IEnumerable, notifier);
 				case IEnumerable<object> generic:
 					return new ListSource(generic);
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsSourceFactory.cs
@@ -16,12 +16,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			switch (itemsSource)
 			{
-				case INotifyCollectionChanged _:
+				case IList _ when itemsSource is INotifyCollectionChanged:
 					return new ObservableItemsSource(itemsSource as IList, collectionViewController);
-				case IEnumerable _:
-				default:
-					return new ListSource(itemsSource);
+				case IEnumerable _ when itemsSource is INotifyCollectionChanged:
+					return new ObservableItemsSource(itemsSource as IEnumerable, collectionViewController);
+				case IEnumerable<object> generic:
+					return new ListSource(generic);
 			}
+
+			return new ListSource(itemsSource);
 		}
 
 		public static IItemsViewSource CreateGrouped(IEnumerable itemsSource, UICollectionViewController collectionViewController)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			for (int n = 0; n < _groupSource.Count; n++)
 			{
-				if (_groupSource[n] is INotifyCollectionChanged && _groupSource[n] is IList list)
+				if (_groupSource[n] is INotifyCollectionChanged && _groupSource[n] is IEnumerable list)
 				{
 					_groups.Add(new ObservableItemsSource(list, _collectionViewController, n));
 				}


### PR DESCRIPTION
### Description of Change ###

Fix crash using an object that implements `IEnumerable` and `INotifyCollectionChanged`.

Initially, I only made changes to `ItemsSourceFactory` to use `ListSource` in this case. This would prevent the crash, however, we would ignore `INotifyCollectionChanged`. For that reason, I made changes also in `ObservableItemsSource` (on Android too) to use IEnumerable. In this way, we guarantee the use of IList (have IEnumerable as base class) and IEnumerable.

### Issues Resolved ### 

- fixes #8200

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
The app crashes with a NullReferenceException

#### After
<img width="412" alt="Captura de pantalla 2019-10-29 a las 11 36 47" src="https://user-images.githubusercontent.com/6755973/67759843-8227ad00-fa40-11e9-9d18-74e89d7eb107.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 8200. If the CollectionView appear with items, the test pass.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
