### PR TITLE
[android] fix NRE in ImageCell / ImageViewExtensions

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.Android
 					// all this animation code will go away if/once we pull in GlideX
 					IFormsAnimationDrawable animation = null;
 
-					if (imageController.GetLoadAsAnimation())
+					if (imageController != null && imageController.GetLoadAsAnimation())
 					{
 						var animationHandler = Registrar.Registered.GetHandlerForObject<IAnimationSourceHandler>(newImageSource);
 						if (animationHandler != null)


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/jonathanpeppers/glidex/tree/xf-4.4

In the linked sample, the `xf-4.4` branch, I am getting this exception
in the log for any `ImageCell` and no image loads:

    [0:] BaseCellView: Error loading image: System.NullReferenceException: Object reference not set to an instance of an object.
      at Xamarin.Forms.Platform.Android.ImageViewExtensions.UpdateBitmap (Android.Widget.ImageView imageView, Xamarin.Forms.IImageElement newView, Xamarin.Forms.IImageElement previousView, Xamarin.Forms.ImageSource newImageSource, Xamarin.Forms.ImageSource previousImageSource) [0x000f8] in D:\a\1\s\Xamarin.Forms.Platform.Android\Extensions\ImageViewExtensions.cs:49
      at Xamarin.Forms.Platform.Android.BaseCellView.UpdateBitmap (Xamarin.Forms.ImageSource source, Xamarin.Forms.ImageSource previousSource) [0x0003a] in D:\a\1\s\Xamarin.Forms.Platform.Android\Cells\BaseCellView.cs:195

Looking at the exact line:

https://github.com/xamarin/Xamarin.Forms/blob/10dafc5dcddede946163a1fd83d7feaac8021e1b/Xamarin.Forms.Platform.Android/Extensions/ImageViewExtensions.cs#L49

It looks like there is a missing null check, and this probably only
happens for `ImageCell`?

It looks like this might have been introduced with:

https://github.com/xamarin/Xamarin.Forms/pull/7330

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 

I did not find an issue for this.

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

`ImageCell` should display now

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Try my solution here: https://github.com/jonathanpeppers/glidex/tree/xf-4.4

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
