### PR TITLE
[Xaml] Throw XamlParseException in MarkupExpressionParser.GetNextPiece

### DIFF
--- a/Xamarin.Forms.Build.Tasks/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/ExpandMarkupsVisitor.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 
 				string piece;
-				while ((piece = GetNextPiece(ref remaining, out var next)) != null)
+				while ((piece = GetNextPiece(serviceProvider, ref remaining, out var next)) != null)
 					HandleProperty(piece, serviceProvider, ref remaining, next != '=');
 
 				return _node;

--- a/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MarkupExpressionParserTests.cs
@@ -374,5 +374,15 @@ namespace Xamarin.Forms.Xaml.UnitTests
 
 			Assert.AreEqual(expected, actual);
 		}
+
+		[TestCase("{Binding")]
+		[TestCase("{Binding 'Foo}")]
+		public void InvalidExpressions (string expression)
+		{
+			var serviceProvider = new Internals.XamlServiceProvider (null, null);
+			serviceProvider.IXamlTypeResolver = typeResolver;
+			serviceProvider.IProvideValueTarget = new MockValueProvider ("Bar", new ReverseConverter());
+			Assert.Throws<XamlParseException> (() => (new MarkupExtensionParser ()).ParseExpression (ref expression, serviceProvider));
+		}
 	}
 }

--- a/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
+++ b/Xamarin.Forms.Xaml/ExpandMarkupsVisitor.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Forms.Xaml
 				}
 
 				string piece;
-				while ((piece = GetNextPiece(ref remaining, out var next)) != null)
+				while ((piece = GetNextPiece(serviceProvider, ref remaining, out var next)) != null)
 					HandleProperty(piece, serviceProvider, ref remaining, next != '=');
 
 				return _node;

--- a/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Xaml
 				return expression.Substring(2);
 
 			if (expression[expression.Length - 1] != '}')
-				throw new Exception("Expression must end with '}'");
+				throw new XamlParseException("Expression must end with '}'", serviceProvider);
 
 			int len;
 			string match;
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Xaml
 				return false;
 			expression = expression.Substring(len).TrimStart();
 			if (expression.Length == 0)
-				throw new Exception("Expression did not end in '}'");
+				throw new XamlParseException("Expression did not end in '}'", serviceProvider);
 
 			var parser = Activator.CreateInstance(GetType()) as IExpressionParser;
 			return parser.Parse(match, ref expression, serviceProvider);
@@ -137,14 +137,14 @@ namespace Xamarin.Forms.Xaml
 				str_value = value as string;
 			}
 			else
-				str_value = GetNextPiece(ref remaining, out next);
+				str_value = GetNextPiece(serviceProvider, ref remaining, out next);
 
 			SetPropertyValue(prop, str_value, value, serviceProvider);
 		}
 
 		protected abstract void SetPropertyValue(string prop, string strValue, object value, IServiceProvider serviceProvider);
 
-		protected string GetNextPiece(ref string remaining, out char next)
+		protected string GetNextPiece(IServiceProvider serviceProvider, ref string remaining, out char next)
 		{
 			bool inString = false;
 			int end = 0;
@@ -193,10 +193,10 @@ namespace Xamarin.Forms.Xaml
 			}
 
 			if (inString && end == remaining.Length)
-				throw new Exception("Unterminated quoted string");
+				throw new XamlParseException("Unterminated quoted string", serviceProvider);
 
 			if (end == remaining.Length && !remaining.EndsWith("}", StringComparison.Ordinal))
-				throw new Exception("Expression did not end with '}'");
+				throw new XamlParseException("Expression did not end with '}'", serviceProvider);
 
 			if (end == 0)
 			{

--- a/Xamarin.Forms.Xaml/MarkupExtensionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensionParser.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Xaml
 				return markupExtension.ProvideValue(serviceProvider);
 
 			string piece;
-			while ((piece = GetNextPiece(ref remaining, out char next)) != null)
+			while ((piece = GetNextPiece(serviceProvider, ref remaining, out char next)) != null)
 				HandleProperty(piece, serviceProvider, ref remaining, next != '=');
 
 			return markupExtension.ProvideValue(serviceProvider);


### PR DESCRIPTION
### Description of Change ###

Throw `XamlParseException` in `MarkupExpressionParser.GetNextPiece`.

### Issues Resolved ### 

None

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

A source code location information will be shown for erroneous markup expressions.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run `Xamarin.Forms.Xaml.UnitTests`.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
