### PR TITLE
Account for item spacing when providing grouped insets

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8345.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8345.cs
@@ -1,0 +1,51 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8345, "[Bug] CollectionView ItemSpacing does not affect the Item spacing on iOS",
+		PlatformAffected.iOS)]
+	public class Issue8345 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var groups = new List<_8345Group>
+			{
+				new _8345Group() { HeaderText = "Group 1" },
+				new _8345Group() { HeaderText = "Group 2" },
+				new _8345Group() { HeaderText = "Group 3" }
+			};
+
+			var cv = new CollectionView { IsGrouped = true, ItemsSource = groups, 
+				GroupHeaderTemplate = new DataTemplate(() => {
+					var label = new Label
+					{
+						BackgroundColor = Color.Red
+					};
+					label.SetBinding(Label.TextProperty, new Binding("HeaderText"));
+					return label;
+			})};
+
+			cv.ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical) { ItemSpacing = 20 };
+
+			var instructions = new Label { Text = "The CollectionView group headers below should have space between " +
+				"them; if they are right next to each other, this test has failed." };
+
+			var layout = new StackLayout();
+			layout.Children.Add(instructions);
+			layout.Children.Add(cv);
+			Content = layout;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class _8345Group : List<_8345Item> 
+	{
+		public string HeaderText { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class _8345Item { }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -131,6 +131,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8087.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8222.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8167.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8345.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8366.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8269.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8526.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -156,7 +156,6 @@ namespace Xamarin.Forms.Platform.iOS
 			return cell.Measure();
 		}
 
-
 		internal void SetScrollAnimationEndedCallback(Action callback)
 		{
 			_scrollAnimationEndedCallback = callback;
@@ -166,6 +165,47 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_scrollAnimationEndedCallback?.Invoke();
 			_scrollAnimationEndedCallback = null;
+		}
+
+		internal UIEdgeInsets GetInsetForSection(ItemsViewLayout itemsViewLayout,
+			UICollectionView collectionView, nint section)
+		{
+			var uIEdgeInsets = ItemsViewLayout.GetInsetForSection(collectionView, itemsViewLayout, section);
+
+			if (!ItemsView.IsGrouped)
+			{
+				return uIEdgeInsets;
+			}
+
+			// If we're grouping, we'll need to inset the sections to maintain the item spacing between the 
+			// groups and/or their group headers/footers
+
+			var itemsLayout = ItemsView.ItemsLayout;
+			var scrollDirection = itemsViewLayout.ScrollDirection;
+			nfloat lineSpacing = itemsViewLayout.GetMinimumLineSpacingForSection(collectionView, itemsViewLayout, section);
+
+			if (itemsLayout is GridItemsLayout)
+			{
+				nfloat itemSpacing = itemsViewLayout.GetMinimumInteritemSpacingForSection(collectionView, itemsViewLayout, section);
+
+				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
+				{
+					return new UIEdgeInsets(itemSpacing + uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left, 
+						uIEdgeInsets.Bottom, uIEdgeInsets.Right);
+				}
+
+				return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, itemSpacing + uIEdgeInsets.Left, 
+					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
+			}
+
+			if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
+			{
+				return new UIEdgeInsets(uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left, 
+					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
+			}
+
+			return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left, 
+				uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewDelegator.cs
@@ -27,5 +27,15 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			ViewController?.HandleScrollAnimationEnded();
 		}
+
+		public override UIEdgeInsets GetInsetForSection(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
+		{
+			if (ItemsViewLayout == null)
+			{
+				return default;
+			}
+
+			return ViewController.GetInsetForSection(ItemsViewLayout, collectionView, section);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Adds insets to UICollectionView sections when CollectionView is grouped so that group headers/footers respect ItemSpacing.

### Issues Resolved ### 
- fixes #8345

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Manual test, Issue 8345

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
