### PR TITLE
Fixed EmptyView issues on CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8326.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8326.xaml
@@ -4,25 +4,48 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
     x:Class="Xamarin.Forms.Controls.Issues.Issue8326">
- <CollectionView x:Name="collectionView">
-     <CollectionView.Header>
-         <StackLayout BackgroundColor="Green" Padding="65,100" Spacing="0">
-             <Label HorizontalOptions="Center" Text="Header" FontSize="Large" FontAttributes="Bold" TextColor="White" />
-         </StackLayout>
-     </CollectionView.Header>
-     <CollectionView.EmptyView>
-         <StackLayout BackgroundColor="Red">
-             <Label Text="Empty view" TextColor="White" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
-         </StackLayout>
-     </CollectionView.EmptyView>
-     <CollectionView.ItemTemplate>
-         <DataTemplate>
-                <Grid>
-                    <Frame Margin="5" Padding="40" HasShadow="True" BackgroundColor="Blue" CornerRadius="5" IsClippedToBounds="True">
-                        <Label Text="{Binding Title}" TextColor="White" VerticalOptions="Center" HorizontalOptions="Center" FontAttributes="Bold" />
-                    </Frame>
-                </Grid>
-         </DataTemplate>
-     </CollectionView.ItemTemplate>
- </CollectionView>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <StackLayout
+            Grid.Row="0"
+            Orientation="Horizontal">
+            <Button
+                Text="Clear Items"
+                Command="{Binding ClearItemsCommand}"/>
+            <Button
+                Text="Add Items"
+                Command="{Binding AddItemsCommand}"/>
+        </StackLayout>
+        <CollectionView
+            Grid.Row="1"
+            ItemsSource="{Binding Items}">
+            <CollectionView.Header>
+                <StackLayout BackgroundColor="Green" Padding="65,100" Spacing="0">
+                    <Label HorizontalOptions="Center" Text="Header" FontSize="Large" FontAttributes="Bold" TextColor="White" />
+                </StackLayout>
+            </CollectionView.Header>
+            <CollectionView.EmptyView>
+                <StackLayout BackgroundColor="Red">
+                    <Label Text="Empty view" TextColor="White" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
+                </StackLayout>
+            </CollectionView.EmptyView>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Frame Margin="5" Padding="40" HasShadow="True" BackgroundColor="Red" CornerRadius="5" IsClippedToBounds="True">
+                            <Label Text="{Binding Text}" TextColor="White" VerticalOptions="Center" HorizontalOptions="Center" FontAttributes="Bold" />
+                        </Frame>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+            <CollectionView.Footer>
+                <StackLayout BackgroundColor="Blue" Padding="65,100" Spacing="0">
+                    <Label HorizontalOptions="Center" Text="Footer" FontSize="Large" FontAttributes="Bold" TextColor="White" />
+                </StackLayout>
+            </CollectionView.Footer>
+        </CollectionView>
+    </Grid>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8326.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8326.xaml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8326">
+ <CollectionView x:Name="collectionView">
+     <CollectionView.Header>
+         <StackLayout BackgroundColor="Green" Padding="65,100" Spacing="0">
+             <Label HorizontalOptions="Center" Text="Header" FontSize="Large" FontAttributes="Bold" TextColor="White" />
+         </StackLayout>
+     </CollectionView.Header>
+     <CollectionView.EmptyView>
+         <StackLayout BackgroundColor="Red">
+             <Label Text="Empty view" TextColor="White" VerticalOptions="CenterAndExpand" HorizontalOptions="CenterAndExpand" />
+         </StackLayout>
+     </CollectionView.EmptyView>
+     <CollectionView.ItemTemplate>
+         <DataTemplate>
+                <Grid>
+                    <Frame Margin="5" Padding="40" HasShadow="True" BackgroundColor="Blue" CornerRadius="5" IsClippedToBounds="True">
+                        <Label Text="{Binding Title}" TextColor="White" VerticalOptions="Center" HorizontalOptions="Center" FontAttributes="Bold" />
+                    </Frame>
+                </Grid>
+         </DataTemplate>
+     </CollectionView.ItemTemplate>
+ </CollectionView>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8326.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8326.xaml.cs
@@ -1,0 +1,83 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8326, "[Bug] CollectionView: empty view doesn't show if collection view contains a header", PlatformAffected.Android)]
+	public partial class Issue8326 : TestContentPage
+	{
+#if APP
+		public Issue8326()
+		{
+			InitializeComponent();
+			BindingContext = new Issue8326ViewModel();
+		}
+#endif
+
+		protected override void Init()
+		{
+			Title = "Issue 8326";
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8326Model
+	{
+		public string Text { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8326ViewModel : BindableObject
+	{
+		ObservableCollection<Issue8326Model> _items;
+
+		public Issue8326ViewModel()
+		{
+			Items = new ObservableCollection<Issue8326Model>();
+		}
+
+		public ObservableCollection<Issue8326Model> Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ICommand ClearItemsCommand => new Command(ClearItems);
+		public ICommand AddItemsCommand => new Command(AddItems);
+
+		void ClearItems()
+		{
+			Items.Clear();
+		}
+
+		void AddItems()
+		{
+			for (int i = 0; i < 20; i++)
+			{
+				Items.Add(new Issue8326Model { Text = $"Item {i+1}" });
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8449.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8449.xaml
@@ -1,0 +1,67 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage  
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" 
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8449">
+     <StackLayout>
+         <Label
+             BackgroundColor="Black"
+             TextColor="White"
+             Text="If the Header and EmptyView appear in the CollectionView below, the test has passed."/>
+         <CollectionView
+             ItemsSource="{Binding Items}"
+             IsGrouped="True">
+             <CollectionView.Header>
+                 <Grid
+                     HeightRequest="100"
+                     BackgroundColor="Red">
+                     <Label
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center"
+                         FontSize="18"
+                         Text="Header"/>
+                 </Grid>
+             </CollectionView.Header>
+             <CollectionView.GroupHeaderTemplate>
+                 <DataTemplate>
+                     <Frame
+                         BackgroundColor="LightGray"
+                         Padding="2">
+                         <StackLayout>
+                             <Label
+                                 Text="{Binding Title}"
+                                 FontSize="Medium"/>
+                         </StackLayout>
+                     </Frame>
+                 </DataTemplate>
+             </CollectionView.GroupHeaderTemplate>
+             <CollectionView.ItemTemplate>
+                 <DataTemplate>
+                     <Frame
+                         BackgroundColor="LightBlue"
+                         Padding="2">
+                         <StackLayout>
+                             <Label Text="{Binding Title}"/>
+                             <Label Text="{Binding Comment}"/>
+                             <Label Text="{Binding Combo}"/>
+                         </StackLayout>
+                     </Frame>
+                 </DataTemplate>
+             </CollectionView.ItemTemplate>
+             <CollectionView.EmptyView>
+                      <Grid
+                     BackgroundColor="Orange">
+                     <Label
+                         HorizontalOptions="Center"
+                         VerticalOptions="Center"
+                         FontSize="18"
+                         Text="EmptyView"/>
+                 </Grid>
+             </CollectionView.EmptyView>
+         </CollectionView>
+     </StackLayout>
+</controls:TestContentPage> 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8449.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8449.xaml.cs
@@ -1,0 +1,80 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8449, "[Android] CollectionView.EmptyView not displaying when IsGrouped", PlatformAffected.iOS)]
+	public partial class Issue8449 : TestContentPage
+	{
+		public Issue8449()
+		{
+#if APP
+			Title = "Issue 8449";
+			InitializeComponent();
+			BindingContext = new Issue8449ViewModel();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+    }
+
+	[Preserve(AllMembers = true)]
+	public class Issue8449CategoryModel : List<Issue8449Model>
+	{
+		public string Title { get; set; }
+
+		public Issue8449CategoryModel(string title, List<Issue8449Model> items) : base(items)
+		{
+			Title = title;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8449Model
+	{
+		public string Title { get; set; }
+		public string Comment { get; set; }
+		public string Combo { get; set; }
+		public string Type { get; set; }
+		public bool IsStock { get; set; }
+		public int FighterId { get; set; }
+		public int UniqueId { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8449ViewModel
+	{
+		public List<Issue8449CategoryModel> Items { get; private set; } = new List<Issue8449CategoryModel>();
+
+		public Issue8449ViewModel()
+		{
+			//CreateCollection();
+		}
+
+		private void CreateCollection()
+		{
+			Items.Add(new Issue8449CategoryModel("Title_1", new List<Issue8449Model>
+			{
+				new Issue8449Model { Title ="title_1", Comment="comment_1",Combo="combo_1",Type="type_1",IsStock=false,FighterId=1, UniqueId=1},
+				new Issue8449Model { Title ="title_2", Comment="comment_2",Combo="combo_2",Type="type_2",IsStock=false,FighterId=2, UniqueId=2}
+			}));
+
+			Items.Add(new Issue8449CategoryModel("Title_2", new List<Issue8449Model>
+			{
+				new Issue8449Model { Title ="title_1", Comment="comment_1",Combo="combo_1",Type="type_1",IsStock=false,FighterId=1, UniqueId=1},
+				new Issue8449Model { Title ="title_2", Comment="comment_2",Combo="combo_2",Type="type_2",IsStock=false,FighterId=2, UniqueId=2}
+			}));
+
+			Items.Add(new Issue8449CategoryModel("Title_3", new List<Issue8449Model>
+			{
+				new Issue8449Model { Title ="title_1", Comment="comment_1",Combo="combo_1",Type="type_1",IsStock=false,FighterId=1, UniqueId=1},
+				new Issue8449Model { Title ="title_2", Comment="comment_2",Combo="combo_2",Type="type_2",IsStock=false,FighterId=2, UniqueId=2}
+			}));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1144,6 +1144,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7510.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8672.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8198.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8326.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8449.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1279,6 +1282,8 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7886.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8326.xaml" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8449.xaml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla27417Xaml.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1144,7 +1144,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7510.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8672.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue8198.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8326.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8449.xaml.cs" />
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -268,21 +268,12 @@ namespace Xamarin.Forms.Platform.Android
 		int GetHeight(ViewGroup parent)
 		{
 			var headerFooterHeight = parent.Context.ToPixels(_headerHeight + _footerHeight);
-			return Math.Abs((int)(parent.Height - headerFooterHeight));
+			return Math.Abs((int)(parent.MeasuredHeight - headerFooterHeight));
 		}
 
 		int GetWidth(ViewGroup parent)
-		{
-			var orientation = parent.Context.Resources.Configuration.Orientation;
-   			var request = ItemsView.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-
-			if (orientation == Orientation.Portrait)
-				return (int)parent.Context.ToPixels(request.Request.Width);
-
-			if (orientation == Orientation.Landscape)
-				return (int) parent.Context.ToPixels(request.Request.Height);
-	
-			return parent.Width;
+		{	
+			return parent.MeasuredWidth;
 		}
 
 		void UpdateHeaderFooterHeight(object item, bool isHeader)

--- a/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/EmptyViewAdapter.cs
@@ -1,18 +1,72 @@
 using System;
 using Android.Content;
+using Android.Content.Res;
 using Android.Support.V7.Widget;
 using Android.Views;
-using Android.Widget;
-using Java.Lang;
 using Object = Java.Lang.Object;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	public class EmptyViewAdapter : RecyclerView.Adapter
 	{
-		int _itemViewType;
+		int _headerHeight;
+		int _headerViewType;
+		object _headerView;
+		DataTemplate _headerViewTemplate;
+
+		int _footerHeight;
+		int _footerViewType;
+		object _footerView;
+		DataTemplate _footerViewTemplate;
+
+		int _emptyItemViewType;
 		object _emptyView;
 		DataTemplate _emptyViewTemplate;
+
+		public object Header
+		{
+			get => _headerView;
+			set
+			{
+				_headerView = value;
+				_headerViewType += 1;
+				UpdateHeaderFooterHeight(_headerView, true);
+			}
+		}
+
+		public DataTemplate HeaderTemplate
+		{
+			get => _headerViewTemplate;
+			set
+			{
+				_headerViewTemplate = value;
+				_headerViewType += 1;
+				UpdateHeaderFooterHeight(_headerViewTemplate, true);
+			}
+		}
+
+		public object Footer
+		{
+			get => _footerView;
+			set
+			{
+				_footerView = value;
+				_footerViewType += 1;
+				UpdateHeaderFooterHeight(_footerView, false);
+			}
+		}
+
+		public DataTemplate FooterTemplate
+		{
+			get => _footerViewTemplate;
+			set
+			{
+				_footerViewTemplate = value;
+				_footerViewType += 1;
+				UpdateHeaderFooterHeight(_footerViewTemplate, false);
+			}
+		}
+
 
 		public object EmptyView
 		{
@@ -22,7 +76,7 @@ namespace Xamarin.Forms.Platform.Android
 				_emptyView = value;
 
 				// Change _itemViewType to force OnCreateViewHolder to run again and use this new EmptyView
-				_itemViewType += 1;
+				_emptyItemViewType += 1;
 			}
 		}
 		
@@ -32,18 +86,22 @@ namespace Xamarin.Forms.Platform.Android
 			set
 			{
 				_emptyViewTemplate = value;
-				
+
 				// Change _itemViewType to force OnCreateViewHolder to run again and use this new template
-				_itemViewType += 1;
+				_emptyItemViewType += 1;
 			}
 		}
 
 		protected readonly ItemsView ItemsView;
-		public override int ItemCount => 1;
+		public override int ItemCount => 1 + ((Header != null || HeaderTemplate != null) ? 1 : 0) + ((Footer != null || FooterTemplate != null) ? 1 : 0);
 
 		public EmptyViewAdapter(ItemsView itemsView)
 		{
 			ItemsView = itemsView;
+
+			_headerViewType = 1;
+			_emptyItemViewType = 2;
+			_footerViewType = 3;
 		}
 
 		public override void OnViewRecycled(Object holder)
@@ -62,22 +120,40 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
 		{
-			if (EmptyView == null)
+			if (IsHeader(position))
 			{
+				if (holder is TemplatedItemViewHolder templatedItemViewHolder)
+				{
+					BindTemplatedItemViewHolder(templatedItemViewHolder, Header);
+				}
+
 				return;
 			}
 
-			if (holder is SimpleViewHolder emptyViewHolder && emptyViewHolder.View != null)
+			if (IsFooter(position))
 			{
-				// For templated empty views, this will happen on bind. But if we just have a plain-old View,
-				// we need to add it as a "child" of the ItemsView here so that stuff like Visual and FlowDirection
-				// propagate to the controls in the EmptyView
-				ItemsView.AddLogicalChild(emptyViewHolder.View);
+				if (holder is TemplatedItemViewHolder templatedItemViewHolder)
+				{
+					BindTemplatedItemViewHolder(templatedItemViewHolder, Footer);
+				}
+
+				return;
 			}
-			else if (holder is TemplatedItemViewHolder templatedItemViewHolder && EmptyViewTemplate != null)
+
+			if (IsEmpty(position))
 			{
-				// Use EmptyView as the binding context for the template
-				templatedItemViewHolder.Bind(EmptyView, ItemsView);
+				if (holder is SimpleViewHolder emptyViewHolder && emptyViewHolder.View != null)
+				{
+					// For templated empty views, this will happen on bind. But if we just have a plain-old View,
+					// we need to add it as a "child" of the ItemsView here so that stuff like Visual and FlowDirection
+					// propagate to the controls in the EmptyView
+					ItemsView.AddLogicalChild(emptyViewHolder.View);
+				}
+				else if (holder is TemplatedItemViewHolder templatedItemViewHolder && EmptyViewTemplate != null)
+				{
+					// Use EmptyView as the binding context for the template
+					templatedItemViewHolder.Bind(EmptyView, ItemsView);
+				}
 			}
 		}
 
@@ -85,27 +161,152 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var context = parent.Context;
 
-			var template = EmptyViewTemplate;
-
-			if (template == null)
+			if (viewType == _headerViewType)
 			{
-				if (!(EmptyView is View formsView))
-				{
-					// No template, EmptyView is not a Forms View, so just display EmptyView.ToString
-					return SimpleViewHolder.FromText(EmptyView?.ToString(), context);
-				}
-
-				// EmptyView is a Forms View; display that
-				return SimpleViewHolder.FromFormsView(formsView, context, () => parent.Width, () => parent.Height);
+				return CreateHeaderFooterViewHolder(Header, HeaderTemplate, context);
 			}
 
-			var itemContentView = new SizedItemContentView(parent.Context, () => parent.Width, () => parent.Height);
-			return new TemplatedItemViewHolder(itemContentView, template, isSelectionEnabled: false);
+			if (viewType == _footerViewType)
+			{
+				return CreateHeaderFooterViewHolder(Footer, FooterTemplate, context);
+			}
+
+			if (viewType == _emptyItemViewType)
+			{
+				return CreateEmptyViewHolder(EmptyView, EmptyViewTemplate, parent);
+			}
+
+			return CreateEmptyViewHolder(EmptyView, EmptyViewTemplate, parent);
 		}
 
 		public override int GetItemViewType(int position)
 		{
-			return _itemViewType;
+			if (IsHeader(position))
+			{
+				return _headerViewType;
+			}
+
+			if (IsFooter(position))
+			{
+				return _footerViewType;
+			}
+
+			if (IsEmpty(position))
+			{
+				return _emptyItemViewType;
+			}
+
+			return base.GetItemViewType(position);
+		}
+
+		protected RecyclerView.ViewHolder CreateHeaderFooterViewHolder(object content, DataTemplate template, Context context)
+		{
+			if (template != null)
+			{
+				var footerContentView = new ItemContentView(context);
+				return new TemplatedItemViewHolder(footerContentView, template, isSelectionEnabled: false);
+			}
+
+			if (content is View formsView)
+			{
+				return SimpleViewHolder.FromFormsView(formsView, context);
+			}
+
+			// No template, Footer is not a Forms View, so just display Footer.ToString
+			return SimpleViewHolder.FromText(content?.ToString(), context, false);
+		}
+
+		protected RecyclerView.ViewHolder CreateEmptyViewHolder(object content, DataTemplate template, ViewGroup parent)
+		{
+			var context = parent.Context;
+
+			if (template == null)
+			{
+				if (!(content is View formsView))
+				{
+					// No template, EmptyView is not a Forms View, so just display EmptyView.ToString
+					return SimpleViewHolder.FromText(content?.ToString(), context);
+				}
+
+				// EmptyView is a Forms View; display that
+				return SimpleViewHolder.FromFormsView(formsView, context, () => GetWidth(parent), () => GetHeight(parent));
+			}
+
+			var itemContentView = new SizedItemContentView(parent.Context, () => GetWidth(parent), () => GetHeight(parent));
+			return new TemplatedItemViewHolder(itemContentView, template, isSelectionEnabled: false);
+		}
+
+		protected void BindTemplatedItemViewHolder(TemplatedItemViewHolder templatedItemViewHolder, object context)
+		{
+			templatedItemViewHolder.Bind(context, ItemsView);
+		}
+
+		bool IsHeader(int position)
+		{
+			if (Header == null && HeaderTemplate == null)
+				return false;
+
+			return position == 0;
+		}
+
+		bool IsFooter(int position)
+		{
+			if (Footer == null && FooterTemplate == null)
+				return false;
+
+			return position == ItemCount - 1;
+		}
+
+		bool IsEmpty(int position)
+		{
+			if (EmptyView == null && EmptyViewTemplate == null)
+				return false;
+
+			return (Header == null && HeaderTemplate == null) ? position == 0 : position == 1;
+		}
+
+		int GetHeight(ViewGroup parent)
+		{
+			var headerFooterHeight = parent.Context.ToPixels(_headerHeight + _footerHeight);
+			return Math.Abs((int)(parent.Height - headerFooterHeight));
+		}
+
+		int GetWidth(ViewGroup parent)
+		{
+			var orientation = parent.Context.Resources.Configuration.Orientation;
+   			var request = ItemsView.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+
+			if (orientation == Orientation.Portrait)
+				return (int)parent.Context.ToPixels(request.Request.Width);
+
+			if (orientation == Orientation.Landscape)
+				return (int) parent.Context.ToPixels(request.Request.Height);
+	
+			return parent.Width;
+		}
+
+		void UpdateHeaderFooterHeight(object item, bool isHeader)
+		{
+			if (item == null)
+				return;
+
+			var sizeRequest = new SizeRequest(new Size(0, 0));
+
+			if (item is View view)
+				sizeRequest = view.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+
+			if (item is DataTemplate dataTemplate)
+			{
+				var content = dataTemplate.CreateContent() as View;
+				sizeRequest = content.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+			}
+
+			var itemHeight = (int)sizeRequest.Request.Height;
+
+			if (isHeader)
+				_headerHeight = itemHeight;
+			else
+				_footerHeight = itemHeight;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -492,6 +492,15 @@ namespace Xamarin.Forms.Platform.Android
 					_emptyViewAdapter = new EmptyViewAdapter(ItemsView);
 				}
 
+				if (ItemsView is StructuredItemsView structuredItemsView)
+				{
+					_emptyViewAdapter.Header = structuredItemsView.Header;
+					_emptyViewAdapter.HeaderTemplate = structuredItemsView.HeaderTemplate;
+
+					_emptyViewAdapter.Footer = structuredItemsView.Footer;
+					_emptyViewAdapter.FooterTemplate = structuredItemsView.FooterTemplate;
+				}
+
 				_emptyViewAdapter.EmptyView = emptyView;
 				_emptyViewAdapter.EmptyViewTemplate = emptyViewTemplate;
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -605,7 +605,16 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			var showEmptyView = ItemsView?.EmptyView != null && ItemsViewAdapter.ItemCount == 0;
+			int itemCount = 0;
+			if(ItemsView is StructuredItemsView itemsView)
+			{
+				if (itemsView.Header != null || itemsView.HeaderTemplate != null)
+					itemCount++;
+				if (itemsView.Footer != null || itemsView.FooterTemplate != null)
+					itemCount++;
+			}
+   
+			var showEmptyView = ItemsView?.EmptyView != null && ItemsViewAdapter.ItemCount == itemCount;
 
 			var currentAdapter = GetAdapter();
 			if (showEmptyView && currentAdapter != _emptyViewAdapter)

--- a/Xamarin.Forms.Platform.Android/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ListSource.cs
@@ -20,6 +20,10 @@ namespace Xamarin.Forms.Platform.Android
 		public ListSource(IEnumerable enumerable)
 		{
 			_itemsSource = new List<object>();
+
+			if (enumerable == null)
+				return;
+
 			foreach (object item in enumerable)
 			{
 				_itemsSource.Add(item);

--- a/Xamarin.Forms.Platform.Android/CollectionView/SimpleViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SimpleViewHolder.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		public static SimpleViewHolder FromText(string text, Context context, bool fill = true)
 		{
 			var textView = new TextView(context) { Text = text };
+
 			if (fill)
 			{
 				var layoutParams = new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MatchParent,

--- a/Xamarin.Forms.Platform.UAP/CollectionView/FormsGridView.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/FormsGridView.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Platform.UWP
 		ItemsWrapGrid _wrapGrid;
 		ContentControl _emptyViewContentControl;
 		FrameworkElement _emptyView;
+		View _formsEmptyView;
 		Orientation _orientation;
 
 		public FormsGridView()
@@ -105,9 +106,10 @@ namespace Xamarin.Forms.Platform.UWP
 			FindItemsWrapGrid();
 		}
 
-		public void SetEmptyView(FrameworkElement emptyView)
+		public void SetEmptyView(FrameworkElement emptyView, View formsEmptyView)
 		{
 			_emptyView = emptyView;
+			_formsEmptyView = formsEmptyView;
 
 			if (_emptyViewContentControl != null)
 			{
@@ -125,6 +127,16 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_emptyViewContentControl.Content = _emptyView;
 			}
+		}
+
+		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
+		{
+			if (_formsEmptyView != null)
+			{
+				_formsEmptyView.Layout(new Rectangle(0, 0, finalSize.Width, finalSize.Height));
+			}
+
+			return base.ArrangeOverride(finalSize);
 		}
 
 		protected override void PrepareContainerForItemOverride(DependencyObject element, object item)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/FormsListView.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/FormsListView.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		ContentControl _emptyViewContentControl;
 		FrameworkElement _emptyView;
+		View _formsEmptyView;
 
 		public FormsListView()
 		{
@@ -25,9 +26,10 @@ namespace Xamarin.Forms.Platform.UWP
 			set { SetValue(EmptyViewVisibilityProperty, value); }
 		}
 
-		public void SetEmptyView(FrameworkElement emptyView)
+		public void SetEmptyView(FrameworkElement emptyView, View formsEmptyView)
 		{
 			_emptyView = emptyView;
+			_formsEmptyView = formsEmptyView;
 
 			if (_emptyViewContentControl != null)
 			{
@@ -45,6 +47,16 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_emptyViewContentControl.Content = _emptyView;
 			}
+		}
+
+		protected override Windows.Foundation.Size ArrangeOverride(Windows.Foundation.Size finalSize)
+		{
+			if (_formsEmptyView != null)
+			{
+				_formsEmptyView.Layout(new Rectangle(0, 0, finalSize.Width, finalSize.Height));
+			}
+
+			return base.ArrangeOverride(finalSize);
 		}
 
 		protected override void PrepareContainerForItemOverride(DependencyObject element, object item)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/IEmptyView.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/IEmptyView.cs
@@ -5,6 +5,6 @@ namespace Xamarin.Forms.Platform.UWP
 	internal interface IEmptyView
 	{
 		Visibility EmptyViewVisibility { get; set; }
-		void SetEmptyView(FrameworkElement emptyView);
+		void SetEmptyView(FrameworkElement emptyView, View formsEmptyView);
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using System.ComponentModel;
 using System.Threading.Tasks;
+using System.Collections.Specialized;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
@@ -7,7 +8,6 @@ using Xamarin.Forms.Internals;
 using UwpScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility;
 using UWPApp = Windows.UI.Xaml.Application;
 using UWPDataTemplate = Windows.UI.Xaml.DataTemplate;
-using System.Collections.Specialized;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -335,7 +335,12 @@ namespace Xamarin.Forms.Platform.UWP
 			switch (emptyView)
 			{
 				case string text:
-					_emptyView = new TextBlock { Text = text };
+					_emptyView = new TextBlock
+					{
+						HorizontalAlignment = HorizontalAlignment.Center,
+						VerticalAlignment = VerticalAlignment.Center,
+						Text = text
+					};
 					break;
 				case View view:
 					_emptyView = RealizeEmptyView(view);
@@ -345,7 +350,7 @@ namespace Xamarin.Forms.Platform.UWP
 					break;
 			}
 
-			(ListViewBase as IEmptyView)?.SetEmptyView(_emptyView);
+			(ListViewBase as IEmptyView)?.SetEmptyView(_emptyView, _formsEmptyView);
 
 			UpdateEmptyViewVisibility();
 		}
@@ -354,13 +359,18 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (emptyViewTemplate == null)
 			{
-				return new TextBlock { Text = bindingContext.ToString() };
+				return new TextBlock
+				{
+					HorizontalAlignment = HorizontalAlignment.Center,
+					VerticalAlignment = VerticalAlignment.Center,
+					Text = bindingContext.ToString()
+				};
 			}
 
 			var template = emptyViewTemplate.SelectDataTemplate(bindingContext, null);
 			var view = template.CreateContent() as View;
-
 			view.BindingContext = bindingContext;
+
 			return RealizeEmptyView(view);
 		}
 

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
@@ -60,7 +60,8 @@
     <ControlTemplate x:Key="FormsListViewTemplate" TargetType="local:FormsListView">
         <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
             <Grid>
-                <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"></ContentControl>
+                <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"
+                                HorizontalContentAlignment="Stretch" VerticalAlignment="Stretch"/>
                 <ScrollViewer x:Name="ScrollViewer" 
                                 TabNavigation="{TemplateBinding TabNavigation}"
                                 HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"
@@ -129,7 +130,8 @@
                 <ControlTemplate TargetType="local:FormsGridView">
                     <Border BorderBrush="{TemplateBinding BorderBrush}" Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}">
                         <Grid>
-                            <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"></ContentControl>
+                            <ContentControl x:Name="EmptyViewContentControl" Visibility="{TemplateBinding EmptyViewVisibility}"
+                                            HorizontalContentAlignment="Stretch" VerticalContentAlignment="Stretch"/>
                             <ScrollViewer x:Name="ScrollViewer"
                             TabNavigation="{TemplateBinding TabNavigation}"
                             HorizontalScrollMode="{TemplateBinding ScrollViewer.HorizontalScrollMode}"

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -50,14 +50,18 @@ namespace Xamarin.Forms.Platform.iOS
 			// based on the ContentSize so we just update the positions if the ContentSize has changed
 			if (_footerUIView != null)
 			{
+				var emptyView = CollectionView.ViewWithTag(EmptyTag);
+
 				if (IsHorizontal)
 				{
-					if (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width)
+					if (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width ||
+						_footerUIView.Frame.X < emptyView?.Frame.X)
 						UpdateHeaderFooterPosition();
 				}
 				else
 				{
-					if (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height)
+					if (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height ||
+						_footerUIView.Frame.Y < emptyView?.Frame.Y)
 						UpdateHeaderFooterPosition();
 				}
 			}
@@ -65,19 +69,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal void UpdateFooterView()
 		{
-			UpdateSubview(ItemsView?.Footer, ItemsView?.FooterTemplate, 
+			UpdateSubview(ItemsView?.Footer, ItemsView?.FooterTemplate, FooterTag,
 				ref _footerUIView, ref _footerViewFormsElement);
 			UpdateHeaderFooterPosition();
 		}
 
 		internal void UpdateHeaderView()
 		{
-			UpdateSubview(ItemsView?.Header, ItemsView?.HeaderTemplate, 
+			UpdateSubview(ItemsView?.Header, ItemsView?.HeaderTemplate, HeaderTag,
 				ref _headerUIView, ref _headerViewFormsElement);
 			UpdateHeaderFooterPosition();
 		}
 
-		internal void UpdateSubview(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)
+		internal void UpdateSubview(object view, DataTemplate viewTemplate, nint viewTag, ref UIView uiView, ref VisualElement formsElement)
 		{
 			uiView?.RemoveFromSuperview();
 
@@ -91,6 +95,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (uiView != null)
 			{
+				uiView.Tag = viewTag;
 				CollectionView.AddSubview(uiView);
 			}
 
@@ -110,18 +115,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateHeaderFooterPosition()
 		{
+			var emptyView = CollectionView.ViewWithTag(EmptyTag);
+
 			if (IsHorizontal)
 			{
 				var currentInset = CollectionView.ContentInset;
 
 				nfloat headerWidth = _headerUIView?.Frame.Width ?? 0f;
 				nfloat footerWidth = _footerUIView?.Frame.Width ?? 0f;
+				nfloat emptyWidth = emptyView?.Frame.Width ?? 0f;
 
 				if (_headerUIView != null && _headerUIView.Frame.X != headerWidth)
 					_headerUIView.Frame = new CoreGraphics.CGRect(-headerWidth, 0, headerWidth, CollectionView.Frame.Height);
 
-				if (_footerUIView != null && (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width))
-					_footerUIView.Frame = new CoreGraphics.CGRect(ItemsViewLayout.CollectionViewContentSize.Width, 0, footerWidth, CollectionView.Frame.Height);
+				if (_footerUIView != null && (_footerUIView.Frame.X != ItemsViewLayout.CollectionViewContentSize.Width || emptyWidth > 0))
+					_footerUIView.Frame = new CoreGraphics.CGRect(ItemsViewLayout.CollectionViewContentSize.Width + emptyWidth, 0, footerWidth, CollectionView.Frame.Height);
 
 				if (CollectionView.ContentInset.Left != headerWidth || CollectionView.ContentInset.Right != footerWidth)
 				{
@@ -143,6 +151,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var currentInset = CollectionView.ContentInset;
 				nfloat headerHeight = _headerUIView?.Frame.Height ?? 0f;
 				nfloat footerHeight = _footerUIView?.Frame.Height ?? 0f;
+				nfloat emptyHeight = emptyView?.Frame.Height ?? 0f;
 
 				if (CollectionView.ContentInset.Top != headerHeight || CollectionView.ContentInset.Bottom != footerHeight)
 				{
@@ -165,9 +174,9 @@ namespace Xamarin.Forms.Platform.iOS
 					_headerUIView.Frame = new CoreGraphics.CGRect(0, -headerHeight, CollectionView.Frame.Width, headerHeight);
 				}
 
-				if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height))
+				if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height || emptyHeight > 0))
 				{
-					_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height, CollectionView.Frame.Width, footerHeight);
+					_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height + emptyHeight, CollectionView.Frame.Width, footerHeight);
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplateHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplateHelpers.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return (renderer.NativeView, renderer.Element);
 			}
 
-			return (new UILabel { Text = $"{view}" }, null);
+			return (new UILabel { TextAlignment = UITextAlignment.Center, Text = $"{view}" }, null);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

We had a different behavior managing EmptyView on Android, iOS and UWP.
The behavior we had was the following:
- Android: EmptyView occupied the entire size of the CollectionView. However, we had an issue that it did not appear using Header and/or Footer. This is because we Swap the Adapter to change to `EmptyViewAdapter` when not having items.
- iOS: EmptyView was rendered behind the Header and/or Footer. We used `BackgroundView` to manage EmptyView (that's why it is rendered behind and taking all the space).
- UWP: EmptyView is not rendered. The problem was related to size calcs.

### Issues Resolved ### 

- fixes #8326
- fixes #7457
- fixes #8449 

Other fixes:
- EmptyView does not change its size by changing the size of the window in UWP.
- On some platforms, when using just a text as EmptyView it appeared centered and on others it did not, now it appears centered on all.

### API Changes ###
 
 None

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
iOS
![issue8326-ios-before](https://user-images.githubusercontent.com/6755973/68393501-789ef300-016c-11ea-89d2-f596db529877.gif)
UWP
![issue8326-uwp-before](https://user-images.githubusercontent.com/6755973/68393496-75a40280-016c-11ea-9a81-f1d4bc3daf94.gif)

#### After
iOS
![issue8326-ios-after](https://user-images.githubusercontent.com/6755973/68393551-92403a80-016c-11ea-8dbc-c7add50cda5a.gif)

UWP
![issue8326-uwp-after](https://user-images.githubusercontent.com/6755973/68393547-8fdde080-016c-11ea-8a8f-ad897bddfc6e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue8326. The EmptyView must be visible without items.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
