### PR TITLE
Fix 6693 - [Bug] [WPF] ViewRenderer does not work properly with FrameworkElement derived native controls

### DIFF
--- a/Xamarin.Forms.ControlGallery.WPF/Renderers/Issue6693ControlRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WPF/Renderers/Issue6693ControlRenderer.cs
@@ -1,0 +1,54 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows;
+using System.Windows.Media;
+using Xamarin.Forms.ControlGallery.WPF.Renderers;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.WPF;
+using WColor = System.Windows.Media.Color;
+
+[assembly:ExportRenderer(typeof(Issue6693Control), typeof(Issue6693ControlRenderer))]
+namespace Xamarin.Forms.ControlGallery.WPF.Renderers
+{
+	public class Issue6693ControlRenderer:ViewRenderer<Issue6693Control,WIssue6693Control>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Issue6693Control> e)
+		{
+			base.OnElementChanged(e);
+
+			SetNativeControl(new WIssue6693Control());
+
+
+		}
+	}
+
+	public class WIssue6693Control : FrameworkElement
+	{
+		public WIssue6693Control()
+		{
+			
+		}
+
+		protected override void OnRender(DrawingContext drawingContext)
+		{
+			drawingContext.DrawRectangle(Brushes.LightGray, new Pen(Brushes.Black, 1), new Rect(0,0,ActualWidth, ActualHeight));
+			var isEnabledText = IsEnabled ? "I'm enabled :)" : "I'm disabled :(";
+			drawingContext.DrawText(new FormattedText(isEnabledText, 
+				System.Globalization.CultureInfo.CurrentCulture, 
+				System.Windows.FlowDirection.LeftToRight, new Typeface("Arial"), 14, Brushes.Green), new System.Windows.Point(10,10));
+		}
+
+		protected override void OnPropertyChanged(DependencyPropertyChangedEventArgs e)
+		{
+			base.OnPropertyChanged(e);
+			if(e.Property.Name == WIssue6693Control.IsEnabledProperty.Name)
+			{
+				InvalidateVisual();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WPF/Xamarin.Forms.ControlGallery.WPF.csproj
+++ b/Xamarin.Forms.ControlGallery.WPF/Xamarin.Forms.ControlGallery.WPF.csproj
@@ -70,6 +70,7 @@
     </Compile>
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
     <Compile Include="RegistrarValidationService.cs" />
+    <Compile Include="Renderers\Issue6693ControlRenderer.cs" />
     <Compile Include="SampleNativeControl.cs" />
     <Page Include="MainWindow.xaml">
       <Generator>MSBuild:Compile</Generator>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6693.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6693.xaml
@@ -1,0 +1,27 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue6693">
+    <Grid HorizontalOptions="Center" VerticalOptions="Center">
+        <Grid.ColumnDefinitions>
+            <ColumnDefinition/>
+            <ColumnDefinition/>
+        </Grid.ColumnDefinitions>
+
+        <StackLayout Grid.Column="0">
+            <Label Text="IsEnabled"/>
+            <Switch x:Name="isEnabledSwitch"/>
+        </StackLayout>
+
+        <StackLayout Grid.Column="1">
+            <local:Issue6693Control IsEnabled="{Binding IsToggled, Source={x:Reference isEnabledSwitch}}"
+                                    HeightRequest="100"
+                                    WidthRequest="200"/>
+        </StackLayout>
+
+    </Grid>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6693.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6693.xaml.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6693, "[Bug] [WPF] ViewRenderer does not work properly with FrameworkElement derived native controls", PlatformAffected.WPF)]
+	public partial class Issue6693 : ContentPage
+	{
+		public Issue6693()
+		{
+			InitializeComponent();
+		}
+	}
+
+	public class Issue6693Control : View
+	{
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6693.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6693.xaml.cs
@@ -17,7 +17,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue6693()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -27,6 +27,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue6556.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5830.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6476.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6693.xaml.cs">
+      <DependentUpon>Issue6693.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7396.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7825.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2271.cs" />
@@ -1636,6 +1640,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7048.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6693.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ViewRenderer.cs
@@ -25,7 +25,6 @@ namespace Xamarin.Forms.Platform.WPF
 			new List<EventHandler<VisualElementChangedEventArgs>>();
 
 		VisualElementTracker _tracker;
-		WControl _wcontrol => Control as WControl;
 		bool _disposed;
 
 		IElementController ElementController => Element as IElementController;
@@ -212,7 +211,8 @@ namespace Xamarin.Forms.Platform.WPF
 
 		protected virtual void UpdateBackground()
 		{
-			_wcontrol?.UpdateDependencyColor(WControl.BackgroundProperty, Element.BackgroundColor);
+			if(Control is WControl wControl)
+				wControl?.UpdateDependencyColor(WControl.BackgroundProperty, Element.BackgroundColor);
 		}
 
 		protected virtual void UpdateHeight()
@@ -240,19 +240,19 @@ namespace Xamarin.Forms.Platform.WPF
 
 		internal virtual void OnModelFocusChangeRequested(object sender, VisualElement.FocusRequestArgs args)
 		{
-			if (_wcontrol == null)
+			if (Control == null)
 				return;
 
 			if (args.Focus)
-				args.Result = _wcontrol.Focus();
+				args.Result = Control.Focus();
 			else
 			{
-				UnfocusControl(_wcontrol);
+				UnfocusControl(Control);
 				args.Result = true;
 			}
 		}
 
-		internal void UnfocusControl(WControl control)
+		internal void UnfocusControl(FrameworkElement control)
 		{
 			if (control == null || !control.IsEnabled)
 				return;
@@ -266,26 +266,27 @@ namespace Xamarin.Forms.Platform.WPF
 
 		protected void UpdateTabStop()
 		{
-			if (_wcontrol == null)
-				return;
-			_wcontrol.IsTabStop = Element.IsTabStop;
+			if (Control is WControl wControl)
+			{
+				wControl.IsTabStop = Element.IsTabStop;
 
-			// update TabStop of children for complex controls (like as DatePicker, TimePicker, SearchBar and Stepper)
-			var children = FrameworkElementExtensions.GetChildren<WControl>(_wcontrol);
-			foreach (var child in children)
-				child.IsTabStop = _wcontrol.IsTabStop;
+				// update TabStop of children for complex controls (like as DatePicker, TimePicker, SearchBar and Stepper)
+				var children = FrameworkElementExtensions.GetChildren<WControl>(Control);
+				foreach (var child in children)
+					child.IsTabStop = wControl.IsTabStop;
+			}
 		}
 
 		protected void UpdateTabIndex()
 		{
-			if (_wcontrol != null)
-				_wcontrol.TabIndex = Element.TabIndex;
+			if (Control is WControl wControl)
+				wControl.TabIndex = Element.TabIndex;
 		}
 
 		protected virtual void UpdateEnabled()
 		{
-			if (_wcontrol != null)
-				_wcontrol.IsEnabled = Element.IsEnabled;
+			if (Control != null)
+				Control.IsEnabled = Element.IsEnabled;
 		}
 
 		void UpdateAlignment()

--- a/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
+++ b/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
@@ -21,7 +21,6 @@
     <DefineConstants>TRACE;DEBUG</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>default</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -30,7 +29,6 @@
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <LangVersion>default</LangVersion>
     <TreatWarningsAsErrors>false</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###
Refactored ViewRenderer to use Control, which is the TNativeElement where T is FrameworkElement. This replaces the use of _wcontrol (System.Windows.Controls.Control) which was preventing FrameworkElement derived controls' IsEnabled property from working.

### Issues Resolved ### 
Fixes #6693 

### API Changes ###
None

### Platforms Affected ### 
WPF

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Added Issue6693.xaml page as well as Issue6693Control with WPF renderer to demonstrate issue fix. Undo changes to ViewRenderer to see issue.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
