### PR TITLE
[Android] Fix to 7534 - Prevent to breaking when spans have paragraph…

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7534.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7534.cs
@@ -1,0 +1,58 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7534, "Span with tail truncation and paragraph breaks with Java.Lang.IndexOutOfBoundsException", PlatformAffected.Android)]
+	public partial class Issue7534 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var span = new Span
+			{
+				Text =
+				" Mi augue molestie ligula lobortis enim Velit, in. \n Imperdiet eu dignissim odio. Massa erat Hac inceptos facilisis nibh " +
+				" Interdum massa Consectetuer risus sociis molestie facilisi enim. Class gravida. \n Gravida sociosqu cras Quam velit, suspendisse" +
+				"  leo auctor odio integer primis dui potenti dolor faucibus augue justo morbi ornare sem. "
+			};
+
+			var formattedString = new FormattedString();
+			formattedString.Spans.Add(span);
+
+			var label = new Xamarin.Forms.Label
+			{
+				LineBreakMode = LineBreakMode.TailTruncation,
+				VerticalOptions = LayoutOptions.Start,
+				FormattedText = formattedString,
+				MaxLines = 3
+				//max line is less than the text reproduce and textViewExtensions couldn't identify when
+				//it's already pass the MaxLines range because of the paragraph('\n' character).
+			};
+
+			var labelDescription = new Label
+			{
+				Text = "If you opened this page, the app didn't crash and you can read three lines in the label above, this test has passed",
+				VerticalOptions = LayoutOptions.StartAndExpand
+			};
+
+			var layout = new Xamarin.Forms.StackLayout();
+			layout.Children.Add(label);
+			layout.Children.Add(labelDescription);
+
+			Content = layout;
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void ExpectingPageNotToBreak()
+		{
+			RunningApp.Screenshot("Test passed, label is showing as it should!");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -44,6 +44,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue4606.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8161.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8644.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7534.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8177.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4744.xaml.cs">
       <DependentUpon>Issue4744.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -117,6 +117,15 @@ namespace Xamarin.Forms.Platform.Android
 				var startSpanOffset = spannableString.GetSpanStart(startSpan);
 				var endSpanOffset = spannableString.GetSpanEnd(endSpan);
 
+				var thisLine = layout.GetLineForOffset(endSpanOffset);
+				var lineStart = layout.GetLineStart(thisLine);
+				var lineEnd = layout.GetLineEnd(thisLine);
+
+				//If this is true, endSpanOffset has the value for another line that belong to the next span and not it self. 
+				//So it should be rearranged to value not pass the lineEnd.
+				if (endSpanOffset > (lineEnd - lineStart))
+					endSpanOffset = lineEnd;
+
 				var startX = layout.GetPrimaryHorizontal(startSpanOffset);
 				var endX = layout.GetPrimaryHorizontal(endSpanOffset);
 
@@ -136,6 +145,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				var yaxis = 0.0;
+
 
 				for (var line = startLine; line > 0; line--)
 					yaxis += totalLineHeights[line];


### PR DESCRIPTION
<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

When spans has a paragraph, the textView Extension, RecalculateSpanPositions, can't recognize that the targeting line is not in the range of the lines defined in textView(MaxLines property in xamarin forms label) causing the Java.Lang.IndexOutOfBoundsException.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7534

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Android


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
