### PR TITLE
Disable packager for CollectionView on UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8366.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8366.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 8366, "[Bug] UWP CollectionView Floating Row and Toolbar clipped")]
+	public class Issue8366 : TestMasterDetailPage
+	{
+		NavigationPage _items;
+		NavigationPage _other;
+
+		protected override void Init()
+		{
+			MasterBehavior = MasterBehavior.Split;
+
+			_items = new NavigationPage(Items());
+			_other = new NavigationPage(Other());
+
+			Detail = _items;
+			Master = MasterPage();
+		}
+
+		ContentPage MasterPage() 
+		{
+			var page = new ContentPage();
+
+			var menu = new StackLayout();
+
+			var instructions = new Label { Margin = 3, Text = "Tap 'Other' to change the Detail page. " +
+				"Then tap 'Items' to return to this page. " +
+				"If the CollectionView does not show a garbled mess at the top, this test has passed." };
+
+			menu.Children.Add(instructions);
+
+			var buttonItems = new Button { Text = "Items" };
+			var buttonOther = new Button { Text = "Other" };
+
+			page.Content = menu;
+
+			buttonItems.Clicked += (sender, args) => { Detail = _items; };
+			buttonOther.Clicked += (sender, args) => { Detail = _other; };
+
+			menu.Children.Add(buttonItems);
+			menu.Children.Add(buttonOther);
+
+			page.Title = "8366 Master";
+
+			return page;
+		}
+
+		ContentPage Items()
+		{
+			var page = new ContentPage
+			{
+				Title = "Items"
+			};
+
+			var cv = new CollectionView();
+
+			var items = new List<string>() { "uno", "dos", "tres" };
+
+			cv.ItemsSource = items;
+
+			cv.ItemTemplate = new DataTemplate(() => {
+				var root = new Label();
+				root.SetBinding(Label.TextProperty, new Binding("."));
+				return root;
+			});
+
+			page.Content = cv;
+
+			return page;
+		}
+
+		ContentPage Other()
+		{
+			var page = new ContentPage
+			{
+				Title = "Other",
+				Content = new Label { Text = "Other page" }
+			};
+
+			return page;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -102,6 +102,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8222.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8167.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8366.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -125,10 +125,6 @@ namespace Xamarin.Forms
 			BindableProperty.Create(nameof(ItemsLayout), typeof(IItemsLayout), typeof(ItemsView),
 				LinearItemsLayout.Vertical);
 
-
-		//	public abstract IItemsLayout ItemsLayout { get; }
-
-
 		protected IItemsLayout InternalItemsLayout
 		{
 			get => (IItemsLayout)GetValue(InternalItemsLayoutProperty);
@@ -143,7 +139,6 @@ namespace Xamarin.Forms
 			get => (ItemSizingStrategy)GetValue(ItemSizingStrategyProperty);
 			set => SetValue(ItemSizingStrategyProperty, value);
 		}
-
 
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(ItemsView));

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -26,6 +26,11 @@ namespace Xamarin.Forms.Platform.UWP
 		FrameworkElement _emptyView;
 		View _formsEmptyView;
 
+		protected ItemsViewRenderer()
+		{
+			AutoPackage = false;
+		}
+
 		protected TItemsView ItemsView => Element;
 		protected ItemsControl ItemsControl { get; private set; }
 


### PR DESCRIPTION
### Description of Change ###

The CollectionView on UWP doens't actually need any of the packager features, and the packager is "helpfully" adding all of the templated items to the root container, which means they all show up clumped at the top. 

This is basically the same thing as #8189, just for UWP instead of iOS.

### Issues Resolved ### 
- fixes #8366

### API Changes ###
None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Control Gallery -> Issue 8366. No automated test, since UI Test doesn't have a `WaitForNoGarbledMess()` method.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
