### PR TITLE
#7875: Android: Button size changes when setting Accessibility properties

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7875.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7875.cs
@@ -1,0 +1,65 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Button)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7875, "Button size changes when setting Accessibility properties", PlatformAffected.Android)]
+	public class Issue7875 : TestContentPage
+	{
+		public Issue7875()
+		{
+			Title = "Issue 7875";
+
+			var layout = new Grid();
+
+			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			layout.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If the buttons below have the same size, the test has passed."
+			};
+			layout.Children.Add(instructions, 0, 0);
+
+			var button = new Button
+			{
+				BackgroundColor = Color.Gray,
+				HorizontalOptions = LayoutOptions.Center,
+				ImageSource = "calculator.png",
+				Text = "Text"
+			};
+			layout.Children.Add(button, 0, 1);
+
+			var accesibilityButton = new Button
+			{
+				BackgroundColor = Color.Gray,
+				HorizontalOptions = LayoutOptions.Center,
+				ImageSource = "calculator.png",
+				Text = "Text"
+			};
+			accesibilityButton.SetAutomationPropertiesName("AccesibilityButton");
+			accesibilityButton.SetAutomationPropertiesHelpText("Help Large Text");
+			layout.Children.Add(accesibilityButton, 0, 2);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+		
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7875.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7875.cs
@@ -50,8 +50,8 @@ namespace Xamarin.Forms.Controls.Issues
 				ImageSource = "calculator.png",
 				Text = "Text"
 			};
-			accesibilityButton.SetAutomationPropertiesName("AccesibilityButton");
-			accesibilityButton.SetAutomationPropertiesHelpText("Help Large Text");
+			accesibilityButton.SetValue(AutomationProperties.NameProperty, "AccesibilityButton");
+			accesibilityButton.SetValue(AutomationProperties.HelpTextProperty, "Help Large Text");
 			layout.Children.Add(accesibilityButton, 0, 2);
 
 			Content = layout;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1178,6 +1178,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8672.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8326.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8449.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7875.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return false;
 			}
 
-			if (Element is Picker)
+			if (Element is Picker || Element is Button)
 			{
 				return false;
 			}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -82,10 +82,26 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			((IElementController)Button).SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, hasFocus);
 		}
-
+	
 		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			return _buttonLayoutManager.GetDesiredSize(widthConstraint, heightConstraint);
+			if (_isDisposed)
+			{
+				return new SizeRequest();
+			}
+
+			var hint = Control.Hint;
+
+			if (!string.IsNullOrWhiteSpace(hint))
+			{
+				Control.Hint = string.Empty;
+			}
+
+			var result  = _buttonLayoutManager.GetDesiredSize(widthConstraint, heightConstraint);
+
+			Control.Hint = hint;
+
+			return result;
 		}
 
 		void IVisualElementRenderer.SetElement(VisualElement element)


### PR DESCRIPTION
### Description of Change ###
Applyed the same fix previously added to the default Button renderer


### Issues Resolved ### 


- fixes #7875 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

### Testing Procedure ###

  - Added a Button to a Page, don't set it's text and set it's Icon;
  - Set AutomationProperties.Name of the Button
  - The Button size must be the same
### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
