### PR TITLE
[Android] Fix some views dispose

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -143,10 +143,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 					_visualElementRenderer = null;
 				}
 
-				int count = ChildCount;
-				for (var i = 0; i < count; i++)
+				while (ChildCount > 0)
 				{
-					AView child = GetChildAt(i);
+					AView child = GetChildAt(0);
+					child.RemoveFromParent();
 					child.Dispose();
 				}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -1,8 +1,6 @@
-using System;
-using System.ComponentModel;
 using Android.Content;
-using Android.OS;
 using Android.Views;
+using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -10,7 +8,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		readonly ScrollView _parent;
 		View _childView;
-		bool _isDisposed = false;
+		bool _isDisposed;
 
 		public ScrollViewContainer(ScrollView parent, Context context) : base(context)
 		{
@@ -48,15 +46,18 @@ namespace Xamarin.Forms.Platform.Android
 			if (_isDisposed)
 				return;
 
+			_isDisposed = true;
+			
 			if (disposing)
 			{
-				if (ChildCount > 0)
-					GetChildAt(0).Dispose();
-				RemoveAllViews();
-				_childView = null;
+				while (ChildCount > 0)
+				{
+					AView child = GetChildAt(0);
+					child.RemoveFromParent();
+					child.Dispose();
+				}
 			}
 
-			_isDisposed = true;
 			base.Dispose(disposing);
 		}
 

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -305,10 +305,10 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (ManageNativeControlLifetime)
 				{
-					int count = ChildCount;
-					for (var i = 0; i < count; i++)
+					while (ChildCount > 0)
 					{
-						AView child = GetChildAt(i);
+						AView child = GetChildAt(0);
+						child.RemoveFromParent();
 						child.Dispose();
 					}
 				}


### PR DESCRIPTION
### Description of Change ###
When trying to debug some problem relative to dispose on Android I found some issues with some code responsible of the disposal of views.

Some code only dispose the view but not remove them from their parent.
This can cause the disposed renderer to be accessed during layout and cause "NotSupportedException: Unable to activate instance of type ...", so I added the missing RemoveFromParent call.

I also fixed an issue in the ScrollViewContainer, only the first renderer was disposed.

### Issues Resolved ### 
Fix random issues related to dispose.

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Not specific test applicable, all tests must pass

### PR Checklist ###
- [X] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)