### PR TITLE
Fixes issue #7300 in XF 4.3.0 branch

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7300.cs
@@ -25,41 +25,58 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			// To test FastRenderer.ButtonRenderer, change the folowing to VisualMarker.Default
+			// and comment out setting the LegacyRenderers flag in FormsAppCompatActivity in Xamarin.Forms.ControlGallery.Android
 			Visual = VisualMarker.Material;
-			// Test with Grid
-			Grid theGrid = null;
-			theGrid = new Grid();
-			SetupLayout(theGrid);
+			// Test with Grid with overlap
+			Grid theGrid = new Grid();
+			SetupLayout(theGrid, true);
 
-			// Test with AbsoluteLayout
+			// Test with AbsoluteLayout with overlap
 			AbsoluteLayout absLayout = new AbsoluteLayout();
-			SetupLayout(absLayout);
+			SetupLayout(absLayout, true);
 
-			// Test with RelativeLayout
+			// Test with RelativeLayout with overlap
 			RelativeLayout relLayout = new RelativeLayout() { HeightRequest = 50 };
-			SetupLayout(relLayout);
+			SetupLayout(relLayout, true);
 
-			StackLayout stackLayout = new StackLayout();
-			stackLayout.Children.Add(new Label { Text = "Grid" });
+			// Test with Grid without overlap
+			Grid theGrid2 = new Grid();
+			SetupLayout(theGrid2, false);
+
+			// Test with AbsoluteLayout without overlap
+			AbsoluteLayout absLayout2 = new AbsoluteLayout();
+			SetupLayout(absLayout2, false);
+
+			// Test with RelativeLayout without overlap
+			RelativeLayout relLayout2 = new RelativeLayout() { HeightRequest = 50 };
+			SetupLayout(relLayout2, false);
+
+			StackLayout stackLayout = new StackLayout() { BackgroundColor = Color.Red };
+			stackLayout.Children.Add(new Label { Text = "Grid: Image covers button. Should never see button text" });
 			stackLayout.Children.Add(theGrid);
-			stackLayout.Children.Add(new Label { Text = "AbsoluteLayout" });
+			stackLayout.Children.Add(new Label { Text = "AbsoluteLayout: Image covers button. Should never see button text" });
 			stackLayout.Children.Add(absLayout);
-			stackLayout.Children.Add(new Label { Text = "RelativeLayout" });
+			stackLayout.Children.Add(new Label { Text = "RelativeLayout: Image covers button. Should never see button text" });
 			stackLayout.Children.Add(relLayout);
+			stackLayout.Children.Add(new Label { Text = "Grid: Image does not cover button. " });
+			stackLayout.Children.Add(theGrid2);
+			stackLayout.Children.Add(new Label { Text = "AbsoluteLayout: Image does not cover button. " });
+			stackLayout.Children.Add(absLayout2);
+			stackLayout.Children.Add(new Label { Text = "RelativeLayout: Image does not cover button. " });
+			stackLayout.Children.Add(relLayout2);
 
 			Content = stackLayout;
 		}
 
-		void SetupLayout(Layout layout)
+		void SetupLayout(Layout layout, bool overlap)
 		{
 
 			Button button = new Button()
 			{
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
-				Text = "If you can see this, even briefly, the test has failed",
-				AutomationId = "ClickMe",
-
+				Text = overlap ? "If you can see this, even briefly, the test has failed" : "Button",
 			};
 			button.Clicked += Button_Clicked;
 
@@ -68,7 +85,6 @@ namespace Xamarin.Forms.Controls.Issues
 				Source = "coffee.png",
 				HorizontalOptions = LayoutOptions.Fill,
 				VerticalOptions = LayoutOptions.Fill,
-				AutomationId = "ClickMe",
 				BackgroundColor = Color.Green,
 				InputTransparent = true
 			};
@@ -78,38 +94,73 @@ namespace Xamarin.Forms.Controls.Issues
 				var grid = layout as Grid;
 				grid.Children.Add(button);
 				grid.Children.Add(image);
+				if (!overlap)
+				{
+					grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+					grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+					Grid.SetColumn(button, 0);
+					Grid.SetColumn(image, 1);
+				}
 			}
 			else if (layout is AbsoluteLayout)
 			{
 				var absLayout = layout as AbsoluteLayout;
 
-				AbsoluteLayout.SetLayoutFlags(button, AbsoluteLayoutFlags.All);
-				AbsoluteLayout.SetLayoutBounds(button, new Rectangle(0, 0, 1, 1));
+				if(overlap)
+				{
+					AbsoluteLayout.SetLayoutFlags(button, AbsoluteLayoutFlags.All);
+					AbsoluteLayout.SetLayoutBounds(button, new Rectangle(0, 0, 1, 1));
+
+					AbsoluteLayout.SetLayoutFlags(image, AbsoluteLayoutFlags.All);
+					AbsoluteLayout.SetLayoutBounds(image, new Rectangle(0, 0, 1, 1));
+				}
+				else
+				{
+					AbsoluteLayout.SetLayoutFlags(button, AbsoluteLayoutFlags.None);
+					AbsoluteLayout.SetLayoutBounds(button, new Rectangle(0, 0, 195, 50));
+
+					AbsoluteLayout.SetLayoutFlags(image, AbsoluteLayoutFlags.None);
+					AbsoluteLayout.SetLayoutBounds(image, new Rectangle(205, 0, 195, 50));
+				}
+
 				absLayout.Children.Add(button);
-
-				AbsoluteLayout.SetLayoutFlags(image, AbsoluteLayoutFlags.All);
-				AbsoluteLayout.SetLayoutBounds(image, new Rectangle(0, 0, 1, 1));
 				absLayout.Children.Add(image);
-
 			}
 			else if (layout is RelativeLayout)
 			{
 				var relLayout = layout as RelativeLayout;
 
-				relLayout.Children.Add(button,
-					Forms.Constraint.Constant(0),
-					Forms.Constraint.Constant(0),
-					Forms.Constraint.Constant(320),
-					Forms.Constraint.Constant(50)
-					);
-				relLayout.Children.Add(image,
-					Forms.Constraint.Constant(0),
-					Forms.Constraint.Constant(0),
-					Forms.Constraint.Constant(320),
-					Forms.Constraint.Constant(50)
-					);
+				if (overlap)
+				{
+					relLayout.Children.Add(button,
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(320),
+						Forms.Constraint.Constant(50)
+						);
+					relLayout.Children.Add(image,
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(320),
+						Forms.Constraint.Constant(50)
+						);
+				}
+				else
+				{
+					relLayout.Children.Add(button,
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(195),
+						Forms.Constraint.Constant(50)
+						);
+					relLayout.Children.Add(image,
+						Forms.Constraint.Constant(205),
+						Forms.Constraint.Constant(0),
+						Forms.Constraint.Constant(195),
+						Forms.Constraint.Constant(50)
+						);
+				}
 			}
-
 		}
 
 		private void Button_Clicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7300.cs
@@ -1,0 +1,133 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Data;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7300, "[Bug] [Android] Content rendered above a Material button is not visible when button is pressed",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Layout)]
+#endif
+	public class Issue7300 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Visual = VisualMarker.Material;
+			// Test with Grid
+			Grid theGrid = null;
+			theGrid = new Grid();
+			SetupLayout(theGrid);
+
+			// Test with AbsoluteLayout
+			AbsoluteLayout absLayout = new AbsoluteLayout();
+			SetupLayout(absLayout);
+
+			// Test with RelativeLayout
+			RelativeLayout relLayout = new RelativeLayout() { HeightRequest = 50 };
+			SetupLayout(relLayout);
+
+			StackLayout stackLayout = new StackLayout();
+			stackLayout.Children.Add(new Label { Text = "Grid" });
+			stackLayout.Children.Add(theGrid);
+			stackLayout.Children.Add(new Label { Text = "AbsoluteLayout" });
+			stackLayout.Children.Add(absLayout);
+			stackLayout.Children.Add(new Label { Text = "RelativeLayout" });
+			stackLayout.Children.Add(relLayout);
+
+			Content = stackLayout;
+		}
+
+		void SetupLayout(Layout layout)
+		{
+
+			Button button = new Button()
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				Text = "If you can see this, even briefly, the test has failed",
+				AutomationId = "ClickMe",
+
+			};
+			button.Clicked += Button_Clicked;
+
+			Image image = new Image()
+			{
+				Source = "coffee.png",
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				AutomationId = "ClickMe",
+				BackgroundColor = Color.Green,
+				InputTransparent = true
+			};
+
+			if (layout is Grid)
+			{
+				var grid = layout as Grid;
+				grid.Children.Add(button);
+				grid.Children.Add(image);
+			}
+			else if (layout is AbsoluteLayout)
+			{
+				var absLayout = layout as AbsoluteLayout;
+
+				AbsoluteLayout.SetLayoutFlags(button, AbsoluteLayoutFlags.All);
+				AbsoluteLayout.SetLayoutBounds(button, new Rectangle(0, 0, 1, 1));
+				absLayout.Children.Add(button);
+
+				AbsoluteLayout.SetLayoutFlags(image, AbsoluteLayoutFlags.All);
+				AbsoluteLayout.SetLayoutBounds(image, new Rectangle(0, 0, 1, 1));
+				absLayout.Children.Add(image);
+
+			}
+			else if (layout is RelativeLayout)
+			{
+				var relLayout = layout as RelativeLayout;
+
+				relLayout.Children.Add(button,
+					Forms.Constraint.Constant(0),
+					Forms.Constraint.Constant(0),
+					Forms.Constraint.Constant(320),
+					Forms.Constraint.Constant(50)
+					);
+				relLayout.Children.Add(image,
+					Forms.Constraint.Constant(0),
+					Forms.Constraint.Constant(0),
+					Forms.Constraint.Constant(320),
+					Forms.Constraint.Constant(50)
+					);
+			}
+
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			System.Diagnostics.Debug.WriteLine($"{sender} Clicked");
+		}
+
+#if UITEST
+		[Test]
+		public void ImageShouldLayoutOnTopOfButton()
+		{
+			// Not sure how to make an automated UI test for this since the issue only occurs
+			// during the time that the android button is animating for the state change, so even getting a 
+			// screenshot after the button click likely will not capture the issue if it occurs. 
+			// To manually test, run the 7300 issue test page and click all 3 buttons more than once 
+			// (as issue does not occur every button click, but most times does) and make sure you never see
+			// the button text "If you can see this, even briefly, the test has failed"
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		ButtonLayoutManager _buttonLayoutManager;
 		IPlatformElementConfiguration<PlatformConfiguration.Android, Button> _platformElementConfiguration;
 		Button _button;
+		bool _buttonIsCovered;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
@@ -242,6 +243,65 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			_buttonLayoutManager?.OnLayout(changed, l, t, r, b);
 			base.OnLayout(changed, l, t, r, b);
+
+			var parent = _button.Parent;
+			int buttonIndex = parent.LogicalChildren.IndexOf(_button);
+
+			if (buttonIndex + 1 < parent.LogicalChildren.Count)
+			{
+				for (int i = buttonIndex + 1; i < parent.LogicalChildren.Count; i++)
+				{
+					var higherIndexElement = parent.LogicalChildren[i] as VisualElement;
+
+					if (parent is Grid)
+					{
+						//check to see if there is another child in the same Row/Column, 
+						// and if it has a higher index than _button and they overlap
+						// If so, set _isCovered=true
+						var buttonRow = Grid.GetRow(_button);
+						var buttonColumn = Grid.GetColumn(_button);
+						var higherIndexElementRow = Grid.GetRow(higherIndexElement);
+						var higherIndexElementColumn = Grid.GetColumn(higherIndexElement);
+						if (buttonRow == higherIndexElementRow && buttonColumn == higherIndexElementColumn && DoElementsOverlap(_button, higherIndexElement))
+						{
+							_buttonIsCovered = true;
+						}
+
+					}
+					else if (parent is AbsoluteLayout || parent is RelativeLayout)
+					{
+						// Check to see if any siblings that have a higher index
+						// occupy the same space as the button
+						// If so, set _isCovered=true
+						_buttonIsCovered = DoElementsOverlap(_button, higherIndexElement);
+					}
+
+				}
+			}
+		}
+
+		bool DoElementsOverlap(VisualElement a, VisualElement b)
+		{
+			Point buttonTopLeft = new Point(a.X, a.Y);
+			Point buttonBottomRight = new Point(a.X + a.Width, a.Y + a.Height);
+			Point higherIndexElementTopLeft = new Point(b.X, b.Y);
+			Point higherIndexElementBottomRight = new Point(b.X + b.Width, b.Y + b.Height);
+
+			if (buttonTopLeft.X > higherIndexElementBottomRight.X || higherIndexElementTopLeft.X > buttonBottomRight.X)
+				return false;
+			if (buttonTopLeft.Y > higherIndexElementBottomRight.Y || higherIndexElementTopLeft.Y > buttonBottomRight.Y)
+				return false;
+			return true;
+		}
+
+		public override float TranslationZ
+		{
+			get => base.TranslationZ;
+			set
+			{
+				base.TranslationZ = _buttonIsCovered ? 0 : value;
+				System.Diagnostics.Debug.WriteLine($"FastRenderer.ButtonRenderer TranslationZ: {base.TranslationZ}, IsCovered: {_buttonIsCovered}");
+			}
 		}
 
 		void SetTracker(VisualElementTracker tracker)

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -167,9 +167,6 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			float elevationToSet = 0;
 
-			// index of button in the LogicalChildren
-			int xfButtonIndex = -1;
-
 			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
 			{
 				Element child = ElementController.LogicalChildren[i];
@@ -189,16 +186,8 @@ namespace Xamarin.Forms.Platform.Android
 								if (elevation > elevationToSet)
 									elevationToSet = elevation;
 
-								// If there is a button underneath this element, raise the elevation by an additoinal
-								// 100 so that the element stays above the Button when the Button animates when clicked
-								r.View.Elevation = xfButtonIndex > -1 ? elevationToSet + 100 : elevationToSet;
+								r.View.Elevation = elevationToSet;
 							}
-						}
-
-						// If element is Button, set the index for later comparison
-						if (element is Button)
-						{
-							xfButtonIndex = i;
 						}
 
 						if(!onlyUpdateElevations)

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -166,6 +166,10 @@ namespace Xamarin.Forms.Platform.Android
 		void EnsureChildOrder(bool onlyUpdateElevations)
 		{
 			float elevationToSet = 0;
+
+			// index of button in the LogicalChildren
+			int xfButtonIndex = -1;
+
 			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)
 			{
 				Element child = ElementController.LogicalChildren[i];
@@ -184,9 +188,17 @@ namespace Xamarin.Forms.Platform.Android
 							{
 								if (elevation > elevationToSet)
 									elevationToSet = elevation;
-																
-								r.View.Elevation = elevationToSet;
+
+								// If there is a button underneath this element, raise the elevation by an additoinal
+								// 100 so that the element stays above the Button when the Button animates when clicked
+								r.View.Elevation = xfButtonIndex > -1 ? elevationToSet + 100 : elevationToSet;
 							}
+						}
+
+						// If element is Button, set the index for later comparison
+						if (element is Button)
+						{
+							xfButtonIndex = i;
 						}
 
 						if(!onlyUpdateElevations)
@@ -195,6 +207,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 		}
+
 
 		void OnChildAdded(object sender, ElementEventArgs e)
 		{


### PR DESCRIPTION
### Description of Change ###

- Updates the Platform.Android VisualElementPackager.EnsureChildOrder method to elevate any elements that are after a Button in the LogicalChildren of a layout by a value of 100 so they will stay above the Button when Android OS animates the button by raising the translationZ value while the button is in the Pressed state.
- Adds Issue7300.cs file in Xamarin.Forms.Controls.Issues.Shared project that tests the issue.
 
### Issues Resolved ### 

- fixes #7300

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Before this change, if a user has a button that is covered by other elements, when the button is clicked the button will briefly appear above the the other elements while the button is in the pressed state, but will return to being covered by the other elements when the Android animation finishes. After this fix, the button will remain below the other elements and should never be seen. 

In one test scenario, the button remained over the other elements after the button was clicked, but I could only see this behavior on an Android API 28 emulator running on a Mac. The same emulator on Windows acts as described above. However the fix in EnsureChildOrder method fixes both scenarios. 

### Before/After Screenshots ### 
Since this issue occurs so quickly, it is difficult to get a screen shot, so here is a zip of two screen recordings, one unfixed and one fixed:

[Screen_Recordings_of_Issue_7300.zip](https://github.com/xamarin/Xamarin.Forms/files/3838607/Screen_Recordings_of_Issue_7300.zip)

### Testing Procedure ###
1. Run the ControlGallery.Android project
2. Go to Test Cases
3. Search for 7300 and open the test
4. you will see three images, one each in a Grid, AbsoluteLayout, and RelativeLayout.
5. Each layout contains a Button and an Image, with the Image fully covering the button so you don't see the button at all. 
6. Click the Image and the underlying button will be clicked. (InputTransparent)
7. If the issue is fixed, you will not see the button text "If you see me, even briefly, the test has failed."

To see the original issue, in Xamarin.Forms.Platform.Android.VisualElementPackager.EnsureChildOrder method, change line 194 from  
`r.View.Elevation = xfButtonIndex > -1 ? elevationToSet + 100 : elevationToSet;`
to 
` r.View.Elevation = elevationToSet;`

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
