### PR TITLE
Slow down gesture scroll for UI test and let it retry

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7329.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7329.cs
@@ -68,7 +68,22 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 			RunningApp.WaitForElement("1");
-			RunningApp.ScrollDownTo("30", strategy: ScrollStrategy.Gesture);
+
+			RunningApp.QueryUntilPresent(() =>
+			{
+				try
+				{
+					RunningApp.ScrollDownTo("30", strategy: ScrollStrategy.Gesture, swipeSpeed: 100);
+				}
+				catch
+				{
+					// just ignore if it fails so it can keep trying to scroll
+				}
+
+				return RunningApp.Query("30");
+			});
+
+			RunningApp.Query("30");
 		}
 #endif
 	}


### PR DESCRIPTION
### Description of Change ###

UI Test 7329 occasionally fails because it scrolls past the value it's looking for. This slows down the scroll and then also retries it if the scroll fails just in case it's now scrolling too slow

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Testing Procedure ###
- UI tests for 7329 all pass on iOS and Android

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
