### PR TITLE
[iOS] CollectionView crashes on iOS 12 for repeated adds

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8672.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8672.cs
@@ -1,0 +1,84 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8672, "CollectionView crashes on iOS 12.4 for repeated adds", PlatformAffected.iOS)]
+	public class Issue8672 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var layout = new Grid();
+
+			var collectionView = new CollectionView
+			{
+				ItemTemplate = CreateDataTemplate()
+			};
+
+			collectionView.SetBinding(ItemsView.ItemsSourceProperty, "Collection");
+
+			layout.Children.Add(collectionView);
+
+			Content = layout;
+			BindingContext = new Issue8672ViewModel();
+		}
+
+		DataTemplate CreateDataTemplate()
+		{
+			var template = new DataTemplate(() =>
+			{
+				var layout = new StackLayout();
+
+				var id = new Label();
+				id.SetBinding(Label.TextProperty, "Id");
+				layout.Children.Add(id);
+				
+				var name = new Label();
+				name.SetBinding(Label.TextProperty, "Name");
+				layout.Children.Add(name);
+
+				return layout;
+			});
+
+			return template;
+		}
+	}
+
+	public class Issue8672Model
+	{
+		public string Id { get; set; }
+
+		public string Name { get; set; }
+	}
+
+	public class Issue8672ViewModel
+	{
+		public Issue8672ViewModel()
+		{
+			Task.Run(() =>
+			{
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					for (int i = 0; i < 10; i++)
+					{
+						Collection.Add(new Issue8672Model() { Id = i.ToString(), Name = $"Item {i}" });
+					}
+				});
+			});
+		}
+
+		public ObservableCollection<Issue8672Model> Collection { get; } = new ObservableCollection<Issue8672Model>();
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8672.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8672.cs
@@ -20,7 +20,14 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			var layout = new Grid();
+			var layout = new StackLayout();
+
+			var indications = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If the CollectionView below loads items, the test has passed."
+			};
 
 			var collectionView = new CollectionView
 			{
@@ -29,6 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			collectionView.SetBinding(ItemsView.ItemsSourceProperty, "Collection");
 
+			layout.Children.Add(indications);
 			layout.Children.Add(collectionView);
 
 			Content = layout;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1145,6 +1145,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue7898.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7510.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8672.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">


### PR DESCRIPTION
### Description of Change ###

This issue is fixed in https://github.com/xamarin/Xamarin.Forms/pull/7711 already merged. However, I wanted to validate that it was the same. Indeed it is the same so this PR only contains the repro sample. If it is not considered necessary, this PR can be closed.

![issue8672-fixed](https://user-images.githubusercontent.com/6755973/70229742-10393680-1757-11ea-81c8-9c41df074eb6.gif)

### Issues Resolved ### 

- fixes #8672

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 8672. If the CollectionView below loads items, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
