### PR TITLE
Fix previous page's toolbar item being grayed out when canceling swipe to previous page.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5596.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5596.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 5596, "Previous page's toolbar item being grayed out when canceling swipe to previous page then navigating back", PlatformAffected.iOS)]
+	public class Issue5596 : TestContentPage
+	{
+
+		protected override void Init()
+		{
+			ToolbarItems.Add(new ToolbarItem { Text = "Next Page", Command = new Command(async () => await Navigation.PushAsync(new MyTestPage())) });
+
+
+			Content = new Label
+			{
+				Margin = 10,
+				Text = "Click 'Next Page', start a swipe gesture to go back to the previous page but cancel it before it completes. Swipe again or click the back button on the upper left to go back. The toolbar item should not be grayed out."
+			};
+		}
+
+		private class MyTestPage : ContentPage
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -951,6 +951,18 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				base.ViewDidDisappear(animated);
 
+				// force a redraw for right toolbar items by resetting TintColor to prevent
+				// toolbar items being grayed out when canceling swipe to a previous page
+				foreach (var item in NavigationItem?.RightBarButtonItems)
+				{
+					if (item.Image != null)
+						continue;
+
+					var tintColor = item.TintColor;
+					item.TintColor = tintColor == null ? UIColor.Clear : null;
+					item.TintColor = tintColor;
+				}
+				
 				Disappearing?.Invoke(this, EventArgs.Empty);
 			}
 


### PR DESCRIPTION
### Description of Change ###

Force a redraw for right toolbar items by resetting TintColor to prevent toolbar items from being grayed out when canceling swipe to the previous page.

### Issues Resolved ### 

- fixes #5596

### API Changes ### 

 None

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###
Canceling the swipe gesture to go back to the previous page and then going back either by swiping or clicking the upper-right back button should not gray out the previous page's toolbar item.

### Before/After Screenshots ### 
Before
https://www.dropbox.com/s/i8wrmxnoq0l9bvr/screen%20recording%202019-11-11%20at%2011.22.12%20am.mov?dl=0

After
https://www.dropbox.com/s/jpgk5dlsog9bevw/screen%20recording%202019-11-11%20at%2011.20.06%20am.mov?dl=0

### Testing Procedure ###
Find the 5596 test case in the control gallery, click 'Next Page', start a swipe gesture to go back to the previous page but cancel it before it completes. Swipe again or click the back button on the upper left to go back. The toolbar item should not be grayed out.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)