### PR TITLE
[C] Added ability to predefine value to prompt

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
@@ -7,6 +7,8 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 6713, "[Enhancement] Display prompts", PlatformAffected.iOS | PlatformAffected.Android)]
 	public class Issue6713 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
+		const string PrefilledValue = "1337";
+
 		protected override void Init()
 		{
 			var scrollView = new ScrollView();
@@ -38,6 +40,16 @@ namespace Xamarin.Forms.Controls.Issues
 					(sender as Button).Text = result;
 			};
             stackLayout.Children.Add(button2);
+
+			var button3 = new Button { Text = "Prefilled" };
+			button3.Clicked += async (sender, e) =>
+			{
+				var result = await DisplayPromptAsync("The input field should have a value already", $"And it should be {PrefilledValue}", initialValue: PrefilledValue);
+
+				if (result != null)
+					(sender as Button).Text = result;
+			};
+			stackLayout.Children.Add(button3);
 
 			scrollView.Content = stackLayout;
 			Content = scrollView;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var button = new Button { Text = "Default keyboard" };
 			button.Clicked += async (sender, e) =>
 			{
-				var result = await DisplayPromptAsync("What’s the most useless product around today?", "The USB pet rock is definitely up there. What items do you have a hard time believing they actually exist?");
+				var result = await DisplayPromptAsync("What’s the most useless product around today?", "The USB pet rock is definitely up there. What items do you have a hard time believing they actually exist?", initialValue: "");
 
 				if (result != null)
 					(sender as Button).Text = result;
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls.Issues
             var button2 = new Button { Text = "Numeric keyboard" };
             button2.Clicked += async (sender, e) =>
             {
-	            var result = await DisplayPromptAsync("What’s the meaning of life?", "You know that number.", maxLength:2, keyboard:Keyboard.Numeric);
+	            var result = await DisplayPromptAsync("What’s the meaning of life?", "You know that number.", maxLength:2, keyboard:Keyboard.Numeric, initialValue: "");
 
 	            if (result != null)
 					(sender as Button).Text = result;

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -209,6 +209,13 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
+		[Obsolete("DisplayPromptAsync overload is obsolete as of version 4.5.0 and is no longer supported.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+		{
+			return DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, "");
+		}
+
 		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -209,9 +209,9 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
-			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
+			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);
 			MessagingCenter.Send(this, PromptSignalName, args);
 			return args.Result.Task;
 		}

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
@@ -6,6 +7,12 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{
+		[Obsolete("PromptArguments overload is obsolete as of version 4.5.0 and is no longer supported.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+			: this (title, message, accept, cancel, placeholder, maxLength, keyboard, "")
+		{ }
+
 		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			Title = title;

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -6,13 +6,14 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{
-		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			Title = title;
 			Message = message;
 			Accept = accept;
 			Cancel = cancel;
 			Placeholder = placeholder;
+			InitialValue = initialValue;
 			MaxLength = maxLength;
 			Keyboard = keyboard ?? Keyboard.Default;
 			Result = new TaskCompletionSource<string>();
@@ -27,6 +28,8 @@ namespace Xamarin.Forms.Internals
 		public string Cancel { get; }
 
 		public string Placeholder { get; }
+
+		public string InitialValue { get; }
 
 		public int MaxLength { get; }
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.Android
 				alertDialog.SetMessage(arguments.Message);
 
 				var frameLayout = new FrameLayout(Activity);
-				var editText = new EditText(Activity) { Hint = arguments.Placeholder };
+				var editText = new EditText(Activity) { Hint = arguments.Placeholder, Text = arguments.InitialValue };
 				var layoutParams = new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MatchParent, ViewGroup.LayoutParams.WrapContent)
 				{
 					LeftMargin = (int)(22 * Activity.Resources.DisplayMetrics.Density),

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -366,6 +366,7 @@ namespace Xamarin.Forms.Platform.iOS
 			alert.AddTextField(uiTextField =>
 			{
 				uiTextField.Placeholder = arguments.Placeholder;
+				uiTextField.Text = arguments.InitialValue;
 				uiTextField.ShouldChangeCharacters = (field, range, replacementString) => arguments.MaxLength <= -1 || field.Text.Length + replacementString.Length - range.Length <= arguments.MaxLength;
 				uiTextField.ApplyKeyboard(arguments.Keyboard);
 			});


### PR DESCRIPTION
### Description of Change ###

Allows you to add a predefined value to be set whenever a prompt is opened

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8346

### API Changes ###

Changed:
 - `Xamarin.Forms.Internals.PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")` (added `initialValue`)
-  `Xamarin.Forms.Page.DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")` (added `initialValue`)

Deprecated:
- `Xamarin.Forms.Internals.PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))`
- `Xamarin.Forms.Page.DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Because of the default value in the parameter the string will still be empty on default. The user now has the ability to leverage the new parameter to prefill a value

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
