### PR TITLE
Avoid exception moving from empty to populated grouped CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7393.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7393.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7393, "[Bug] CollectionView problems and crashes with IsGrouped=\"true\"",
+		PlatformAffected.iOS)]
+	public class Issue7393 : TestContentPage
+	{
+		ObservableCollection<_7393Group> _source;
+
+		protected override void Init()
+		{
+			var cv = new CollectionView();
+
+			_source = new ObservableCollection<_7393Group>();
+
+			var groupCount = 3;
+			var itemCount = 3;
+
+			//for (int groupIndex = 0; groupIndex < groupCount; groupIndex++)
+			//{
+			//	var group = new _7393Group { Header = $"{groupIndex} Header", Footer = $"{groupIndex} Footer" };
+
+			//	for (int itemIndex = 0; itemIndex < itemCount; itemIndex++)
+			//	{
+			//		var item = new _7393Item { Name = $"{groupIndex}.{itemIndex} Item" };
+			//		group.Add(item);
+			//	}
+
+			//	_source.Add(group);
+			//}
+
+			cv.GroupHeaderTemplate = new DataTemplate(() => {
+				var label = new Label();
+
+				label.SetBinding(Label.TextProperty, new Binding("Header"));
+
+				return label;
+			});
+
+			cv.GroupFooterTemplate = new DataTemplate(() => {
+				var label = new Label();
+
+				label.SetBinding(Label.TextProperty, new Binding("Footer"));
+
+				return label;
+			});
+
+			cv.ItemTemplate = new DataTemplate(() => {
+				var label = new Label();
+
+				label.SetBinding(Label.TextProperty, new Binding("Name"));
+
+				return label;
+			});
+
+			cv.ItemsSource = _source;
+			cv.IsGrouped = true;
+
+			var layout = new StackLayout();
+			layout.Children.Add(cv);
+
+			Content = layout;
+
+			Appearing += Issue7393Appearing;	
+		}
+
+		async void Issue7393Appearing(object sender, EventArgs e)
+		{
+			await AddItems();	
+		}
+
+		async Task AddItems() 
+		{
+			await Task.Delay(1000);
+
+			var groupIndex = _source.Count + 1;
+
+			var group = new _7393Group { Header = $"{groupIndex} Header (added)", Footer = $"{groupIndex} Footer (added)" };
+
+			for (int itemIndex = 0; itemIndex < 3; itemIndex++)
+			{
+				var item = new _7393Item { Name = $"{groupIndex}.{itemIndex} Item (added)" };
+				group.Add(item);
+			}
+
+			_source.Add(group);
+		}
+
+		class _7393Item 
+		{
+			public string Name { get; set; }
+		}
+
+		class _7393Group : ObservableCollection<_7393Item> 
+		{ 
+			public string Header { get; set; }
+			public string Footer { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void AddingItemsToGroupedCollectionViewShouldNotCrash()
+		{
+			
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7393.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7393.cs
@@ -20,28 +20,15 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Issue7393 : TestContentPage
 	{
 		ObservableCollection<_7393Group> _source;
+		Label _result;
+
+		const string Success = "Success";
 
 		protected override void Init()
 		{
 			var cv = new CollectionView();
 
 			_source = new ObservableCollection<_7393Group>();
-
-			var groupCount = 3;
-			var itemCount = 3;
-
-			//for (int groupIndex = 0; groupIndex < groupCount; groupIndex++)
-			//{
-			//	var group = new _7393Group { Header = $"{groupIndex} Header", Footer = $"{groupIndex} Footer" };
-
-			//	for (int itemIndex = 0; itemIndex < itemCount; itemIndex++)
-			//	{
-			//		var item = new _7393Item { Name = $"{groupIndex}.{itemIndex} Item" };
-			//		group.Add(item);
-			//	}
-
-			//	_source.Add(group);
-			//}
 
 			cv.GroupHeaderTemplate = new DataTemplate(() => {
 				var label = new Label();
@@ -70,7 +57,10 @@ namespace Xamarin.Forms.Controls.Issues
 			cv.ItemsSource = _source;
 			cv.IsGrouped = true;
 
+			_result = new Label { Text = "Waiting..." };
+
 			var layout = new StackLayout();
+			layout.Children.Add(_result);
 			layout.Children.Add(cv);
 
 			Content = layout;
@@ -80,7 +70,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 		async void Issue7393Appearing(object sender, EventArgs e)
 		{
-			await AddItems();	
+			await AddItems();
+			_result.Text = Success;
 		}
 
 		async Task AddItems() 
@@ -115,7 +106,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void AddingItemsToGroupedCollectionViewShouldNotCrash()
 		{
-			
+			RunningApp.WaitForElement(Success, timeout: TimeSpan.FromSeconds(2));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7393.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7393.cs
@@ -76,9 +76,14 @@ namespace Xamarin.Forms.Controls.Issues
 
 		async Task AddItems() 
 		{
-			await Task.Delay(1000);
-
 			var groupIndex = _source.Count + 1;
+
+			if (groupIndex > 2)
+			{
+				return;
+			}
+
+			await Task.Delay(1000);
 
 			var group = new _7393Group { Header = $"{groupIndex} Header (added)", Footer = $"{groupIndex} Footer (added)" };
 
@@ -89,6 +94,8 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 
 			_source.Add(group);
+
+			await AddItems();
 		}
 
 		class _7393Item 
@@ -106,7 +113,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void AddingItemsToGroupedCollectionViewShouldNotCrash()
 		{
-			RunningApp.WaitForElement(Success, timeout: TimeSpan.FromSeconds(2));
+			RunningApp.WaitForElement(Success, timeout: TimeSpan.FromSeconds(30));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8207.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6362.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7393.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -197,6 +197,14 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
+			if (_collectionView.NumberOfSections() == 0)
+			{
+				// Okay, we're going from completely empty to more than 0 items; there's an iOS bug which apparently
+				// will just crash if we call InsertItems here, so we have to do ReloadData.
+				_collectionView.ReloadData();
+				return;
+			}
+
 			_collectionView.InsertSections(CreateIndexSetFrom(startIndex, count));
 		}
 


### PR DESCRIPTION
### Description of Change ###

Starting from a completely empty grouped CollectionView on iOS and adding a group results in an internal consistency exception. These changes avoid that by using ReloadData() in that circumstance, which allows the UICollectionView to get its internal accounting correct.

### Issues Resolved ### 

- fixes #7393

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
