### PR TITLE
Fix generating nugets on 4.3 branch

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,4 @@ caketools/
 *.binlog
 .ionide/**
 /.nuspec
+.XamarinFormsVersionFile.txt

--- a/Version.targets
+++ b/Version.targets
@@ -61,6 +61,13 @@
     </ItemGroup>
 
     <Message Condition="$(CI) and '$(BUILD_REASON)' == 'Schedule'" Importance="high" Text="##vso[build.addbuildtag]$(NightlyTag)"/>
+    <ItemGroup>
+       <XamarinFormsVersionFile Include="../.XamarinFormsVersionFile.txt"/>
+       <XamarinFormsVersionLine Include="$(PackageVersion)"/>
+    </ItemGroup>
+    
+    <!-- Occasionally this throws an error from parallel builds writing to this file. It's fine if only one of them wins. -->
+    <WriteLinesToFile ContinueOnError="WarnAndContinue" File="@(XamarinFormsVersionFile)" Lines="@(XamarinFormsVersionLine)" Overwrite="true" />
     <Message Condition="$(CI)" Importance="high" Text="##vso[build.updatebuildnumber]$(PackageVersion)"/>
     <Message Condition="$(CI)" Importance="high" Text="##vso[task.setvariable variable=XamarinFormsPackageVersion;isOutput=true;]$(PackageVersion)"/>
   </Target>


### PR DESCRIPTION
### Description of Change ###
build.cake was synced with master on 4.3 meaning Version.targets needs to be synced as well so that nugets can be generated locally

This also adds *XamarinFormsVersionFile* to gitignore which is useful when switching branches
### Testing Procedure ###
- generate nugets locally

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
