### PR TITLE
[macOS] Implement entry placeholder text alignment

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -292,7 +292,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var color = Element.IsEnabled && !targetColor.IsDefault ? targetColor : ColorExtensions.SeventyPercentGrey.ToColor();
 
-			Control.PlaceholderAttributedString = formatted.ToAttributed(Element, color);
+			Control.PlaceholderAttributedString = formatted.ToAttributed(Element, color, Element.HorizontalTextAlignment);
 		}
 
 		protected override void SetAccessibilityLabel()


### PR DESCRIPTION
### Description of Change ###

Implement `HorizontalTextAlignmentPlaceholder` on macOS. This is not a standalone property but rather applies the general entry horizontal text alignment for the placeholder.

I'm currently looking into implementing vertical text alignment as well which is neither implemented for the text or placeholder.

### Issues Resolved 

Implementing missing property for platform.

### API Changes ###

 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ### 

None

### Before/After Screenshots ### 

**Before:** Horizontal alignment did not apply on placeholders

**After:** 
Start:
<img width="672" alt="image" src="https://user-images.githubusercontent.com/11095003/67795178-27ad4180-fa7e-11e9-876c-7fbbfe410432.png">

Horizontal:
<img width="685" alt="image" src="https://user-images.githubusercontent.com/11095003/67795113-12381780-fa7e-11e9-9816-6726dd2e1a68.png">

End:
<img width="667" alt="image" src="https://user-images.githubusercontent.com/11095003/67795227-385db780-fa7e-11e9-8ed9-a1fc86185e5d.png">

### Testing Procedure ###

Testable in control gallery

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
