### PR TITLE
Fix #8035 - system font on iOS 13

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
@@ -42,6 +42,20 @@ namespace Xamarin.Forms.Platform.iOS
 						}
 					}
 
+					if (family.StartsWith(".SFUI", System.StringComparison.InvariantCultureIgnoreCase))
+					{
+						var fontWeight = family.Split('-').LastOrDefault();
+
+						if (!string.IsNullOrWhiteSpace(fontWeight) && System.Enum.TryParse<UIFontWeight>(fontWeight, true, out var uIFontWeight))
+						{
+							result = UIFont.SystemFontOfSize(size, uIFontWeight);
+							return result;
+						}
+
+						result = UIFont.SystemFontOfSize(size, UIFontWeight.Regular);
+						return result;
+					}
+					
 					result = UIFont.FromName(family, size);
 					if (result != null)
 						return result;


### PR DESCRIPTION
### Description of Change ###

The system font on iOS 13 must not be received by name anymore but with `UIFont.SystemFontOfSize(size, weight)`.

### Issues Resolved ### 

- fixes #8035 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

You can use the font family .SFUI again with all weights Apple offers, like `.SFUI-Medium`. Without this change the TimesNewRoman font was returned instead when using e.g. `.SFUI` or `.SFUI-Medium` or `.SFUI-Bold` etc.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
