### PR TITLE
Reverse the order of assigning the Current Items on Shell

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
@@ -39,6 +39,34 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(contentAppearing, "Content Appearing");
 		}
 
+		[Test]
+		public void MisfiringOfAppearingWithMultipleTabs()
+		{
+			Shell shell = new Shell();
+
+			var item0 = CreateShellItem(shellContentRoute: "Outbox", templated: true);
+			var item1 = CreateShellItem(shellSectionRoute: "RequestType1", shellContentRoute: "RequestType1Details", templated: true);
+			var section2 = CreateShellSection(shellSectionRoute: "RequestType2",  shellContentRoute: "RequestType2Dates", templated: true);
+
+			item1.Items.Add(section2);
+			shell.Items.Add(item0);
+			shell.Items.Add(item1);
+
+			int appearingCounter = 0;
+			shell.GoToAsync("//Outbox");
+			shell.GoToAsync("//RequestType1Details");
+			shell.GoToAsync("//Outbox");
+
+
+			item1.Items[0].Appearing += (_, __) =>
+			{
+				appearingCounter++;
+			};
+
+			shell.GoToAsync("//RequestType2Dates");
+			Assert.AreEqual(0, appearingCounter);
+		}
+
 
 		[Test]
 		public void AppearingOnCreateFromTemplate()

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -414,9 +414,13 @@ namespace Xamarin.Forms
 			{
 				ApplyQueryAttributes(shellItem, queryData, navigationRequest.Request.Section == null);
 
-				if (CurrentItem != shellItem)
+				if (shellSection != null && shellContent != null)
 				{
-					SetValueFromRenderer(CurrentItemProperty, shellItem);
+					Shell.ApplyQueryAttributes(shellContent, queryData, navigationRequest.Request.GlobalRoutes.Count == 0);
+					if (shellSection.CurrentItem != shellContent)
+					{
+						shellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
+					}
 				}
 
 				if (shellSection != null)
@@ -426,15 +430,11 @@ namespace Xamarin.Forms
 					{
 						shellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, shellSection);
 					}
+				}
 
-					if (shellContent != null)
-					{
-						Shell.ApplyQueryAttributes(shellContent, queryData, navigationRequest.Request.GlobalRoutes.Count == 0);
-						if (shellSection.CurrentItem != shellContent)
-						{
-							shellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);							
-						}
-					}
+				if (CurrentItem != shellItem)
+				{
+					SetValueFromRenderer(CurrentItemProperty, shellItem);
 				}
 
 				if (navigationRequest.Request.GlobalRoutes.Count > 0)


### PR DESCRIPTION
### Description of Change ###

When navigating to a new Shell Item we were setting the current item from the top down.  This means if the user is navigating to a different shell section on a different shell item then the previously active Shell Section would fire OnAppearing before becoming inactive. 

This change inverts setting current item on each layer of shell. 

### Issues Resolved ### 
- fixes #8624 

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
Instead of current item being set from the ShellItem down it is now set from the ShellContent up which makes more sense

### Testing Procedure ###
- unit test included

