### PR TITLE
Check for ValueType items to perform equals

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ListViewRenderer.cs
@@ -774,7 +774,14 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
 		{
-			if (Element.SelectedItem != List.SelectedItem)
+			bool areEqual = false;
+
+			if (Element.SelectedItem != null && Element.SelectedItem.GetType().IsValueType)
+				areEqual = Element.SelectedItem.Equals(List.SelectedItem);
+			else
+				areEqual = Element.SelectedItem == List.SelectedItem;
+
+			if (!areEqual)
 			{
 				if (_itemWasClicked)
 					List.SelectedItem = Element.SelectedItem;


### PR DESCRIPTION
### Description of Change ###

When selecting an item from the List, we need to validate if it's a value type or not. Because KeyValuePair sources won't allow == or != operators, we need to use .Equals().

### Issues Resolved ### 

- fixes #8278

### API Changes ###

Changed:
 - object ListViewRenderer.OnControlSelectionChanged => areEqual check

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
In the ListViewCore gallery page, changed the ItemsSource to List<KeyValuePair>. You will notice a stack overflow exception when selecting 1 element in the list.
After the fix, it will just select the item and don't crash.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
