### PR TITLE
Add virtual methods for all the layers required to create the top tabs on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/IShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IShellSectionRootHeader.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	public interface IShellSectionRootHeader : IDisposable
+	{
+		UIViewController ViewController { get; }
+		ShellSection ShellSection { get; set; }
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -174,12 +174,17 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateTabBarItem();
 		}
 
+		protected virtual IShellSectionRootRenderer CreateShellSectionRootRenderer(ShellSection shellSection, IShellContext shellContext)
+		{
+			return new ShellSectionRootRenderer(shellSection, shellContext);
+		}
+
 		protected virtual void LoadPages()
 		{
-			_renderer = new ShellSectionRootRenderer(ShellSection, _context);
+			_renderer = CreateShellSectionRootRenderer(ShellSection, _context);
 
 			PushViewController(_renderer.ViewController, false);
-
+			
 			var stack = ShellSection.Stack;
 			for (int i = 1; i < stack.Count; i++)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 		UIView _blurView;
 		UIView _containerArea;
 		int _currentIndex;
-		ShellSectionRootHeader _header;
+		IShellSectionRootHeader _header;
 		bool _isAnimating;
 		Dictionary<ShellContent, IVisualElementRenderer> _renderers = new Dictionary<ShellContent, IVisualElementRenderer>();
 		IShellPageRendererTracker _tracker;
@@ -197,6 +197,11 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		protected virtual IShellSectionRootHeader CreateShellSectionRootHeader(IShellContext shellContext)
+		{
+			return new ShellSectionRootHeader(shellContext);
+		}
+
 		protected virtual void UpdateHeaderVisibility()
 		{
 			bool visible = ShellSection.Items.Count > 1;
@@ -205,11 +210,11 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_header == null)
 				{
-					_header = new ShellSectionRootHeader(_shellContext);
+					_header = CreateShellSectionRootHeader(_shellContext);
 					_header.ShellSection = ShellSection;
 
-					AddChildViewController(_header);
-					View.AddSubview(_header.View);
+					AddChildViewController(_header.ViewController);
+					View.AddSubview(_header.ViewController.View);
 				}
 				_blurView.Hidden = false;
 				LayoutHeader();
@@ -218,8 +223,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_header != null)
 				{
-					_header.View.RemoveFromSuperview();
-					_header.RemoveFromParentViewController();
+					_header.ViewController.View.RemoveFromSuperview();
+					_header.ViewController.RemoveFromParentViewController();
 					_header.Dispose();
 					_header = null;
 				}
@@ -267,7 +272,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var headerTop = Forms.IsiOS11OrNewer ? View.SafeAreaInsets.Top : TopLayoutGuide.Length;
 				CGRect frame = new CGRect(View.Bounds.X, headerTop, View.Bounds.Width, HeaderHeight);
 				_blurView.Frame = frame;
-				_header.View.Frame = frame;
+				_header.ViewController.View.Frame = frame;
 			}
 
 			nfloat left;

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -176,6 +176,7 @@
     <Compile Include="Forms.cs" />
     <Compile Include="PageExtensions.cs" />
     <Compile Include="Renderers\IAccessibilityElementsController.cs" />
+    <Compile Include="Renderers\IShellSectionRootHeader.cs" />
     <Compile Include="Renderers\PageContainer.cs" />
     <Compile Include="Renderers\CheckBoxRendererBase.cs" />
     <Compile Include="Renderers\WkWebViewRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###
This PR provides overrides at every level when creating the top tabs on iOS which allows developers to inject themselves into any point

- They can replace the entire UICollectionView used
- They can replace the type of Cell used inside the UICollectionView

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7808
- fixes #8428

### API Changes ###

Added:
 - public interface IShellSectionRootHeader 
  - adds the ability to abstract top tabs View

 - public IShellSectionRootHeader  ShellSectionRenderer.CreateShellSectionRootRenderer
  - Allows users to provide inherited implementation of UICollectionView used for top tabs

- public Type ShellSectionRootHeader.GetCellType
  - Allows users to specify a custom cell type for the header

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- Make sure I didn't break any existing behavior. UI tests should cover it


### Example

The following example sizes all the cells so they take up the entire width of the screen and are equal sized

```C#
 public class CustomShellRenderer : ShellRenderer
    {
        protected override IShellSectionRenderer CreateShellSectionRenderer(ShellSection shellSection)
        {
            return new CustomShellSectionRenderer(this);
        }
    }

    public class CustomShellSectionRenderer : ShellSectionRenderer
    {
        public CustomShellSectionRenderer(IShellContext context) : base(context)
        {
        }

        protected override IShellSectionRootRenderer CreateShellSectionRootRenderer(ShellSection shellSection, IShellContext shellContext)
        {
            return new CustomShellSectionRootRenderer(shellSection, shellContext);
        }
    }

    public class CustomShellSectionRootRenderer : ShellSectionRootRenderer
    {
        public CustomShellSectionRootRenderer(ShellSection shellSection, IShellContext shellContext) : base(shellSection, shellContext)
        {
        }

        protected override IShellSectionRootHeader CreateShellSectionRootHeader(IShellContext shellContext)
        {
            return new CustomShellSectionRootHeader(shellContext);
        }
    }

    public class CustomShellSectionRootHeader : ShellSectionRootHeader
    {
        public CustomShellSectionRootHeader(IShellContext shellContext) : base(shellContext)
        {
        }

        protected override Type GetCellType()
        {
            return typeof(CustomShellSectionHeaderCell);
        }

        public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
        {
            var baseCell =  base.GetCell(collectionView, indexPath);

            if(baseCell is CustomHeaderCell customHeaderCell)
            {
                var shellContent = ShellSection.Items[indexPath.Row];
                customHeaderCell.Label.Text = shellContent.Title;
                customHeaderCell.Label.SetNeedsDisplay();
            }

            if(baseCell is CustomShellSectionHeaderCell sectionHeaderCell)
            {
                var itemCount = base.ShellSection.Items.Count;
                var width = CollectionView.Superview.Frame.Width / itemCount;
                var size = new CGSize(width, 35);
                sectionHeaderCell.SizeToUse = size;
            }



            return baseCell;
        }

        public override void DidRotate(UIInterfaceOrientation fromInterfaceOrientation)
        {
            base.DidRotate(fromInterfaceOrientation);
            CollectionView.ReloadData();
        }
    }

    public class CustomShellSectionHeaderCell : ShellSectionRootHeader.ShellSectionHeaderCell
    {
        [Export("initWithFrame:")]
        public CustomShellSectionHeaderCell(CGRect frame) : base(frame)
        {
        }

        public CGSize SizeToUse { get; set; }

        public override CGSize SizeThatFits(CGSize size)
        {
            return SizeToUse;
        }
    }


    public class CustomHeaderCell : UICollectionViewCell
    {
        [Export("initWithFrame:")]
        public CustomHeaderCell(CGRect frame) : base(frame)
        {
            Label = new UILabel();
            Label.TextAlignment = UITextAlignment.Center;
            Label.Font = UIFont.BoldSystemFontOfSize(14);
            ContentView.AddSubview(Label);
        }

        public UILabel Label { get; }

        public override void LayoutSubviews()
        {
            base.LayoutSubviews();

            Label.Frame = Bounds;
        }

        public override CGSize SizeThatFits(CGSize size)
        {
            return new CGSize(Label.SizeThatFits(size).Width + 30, 35);
        }
    }
```

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
