### PR TITLE
Fix threadpool call when compiling for 14393

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1704.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1704.cs
@@ -459,7 +459,12 @@ namespace Xamarin.Forms.Controls.Issues
 				_abortStressTest = false;
 
 				int.TryParse(_stressTestItertionEntry.Text, out _stressTestIterationCount);
+
+#if __UWP__
+				Windows.System.Threading.ThreadPool.RunAsync(delegate { runStressTest(); });
+#else
 				ThreadPool.QueueUserWorkItem(delegate { runStressTest(); });
+#endif
 			};
 
 			_stressTestProgressBar = new ProgressBar();

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -19,6 +19,9 @@
     <WarningLevel>4</WarningLevel>
     <NoWarn>0114;0108;0109;4014;0649;0169;0472;0414;0168;0219;0429</NoWarn>
   </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework.StartsWith('uap10.0'))">
+    <DefineConstants>$(DefineConstants);__UWP__</DefineConstants>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="BuildNumber.txt" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

The GIF PR uses an API that isn't on UAP14393 so this just adds an if def to use a different one when compiling for UAP instead of NS

This isn't the 100 percent complete fix but for now it gets UWP back to compiling

Second PR incoming

### Testing Procedure ###
- pull down branch and make sure UWP CG compiles and something that's not UWP CG compiles
- pull down branch and make sure UWP UI tests compile and something that's not UWP UI tests compiles

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
