### PR TITLE
[XamlC] Support variance

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlC/TypeReferenceExtensionsTests.cs
@@ -66,6 +66,18 @@ namespace Xamarin.Forms.XamlcUnitTests
 		{
 		}
 
+		interface ICovariant<out T>
+		{
+		}
+
+		interface IContravariant<in T>
+		{
+		}
+
+		class Covariant<T> : ICovariant<T>
+		{
+		}
+
 		XamlCAssemblyResolver resolver;
 		ModuleDefinition module;
 
@@ -145,6 +157,14 @@ namespace Xamarin.Forms.XamlcUnitTests
 		[TestCase(typeof(Bar<string>), typeof(Foo<bool>), ExpectedResult = false)]
 		[TestCase(typeof(Bar<string>), typeof(Foo<string>), ExpectedResult = true)]
 		[TestCase(typeof(Qux<string>), typeof(double), ExpectedResult = false)] //https://github.com/xamarin/Xamarin.Forms/issues/1497
+		[TestCase(typeof(IGrault<object>), typeof(IGrault<string>), ExpectedResult = false)]
+		[TestCase(typeof(IGrault<string>), typeof(IGrault<object>), ExpectedResult = false)]
+		[TestCase(typeof(ICovariant<object>), typeof(ICovariant<string>), ExpectedResult = false)]
+		[TestCase(typeof(ICovariant<string>), typeof(ICovariant<object>), ExpectedResult = true)]
+		[TestCase(typeof(IContravariant<object>), typeof(IContravariant<string>), ExpectedResult = true)]
+		[TestCase(typeof(IContravariant<string>), typeof(IContravariant<object>), ExpectedResult = false)]
+		[TestCase(typeof(Covariant<object>), typeof(ICovariant<string>), ExpectedResult = false)]
+		[TestCase(typeof(Covariant<string>), typeof(ICovariant<object>), ExpectedResult = true)]
 		public bool TestInheritsFromOrImplements(Type typeRef, Type baseClass)
 		{
 			return TypeReferenceExtensions.InheritsFromOrImplements(module.ImportReference(typeRef), module.ImportReference(baseClass));


### PR DESCRIPTION
### Description of Change ###

Variance matters even for basic interfaces like `System.Collections.Generic.IEnumerable<T>`. I think XamlC will cover most use cases of generics with this change and previous improvements.

### Issues Resolved ### 

None

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ###

Not applicable

### Testing Procedure ###

Run the automated tests.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
