### PR TITLE
[Android] Make ItemDecoration implementations accessible

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselSpacingItemDecoration.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselSpacingItemDecoration.cs
@@ -5,7 +5,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class CarouselSpacingItemDecoration : RecyclerView.ItemDecoration
+	public class CarouselSpacingItemDecoration : RecyclerView.ItemDecoration
 	{
 		readonly ItemsLayoutOrientation _orientation;
 		readonly double _verticalSpacing;

--- a/Xamarin.Forms.Platform.Android/CollectionView/SpacingItemDecoration.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SpacingItemDecoration.cs
@@ -5,7 +5,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class SpacingItemDecoration : RecyclerView.ItemDecoration
+	public class SpacingItemDecoration : RecyclerView.ItemDecoration
 	{
 		readonly ItemsLayoutOrientation _orientation;
 		readonly double _verticalSpacing;


### PR DESCRIPTION
### Description of Change ###

Right now, there is no way to extend the functionality of ```SpacingItemDecoration``` and ```CarouselSpacingItemDecoration```. You have to manually copy and paste them and make your own changes by extending ```RecyclerView.ItemDecoration```.

### Platforms Affected ### 

- Android

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
