### PR TITLE
Color.IsDark + Color.IsLight

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -334,24 +334,35 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void TestIsDark()
 		{
 			Assert.IsTrue(Color.Black.IsDark);
-			Assert.IsTrue(Color.Red.IsDark);
-			Assert.IsTrue(Color.DarkBlue.IsDark);
 
-			Assert.IsFalse(Color.Cornsilk.IsDark);
-			Assert.IsFalse(Color.LightGreen.IsDark);
-			Assert.IsFalse(Color.LightCyan.IsDark);
+			Assert.IsTrue(Color.FromHex("#666666").IsDark);
+			Assert.IsTrue(Color.FromHex("#333333").IsDark);
+			Assert.IsTrue(Color.FromHex("#FF0000 ").IsDark);
+			Assert.IsTrue(Color.FromHex("#0000FF").IsDark);
+			Assert.IsTrue(Color.FromHex("#FF00FF").IsDark);
+
+			Assert.IsFalse(Color.FromHex("#CCCCCC").IsDark);
+			Assert.IsFalse(Color.FromHex("#999999").IsDark);
+			Assert.IsFalse(Color.FromHex("#00FF00").IsDark);
+			Assert.IsFalse(Color.FromHex("#FFFF00").IsDark);
+			Assert.IsFalse(Color.FromHex("#00FFFF").IsDark);
 		}
 
 		[Test]
-		public void TestIsWhite()
+		public void TestIsLight()
 		{
-			Assert.IsTrue(Color.White.IsWhite);
-			Assert.IsTrue(Color.LemonChiffon.IsWhite);
-			Assert.IsTrue(Color.Pink.IsWhite);
+			Assert.IsTrue(Color.White.IsLight);
 
-			Assert.IsFalse(Color.Chocolate.IsWhite);
-			Assert.IsFalse(Color.DarkGreen.IsWhite);
-			Assert.IsFalse(Color.DarkOrchid.IsWhite);
+			Assert.IsTrue(Color.FromHex("#FFCC00").IsLight);
+			Assert.IsTrue(Color.FromHex("#CCFF00").IsLight);
+			Assert.IsTrue(Color.FromHex("#00CCFF").IsLight);
+			Assert.IsTrue(Color.FromHex("#CC6666").IsLight);
+
+			Assert.IsFalse(Color.FromHex("#FF0066").IsLight);
+			Assert.IsFalse(Color.FromHex("#006666").IsLight);
+			Assert.IsFalse(Color.FromHex("#0099CC").IsLight);
+			Assert.IsFalse(Color.FromHex("#666600").IsLight);
+			Assert.IsFalse(Color.FromHex("#CC00CC").IsLight);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -329,5 +329,29 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			Assert.AreEqual(Color.Default, (Color)System.Drawing.Color.Empty);
 		}
+
+		[Test]
+		public void TestIsDark()
+		{
+			Assert.IsTrue(Color.Black.IsDark);
+			Assert.IsTrue(Color.Red.IsDark);
+			Assert.IsTrue(Color.DarkBlue.IsDark);
+
+			Assert.IsFalse(Color.Cornsilk.IsDark);
+			Assert.IsFalse(Color.LightGreen.IsDark);
+			Assert.IsFalse(Color.LightCyan.IsDark);
+		}
+
+		[Test]
+		public void TestIsWhite()
+		{
+			Assert.IsTrue(Color.White.IsWhite);
+			Assert.IsTrue(Color.LemonChiffon.IsWhite);
+			Assert.IsTrue(Color.Pink.IsWhite);
+
+			Assert.IsFalse(Color.Chocolate.IsWhite);
+			Assert.IsFalse(Color.DarkGreen.IsWhite);
+			Assert.IsFalse(Color.DarkOrchid.IsWhite);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -406,7 +406,7 @@ namespace Xamarin.Forms
 			var r = _r * 255;
 			var g = _g * 255;
 			var b = _b * 255;
-			return Convert.ToInt32(Math.Round((299 * r + 587 * g + 114 * b) / 1000f));
+			return Convert.ToInt32(((r * 299) + (g * 587) + (b * 114)) / 1000f);
 		}
 
 		public bool IsDark

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -400,7 +400,27 @@ namespace Xamarin.Forms
 		{
 			return new Color(h, s, l, a, Mode.Hsl);
 		}
+
+		int CalculateYiqLuma()
+		{
+			var r = _r * 255;
+			var g = _g * 255;
+			var b = _b * 255;
+			return Convert.ToInt32(Math.Round((299 * r + 587 * g + 114 * b) / 1000f));
+		}
+
+		public bool IsDark
+		{
+			get => CalculateYiqLuma() < 128;
+		}
+
+		public bool IsWhite
+		{
+			get => CalculateYiqLuma() > 128;
+		}
+
 #if !NETSTANDARD1_0
+
 		public static implicit operator System.Drawing.Color(Color color)
 		{
 			if (color.IsDefault)

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -411,10 +411,10 @@ namespace Xamarin.Forms
 
 		public bool IsDark
 		{
-			get => CalculateYiqLuma() < 128;
+			get => CalculateYiqLuma() <= 128;
 		}
 
-		public bool IsWhite
+		public bool IsLight
 		{
 			get => CalculateYiqLuma() > 128;
 		}


### PR DESCRIPTION
### Description of Change ###
With release of the black theme and the ability to change the background of the StatusBar #8298, 
it would be nice to know if the color contrast is dark or light.
Therefore, I think it will be a good addition to Color.

Calculating Color Contrast: https://24ways.org/2010/calculating-color-contrast

That mean, if our color is ``` Color.Black.IsDark ``` we need to use light text. 
So this is the opposite of the link above.

### API Changes ###

Added:
 - bool Color.IsDark {get;} 
 - bool Color.IsLight{get;} 

``` cs
Assert.IsTrue(Color.Black.IsDark); 
Assert.IsTrue(Color.Red.IsDark); 
Assert.IsTrue(Color.DarkBlue.IsDark);
//or
Assert.IsTrue(Color.White.IsLight); 
Assert.IsTrue(Color.LemonChiffon.IsLight); 
Assert.IsTrue(Color.Pink.IsLight);
```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run Unit Tests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
