### PR TITLE
Remove ItemSizingStrategy from CarouselView

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
@@ -33,7 +33,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsNull(carouselView.ItemTemplate);
 			Assert.IsNotNull(carouselView.ItemsLayout);
 			Assert.IsTrue(carouselView.Position == 0);
-			Assert.IsTrue(carouselView.ItemSizingStrategy == ItemSizingStrategy.None);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -180,7 +180,6 @@ namespace Xamarin.Forms
 				SnapPointsType = SnapPointsType.MandatorySingle,
 				SnapPointsAlignment = SnapPointsAlignment.Center
 			};
-			ItemSizingStrategy = ItemSizingStrategy.None;
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/Items/ItemSizingStrategy.cs
+++ b/Xamarin.Forms.Core/Items/ItemSizingStrategy.cs
@@ -3,7 +3,6 @@
 	public enum ItemSizingStrategy
 	{
 		MeasureAllItems,
-		MeasureFirstItem,
-		None
+		MeasureFirstItem
 	}
 }

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -131,15 +131,6 @@ namespace Xamarin.Forms
 			set => SetValue(InternalItemsLayoutProperty, value);
 		}
 
-		public static readonly BindableProperty ItemSizingStrategyProperty =
-			BindableProperty.Create(nameof(ItemSizingStrategy), typeof(ItemSizingStrategy), typeof(ItemsView));
-
-		public ItemSizingStrategy ItemSizingStrategy
-		{
-			get => (ItemSizingStrategy)GetValue(ItemSizingStrategyProperty);
-			set => SetValue(ItemSizingStrategyProperty, value);
-		}
-
 		public static readonly BindableProperty ItemTemplateProperty =
 			BindableProperty.Create(nameof(ItemTemplate), typeof(DataTemplate), typeof(ItemsView));
 

--- a/Xamarin.Forms.Core/Items/StructuredItemsView.cs
+++ b/Xamarin.Forms.Core/Items/StructuredItemsView.cs
@@ -45,5 +45,14 @@
 			get => InternalItemsLayout;
 			set => InternalItemsLayout = value;
 		}
+
+		public static readonly BindableProperty ItemSizingStrategyProperty =
+			BindableProperty.Create(nameof(ItemSizingStrategy), typeof(ItemSizingStrategy), typeof(ItemsView));
+
+		public ItemSizingStrategy ItemSizingStrategy
+		{
+			get => (ItemSizingStrategy)GetValue(ItemSizingStrategyProperty);
+			set => SetValue(ItemSizingStrategyProperty, value);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -167,7 +167,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateAdapter();
 		}
 
-		void UpdateAdapter()
+		protected override void UpdateAdapter()
 		{
 			// By default the CollectionViewAdapter creates the items at whatever size the template calls for
 			// But for the Carousel, we want it to create the items to fit the width/height of the viewport

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -16,8 +16,6 @@ namespace Xamarin.Forms.Platform.Android
 		internal TItemsViewSource ItemsSource;
 
 		bool _disposed;
-		Size? _size;
-
 		bool _usingItemTemplate = false;
 
 		internal ItemsViewAdapter(TItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
@@ -126,16 +124,9 @@ namespace Xamarin.Forms.Platform.Android
 			return ItemsSource.GetPosition(item);
 		}
 
-		protected void BindTemplatedItemViewHolder(TemplatedItemViewHolder templatedItemViewHolder, object context)
+		protected virtual void BindTemplatedItemViewHolder(TemplatedItemViewHolder templatedItemViewHolder, object context)
 		{
-			if (ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem)
-			{
-				templatedItemViewHolder.Bind(context, ItemsView, SetStaticSize, _size);
-			}
-			else
-			{
-				templatedItemViewHolder.Bind(context, ItemsView);
-			}
+			templatedItemViewHolder.Bind(context, ItemsView);
 		}
 
 		void UpdateItemsSource()
@@ -143,11 +134,6 @@ namespace Xamarin.Forms.Platform.Android
 			ItemsSource?.Dispose();
 
 			ItemsSource = CreateItemsSource();
-		}
-
-		void SetStaticSize(Size size)
-		{
-			_size = size;
 		}
 
 		void UpdateUsingItemTemplate()

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -228,10 +228,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateEmptyView();
 			}
-			else if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemSizingStrategyProperty))
-			{
-				UpdateAdapter();
-			}
 			else if (changedProperty.Is(Xamarin.Forms.ItemsView.HorizontalScrollBarVisibilityProperty))
 			{
 				UpdateHorizontalScrollBarVisibility();
@@ -272,7 +268,7 @@ namespace Xamarin.Forms.Platform.Android
 			return (TAdapter)new ItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView);
 		}
 
-		void UpdateAdapter()
+		protected virtual void UpdateAdapter()
 		{
 			var oldItemViewAdapter = ItemsViewAdapter;
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms.Platform.Android
 		where TItemsView : StructuredItemsView
 		where TItemsViewSource : IItemsViewSource
 	{
+		Size? _size;
+
 		internal StructuredItemsViewAdapter(TItemsView itemsView, 
 			Func<View, Context, ItemContentView> createItemContentView = null) : base(itemsView, createItemContentView)
 		{
@@ -90,6 +92,18 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnBindViewHolder(holder, position);
 		}
 
+		protected override void BindTemplatedItemViewHolder(TemplatedItemViewHolder templatedItemViewHolder, object context)
+		{
+			if (ItemsView.ItemSizingStrategy == ItemSizingStrategy.MeasureFirstItem)
+			{
+				templatedItemViewHolder.Bind(context, ItemsView, SetStaticSize, _size);
+			}
+			else
+			{
+				base.BindTemplatedItemViewHolder(templatedItemViewHolder, context);
+			}
+		}
+
 		void UpdateHasHeader()
 		{
 			ItemsSource.HasHeader = ItemsView.Header != null;
@@ -125,6 +139,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			// No template, Footer is not a Forms View, so just display Footer.ToString
 			return SimpleViewHolder.FromText(content?.ToString(), context, fill: false);
+		}
+
+		void SetStaticSize(Size size)
+		{
+			_size = size;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewRenderer.cs
@@ -22,6 +22,10 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateLayoutManager();
 			}
+			else if (changedProperty.Is(StructuredItemsView.ItemSizingStrategyProperty))
+			{
+				UpdateAdapter();
+			}
 		}
 
 		protected override TAdapter CreateAdapter()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(ItemsView.ItemsSourceProperty, UpdateItemsSource);
 			RegisterPropertyHandler(ItemsView.ItemTemplateProperty, UpdateAdaptor);
 			RegisterPropertyHandler(StructuredItemsView.ItemsLayoutProperty, UpdateItemsLayout);
-			RegisterPropertyHandler(ItemsView.ItemSizingStrategyProperty, UpdateSizingStrategy);
+			RegisterPropertyHandler(StructuredItemsView.ItemSizingStrategyProperty, UpdateSizingStrategy);
 			RegisterPropertyHandler(SelectableItemsView.SelectedItemProperty, UpdateSelectedItem);
 			RegisterPropertyHandler(SelectableItemsView.SelectionModeProperty, UpdateSelectionMode);
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly CarouselView _carouselView;
 		readonly ItemsLayout _itemsLayout;
 
-		public CarouselViewLayout(ItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy, CarouselView carouselView) : base(itemsLayout, itemSizingStrategy)
+		public CarouselViewLayout(ItemsLayout itemsLayout, CarouselView carouselView) : base(itemsLayout)
 		{
 			_carouselView = carouselView;
 			_itemsLayout = itemsLayout;
@@ -23,7 +23,6 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ConstrainTo(CGSize size)
 		{
 			//TODO: Should we scale the items 
-			var aspectRatio = size.Width / size.Height;
 			var numberOfVisibleItems = _carouselView.NumberOfSideItems * 2 + 1;
 			var width = (size.Width - _carouselView.PeekAreaInsets.Left - _carouselView.PeekAreaInsets.Right) / numberOfVisibleItems;
 			var height = (size.Height - _carouselView.PeekAreaInsets.Top - _carouselView.PeekAreaInsets.Bottom) / numberOfVisibleItems;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override ItemsViewLayout SelectLayout()
 		{
-			return new CarouselViewLayout(CarouselView.ItemsLayout, CarouselView.ItemSizingStrategy, CarouselView);
+			return new CarouselViewLayout(CarouselView.ItemsLayout, CarouselView);
 		}
 
 		protected override void SetUpNewElement(CarouselView newElement)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -18,7 +18,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public ItemsUpdatingScrollMode ItemsUpdatingScrollMode { get; set; }
 
-		protected ItemsViewLayout(ItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy)
+		public nfloat ConstrainedDimension { get; set; }
+
+		public Func<UICollectionViewCell> GetPrototype { get; set; }
+
+		internal ItemSizingStrategy ItemSizingStrategy { get; private set; }
+
+		protected ItemsViewLayout(ItemsLayout itemsLayout, ItemSizingStrategy itemSizingStrategy = ItemSizingStrategy.MeasureFirstItem)
 		{
 			ItemSizingStrategy = itemSizingStrategy;
 
@@ -74,12 +80,6 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateItemSpacing();
 			}
 		}
-
-		public nfloat ConstrainedDimension { get; set; }
-
-		public Func<UICollectionViewCell> GetPrototype { get; set; }
-
-		internal ItemSizingStrategy ItemSizingStrategy { get; private set; }
 
 		public abstract void ConstrainTo(CGSize size);
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -15,8 +15,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected TItemsView ItemsView => Element;
 
-
-
 		public override UIViewController ViewController => Controller;
 
 		protected TViewController Controller { get; private set; }
@@ -55,10 +53,6 @@ namespace Xamarin.Forms.Platform.iOS
 				Xamarin.Forms.ItemsView.EmptyViewTemplateProperty))
 			{
 				Controller.UpdateEmptyView();
-			}
-			else if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemSizingStrategyProperty))
-			{
-				UpdateItemSizingStrategy();
 			}
 			else if (changedProperty.Is(Xamarin.Forms.ItemsView.HorizontalScrollBarVisibilityProperty))
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewRenderer.cs
@@ -27,6 +27,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UpdateLayout();
 			}
+			else if (changedProperty.Is(StructuredItemsView.ItemSizingStrategyProperty))
+			{
+				UpdateItemSizingStrategy();
+			}
 		}
 
 		protected override void SetUpNewElement(TItemsView newElement)


### PR DESCRIPTION
### Description of Change ###

CarouselView doesn't use it, and `None` doesn't make any sense for the CollectionView.

### Issues Resolved ### 
Confusion

### API Changes ###
 
Removed:
 - ItemsView.ItemSizingStrategy { get; set; }

Added:
 - StructuredItemsView.ItemSizingStrategy { get; set; }
 
### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
