### PR TITLE
Prevent ObjectDisposed exception when updating item ejected from recycled pool

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -205,14 +205,13 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			ElementPropertyChanged?.Invoke(this, changedProperty);
 
-			// TODO hartez 2018/10/24 10:41:55 If the ItemTemplate changes from set to null, we need to make sure to clear the recyclerview pool	
-
 			if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemsSourceProperty))
 			{
 				UpdateItemsSource();
 			}
 			else if (changedProperty.Is(Xamarin.Forms.ItemsView.ItemTemplateProperty))
 			{
+				GetRecycledViewPool().Clear();
 				UpdateAdapter();
 			}
 			else if (changedProperty.Is(VisualElement.BackgroundColorProperty))

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Platform.Android
 		public void Recycle(ItemsView itemsView)
 		{
 			itemsView.RemoveLogicalChild(View);
+			View.BindingContext = null;
 		}
 
 		public void Bind(object itemBindingContext, ItemsView itemsView, 


### PR DESCRIPTION
### Description of Change ###

If a TemplatedItemViewHolder is put into the recycled view pool and then removed from the pool by the RecyclerView (for whatever reason), the view can be collected and disposed while still bound to the underlying data source. At that point, an update to the data source can result in an ObjectDisposedException.

These changes prevent that scenario by setting the BindingContext of the view to null when it is put into the recycled view pool.

### Issues Resolved ### 

- fixes #8435

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

None. We don't have any control over when the RecyclerView ejects views from the pool or when the garbage collector decides to collect them, so setting up a repeatable test is exceedingly difficult. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
