### PR TITLE
#8183 Fix Base Class Selector with Descendant Selection

### DIFF
--- a/Xamarin.Forms.Core/StyleSheets/Selector.cs
+++ b/Xamarin.Forms.Core/StyleSheets/Selector.cs
@@ -82,7 +82,6 @@ namespace Xamarin.Forms.StyleSheets
 									&& c != '>'
 									&& c != ','
 									&& c != '~'
-									&& c != '^'
 									&& c != stopChar);
 						break;
 					}


### PR DESCRIPTION
### Fix Bug With Base Class Selector(^) for CSS in Xamarin.Forms ### 

[Link to Commit that first introduced this issue](https://github.com/xamarin/Xamarin.Forms/commit/5ea86a266b4602215d79bffe8c707f4bf07d5efe)


The root cause of the problem was with incorrect placing connected selector for `^`.

When we try to parse:
* `stacklayout label{` we will get `And=>Elemen;Descendent=>All;And=>Elemen;` 
* `stacklayout>label{` we will get `And=>Elemen;Child=>All;And=>Elemen;` 
sequence of selectors

But with base selector - `^`  we will get:
* `stacklayout ^label{` we will get `And=>Elemen;And=>Base;` 

And here we have a problem, instead of `And=>Base` we should have at first `Descendent=>All` same as it was for `stacklayout label{`

After changes, we will get:
* `stacklayout ^label{` we will get `And=>Elemen;Descendent=>All;And=>Base;` 

@cabal95 your idea with place of the bug was correct thanks nice issue description 😋


### Issues Resolved ### 

- fixes #8183

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Create a new Xamarin.Forms App with on `MainPage.xaml` and set next content inside:
```xaml
 <StackLayout>
        <Label Text="Label One" />
        <Label Text="Label Two" />
        <Label Text="Label Three" />
        <Label Text="Label Four" />
        <Label Text="Label Five" />
        <Label Text="Label Six" />
        <local:TestLabel Text="Test Label One" />
        <local:TestLabel Text="Test Label Two" />
        <local:TestLabel Text="Test Label Three" />
    </StackLayout>
```
2. Define simple `TestLabel` class inherited from `Label`:
```cs
   public class TestLabel : Label
    {
    }
```
3. Create `SimpleStyle.css` file and attach to `MainPage.xaml`:
```xaml
<ContentPage.Resources>
        <StyleSheetExtension Source="SimpleStyle.css"/>
    </ContentPage.Resources>
```
4. Set each of these CSS styles into `SimpleStyle.css` file, one by one and check app => all labels all time should be `blue`:
* `^label { color: blue; }`
* `stacklayout ^label { color: blue; }`
* `stacklayout>^label { color: blue; }`

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
