### PR TITLE
[Android] Fix various memory leaks

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -253,6 +253,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				if (_drawerToggle != null)
 				{
+					_drawerToggle.ToolbarNavigationClickListener = null;
 					_drawerToggle.Dispose();
 					_drawerToggle = null;
 				}
@@ -661,9 +662,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			FastRenderers.AutomationPropertiesProvider.GetDrawerAccessibilityResources(context, _masterDetailPage, out int resourceIdOpen, out int resourceIdClose);
 
+			if (_drawerToggle != null)
+			{
+				_drawerToggle.ToolbarNavigationClickListener = null;
+				_drawerToggle.Dispose();
+			}
+
 			_drawerToggle = new ActionBarDrawerToggle(context.GetActivity(), _drawerLayout, bar,
-													  resourceIdOpen == 0 ? global::Android.Resource.String.Ok : resourceIdOpen,
-													  resourceIdClose == 0 ? global::Android.Resource.String.Ok : resourceIdClose)
+				resourceIdOpen == 0 ? global::Android.Resource.String.Ok : resourceIdOpen,
+				resourceIdClose == 0 ? global::Android.Resource.String.Ok : resourceIdClose)
 			{
 				ToolbarNavigationClickListener = new ClickListener(Element)
 			};
@@ -671,13 +678,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_drawerListener != null)
 			{
 				_drawerLayout.RemoveDrawerListener(_drawerListener);
+				_drawerListener.Dispose();
 			}
 
 			_drawerListener = new DrawerMultiplexedListener { Listeners = { _drawerToggle, renderer } };
 			_drawerLayout.AddDrawerListener(_drawerListener);
 		}
-
-
 
 		Fragment GetPageFragment(Page page)
 		{

--- a/Xamarin.Forms.Platform.Android/BackgroundManager.cs
+++ b/Xamarin.Forms.Platform.Android/BackgroundManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using AView = Android.Views.View;
@@ -21,6 +21,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			renderer.ElementPropertyChanged -= OnElementPropertyChanged;
 			renderer.ElementChanged -= OnElementChanged;
+
+			if (renderer.Element != null)
+			{
+				renderer.Element.PropertyChanged -= OnElementPropertyChanged;
+			}
 		}
 
 		static void UpdateBackgroundColor(AView Control, VisualElement Element, Color? color = null)

--- a/Xamarin.Forms.Platform.Android/BorderBackgroundManager.cs
+++ b/Xamarin.Forms.Platform.Android/BorderBackgroundManager.cs
@@ -1,12 +1,9 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Android.Content.Res;
 using AView = Android.Views.View;
 using Android.Graphics.Drawables;
-using Android.OS;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using Specifics = Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
-using AButton = Android.Widget.Button;
 using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android
@@ -19,7 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _drawableEnabled;
 		bool _disposed;
 		IBorderVisualElementRenderer _renderer;
-		private IBorderElement _borderElement;
+		IBorderElement _borderElement;
 
 		VisualElement Element => _renderer?.Element;
 		AView Control => _renderer?.View;

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Graphics;
@@ -7,8 +7,6 @@ using Android.Support.V4.View;
 using Android.Support.V4.Widget;
 using Android.Support.V7.Widget;
 using Xamarin.Forms.Internals;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
-using Specifics = Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
@@ -72,6 +70,11 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					if (_renderer != null)
 					{
+						if (_renderer.Element != null)
+						{
+							_renderer.Element.PropertyChanged -= OnElementPropertyChanged;
+						}
+
 						_renderer.ElementChanged -= OnElementChanged;
 						_renderer = null;
 					}

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -70,9 +70,9 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					if (_renderer != null)
 					{
-						if (_renderer.Element != null)
+						if (_element != null)
 						{
-							_renderer.Element.PropertyChanged -= OnElementPropertyChanged;
+							_element.PropertyChanged -= OnElementPropertyChanged;
 						}
 
 						_renderer.ElementChanged -= OnElementChanged;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -105,24 +105,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			Performance.Start(out string reference);
 
-			if (oldElement != null)
-			{
-				oldElement.PropertyChanged -= OnElementPropertyChanged;
-			}
-
-
-			element.PropertyChanged += OnElementPropertyChanged;
-
-			if (_tracker == null)
-			{
-				// Can't set up the tracker in the constructor because it access the Element (for now)
-				SetTracker(new VisualElementTracker(this));
-			}
-			if (_visualElementRenderer == null)
-			{
-				_visualElementRenderer = new VisualElementRenderer(this);
-			}
-
 			OnElementChanged(new ElementChangedEventArgs<Button>(oldElement as Button, Button));
 
 			SendVisualElementInitialized(element, this);
@@ -205,9 +187,24 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		protected virtual void OnElementChanged(ElementChangedEventArgs<Button> e)
 		{
+			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
+		
+			if (e.OldElement != null)
+			{
+				e.OldElement.PropertyChanged -= OnElementPropertyChanged;
+			}
+
 			if (e.NewElement != null && !_isDisposed)
 			{
 				this.EnsureId();
+
+				if (_tracker == null)
+				{
+					// Can't set up the tracker in the constructor because it access the Element (for now)
+					SetTracker(new VisualElementTracker(this));
+				}
+
+				e.NewElement.PropertyChanged += OnElementPropertyChanged;
 
 				_textColorSwitcher = new Lazy<TextColorSwitcher>(
 					() => new TextColorSwitcher(TextColors, e.NewElement.UseLegacyColorManagement()));
@@ -221,8 +218,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 				ElevationHelper.SetElevation(this, e.NewElement);
 			}
-
-			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
 		}
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -277,6 +272,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 			_buttonLayoutManager = new ButtonLayoutManager(this);
 			_backgroundTracker = new BorderBackgroundManager(this);
+			_visualElementRenderer = new VisualElementRenderer(this);
 
 			SoundEffectsEnabled = false;
 			SetOnClickListener(this);

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1194,7 +1194,9 @@ namespace Xamarin.Forms.Platform.Android
 		internal class DefaultRenderer : VisualElementRenderer<View>, ILayoutChanges
 		{
 			public bool NotReallyHandled { get; private set; }
+			
 			IOnTouchListener _touchListener;
+			bool _disposed;
 
 			[Obsolete("This constructor is obsolete as of version 2.5. Please use DefaultRenderer(Context) instead.")]
 			[EditorBrowsable(EditorBrowsableState.Never)]
@@ -1282,6 +1284,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			protected override void Dispose(bool disposing)
 			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+
 				if (disposing)
 					SetOnTouchListener(null); 
 

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1283,7 +1283,7 @@ namespace Xamarin.Forms.Platform.Android
 			protected override void Dispose(bool disposing)
 			{
 				if (disposing)
-					_touchListener = null;
+					SetOnTouchListener(null); 
 
 				base.Dispose(disposing);
 			}

--- a/Xamarin.Forms.Platform.Android/RendererPool.cs
+++ b/Xamarin.Forms.Platform.Android/RendererPool.cs
@@ -55,10 +55,15 @@ namespace Xamarin.Forms.Platform.Android
 			foreach (Element logicalChild in ((IElementController)view).LogicalChildren)
 			{
 				var child = logicalChild as VisualElement;
+				
 				if (child != null)
 				{
 					IVisualElementRenderer renderer = Platform.GetRenderer(child);
+			
 					if (renderer == null)
+						continue;
+
+					if (renderer.View.IsDisposed())
 						continue;
 
 					if (renderer.View.Parent != _parent.View)
@@ -67,6 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 					renderer.View.RemoveFromParent();
 
 					Platform.SetRenderer(child, null);
+					
 					PushRenderer(renderer);
 				}
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageContainer.cs
@@ -7,12 +7,14 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal class PageContainer : ViewGroup
 	{
+		bool _disposed;
+
 		public PageContainer(Context context, IVisualElementRenderer child, bool inFragment = false) : base(context)
 		{
-			AddView(child.View);
+			Id = Platform.GenerateViewId();
 			Child = child;
 			IsInFragment = inFragment;
-			Id = Platform.GenerateViewId();
+			AddView(child.View);
 		}
 
 		public IVisualElementRenderer Child { get; set; }
@@ -32,6 +34,28 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Child.View.Measure(widthMeasureSpec, heightMeasureSpec);
 			SetMeasuredDimension(Child.View.MeasuredWidth, Child.View.MeasuredHeight);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				if (Child != null)
+				{
+					RemoveView(Child.View);
+
+					Child = null;
+				}
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -306,10 +306,12 @@ namespace Xamarin.Forms.Platform.Android
 					else
 						sameChildrenTypes = false;
 				}
-
-				for (var i = 0; i < oldChildren.Count; i++)
+				else
 				{
-					RemoveChild((VisualElement)oldChildren[i]);
+					for (var i = 0; i < oldChildren.Count; i++)
+					{
+						RemoveChild((VisualElement)oldChildren[i]);
+					}
 				}
 
 				if (!sameChildrenTypes)

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using Android.Content;
 using Xamarin.Forms.Internals;
 using Android.Views;
 using AView = Android.Views.View;
@@ -38,7 +37,7 @@ namespace Xamarin.Forms.Platform.Android
 			_renderer = renderer;
 			_renderer.ElementChanged += OnElementChanged;
 
-			if(renderer.View is ILayoutChanges layout)
+			if (renderer.View is ILayoutChanges layout)
 				layout.LayoutChange += OnInitialLayoutChange;
 		}
 
@@ -73,7 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_renderer != null)
 			{
 				_renderer.ElementChanged -= OnElementChanged;
-				
+
 				if (_renderer.Element != null)
 				{
 					_renderer.Element.ChildAdded -= _childAddedHandler;
@@ -83,6 +82,8 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_renderer.View is ILayoutChanges layout)
 					layout.LayoutChange -= OnInitialLayoutChange;
+
+				SetElement(_element, null);
 
 				if (_childViews != null)
 				{
@@ -101,8 +102,6 @@ namespace Xamarin.Forms.Platform.Android
 
 				_renderer = null;
 			}
-
-			_element = null;
 		}
 
 		public void Load()
@@ -184,12 +183,12 @@ namespace Xamarin.Forms.Platform.Android
 							{
 								if (elevation > elevationToSet)
 									elevationToSet = elevation;
-																
+
 								r.View.Elevation = elevationToSet;
 							}
 						}
 
-						if(!onlyUpdateElevations)
+						if (!onlyUpdateElevations)
 							(_renderer.View as ViewGroup)?.BringChildToFront(r.View);
 					}
 				}
@@ -206,10 +205,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (itemCount <= 1)
 				return;
 
-
 			Element lastChild = ElementController.LogicalChildren[itemCount - 1];
 
-			if(lastChild != view)
+			if (lastChild != view)
 			{
 				EnsureChildOrder();
 				return;
@@ -253,7 +251,7 @@ namespace Xamarin.Forms.Platform.Android
 			IVisualElementRenderer renderer = Platform.GetRenderer(view);
 			if (renderer == null) // child is itself a compressed layout
 			{
-				if (_childPackagers != null && _childPackagers.TryGetValue (view, out VisualElementPackager packager))
+				if (_childPackagers != null && _childPackagers.TryGetValue(view, out VisualElementPackager packager))
 				{
 					foreach (var child in view.LogicalChildren)
 					{
@@ -279,14 +277,21 @@ namespace Xamarin.Forms.Platform.Android
 			ReadOnlyCollection<Element> newChildren = null, oldChildren = null;
 
 			RendererPool pool = null;
+			
 			if (oldElement != null)
 			{
+				oldElement.ChildAdded -= _childAddedHandler;
+				oldElement.ChildRemoved -= _childRemovedHandler;
+				oldElement.ChildrenReordered -= _childReorderedHandler;
+
+				oldChildren = ((IElementController)oldElement).LogicalChildren;
+
 				if (newElement != null)
 				{
 					sameChildrenTypes = true;
 
-					oldChildren = ((IElementController)oldElement).LogicalChildren;
 					newChildren = ((IElementController)newElement).LogicalChildren;
+					
 					if (oldChildren.Count == newChildren.Count)
 					{
 						for (var i = 0; i < oldChildren.Count; i++)
@@ -302,10 +307,10 @@ namespace Xamarin.Forms.Platform.Android
 						sameChildrenTypes = false;
 				}
 
-				oldElement.ChildAdded -= _childAddedHandler;
-				oldElement.ChildRemoved -= _childRemovedHandler;
-
-				oldElement.ChildrenReordered -= _childReorderedHandler;
+				for (var i = 0; i < oldChildren.Count; i++)
+				{
+					RemoveChild((VisualElement)oldChildren[i]);
+				}
 
 				if (!sameChildrenTypes)
 				{
@@ -318,6 +323,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (newElement != null)
 			{
 				Performance.Start(reference, "Setup");
+
 				newElement.ChildAdded += _childAddedHandler;
 				newElement.ChildRemoved += _childRemovedHandler;
 
@@ -346,4 +352,3 @@ namespace Xamarin.Forms.Platform.Android
 		}
 	}
 }
-

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Android.Content;
-using Android.Graphics;
-using Android.OS;
 using Android.Views;
 using AView = Android.Views.View;
 using Object = Java.Lang.Object;
@@ -27,13 +25,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		public VisualElementTracker(IVisualElementRenderer renderer)
 		{
-			if (renderer == null)
-				throw new ArgumentNullException("renderer");
-
 			_batchCommittedHandler = HandleRedrawNeeded;
 			_propertyChangedHandler = HandlePropertyChanged;
 
-			_renderer = renderer;
+			_renderer = renderer ?? throw new ArgumentNullException(nameof(renderer));
 			_context = renderer.View.Context;
 			_renderer.ElementChanged += RendererOnElementChanged;
 


### PR DESCRIPTION
### Description of Change ###
I have some time to fix an issue, and because I now know relatively well the issues relative to dispose, I choose the issue #3332.
Following my investigations I found several causes of memory leak.
With all these fixes, I'm no longer see any memory leak with the reproduction code provided in the referenced issue.

Below, the list of the differents issues :
- NavigationPageRenderer : Fix a potential memory leak caused by the toolbar which was not correctly disposed.
- BackgroundManager : The element PropertyChanged event is never unsubscribed and cause a leak. (_leak confirmed with the profiler_)
- ButtonLayoutManager : The element PropertyChanged event is never unsubscribed and cause a leak. (_leak confirmed with the profiler_)
- ButtonRenderer (FastRenderer) : The SetTracker call in the SetElement method trigger the OnElementPropertyChanged handler twice which cause a leak in the VisualElementTracker class.
So I refactored the code based on the code of the LabelRenderer that does not present this issue.
(_leak confirmed with the profiler_)
- DefaultRenderer : Correctly remove the TouchListener on dispose. (Not sure if this one can cause a leak, but for correctness I kept it)
- DefaultRenderer : Ensure that the renderer is not disposed twice (_It cause issue with the TouchListener_)
- PageContainer : When the container is disposed, the child view is not detached which cause a leak.(_leak confirmed with the profiler_)
- VisualElementPackager : Call SetElement to ensure that the events are unsubscribed. (_leak confirmed with the profiler_)
- VisualElementPackager : Move the unsubscribe earlier to prevent race condition.
- VisualElementPackager : Add missing RemoveChild call, the views was never removed. (_leak confirmed with the profiler_)

I will make a pass to check the others GitHub issues relative to memory leaks on Android.
Perhaps several of them are fixed by this Pull Request.

### Issues Resolved ### 
- fixes #3332
- fixes #3742

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
No specific test applicable, all tests must pass

### PR Checklist ###
- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
