### PR TITLE
[Tizen] Enhances the Static Registrar

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms
 			Assemblies = assemblies;
 		}
 
-		public void UseStaticRegistrar(StaticRegistrarStrategy strategy, Dictionary<Type, Type> customHandlers=null, bool disableCss=false)
+		public void UseStaticRegistrar(StaticRegistrarStrategy strategy, Dictionary<Type, Func<IRegisterable>> customHandlers=null, bool disableCss=false)
 		{
 			StaticRegistarStrategy = strategy;
 			CustomHandlers = customHandlers;
@@ -58,7 +58,7 @@ namespace Xamarin.Forms
 		public CoreApplication Context;
 		public bool UseDeviceIndependentPixel;
 		public HandlerAttribute[] Handlers;
-		public Dictionary<Type, Type> CustomHandlers; // for static registers
+		public Dictionary<Type, Func<IRegisterable>> CustomHandlers; // for static registers
 		public Assembly[] Assemblies;
 		public EffectScope[] EffectScopes;
 		public InitializationFlags Flags;

--- a/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
+++ b/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
@@ -475,6 +475,22 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		GestureHandler CreateHandler(IGestureRecognizer recognizer)
 		{
+			if (recognizer is TapGestureRecognizer)
+			{
+				return new TapGestureHandler(recognizer);
+			}
+			else if (recognizer is PinchGestureRecognizer)
+			{
+				return new PinchGestureHandler(recognizer);
+			}
+			else if (recognizer is PanGestureRecognizer)
+			{
+				return new PanGestureHandler(recognizer);
+			}
+			else if (recognizer is SwipeGestureRecognizer)
+			{
+				return new SwipeGestureHandler(recognizer);
+			}
 			return Forms.GetHandlerForObject<GestureHandler>(recognizer, recognizer);
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -8,38 +8,37 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class StaticRegistrar<TRegistrable> where TRegistrable : class
 	{
-		readonly Dictionary<Type, Type> _handlers = new Dictionary<Type, Type>();
+		readonly Dictionary<Type, Func<TRegistrable>> _handlers = new Dictionary<Type, Func<TRegistrable>>();
 
-		public void Register(Type tview, Type trender)
+		public void Register(Type tview, Func<TRegistrable> renderer)
 		{
-			if (trender == null)
+			if (renderer == null)
 				return;
 
-			_handlers[tview] = trender;
+			_handlers[tview] = renderer;
 		}
 
 		public TOut GetHandler<TOut>(Type type, params object[] args) where TOut : class, TRegistrable
 		{
-			if (LookupHandlerType(type, out Type handlerType))
+			if (LookupHandler(type, out Func<TRegistrable> renderer))
 			{
-				object handler = Activator.CreateInstance(handlerType, args);
-				return (TRegistrable)handler as TOut;
+				return (TRegistrable)renderer() as TOut;
 			}
 			Log.Error("No handler could be found for that type :" + type);
 			return null;
 
 		}
 
-		public bool LookupHandlerType(Type viewType, out Type handlerType)
+		public bool LookupHandler(Type viewType, out Func<TRegistrable> handler)
 		{
 			while (viewType != null && viewType != typeof(Element))
 			{
-				if (_handlers.TryGetValue(viewType, out handlerType))
+				if (_handlers.TryGetValue(viewType, out handler))
 					return true;
 
 				viewType = viewType.GetTypeInfo().BaseType;
 			}
-			handlerType = null;
+			handler = null;
 			return false;
 		}
 
@@ -65,61 +64,55 @@ namespace Xamarin.Forms.Platform.Tizen
 			Registered = new StaticRegistrar<IRegisterable>();
 		}
 
-		public static void RegisterHandlers(Dictionary<Type, Type> customHandlers)
+		public static void RegisterHandlers(Dictionary<Type, Func<IRegisterable>> customHandlers)
 		{
-			//Renderers
-			Registered.Register(typeof(Layout), typeof(LayoutRenderer));
-			Registered.Register(typeof(ScrollView), typeof(ScrollViewRenderer));
-			Registered.Register(typeof(CarouselPage), typeof(CarouselPageRenderer));
-			Registered.Register(typeof(Page), typeof(PageRenderer));
-			Registered.Register(typeof(NavigationPage), typeof(NavigationPageRenderer));
-			Registered.Register(typeof(MasterDetailPage), typeof(MasterDetailPageRenderer));
-			Registered.Register(typeof(TabbedPage), typeof(TabbedPageRenderer));
-			Registered.Register(typeof(Shell), typeof(ShellRenderer));
-			Registered.Register(typeof(Label), typeof(LabelRenderer));
-			Registered.Register(typeof(Button), typeof(ButtonRenderer));
-			Registered.Register(typeof(Image), typeof(ImageRenderer));
-			Registered.Register(typeof(Slider), typeof(SliderRenderer));
-			Registered.Register(typeof(Picker), typeof(PickerRenderer));
-			Registered.Register(typeof(Frame), typeof(FrameRenderer));
-			Registered.Register(typeof(Stepper), typeof(StepperRenderer));
-			Registered.Register(typeof(DatePicker), typeof(DatePickerRenderer));
-			Registered.Register(typeof(TimePicker), typeof(TimePickerRenderer));
-			Registered.Register(typeof(ProgressBar), typeof(ProgressBarRenderer));
-			Registered.Register(typeof(Switch), typeof(SwitchRenderer));
-			Registered.Register(typeof(CheckBox), typeof(CheckBoxRenderer));
-			Registered.Register(typeof(ListView), typeof(ListViewRenderer));
-			Registered.Register(typeof(BoxView), typeof(BoxViewRenderer));
-			Registered.Register(typeof(ActivityIndicator), typeof(ActivityIndicatorRenderer));
-			Registered.Register(typeof(SearchBar), typeof(SearchBarRenderer));
-			Registered.Register(typeof(Entry), typeof(EntryRenderer));
-			Registered.Register(typeof(Editor), typeof(EditorRenderer));
-			Registered.Register(typeof(TableView), typeof(TableViewRenderer));
-			Registered.Register(typeof(NativeViewWrapper), typeof(NativeViewWrapperRenderer));
-			Registered.Register(typeof(WebView), typeof(WebViewRenderer));
-			Registered.Register(typeof(ImageButton), typeof(ImageButtonRenderer));
-			Registered.Register(typeof(StructuredItemsView), typeof(StructuredItemsViewRenderer));
-			Registered.Register(typeof(CarouselView), typeof(CarouselViewRenderer));
-			Registered.Register(typeof(SwipeView), typeof(SwipeViewRenderer));
-			Registered.Register(typeof(RefreshView), typeof(RefreshViewRenderer));
+			////Renderers
+			Registered.Register(typeof(Layout), () => new LayoutRenderer());
+			Registered.Register(typeof(ScrollView), () => new ScrollViewRenderer());
+			Registered.Register(typeof(CarouselPage), () => new CarouselPageRenderer());
+			Registered.Register(typeof(Page), () => new PageRenderer());
+			Registered.Register(typeof(NavigationPage), () => new NavigationPageRenderer());
+			Registered.Register(typeof(MasterDetailPage), () => new MasterDetailPageRenderer());
+			Registered.Register(typeof(TabbedPage), () => new TabbedPageRenderer());
+			Registered.Register(typeof(Shell), () => new ShellRenderer());
+			Registered.Register(typeof(Label), () => new LabelRenderer());
+			Registered.Register(typeof(Button), () => new ButtonRenderer());
+			Registered.Register(typeof(Image), () => new ImageRenderer());
+			Registered.Register(typeof(Slider), () => new SliderRenderer());
+			Registered.Register(typeof(Picker), () => new PickerRenderer());
+			Registered.Register(typeof(Frame), () => new FrameRenderer());
+			Registered.Register(typeof(Stepper), () => new StepperRenderer());
+			Registered.Register(typeof(DatePicker), () => new DatePickerRenderer());
+			Registered.Register(typeof(TimePicker), () => new TimePickerRenderer());
+			Registered.Register(typeof(ProgressBar), () => new ProgressBarRenderer());
+			Registered.Register(typeof(Switch), () => new SwitchRenderer());
+			Registered.Register(typeof(CheckBox), () => new CheckBoxRenderer());
+			Registered.Register(typeof(ListView), () => new ListViewRenderer());
+			Registered.Register(typeof(BoxView), () => new BoxViewRenderer());
+			Registered.Register(typeof(ActivityIndicator), () => new ActivityIndicatorRenderer());
+			Registered.Register(typeof(SearchBar), () => new SearchBarRenderer());
+			Registered.Register(typeof(Entry), () => new EntryRenderer());
+			Registered.Register(typeof(Editor), () => new EditorRenderer());
+			Registered.Register(typeof(TableView), () => new TableViewRenderer());
+			Registered.Register(typeof(NativeViewWrapper), () => new NativeViewWrapperRenderer());
+			Registered.Register(typeof(WebView), () => new WebViewRenderer());
+			Registered.Register(typeof(ImageButton), () => new ImageButtonRenderer());
+			Registered.Register(typeof(StructuredItemsView), () => new StructuredItemsViewRenderer());
+			Registered.Register(typeof(CarouselView), () => new CarouselViewRenderer());
+			Registered.Register(typeof(SwipeView), () => new SwipeViewRenderer());
+			Registered.Register(typeof(RefreshView), () => new RefreshViewRenderer());
 
-			//ImageSourceHandlers
-			Registered.Register(typeof(FileImageSource), typeof(FileImageSourceHandler));
-			Registered.Register(typeof(StreamImageSource), typeof(StreamImageSourceHandler));
-			Registered.Register(typeof(UriImageSource), typeof(UriImageSourceHandler));
+			////ImageSourceHandlers
+			Registered.Register(typeof(FileImageSource), () => new FileImageSourceHandler());
+			Registered.Register(typeof(StreamImageSource), () => new StreamImageSourceHandler());
+			Registered.Register(typeof(UriImageSource), () => new UriImageSourceHandler());
 
-			//Cell Renderers
-			Registered.Register(typeof(TextCell), typeof(TextCellRenderer));
-			Registered.Register(typeof(ImageCell), typeof(ImageCellRenderer));
-			Registered.Register(typeof(SwitchCell), typeof(SwitchCellRenderer));
-			Registered.Register(typeof(EntryCell), typeof(EntryCellRenderer));
-			Registered.Register(typeof(ViewCell), typeof(ViewCellRenderer));
-
-			//Gesture Handlers
-			Registered.Register(typeof(TapGestureRecognizer), typeof(TapGestureHandler));
-			Registered.Register(typeof(PinchGestureRecognizer), typeof(PinchGestureHandler));
-			Registered.Register(typeof(PanGestureRecognizer), typeof(PanGestureHandler));
-			Registered.Register(typeof(SwipeGestureRecognizer), typeof(SwipeGestureHandler));
+			////Cell Renderers
+			Registered.Register(typeof(TextCell), () => new TextCellRenderer());
+			Registered.Register(typeof(ImageCell), () => new ImageCellRenderer());
+			Registered.Register(typeof(SwitchCell), () => new SwitchCellRenderer());
+			Registered.Register(typeof(EntryCell), () => new EntryCellRenderer());
+			Registered.Register(typeof(ViewCell), () => new ViewCellRenderer());
 
 			//Dependencies
 			DependencyService.Register<ISystemResourcesProvider, ResourcesProvider>();
@@ -130,7 +123,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			//Custom Handlers
 			if (customHandlers != null)
 			{
-				foreach (KeyValuePair<Type, Type> handler in customHandlers)
+				foreach (KeyValuePair<Type, Func<IRegisterable>> handler in customHandlers)
 				{
 					Registered.Register(handler.Key, handler.Value);
 				}


### PR DESCRIPTION
### Description of Change ###

This PR is an improvement over Static Registrar, which was introduced previous PR (#8642). We did various experiments to improve the startup performance of tizen application and provided many improvements by using Static Registrar. But we found some small improvements to the process of creating instances dynamically, and in this PR we're dealing with them.

As everyone knows, we are using expensive `Activator.CreateInstance()` to create a handler for a given view type. Yes, this is much more expensive than initializing with `new` operator. When using static registers, I thought about alternatives, and the experimental results were as follows. 
>_The test measured the time taken to create the instance of `CirclePageRendere` 10 times each in the Galaxy Watch._

- AS-IS. Using `Activator.CreateInstance()` -> **9.736 ms**

- case 1. Using  `new` operator -> **1.571 ms**
```cs
new CirclePageRenderer();
```
- case 2. Using Lambda expression with Action delegate -> **1.578 ms**
```cs
Action action = () => new CirclePageRenderer();
action.Invoke();
```

- case 3. Using Generic Template -> 3.81 ms
```cs
static T Create<T>() where T :new()
{
    return new T();
}
 
Create<CirclePageRenderer>();
```
- case 4. IL Emit -> 2.828 ms
```cs
public static class ILEmit
{
    public delegate object DynamicObjectActivator();
    private static readonly Dictionary<Type, DynamicObjectActivator> cache = new Dictionary<Type, DynamicObjectActivator>();
 
    public static object Build(Type t)
    {
        if (cache.TryGetValue(t, out DynamicObjectActivator value))
        {
            return value();
        }
 
        var dynamicMethod = new DynamicMethod("CreateInstance", t, Type.EmptyTypes, true);
        var ilGenerator = dynamicMethod.GetILGenerator();
        ilGenerator.Emit(OpCodes.Nop);
        ConstructorInfo emptyConstructor = t.GetConstructor(Type.EmptyTypes);
        ilGenerator.Emit(OpCodes.Newobj, emptyConstructor);
        ilGenerator.Emit(OpCodes.Ret);
 
        var del = (DynamicObjectActivator)dynamicMethod.CreateDelegate(typeof(DynamicObjectActivator));
        cache.Add(t, del);
        return del();
    }
}

ILEmit.Build(typeof(CirclePageRenderer);
```

As shown above test result, we can see that Case 1 (using Lambda expression with Action delegate) is as fast as `new` operator. So I applied this to Static Registrar.  If you want to register a custom handler in your app using the Static Registrar, you can do the following:

Before:
```cs
var option = new InitializationOptions(app, true);
var customRenderers = new Dictionary<Type, Type> { {typeof(CirclePage), typeof(CirclePageRenderer)} };
option.UseStaticRegistrar(StaticRegistrarStrategy.StaticRegistrarOnly, customRenderers, true);
Forms.Init(option);
```

After:
```cs
var option = new InitializationOptions(app, true);
var customRenderers = new Dictionary<Type,  Func<IRegisterable>> { {typeof(CirclePage), () => new CirclePageRenderer()} };
option.UseStaticRegistrar(StaticRegistrarStrategy.StaticRegistrarOnly, customRenderers, true);
Forms.Init(option);
```

### Issues Resolved ### 
None

### API Changes ###
Changed:
 - Dictionary<Type, Type> CustomHandlers => Dictionary<Type, Func<IRegisterable>> CustomHandlers

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
