### PR TITLE
WPF GTK Set flags

### DIFF
--- a/Xamarin.Forms.ControlGallery.GTK/Program.cs
+++ b/Xamarin.Forms.ControlGallery.GTK/Program.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.ControlGallery.GTK
             GtkOpenGL.Init();
             GtkThemes.Init();
             Gtk.Application.Init();
+            Forms.SetFlags("CarouselView_Experimental", "CollectionView_Experimental");
             FormsMaps.Init(string.Empty);
             Forms.Init();
             var app = new App();

--- a/Xamarin.Forms.ControlGallery.GTK/Program.cs
+++ b/Xamarin.Forms.ControlGallery.GTK/Program.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.ControlGallery.GTK
             GtkOpenGL.Init();
             GtkThemes.Init();
             Gtk.Application.Init();
-            Forms.SetFlags("CarouselView_Experimental", "CollectionView_Experimental");
+            Forms.SetFlags("CarouselView_Experimental");
             FormsMaps.Init(string.Empty);
             Forms.Init();
             var app = new App();

--- a/Xamarin.Forms.ControlGallery.WPF/MainWindow.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WPF/MainWindow.xaml.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.ControlGallery.WPF
 		public MainWindow()
 		{
 			InitializeComponent();
-			Forms.SetFlags("CarouselView_Experimental", "CollectionView_Experimental");
+			Forms.SetFlags("CarouselView_Experimental");
 			Xamarin.Forms.Forms.Init();
 			FormsMaps.Init("");
 			LoadApplication(new Controls.App());

--- a/Xamarin.Forms.ControlGallery.WPF/MainWindow.xaml.cs
+++ b/Xamarin.Forms.ControlGallery.WPF/MainWindow.xaml.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.ControlGallery.WPF
 		public MainWindow()
 		{
 			InitializeComponent();
+			Forms.SetFlags("CarouselView_Experimental", "CollectionView_Experimental");
 			Xamarin.Forms.Forms.Init();
 			FormsMaps.Init("");
 			LoadApplication(new Controls.App());

--- a/Xamarin.Forms.Platform.WPF/Forms.cs
+++ b/Xamarin.Forms.Platform.WPF/Forms.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Forms
 	{
 		public static bool IsInitialized { get; private set; }
 
+		static bool FlagsSet { get; set; }
+
+		static IReadOnlyList<string> s_flags;
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+
 		public static void Init(IEnumerable<Assembly> rendererAssemblies = null)
 		{
 			if (IsInitialized)
@@ -36,11 +41,28 @@ namespace Xamarin.Forms
 			ExpressionSearch.Default = new WPFExpressionSearch();
 
 			Registrar.RegisterAll(new[] { typeof(ExportRendererAttribute), typeof(ExportCellAttribute), typeof(ExportImageSourceHandlerAttribute) });
-			
+
 			Ticker.SetDefault(new WPFTicker());
 			Device.SetIdiom(TargetIdiom.Desktop);
+			Device.SetFlags(s_flags);
 
 			IsInitialized = true;
+		}
+
+		public static void SetFlags(params string[] flags)
+		{
+			if (FlagsSet)
+			{
+				return;
+			}
+
+			if (IsInitialized)
+			{
+				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
+			}
+
+			s_flags = flags.ToList().AsReadOnly();
+			FlagsSet = true;
 		}
 	}
 }


### PR DESCRIPTION
# Description of Change ###

Allows you to set experimental flags on WPF and GTK so that the application does not crash.

### API Changes ###

Added:
 - void SetFlags(params string[] flags)
 - IReadOnlyList<string> Flags {get;}
 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- GTK
- WPF

### Testing Procedure ###

Run ControlGallery, open CollectionView. 
Previous behavior - exception is thrown
Actual behavior - Application is running 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
