### PR TITLE
[Android] Optimize RecalculateSpanPositions method

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using Android.Text;
 using Android.Widget;
 using System.Collections.Generic;
@@ -74,21 +74,19 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static void RecalculateSpanPositions(this TextView textView, Label element, SpannableString spannableString, SizeRequest finalSize)
 		{
-			var layout = textView.Layout;
-			if (layout == null)
-				return;
-
 			if (element?.FormattedText?.Spans == null || element.FormattedText.Spans.Count == 0)
-				return;
-
-			if (spannableString == null || spannableString.IsDisposed())
 				return;
 
 			var labelWidth = finalSize.Request.Width;
 			if (labelWidth <= 0 || finalSize.Request.Height <= 0)
 				return;
 
-			var text = spannableString.ToString();
+			if (spannableString == null || spannableString.IsDisposed())
+				return;
+
+			var layout = textView.Layout;
+			if (layout == null)
+				return;
 
 			int next = 0;
 			int count = 0;


### PR DESCRIPTION
### Description of Change ###
When using the profiler, I noticed that the RecalculateSpanPositions method caused a lot of string  allocations when accessing to the TextView layout.
In reordering the conditions, this method can be a lot of faster, because in most cases now, this condition will never be evaluated.
So less memory allocation, less GC and more performance.
I also removed the unused ToString call.

### Issues Resolved ### 
None

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
None

### PR Checklist ###
- [X] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
