### PR TITLE
[iOS] Expose UISearchBarStyle through platform-specific

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/SearchBariOS.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGalleries/SearchBariOS.cs
@@ -1,0 +1,41 @@
+﻿using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls.GalleryPages.PlatformSpecificsGalleries
+{
+	public class SearchBariOS : ContentPage
+	{
+		public SearchBariOS()
+		{
+			var prominent = new SearchBar { Placeholder = "Prominent" };
+			prominent.On<iOS>().SetSearchBarStyle(UISearchBarStyle.Prominent);
+
+			var minimal = new SearchBar { Placeholder = "Minimal" };
+			minimal.On<iOS>().SetSearchBarStyle(UISearchBarStyle.Minimal);
+
+			var prominentBackground = new SearchBar { Placeholder = "Prominent on colored background" };
+			prominentBackground.On<iOS>().SetSearchBarStyle(UISearchBarStyle.Prominent);
+
+			var minimalBackground = new SearchBar { Placeholder = "Minimal on colored background" };
+			minimalBackground.On<iOS>().SetSearchBarStyle(UISearchBarStyle.Minimal);
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+					prominent,
+					minimal,
+					new StackLayout()
+					{
+						BackgroundColor = Color.Red, 
+						Children =
+						{
+							prominentBackground,
+							minimalBackground
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/PlatformSpecificsGallery.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Controls
 			var modalformsheetiOSButton = new Button() { Text = "Modal FormSheet (iOS)" };
 			var homeIndicatoriOSButton = new Button() { Text = "Home indicator (iOS)" };
 			var refreshWindowsButton = new Button { Text = "RefreshView (Windows)" };
+			var searchBariOSButton = new Button { Text = "SearchBar (iOS)" };
 
 			mdpiOSButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageiOS(new Command(RestoreOriginal))); };
 			mdpWindowsButton.Clicked += (sender, args) => { SetRoot(new MasterDetailPageWindows(new Command(RestoreOriginal))); };
@@ -45,6 +46,7 @@ namespace Xamarin.Forms.Controls
 			modalformsheetiOSButton.Clicked += async (sender, args) => { await Navigation.PushModalAsync(new ModalFormSheetPageiOS()); };
 			homeIndicatoriOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new HomeIndicatorPageiOS(new Command(RestoreOriginal))); };
 			refreshWindowsButton.Clicked += (sender, args) => { Navigation.PushAsync(new RefreshViewWindows()); };
+			searchBariOSButton.Clicked += (sender, args) => { Navigation.PushAsync(new SearchBariOS()); };
 
 			Content = new ScrollView
 			{
@@ -52,7 +54,7 @@ namespace Xamarin.Forms.Controls
 				{
 					Children = { mdpiOSButton, mdpWindowsButton, npWindowsButton, tbiOSButton, tbWindowsButton, viselemiOSButton,
 						appAndroidButton, tbAndroidButton, entryiOSButton, entryAndroidButton, largeTitlesiOSButton, safeareaiOSButton, 
-						modalformsheetiOSButton, homeIndicatoriOSButton, refreshWindowsButton }
+						modalformsheetiOSButton, homeIndicatoriOSButton, refreshWindowsButton, searchBariOSButton }
 				}
 			};
 		}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/SearchBar.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.PlatformConfiguration;
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	using FormsElement = Xamarin.Forms.SearchBar;
+
+	public static class SearchBar
+	{
+		public static readonly BindableProperty SearchBarStyleProperty = BindableProperty.Create("SearchBarStyle", typeof(UISearchBarStyle), typeof(SearchBar), UISearchBarStyle.Default);
+
+		public static UISearchBarStyle GetSearchBarStyle(BindableObject element)
+		{
+			return (UISearchBarStyle)element.GetValue(SearchBarStyleProperty);
+		}
+
+		public static void SetSearchBarStyle(BindableObject element, UISearchBarStyle style)
+		{
+			element.SetValue(SearchBarStyleProperty, style);
+		}
+
+		public static UISearchBarStyle GetSearchBarStyle(this IPlatformElementConfiguration<iOS, FormsElement> config)
+		{
+			return GetSearchBarStyle(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<iOS, FormsElement> SetSearchBarStyle(
+			this IPlatformElementConfiguration<iOS, FormsElement> config, UISearchBarStyle style)
+		{
+			SetSearchBarStyle(config.Element, style);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UISearchBarStyle.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/iOSSpecific/UISearchBarStyle.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.PlatformConfiguration.iOSSpecific
+{
+	public enum UISearchBarStyle
+	{
+		Default,
+		Prominent,
+		Minimal
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -89,6 +89,21 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		internal static UISearchBarStyle ToNativeSearchBarStyle(this PlatformConfiguration.iOSSpecific.UISearchBarStyle style)
+		{
+			switch (style)
+			{
+				case PlatformConfiguration.iOSSpecific.UISearchBarStyle.Default:
+					return UISearchBarStyle.Default;
+				case PlatformConfiguration.iOSSpecific.UISearchBarStyle.Prominent:
+					return UISearchBarStyle.Prominent;
+				case PlatformConfiguration.iOSSpecific.UISearchBarStyle.Minimal:
+					return UISearchBarStyle.Minimal;
+				default:
+					throw new ArgumentOutOfRangeException(nameof(style));
+			}
+		}
+
 		internal static UIReturnKeyType ToUIReturnKeyType(this ReturnType returnType)
 		{
 			switch (returnType)

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using CoreGraphics;
 using Foundation;
 using UIKit;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -81,6 +82,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateCharacterSpacing();
 				UpdateMaxLength();
 				UpdateKeyboard();
+				UpdateSearchBarStyle();
 			}
 
 			base.OnElementChanged(e);
@@ -129,6 +131,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateKeyboard();
 			else if(e.PropertyName == Xamarin.Forms.InputView.IsSpellCheckEnabledProperty.PropertyName)
 				UpdateKeyboard();
+			else if(e.PropertyName == PlatformConfiguration.iOSSpecific.SearchBar.SearchBarStyleProperty.PropertyName)
+				UpdateSearchBarStyle();
 		}
 
 		protected override void SetBackgroundColor(Color color)
@@ -396,6 +400,11 @@ namespace Xamarin.Forms.Platform.iOS
 			accessoryView.SetItems(new[] { spacer, searchButton }, false);
 
 			return accessoryView;
+		}
+
+		void UpdateSearchBarStyle()
+		{
+			Control.SearchBarStyle = Element.OnThisPlatform().GetSearchBarStyle().ToNativeSearchBarStyle();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Expose the UISearchBarStyle enum through a platform-specific. See https://developer.apple.com/documentation/uikit/uisearchbar/style for details on the enum values.

### Issues Resolved ### 

- N/A

### API Changes ###

Added:
 - public static class Xamarin.Forms.PlatformConfiguration.iOSSpecific.SearchBar
 - public enum Xamarin.Forms.PlatformConfiguration.iOSSpecific.UISearchBarStyle

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###

Users must set the value to Minimal for a visual change to occur.

### Before/After Screenshots ### 

iOS 12:
![SearchBarStyle_iOS12](https://user-images.githubusercontent.com/6132629/70476482-5dd9da00-1a9c-11ea-89fb-3bc8974917ef.jpeg)

iOS 13:
On iOS 13, the appearance of the UISearchBar changed, and with it the effects of the SearchBarStyle. While they are identical on a white background, Prominent is a little translucent and Minimal is transparent.
![SearchBarStyle_iOS13](https://user-images.githubusercontent.com/6132629/70476489-64685180-1a9c-11ea-85af-4d8192f97bf1.jpeg)

### Testing Procedure ###

Control Gallery -> Platform Specifics -> SearchBar (iOS)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
