### PR TITLE
Fixed 7808 - [Enhancement] Allow providing custom ShellSectionRootRenderer

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -691,5 +691,35 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		}
 	}
 
+	public class Issue7808ShellRenderer : ShellRenderer
+	{
+		protected override IShellSectionRenderer CreateShellSectionRenderer(ShellSection shellSection)
+		{
+			return new Issue7808ShellSectionRenderer(this);
+		}
+	}
+
+	public class Issue7808ShellSectionRenderer : ShellSectionRenderer
+	{
+		public Issue7808ShellSectionRenderer(IShellContext context) : base(context)
+		{
+		}
+
+		//This is what is needed
+		protected override IShellSectionRootRenderer CreateShellSectionRootRenderer(ShellSection shellSection)
+		{
+			var renderer = base.CreateShellSectionRootRenderer(shellSection);
+			if (renderer != null)
+			{
+				//customize your stuff here, for example:
+				(renderer as ShellSectionRootRenderer).View.BackgroundColor = UIColor.Blue;
+				var header = renderer.CreateShellSectionRootHeader();
+				if (header != null)
+					header.View.BackgroundColor = UIColor.Red;
+			}
+			return renderer;
+		}
+	}
+
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7808.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7808.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7808, "[Enhancement] Allow providing custom ShellSectionRootRenderer",
+		PlatformAffected.iOS)]
+
+	public class Issue7808 : TestShell
+	{
+		const string CreateBottomTabButton = "CreateBottomTabButton";
+		protected override void Init()
+		{
+			
+			var page = CreateContentPage();
+			page.Title = "Main";
+			page.Content = CreateEntryInsetView();
+			CurrentItem = Items.Last();
+		}
+
+		View CreateEntryInsetView()
+		{
+			var random = new Random();
+			ScrollView view = null;
+			view = new ScrollView()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+						{
+							new Button()
+							{
+								Text = "Bottom Tab",
+								AutomationId = CreateBottomTabButton,
+								Command = new Command(() => AddBottomTab("bottom", "coffee.png"))
+							}
+						}
+				}
+			};
+			return view;
+		}
+
+#if (UITEST && __IOS__)
+
+		[Test]
+		[Category(UITestCategories.Shell)]
+		[Category(UITestCategories.ManualReview)]
+		public void CustomShellSectionRootRendererTest()
+		{
+			RunningApp.WaitForElement(CreateBottomTabButton);
+			RunningApp.Tap(CreateBottomTabButton);
+			RunningApp.Screenshot("ShellSection View with Blue and header as Red background color");
+			Assert.Inconclusive("Check that ShellSection View with Blue and header as Red background color");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -22,6 +22,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue3475.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6476.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7396.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7808.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7825.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5354.xaml.cs">
       <DependentUpon>Issue5354.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.iOS/Renderers/IShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IShellSectionRenderer.cs
@@ -8,5 +8,6 @@ namespace Xamarin.Forms.Platform.iOS
 		bool IsInMoreTab { get; set; }
 		ShellSection ShellSection { get; set; }
 		UIViewController ViewController { get; }
+		IShellSectionRootRenderer CreateShellSectionRootRenderer(ShellSection shellSection);
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/IShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IShellSectionRootRenderer.cs
@@ -8,5 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool ShowNavBar { get; }
 
 		UIViewController ViewController { get; }
+
+		ShellSectionRootHeader CreateShellSectionRootHeader();
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -33,6 +33,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public UIViewController ViewController => this;
 
+		IShellSectionRootRenderer IShellSectionRenderer.CreateShellSectionRootRenderer(ShellSection shellSection)
+		{
+			return CreateShellSectionRootRenderer(shellSection);
+		}
+
 		#endregion IShellContentRenderer
 
 		#region IAppearanceObserver
@@ -69,6 +74,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			Delegate = new NavDelegate(this);
 			_context = context;
+		}
+
+		protected virtual IShellSectionRootRenderer CreateShellSectionRootRenderer(ShellSection shellSection)
+		{
+			return new ShellSectionRootRenderer(ShellSection, _context);
 		}
 
 		public override UIViewController PopViewController(bool animated)
@@ -176,8 +186,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void LoadPages()
 		{
-			_renderer = new ShellSectionRootRenderer(ShellSection, _context);
-
+			_renderer = CreateShellSectionRootRenderer(ShellSection);
 			PushViewController(_renderer.ViewController, false);
 
 			var stack = ShellSection.Stack;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -15,6 +15,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		UIViewController IShellSectionRootRenderer.ViewController => this;
 
+		ShellSectionRootHeader IShellSectionRootRenderer.CreateShellSectionRootHeader()
+		{
+			return CreateShellSectionRootHeader();
+		}
+
 		#endregion IShellSectionRootRenderer
 
 		const int HeaderHeight = 35;
@@ -36,6 +41,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			ShellSection = shellSection ?? throw new ArgumentNullException(nameof(shellSection));
 			_shellContext = shellContext;
+		}
+
+		protected virtual ShellSectionRootHeader CreateShellSectionRootHeader()
+		{
+			return new ShellSectionRootHeader(_shellContext);
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -205,7 +215,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_header == null)
 				{
-					_header = new ShellSectionRootHeader(_shellContext);
+					_header = CreateShellSectionRootHeader();
 					_header.ShellSection = ShellSection;
 
 					AddChildViewController(_header);


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->
As mentioned in the ticket #7808 , allowed access for `ShellSectionRootRenderer` and `ShellSectionRootHeader` to allow for further customization from platform-specific renderers. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7808

### API Changes ###

Added:

- Added `CreateShellSectionRootRenderer()` to `IShellSectionRenderer` instead of instantiating the renderer in LoadPages() https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs#L179

- Added `CreateShellSectionRootHeader()` to `IShellSectionRootRenderer` instead of instantiating it internally in `UpdateHeaderVisibility()` https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs#L208

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Just run `Issue7808.cs` from Control Gallery. I tried to create a test/use case (might not be a best usecase) and customized the `ShellSectionRootRenderer` and `ShellSectionRootHeader` (as described in the ticket). On iOS, if ShellSection View with 'Blue' and header as 'Red' background color are shown, this test has passed.

Please Note: I don't have iOS setup so I'd need help from someone from Xamarin Team to review the above test on iOS. I've implemented all the required changes (including Custom Renderer) in order to run the above test page (Issue7808.cs). Please let me know in case of any questions.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
