### PR TITLE
Allow multiple selection updates with one notification in CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8203.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8203.cs
@@ -1,0 +1,77 @@
+﻿using System.Collections;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8203, 
+	"CollectionView fires SelectionChanged x (number of items selected +1) times, while incrementing SelectedItems from 0 " +
+	"to number of items each time", 
+	PlatformAffected.UWP)]
+
+	public class Issue8203 : TestContentPage
+	{
+		int _raisedCount;
+		Label _eventRaisedCount;
+
+		protected override void Init()
+		{
+			var instructions = new Label { Text = "Select an item below. Then select another one. The SelectionChanged " +
+				"event should have been raised twice. If not, this test has failed." };
+
+			_eventRaisedCount = new Label();
+
+			var layout = new StackLayout();
+			var cv = new CollectionView();
+
+			var source = new List<string> { "one", "two", "three" };
+
+			cv.ItemsSource = source;
+			cv.SelectionMode = SelectionMode.Multiple;
+
+			cv.SelectionChanged += SelectionChangedHandler;
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(_eventRaisedCount);
+			layout.Children.Add(cv);
+
+			Content = layout;
+		}
+
+		void UpdateRaisedCount() 
+		{
+			_eventRaisedCount.Text = $"SelectionChanged has been raised {_raisedCount} times.";
+		}
+
+		void SelectionChangedHandler(object sender, SelectionChangedEventArgs e)
+		{
+			_raisedCount += 1;
+			UpdateRaisedCount();
+		}
+
+#if UITEST
+		[Test]
+		public void SelectionChangedShouldBeRaisedOnceWhenSelectionChanges()
+		{
+			RunningApp.WaitForElement("one");
+			RunningApp.Tap("one");
+			RunningApp.Tap("two");
+			RunningApp.WaitForElement("SelectionChanged has been raised 2 times.");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -129,6 +129,7 @@
       <DependentUpon>Issue7803.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8087.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8203.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8222.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8167.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8366.cs" />

--- a/Xamarin.Forms.Core/Items/SelectableItemsView.cs
+++ b/Xamarin.Forms.Core/Items/SelectableItemsView.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Forms
 
 		static readonly IList<object> s_empty = new List<object>(0);
 
+		bool _suppressSelectionChangeNotification;
+
 		public SelectableItemsView()
 		{
 		}
@@ -67,6 +69,27 @@ namespace Xamarin.Forms
 
 		public event EventHandler<SelectionChangedEventArgs> SelectionChanged;
 
+		public void UpdateSelectedItems(IList<object> newSelection) 
+		{
+			var oldSelection = new List<object>(SelectedItems);
+			
+			_suppressSelectionChangeNotification = true;
+			
+			SelectedItems.Clear();
+
+			if (newSelection?.Count > 0)
+			{
+				for (int n = 0; n < newSelection.Count; n++)
+				{
+					SelectedItems.Add(newSelection[n]);
+				}
+			}
+
+			_suppressSelectionChangeNotification = false;
+
+			SelectedItemsPropertyChanged(oldSelection, newSelection);
+		}
+
 		protected virtual void OnSelectionChanged(SelectionChangedEventArgs args)
 		{
 		}
@@ -102,6 +125,11 @@ namespace Xamarin.Forms
 
 		internal void SelectedItemsPropertyChanged(IList<object> oldSelection, IList<object> newSelection)
 		{
+			if (_suppressSelectionChangeNotification)
+			{
+				return;
+			}
+
 			SelectionPropertyChanged(this, new SelectionChangedEventArgs(oldSelection, newSelection));
 			
 			OnPropertyChanged(SelectedItemsProperty.PropertyName);
@@ -120,9 +148,8 @@ namespace Xamarin.Forms
 					command.Execute(commandParameter);
 				}
 			}
-			
-			selectableItemsView.SelectionChanged?.Invoke(selectableItemsView, args);
 
+			selectableItemsView.SelectionChanged?.Invoke(selectableItemsView, args);
 			selectableItemsView.OnSelectionChanged(args);
 		}
 
@@ -185,7 +212,6 @@ namespace Xamarin.Forms
 			}
 
 			var args = new SelectionChangedEventArgs(previousSelection, newSelection);
-
 			SelectionPropertyChanged(selectableItemsView, args);
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

CollectionView in multi-select mode does not have a mechanism for atomically updating multiple selected items at once with a single change notification. This isn't an issue for platforms where only one item can be added/removed from the selection at a time, but UWP allows multiple selection (e.g., while holding Shift). We need to support that (and possible future multiple-simultaneous-select methods on other platforms). Because of that mechanism, the UWP selection was also firing many extra `SelectionChanged` events for each update of the selected items.

This change adds a method to SelectableItemsView which allows for a list of selected items to be passed in as one atomic update to SelectedItems (while preserving binding to the underlying list).

### Issues Resolved ### 

- fixes #8203

### API Changes ###

Added:

`SelectableItemsView.UpdateSelectedItems(IList<object> newSelection);`

### Platforms Affected ### 

- Core/XAML (all platforms)
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
For UWP, run Issue 8203 in Control Gallery. The test is automated for the other platforms.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
