### PR TITLE
Fixed 5830 - [Enhancement] EntryCellTableViewCell should be public

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -24,6 +24,7 @@ using RectangleF = CoreGraphics.CGRect;
 [assembly: ExportRenderer(typeof(Bugzilla52700.NoSelectionViewCell), typeof(NoSelectionViewCellRenderer))]
 [assembly: ExportRenderer(typeof(Issue1683.EntryKeyboardFlags), typeof(EntryRendererKeyboardFlags))]
 [assembly: ExportRenderer(typeof(Issue1683.EditorKeyboardFlags), typeof(EditorRendererKeyboardFlags))]
+[assembly: ExportRenderer(typeof(Issue5830.ExtendedEntryCell), typeof(ExtendedEntryCellRenderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
 
@@ -688,6 +689,26 @@ namespace Xamarin.Forms.ControlGallery.iOS
 					throw new Exception("CapitalizeWord not correctly set");
 				}
 			}
+		}
+	}
+
+	public class ExtendedEntryCellRenderer : EntryCellRenderer
+	{
+		public override UITableViewCell GetCell(Cell item, UITableViewCell reusableCell, UITableView tv)
+		{
+			var entryCell = (EntryCell)item;
+			var cell = base.GetCell(item, reusableCell, tv);
+			if (cell != null && entryCell != null)
+			{
+				var tvc = cell as EntryCellTableViewCell;
+				if (tvc != null)
+				{
+					// cell.TextField.thingstocallhere, for example:
+					tvc.TextField.Text = entryCell.Text;
+					tvc.TextField.TextColor = UIColor.Red;
+				}
+			}
+			return cell;
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5830.cs
@@ -1,0 +1,56 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5830, "[Enhancement] EntryCellTableViewCell should be public", PlatformAffected.iOS)]
+	public class Issue5830 : TestContentPage
+	{
+		const string Instructions = "On iOS, if the below Entry Cell displays 'Text from Custom Entry Cell' in 'Red' color, this test has passed.";
+		ListView lstView;
+
+		public class ExtendedEntryCell : EntryCell
+		{
+			public ExtendedEntryCell()
+			{
+				base.Text = "Text from Custom Entry Cell";
+			}
+		}
+
+		protected override void Init()
+		{
+			var label = new Label { Text = Instructions };
+			lstView = new ListView(ListViewCachingStrategy.RecycleElement)
+			{
+				ItemTemplate = new DataTemplate(typeof(ExtendedEntryCell)),
+				ItemsSource = new[] { "item1" }
+			};
+
+			Content = new StackLayout
+			{
+				Children = {
+					label,
+					lstView
+				}
+			};
+		}
+
+#if (UITEST && __IOS__)
+        [Test]
+		[Category(UITestCategories.ManualReview)]
+        public void Issue5830Test()
+        {
+            RunningApp.Screenshot("EntryTableViewCell Test with custom Text and TextColor");
+        }
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -20,6 +20,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewHeaderFooterView.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsUpdatingScrollMode.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue5830.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7825.cs" />

--- a/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
@@ -125,7 +125,7 @@ namespace Xamarin.Forms.Platform.iOS
 			cell.TextField.Text = entryCell.Text;
 		}
 
-		class EntryCellTableViewCell : CellTableViewCell
+		public class EntryCellTableViewCell : CellTableViewCell
 		{
 			public EntryCellTableViewCell(string cellName) : base(UITableViewCellStyle.Value1, cellName)
 			{


### PR DESCRIPTION
### Description of Change ###

As mentioned in the ticket #5830, updated access modifier for `EntryCellTableViewCell` to allow for further customization from platform-specific renderers.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5830

### API Changes ###

Changed:
 - `class EntryCellTableViewCell : CellTableViewCell` => `public class EntryCellTableViewCell : CellTableViewCell`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Just run `Issue5830.cs` from Control Gallery. On iOS, if the Entry Cell displays 'Text from Custom Entry Cell' in 'Red' color, this test has passed.
Please Note: I don't have iOS setup so I'd need help from someone from Xamarin Team to review the above test on iOS. I've tested it on Android device and the page loads fine with the Text set (except the TextColor as Red which is only implemented in iOS custom renderer). I've implemented all the required changes (including Custom Renderer) in order to run the above test page (`Issue5830.cs`). Please let me know in case of any questions.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
