### PR TITLE
Prevent UWP NullReferenceException when calling SavePropertiesAsync method off the main thread

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8682.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8682.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1Test() 
+		public void SavePropertiesAsyncOffMainThreadDoesNotCrash() 
 		{
 			RunningApp.WaitForElement(Run);
 			RunningApp.Tap(Run);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8682.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8682.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8682, "[Bug] [UWP] NullReferenceException when call SavePropertiesAsync method off the main thread", PlatformAffected.UWP)]
+	public class Issue8682 : TestContentPage
+	{
+		const string Run = "Save properties";
+		const string Success = "Success";
+
+		Label _result;
+
+		protected override void Init()
+		{
+			var instructions = new Label
+			{
+				Text = $"Tap the button marked {Run}. If the Label below reads {Success} then the test has passed."
+			};
+
+			_result = new Label();
+
+			var testButton = new Button
+			{
+				Text = Run
+			};
+			testButton.Clicked += OnTestButtonClicked;
+
+			var layout = new StackLayout();
+			layout.Children.Add(instructions);
+			layout.Children.Add(_result);
+			layout.Children.Add(testButton);
+
+			Content = layout;
+		}
+
+		async void OnTestButtonClicked(object sender, EventArgs e)
+		{
+			_result.Text = await SavePropertiesAsyncOffMainThread();
+		}
+
+		async Task<string> SavePropertiesAsyncOffMainThread()
+		{
+			return await Task.Run(async () => 
+			{
+				try
+				{
+					await Application.Current.SavePropertiesAsync();
+
+					return Success;
+				} 
+				catch (Exception e)
+				{
+					return $"Test failed: {e.Message}.";
+				}
+			});
+		}
+
+#if UITEST
+		[Test]
+		public void Issue1Test() 
+		{
+			RunningApp.WaitForElement(Run);
+			RunningApp.Tap(Run);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -131,6 +131,7 @@
       <DependentUpon>Github5623.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8682.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Bugzilla59172.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FlagTestHelpers.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue5886.cs" />

--- a/Xamarin.Forms.Core/DispatcherExtensions.cs
+++ b/Xamarin.Forms.Core/DispatcherExtensions.cs
@@ -26,7 +26,14 @@ namespace Xamarin.Forms
 			}
 
 			// Use the DispatcherProvider to retrieve an appropriate dispatcher for this BindableObject
-			return s_current.GetDispatcher(bindableObject);
+			IDispatcher dispatcher = s_current.GetDispatcher(bindableObject);
+
+			if (dispatcher == null)
+			{
+				dispatcher = new FallbackDispatcher();
+			}
+
+			return dispatcher;
 		}
 
 		public static void Dispatch(this IDispatcher dispatcher, Action action)

--- a/Xamarin.Forms.Core/DispatcherExtensions.cs
+++ b/Xamarin.Forms.Core/DispatcherExtensions.cs
@@ -26,14 +26,7 @@ namespace Xamarin.Forms
 			}
 
 			// Use the DispatcherProvider to retrieve an appropriate dispatcher for this BindableObject
-			IDispatcher dispatcher = s_current.GetDispatcher(bindableObject);
-
-			if (dispatcher == null)
-			{
-				dispatcher = new FallbackDispatcher();
-			}
-
-			return dispatcher;
+			return s_current.GetDispatcher(bindableObject) ?? new FallbackDispatcher();
 		}
 
 		public static void Dispatch(this IDispatcher dispatcher, Action action)


### PR DESCRIPTION
### Description of Change ###

When DispatcherProvider returns null, because context parameter does not inherit from VisualElement, then new instance of FallbackDispatcher is used.

### Issues Resolved ### 

- fixes #8682 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

Issue is fixed in Xamarin.Forms.Core project, but other platforms are not affected, because for other platforms IDispatcherProvider is not implemented and thus method DispatcherExtensions.GetDispatcher already returns FallbackDispatcher instance on line 25.

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Automated test added; for UWP, manually run the test for Issue 8682.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
