### PR TITLE
Allow to use SwipeItem only with text or icon

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8777.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8777.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Category(UITestCategories.SwipeView)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 8777, "SwipeView crash if Text not is set on SwipeItem", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Github, 8777, "SwipeView crash if Text not is set on SwipeItem", PlatformAffected.iOS | PlatformAffected.Android)]
 	public class Issue8777 : TestContentPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8777.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8777.cs
@@ -1,0 +1,75 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8777, "SwipeView crash if Text not is set on SwipeItem", PlatformAffected.iOS)]
+	public class Issue8777 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 8777";
+
+			var layout = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Swipe to the right, if can open the SwipeView the test has passed."
+			};
+
+			var swipeItem = new SwipeItem
+			{
+				BackgroundColor = Color.Red,
+				IconImageSource = "calculator.png"
+			};
+
+			swipeItem.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Invoked", "Ok"); };
+
+			var swipeItems = new SwipeItems { swipeItem };
+
+			swipeItems.Mode = SwipeMode.Reveal;
+
+			var swipeContent = new Grid
+			{
+				BackgroundColor = Color.Gray
+			};
+
+			var swipeLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Right (No Text)"
+			};
+
+			swipeContent.Children.Add(swipeLabel);
+
+			var swipeView = new SwipeView
+			{
+				HeightRequest = 60,
+				WidthRequest = 300,
+				LeftItems = swipeItems,
+				Content = swipeContent
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(swipeView);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1241,6 +1241,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8973.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7924.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8461.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8777.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -598,7 +598,7 @@ namespace Xamarin.Forms.Platform.Android
 			var swipeButton = new AButton(_context)
 			{
 				Background = new ColorDrawable(formsSwipeItem.BackgroundColor.ToAndroid()),
-				Text = formsSwipeItem.Text
+				Text = formsSwipeItem.Text ?? string.Empty
 			};
 
 			var textColor = GetSwipeItemColor(formsSwipeItem.BackgroundColor);
@@ -616,7 +616,7 @@ namespace Xamarin.Forms.Platform.Android
 				swipeButton.SetCompoundDrawables(null, drawable, null, null);
 			});
 
-			var textSize = !string.IsNullOrEmpty(formsSwipeItem.Text) ? (int)swipeButton.TextSize : 0;
+			var textSize = !string.IsNullOrEmpty(swipeButton.Text) ? (int)swipeButton.TextSize : 0;
 			var buttonPadding = (contentHeight - (iconSize + textSize + 6)) / 2;
 			swipeButton.SetPadding(0, buttonPadding, 0, buttonPadding);
 			swipeButton.SetOnTouchListener(null);


### PR DESCRIPTION
### Description of Change ###

Allow to use SwipeItem only with text or icon.

### Issues Resolved ### 

- fixes #8777
- fixes #9108
- fixes #9271

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
`System.NullReferenceException` has been thrown on iOS, no centered icon on Android.

#### After
![issue8777-droid](https://user-images.githubusercontent.com/6755973/70513076-354fef80-1b31-11ea-836f-975ab6d6fe1c.gif)
![issue8777-ios](https://user-images.githubusercontent.com/6755973/70513077-354fef80-1b31-11ea-975f-6f2c77b25533.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 8777. Open the SwipeView and verify that only appears the centered icon.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
