### PR TITLE
Resolve issues with Shell ToolbarItems not reacting to CanExecute Changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
@@ -2,6 +2,7 @@
 using Xamarin.Forms.Internals;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -40,7 +41,6 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, "EnabledText");
 
-
 			var clickCount = new Label();
 			clickCount.AutomationId = "ClickCount";
 			clickCount.SetBinding(Label.TextProperty, "ClickCount");
@@ -65,17 +65,41 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("Add");
 			RunningApp.Tap("Add");
-			
+#if __ANDROID__
+			var toolbarItemColorValue = GetToolbarItemColorValue();
+			int disabledAlpha = GetAlphaValue(toolbarItemColorValue);
+#endif
 			Assert.AreEqual("0", RunningApp.WaitForElement("ClickCount")[0].ReadText());
-			
+
 			RunningApp.Tap("ToggleEnabled");
 			RunningApp.Tap("Add");
-			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
-			
+#if __ANDROID__
+			toolbarItemColorValue = GetToolbarItemColorValue();
+			int enabledAlpha = GetAlphaValue(toolbarItemColorValue);
+			Assert.Less(disabledAlpha, enabledAlpha);
+#endif
+			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());			
+
 			RunningApp.Tap("ToggleEnabled");
 			RunningApp.Tap("Add");
+
 			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
 		}
+
+#if __ANDROID__
+		private object GetToolbarItemColorValue()
+		{
+			return RunningApp.Query(x => x.Text("Add").Invoke("getCurrentTextColor"))[0];
+		}
+
+		private int GetAlphaValue(object toolbarItemColorValue)
+		{
+			int color = Convert.ToInt32(toolbarItemColorValue);
+			int a = (color >> 24) & 0xff;
+			return a;
+		}
+#endif
+
 #endif
 
 		[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
@@ -1,0 +1,142 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8741, "[Bug] [Shell] [Android] ToolbarItem Enabled/Disabled behavior does not work for Shell apps", PlatformAffected.Android)]
+	public class Issue8741 : TestShell
+	{
+		protected override void Init()
+		{
+			var page = CreateContentPage();
+			var toolbarItem = new ToolbarItem
+			{
+				Text = "Add",
+				AutomationId = "Add"
+			};
+
+			toolbarItem.SetBinding(MenuItem.CommandProperty, "ToolbarTappedCommand");
+			page.ToolbarItems.Add(toolbarItem);
+
+			var button = new Button
+			{
+				Text = "Toggle Enabled/Disabled",
+				AutomationId = "ToggleEnabled"
+			};
+
+			button.SetBinding(Button.CommandProperty, "ChangeToggleCommand");
+			var label = new Label();
+			label.SetBinding(Label.TextProperty, "EnabledText");
+
+
+			var clickCount = new Label();
+			clickCount.AutomationId = "ClickCount";
+			clickCount.SetBinding(Label.TextProperty, "ClickCount");
+
+			page.Content =
+				new StackLayout
+				{
+					Children =
+					{
+						label,
+						clickCount,
+						button
+					}
+				};
+
+			BindingContext = new ViewModelIssue8741();
+		}
+
+#if UITEST
+		[Test]
+		public void Issue8741Test()
+		{
+			RunningApp.WaitForElement("Add");
+			RunningApp.Tap("Add");
+			
+			Assert.AreEqual("0", RunningApp.WaitForElement("ClickCount")[0].ReadText());
+			
+			RunningApp.Tap("ToggleEnabled");
+			RunningApp.Tap("Add");
+			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
+			
+			RunningApp.Tap("ToggleEnabled");
+			RunningApp.Tap("Add");
+			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
+		}
+#endif
+
+		[Preserve(AllMembers = true)]
+		public class ViewModelIssue8741 : INotifyPropertyChanged
+		{
+			bool _canAddNewItem;
+			int _clickCount;
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+
+			public bool Enabled
+			{
+				get => _canAddNewItem;
+				set
+				{
+					_canAddNewItem = value;
+					OnPropertyChanged(nameof(Enabled));
+					ToolbarTappedCommand.ChangeCanExecute();
+				}
+			}
+
+			public int ClickCount
+			{
+				get
+				{
+					return _clickCount;
+				}
+				set
+				{
+					_clickCount = value;
+					OnPropertyChanged(nameof(ClickCount));
+				}
+			}
+
+			public string EnabledText { get; set; }
+			public Command ChangeToggleCommand { get; set; }
+			public Command ToolbarTappedCommand { get; set; }
+
+			public ViewModelIssue8741()
+			{
+				ChangeToggleCommand = new Command(ChangeToggle);
+				ToolbarTappedCommand = new Command(ToolbarTapped, () => Enabled);
+				EnabledText = Enabled ? "Enabled" : "Disabled";
+			}
+
+			void ToolbarTapped()
+			{
+				ClickCount++;
+			}
+
+			void ChangeToggle()
+			{
+				Enabled = !Enabled;
+				EnabledText = Enabled ? "Enabled" : "Disabled";
+				OnPropertyChanged(nameof(EnabledText));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -123,6 +123,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8508.xaml.cs">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -12,6 +12,11 @@ namespace Xamarin.Forms.Internals
 	{
 		int _masterDetails;
 		Page _target;
+		ToolBarItemComparer _toolBarItemComparer;
+		public ToolbarTracker()
+		{
+			_toolBarItemComparer = new ToolBarItemComparer();
+		}
 
 		public IEnumerable<Page> AdditionalTargets { get; set; }
 
@@ -42,14 +47,22 @@ namespace Xamarin.Forms.Internals
 		public IEnumerable<ToolbarItem> ToolbarItems
 		{
 			get
-			{
+			{				
 				if (Target == null)
-					return Enumerable.Empty<ToolbarItem>();
-				IEnumerable<ToolbarItem> items = GetCurrentToolbarItems(Target);
-				if (AdditionalTargets != null)
-					items = items.Concat(AdditionalTargets.SelectMany(t => t.ToolbarItems));
+					return new ToolbarItem[0];
 
-				return items.OrderBy(ti => ti.Priority);
+				// I realize this is sorting on every single get but we don't have 
+				// a mechanism in place currently to invalidate a stored version of this
+
+				List<ToolbarItem> returnValue = GetCurrentToolbarItems(Target);
+
+				if (AdditionalTargets != null)
+					foreach(var item in AdditionalTargets)
+						foreach(var toolbarItem in item.ToolbarItems)
+							returnValue.Add(toolbarItem);
+
+				returnValue.Sort(_toolBarItemComparer);
+				return returnValue;
 			}
 		}
 
@@ -58,7 +71,7 @@ namespace Xamarin.Forms.Internals
 		void EmitCollectionChanged()
 			=> CollectionChanged?.Invoke(this, EventArgs.Empty);
 
-		IEnumerable<ToolbarItem> GetCurrentToolbarItems(Page page)
+		List<ToolbarItem> GetCurrentToolbarItems(Page page)
 		{
 			var result = new List<ToolbarItem>();
 			result.AddRange(page.ToolbarItems);
@@ -177,6 +190,11 @@ namespace Xamarin.Forms.Internals
 			page.DescendantAdded -= OnChildAdded;
 			page.DescendantRemoved -= OnChildRemoved;
 			page.PropertyChanged -= OnPropertyChanged;
+		}
+
+		class ToolBarItemComparer : IComparer<ToolbarItem>
+		{
+			public int Compare(ToolbarItem x, ToolbarItem y) => x.Priority.CompareTo(y.Priority);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Internals
 		public IEnumerable<ToolbarItem> ToolbarItems
 		{
 			get
-			{				
+			{
 				if (Target == null)
 					return new ToolbarItem[0];
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -218,8 +218,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					_toolbarTracker.CollectionChanged -= ToolbarTrackerOnCollectionChanged;
 
-					foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
-						item.PropertyChanged -= OnToolbarItemPropertyChanged;
+					_toolbar.DisposeMenuItems(_toolbarTracker?.ToolbarItems, OnToolbarItemPropertyChanged);
 
 					_toolbarTracker.Target = null;
 					_toolbarTracker = null;
@@ -559,7 +558,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		protected virtual void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			_toolbar.OnToolbarItemPropertyChanged(e, _toolbarTracker.ToolbarItems, Context, Color.Default, OnToolbarItemPropertyChanged);
+			_toolbar.OnToolbarItemPropertyChanged(e, _toolbarTracker?.ToolbarItems, Context, null, OnToolbarItemPropertyChanged);
 		}
 
 		void InsertPageBefore(Page page, Page before)
@@ -900,7 +899,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_disposed)
 				return;
 
-			_toolbar.UpdateMenuItems(_toolbarTracker.ToolbarItems, Context, Color.Default, OnToolbarItemPropertyChanged);
+			_toolbar.UpdateMenuItems(_toolbarTracker?.ToolbarItems, Context, null, OnToolbarItemPropertyChanged);
 		}
 
 		void UpdateToolbar()

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -32,8 +32,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 {
 	public class NavigationPageRenderer : VisualElementRenderer<NavigationPage>, IManageFragments, IOnClickListener, ILifeCycleState
 	{
-		const int DefaultDisabledToolbarAlpha = 127;
-
 		readonly List<Fragment> _fragmentStack = new List<Fragment>();
 
 		Drawable _backgroundDrawable;
@@ -561,8 +559,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		protected virtual void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == MenuItem.IsEnabledProperty.PropertyName || e.PropertyName == MenuItem.TextProperty.PropertyName || e.PropertyName == MenuItem.IconImageSourceProperty.PropertyName)
-				UpdateMenu();
+			_toolbar.OnToolbarItemPropertyChanged(e, _toolbarTracker.ToolbarItems, Context, Color.Default, OnToolbarItemPropertyChanged);
 		}
 
 		void InsertPageBefore(Page page, Page before)
@@ -903,51 +900,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (_disposed)
 				return;
 
-			AToolbar bar = _toolbar;
-			Context context = Context;
-			IMenu menu = bar.Menu;
-
-			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
-				item.PropertyChanged -= OnToolbarItemPropertyChanged;
-			menu.Clear();
-
-			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
-			{
-				IMenuItemController controller = item;
-				item.PropertyChanged += OnToolbarItemPropertyChanged;
-				if (item.Order == ToolbarItemOrder.Secondary)
-				{
-					IMenuItem menuItem = menu.Add(item.Text);
-					menuItem.SetEnabled(controller.IsEnabled);
-					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));					
-					menuItem.SetTitleOrContentDescription(item);
-				}
-				else
-				{
-					IMenuItem menuItem = menu.Add(item.Text);
-					menuItem.SetEnabled(controller.IsEnabled);
-					UpdateMenuItemIcon(context, menuItem, item);
-					menuItem.SetShowAsAction(ShowAsAction.Always);
-					menuItem.SetOnMenuItemClickListener(new GenericMenuClickListener(controller.Activate));
-					menuItem.SetTitleOrContentDescription(item);
-				}
-			}
-		}
-
-		protected virtual void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
-		{
-			_ = this.ApplyDrawableAsync(toolBarItem, ToolbarItem.IconImageSourceProperty, Context, iconDrawable =>
-			{
-				if (iconDrawable != null)
-				{
-					if (!menuItem.IsEnabled)
-					{
-						iconDrawable.Mutate().SetAlpha(DefaultDisabledToolbarAlpha);
-					}
-
-					menuItem.SetIcon(iconDrawable);
-				}
-			});
+			_toolbar.UpdateMenuItems(_toolbarTracker.ToolbarItems, Context, Color.Default, OnToolbarItemPropertyChanged);
 		}
 
 		void UpdateToolbar()

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				using (var title = new Java.Lang.String(item.Text))
 				{
-					var menuitem = menu.Add(title);
+					var menuitem = menu.Add(global::Android.Views.Menu.None, 0, item.Priority, title);
 					menuitem.SetEnabled(item.IsEnabled);
 					menuitem.SetTitleOrContentDescription(item);
 					UpdateMenuItemIcon(context, menuitem, item, tintColor);

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -1,0 +1,106 @@
+﻿using System.ComponentModel;
+using Android.Views;
+using AToolbar = Android.Support.V7.Widget.Toolbar;
+using ATextView = global::Android.Widget.TextView;
+using Android.Content;
+using Android.Graphics;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal static class ToolbarExtensions
+	{
+		const int DefaultDisabledToolbarAlpha = 127;
+		public static void DisposeMenuItems(this AToolbar toolbar, Page page, PropertyChangedEventHandler toolbarItemChanged)
+		{
+			if (page?.ToolbarItems?.Count > 0)
+			{
+				foreach (var item in page.ToolbarItems)
+					item.PropertyChanged -= toolbarItemChanged;
+			}
+		}
+
+		public static void UpdateMenuItems(this AToolbar toolbar,
+			IEnumerable<ToolbarItem> toolbarItems, 
+			Context context, 
+			Color tintColor,
+			PropertyChangedEventHandler toolbarItemChanged
+			)
+		{
+			var menu = toolbar.Menu;
+			menu.Clear();
+
+			foreach (var item in toolbarItems)
+			{
+				item.PropertyChanged -= toolbarItemChanged;
+				item.PropertyChanged += toolbarItemChanged;
+
+				using (var title = new Java.Lang.String(item.Text))
+				{
+					var menuitem = menu.Add(title);
+					menuitem.SetEnabled(item.IsEnabled);
+					menuitem.SetTitleOrContentDescription(item);
+					UpdateMenuItemIcon(context, menuitem, item, tintColor);
+
+					if (item.Order != ToolbarItemOrder.Secondary)
+						menuitem.SetShowAsAction(ShowAsAction.Always);
+
+					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
+
+					if (tintColor != Color.Default)
+					{
+						var view = toolbar.FindViewById(menuitem.ItemId);
+						if (view is ATextView textView)
+						{
+							if (item.IsEnabled)
+								textView.SetTextColor(tintColor.ToAndroid());
+							else
+								textView.SetTextColor(tintColor.MultiplyAlpha(0.302).ToAndroid());
+						}
+					}
+
+					menuitem.Dispose();
+				}
+			}
+
+		}
+
+		static void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem, Color tintColor)
+		{
+			_ = context.ApplyDrawableAsync(toolBarItem, ToolbarItem.IconImageSourceProperty, baseDrawable =>
+			{
+				if (baseDrawable != null)
+				{
+					using (var constant = baseDrawable.GetConstantState())
+					using (var newDrawable = constant.NewDrawable())
+					using (var iconDrawable = newDrawable.Mutate())
+					{
+						iconDrawable.SetColorFilter(tintColor.ToAndroid(Color.White), PorterDuff.Mode.SrcAtop);
+						if (!menuItem.IsEnabled)
+						{
+							iconDrawable.Mutate().SetAlpha(DefaultDisabledToolbarAlpha);
+						}
+
+						menuItem.SetIcon(iconDrawable);
+					}
+				}
+			});
+		}
+
+		public static void OnToolbarItemPropertyChanged(
+			this AToolbar toolbar,
+			PropertyChangedEventArgs e,
+			IEnumerable<ToolbarItem> toolbarItems,
+			Context context,
+			Color tintColor,
+			PropertyChangedEventHandler toolbarItemChanged)
+		{
+			if (e.IsOneOf(MenuItem.TextProperty, MenuItem.IconImageSourceProperty, MenuItem.IsEnabledProperty))
+			{
+				toolbar.UpdateMenuItems(toolbarItems, context, tintColor, toolbarItemChanged);
+			}
+		}
+
+		
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -11,22 +11,25 @@ namespace Xamarin.Forms.Platform.Android
 	internal static class ToolbarExtensions
 	{
 		const int DefaultDisabledToolbarAlpha = 127;
-		public static void DisposeMenuItems(this AToolbar toolbar, Page page, PropertyChangedEventHandler toolbarItemChanged)
+		public static void DisposeMenuItems(this AToolbar toolbar, IEnumerable<ToolbarItem> toolbarItems, PropertyChangedEventHandler toolbarItemChanged)
 		{
-			if (page?.ToolbarItems?.Count > 0)
-			{
-				foreach (var item in page.ToolbarItems)
-					item.PropertyChanged -= toolbarItemChanged;
-			}
+			if (toolbarItems == null)
+				return;
+
+			foreach (var item in toolbarItems)
+				item.PropertyChanged -= toolbarItemChanged;
 		}
 
 		public static void UpdateMenuItems(this AToolbar toolbar,
 			IEnumerable<ToolbarItem> toolbarItems, 
 			Context context, 
-			Color tintColor,
+			Color? tintColor,
 			PropertyChangedEventHandler toolbarItemChanged
 			)
 		{
+			if (toolbarItems == null)
+				return;
+
 			var menu = toolbar.Menu;
 			menu.Clear();
 
@@ -47,25 +50,24 @@ namespace Xamarin.Forms.Platform.Android
 
 					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
 
-					if (tintColor != Color.Default)
+					if (tintColor != null && tintColor != Color.Default)
 					{
 						var view = toolbar.FindViewById(menuitem.ItemId);
 						if (view is ATextView textView)
 						{
 							if (item.IsEnabled)
-								textView.SetTextColor(tintColor.ToAndroid());
+								textView.SetTextColor(tintColor.Value.ToAndroid());
 							else
-								textView.SetTextColor(tintColor.MultiplyAlpha(0.302).ToAndroid());
+								textView.SetTextColor(tintColor.Value.MultiplyAlpha(0.302).ToAndroid());
 						}
 					}
 
 					menuitem.Dispose();
 				}
 			}
-
 		}
 
-		static void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem, Color tintColor)
+		static void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
 		{
 			_ = context.ApplyDrawableAsync(toolBarItem, ToolbarItem.IconImageSourceProperty, baseDrawable =>
 			{
@@ -75,7 +77,9 @@ namespace Xamarin.Forms.Platform.Android
 					using (var newDrawable = constant.NewDrawable())
 					using (var iconDrawable = newDrawable.Mutate())
 					{
-						iconDrawable.SetColorFilter(tintColor.ToAndroid(Color.White), PorterDuff.Mode.SrcAtop);
+						if(tintColor != null)
+							iconDrawable.SetColorFilter(tintColor.Value.ToAndroid(Color.White), PorterDuff.Mode.SrcAtop);
+
 						if (!menuItem.IsEnabled)
 						{
 							iconDrawable.Mutate().SetAlpha(DefaultDisabledToolbarAlpha);
@@ -92,15 +96,16 @@ namespace Xamarin.Forms.Platform.Android
 			PropertyChangedEventArgs e,
 			IEnumerable<ToolbarItem> toolbarItems,
 			Context context,
-			Color tintColor,
+			Color? tintColor,
 			PropertyChangedEventHandler toolbarItemChanged)
 		{
+			if (toolbarItems == null)
+				return;
+
 			if (e.IsOneOf(MenuItem.TextProperty, MenuItem.IconImageSourceProperty, MenuItem.IsEnabledProperty))
 			{
 				toolbar.UpdateMenuItems(toolbarItems, context, tintColor, toolbarItemChanged);
 			}
 		}
-
-		
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -405,14 +405,15 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
+			var toolbarItems = _toolbarTracker.ToolbarItems;
+			foreach (ToolbarItem item in toolbarItems)
 				item.PropertyChanged -= HandleToolbarItemPropertyChanged;
 			menu.Clear();
 
 			if (!ShouldShowActionBarTitleArea())
 				return;
 
-			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
+			foreach (ToolbarItem item in toolbarItems)
 			{
 				IMenuItemController controller = item;
 				item.PropertyChanged += HandleToolbarItemPropertyChanged;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -20,6 +20,7 @@ using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
 using ATextView = global::Android.Widget.TextView;
 using Android.Support.Design.Widget;
 using AColor = Android.Graphics.Color;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -169,7 +170,7 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.SearchConfirmed -= OnSearchConfirmed;
 					_searchView.Dispose();
 				}
-        
+
 				_drawerToggle?.Dispose();
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -487,8 +487,6 @@ namespace Xamarin.Forms.Platform.Android
 				_titleViewContainer.View = titleView;
 			}
 		}
-		
-
 
 		protected virtual void UpdateToolbarItems(Toolbar toolbar, Page page)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -19,6 +19,7 @@ using Toolbar = Android.Support.V7.Widget.Toolbar;
 using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
 using ATextView = global::Android.Widget.TextView;
 using Android.Support.Design.Widget;
+using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -153,6 +154,10 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_backButtonBehavior != null)
 					_backButtonBehavior.PropertyChanged -= OnBackButtonBehaviorChanged;
+
+
+				_toolbar.DisposeMenuItems(Page, OnToolbarItemPropertyChanged);
+
 				((IShellController)_shellContext?.Shell)?.RemoveFlyoutBehaviorObserver(this);
 
 				UpdateTitleView(_shellContext.AndroidContext, _toolbar, null);
@@ -481,38 +486,13 @@ namespace Xamarin.Forms.Platform.Android
 				_titleViewContainer.View = titleView;
 			}
 		}
+		
+
 
 		protected virtual void UpdateToolbarItems(Toolbar toolbar, Page page)
 		{
 			var menu = toolbar.Menu;
-			menu.Clear();
-
-			foreach (var item in page.ToolbarItems)
-			{
-				using (var title = new Java.Lang.String(item.Text))
-				{
-					var menuitem = menu.Add(title);
-					UpdateMenuItemIcon(_shellContext.AndroidContext, menuitem, item);
-
-					menuitem.SetTitleOrContentDescription(item);
-					menuitem.SetEnabled(item.IsEnabled);
-
-					if (item.Order != ToolbarItemOrder.Secondary)
-						menuitem.SetShowAsAction(ShowAsAction.Always);
-
-					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
-					
-					if(TintColor != Color.Default)
-					{
-						var view = toolbar.FindViewById(menuitem.ItemId);
-						if (view is ATextView  textView)
-							textView.SetTextColor(TintColor.ToAndroid());
-					}
-
-					menuitem.Dispose();
-
-				}
-			}
+			toolbar.UpdateMenuItems(page.ToolbarItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
 
 			SearchHandler = Shell.GetSearchHandler(page);
 			if (SearchHandler != null && SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Hidden)
@@ -571,6 +551,11 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			menu.Dispose();
+		}
+
+		void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			_toolbar.OnToolbarItemPropertyChanged(e, Page.ToolbarItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
 		}
 
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -156,7 +156,7 @@ namespace Xamarin.Forms.Platform.Android
 					_backButtonBehavior.PropertyChanged -= OnBackButtonBehaviorChanged;
 
 
-				_toolbar.DisposeMenuItems(Page, OnToolbarItemPropertyChanged);
+				_toolbar.DisposeMenuItems(Page?.ToolbarItems, OnToolbarItemPropertyChanged);
 
 				((IShellController)_shellContext?.Shell)?.RemoveFlyoutBehaviorObserver(this);
 

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -116,6 +116,7 @@
     <Compile Include="Extensions\FragmentManagerExtensions.cs" />
     <Compile Include="Extensions\ScrollViewExtensions.cs" />
     <Compile Include="Extensions\TextAlignmentExtensions.cs" />
+    <Compile Include="Extensions\ToolbarExtensions.cs" />
     <Compile Include="FastRenderers\AutomationPropertiesProvider.cs" />
     <Compile Include="AppCompat\PageExtensions.cs" />
     <Compile Include="Extensions\JavaObjectExtensions.cs" />

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -431,7 +431,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var toolBarForegroundBinder = GetToolbarProvider() as IToolBarForegroundBinder;
 
-			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems.OrderBy(ti => ti.Priority))
+			foreach (ToolbarItem item in _toolbarTracker.ToolbarItems)
 			{
 				toolBarForegroundBinder?.BindForegroundColor(commandBar);
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1210,7 +1210,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 				List<UIBarButtonItem> primaries = null;
 				List<UIBarButtonItem> secondaries = null;
-				foreach (var item in _tracker.ToolbarItems)
+				var toolbarItems = _tracker.ToolbarItems;
+				foreach (var item in toolbarItems)
 				{
 					if (item.Order == ToolbarItemOrder.Secondary)
 						(secondaries = secondaries ?? new List<UIBarButtonItem>()).Add(item.ToUIBarButtonItem(true));

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -200,7 +200,7 @@ namespace Xamarin.Forms.Platform.iOS
 			List<UIBarButtonItem> items = new List<UIBarButtonItem>();
 			if (Page != null)
 			{
-				foreach (var item in Page.ToolbarItems)
+				foreach (var item in System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x=> x.Priority))
 				{
 					items.Add(item.ToUIBarButtonItem(false, true));
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -197,19 +197,19 @@ namespace Xamarin.Forms.Platform.iOS
 					NavigationItem.RightBarButtonItems[i].Dispose();
 			}
 
-			UIBarButtonItem[] items = null;
-			if (Page != null)
+			List<UIBarButtonItem> primaries = null;
+			if (Page.ToolbarItems.Count > 0)
 			{
-				int index = 0;
-				foreach (var item in System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x=> x.Priority))
+				foreach (var item in System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x => x.Priority))
 				{
-					items[index] = item.ToUIBarButtonItem(false, true);
-					index++;
+					(primaries = primaries ?? new List<UIBarButtonItem>()).Add(item.ToUIBarButtonItem(false, true));
 				}
+
+				if (primaries != null)
+					primaries.Reverse();
 			}
-						
-			Array.Reverse(items);
-			NavigationItem.SetRightBarButtonItems(items, false);
+
+			NavigationItem.SetRightBarButtonItems(primaries == null ? new UIBarButtonItem[0] : primaries.ToArray(), false);
 
 			var behavior = BackButtonBehavior;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -197,17 +197,19 @@ namespace Xamarin.Forms.Platform.iOS
 					NavigationItem.RightBarButtonItems[i].Dispose();
 			}
 
-			List<UIBarButtonItem> items = new List<UIBarButtonItem>();
+			UIBarButtonItem[] items = null;
 			if (Page != null)
 			{
+				int index = 0;
 				foreach (var item in System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x=> x.Priority))
 				{
-					items.Add(item.ToUIBarButtonItem(false, true));
+					items[index] = item.ToUIBarButtonItem(false, true);
+					index++;
 				}
 			}
-
-			items.Reverse();
-			NavigationItem.SetRightBarButtonItems(items.ToArray(), false);
+						
+			Array.Reverse(items);
+			NavigationItem.SetRightBarButtonItems(items, false);
 
 			var behavior = BackButtonBehavior;
 


### PR DESCRIPTION
### Description of Change ###
Fixed Android ToolbarItems so that they update functionally and visually as CanExecuteChages toggles. This addressed both the Text and Icon not changing alpha values when disabled

The code on the NavigationPage was identical to the shell code so I extracted all of that to a reusable Extension method for both of them


### Issues Resolved ### 
- fixes #8741 
- fixes #8327

### Platforms Affected ### 
- Android
- iOS

### Testing Procedure ###
- UI test included
- run through a few tool bar item tests with navigation page to make sure it works as well

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
