### PR TITLE
[Android] Fix API usage on Android19 

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
@@ -141,7 +141,8 @@ namespace Xamarin.Forms.Platform.Android
 
 				using (var innerLayout = new LinearLayout(context))
 				{
-					innerLayout.ClipToOutline = true;
+					if(Forms.IsLollipopOrNewer)
+						innerLayout.ClipToOutline = true;
 					innerLayout.SetBackground(CreateItemBackgroundDrawable());
 					innerLayout.SetPadding(0, (int)context.ToPixels(6), 0, (int)context.ToPixels(6));
 					innerLayout.Orientation = Orientation.Horizontal;
@@ -169,8 +170,12 @@ namespace Xamarin.Forms.Platform.Android
 					};
 					image.LayoutParameters = lp;
 					lp.Dispose();
+					
+					if (Forms.IsLollipopOrNewer)
+					{
+						image.ImageTintList = ColorStateList.ValueOf(Color.Black.MultiplyAlpha(0.6).ToAndroid());
+					}
 
-					image.ImageTintList = ColorStateList.ValueOf(Color.Black.MultiplyAlpha(0.6).ToAndroid());
 					image.SetImage(shellContent.icon, context);
 
 					innerLayout.AddView(image);

--- a/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
@@ -142,7 +142,9 @@ namespace Xamarin.Forms.Platform.Android
 				using (var innerLayout = new LinearLayout(context))
 				{
 					if(Forms.IsLollipopOrNewer)
+					{
 						innerLayout.ClipToOutline = true;
+					}
 					innerLayout.SetBackground(CreateItemBackgroundDrawable());
 					innerLayout.SetPadding(0, (int)context.ToPixels(6), 0, (int)context.ToPixels(6));
 					innerLayout.Orientation = Orientation.Horizontal;


### PR DESCRIPTION
Make sure we don't use new API for setting Colors, so it won't fail on API19 devices.

### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 

- fixes filing test 8145 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Should not crash

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

Check 8145 on Android API19 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
