### PR TITLE
[previewer] removed empty ItemsSource attribute from toolbox snippets

### DIFF
--- a/Xamarin.Forms.Core.Design/toolbox/Xamarin.Forms.toolbox.xml
+++ b/Xamarin.Forms.Core.Design/toolbox/Xamarin.Forms.toolbox.xml
@@ -19,7 +19,7 @@
 		</Item>
 		<Item Class="Xamarin.Forms.CarouselView" Name="CarouselView" Image="view-ListView.png">
 			<Snippet>
-				<CarouselView ItemsSource="">
+				<CarouselView>
 					<CarouselView.ItemTemplate>
 						<DataTemplate>
 						</DataTemplate>
@@ -29,7 +29,7 @@
 		</Item>
 		<Item Class="Xamarin.Forms.CollectionView" Name="CollectionView" Image="view-ListView.png">
 			<Snippet>
-				<CollectionView ItemsSource="">
+				<CollectionView>
 					<CollectionView.ItemsLayout>
 						<GridItemsLayout Span="2" Orientation="Vertical"/>
 					</CollectionView.ItemsLayout>
@@ -67,7 +67,7 @@
 		</Item>
 		<Item Class="Xamarin.Forms.ListView" Name="ListView" Image="view-ListView.png">
 			<Snippet>
-				<ListView ItemsSource="">
+				<ListView>
 					<ListView.ItemTemplate>
 						<DataTemplate>
 						</DataTemplate>


### PR DESCRIPTION
### Description of Change ###

The user does not need to specify an empty `ItemSource` attribute when adding a new item from toolbox.

### API Changes ###
 
 None

### Platforms Affected ### 

- toolbox in VS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
