### PR TITLE
Fix dynamic heights for iOS Flyout Item Templates

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml
@@ -32,8 +32,14 @@
 			<ContentView>
 				<Button Visual="Material" ImageSource="{Binding FlyoutIcon}" Text="{Binding Text}"  />
 			</ContentView>
-		</DataTemplate>
-		<DataTemplate x:Key="ShellItemTemplate">
+        </DataTemplate>
+        <DataTemplate x:Key="MenuItemTemplateWithHeight">
+            <StackLayout HeightRequest="200" BackgroundColor="Purple">
+                <Label Text="{Binding Text}"></Label>
+                <Label VerticalTextAlignment="End" VerticalOptions="EndAndExpand" Text="{Binding Text}"></Label>
+            </StackLayout>
+        </DataTemplate>
+        <DataTemplate x:Key="ShellItemTemplate">
 			<ContentView BackgroundColor="LightBlue">
 				<StackLayout Orientation="Horizontal">
 					<Image Source="{Binding FlyoutIcon}"/>
@@ -119,5 +125,6 @@
 			<ShellContent Route="sharednotab" Title="No Tabs" ContentTemplate="{DataTemplate local:UpdatesPage}" />
 			<ShellContent Route="Notificationstabs" Shell.TabBarIsVisible="true" Title="Yes Tabs" ContentTemplate="{DataTemplate local:LibraryPage}" />
 		</ShellSection>
-	</ShellItem>
+    </ShellItem>
+    <MenuItem Shell.MenuItemTemplate="{StaticResource MenuItemTemplateWithHeight}" Text="Height 200"/>
 </localTest:TestShell>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -18,16 +18,23 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public ShellFlyoutContentRenderer(IShellContext context)
 		{
+			_shellContext = context;
+
 			var header = ((IShellController)context.Shell).FlyoutHeader;
 			if (header != null)
 				_headerView = new UIContainerView(((IShellController)context.Shell).FlyoutHeader);
-			_tableViewController = new ShellTableViewController(context, _headerView, OnElementSelected);
+
+			_tableViewController = CreateShellTableViewController();
 
 			AddChildViewController(_tableViewController);
 
 			context.Shell.PropertyChanged += HandleShellPropertyChanged;
 
-			_shellContext = context;
+		}
+
+		protected virtual ShellTableViewController CreateShellTableViewController()
+		{
+			return new ShellTableViewController(_shellContext, _headerView, OnElementSelected);
 		}
 
 		protected virtual void HandleShellPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		}
 
-		protected virtual ShellTableViewController CreateShellTableViewController()
+		protected ShellTableViewController CreateShellTableViewController()
 		{
 			return new ShellTableViewController(_shellContext, _headerView, OnElementSelected);
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -15,18 +15,25 @@ namespace Xamarin.Forms.Platform.iOS
 		double _headerOffset = 0;
 		double _headerSize;
 		bool _isDisposed;
+		Action<Element> _onElementSelected;
 
 		public ShellTableViewController(IShellContext context, UIContainerView headerView, Action<Element> onElementSelected)
 		{
 			_context = context;
+			_onElementSelected = onElementSelected;
 			_headerView = headerView;
-			_source = new ShellTableViewSource(context, onElementSelected);
+			_source = CreateShellTableViewSource();
 			_source.ScrolledEvent += OnScrolled;
 			if (_headerView != null)
 				_headerView.HeaderSizeChanged += OnHeaderSizeChanged;
 			((IShellController)_context.Shell).StructureChanged += OnStructureChanged;
 
 			_context.Shell.PropertyChanged += OnShellPropertyChanged;
+		}
+
+		protected virtual ShellTableViewSource CreateShellTableViewSource()
+		{
+			return new ShellTableViewSource(_context, _onElementSelected);
 		}
 
 		void OnShellPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -59,22 +66,16 @@ namespace Xamarin.Forms.Platform.iOS
 			switch (_context.Shell.FlyoutVerticalScrollMode)
 			{
 				case ScrollMode.Auto:
-					var pathToFirstRow = Foundation.NSIndexPath.FromRowSection(0, 0);
-					var firstCellRect = TableView.RectForRowAtIndexPath(pathToFirstRow);
-					var firstCellIsVisible = TableView.Bounds.Contains(firstCellRect);
-
-					var lastRowIndex = NMath.Max(0, TableView.NumberOfRowsInSection(0) - 1);
-					var pathToLastRow = Foundation.NSIndexPath.FromRowSection(lastRowIndex, 0);
-					var cellRect = TableView.RectForRowAtIndexPath(pathToLastRow);
-					var lastCellIsVisible = TableView.Bounds.Contains(cellRect);
-
-					TableView.ScrollEnabled = !firstCellIsVisible || !lastCellIsVisible;
+					TableView.ScrollEnabled = true;
+					TableView.AlwaysBounceVertical = false;
 					break;
 				case ScrollMode.Enabled:
 					TableView.ScrollEnabled = true;
+					TableView.AlwaysBounceVertical = true;
 					break;
 				case ScrollMode.Disabled:
 					TableView.ScrollEnabled = false;
+					TableView.AlwaysBounceVertical = false;
 					break;
 			}
 		}
@@ -152,8 +153,11 @@ namespace Xamarin.Forms.Platform.iOS
 					_headerView.HeaderSizeChanged -= OnHeaderSizeChanged;
 
 				_context.Shell.PropertyChanged -= OnShellPropertyChanged;
+
+				_onElementSelected = null;
 			}
 
+			
 			_isDisposed = true;
 			base.Dispose(disposing);
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_context.Shell.PropertyChanged += OnShellPropertyChanged;
 		}
 
-		protected virtual ShellTableViewSource CreateShellTableViewSource()
+		protected ShellTableViewSource CreateShellTableViewSource()
 		{
 			return new ShellTableViewSource(_context, _onElementSelected);
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -58,7 +58,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!_views.TryGetValue(context, out view))
 				return UITableView.AutomaticDimension;
 
-			var height = tableView.EstimatedRowHeight;
+			nfloat defaultHeight = tableView.EstimatedRowHeight == -1 ? 44 : tableView.EstimatedRowHeight;
+			nfloat height = -1;
 
 			if (view.HeightRequest >= 0)
 				height = (float)view.HeightRequest;
@@ -66,14 +67,14 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var request = view.Measure(tableView.Bounds.Width, double.PositiveInfinity, MeasureFlags.None);
 
-				if(request.Request.Height > 44)
+				if(request.Request.Height > defaultHeight)
 					height = (float)request.Request.Height;
 				else
-					height = 44;
+					height = defaultHeight;
 			}
 
 			if (height == -1)
-				height = 44;
+				height = defaultHeight;
 
 			return height;
 		}


### PR DESCRIPTION
### Description of Change ###
- Calculate the height of the templates used on the flyout so that they will size correctly
- Expose the creation of the TableViewController and TableViewSource for the flyout so users can override these and supply custom implementations
- This also fixes a regression on iOS where currently the flyout is unscrollable if content is too large

### Issues Resolved ### 

- fixes #8290 


### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
The height behavior will change on iOS if the templates that have been supplied have a HeightRequest specified or if they have a height > 44. This makes the behavior match Android and it is more expected

### Testing Procedure ###
- compare store shell with and without this change to make sure results makes sense
- verify the menu item with a templated height has specified height
- verify android and ios are consistent

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
