### PR TITLE
Updating DependencyResolver to use TypedParameter

### DIFF
--- a/Xamarin.Forms.Core/DependencyResolver.cs
+++ b/Xamarin.Forms.Core/DependencyResolver.cs
@@ -7,9 +7,15 @@ namespace Xamarin.Forms.Internals
 	public static class DependencyResolver
 	{
 		static Type _defaultVisualType = typeof(VisualMarker.DefaultVisual);
-		static Func<Type, object[], object> Resolver { get; set; }
+		static Func<Type, TypedParameter[], object> Resolver { get; set; }
 
+		[Obsolete("Use `ResolveUsing(Func<Type, TypedParameter[], object> resolver)` instead")]
 		public static void ResolveUsing(Func<Type, object[], object> resolver)
+		{
+			Resolver = (type, parameters) => resolver(type, parameters.Select(x => x.Instance).ToArray());
+		}
+
+		public static void ResolveUsing(Func<Type, TypedParameter[], object> resolver)
 		{
 			Resolver = resolver;
 		}
@@ -19,16 +25,13 @@ namespace Xamarin.Forms.Internals
 			Resolver = (type, objects) => resolver.Invoke(type);
 		}
 
-		internal static object Resolve(Type type, params object[] args)
+		internal static object Resolve(Type type, params TypedParameter[] args)
 		{
 			var result = Resolver?.Invoke(type, args);
 
-			if (result != null)
+			if (result != null && !type.IsInstanceOfType(result))
 			{
-				if (!type.IsInstanceOfType(result))
-				{
-					throw new InvalidCastException("Resolved instance is not of the correct type.");
-				}
+				throw new InvalidCastException("Resolved instance is not of the correct type.");
 			}
 
 			return result;
@@ -36,7 +39,7 @@ namespace Xamarin.Forms.Internals
 
 		internal static object ResolveOrCreate(Type type) => ResolveOrCreate(type, null, null);
 
-		internal static object ResolveOrCreate(Type type, object source, Type visualType, params object[] args)
+		internal static object ResolveOrCreate(Type type, object source, Type visualType, params TypedParameter[] args)
 		{
 			visualType = visualType ?? _defaultVisualType;
 
@@ -48,14 +51,14 @@ namespace Xamarin.Forms.Internals
 			{
 				if(visualType != _defaultVisualType)
 					if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == 2))
-						return Activator.CreateInstance(type, new[] { args[0], source });
+						return Activator.CreateInstance(type, new[] { args[0].Instance, source });
 
 				// This is by no means a general solution to matching with the correct constructor, but it'll
 				// do for finding Android renderers which need Context (vs older custom renderers which may still use
 				// parameterless constructors)
 				if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == args.Length))
 				{
-					return Activator.CreateInstance(type, args);
+					return Activator.CreateInstance(type, args.Select(x => x.Instance).ToArray());
 				}
 			}
 			

--- a/Xamarin.Forms.Core/Internals/TypedParameter.cs
+++ b/Xamarin.Forms.Core/Internals/TypedParameter.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Xamarin.Forms.Internals
+{
+	public struct TypedParameter
+	{
+		public TypedParameter(Type type, object instance)
+		{
+			Type = type;
+			Instance = instance;
+		}
+
+		public Type Type { get; }
+
+		public object Instance { get; }
+	}
+}

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Internals
 			return (TRegistrable)handler;
 		}
 
-		internal TRegistrable GetHandler(Type type, object source, IVisual visual, params object[] args)
+		internal TRegistrable GetHandler(Type type, object source, IVisual visual, params TypedParameter[] args)
 		{
 			if (args.Length == 0)
 			{
@@ -95,7 +95,7 @@ namespace Xamarin.Forms.Internals
 			return GetHandler(type) as TOut;
 		}
 
-		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
+		public TOut GetHandler<TOut>(Type type, params TypedParameter[] args) where TOut : class, TRegistrable
 		{
 			return GetHandler(type, null, null, args) as TOut;
 		}
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Internals
 			return GetHandler(type, (obj as IVisualController)?.EffectiveVisual?.GetType()) as TOut;
 		}
 
-		public TOut GetHandlerForObject<TOut>(object obj, params object[] args) where TOut : class, TRegistrable
+		public TOut GetHandlerForObject<TOut>(object obj, params TypedParameter[] args) where TOut : class, TRegistrable
 		{
 			if (obj == null)
 				throw new ArgumentNullException(nameof(obj));

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -338,7 +338,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
 		{
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, context)
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, new TypedParameter(typeof(Context), context))
 				?? new DefaultRenderer(context);
 
 			renderer.SetElement(element);
@@ -383,7 +383,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static IVisualElementRenderer CreateRenderer(VisualElement element, FragmentManager fragmentManager, Context context)
 		{
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, context) ?? new DefaultRenderer(context);
+			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, new TypedParameter(typeof(Context), context)) ?? new DefaultRenderer(context);
 
 			var managesFragments = renderer as IManageFragments;
 			managesFragments?.SetFragmentManager(fragmentManager);

--- a/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
+++ b/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
@@ -476,7 +476,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		GestureHandler CreateHandler(IGestureRecognizer recognizer)
 		{
-			return Registrar.Registered.GetHandlerForObject<GestureHandler>(recognizer, recognizer);
+			return Registrar.Registered.GetHandlerForObject<GestureHandler>(recognizer, new TypedParameter(typeof(IGestureRecognizer), recognizer));
 		}
 
 		GestureHandler LookupHandler(IGestureRecognizer recognizer)


### PR DESCRIPTION
### Description of Change ###

Updates the Dependency Resolver to take a new TypedParameter. This helps with providing a proper Dependency Injection tie in as containers prefer to know the type a specified instance is for. 

### Issues Resolved ### 

- fixes #3088

### API Changes ###

Public API changes are in the `DependencyResolver`

Added:
 - public static void ResolveUsing(Func<Type, TypedParameter[], object>)

Changed:
 - public static void ResolveUsing(Func<Type, object[], object) [Obsolete]
 
### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS (only via Core)
- Android (updates Platform create Renderer)
- UWP (only via Core)
- Tizen (updates GestureDetector create GestureHandler)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

no changes

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
