### PR TITLE
Queue DisplayPromptAsync for display after pages loads

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8526.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8526.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8526, "[Bug] DisplayPromptAsync hangs app, doesn't display when called in page load",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.DisplayPrompt)]
+#endif
+	public class Issue8526 : TestContentPage
+	{
+		const string Success = "Success";
+
+		protected override async void Init()
+		{
+			await DisplayPromptAsync(Success, "This prompt should display when the page loads.");
+		}
+
+#if UITEST
+		[Test]
+		public void DisplayPromptShouldWorkInPageLoad()
+		{
+			RunningApp.WaitForElement(Success);
+			RunningApp.Tap("Cancel");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -38,7 +38,7 @@
       <DependentUpon>Issue7048.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
-	<Compile Include="$(MSBuildThisFileDirectory)Issue6878.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6878.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7253.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7581.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7361.cs" />
@@ -112,6 +112,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8167.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8366.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8269.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8526.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8529.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8529_1.xaml.cs">
       <DependentUpon>Issue8529_1.xaml</DependentUpon>

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -56,5 +56,6 @@
 		public const string Page = "Page";
 		public const string RefreshView = "RefreshView";
 		public const string TitleView = "TitleView";
+		public const string DisplayPrompt = "DisplayPrompt";
 	}
 }

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -212,7 +212,12 @@ namespace Xamarin.Forms
 		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard);
-			MessagingCenter.Send(this, PromptSignalName, args);
+
+			if (IsPlatformEnabled)
+				MessagingCenter.Send(this, PromptSignalName, args);
+			else
+				_pendingActions.Add(() => MessagingCenter.Send(this, PromptSignalName, args));
+			
 			return args.Result.Task;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Uses the same mechanism as DisplayAlert and DisplayActionSheet to queue a DisplayPrompAsync call up for display after the page has finished loading.

### Issues Resolved ### 
- fixes #8526

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated test.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
