### PR TITLE
[UWP] Fix PageControl "Padding" issue

### DIFF
--- a/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/PageControlStyle.xaml
@@ -18,7 +18,7 @@
 						</Grid.RowDefinitions>
 
 						<Border x:Name="TopCommandBarArea" HorizontalAlignment="Stretch" Background="{TemplateBinding ToolbarBackground}">
-							<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" MinHeight="{ThemeResource TitleBarHeight}" HorizontalAlignment="Stretch">
+							<uwp:FormsCommandBar x:Name="CommandBar" Background="{TemplateBinding ToolbarBackground}" HorizontalAlignment="Stretch">
 								<uwp:FormsCommandBar.Content>
 									<Border x:Name="TitleArea" Height="{ThemeResource TitleBarHeight}" Visibility="{TemplateBinding TitleVisibility}" HorizontalAlignment="Stretch">
 										<Grid x:Name="TitleViewPresenter" VerticalAlignment="Center" Background="{TemplateBinding ToolbarBackground}" HorizontalAlignment="Stretch">


### PR DESCRIPTION
### Description of Change ###

This is in addition to #8610. The padding was also there on other pages which used the `PageControlStyle.xaml` although it wasn't visible there.

This change removes the `MinHeight` from the style, which makes it use the default value and the padding then disappears.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- related to #5661

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The `MinHeight` before was 48, now it will change to 40, maybe depending on which UWP SDK you target. I've checked the behavior with vanilla UWP in regard to how buttons and labels etc. are shown and that remains the same.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run the gallery app and navigate to B54977. Without the fix in place, when you press the overflow button (all the way to the right) you will notice in the animation that there is a thin line at the bottom. With this fix, that line is gone.

In addition, bump up the gallery app UWP target and run through both scenarios again. The animation has changed, the effect is the same.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
