### PR TITLE
Update MacDeviceInfo.cs

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/MacDeviceInfo.cs
+++ b/Xamarin.Forms.Platform.MacOS/MacDeviceInfo.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Platform.macOS
 
 		public MacDeviceInfo()
 		{
+			UpdateScreenSize();
 		}
 
 		public override Size PixelScreenSize => _pixelScreenSize;


### PR DESCRIPTION
### Description of Change ###

Probably originated somewhere around #5975. The `UpdateScreenSize` method was never called and thus the values for the screen size were never initialized.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8559

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- MacOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
