### PR TITLE
[Android] Fix crash by delaying renderer dispose in the packager

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using Android.OS;
 using Xamarin.Forms.Internals;
 using Android.Views;
 using AView = Android.Views.View;
@@ -263,8 +264,11 @@ namespace Xamarin.Forms.Platform.Android
 			else
 			{
 				_childViews.Remove(renderer);
+
 				renderer.View.RemoveFromParent();
-				renderer.Dispose();
+
+				// Delay the dispose to let the animation finish
+				new Handler(Looper.MainLooper).Post(() => renderer.Dispose());
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
I made several debug sessions to fix crash in the repro #8262.
This kind of issue is always a race condition between the view removal and the view's renderer disposal.

I first identified the problematic dispose in the ViewElementPackager class, if I remove the dispose of the renderer it no more crash.

After that, I succeeded to reproduce the issue with the DefaultRenderer, so it prove that the issue is not specific to the LabelRenderer and is more global.

I noticed that when the DataTemplate contains an image the issue is triggered, but not if I remove it, I think it's confirm the race/timing issue, because the image slow the dispose process of all the layout (image + label in the sample).

The last information that I have found is that a lot of stacktrace contains this line :
> at android.view.ViewRootImpl$InvalidateOnAnimationRunnable.run(ViewRootImpl.java)

https://github.com/xamarin/Xamarin.Forms/issues/2444#issue-313689253
https://github.com/xamarin/Xamarin.Forms/issues/2444#issuecomment-527560451
https://github.com/xamarin/Xamarin.Forms/issues/2444#issuecomment-544620390
https://github.com/xamarin/Xamarin.Forms/issues/2584#issuecomment-400264717
https://github.com/xamarin/Xamarin.Forms/issues/7663#issue-498022043

In the code, the renderer is always disposed after the view has been removed which is right.
But all these stacktraces seem to indicate that the animation has triggered the view invalidation, which called the disposed renderer. This prove that the animation code is executed after the view has been removed. 

So my first try was to cancel the animation of the view removed, but the animation was null because the animation is triggered by the scroll (by the view recycler), so it's not possible to cancel that at the child element level.

So my solution is to delay the dispose of the renderer to be sure that the animation is finished.

This will fix the issue #8262 and all the similar issue with a CollectionView as layout.

Others cases seem similar but it's not clear the layout used : 
- #2444
- #2584
- #7663

If the ListviewRenderer also use the ViewElementPackager it will also fix these issues, if not, a similar fix will need to be applied in others places in the framework code.

### Issues Resolved ### 
- fixes #8262

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Like a lot of dispose issues triggered by some race conditions, the issue can be very hard to trigger so we have no reliable way to test it. We can just test that the others tests not regress.

### PR Checklist ###
- [X] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
