### PR TITLE
Add export method for transform string on UI Tests

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
@@ -16,6 +16,8 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: ExportRenderer(typeof(ActivityIndicator), typeof(PerformanceTrackingActivityIndicator))]
 [assembly: ExportRenderer(typeof(BoxView), typeof(PerformanceTrackingBoxView))]
 [assembly: ExportRenderer(typeof(Button), typeof(PerformanceTrackingButton))]
+[assembly: ExportRenderer(typeof(ImageButton), typeof(PerformanceTrackingImageButton))]
+[assembly: ExportRenderer(typeof(CheckBox), typeof(PerformanceTrackingCheckBox))]
 [assembly: ExportRenderer(typeof(DatePicker), typeof(PerformanceTrackingDatePicker))]
 [assembly: ExportRenderer(typeof(Editor), typeof(PerformanceTrackingEditor))]
 [assembly: ExportRenderer(typeof(Entry), typeof(PerformanceTrackingEntry))]
@@ -32,6 +34,8 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: ExportRenderer(typeof(TableView), typeof(PerformanceTrackingTableView))]
 [assembly: ExportRenderer(typeof(TimePicker), typeof(PerformanceTrackingTimePicker))]
 [assembly: ExportRenderer(typeof(WebView), typeof(PerformanceTrackingWebView))]
+[assembly: ExportRenderer(typeof(Entry), typeof(PerformanceTrackingMaterialEntry), new[] { typeof(VisualMarker.MaterialVisual) })]
+[assembly: ExportRenderer(typeof(Frame), typeof(FrameRenderer))]
 
 namespace Xamarin.Forms.ControlGallery.iOS
 {
@@ -230,6 +234,55 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		}
 	}
 
+	public class PerformanceTrackingFrame : FrameRenderer, IDrawnObservable
+	{
+		readonly SubviewWatcher<PerformanceTrackingFrame> _watcher;
+		int _Drawn;
+
+		public PerformanceTrackingFrame()
+		{
+			_watcher = new SubviewWatcher<PerformanceTrackingFrame>(this);
+		}
+
+		[Export(nameof(IDrawnObservable.Drawn))]
+		public int Drawn
+		{
+			get { return _Drawn; }
+			set
+			{
+				WillChangeValue(nameof(IDrawnObservable.Drawn));
+				_Drawn = value;
+				DidChangeValue(nameof(IDrawnObservable.Drawn));
+			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
+		public override void Draw(CGRect rect)
+		{
+			base.Draw(rect);
+			Drawn++;
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+			_watcher.SubscribeToDrawn(this);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_watcher.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+
 	public class PerformanceTrackingButton : ButtonRenderer, IDrawnObservable
 	{
 		readonly SubviewWatcher<PerformanceTrackingButton> _watcher;
@@ -238,6 +291,104 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		public PerformanceTrackingButton()
 		{
 			_watcher = new SubviewWatcher<PerformanceTrackingButton>(this);
+		}
+
+		[Export(nameof(IDrawnObservable.Drawn))]
+		public int Drawn
+		{
+			get { return _Drawn; }
+			set
+			{
+				WillChangeValue(nameof(IDrawnObservable.Drawn));
+				_Drawn = value;
+				DidChangeValue(nameof(IDrawnObservable.Drawn));
+			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
+		public override void Draw(CGRect rect)
+		{
+			base.Draw(rect);
+			Drawn++;
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+			_watcher.SubscribeToDrawn(this);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_watcher.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+
+	public class PerformanceTrackingImageButton : ImageButtonRenderer, IDrawnObservable
+	{
+		readonly SubviewWatcher<PerformanceTrackingImageButton> _watcher;
+		int _Drawn;
+
+		public PerformanceTrackingImageButton()
+		{
+			_watcher = new SubviewWatcher<PerformanceTrackingImageButton>(this);
+		}
+
+		[Export(nameof(IDrawnObservable.Drawn))]
+		public int Drawn
+		{
+			get { return _Drawn; }
+			set
+			{
+				WillChangeValue(nameof(IDrawnObservable.Drawn));
+				_Drawn = value;
+				DidChangeValue(nameof(IDrawnObservable.Drawn));
+			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
+		public override void Draw(CGRect rect)
+		{
+			base.Draw(rect);
+			Drawn++;
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+			_watcher.SubscribeToDrawn(this);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_watcher.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+
+	public class PerformanceTrackingCheckBox : CheckBoxRenderer, IDrawnObservable
+	{
+		readonly SubviewWatcher<PerformanceTrackingCheckBox> _watcher;
+		int _Drawn;
+
+		public PerformanceTrackingCheckBox()
+		{
+			_watcher = new SubviewWatcher<PerformanceTrackingCheckBox>(this);
 		}
 
 		[Export(nameof(IDrawnObservable.Drawn))]
@@ -385,6 +536,55 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		public PerformanceTrackingEntry()
 		{
 			_watcher = new SubviewWatcher<PerformanceTrackingEntry>(this);
+		}
+
+		[Export(nameof(IDrawnObservable.Drawn))]
+		public int Drawn
+		{
+			get { return _Drawn; }
+			set
+			{
+				WillChangeValue(nameof(IDrawnObservable.Drawn));
+				_Drawn = value;
+				DidChangeValue(nameof(IDrawnObservable.Drawn));
+			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
+		public override void Draw(CGRect rect)
+		{
+			base.Draw(rect);
+			Drawn++;
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			MessagingCenter.Instance.Send((IDrawnObservable)this, PerformanceTrackerRenderer.SubviewAddedMessage);
+			_watcher.SubscribeToDrawn(this);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_watcher.Dispose();
+			base.Dispose(disposing);
+		}
+	}
+
+	public class PerformanceTrackingMaterialEntry : Material.iOS.MaterialEntryRenderer, IDrawnObservable
+	{
+		readonly SubviewWatcher<PerformanceTrackingMaterialEntry> _watcher;
+		int _Drawn;
+
+		public PerformanceTrackingMaterialEntry()
+		{
+			_watcher = new SubviewWatcher<PerformanceTrackingMaterialEntry>(this);
 		}
 
 		[Export(nameof(IDrawnObservable.Drawn))]

--- a/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
@@ -35,7 +35,7 @@ using Xamarin.Forms.Platform.iOS;
 [assembly: ExportRenderer(typeof(TimePicker), typeof(PerformanceTrackingTimePicker))]
 [assembly: ExportRenderer(typeof(WebView), typeof(PerformanceTrackingWebView))]
 [assembly: ExportRenderer(typeof(Entry), typeof(PerformanceTrackingMaterialEntry), new[] { typeof(VisualMarker.MaterialVisual) })]
-[assembly: ExportRenderer(typeof(Frame), typeof(FrameRenderer))]
+[assembly: ExportRenderer(typeof(Frame), typeof(PerformanceTrackingFrame))]
 
 namespace Xamarin.Forms.ControlGallery.iOS
 {

--- a/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/PerformanceTrackerRenderer.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using ObjCRuntime;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -153,6 +154,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -194,6 +201,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -239,6 +252,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -280,6 +299,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -325,6 +350,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -368,6 +399,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -409,6 +446,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -455,6 +498,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -497,6 +546,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -543,6 +598,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -584,6 +645,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -629,6 +696,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -670,6 +743,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -715,6 +794,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -756,6 +841,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -801,6 +892,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -842,6 +939,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)
@@ -887,6 +990,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			}
 		}
 
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
+		}
+
 		public override void Draw(CGRect rect)
 		{
 			base.Draw(rect);
@@ -928,6 +1037,12 @@ namespace Xamarin.Forms.ControlGallery.iOS
 				_Drawn = value;
 				DidChangeValue(nameof(IDrawnObservable.Drawn));
 			}
+		}
+
+		[Export("getLayerTransformString", ArgumentSemantic.Retain)]
+		public NSString GetLayerTransformString
+		{
+			get => new NSString(Layer.Transform.ToString());
 		}
 
 		public override void Draw(CGRect rect)

--- a/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
@@ -17,15 +17,15 @@ namespace Xamarin.Forms.Core.UITests
 			{ Button.TextColorProperty, Tuple.Create (new[] { "titleLabel", "textColor" }, false) },
 			{ ImageButton.CornerRadiusProperty, Tuple.Create (new[] { "layer", "cornerRadius" }, false) },
 			{ ImageButton.BorderWidthProperty, Tuple.Create (new[] { "layer", "borderWidth" }, false) },
-			{ View.AnchorXProperty, Tuple.Create (new[] { "layer", "transform" }, true) },
-			{ View.AnchorYProperty, Tuple.Create (new[] { "layer", "transform" }, true) },
+			{ View.AnchorXProperty, Tuple.Create (new[] { "getLayerTransformString" }, true) },
+			{ View.AnchorYProperty, Tuple.Create (new[] { "lgetLayerTransformString" }, true) },
 			{ View.BackgroundColorProperty, Tuple.Create (new[] { "backgroundColor" }, false) },
 			{ View.IsEnabledProperty, Tuple.Create (new[] { "isEnabled" }, false) },
 			{ View.OpacityProperty, Tuple.Create (new [] { "alpha" }, true) },
-			{ View.RotationProperty, Tuple.Create (new[] { "layer", "transform" }, true) },
-			{ View.RotationXProperty, Tuple.Create (new[] { "layer", "transform" }, true) },
-			{ View.RotationYProperty, Tuple.Create (new[] { "layer", "transform" }, true) },
-			{ View.ScaleProperty, Tuple.Create (new[] { "layer", "transform" }, true) },
+			{ View.RotationProperty, Tuple.Create (new[] { "getLayerTransformString" }, true) },
+			{ View.RotationXProperty, Tuple.Create (new[] { "getLayerTransformString" }, true) },
+			{ View.RotationYProperty, Tuple.Create (new[] { "getLayerTransformString" }, true) },
+			{ View.ScaleProperty, Tuple.Create (new[] { "getLayerTransformString" }, true) },
 		};
 
 #elif __ANDROID__ || __WINDOWS__

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/ParsingUtils.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/ParsingUtils.cs
@@ -36,19 +36,14 @@ namespace Xamarin.Forms.Core.UITests
 		public static Matrix ParseCATransform3D (string CATransform3D)
 		{
 			// Logger.Log (CATransform3D);
-			char[] delimiters = { '<', ' ', '>' };
+			char[] delimiters = { '[', ' ', ']', ';' };
 			string[] words = CATransform3D.Split (delimiters, StringSplitOptions.RemoveEmptyEntries);
 
 			List<double> numbers = new List<double> ();
 
 			// Each number is represented by 2 blocks returned by server
-			for (int i = 0; i < (words.Length - 1); i += 2) {
-				string word = words[i] + words[i + 1];
-				var number = Int64.Parse (word, NumberStyles.HexNumber);
-				byte[] bytes = BitConverter.GetBytes (number);
-				byte[] reversedBytes = bytes.Reverse ().ToArray ();
-				double value = BitConverter.ToDouble (reversedBytes, 0);
-				numbers.Add (value);
+			for (int i = 0; i < words.Length; i++) {
+				numbers.Add (Convert.ToDouble(words[i]));
 			}
 
 			var transformationMatrix = new Matrix ();


### PR DESCRIPTION
### Description of Change ###
Work around change in behavior with how *Layer.Transform* is being exported to UI Tests

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- UI tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
