### PR TITLE
[android] remove Anticipator.cs for now

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -68,10 +68,6 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = AndroidApplicationLifecycleState.Uninitialized;
 			_currentState = AndroidApplicationLifecycleState.Uninitialized;
 			PopupManager.Subscribe(this);
-
-			var anticipator = new Anticipator();
-			anticipator.AnticipateClassConstruction(typeof(Resource.Layout));
-			anticipator.AnticipateClassConstruction(typeof(Resource.Attribute));
 		}
 
 		public event EventHandler ConfigurationChanged;

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -56,7 +56,6 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Anticipator.cs" />
     <Compile Include="ActivityResultCallbackRegistry.cs" />
     <Compile Include="AndroidApplicationLifecycleState.cs" />
     <Compile Include="AndroidTitleBarVisibility.cs" />


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/jonathanpeppers/anticipator
Context: https://github.com/xamarin/Xamarin.Forms/pull/8245

I was profiling the Blank Xamarin.Forms app template and saw this:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
       40095        0         11 (wrapper runtime-invoke) <Module>:runtime_invoke_void__this___object (object,intptr,intptr,intptr)
       40094        0          8 System.Threading.ThreadHelper:ThreadStart (object)
       40094        0          8 System.Threading.ExecutionContext:Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object)
       40094        0          8 System.Threading.ExecutionContext:Run (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool)
       40094        0          8 System.Threading.ExecutionContext:RunInternal (System.Threading.ExecutionContext,System.Threading.ContextCallback,object,bool)
       40092        0          8 System.Threading.ThreadHelper:ThreadStart_Context (object)
       40092        0          8 Xamarin.Forms.Platform.Android.Anticipator:Loop (object)
       40035        0         16 System.Threading.WaitHandle:WaitOne (System.TimeSpan)
       40035        0         16 System.Threading.WaitHandle:WaitOne (System.TimeSpan,bool)
       40035        0         16 System.Threading.WaitHandle:WaitOne (long,bool)
       40035        0         16 System.Threading.WaitHandle:InternalWaitOne (System.Runtime.InteropServices.SafeHandle,long,bool,bool)
       40034        0         16 System.Threading.WaitHandle:WaitOneNative (System.Runtime.InteropServices.SafeHandle,uint,bool,bool)
       40034    40034         16 (wrapper managed-to-native) System.Threading.WaitHandle:Wait_internal (intptr*,int,bool,int)

The `Anticipator` class stuck out, so I profiled it separately in a
blank app (not using Xamarin.Forms at all). This project isolates the
`Anticipator`, in timing specifically `Build.VERSION.SdkInt` and the
`Resource.designer.cs` class. This launches an app 10 times and
averages the result.

The results were that it hurt performance in every scenario:

    HAXM Emulator / Debug
        Anticipator: 141.273
        No Anticipator: 108.182
    HAXM Emulator / Release
        Anticipator: 86.182
        No Anticipator: 63.545
    Pixel 3XL / Debug
        Anticipator: 101.545
        No Anticipator: 93.182
    Pixel 3XL / Release
        Anticipator: 45.818
        No Anticipator: 38.455
    Pixel 3XL / Release+AOT
        Anticipator: 33.636
        No Anticipator: 30.545

Feel free to try out my sample as additional verification.

I would recommend removing this class for now, and only bring it back
when we have some numbers showing it improves things. Sorry!

Let me know if I need to target a branch other than master, thanks!

### Issues Resolved ### 

n/a

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable, I think

### Testing Procedure ###

Feel free to the project here, for additional verification: https://github.com/jonathanpeppers/anticipator

I will work on getting a script like this in Xamarin.Forms itself, documentation, etc.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
