### PR TITLE
[UWP] Fixed CollectionView item spacing

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ScrollModeGall
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.AlternateLayoutGalleries;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ItemSizeGalleries;
+using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SpacingGalleries;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
@@ -30,6 +31,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 						GalleryBuilder.NavButton("Selection Galleries", () => new SelectionGallery(), Navigation),
 						GalleryBuilder.NavButton("Propagation Galleries", () => new PropagationGallery(), Navigation),
 						GalleryBuilder.NavButton("Grouping Galleries", () => new GroupingGallery(), Navigation),
+						GalleryBuilder.NavButton("Item Spacing Galleries", () => new ItemsSpacingGallery(), Navigation),
 						GalleryBuilder.NavButton("Item Size Galleries", () => new ItemsSizeGallery(), Navigation),
 						GalleryBuilder.NavButton("Scroll Mode Galleries", () => new ScrollModeGallery(), Navigation),
 						GalleryBuilder.NavButton("Alternate Layout Galleries", () => new AlternateLayoutGallery(), Navigation),

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -163,6 +163,39 @@ namespace Xamarin.Forms.Platform.UWP
 					formsGridView.Span = ((GridItemsLayout)Layout).Span;
 				}
 			}
+			else if (property.Is(GridItemsLayout.HorizontalItemSpacingProperty) || property.Is(GridItemsLayout.VerticalItemSpacingProperty))
+			{
+				UpdateGridItemsLayoutSpacing();
+			}
+			else if (property.Is(LinearItemsLayout.ItemSpacingProperty))
+			{
+				UpdateLinearItemsLayoutSpacing();
+			}
+		}
+
+		private void UpdateGridItemsLayoutSpacing()
+		{
+			if (ListViewBase is FormsGridView formsGridView)
+			{
+				// TODO: Update the style on the XAML control.
+				var horizontalSpacing = ((GridItemsLayout)Layout).HorizontalItemSpacing;
+				var verticalSpacing = ((GridItemsLayout)Layout).VerticalItemSpacing;
+			}
+		}
+
+		private void UpdateLinearItemsLayoutSpacing()
+		{
+			if (ListViewBase is FormsListView formsListView)
+			{
+				// TODO: Update the style on the XAML control.
+				var itemSpacing = ((LinearItemsLayout)Layout).ItemSpacing;
+
+			}
+			else if (ListViewBase is Windows.UI.Xaml.Controls.ListView listView)
+			{
+				// TODO: Update the style on the XAML control.
+				var itemSpacing = ((LinearItemsLayout)Layout).ItemSpacing;
+			}
 		}
 
 		static ListViewBase CreateGridView(GridItemsLayout gridItemsLayout)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -4,6 +4,9 @@ using Windows.UI.Xaml.Controls;
 using UWPApp = Windows.UI.Xaml.Application;
 using WListView = Windows.UI.Xaml.Controls.ListView;
 using WScrollMode = Windows.UI.Xaml.Controls.ScrollMode;
+using WSetter = Windows.UI.Xaml.Setter;
+using WStyle = Windows.UI.Xaml.Style;
+using WThickness = Windows.UI.Xaml.Thickness;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -176,10 +179,10 @@ namespace Xamarin.Forms.Platform.UWP
 				switch (ListViewBase)
 				{
 					case FormsListView formsListView:
-						formsListView.ItemContainerStyle = GetItemContainerStyle((LinearItemsLayout)Layout);
+						formsListView.ItemContainerStyle = GetVerticalItemContainerStyle((LinearItemsLayout)Layout);
 						break;
 					case WListView listView:
-						listView.ItemContainerStyle = GetItemContainerStyle((LinearItemsLayout)Layout);
+						listView.ItemContainerStyle = GetHorizontalItemContainerStyle((LinearItemsLayout)Layout);
 						break;
 				}
 			}
@@ -202,7 +205,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			return new FormsListView()
 			{
-				ItemContainerStyle = GetItemContainerStyle(listItemsLayout)
+				ItemContainerStyle = GetVerticalItemContainerStyle(listItemsLayout)
 			};
 		}
 
@@ -211,7 +214,7 @@ namespace Xamarin.Forms.Platform.UWP
 			var horizontalListView = new WListView()
 			{
 				ItemsPanel = (ItemsPanelTemplate)UWPApp.Current.Resources["HorizontalListItemsPanel"],
-				ItemContainerStyle = GetItemContainerStyle(listItemsLayout)
+				ItemContainerStyle = GetHorizontalItemContainerStyle(listItemsLayout)
 			};
 
 			ScrollViewer.SetHorizontalScrollMode(horizontalListView, WScrollMode.Auto);
@@ -221,22 +224,34 @@ namespace Xamarin.Forms.Platform.UWP
 			return horizontalListView;
 		}
 
-		static Windows.UI.Xaml.Style GetItemContainerStyle(GridItemsLayout layout)
+		static WStyle GetItemContainerStyle(GridItemsLayout layout)
 		{
 			var h = layout.HorizontalItemSpacing;
 			var v = layout.VerticalItemSpacing;
-			var margin = new Windows.UI.Xaml.Thickness(h, v, h, v);
+			var margin = new WThickness(h, v, h, v);
 
-			var style = new Windows.UI.Xaml.Style(typeof(GridViewItem));
-			style.Setters.Add(new Windows.UI.Xaml.Setter(GridViewItem.MarginProperty, margin));
+			var style = new WStyle(typeof(GridViewItem));
+			style.Setters.Add(new WSetter(GridViewItem.MarginProperty, margin));
 			return style;
 		}
 
-		static Windows.UI.Xaml.Style GetItemContainerStyle(LinearItemsLayout layout)
+		static WStyle GetVerticalItemContainerStyle(LinearItemsLayout layout)
 		{
-			var margin = new Windows.UI.Xaml.Thickness(layout.ItemSpacing);			
-			var style = new Windows.UI.Xaml.Style(typeof(ListViewItem));
-			style.Setters.Add(new Windows.UI.Xaml.Setter(ListViewItem.MarginProperty, margin));
+			var v = layout.ItemSpacing;
+			var margin = new WThickness(0, v, 0, v);	
+			
+			var style = new WStyle(typeof(ListViewItem));
+			style.Setters.Add(new WSetter(ListViewItem.MarginProperty, margin));
+			return style;
+		}
+
+		static WStyle GetHorizontalItemContainerStyle(LinearItemsLayout layout)
+		{
+			var h = layout.ItemSpacing;
+			var padding = new WThickness(h, 0, h, 0);
+
+			var style = new WStyle(typeof(ListViewItem));
+			style.Setters.Add(new WSetter(ListViewItem.PaddingProperty, padding));
 			return style;
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -226,8 +226,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static WStyle GetItemContainerStyle(GridItemsLayout layout)
 		{
-			var h = layout.HorizontalItemSpacing;
-			var v = layout.VerticalItemSpacing;
+			var h = layout?.HorizontalItemSpacing ?? 0;
+			var v = layout?.VerticalItemSpacing ?? 0;
 			var margin = new WThickness(h, v, h, v);
 
 			var style = new WStyle(typeof(GridViewItem));
@@ -237,7 +237,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static WStyle GetVerticalItemContainerStyle(LinearItemsLayout layout)
 		{
-			var v = layout.ItemSpacing;
+			var v = layout?.ItemSpacing ?? 0;
 			var margin = new WThickness(0, v, 0, v);	
 			
 			var style = new WStyle(typeof(ListViewItem));
@@ -247,7 +247,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static WStyle GetHorizontalItemContainerStyle(LinearItemsLayout layout)
 		{
-			var h = layout.ItemSpacing;
+			var h = layout?.ItemSpacing ?? 0;
 			var padding = new WThickness(h, 0, h, 0);
 
 			var style = new WStyle(typeof(ListViewItem));


### PR DESCRIPTION
### Description of Change ###
Fixes item spacing with the `CollectionView` on UWP.
Also, reinstated the item spacing gallery in the `CollectionView` control galleries.

### Issues Resolved ### 
- fixes #7842 

### API Changes ###
None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
Item spacing now works with `CollectionView`.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
- Open the Item Spacing Gallery in the Collection View gallery.
- Run the gallery tests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
