### PR TITLE
[p/gtk]Fix for #4880 -Text not shown as it should Xamarin.Forms.GTK

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/EntryWrapper.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 			set
 			{
-				_placeholder.Text = GLib.Markup.EscapeText(value ?? string.Empty);
+				_placeholder.Text = value ?? string.Empty;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.GTK/Controls/ScrolledTextView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/ScrolledTextView.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			}
 			set
 			{
-				_placeholder.Text = GLib.Markup.EscapeText(value ?? string.Empty);
+				_placeholder.Text = value ?? string.Empty;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ButtonRenderer.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				FontAttributes = Element.FontAttributes,
 				FontFamily = Element.FontFamily,
 				FontSize = Element.FontSize,
-				Text = GLib.Markup.EscapeText(Element.Text ?? string.Empty)
+				Text = Element.Text ?? string.Empty
 			};
 
 			Control.LabelWidget.SetTextFromSpan(span);

--- a/Xamarin.Forms.Platform.GTK/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/LabelRenderer.cs
@@ -138,7 +138,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 					FontAttributes = Element.FontAttributes,
 					FontFamily = Element.FontFamily,
 					FontSize = Element.FontSize,
-					Text = GLib.Markup.EscapeText(Element.Text ?? string.Empty)
+					Text = Element.Text ?? string.Empty
 				};
 
 				Control.SetTextFromSpan(span);


### PR DESCRIPTION
### Description of Change ###

Fix for #4880 -Text not shown as it should Xamarin.Forms.GTK.
Text were being encoded twice, once when they were assigned to Span, and once in`GenerateMarkupText()` method.

### Issues Resolved ### 
- fixes #4880

### API Changes ###
N/A

Added:
NA

Changed:

 -  _placeholder.Text = GLib.Markup.EscapeText(value ?? string.Empty) => _placeholder.Text = value ?? string.Empty;
- Text = GLib.Markup.EscapeText(Element.Text ?? string.Empty) => Text = Element.Text ?? string.Empty
 
 Removed:
 
 None

### Platforms Affected ### 

- GTK

### Behavioral/Visual Changes ###
XML/HTML special characters now display correctly.


### Before/After Screenshots ### 
Before:
<img width="802" alt="Screen Shot 2019-11-12 at 1 34 45 PM" src="https://user-images.githubusercontent.com/2817652/68704308-b7102580-0551-11ea-82e0-e6cf23500aad.png">

After:
<img width="801" alt="Screen Shot 2019-11-12 at 1 31 42 PM" src="https://user-images.githubusercontent.com/2817652/68703738-cf337500-0550-11ea-8ff5-d6a156248ef5.png">

Not applicable

### Testing Procedure ###
There isn't a UITest for the GTK platform yet. So I manually tested the changes by adding known special characters & ' - to one of the labels in the controls projects. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
