### PR TITLE
Fix NRE when navigating away from grouped CollectionView on iOS 10

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalTemplatedHeaderView.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalTemplatedHeaderView.cs
@@ -14,6 +14,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override CGSize Measure()
 		{
+			if (VisualElementRenderer?.Element == null)
+			{
+				return CGSize.Empty;
+			}
+
 			var measure = VisualElementRenderer.Element.Measure(double.PositiveInfinity, 
 				ConstrainedDimension, MeasureFlags.IncludeMargins);
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalSupplementaryView.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalSupplementaryView.cs
@@ -14,6 +14,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override CGSize Measure()
 		{
+			if (VisualElementRenderer?.Element == null)
+			{
+				return CGSize.Empty;
+			}
+
 			var measure = VisualElementRenderer.Element.Measure(ConstrainedDimension, 
 				double.PositiveInfinity, MeasureFlags.IncludeMargins);
 


### PR DESCRIPTION
### Description of Change ###

Navigating away from a page with a grouped CollectionView can cause a NullReferenceException on iOS 10 when it tries to do a final measurement. 

This change adds a null check to prevent the exception.

### Issues Resolved ### 
- Failing tests on 4.4.0 CI 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Covered by CollectionView grouping automated tests

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
