### PR TITLE
[AND] Fix NRE in OnBackPressed

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -373,8 +373,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (NavAnimationInProgress)
 				return true;
 
-			Page root = _navModel.Roots.Last();
-			bool handled = root.SendBackButtonPressed();
+			Page root = _navModel.Roots.LastOrDefault();
+			bool handled = root?.SendBackButtonPressed() ?? false;
 
 			return handled;
 		}

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -812,8 +812,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (NavAnimationInProgress)
 				return true;
 
-			Page root = _navModel.Roots.Last();
-			bool handled = root.SendBackButtonPressed();
+			Page root = _navModel.Roots.LastOrDefault();
+			bool handled = root?.SendBackButtonPressed() ?? false;
 
 			return handled;
 		}


### PR DESCRIPTION
### Description of Change ###

Added some defensive code to prevent an NRE.

Targets 4.3 since it is a regression since 3.4 apparently.

#### Background
This fix has been proposed a couple of times before but was never implemented. For instance because of what @hartez mentions here: https://github.com/xamarin/Xamarin.Forms/issues/4715#issuecomment-449056787

> There's no check there because a nav model with no elements in it shouldn't be handling a back button press in the first place. So somehow we're getting into an invalid navigation state. You mention that you do some navigation when the app goes to sleep - do you handle Resume at all?

While I do agree, on the other hand I also see no harm in adding it this way to prevent the NRE. But I'm basically opening this PR to get some discussion going around this.

Since no one is able to produce a reproduction, it is kind of hard to make progress on this.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6700

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

N/A

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
