### PR TITLE
Convert elevation platform specific to correct pixel scale

### DIFF
--- a/Xamarin.Forms.Platform.Android/Elevation.cs
+++ b/Xamarin.Forms.Platform.Android/Elevation.cs
@@ -1,3 +1,4 @@
+using Android.Content;
 using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
@@ -11,9 +12,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			var iec = element as IElementConfiguration<VisualElement>;
-			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
-
+			var elevation = GetElevation(element, view.Context);
 			if (!elevation.HasValue)
 			{
 				return;
@@ -32,7 +31,7 @@ namespace Xamarin.Forms.Platform.Android
 			return view.Elevation;
 		}
 
-		internal static float? GetElevation(VisualElement element)
+		internal static float? GetElevation(VisualElement element, Context context)
 		{
 			if (element == null || !Forms.IsLollipopOrNewer)
 			{
@@ -42,7 +41,10 @@ namespace Xamarin.Forms.Platform.Android
 			var iec = element as IElementConfiguration<VisualElement>;
 			var elevation = iec?.On<PlatformConfiguration.Android>().GetElevation();
 
-			return elevation;
+			if (elevation == null)
+				return elevation;
+
+			return context.ToPixels(elevation.Value);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -178,7 +178,7 @@ namespace Xamarin.Forms.Platform.Android
 						if (Forms.IsLollipopOrNewer)
 						{
 							var elevation = ElevationHelper.GetElevation(r.View) ?? 0;
-							var elementElevation = ElevationHelper.GetElevation(element);
+							var elementElevation = ElevationHelper.GetElevation(element, r.View.Context);
 
 							if (elementElevation == null)
 							{


### PR DESCRIPTION
### Description of Change ###
The elevation property on the android view is scaled to the device density. Currently we are just setting the elevation to the exact same value specified on the platform specific but this will cause different behavior on different devices.

You can see this issue if you try to match the elevation of a control at the xplat level with the native level

For example the code below works fine across APIs and device scales with this change but without it you can't correctly set an Elevation that works across devices

```
<Grid>
            <Grid.RowDefinitions>
                <RowDefinition Height="300"></RowDefinition>
                <RowDefinition Height="*"></RowDefinition>
            </Grid.RowDefinitions>
            <Grid.ColumnDefinitions>
                <ColumnDefinition Width="300"></ColumnDefinition>
                <ColumnDefinition Width="*"></ColumnDefinition>
            </Grid.ColumnDefinitions>
            <Button BackgroundColor="Green" />
            <Image android:VisualElement.Elevation="6" Source="coffee.png" VerticalOptions="Center" HorizontalOptions="Center"></Image>
        </Grid>
```

### Issues Resolved ### 
- partially fixes #8869

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
- This is going to cause the behavior for anyone using the elevation platform specific to change slightly since it's now going to be multiplied by the device density. 

### Testing Procedure ###
- run through any elevation UI tests and convince yourself this isn't the wrong change

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
