### PR TITLE
Fixed - 8279 - [Enhancement] ListView ScrollTo with empty groups - Android

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
@@ -6,6 +6,11 @@ using System.Linq;
 
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -15,9 +20,16 @@ namespace Xamarin.Forms.Controls.Issues
     {
         public static ListView List { get; set; }
         public static List<MyGroup> Data { get; set;  }
-        public Issue8279()
+		const string ScrollWithNoItemButGroup = "ScrollWithNoItemButGroup";
+		const string ScrollWithItemButNoGroup = "ScrollWithItemButNoGroup";
+		const string ScrollWithItemWithGroup = "ScrollWithItemWithGroup";
+		const string ScrollWithNoItemNoGroup = "ScrollWithNoItemNoGroup";
+		const string ScrollWithNoItemEmptyGroup = "ScrollWithNoItemEmptyGroup";
+
+		public Issue8279()
         {
-            Data = new List<MyGroup>();
+#if APP
+			Data = new List<MyGroup>();
             Data.Add(new MyGroup(){Headertitle = "Header 1"});
             Data.First().Add(new MyData(){Title = "title 1"});
             Data.First().Add(new MyData() { Title = "title 2" });
@@ -52,30 +64,35 @@ namespace Xamarin.Forms.Controls.Issues
 			var button1 = new Button()
 			{
 				Text = "Scroll with no item but group",
+				AutomationId = ScrollWithNoItemButGroup,
 				Command = new Command(()=> List.ScrollTo(null, lastGroup, ScrollToPosition.MakeVisible, true))
 			};
 
 			var button2 = new Button()
 			{
 				Text = "Scroll with item but no group",
+				AutomationId = ScrollWithItemButNoGroup,
 				Command = new Command(() => List.ScrollTo(firstItem, ScrollToPosition.MakeVisible, true))
 			};
 
 			var button3 = new Button()
 			{
 				Text = "Scroll with item with group",
+				AutomationId = ScrollWithItemWithGroup,
 				Command = new Command(() => List.ScrollTo(firstItem, lastGroup, ScrollToPosition.MakeVisible, true))
 			};
 
 			var button4 = new Button()
 			{
 				Text = "Scroll with no item no group",
+				AutomationId = ScrollWithNoItemNoGroup,
 				Command = new Command(() => List.ScrollTo(null, null, ScrollToPosition.MakeVisible, true))
 			};
 
 			var button5 = new Button()
 			{
 				Text = "Scroll with no item but empty group",
+				AutomationId = ScrollWithNoItemEmptyGroup,
 				Command = new Command(() => List.ScrollTo(null, emptyGroup, ScrollToPosition.MakeVisible, true))
 			};
 
@@ -84,7 +101,55 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.FillAndExpand,
 				Children = { button1, button2, button3, button4, button5, List },
 			};
-        }
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void ScrollWithNoItemButGroup()
+		{
+			RunningApp.WaitForElement(ScrollWithNoItemButGroup);
+			RunningApp.Tap(ScrollWithNoItemButGroup);
+			// This will fail if the list didn't scroll. If it did scroll, it will succeed
+			RunningApp.WaitForElement(q => q.Marked("Header 3"), timeout: TimeSpan.FromSeconds(2));
+		}
+
+		[Test]
+		public void ScrollWithItemButNoGroup()
+		{
+			RunningApp.WaitForElement(ScrollWithItemButNoGroup);
+			RunningApp.Tap(ScrollWithItemButNoGroup);
+			// This will fail if the list didn't scroll. If it did scroll, it will succeed
+			RunningApp.WaitForElement(q => q.Marked("title 1"), timeout: TimeSpan.FromSeconds(2));
+		}
+
+		[Test]
+		public void ScrollWithItemWithGroup()
+		{
+			RunningApp.WaitForElement(ScrollWithItemWithGroup);
+			RunningApp.Tap(ScrollWithItemWithGroup);
+			// This will fail if the list didn't scroll. If it did scroll, it will succeed
+			RunningApp.WaitForElement(q => q.Marked("Header 3"), timeout: TimeSpan.FromSeconds(2));
+		}
+
+		[Test]
+		public void ScrollWithNoItemNoGroup()
+		{
+			RunningApp.WaitForElement(ScrollWithNoItemNoGroup);
+			RunningApp.Tap(ScrollWithNoItemNoGroup);
+			// This will pass if the list didn't scroll and remain on the same state
+			RunningApp.WaitForElement(q => q.Marked("Header 3"), timeout: TimeSpan.FromSeconds(2));
+		}
+
+		[Test]
+		public void ScrollWithNoItemEmptyGroup()
+		{
+			RunningApp.WaitForElement(ScrollWithNoItemEmptyGroup);
+			RunningApp.Tap(ScrollWithNoItemEmptyGroup);
+			// This will fail if the list didn't scroll. If it did scroll, it will succeed
+			RunningApp.WaitForElement(q => q.Marked("Header 2"), timeout: TimeSpan.FromSeconds(2));
+		}
+#endif
 
 		[Preserve(AllMembers = true)]
 		public class MyData : INotifyPropertyChanged

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void ScrollWithNoItemButGroup()
+		public void ScrollWithNoItemButGroupTest()
 		{
 			RunningApp.WaitForElement(ScrollWithNoItemButGroup);
 			RunningApp.Tap(ScrollWithNoItemButGroup);
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
-		public void ScrollWithItemButNoGroup()
+		public void ScrollWithItemButNoGroupTest()
 		{
 			RunningApp.WaitForElement(ScrollWithItemButNoGroup);
 			RunningApp.Tap(ScrollWithItemButNoGroup);
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
-		public void ScrollWithItemWithGroup()
+		public void ScrollWithItemWithGroupTest()
 		{
 			RunningApp.WaitForElement(ScrollWithItemWithGroup);
 			RunningApp.Tap(ScrollWithItemWithGroup);
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
-		public void ScrollWithNoItemNoGroup()
+		public void ScrollWithNoItemNoGroupTest()
 		{
 			RunningApp.WaitForElement(ScrollWithNoItemNoGroup);
 			RunningApp.Tap(ScrollWithNoItemNoGroup);
@@ -142,7 +142,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
-		public void ScrollWithNoItemEmptyGroup()
+		public void ScrollWithNoItemEmptyGroupTest()
 		{
 			RunningApp.WaitForElement(ScrollWithNoItemEmptyGroup);
 			RunningApp.Tap(ScrollWithNoItemEmptyGroup);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
@@ -16,8 +16,8 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve (AllMembers=true)]
 	[Issue (IssueTracker.Github, 8279, "[Feature requested] ListView do not ScrollTo a group when there is no child of this group", PlatformAffected.Android)]
-    public class Issue8279 : ContentPage
-    {
+    public class Issue8279 : TestContentPage
+	{
         public static ListView List { get; set; }
         public static List<MyGroup> Data { get; set;  }
 		const string ScrollWithNoItemButGroup = "ScrollWithNoItemButGroup";
@@ -26,6 +26,10 @@ namespace Xamarin.Forms.Controls.Issues
 		const string ScrollWithNoItemNoGroup = "ScrollWithNoItemNoGroup";
 		const string ScrollWithNoItemEmptyGroup = "ScrollWithNoItemEmptyGroup";
 
+		protected override void Init()
+		{
+
+		}
 		public Issue8279()
         {
 #if APP

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
@@ -25,11 +25,13 @@ namespace Xamarin.Forms.Controls.Issues
 		const string ScrollWithItemWithGroup = "ScrollWithItemWithGroup";
 		const string ScrollWithNoItemNoGroup = "ScrollWithNoItemNoGroup";
 		const string ScrollWithNoItemEmptyGroup = "ScrollWithNoItemEmptyGroup";
+		const string Reset = "Reset";
 
 		protected override void Init()
 		{
 
 		}
+
 		public Issue8279()
         {
 #if APP
@@ -100,10 +102,17 @@ namespace Xamarin.Forms.Controls.Issues
 				Command = new Command(() => List.ScrollTo(null, emptyGroup, ScrollToPosition.MakeVisible, true))
 			};
 
+			var resetButton = new Button()
+			{
+				Text = "Reset",
+				AutomationId = Reset,
+				Command = new Command(() => List.ScrollTo(null, firstGroup, ScrollToPosition.Center, true))
+			};
+
 			Content = new StackLayout () {
 				VerticalOptions = LayoutOptions.StartAndExpand,
 				HorizontalOptions = LayoutOptions.FillAndExpand,
-				Children = { button1, button2, button3, button4, button5, List },
+				Children = { resetButton, button1, button2, button3, button4, button5, List },
 			};
 #endif
 		}
@@ -112,6 +121,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ScrollWithNoItemButGroupTest()
 		{
+			RunningApp.WaitForElement(Reset);
+			RunningApp.Tap(Reset);
 			RunningApp.WaitForElement(ScrollWithNoItemButGroup);
 			RunningApp.Tap(ScrollWithNoItemButGroup);
 			// This will fail if the list didn't scroll. If it did scroll, it will succeed
@@ -121,6 +132,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ScrollWithItemButNoGroupTest()
 		{
+			RunningApp.WaitForElement(Reset);
+			RunningApp.Tap(Reset);
 			RunningApp.WaitForElement(ScrollWithItemButNoGroup);
 			RunningApp.Tap(ScrollWithItemButNoGroup);
 			// This will fail if the list didn't scroll. If it did scroll, it will succeed
@@ -130,6 +143,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ScrollWithItemWithGroupTest()
 		{
+			RunningApp.WaitForElement(Reset);
+			RunningApp.Tap(Reset);
 			RunningApp.WaitForElement(ScrollWithItemWithGroup);
 			RunningApp.Tap(ScrollWithItemWithGroup);
 			// This will fail if the list didn't scroll. If it did scroll, it will succeed
@@ -139,15 +154,19 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ScrollWithNoItemNoGroupTest()
 		{
+			RunningApp.WaitForElement(Reset);
+			RunningApp.Tap(Reset);
 			RunningApp.WaitForElement(ScrollWithNoItemNoGroup);
 			RunningApp.Tap(ScrollWithNoItemNoGroup);
 			// This will pass if the list didn't scroll and remain on the same state
-			RunningApp.WaitForElement(q => q.Marked("Header 3"), timeout: TimeSpan.FromSeconds(2));
+			RunningApp.WaitForElement(q => q.Marked("Header 1"), timeout: TimeSpan.FromSeconds(2));
 		}
 
 		[Test]
 		public void ScrollWithNoItemEmptyGroupTest()
 		{
+			RunningApp.WaitForElement(Reset);
+			RunningApp.Tap(Reset);
 			RunningApp.WaitForElement(ScrollWithNoItemEmptyGroup);
 			RunningApp.Tap(ScrollWithNoItemEmptyGroup);
 			// This will fail if the list didn't scroll. If it did scroll, it will succeed

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8279.cs
@@ -1,0 +1,157 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve (AllMembers=true)]
+	[Issue (IssueTracker.Github, 8279, "[Feature requested] ListView do not ScrollTo a group when there is no child of this group", PlatformAffected.Android)]
+    public class Issue8279 : ContentPage
+    {
+        public static ListView List { get; set; }
+        public static List<MyGroup> Data { get; set;  }
+        public Issue8279()
+        {
+            Data = new List<MyGroup>();
+            Data.Add(new MyGroup(){Headertitle = "Header 1"});
+            Data.First().Add(new MyData(){Title = "title 1"});
+            Data.First().Add(new MyData() { Title = "title 2" });
+			Data.First().Add(new MyData() { Title = "title 3" });
+			Data.First().Add(new MyData() { Title = "title 4" });
+			Data.First().Add(new MyData() { Title = "title 5" });
+			Data.First().Add(new MyData() { Title = "title 6" });
+			Data.First().Add(new MyData() { Title = "title 7" });
+			Data.First().Add(new MyData() { Title = "title 8" });
+			Data.Add(new MyGroup() { Headertitle = "Header 2" });
+			Data.Add(new MyGroup() { Headertitle = "Header 3" });
+			Data.Last().Add(new MyData() { Title = "title 3a" });
+			Data.Last().Add(new MyData() { Title = "title 3b" });
+			Data.Last().Add(new MyData() { Title = "title 3b" });
+			Data.Last().Add(new MyData() { Title = "title 3b" });
+
+			List = new ListView();
+            List.HorizontalOptions = LayoutOptions.FillAndExpand;
+            List.VerticalOptions = LayoutOptions.FillAndExpand;
+            List.BackgroundColor = Color.Yellow;
+            List.ItemTemplate = new DataTemplate(typeof (VCTest));
+            List.GroupHeaderTemplate = new DataTemplate(typeof(VCHeader));
+            List.IsGroupingEnabled = true;
+            List.ItemsSource = Data;
+
+			var lastGroup = Data.Last();
+			var lastItem = lastGroup.First();
+			var firstGroup = Data.First();
+			var firstItem = firstGroup.First();
+			var emptyGroup = Data[1];
+
+			var button1 = new Button()
+			{
+				Text = "Scroll with no item but group",
+				Command = new Command(()=> List.ScrollTo(null, lastGroup, ScrollToPosition.MakeVisible, true))
+			};
+
+			var button2 = new Button()
+			{
+				Text = "Scroll with item but no group",
+				Command = new Command(() => List.ScrollTo(firstItem, ScrollToPosition.MakeVisible, true))
+			};
+
+			var button3 = new Button()
+			{
+				Text = "Scroll with item with group",
+				Command = new Command(() => List.ScrollTo(firstItem, lastGroup, ScrollToPosition.MakeVisible, true))
+			};
+
+			var button4 = new Button()
+			{
+				Text = "Scroll with no item no group",
+				Command = new Command(() => List.ScrollTo(null, null, ScrollToPosition.MakeVisible, true))
+			};
+
+			var button5 = new Button()
+			{
+				Text = "Scroll with no item but empty group",
+				Command = new Command(() => List.ScrollTo(null, emptyGroup, ScrollToPosition.MakeVisible, true))
+			};
+
+			Content = new StackLayout () {
+				VerticalOptions = LayoutOptions.StartAndExpand,
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				Children = { button1, button2, button3, button4, button5, List },
+			};
+        }
+
+		[Preserve(AllMembers = true)]
+		public class MyData : INotifyPropertyChanged
+		{
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			string _title;
+
+			public const string PropTitle = "Title";
+
+			public string Title
+			{
+				get { return _title; }
+				set
+				{
+					if (value.Equals(_title, StringComparison.Ordinal))
+						return;
+					_title = value;
+					OnPropertyChanged(new PropertyChangedEventArgs(PropTitle));
+				}
+			}
+
+			public void OnPropertyChanged(PropertyChangedEventArgs e)
+			{
+				if (PropertyChanged != null)
+					PropertyChanged(this, e);
+			}
+		}
+		[Preserve(AllMembers = true)]
+		public class MyGroup : ObservableCollection<MyData>, INotifyPropertyChanged
+		{
+			string _headertitle;
+
+			public const string PropHeadertitle = "Headertitle";
+
+			public string Headertitle
+			{
+				get { return _headertitle; }
+				set
+				{
+					if (value.Equals(_headertitle, StringComparison.Ordinal))
+						return;
+					_headertitle = value;
+					OnPropertyChanged(new PropertyChangedEventArgs(PropHeadertitle));
+				}
+			}
+		}
+		[Preserve(AllMembers = true)]
+		internal class VCTest : ViewCell
+		{
+			public VCTest()
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, "Title");
+				View = label;
+			}
+		}
+		[Preserve(AllMembers = true)]
+		internal class VCHeader : ViewCell
+		{
+			public VCHeader()
+			{
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, "Headertitle");
+				View = label;
+			}
+		}
+	}
+	
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -280,12 +280,15 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element.IsGroupingEnabled)
 			{
 				var results = templatedItems.GetGroupAndIndexOfItem(scrollArgs.Group, scrollArgs.Item);
-				if (results.Item1 == -1 || (results.Item1 == -1 && results.Item2 == -1))
+				int indexOfGroup = results.Item1;
+				int indexOfItem = results.Item2;
+				
+				if (indexOfGroup == -1 || (indexOfGroup == -1 && indexOfItem == -1))
 					return;
 
-				int item = results.Item2 == -1 ? 0 : results.Item2;
+				int item = indexOfItem == -1 ? 0 : indexOfItem;
 
-				var group = templatedItems.GetGroup(results.Item1);
+				var group = templatedItems.GetGroup(indexOfGroup);
 				if (group.Count == 0)
 					cell = group.HeaderContent;
 				else

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -273,7 +273,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			Cell cell;
-			int position;
+			int scrollPosition;
 			var scrollArgs = (ITemplatedItemsListScrollToRequestedEventArgs)e;
 
 			var templatedItems = TemplatedItemsView.TemplatedItems;
@@ -283,30 +283,31 @@ namespace Xamarin.Forms.Platform.Android
 				int indexOfGroup = results.Item1;
 				int indexOfItem = results.Item2;
 				
-				if (indexOfGroup == -1 || (indexOfGroup == -1 && indexOfItem == -1))
+				if (indexOfGroup == -1)
 					return;
 
-				int item = indexOfItem == -1 ? 0 : indexOfItem;
+				int itemIndex = indexOfItem == -1 ? 0 : indexOfItem;
 
 				var group = templatedItems.GetGroup(indexOfGroup);
 				if (group.Count == 0)
 					cell = group.HeaderContent;
 				else
-					cell = group[item];
+					cell = group[itemIndex];
 
-				position = templatedItems.GetGlobalIndexForGroup(group) + item + 1;
+				//Increment Scroll Position by 1 when Grouping is enabled. Android offsets position of cells when using header.
+				scrollPosition = templatedItems.GetGlobalIndexForGroup(group) + itemIndex + 1;
 			}
 			else
 			{
-				position = templatedItems.GetGlobalIndexOfItem(scrollArgs.Item);
-				if (position == -1)
+				scrollPosition = templatedItems.GetGlobalIndexOfItem(scrollArgs.Item);
+				if (scrollPosition == -1)
 					return;
 
-				cell = templatedItems[position];
+				cell = templatedItems[scrollPosition];
 			}
 
 			//Android offsets position of cells when using header
-			int realPositionWithHeader = position + 1;
+			int realPositionWithHeader = scrollPosition + 1;
 
 			if (e.Position == ScrollToPosition.MakeVisible)
 			{
@@ -322,11 +323,11 @@ namespace Xamarin.Forms.Platform.Android
 			if (cellHeight == -1)
 			{
 				int first = Control.FirstVisiblePosition;
-				if (first <= position && position <= Control.LastVisiblePosition)
-					cellHeight = Control.GetChildAt(position - first).Height;
+				if (first <= scrollPosition && scrollPosition <= Control.LastVisiblePosition)
+					cellHeight = Control.GetChildAt(scrollPosition - first).Height;
 				else
 				{
-					AView view = _adapter.GetView(position, null, null);
+					AView view = _adapter.GetView(scrollPosition, null, null);
 					view.Measure(MeasureSpecFactory.MakeMeasureSpec(Control.Width, MeasureSpecMode.AtMost), MeasureSpecFactory.MakeMeasureSpec(0, MeasureSpecMode.Unspecified));
 					cellHeight = view.MeasuredHeight;
 				}

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -280,13 +280,18 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element.IsGroupingEnabled)
 			{
 				var results = templatedItems.GetGroupAndIndexOfItem(scrollArgs.Group, scrollArgs.Item);
-				if (results.Item1 == -1 || results.Item2 == -1)
+				if (results.Item1 == -1 || (results.Item1 == -1 && results.Item2 == -1))
 					return;
 
-				var group = templatedItems.GetGroup(results.Item1);
-				cell = group[results.Item2];
+				int item = results.Item2 == -1 ? 0 : results.Item2;
 
-				position = templatedItems.GetGlobalIndexForGroup(group) + results.Item2 + 1;
+				var group = templatedItems.GetGroup(results.Item1);
+				if (group.Count == 0)
+					cell = group.HeaderContent;
+				else
+					cell = group[item];
+
+				position = templatedItems.GetGlobalIndexForGroup(group) + item + 1;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->
As requested in the ticket #8279, I've enhanced ListView ScrollTo method to scroll to a group with no child and also handled other use-cases discussed here: https://github.com/xamarin/Xamarin.Forms/issues/8279#issuecomment-547885319

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8279

### API Changes ###
My initial idea was to change the `GetGroupAndIndexOfItem()` method of `TemplatedItemsList.cs` to return corresponding group if there's no child or item found (we should be sending item index as zero instead of -1 to consider the groups with no child or no item found). The existing implementation returns `new Tuple<int, int>(groupIndex, -1);` which was the problem. But I noticed that `GetGroupAndIndexOfItem()` method is being used by other platform's ListViewRenderer and this approach also required further changes in the corresponding renderer to check for the group count. This isn't a good approach (and I don't want it to break for other platforms).

Hence, we need to handle the logic only in the corresponding `ListViewRenderer`. I've updated the following logic in `OnScrollToRequested` of `ListViewRenderer.cs` on Android to handle Scroll To use-cases as discussed above:
```
if (Element.IsGroupingEnabled)
{
	var results = templatedItems.GetGroupAndIndexOfItem(scrollArgs.Group, scrollArgs.Item);
	if (results.Item1 == -1 || (results.Item1 == -1 && results.Item2 == -1))
		return;

	int item = results.Item2 == -1 ? 0 : results.Item2;

	var group = templatedItems.GetGroup(results.Item1);
	if (group.Count == 0)
		cell = group.HeaderContent;
	else
		cell = group[item];

	position = templatedItems.GetGlobalIndexForGroup(group) + item + 1;
}
```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Android

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

![8279_working](https://user-images.githubusercontent.com/17450941/67890984-bc479a80-fb77-11e9-975e-673d1c30df5c.gif)

- Just run `Issue8279.cs` from Control Gallery as this requires manual review for verification. I've included all the use-cases as discussed and demonstrated above in this test page.
Please Note: I don't have iOS setup so I'd need help of someone from Xamarin Team to review the above test on iOS (though I have not added anything to break other platforms).

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
