### PR TITLE
[UWP] Fix MDP Button "Padding" issue

### DIFF
--- a/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
@@ -36,6 +36,21 @@
 								<Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
 									<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}" HorizontalAlignment="Stretch">
                                         <uwp:FormsCommandBar.Resources>
+                                            <Thickness x:Key="AppBarButtonContentViewboxMargin">12,14,0,14</Thickness>
+                                            <Thickness x:Key="AppBarButtonContentViewboxCompactMargin">0,14,0,14</Thickness>
+                                            <Thickness x:Key="AppBarButtonContentViewboxCollapsedMargin">0,14,0,4</Thickness>
+                                            <Thickness x:Key="AppBarButtonOverflowTextTouchMargin">0,11,0,13</Thickness>
+                                            <Thickness x:Key="AppBarButtonOverflowTextLabelPadding">0,5,0,7</Thickness>
+                                            <Thickness x:Key="AppBarButtonTextLabelMargin">2,0,2,8</Thickness>
+                                            <Thickness x:Key="AppBarButtonTextLabelOnRightMargin">8,15,12,17</Thickness>
+                                            <Thickness x:Key="AppBarToggleButtonOverflowTextTouchMargin">0,11,0,13</Thickness>
+                                            <Thickness x:Key="AppBarToggleButtonOverflowCheckTouchMargin">12,12,12,12</Thickness>
+                                            <Thickness x:Key="AppBarToggleButtonOverflowCheckMargin">12,6,12,6</Thickness>
+                                            <Thickness x:Key="AppBarToggleButtonTextLabelMargin">2,0,2,8</Thickness>
+                                            <Thickness x:Key="AppBarToggleButtonTextLabelOnRightMargin">8,15,12,17</Thickness>
+                                            <Thickness x:Key="AppBarToggleButtonOverflowTextLabelPadding">0,5,0,7</Thickness>
+                                            <x:Double x:Key="AppBarButtonContentHeight">20</x:Double>
+                                            <x:Double x:Key="AppBarThemeMinHeight">60</x:Double>
                                             <!-- We probably want to keep this in sync with TitleBarHeight in Resources.xaml -->
                                             <x:Double x:Key="AppBarThemeCompactHeight">48</x:Double>
                                         </uwp:FormsCommandBar.Resources>

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
@@ -36,6 +36,7 @@
 								<Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
 									<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}" HorizontalAlignment="Stretch">
                                         <uwp:FormsCommandBar.Resources>
+                                            <!-- We probably want to keep this in sync with TitleBarHeight in Resources.xaml -->
                                             <x:Double x:Key="AppBarThemeCompactHeight">48</x:Double>
                                         </uwp:FormsCommandBar.Resources>
                                         <uwp:FormsCommandBar.Content>

--- a/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/MasterDetailControlStyle.xaml
@@ -35,7 +35,10 @@
 
 								<Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
 									<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}" HorizontalAlignment="Stretch">
-										<uwp:FormsCommandBar.Content>
+                                        <uwp:FormsCommandBar.Resources>
+                                            <x:Double x:Key="AppBarThemeCompactHeight">48</x:Double>
+                                        </uwp:FormsCommandBar.Resources>
+                                        <uwp:FormsCommandBar.Content>
 											<Border x:Name="TitleArea" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding DetailTitleVisibility}" HorizontalAlignment="Stretch">
 												<Grid x:Name="TitleViewPresenter" VerticalAlignment="Center" Background="{TemplateBinding ToolbarBackground}" HorizontalAlignment="Stretch">
 

--- a/Xamarin.Forms.Platform.UAP/Resources.xaml
+++ b/Xamarin.Forms.Platform.UAP/Resources.xaml
@@ -34,6 +34,7 @@
 	<uwp:KeyboardConverter x:Key="KeyboardConverter" />
 	<uwp:MasterBackgroundConverter x:Key="MasterBackgroundConverter" />
 	<uwp:ImageSourceIconElementConverter x:Key="ImageSourceIconElementConverter" />
+    <!-- We probably want to keep this in sync with AppBarThemeCompactHeight in MasterDetailControlStyle.xaml (in uwp:FormsCommandBar.Resources) -->
 	<x:Double x:Key="TitleBarHeight">48</x:Double>
 
 	<DataTemplate x:Key="PushPinTemplate">


### PR DESCRIPTION
### Description of Change ###

Added correct height for the `CommandBar` to make it use the full height again.

Looks like we've hit this issue on the UWP side: https://github.com/microsoft/microsoft-ui-xaml/issues/275

They decided to just leave it like this, so I implemented the suggested fix from this issue which works.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #5661

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

#### Before
![Aantekening 2019-11-21 145933](https://user-images.githubusercontent.com/939291/69344543-cee15b00-0c6f-11ea-8efc-326b4fce3151.png)


#### After
![Aantekening 2019-11-21 145620](https://user-images.githubusercontent.com/939291/69344191-3f3bac80-0c6f-11ea-9e05-2e177fac37b7.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Add/remove this change and go to the Bugzilla 44453 issue in the Gallery app to verify

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
