### PR TITLE
[iOS] Fix Issue #8529 - Shell BackButtonBehavior crashing on Command p…

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8529,
+		"[Bug] [Shell] iOS - BackButtonBehavior Command property binding throws InvalidCastException when using a custom command class that implements ICommand",
+		PlatformAffected.iOS)]
+	public class Issue8529 : TestShell
+	{
+		const string ContentPageTitle = "Item1";
+		const string ButtonId = "ButtonId";
+
+		protected override void Init()
+		{
+			CreateContentPage(ContentPageTitle).Content =
+				new StackLayout
+				{
+					Children =
+					{
+						new Button
+						{
+							AutomationId = ButtonId,
+							Text = "Tap to Navigate To the Page With BackButtonBehavior",
+							Command = new Command(NavToBackButtonBehaviorPage)
+						}
+					}
+				};
+		}
+
+		private void NavToBackButtonBehaviorPage()
+		{
+			_ = Shell.Current.Navigation.PushAsync(new Issue8529_1());
+		}
+
+#if UITEST && __IOS__
+		public void NavigateBack()
+		{
+			RunningApp.Tap(c => c.Marked("BackButtonImage"));
+		}
+
+		[Test]
+		public void Issue8529ShellBackButtonBehaviorCommandPropertyCanUseICommand()
+		{
+			RunningApp.WaitForElement(ButtonId, "Timed out waiting for first page.");
+			RunningApp.Tap(ButtonId);
+			RunningApp.WaitForElement("LabelId", "Timed out waiting for the destination page.");
+			NavigateBack();
+			RunningApp.WaitForElement(ButtonId, "Timed out waiting to navigate back to the first page.");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529.cs
@@ -46,10 +46,14 @@ namespace Xamarin.Forms.Controls.Issues
 			_ = Shell.Current.Navigation.PushAsync(new Issue8529_1());
 		}
 
-#if UITEST && __IOS__
+#if UITEST && __SHELL__
 		public void NavigateBack()
 		{
+#if __IOS__
 			RunningApp.Tap(c => c.Marked("BackButtonImage"));
+#else
+			RunningApp.Tap(FlyoutIconAutomationId);
+#endif
 		}
 
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529_1.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529_1.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8529_1"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    Title="BackButtonPage">
+
+    <Shell.BackButtonBehavior>
+        <BackButtonBehavior Command="{Binding BackCommand}">
+            <BackButtonBehavior.IconOverride>
+                <FileImageSource AutomationId="BackButtonImage" File="star-flyout.png" />
+            </BackButtonBehavior.IconOverride>
+        </BackButtonBehavior>
+    </Shell.BackButtonBehavior>
+
+    <StackLayout>
+        <Label AutomationId="LabelId" Text="This page has back button behavior." />
+    </StackLayout>
+
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529_1.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529_1.xaml.cs
@@ -1,0 +1,174 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using System;
+using System.Windows.Input;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	public partial class Issue8529_1 : ContentPage
+	{
+		public Issue8529_1()
+		{
+#if APP
+			InitializeComponent();
+#endif
+			BindingContext = new Issue8529ViewModel();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8529ViewModel
+	{
+		public ICommand BackCommand { get; set; }
+
+		public Issue8529ViewModel()
+		{
+			BackCommand = new Issue8529AsyncCommand(() =>
+				{
+					return Shell.Current.Navigation.PopAsync();
+				});
+		}
+	}
+
+	#region AsyncCommand
+
+	public interface Issue8529IAsyncCommand : ICommand
+	{
+		Task ExecuteAsync();
+		bool CanExecute();
+	}
+
+	public interface Issue8529IAsyncCommand<in T> : ICommand
+	{
+		Task ExecuteAsync(T parameter);
+		bool CanExecute(T parameter);
+	}
+
+	public static class Issue8529TaskUtilities
+	{
+		public static async void Issue8529FireAndForgetSafeAsync(this Task task)
+		{
+			try
+			{
+				await task;
+			}
+			catch (Exception)
+			{
+
+			}
+		}
+	}
+
+	/// <summary>
+	/// Custom command class to demonstrate the crash. 
+	/// </summary>
+	public class Issue8529AsyncCommand : Issue8529IAsyncCommand
+	{
+		private bool _isExecuting;
+		private readonly Func<Task> _execute;
+		private readonly Func<bool> _canExecute;
+		public event EventHandler CanExecuteChanged;
+
+		public Issue8529AsyncCommand(Func<Task> execute, Func<bool> canExecute = null)
+		{
+			_execute = execute;
+			_canExecute = canExecute;
+		}
+
+		public bool CanExecute()
+		{
+			return !_isExecuting && (_canExecute?.Invoke() ?? true);
+		}
+
+		public async Task ExecuteAsync()
+		{
+			if (CanExecute())
+			{
+				try
+				{
+					_isExecuting = true;
+					await _execute();
+				}
+				finally
+				{
+					_isExecuting = false;
+				}
+			}
+
+			RaiseCanExecuteChanged();
+		}
+
+		public void RaiseCanExecuteChanged()
+		{
+			CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		bool ICommand.CanExecute(object parameter)
+		{
+			return CanExecute();
+		}
+
+		void ICommand.Execute(object parameter)
+		{
+			ExecuteAsync().Issue8529FireAndForgetSafeAsync();
+		}
+	}
+
+	public class Issue8529AsyncCommand<T> : Issue8529IAsyncCommand<T>
+	{
+		private bool _isExecuting;
+		private readonly Func<T, Task> _execute;
+		private readonly Func<T, bool> _canExecute;
+		public event EventHandler CanExecuteChanged;
+
+		public Issue8529AsyncCommand(Func<T, Task> execute, Func<T, bool> canExecute = null)
+		{
+			_execute = execute;
+			_canExecute = canExecute;
+		}
+
+		public bool CanExecute(T parameter)
+		{
+			return !_isExecuting && (_canExecute?.Invoke(parameter) ?? true);
+		}
+
+		public async Task ExecuteAsync(T parameter)
+		{
+			if (CanExecute(parameter))
+			{
+				try
+				{
+					_isExecuting = true;
+					await _execute(parameter);
+				}
+				finally
+				{
+					_isExecuting = false;
+				}
+			}
+
+			RaiseCanExecuteChanged();
+		}
+
+		public void RaiseCanExecuteChanged()
+		{
+			CanExecuteChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		bool ICommand.CanExecute(object parameter)
+		{
+			return parameter == null || CanExecute((T)parameter);
+		}
+
+		void ICommand.Execute(object parameter)
+		{
+			ExecuteAsync((T)parameter).Issue8529FireAndForgetSafeAsync();
+		}
+	}
+
+	#endregion
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -99,6 +99,11 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8167.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8269.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8529.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8529_1.xaml.cs">
+      <DependentUpon>Issue8529_1.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1601,7 +1606,12 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7048.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8529_1.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -269,7 +269,8 @@ namespace Xamarin.Forms.Platform.iOS
 		void LeftBarButtonItemHandler(UIViewController controller, bool isRootPage)
 		{
 			var behavior = BackButtonBehavior;
-			var command = behavior.GetPropertyIfSet(BackButtonBehavior.CommandProperty, new Command(() => OnMenuButtonPressed(this, EventArgs.Empty)));
+			ICommand defaultCommand = new Command(() => OnMenuButtonPressed(this, EventArgs.Empty));
+			var command = behavior.GetPropertyIfSet(BackButtonBehavior.CommandProperty, defaultCommand);
 			var commandParameter = behavior.GetPropertyIfSet<object>(BackButtonBehavior.CommandParameterProperty, null);
 
 			if (command == null && !isRootPage && controller?.ParentViewController is UINavigationController navigationController)


### PR DESCRIPTION
…roperty binding on non-Xamarin.Forms.Command ICommand implementations

### Description of Change ###
Sets type of a variable to be `ICommand` and sets its value to a default `Xamarin.Forms.Command` to be used for `Shell.BackButtonBehavior.` 

This ensures that a when using this variable in a call to `BackButtonBehavior.GetPropertyIfSet<T>()` that `T` is an `ICommand` instead of `Command,` `T` being used in a cast of the return value of the method. 

Otherwise the cast fails with an `InvalidCastException` when the `BackButtonBehavior Command` property is bound to a class that implements `ICommand` (that isn't `Xamarin.Forms.Command`). 

See the Issue8529 UI test.

[This](https://github.com/xamarin/Xamarin.Forms/commit/9311b5f4894f127fa8f82f7bd6b5e5b04996a0ce) is the commit that introduced the issue.

### Issues Resolved ### 
- fixes #8529 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
See issue #8529 and/or the Issue8529 UI test.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
