### PR TITLE
[iOS] SelectedImageTintColor to TintColor

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -438,9 +438,9 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			if (Tabbed.IsSet(TabbedPage.SelectedTabColorProperty) && Tabbed.SelectedTabColor != Color.Default)
-				TabBar.SelectedImageTintColor = Tabbed.SelectedTabColor.ToUIColor();
+				TabBar.TintColor = Tabbed.SelectedTabColor.ToUIColor();
 			else
-				TabBar.SelectedImageTintColor = null;
+				TabBar.TintColor = null;
 
 			if (!Forms.IsiOS10OrNewer)
 				return;


### PR DESCRIPTION
### Description of Change ###

Changes the use of `SelectedImageTintColor` to `TintColor`.

While looking into another issue I noticed that `SelectedImageTintColor` was deprecated, as indicated [here](https://developer.apple.com/documentation/uikit/uitabbar/1623470-selectedimagetintcolor).

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None. From the documentation it seems that by using this new property the tint color might be inherited from a higher level, while this didn't seem to happen with the old API. However, since Forms doesn't implement it that way, I don't think this is likely to happen.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

From what I could see nothing changes by this, at least visually

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
