### PR TITLE
[Android] Fixed Gif animation loading from files 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8821.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8821.cs
@@ -4,6 +4,12 @@ using System.Net;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8821.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8821.cs
@@ -1,0 +1,108 @@
+﻿using System;
+using System.IO;
+using System.Net;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Image)]
+#endif
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 8821, "Animations of downloaded gifs are not playing on Android", PlatformAffected.Android)]
+    public class Issue8821 : TestContentPage
+    {
+        private WebClient _webClientBlobDownload = null;
+        private readonly Button _downloadButton;
+        private readonly Image _image;
+
+        public Issue8821()
+        {
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Press the DownloadFile button and then the Animate button. Verify that the gif is downloaded and animate without problems."
+            };
+
+			_downloadButton = new Button { Text = "DownloadFile" };
+            _downloadButton.Clicked += DownloadFile;
+			var animateButton = new Button { Text = "Animate" };
+            animateButton.Clicked += Animate;
+            _image = new Image { Source = string.Empty };
+
+            Content = new StackLayout
+            {
+                Padding = new Thickness(20, 35, 20, 20),
+                Children =
+                {
+                    instructions,
+                    _downloadButton,
+                    _image,
+                    animateButton
+                }
+            };
+        }
+
+        public string SecondImageSource { get; set; }
+
+        protected override void Init()
+        {
+            Title = "Issue 8821";
+        }
+
+        void Animate(object sender, EventArgs e)
+        {
+            _image.IsAnimationPlaying = true;
+        }
+
+        void DownloadFile(object sender, EventArgs e)
+        {
+            if (_webClientBlobDownload == null)
+            {
+                _webClientBlobDownload = new WebClient();
+                _webClientBlobDownload.DownloadDataCompleted += new DownloadDataCompletedEventHandler(OnImageDownloadDataCompleted);
+            }
+
+            string nextURL = "https://upload.wikimedia.org/wikipedia/commons/c/c0/An_example_animation_made_with_Pivot.gif";
+
+            _webClientBlobDownload.DownloadDataAsync(new Uri(nextURL), SecondImageSource);
+        }
+
+        void OnImageDownloadDataCompleted(object sender, DownloadDataCompletedEventArgs e)
+        {
+            try
+            {
+                if (e.Cancelled == true)
+                    return;
+
+                if (e.Error != null)
+                    return;
+                
+                byte[] bytes = new byte[e.Result.Length]; 
+                bytes = e.Result;
+                SecondImageSource = Path.Combine(GetCurrentImagePath(), "Dmg.gif");
+                File.WriteAllBytes(SecondImageSource, bytes);
+            }
+            catch 
+            {
+                return;
+            }
+
+            _image.Source = SecondImageSource;
+            OnPropertyChanged(nameof(SecondImageSource));
+        }
+
+        string GetCurrentImagePath()
+        {
+			var imagePath = "imagePath";
+            var path = Environment.GetFolderPath(Environment.SpecialFolder.Personal) + "/" + imagePath;
+
+            if (!Directory.Exists(path))
+				Directory.CreateDirectory(path);
+
+			return path;
+        }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1179,6 +1179,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8638.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8392.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8672.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8821.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8326.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8449.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7875.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/AndroidGIFImageParser.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AndroidGIFImageParser.cs
@@ -38,6 +38,8 @@ namespace Xamarin.Forms.Platform.Android
 
 	public class FormsAnimationDrawable : AnimationDrawable, IFormsAnimationDrawable
 	{
+		const int DefaultBufferSize = 4096;
+
 		int _repeatCounter = 0;
 		int _frameCount = 0;
 		bool _finished = false;
@@ -192,28 +194,19 @@ namespace Xamarin.Forms.Platform.Android
 				InJustDecodeBounds = true
 			};
 
-			if (!FileImageSourceHandler.DecodeSynchronously)
-				await BitmapFactory.DecodeResourceAsync(context.Resources, ResourceManager.GetDrawableByName(file), options);
-			else
-				BitmapFactory.DecodeResource(context.Resources, ResourceManager.GetDrawableByName(file), options);
+			int drawableIdentifier = ResourceManager.GetDrawableByName(file);
 
-			using (var stream = context.Resources.OpenRawResource(ResourceManager.GetDrawableByName(file)))
-			using (var decoder = new AndroidGIFImageParser(context, options.InDensity, options.InTargetDensity))
+			if (drawableIdentifier != 0)
 			{
-				try
-				{
-					if (!FileImageSourceHandler.DecodeSynchronously)
-						await decoder.ParseAsync(stream).ConfigureAwait(false);
-					else
-						decoder.ParseAsync(stream).Wait();
+				if (!FileImageSourceHandler.DecodeSynchronously)
+					await BitmapFactory.DecodeResourceAsync(context.Resources, drawableIdentifier, options);
+				else
+					BitmapFactory.DecodeResource(context.Resources, drawableIdentifier, options);
 
-					animation = decoder.Animation;
-				}
-				catch (GIFDecoderFormatException)
-				{
-					animation = null;
-				}
+				animation = await GetFormsAnimationDrawableFromResource(file, context, options);
 			}
+			else
+				animation = await GetFormsAnimationDrawableFromFile(file, context, options);
 
 			if (animation == null)
 			{
@@ -262,6 +255,56 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
    
+			return animation;
+		}
+
+		internal static async Task<FormsAnimationDrawable> GetFormsAnimationDrawableFromResource(string resource, Context context, BitmapFactory.Options options)
+		{
+			FormsAnimationDrawable animation = null;
+
+			using (var stream = context.Resources.OpenRawResource(ResourceManager.GetDrawableByName(resource)))
+			using (var decoder = new AndroidGIFImageParser(context, options.InDensity, options.InTargetDensity))
+			{
+				try
+				{
+					if (!FileImageSourceHandler.DecodeSynchronously)
+						await decoder.ParseAsync(stream).ConfigureAwait(false);
+					else
+						decoder.ParseAsync(stream).Wait();
+
+					animation = decoder.Animation;
+				}
+				catch (GIFDecoderFormatException)
+				{
+					animation = null;
+				}
+			}
+
+			return animation;
+		}
+
+		internal static async Task<FormsAnimationDrawable> GetFormsAnimationDrawableFromFile(string file, Context context, BitmapFactory.Options options)
+		{
+			FormsAnimationDrawable animation = null;
+
+			using (var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, true))
+			using (var decoder = new AndroidGIFImageParser(context, options.InDensity, options.InTargetDensity))
+			{
+				try
+				{
+					if (!FileImageSourceHandler.DecodeSynchronously)
+						await decoder.ParseAsync(stream).ConfigureAwait(false);
+					else
+						decoder.ParseAsync(stream).Wait();
+
+					animation = decoder.Animation;
+				}
+				catch (GIFDecoderFormatException)
+				{
+					animation = null;
+				}
+			}
+
 			return animation;
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/AndroidGIFImageParser.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/AndroidGIFImageParser.cs
@@ -203,7 +203,7 @@ namespace Xamarin.Forms.Platform.Android
 				else
 					BitmapFactory.DecodeResource(context.Resources, drawableIdentifier, options);
 
-				animation = await GetFormsAnimationDrawableFromResource(file, context, options);
+				animation = await GetFormsAnimationDrawableFromResource(drawableIdentifier, context, options);
 			}
 			else
 				animation = await GetFormsAnimationDrawableFromFile(file, context, options);
@@ -258,27 +258,12 @@ namespace Xamarin.Forms.Platform.Android
 			return animation;
 		}
 
-		internal static async Task<FormsAnimationDrawable> GetFormsAnimationDrawableFromResource(string resource, Context context, BitmapFactory.Options options)
+		internal static async Task<FormsAnimationDrawable> GetFormsAnimationDrawableFromResource(int resourceId, Context context, BitmapFactory.Options options)
 		{
 			FormsAnimationDrawable animation = null;
 
-			using (var stream = context.Resources.OpenRawResource(ResourceManager.GetDrawableByName(resource)))
-			using (var decoder = new AndroidGIFImageParser(context, options.InDensity, options.InTargetDensity))
-			{
-				try
-				{
-					if (!FileImageSourceHandler.DecodeSynchronously)
-						await decoder.ParseAsync(stream).ConfigureAwait(false);
-					else
-						decoder.ParseAsync(stream).Wait();
-
-					animation = decoder.Animation;
-				}
-				catch (GIFDecoderFormatException)
-				{
-					animation = null;
-				}
-			}
+			using (var stream = context.Resources.OpenRawResource(resourceId))
+				animation = await GetFormsAnimationDrawableFromStream(stream, context, options);
 
 			return animation;
 		}
@@ -288,6 +273,15 @@ namespace Xamarin.Forms.Platform.Android
 			FormsAnimationDrawable animation = null;
 
 			using (var stream = new FileStream(file, FileMode.Open, FileAccess.Read, FileShare.Read, DefaultBufferSize, true))
+				animation = await GetFormsAnimationDrawableFromStream(stream, context, options);
+
+			return animation;
+		}
+
+		internal static async Task<FormsAnimationDrawable> GetFormsAnimationDrawableFromStream(Stream stream, Context context, BitmapFactory.Options options)
+		{
+			FormsAnimationDrawable animation = null;
+
 			using (var decoder = new AndroidGIFImageParser(context, options.InDensity, options.InTargetDensity))
 			{
 				try


### PR DESCRIPTION
### Description of Change ###

Fixed Gif animation loading from local files (no resources).

### Issues Resolved ### 

- fixes #8821

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before 
![issue8821-before](https://user-images.githubusercontent.com/6755973/70714152-d41e4c80-1ce7-11ea-900f-708d1a758dd7.gif)

#### After
![issue8821-after](https://user-images.githubusercontent.com/6755973/70714155-d4b6e300-1ce7-11ea-85cc-fbeb51c326d6.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 8821. Press the "DownloadFile" button and then press the "Animate" button. If the gif is loaded and animated, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
