### PR TITLE
Fix for 8741: Assert that ToolbarItem is grayed-out (PR 8889)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
@@ -2,6 +2,7 @@
 using Xamarin.Forms.Internals;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -40,7 +41,6 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label();
 			label.SetBinding(Label.TextProperty, "EnabledText");
 
-
 			var clickCount = new Label();
 			clickCount.AutomationId = "ClickCount";
 			clickCount.SetBinding(Label.TextProperty, "ClickCount");
@@ -65,16 +65,35 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("Add");
 			RunningApp.Tap("Add");
-			
+			var toolbarItemColorValue = GetToolbarItemColorValue();
+			int disabledAlpha = GetAlphaValue(toolbarItemColorValue);
+
 			Assert.AreEqual("0", RunningApp.WaitForElement("ClickCount")[0].ReadText());
-			
+
 			RunningApp.Tap("ToggleEnabled");
 			RunningApp.Tap("Add");
+			toolbarItemColorValue = GetToolbarItemColorValue();
+			int enabledAlpha = GetAlphaValue(toolbarItemColorValue);
+
 			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
-			
+			Assert.Less(disabledAlpha, enabledAlpha);
+
 			RunningApp.Tap("ToggleEnabled");
 			RunningApp.Tap("Add");
+
 			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
+		}
+
+		private object GetToolbarItemColorValue()
+		{
+			return RunningApp.Query(x => x.Text("Add").Invoke("getCurrentTextColor"))[0];
+		}
+
+		private int GetAlphaValue(object toolbarItemColorValue)
+		{
+			int color = Convert.ToInt32(toolbarItemColorValue);
+			int a = (color >> 24) & 0xff;
+			return a;
 		}
 #endif
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8741.cs
@@ -65,18 +65,20 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("Add");
 			RunningApp.Tap("Add");
+#if __ANDROID__
 			var toolbarItemColorValue = GetToolbarItemColorValue();
 			int disabledAlpha = GetAlphaValue(toolbarItemColorValue);
-
+#endif
 			Assert.AreEqual("0", RunningApp.WaitForElement("ClickCount")[0].ReadText());
 
 			RunningApp.Tap("ToggleEnabled");
 			RunningApp.Tap("Add");
+#if __ANDROID__
 			toolbarItemColorValue = GetToolbarItemColorValue();
 			int enabledAlpha = GetAlphaValue(toolbarItemColorValue);
-
-			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
 			Assert.Less(disabledAlpha, enabledAlpha);
+#endif
+			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());			
 
 			RunningApp.Tap("ToggleEnabled");
 			RunningApp.Tap("Add");
@@ -84,6 +86,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.AreEqual("1", RunningApp.WaitForElement("ClickCount")[0].ReadText());
 		}
 
+#if __ANDROID__
 		private object GetToolbarItemColorValue()
 		{
 			return RunningApp.Query(x => x.Text("Add").Invoke("getCurrentTextColor"))[0];
@@ -95,6 +98,8 @@ namespace Xamarin.Forms.Controls.Issues
 			int a = (color >> 24) & 0xff;
 			return a;
 		}
+#endif
+
 #endif
 
 		[Preserve(AllMembers = true)]


### PR DESCRIPTION
@PureWeen 
There have been some recent changes around the tint color of toolbar/menu items on Android. Such changes being the second aspect of this fix, I'd like us to assert in the issue test that the graying-out works, in order to keep the code around this stable. 