### PR TITLE
[android/ios] improve perf when not using Application.Properties

### DIFF
--- a/Xamarin.Forms.Platform.Android/Deserializer.cs
+++ b/Xamarin.Forms.Platform.Android/Deserializer.cs
@@ -55,29 +55,30 @@ namespace Xamarin.Forms.Platform.Android
 			// Make sure to use Internal
 			return Task.Run(() =>
 			{
-				var success = false;
 				using (IsolatedStorageFile store = IsolatedStorageFile.GetUserStoreForApplication())
-				using (IsolatedStorageFileStream stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
-				using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 				{
-					try
+					using (IsolatedStorageFileStream stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
+					using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 					{
-						var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
-						dcs.WriteObject(writer, properties);
-						writer.Flush();
-						success = true;
+						try
+						{
+							// No need to write 0 properties if no file exists
+							if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
+							{
+								return;
+							}
+							var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
+							dcs.WriteObject(writer, properties);
+							writer.Flush();
+						}
+						catch (Exception e)
+						{
+							Debug.WriteLine("Could not serialize properties: " + e.Message);
+							Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
+							return;
+						}
 					}
-					catch (Exception e)
-					{
-						Debug.WriteLine("Could not serialize properties: " + e.Message);
-						Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
-					}
-				}
 
-				if (!success)
-					return;
-				using (IsolatedStorageFile store = IsolatedStorageFile.GetUserStoreForApplication())
-				{
 					try
 					{
 						if (store.FileExists(PropertyStoreFile))

--- a/Xamarin.Forms.Platform.Android/Deserializer.cs
+++ b/Xamarin.Forms.Platform.Android/Deserializer.cs
@@ -57,16 +57,16 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				using (IsolatedStorageFile store = IsolatedStorageFile.GetUserStoreForApplication())
 				{
+					// No need to write 0 properties if no file exists
+					if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
+					{
+						return;
+					}
 					using (IsolatedStorageFileStream stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
 					using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 					{
 						try
 						{
-							// No need to write 0 properties if no file exists
-							if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
-							{
-								return;
-							}
 							var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
 							dcs.WriteObject(writer, properties);
 							writer.Flush();

--- a/Xamarin.Forms.Platform.Tizen/Deserializer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Deserializer.cs
@@ -1,15 +1,14 @@
 using System;
 using System.Collections.Generic;
-using System.Threading.Tasks;
-using System.Runtime.Serialization;
-using System.Xml;
 using System.Diagnostics;
-using System.IO;
-using Xamarin.Forms.Internals;
+using System.IO.IsolatedStorage;
+using System.Runtime.Serialization;
+using System.Threading.Tasks;
+using System.Xml;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	internal class Deserializer : IDeserializer
+	internal class Deserializer : Internals.IDeserializer
 	{
 		const string PropertyStoreFile = "PropertyStore.forms";
 
@@ -19,33 +18,29 @@ namespace Xamarin.Forms.Platform.Tizen
 			// Make sure to use Internal
 			return Task.Run(() =>
 			{
-				var store = new TizenIsolatedStorageFile();
-				Stream stream = null;
-				try
+				using (IsolatedStorageFile store = IsolatedStorageFile.GetUserStoreForApplication())
 				{
-					stream = store.OpenFile(PropertyStoreFile, System.IO.FileMode.OpenOrCreate);
-					if (stream.Length == 0)
-					{
+					if (!store.FileExists(PropertyStoreFile))
 						return null;
-					}
+
+					using (IsolatedStorageFileStream stream = store.OpenFile(PropertyStoreFile, System.IO.FileMode.Open, System.IO.FileAccess.Read))
 					using (XmlDictionaryReader reader = XmlDictionaryReader.CreateBinaryReader(stream, XmlDictionaryReaderQuotas.Max))
 					{
-						stream = null;
-						var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
-						return (IDictionary<string, object>)dcs.ReadObject(reader);
+						if (stream.Length == 0)
+							return null;
+
+						try
+						{
+							var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
+							return (IDictionary<string, object>)dcs.ReadObject(reader);
+						}
+						catch (Exception e)
+						{
+							Debug.WriteLine("Could not deserialize properties: " + e.Message);
+							Internals.Log.Warning("Xamarin.Forms PropertyStore", $"Exception while reading Application properties: {e}");
+						}
 					}
-				}
-				catch (Exception e)
-				{
-					Debug.WriteLine("Could not deserialize properties: " + e.Message);
-					Internals.Log.Warning("Xamarin.Forms PropertyStore", $"Exception while reading Application properties: {e}");
-				}
-				finally
-				{
-					if (stream != null)
-					{
-						stream.Dispose();
-					}
+
 				}
 
 				return null;
@@ -59,52 +54,41 @@ namespace Xamarin.Forms.Platform.Tizen
 			// Make sure to use Internal
 			return Task.Run(() =>
 			{
-				var success = false;
-				var store = new TizenIsolatedStorageFile();
-				Stream stream = null;
-				try
+				using (IsolatedStorageFile store = IsolatedStorageFile.GetUserStoreForApplication())
 				{
 					// No need to write 0 properties if no file exists
 					if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
 					{
 						return;
 					}
-					stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate);
+					using (IsolatedStorageFileStream stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
 					using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 					{
-						stream = null;
-						var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
-						dcs.WriteObject(writer, properties);
-						writer.Flush();
-						success = true;
+						try
+						{
+							var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
+							dcs.WriteObject(writer, properties);
+							writer.Flush();
+						}
+						catch (Exception e)
+						{
+							Debug.WriteLine("Could not serialize properties: " + e.Message);
+							Internals.Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
+							return;
+						}
 					}
-				}
-				catch (Exception e)
-				{
-					Debug.WriteLine("Could not serialize properties: " + e.Message);
-					Internals.Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
-				}
-				finally
-				{
-					if (stream != null)
+
+					try
 					{
-						stream.Dispose();
+						if (store.FileExists(PropertyStoreFile))
+							store.DeleteFile(PropertyStoreFile);
+						store.MoveFile(PropertyStoreFile + ".tmp", PropertyStoreFile);
 					}
-				}
-
-				if (!success)
-					return;
-
-				try
-				{
-					if (store.FileExists(PropertyStoreFile))
-						store.DeleteFile(PropertyStoreFile);
-					store.MoveFile(PropertyStoreFile + ".tmp", PropertyStoreFile);
-				}
-				catch (Exception e)
-				{
-					Debug.WriteLine("Could not move new serialized property file over old: " + e.Message);
-					Internals.Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
+					catch (Exception e)
+					{
+						Debug.WriteLine("Could not move new serialized property file over old: " + e.Message);
+						Internals.Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
+					}
 				}
 			});
 		}

--- a/Xamarin.Forms.Platform.Tizen/Deserializer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Deserializer.cs
@@ -64,6 +64,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				Stream stream = null;
 				try
 				{
+					// No need to write 0 properties if no file exists
+					if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
+					{
+						return;
+					}
 					stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate);
 					using (XmlDictionaryWriter writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 					{

--- a/Xamarin.Forms.Platform.iOS/Deserializer.cs
+++ b/Xamarin.Forms.Platform.iOS/Deserializer.cs
@@ -56,16 +56,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				using (var store = IsolatedStorageFile.GetUserStoreForApplication())
 				{
+					// No need to write 0 properties if no file exists
+					if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
+					{
+						return;
+					}
 					using (var stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
 					using (var writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 					{
 						try
 						{
-							// No need to write 0 properties if no file exists
-							if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
-							{
-								return;
-							}
 							var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
 							dcs.WriteObject(writer, properties);
 							writer.Flush();

--- a/Xamarin.Forms.Platform.iOS/Deserializer.cs
+++ b/Xamarin.Forms.Platform.iOS/Deserializer.cs
@@ -54,29 +54,30 @@ namespace Xamarin.Forms.Platform.MacOS
 			// Make sure to use Internal
 			return Task.Run(() =>
 			{
-				var success = false;
 				using (var store = IsolatedStorageFile.GetUserStoreForApplication())
-				using (var stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
-				using (var writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 				{
-					try
+					using (var stream = store.OpenFile(PropertyStoreFile + ".tmp", System.IO.FileMode.OpenOrCreate))
+					using (var writer = XmlDictionaryWriter.CreateBinaryWriter(stream))
 					{
-						var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
-						dcs.WriteObject(writer, properties);
-						writer.Flush();
-						success = true;
+						try
+						{
+							// No need to write 0 properties if no file exists
+							if (properties.Count == 0 && !store.FileExists(PropertyStoreFile))
+							{
+								return;
+							}
+							var dcs = new DataContractSerializer(typeof(Dictionary<string, object>));
+							dcs.WriteObject(writer, properties);
+							writer.Flush();
+						}
+						catch (Exception e)
+						{
+							Debug.WriteLine("Could not serialize properties: " + e.Message);
+							Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
+							return;
+						}
 					}
-					catch (Exception e)
-					{
-						Debug.WriteLine("Could not serialize properties: " + e.Message);
-						Log.Warning("Xamarin.Forms PropertyStore", $"Exception while writing Application properties: {e}");
-					}
-				}
 
-				if (!success)
-					return;
-				using (var store = IsolatedStorageFile.GetUserStoreForApplication())
-				{
 					try
 					{
 						if (store.FileExists(PropertyStoreFile))


### PR DESCRIPTION
### Description of Change ###

When profiling startup, I was seeing things like:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
          52        0          3 System.IO.IsolatedStorage.IsolatedStorageFile:GetUserStoreForApplication ()
          52        0          3 (wrapper remoting-invoke-with-check) System.IO.IsolatedStorage.IsolatedStorageFile:PostInit ()
          51        0          3 System.IO.IsolatedStorage.IsolatedStorageFile:PostInit ()
          51        0          2 (wrapper remoting-invoke-with-check) System.IO.IsolatedStorage.IsolatedStorageFile:FileExists (string)
          51        0          2 System.IO.IsolatedStorage.IsolatedStorageFile:FileExists (string)
          49        0          4 System.IO.IsolatedStorage.IsolatedStorageFile:IsPathInStorage (string)

This app has no `Properties` at all, but it seems to still be doing
the file I/O for it.

I found that a file was being written that contain a serialized empty
dictionary:

    > adb shell run-as com.xamarin.forms.helloforms cat /data/user/0/com.xamarin.forms.helloforms/files/.config/.isolated-storage/PropertyStore.forms
    @▲ArrayOfKeyValueOfstringanyTyp9http://schemas.microsoft.com/2003/10/Serialization/Arrays       ☺i)http://www.w3.org/2001/XMLSchema-instance☺

Any subsequent startup would parse this file.

Two changes will help here:

1) For writes, use a single instance of:

```csharp
using (var store = IsolatedStorageFile.GetUserStoreForApplication())
```
It appears this call is expensive.

2) On writes, we don't need to write a file at all if the `Properties`
   dictionary is empty and no file is on disk. This way apps that
   don't use `Properties` at all won't load a file with an empty
   dictionary.

#### Results

Using a Release build of the Blank Forms app template on a Pixel 3 XL:

    Before:
    12-13 14:01:42.826  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +606ms
    12-13 14:01:46.541  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +588ms
    12-13 14:01:50.325  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +597ms
    12-13 14:01:54.088  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +600ms
    12-13 14:01:57.855  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +579ms
    12-13 14:02:01.619  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +594ms
    12-13 14:02:05.371  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +605ms
    12-13 14:02:09.106  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +597ms
    12-13 14:02:12.869  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +600ms
    12-13 14:02:16.635  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +601ms
    Average(ms): 596.7
    Std Err(ms): 2.56493448042808
    Std Dev(ms): 8.11103500725332
    After:
    12-13 13:59:46.260  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +600ms
    12-13 13:59:49.993  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +579ms
    12-13 13:59:53.739  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +587ms
    12-13 13:59:57.506  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +592ms
    12-13 14:00:01.255  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +586ms
    12-13 14:00:05.007  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +580ms
    12-13 14:00:08.841  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +581ms
    12-13 14:00:12.587  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +591ms
    12-13 14:00:16.320  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +585ms
    12-13 14:00:20.052  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +577ms
    Average(ms): 585.8
    Std Err(ms): 2.23507394856536
    Std Dev(ms): 7.06792441637257

I think this change saves ~10ms on startup for apps that don't use
`Application.Properties` at all.

I made this change for Android & iOS, as they had similar
implementations.


### Issues Resolved ### 

None

### API Changes ###
 
None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

You could just test startup with an app that doesn't use `Application.Properties`.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
