### PR TITLE
[Tizen] Provides Static Registrar

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -245,33 +245,15 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				if (s_staticRegistrarStrategy == StaticRegistrarStrategy.StaticRegistrarOnly)
+				// 1. Find hander in static registrar first
+				TOut ret = StaticRegistrar.Registered.GetHandler<TOut>(type, args);
+
+				// 2. If there is no handler, try to find hander in internal registrar, that is using reflection.
+				if (ret == null && s_staticRegistrarStrategy == StaticRegistrarStrategy.All)
 				{
-					TOut ret = StaticRegistrar.Registered.GetHandler<TOut>(type, args);
-					if (ret == null)
-					{
-						// In case of using static registrar only, the page or layout defined in the app cannot be specified,
-						// so you should allow to use fallback handler.
-						ret = StaticRegistrar.Registered.GetFallbackHandler<TOut>(type, args);
-					}
-					return ret;
+					ret = Registrar.Registered.GetHandler<TOut>(type, args);
 				}
-				else
-				{
-					// 1. Find hander in static registrar first without fallback handler.
-					TOut ret = StaticRegistrar.Registered.GetHandler<TOut>(type, args);
-					if (ret == null)
-					{
-						// 2. Find hander in internal registrar, that is using reflection.
-						ret = Registrar.Registered.GetHandler<TOut>(type, args);
-						if (ret == null)
-						{
-							// 3. Find fallback hander in static registrar.
-							ret = StaticRegistrar.Registered.GetFallbackHandler<TOut>(type, args);
-						}
-					}
-					return ret;
-				}
+				return ret;
 			}
 		}
 
@@ -284,29 +266,15 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				if (s_staticRegistrarStrategy == StaticRegistrarStrategy.StaticRegistrarOnly)
-				{
-					// In case of using static registrar only, the page or layout defined in the app cannot be specified,
-					// so you should allow to use fallback handler.
-					return StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj, true);
-				}
-				else
-				{
-					// 1. Find hander in static registrar first without fallback handler.
-					TOut ret = StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj, false);
+				// 1. Find hander in static registrar first
+				TOut ret = StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj);
 
-					if (ret == null)
-					{
-						// 2. Find hander in internal registrar, that is using reflection.
-						ret = Registrar.Registered.GetHandlerForObject<TOut>(obj);
-						if (ret == null)
-						{
-							// 3. Find fallback hander in static registrar.
-							ret = StaticRegistrar.Registered.GetFallbackHandlerForObject<TOut>(obj);
-						}
-					}
-					return ret;
+				// 2. If there is no handler, try to find hander in internal registrar, that is using reflection.
+				if (ret == null && s_staticRegistrarStrategy == StaticRegistrarStrategy.All)
+				{
+					ret = Registrar.Registered.GetHandlerForObject<TOut>(obj);
 				}
+				return ret;
 			}
 		}
 
@@ -319,28 +287,15 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				if (s_staticRegistrarStrategy == StaticRegistrarStrategy.StaticRegistrarOnly)
+				// 1. Find hander in static registrar first without fallback handler.
+				TOut ret = StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj, args);
+
+				// 2. If there is no handler, try to find hander in internal registrar, that is using reflection.
+				if (ret == null && s_staticRegistrarStrategy == StaticRegistrarStrategy.All)
 				{
-					// In case of using static registrar only, the page or layout defined in the app cannot be specified,
-					// so you should allow to use fallback handler.
-					return StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj, true, args);
+					ret = StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj, args);
 				}
-				else
-				{
-					// 1. Find hander in static registrar first without fallback handler.
-					TOut ret = StaticRegistrar.Registered.GetHandlerForObject<TOut>(obj, false, args);
-					if (ret == null)
-					{
-						// 2. Find hander in internal registrar, that is using reflection.
-						ret = Registrar.Registered.GetHandlerForObject<TOut>(obj, args);
-						if (ret == null)
-						{
-							// 3. Find fallback hander in static registrar.
-							ret = StaticRegistrar.Registered.GetFallbackHandlerForObject<TOut>(obj, args);
-						}
-					}
-					return ret;
-				}
+				return ret;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
+++ b/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
@@ -4,7 +4,6 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.Linq;
 using ElmSharp;
-using Xamarin.Forms.Internals;
 using EGestureType = ElmSharp.GestureLayer.GestureType;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -476,7 +475,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		GestureHandler CreateHandler(IGestureRecognizer recognizer)
 		{
-			return Registrar.Registered.GetHandlerForObject<GestureHandler>(recognizer, recognizer);
+			return Forms.GetHandlerForObject<GestureHandler>(recognizer, recognizer);
 		}
 
 		GestureHandler LookupHandler(IGestureRecognizer recognizer)

--- a/Xamarin.Forms.Platform.Tizen/Native/Image.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Image.cs
@@ -1,6 +1,5 @@
 ﻿using System.Threading.Tasks;
 using ElmSharp;
-using Xamarin.Forms.Internals;
 using EImage = ElmSharp.Image;
 using ESize = ElmSharp.Size;
 
@@ -55,7 +54,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			IImageSourceHandler handler;
 			bool isLoadComplate = false;
-			if (source != null && (handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source)) != null)
+			if (source != null && (handler = Forms.GetHandlerForObject<IImageSourceHandler>(source)) != null)
 			{
 				isLoadComplate = await handler.LoadImageAsync(this, source);
 			}

--- a/Xamarin.Forms.Platform.Tizen/Native/ListView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/ListView.cs
@@ -446,7 +446,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				return cache[type];
 
 			CellRenderer renderer = null;
-			renderer = Registrar.Registered.GetHandler<CellRenderer>(type);
+			renderer = Forms.GetHandler<CellRenderer>(type);
 
 			if (renderer == null)
 			{

--- a/Xamarin.Forms.Platform.Tizen/Platform.cs
+++ b/Xamarin.Forms.Platform.Tizen/Platform.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		internal static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
+			IVisualElementRenderer renderer = Forms.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
 			renderer.SetElement(element);
 			return renderer;
 		}

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -1,0 +1,159 @@
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml.Internals;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class StaticRegistrar<TRegistrable> where TRegistrable : class
+	{
+		readonly Dictionary<Type, Type> _handlers = new Dictionary<Type, Type>();
+
+		public void Register(Type tview, Type trender)
+		{
+			if (trender == null)
+				return;
+
+			_handlers[tview] = trender;
+		}
+
+		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
+		{
+			if (_handlers.TryGetValue(type, out Type handlerType))
+			{
+				object handler = Activator.CreateInstance(handlerType, args);
+				return (TRegistrable)handler as TOut;
+			}
+			Log.Error("No handler could be found for that type :" + type);
+			return null;
+		}
+
+		public TOut GetFallbackHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
+		{
+			if (type.IsSubclassOf(typeof(Page)))
+			{
+				return GetHandler<TOut>(typeof(Page), args);
+			}
+			else if (type.IsSubclassOf(typeof(Layout)))
+			{
+				return GetHandler<TOut>(typeof(Layout), args);
+			}
+			Log.Error("No fallback handler could be found for that type :" + type);
+			return null;
+		}
+
+		public TOut GetHandlerForObject<TOut>(object obj, bool allowFallback = true) where TOut : class, TRegistrable
+		{
+			return GetHandlerForObject<TOut>(obj, allowFallback, null);
+		}
+
+		public TOut GetHandlerForObject<TOut>(object obj, bool allowFallback ,params object[] args) where TOut : class, TRegistrable
+		{
+			var reflectableType = obj as IReflectableType;
+			var type = reflectableType != null ? reflectableType.GetTypeInfo().AsType() : obj.GetType();
+
+			if (_handlers.ContainsKey(type))
+			{
+				return GetHandler<TOut>(type, args);
+			}
+			else if (allowFallback)
+			{
+				return GetFallbackHandlerForObject<TOut>(obj, args);
+			}
+			return null;
+		}
+
+		public TOut GetFallbackHandlerForObject<TOut>(object obj, params object[] args) where TOut : class, TRegistrable
+		{
+			if (obj is Page)
+			{
+				return GetHandler<TOut>(typeof(Page), args);
+			}
+			else if (obj is Layout)
+			{
+				return GetHandler<TOut>(typeof(Layout), args);
+			}
+			Log.Error("No fallback handler could be found for that type :" + obj.GetType());
+			return null;
+		}
+	}
+
+	public static class StaticRegistrar
+	{
+		public static StaticRegistrar<IRegisterable> Registered { get; internal set; }
+
+		static StaticRegistrar()
+		{
+			Registered = new StaticRegistrar<IRegisterable>();
+		}
+
+		public static void RegisterHandlers(Dictionary<Type, Type> customHandlers)
+		{
+			//Renderers
+			Registered.Register(typeof(Layout), typeof(LayoutRenderer));
+			Registered.Register(typeof(ScrollView), typeof(ScrollViewRenderer));
+			Registered.Register(typeof(CarouselPage), typeof(CarouselPageRenderer));
+			Registered.Register(typeof(Page), typeof(PageRenderer));
+			Registered.Register(typeof(NavigationPage), typeof(NavigationPageRenderer));
+			Registered.Register(typeof(MasterDetailPage), typeof(MasterDetailPageRenderer));
+			Registered.Register(typeof(TabbedPage), typeof(TabbedPageRenderer));
+			Registered.Register(typeof(Shell), typeof(ShellRenderer));
+			Registered.Register(typeof(Label), typeof(LabelRenderer));
+			Registered.Register(typeof(Button), typeof(ButtonRenderer));
+			Registered.Register(typeof(Image), typeof(ImageRenderer));
+			Registered.Register(typeof(Slider), typeof(SliderRenderer));
+			Registered.Register(typeof(Picker), typeof(PickerRenderer));
+			Registered.Register(typeof(Frame), typeof(FrameRenderer));
+			Registered.Register(typeof(Stepper), typeof(StepperRenderer));
+			Registered.Register(typeof(DatePicker), typeof(DatePickerRenderer));
+			Registered.Register(typeof(TimePicker), typeof(TimePickerRenderer));
+			Registered.Register(typeof(ProgressBar), typeof(ProgressBarRenderer));
+			Registered.Register(typeof(Switch), typeof(SwitchRenderer));
+			Registered.Register(typeof(CheckBox), typeof(CheckBoxRenderer));
+			Registered.Register(typeof(ListView), typeof(ListViewRenderer));
+			Registered.Register(typeof(BoxView), typeof(BoxViewRenderer));
+			Registered.Register(typeof(ActivityIndicator), typeof(ActivityIndicatorRenderer));
+			Registered.Register(typeof(SearchBar), typeof(SearchBarRenderer));
+			Registered.Register(typeof(Entry), typeof(EntryRenderer));
+			Registered.Register(typeof(Editor), typeof(EditorRenderer));
+			Registered.Register(typeof(TableView), typeof(TableViewRenderer));
+			Registered.Register(typeof(NativeViewWrapper), typeof(NativeViewWrapperRenderer));
+			Registered.Register(typeof(WebView), typeof(WebViewRenderer));
+			Registered.Register(typeof(ImageButton), typeof(ImageButtonRenderer));
+			Registered.Register(typeof(ItemsView), typeof(ItemsViewRenderer));
+
+			//ImageSourceHandlers
+			Registered.Register(typeof(FileImageSource), typeof(FileImageSourceHandler));
+			Registered.Register(typeof(StreamImageSource), typeof(StreamImageSourceHandler));
+			Registered.Register(typeof(UriImageSource), typeof(UriImageSourceHandler));
+
+			//Cell Renderers
+			Registered.Register(typeof(TextCell), typeof(TextCellRenderer));
+			Registered.Register(typeof(ImageCell), typeof(ImageCellRenderer));
+			Registered.Register(typeof(SwitchCell), typeof(SwitchCellRenderer));
+			Registered.Register(typeof(EntryCell), typeof(EntryCellRenderer));
+			Registered.Register(typeof(ViewCell), typeof(ViewCellRenderer));
+
+			//Gesture Handlers
+			Registered.Register(typeof(TapGestureRecognizer), typeof(TapGestureHandler));
+			Registered.Register(typeof(PinchGestureRecognizer), typeof(PinchGestureHandler));
+			Registered.Register(typeof(PanGestureRecognizer), typeof(PanGestureHandler));
+
+			//Dependencies
+			DependencyService.Register<ISystemResourcesProvider, ResourcesProvider>();
+			DependencyService.Register<IDeserializer, Deserializer>();
+			DependencyService.Register<INativeBindingService, NativeBindingService>();
+			DependencyService.Register<INativeValueConverterService, NativeValueConverterService>();
+
+			//Custom Handlers
+			if (customHandlers != null)
+			{
+				foreach (KeyValuePair<Type, Type> handler in customHandlers)
+				{
+					Registered.Register(handler.Key, handler.Value);
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -208,14 +208,19 @@ namespace Xamarin.Forms.Platform.Tizen
 				_assemblies.Add(GetType().GetTypeInfo().Assembly);
 			}
 
+			public void AddAssembly(Assembly assembly)
+			{
+				if (!_assemblies.Contains(assembly))
+				{
+					_assemblies.Add(assembly);
+				}
+			}
+
 			public void AddAssemblies(Assembly[] assemblies)
 			{
 				foreach (var asm in assemblies)
 				{
-					if (!_assemblies.Contains(asm))
-					{
-						_assemblies.Add(asm);
-					}
+					AddAssembly(asm);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###
This PR introduce a static registrar for improving startup performance for Tizen. As we analyzed various Tizen apps, we found that in most cases they used the default handlers defined in the Xamarin.Forms assembly (e.g. `Xamarin.Forms.Platform.Tizen.dll`) and that the cost of registering the default handler through reflection at runtime is quite expensive (about `100~130ms` in Galaxy Watch environment).

The user has three strategies to choose from when initializing:
 - None (Default)
   - Do not use `StaticRegistrar`. If you don't make any settings, nothing will change.
 - StaticRegistrarOnly
   - Use `StaticRegistrar` only. In this case, we use the predefined default handlers statically, without doing any reflection to find the handlers.
 - All
    - Use `StaticRegistrar` and internal registers (`Xamarin.Forms.Internals.Registrar`) using reflection at the same time. The order of finding handlers is to find `StaticRegistrar` first, then legacy registrar.

```cs
var option = new InitializationOptions(app, true);
option.UseStaticRegistrar(StaticRegistrarStrategy.StaticRegistrarOnly);
Form.Init(option)
```

If your app uses external libraries or custom renderers, you can specify a handler like the code below.

```cs
// define your custom handlers
var customRenderers = new Dictionary<Type, Type>()
{
    {typeof(StopWatch), typeof(CirclePageRenderer) },
    {typeof(LapsPage), typeof(CirclePageRenderer) },
    {typeof(CirclePage), typeof(CirclePageRenderer) },
    {typeof(CircleListView), typeof(CircleListViewRenderer) }
 };

option.UseStaticRegistrar(StaticRegistrarStrategy.StaticRegistrarOnly, customRenderers);
Form.Init(option);
```

Below is a test result of [StopWatch](https://github.com/Samsung/Tizen-CSharp-Samples/tree/master/Wearable/XStopWatch) sample app on [Galaxy Watch](https://www.samsung.com/global/galaxy/galaxy-watch/). As you can see, using `StaticRegistrar` has reduced launch time without any functional changes.
<img src="https://user-images.githubusercontent.com/1029134/69522335-7cbc7480-0fa4-11ea-9c31-8f92a376cf1a.png" width=180/>

**- Before**
![static-before](https://user-images.githubusercontent.com/1029134/69522348-80e89200-0fa4-11ea-9192-0ef775966b45.png)

**- After (with StaticRegistrar)**
![static-after](https://user-images.githubusercontent.com/1029134/69522357-85ad4600-0fa4-11ea-9fb6-152fa0752549.png)

### Issues Resolved ### 
None

### API Changes ###
Added:
- TOut Forms.GetHandler<TOut>(Type type, params object[] args)
- TOut Forms.GetHandlerForObject<TOut>(object obj)
- TOut Forms.GetHandlerForObject<TOut>(object obj, parmas object[] args)
- void InitializationOptions.UseStaticRegistrar()

```Xamarin.Forms.Platform.Tizen```
- class StaticRegistrar<TRegistrable>
- class StaticRegistrar

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
