### PR TITLE
[Android] Fix Label size when using Hint text (FR)

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -113,8 +113,17 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 					return _lastSizeRequest.Value;
 			}
 
+			//We need to clear the Hint or else it will interfere with the sizing of the Label
+			var hint = Control.Hint;
+			if (!string.IsNullOrEmpty(hint))
+				Control.Hint = string.Empty;
+
 			Measure(widthConstraint, heightConstraint);
-			SizeRequest result = new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), new Size());
+			var result = new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), new Size());
+
+			//Set Hint back after sizing
+			Control.Hint = hint;
+
 			result.Minimum = new Size(Math.Min(Context.ToPixels(10), result.Request.Width), result.Request.Height);
 
 			// if the measure of the view has changed then trigger a request for layout


### PR DESCRIPTION
### Description of Change ###

The fix from #4433 was not applied in the fast renderer. This PR implements the same fix for the fast renderer.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7019

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android (FR)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

While in other areas there might be some wrong measurements, in this specific case it was when a `Label` was used in the title view. When navigating to a second page with a title view that contains a `Label` it would not show. Now it does.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

#### Before (no title)

![Before: No title view visible](https://user-images.githubusercontent.com/939291/69176429-003e1780-0b06-11ea-9332-e63d6994d8eb.png)

#### After (title)

![After: No title view visible](https://user-images.githubusercontent.com/939291/69176767-a427c300-0b06-11ea-9e42-7aa398cab7b0.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Unfortunately, I could only repro this by hooking up the repro project to the Sandbox, so if you really want to see it in action you should probably do the same. Or take the Nuget from this PR, install that on the repro project and notice that it now works.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
