### PR TITLE
[Tizen] Creates the GestureDetector on demand

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
+++ b/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
@@ -1,7 +1,4 @@
-using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.Collections.Specialized;
 using System.Linq;
 using ElmSharp;
 using EGestureType = ElmSharp.GestureLayer.GestureType;
@@ -10,7 +7,7 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	internal class GestureDetector
 	{
-		readonly IDictionary<EGestureType, List<GestureHandler>> _handlerCache = new Dictionary<EGestureType, List<GestureHandler>>();
+		readonly IDictionary<EGestureType, List<GestureHandler>> _handlerCache;
 
 		readonly IVisualElementRenderer _renderer;
 		GestureLayer _gestureLayer;
@@ -49,17 +46,10 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		public GestureDetector(IVisualElementRenderer renderer)
 		{
+			_handlerCache = new Dictionary<EGestureType, List<GestureHandler>>();
 			_renderer = renderer;
 			_isEnabled = View.IsEnabled;
 			_inputTransparent = View.InputTransparent;
-
-			(View.GestureRecognizers as ObservableCollection<IGestureRecognizer>).CollectionChanged += OnGestureRecognizerCollectionChanged;
-
-			if (View.GestureRecognizers.Count > 0)
-			{
-				CreateGestureLayer();
-				AddGestures(View.GestureRecognizers);
-			}
 		}
 
 		public void Clear()
@@ -75,6 +65,23 @@ namespace Xamarin.Forms.Platform.Tizen
 				}
 			}
 			_handlerCache.Clear();
+		}
+
+		public void AddGestures(IEnumerable<IGestureRecognizer> recognizers)
+		{
+			if (_gestureLayer == null)
+			{
+				CreateGestureLayer();
+			}
+
+			foreach (var item in recognizers)
+				AddGesture(item);
+		}
+
+		public void RemoveGestures(IEnumerable<IGestureRecognizer> recognizers)
+		{
+			foreach (var item in recognizers)
+				RemoveGesture(item);
 		}
 
 		void CreateGestureLayer()
@@ -95,19 +102,6 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				_gestureLayer.IsEnabled = !_inputTransparent && _isEnabled;
 			}
-		}
-
-
-		void AddGestures(IEnumerable<IGestureRecognizer> recognizers)
-		{
-			foreach (var item in recognizers)
-				AddGesture(item);
-		}
-
-		void RemoveGestures(IEnumerable<IGestureRecognizer> recognizers)
-		{
-			foreach (var item in recognizers)
-				RemoveGesture(item);
 		}
 
 		void AddGesture(IGestureRecognizer recognizer)
@@ -554,32 +548,6 @@ namespace Xamarin.Forms.Platform.Tizen
 					default:
 						break;
 				}
-			}
-		}
-
-		void OnGestureRecognizerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
-		{
-			// Gestures will be registered/unregistered according to changes in the GestureRecognizers list
-			switch (e.Action)
-			{
-				case NotifyCollectionChangedAction.Add:
-					if (_gestureLayer == null)
-						CreateGestureLayer();
-					AddGestures(e.NewItems.OfType<IGestureRecognizer>());
-					break;
-
-				case NotifyCollectionChangedAction.Replace:
-					RemoveGestures(e.OldItems.OfType<IGestureRecognizer>());
-					AddGestures(e.NewItems.OfType<IGestureRecognizer>());
-					break;
-
-				case NotifyCollectionChangedAction.Remove:
-					RemoveGestures(e.OldItems.OfType<IGestureRecognizer>());
-					break;
-
-				case NotifyCollectionChangedAction.Reset:
-					Clear();
-					break;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/LayoutRenderer.cs
@@ -80,7 +80,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				NativeView.PassEvents = false;
 				NativeView.RepeatEvents = false;
 			}
-			GestureDetector.InputTransparent = Element.InputTransparent;
+
+			if (GestureDetector != null)
+			{
+				GestureDetector.InputTransparent = Element.InputTransparent;
+			}
 		}
 
 		void OnLayoutUpdated(object sender, Native.LayoutEventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ViewRenderer.cs
@@ -1,6 +1,7 @@
-using System;
-using System.ComponentModel;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.Diagnostics;
+using System.Linq;
 using ElmSharp;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -12,26 +13,9 @@ namespace Xamarin.Forms.Platform.Tizen
 		where TView : View
 		where TNativeView : EvasObject
 	{
-		readonly Lazy<GestureDetector> _gestureDetector;
+		ObservableCollection<IGestureRecognizer> GestureRecognizers => Element.GestureRecognizers as ObservableCollection<IGestureRecognizer>;
 
-		internal GestureDetector GestureDetector => _gestureDetector.Value;
-
-		/// <summary>
-		/// Default constructor.
-		/// </summary>
-		protected ViewRenderer()
-		{
-			_gestureDetector = new Lazy<GestureDetector>(() => new GestureDetector(this));
-		}
-
-		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)
-		{
-			base.OnElementChanged(e);
-			if (e.OldElement != null && _gestureDetector.IsValueCreated)
-			{
-				_gestureDetector.Value.Clear();
-			}
-		}
+		internal GestureDetector GestureDetector { get; private set; }
 
 		/// <summary>
 		/// Native control associated with this renderer.
@@ -44,6 +28,24 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
+		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)
+		{
+			base.OnElementChanged(e);
+			if (GestureDetector != null)
+			{
+				GestureRecognizers.CollectionChanged -= OnGestureRecognizerCollectionChanged;
+				GestureDetector.Clear();
+				GestureDetector = null;
+			}
+
+			GestureRecognizers.CollectionChanged += OnGestureRecognizerCollectionChanged;
+			if (Element.GestureRecognizers.Count > 0)
+			{
+				GestureDetector = new GestureDetector(this);
+				GestureDetector.AddGestures(Element.GestureRecognizers);
+			}
+		}
+
 		protected void SetNativeControl(TNativeView control)
 		{
 			Debug.Assert(control != null);
@@ -53,7 +55,42 @@ namespace Xamarin.Forms.Platform.Tizen
 		protected override void UpdateIsEnabled(bool initialize)
 		{
 			base.UpdateIsEnabled(initialize);
-			_gestureDetector.Value.IsEnabled = Element.IsEnabled;
+			if (initialize && Element.IsEnabled)
+				return;
+
+			if (GestureDetector != null)
+			{
+				GestureDetector.IsEnabled = Element.IsEnabled;
+			}
+		}
+
+		void OnGestureRecognizerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (GestureDetector == null)
+			{
+				GestureDetector = new GestureDetector(this);
+			}
+
+			// Gestures will be registered/unregistered according to changes in the GestureRecognizers list
+			switch (e.Action)
+			{
+				case NotifyCollectionChangedAction.Add:
+					GestureDetector.AddGestures(e.NewItems.OfType<IGestureRecognizer>());
+					break;
+
+				case NotifyCollectionChangedAction.Replace:
+					GestureDetector.RemoveGestures(e.OldItems.OfType<IGestureRecognizer>());
+					GestureDetector.AddGestures(e.NewItems.OfType<IGestureRecognizer>());
+					break;
+
+				case NotifyCollectionChangedAction.Remove:
+					GestureDetector.RemoveGestures(e.OldItems.OfType<IGestureRecognizer>());
+					break;
+
+				case NotifyCollectionChangedAction.Reset:
+					GestureDetector.Clear();
+					break;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
This PR fixes the creation time of `GestureDetector` so that it can be generated correctly when needed. Existing implementations was to create `GestureDetector` even if View doesn't have any `GestureRecoginzer`. The suggested way is to create `GestureDetector` when the `GestureRecognizer` is added to the View.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
