### PR TITLE
[CollectionView] Set default Layout ItemSizingStrategy value to MeasureFirstItem

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8314.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8314.cs
@@ -1,0 +1,106 @@
+﻿using System.Collections.Generic;
+using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8314, "Performance issue with ItemSizingStrategy on CollectionView", PlatformAffected.All)]
+	public class Issue8314 : TestContentPage
+	{
+		Stopwatch _watch;
+		Label _watchLabel;
+
+		protected override void Init()
+		{
+			_watch = new Stopwatch();
+			_watch.Start();
+
+   			Title = "Issue 8314";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "The loading time must be below 1000 ms (100000 items). ItemSizingStrategy is MeasureFirstItem by default."
+			};
+
+			_watchLabel = new Label
+			{
+				FontSize = 14
+			};
+
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = GetDataTemplate()
+			};
+
+			Debug.WriteLine(collectionView.ItemSizingStrategy);
+   
+			collectionView.ItemsLayout = new GridItemsLayout(ItemsLayoutOrientation.Vertical)
+			{
+				Span = 3
+			};
+
+			var items = new List<string>();
+
+			for(int i = 0; i < 100000; i++)
+			{
+				items.Add($"Item {i + 1}");
+			}
+
+			collectionView.ItemsSource = items;
+   
+			layout.Children.Add(instructions);
+			layout.Children.Add(_watchLabel);
+			layout.Children.Add(collectionView);
+
+			Content = layout;
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+   			_watch.Stop();
+			_watchLabel.Text = $"{_watch.ElapsedMilliseconds} ms";
+		}
+
+		DataTemplate GetDataTemplate()
+		{
+			var template = new DataTemplate(() =>
+			{
+				var scroll = new ScrollView();
+				var stack = new StackLayout();
+
+				var icon = new Image
+				{
+					Source = "calculator.png"
+				};
+				stack.Children.Add(icon);
+
+				var cell = new Label();
+				cell.SetBinding(Label.TextProperty, ".");
+				cell.FontSize = 20;
+				cell.BackgroundColor = Color.LightBlue;
+				stack.Children.Add(cell);
+
+				scroll.Content = stack;
+				return scroll;
+			});
+			return template;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1147,6 +1147,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8198.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8314.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly BindableProperty ItemSizingStrategyProperty =
-			BindableProperty.Create(nameof(ItemSizingStrategy), typeof(ItemSizingStrategy), typeof(ItemsView));
+			BindableProperty.Create(nameof(ItemSizingStrategy), typeof(ItemSizingStrategy), typeof(ItemsView), ItemSizingStrategy.MeasureFirstItem);
 
 		public ItemSizingStrategy ItemSizingStrategy
 		{


### PR DESCRIPTION
### Description of Change ###

Set default Layout ItemSizingStrategy value to MeasureFirstItem. This has a positive impact on the performance and time required when rendering CollectionView (and CarouselView).

<img width="488" alt="Captura de pantalla 2019-10-31 a las 14 42 05" src="https://user-images.githubusercontent.com/6755973/67951891-ab853c00-fbec-11e9-995b-d35138a601e6.png">

_NOTE: Performing tests, the time difference using MeasureFirstItem or MeasureAllItems is an average of 110ms better with MeasureFirstItem._

### Issues Resolved ### 

- fixes #8314

### API Changes ###

The default Layout ItemSizingStrategy value is now MeasureFirstItem.

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue8314. The time to load the elements must be below a second. The ItemSizingStrategy  property used in the Layout by default (not specified in the sample) must be MeasureFirstItem.
Change the ItemSizingStrategy to set MeasureAllItems and validate that the time required to load the items is higher. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
