### PR TITLE
[Android] MasterDetailPageRenderer - Add guard and add missing unsubscribe

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -117,10 +117,25 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (oldElement != null)
 			{
+				Device.Info.PropertyChanged -= DeviceInfoPropertyChanged;
+
 				((IMasterDetailPageController)oldElement).BackButtonPressed -= OnBackButtonPressed;
+
 				oldElement.PropertyChanged -= HandlePropertyChanged;
 				oldElement.Appearing -= MasterDetailPageAppearing;
 				oldElement.Disappearing -= MasterDetailPageDisappearing;
+
+				RemoveDrawerListener(this);
+			
+				if (_detailLayout != null)
+				{
+					RemoveView(_detailLayout);
+				}
+
+				if (_masterLayout != null)
+				{
+					RemoveView(_masterLayout);
+				}
 			}
 
 			if (newElement != null)
@@ -167,9 +182,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				SetGestureState();
 
 				Presented = newElement.IsPresented;
-
-				if (element != null && !string.IsNullOrEmpty(element.AutomationId))
-					SetAutomationId(element.AutomationId);
 
 				newElement.SendViewInitialized(this);
 			}
@@ -294,10 +306,18 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					MasterDetailPageController.CanChangeIsPresented = true;
 					//hack : when the orientation changes and we try to close the Master on Android		
 					//sometimes Android picks the width of the screen previous to the rotation 		
-					//this leaves a little of the master visible, the hack is to delay for 50ms closing the drawer
+					//this leaves a little of the master visible, the hack is to delay for 100ms closing the drawer
 					await Task.Delay(100);
+
+					//Renderer may have been disposed during the delay
+					if (_disposed)
+					{
+						return;
+					}
+
 					CloseDrawer(_masterLayout);
 				}
+
 				UpdateSplitViewLayout();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###
I added some missing code in the SetElement method when element change.
I never seen this case happen, but this must not prevent the code to be correct.

I also removed SetAutomationId duplicated call.

Finally, I added a dispose check after the delay in the DeviceInfoPropertyChanged method.
This issue happened once in one of my application.

### Issues Resolved ### 
Fix random issues related to dispose.

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Not specific test applicable, all tests must pass

### PR Checklist ###
- [X] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)