### PR TITLE
Centered text and icon in SwipeItem

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/CustomSwipeItemGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/CustomSwipeItemGallery.cs
@@ -12,7 +12,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 			{
 				Children =
 				{
-					GalleryBuilder.NavButton("Customize SwipeItem Gallery", () => new CustomizeSwipeItemGallery(), Navigation)
+					GalleryBuilder.NavButton("Customize SwipeItem Gallery", () => new CustomizeSwipeItemGallery(), Navigation),
+					GalleryBuilder.NavButton("No Icon or Text SwipeItem Gallery", () => new NoIconTextSwipeItemGallery(), Navigation)
 				}
 			};
 

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/NoIconTextSwipeItemGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/NoIconTextSwipeItemGallery.cs
@@ -1,0 +1,58 @@
+﻿using System;
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public class NoIconTextSwipeItemGallery : ContentPage
+	{
+		public NoIconTextSwipeItemGallery()
+		{
+			Title = "No Icon or Text SwipeItem Gallery";
+
+			var swipeLayout = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var noIconSwipeItem = new SwipeItem
+			{
+				BackgroundColor = Color.Red,
+				Text = "File"
+			};
+
+			var noTextSwipeItem = new SwipeItem
+			{
+				BackgroundColor = Color.BlueViolet,
+				IconImageSource = "calculator.png"
+			};
+
+			var swipeItems = new SwipeItems { noIconSwipeItem, noTextSwipeItem };
+
+			swipeItems.Mode = SwipeMode.Reveal;
+
+			var swipeContent = new Grid
+			{
+				BackgroundColor = Color.Gray
+			};
+
+			var swipeLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Right (File)"
+			};
+
+			swipeContent.Children.Add(swipeLabel);
+
+			var swipeView = new SwipeView
+			{
+				HeightRequest = 60,
+				WidthRequest = 300,
+				LeftItems = swipeItems,
+				Content = swipeContent
+			};
+
+			swipeLayout.Children.Add(swipeView);
+
+			Content = swipeLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
@@ -9,8 +9,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 		{
 			var button = new Button
 			{
-				Text = "Enable CarouselView",
-				AutomationId = "EnableCarouselView"
+				Text = "Enable SwipeView",
+				AutomationId = "EnableSwipeView"
 			};
 			button.Clicked += ButtonClicked;
 
@@ -43,11 +43,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 		{
 			var button = sender as Button;
 
-			button.Text = "CarouselView Enabled!";
+			button.Text = "SwipeView Enabled!";
 			button.TextColor = Color.Black;
 			button.IsEnabled = false;
 
-			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental });
+			Device.SetFlags(new[] { ExperimentalFlags.SwipeViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public SwipeViewRenderer(Context context) : base(context)
 		{
-			Xamarin.Forms.SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
+			SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
 			_context = context;
 
 			AutoPackage = false;
@@ -595,8 +595,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			int contentHeight = _contentView.Height;
 			int contentWidth = (int)_context.ToPixels(SwipeItemWidth);
-			int iconSize = Math.Min(contentHeight, contentWidth) / 2;
-	
+			int iconSize = formsSwipeItem.IconImageSource != null ? Math.Min(contentHeight, contentWidth) / 2 : 0;
+
 			_ = this.ApplyDrawableAsync(formsSwipeItem, MenuItem.IconImageSourceProperty, Context, drawable =>
 			{
 				drawable.SetBounds(0, 0, iconSize, iconSize);
@@ -604,7 +604,7 @@ namespace Xamarin.Forms.Platform.Android
 				swipeButton.SetCompoundDrawables(null, drawable, null, null);
 			});
 
-			var textSize = (int)swipeButton.TextSize;
+			var textSize = !string.IsNullOrEmpty(formsSwipeItem.Text) ? (int)swipeButton.TextSize : 0;
 			var buttonPadding = (contentHeight - (iconSize + textSize + 6)) / 2;
 			swipeButton.SetPadding(0, buttonPadding, 0, buttonPadding);
 			swipeButton.SetOnTouchListener(null);

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public SwipeViewRenderer()
 		{
-			Xamarin.Forms.SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
+			SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
 
 			_tapGestureRecognizer = new UITapGestureRecognizer(OnTap)
 			{
@@ -389,8 +389,8 @@ namespace Xamarin.Forms.Platform.iOS
 			var titleEdgeInsets = new UIEdgeInsets(spacing, -imageSize.Width, -imageSize.Height, 0.0f);
 			button.TitleEdgeInsets = titleEdgeInsets;
 
-			var labelString = button.TitleLabel.Text;
-			var titleSize = labelString.StringSize(button.TitleLabel.Font);
+			var labelString = button.TitleLabel.Text ?? string.Empty;
+			var titleSize = !string.IsNullOrEmpty(labelString) ? labelString.StringSize(button.TitleLabel.Font) : CGSize.Empty;
 			var imageEdgeInsets = new UIEdgeInsets(-(titleSize.Height + spacing), 0.0f, 0.0f, -titleSize.Width);
 			button.ImageEdgeInsets = imageEdgeInsets;
 		}


### PR DESCRIPTION
### Description of Change ###

Centered text and icon in SwipeItem. In case of using a SwipeItem only with text or icon, always center the content (text or icon).

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="526" alt="Captura de pantalla 2019-12-10 a las 9 55 18" src="https://user-images.githubusercontent.com/6755973/70516055-929a6f80-1b36-11ea-9bda-a1ff7bc6626b.png">

#### After
<img width="529" alt="Captura de pantalla 2019-12-10 a las 10 07 26" src="https://user-images.githubusercontent.com/6755973/70516069-9cbc6e00-1b36-11ea-9e81-6ba50511855d.png">
<img width="459" alt="Captura de pantalla 2019-12-10 a las 10 10 50" src="https://user-images.githubusercontent.com/6755973/70516070-9d550480-1b36-11ea-8ecd-daa873b82934.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the _"No Text or Icon"_ custom SwipeItem sample. 

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
