### PR TITLE
When application is running outside previewer set a flag early on so inspection code doesn't slow down startup

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -264,6 +264,7 @@ namespace Xamarin.Forms.Platform.Android
 				_powerSaveModeBroadcastReceiver = new PowerSaveModeBroadcastReceiver();
 			}
 
+			ContextExtensions.SetDesignerContext(_layout);
 			Profile.FrameEnd();
 		}
 
@@ -429,7 +430,6 @@ namespace Xamarin.Forms.Platform.Android
 			PopupManager.ResetBusyCount(this);
 
 			Platform = new AppCompat.Platform(this);
-
 			Platform.SetPage(page);
 			_layout.AddView(Platform);
 			_layout.BringToFront();

--- a/Xamarin.Forms.Platform.Android/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ContextExtensions.cs
@@ -121,14 +121,32 @@ namespace Xamarin.Forms.Platform.Android
 			if (_isDesignerContext.HasValue)
 				return _isDesignerContext.Value;
 
+			context.SetDesignerContext();
+			return _isDesignerContext.Value;
+		}
+
+		internal static void SetDesignerContext(this Context context)
+		{
+			if (_isDesignerContext.HasValue)
+				return;
+
 			if (context == null)
 				_isDesignerContext = false;
 			else if ($"{context}".Contains("com.android.layoutlib.bridge.android.BridgeContext"))
 				_isDesignerContext = true;
-			else if (context is ContextWrapper contextWrapper)
-				return contextWrapper.BaseContext.IsDesignerContext();
 			else
 				_isDesignerContext = false;
+		}
+
+		internal static void SetDesignerContext(global::Android.Views.View view)
+		{
+			_isDesignerContext = view.IsInEditMode;
+		}
+
+		internal static bool IsDesignerContext(this global::Android.Views.View view)
+		{
+			if (!_isDesignerContext.HasValue)
+				SetDesignerContext(view);
 
 			return _isDesignerContext.Value;
 		}


### PR DESCRIPTION
### Description of Change ###

The Previewer doesn't execute any of the code inside FormAppCompatActivity so this code just sets a flag during startup to indicate that we aren't the previewer so you don't need to perform expensive checks

### Platforms Affected ### 
- Android


### Testing Procedure ###
- @kingces95 will check if this helps startup speed and make sure the IsEdit check doesn't just exchange one slow down for another
- Make sure previewer still works on Android

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
