### PR TITLE
[Android] Fix issue automatically closing the SwipeView when scrolling

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -409,7 +409,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool ProcessTouchMove(APointF point)
 		{
-			if (_contentView == null)
+			if (_contentView == null || !TouchInsideContent(point))
 				return false;
 
 			if (!_isSwiping)


### PR DESCRIPTION
### Description of Change ###

The `SwipeView` closes automatically when scrolling. It works correctly as long as the start of the scroll is not performed on a `SwipeItem`, in that case it does not work on **Android**.
This PR applies changes to fix this issue.

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![scroll-close-before](https://user-images.githubusercontent.com/6755973/69553218-1a617500-0fa0-11ea-8701-98b33b4179b6.gif)

#### After
![scroll-close-after](https://user-images.githubusercontent.com/6755973/69553209-1897b180-0fa0-11ea-84e6-079b3e2e87b1.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the SwipeView samples gallery. Select a sample where SwipeView is used with scroll (BindableLayout, ListView, CollectionView, etc). Open a SwipeView and start the scroll clicking on a SwipeItem. If the SwipeView closes when scrolling, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
