### PR TITLE
Improve animation behavior with regard to power saving mode

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MotionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MotionTests.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Threading.Tasks;
 using NUnit.Framework;
 using Xamarin.Forms.Internals;
@@ -247,7 +248,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public async Task AnimationExtensionsReturnTrueIfAnimationsDisabled() 
 		{
-			DisableTicker();
+			await DisableTicker();
 
 			var label = new Label { Text = "Foo" };
 			var result = await label.ScaleTo(2, 500);
@@ -258,7 +259,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test, Timeout(2000)]
 		public async Task CanExitAnimationLoopIfAnimationsDisabled() 
 		{
-			DisableTicker();
+			await DisableTicker();
 
 			var run = true;
 			var label = new Label { Text = "Foo" };

--- a/Xamarin.Forms.Core.UnitTests/MotionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MotionTests.cs
@@ -174,6 +174,12 @@ namespace Xamarin.Forms.Core.UnitTests
 			((AsyncTicker)Ticker.Default).SetEnabled(false);
 		}
 
+		static async Task EnableTicker()
+		{
+			await Task.Delay(32);
+			((AsyncTicker)Ticker.Default).SetEnabled(true);
+		}
+
 		async Task SwapFadeViews(View view1, View view2)
 		{
 			await view1.FadeTo(0, 1000);
@@ -262,6 +268,16 @@ namespace Xamarin.Forms.Core.UnitTests
 				await label.ScaleTo(2, 500);
 				run = !(await label.ScaleTo(0.5, 500));
 			}
-		} 
+		}
+
+		[Test]
+		public async Task CanCheckThatAnimationsAreEnabled() 
+		{
+			await EnableTicker();
+			Assert.That(Animation.IsEnabled, Is.True);
+
+			await DisableTicker();
+			Assert.That(Animation.IsEnabled, Is.False);
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/MotionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MotionTests.cs
@@ -237,5 +237,31 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(view.RotationY, Is.EqualTo(200));
 		}
+
+		[Test]
+		public async Task AnimationExtensionsReturnTrueIfAnimationsDisabled() 
+		{
+			DisableTicker();
+
+			var label = new Label { Text = "Foo" };
+			var result = await label.ScaleTo(2, 500);
+
+			Assert.That(result, Is.True);
+		}
+
+		[Test, Timeout(2000)]
+		public async Task CanExitAnimationLoopIfAnimationsDisabled() 
+		{
+			DisableTicker();
+
+			var run = true;
+			var label = new Label { Text = "Foo" };
+
+			while (run)
+			{
+				await label.ScaleTo(2, 500);
+				run = !(await label.ScaleTo(0.5, 500));
+			}
+		} 
 	}
 }

--- a/Xamarin.Forms.Core/Animation.cs
+++ b/Xamarin.Forms.Core/Animation.cs
@@ -140,5 +140,13 @@ namespace Xamarin.Forms
 			_children.Add(child);
 			return this;
 		}
+
+		public static bool IsEnabled 
+		{
+			get 
+			{
+				return Internals.Ticker.Default.SystemEnabled;
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Core/AnimationExtensions.cs
+++ b/Xamarin.Forms.Core/AnimationExtensions.cs
@@ -239,7 +239,9 @@ namespace Xamarin.Forms
 				var repeat = false;
 
 				// If the Ticker has been disabled (e.g., by power save mode), then don't repeat the animation
-				if (info.Repeat != null && Ticker.Default.SystemEnabled)
+				var animationsEnabled = Ticker.Default.SystemEnabled;
+
+				if (info.Repeat != null && animationsEnabled)
 					repeat = info.Repeat();
 
 				if (!repeat)
@@ -249,7 +251,7 @@ namespace Xamarin.Forms
 					tweener.Finished -= HandleTweenerFinished;
 				}
 
-				info.Finished?.Invoke(tweener.Value, false);
+				info.Finished?.Invoke(tweener.Value, !animationsEnabled);
 
 				if (info.Owner.TryGetTarget(out owner))
 					owner.BatchCommit();

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -20,7 +20,6 @@ using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android;
 using Resource = Android.Resource;
 using Trace = System.Diagnostics.Trace;
-using ALayoutDirection = Android.Views.LayoutDirection;
 using System.ComponentModel;
 
 namespace Xamarin.Forms
@@ -36,9 +35,9 @@ namespace Xamarin.Forms
 		public InitializationOptions(Context activity, Bundle bundle, Assembly resourceAssembly)
 		{
 			this = default(InitializationOptions);
-			this.Activity = activity;
-			this.Bundle = bundle;
-			this.ResourceAssembly = resourceAssembly;
+			Activity = activity;
+			Bundle = bundle;
+			ResourceAssembly = resourceAssembly;
 		}
 		public Context Activity;
 		public Bundle Bundle;
@@ -50,7 +49,6 @@ namespace Xamarin.Forms
 
 	public static class Forms
 	{
-
 		const int TabletCrossover = 600;
 
 		static BuildVersionCodes? s_sdkInt;
@@ -58,6 +56,8 @@ namespace Xamarin.Forms
 		static bool? s_is29OrNewer;
 		static bool? s_isMarshmallowOrNewer;
 		static bool? s_isNougatOrNewer;
+		static bool? s_isOreoOrNewer;
+		static bool? s_isJellyBeanMr1OrNewer;
 
 		[Obsolete("Context is obsolete as of version 2.5. Please use a local context instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -73,14 +73,8 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static BuildVersionCodes SdkInt {
-			get {
-				if (!s_sdkInt.HasValue)
-					s_sdkInt = Build.VERSION.SdkInt;
-				return (BuildVersionCodes)s_sdkInt;
-			}
-		}
-
+		internal static BuildVersionCodes SdkInt => Anticipator.SdkInt;
+		
 		internal static bool Is29OrNewer
 		{
 			get
@@ -90,13 +84,23 @@ namespace Xamarin.Forms
 				return s_is29OrNewer.Value;
 			}
 		}
+		
+		internal static bool IsJellyBeanMr1OrNewer
+		{
+			get
+			{
+				if (!s_isJellyBeanMr1OrNewer.HasValue)
+					s_isJellyBeanMr1OrNewer = SdkInt >= BuildVersionCodes.JellyBeanMr1;
+				return s_isJellyBeanMr1OrNewer.Value;
+			}
+		}
 
 		internal static bool IsLollipopOrNewer
 		{
 			get
 			{
 				if (!s_isLollipopOrNewer.HasValue)
-					s_isLollipopOrNewer = (int)SdkInt >= 21;
+					s_isLollipopOrNewer = SdkInt >= BuildVersionCodes.Lollipop;
 				return s_isLollipopOrNewer.Value;
 			}
 		}
@@ -106,7 +110,7 @@ namespace Xamarin.Forms
 			get
 			{
 				if (!s_isMarshmallowOrNewer.HasValue)
-					s_isMarshmallowOrNewer = (int)SdkInt >= 23;
+					s_isMarshmallowOrNewer = SdkInt >= BuildVersionCodes.M;
 				return s_isMarshmallowOrNewer.Value;
 			}
 		}
@@ -116,8 +120,18 @@ namespace Xamarin.Forms
 			get
 			{
 				if (!s_isNougatOrNewer.HasValue)
-					s_isNougatOrNewer = (int)Build.VERSION.SdkInt >= 24;
+					s_isNougatOrNewer = SdkInt >= BuildVersionCodes.N;
 				return s_isNougatOrNewer.Value;
+			}
+		}
+
+		internal static bool IsOreoOrNewer
+		{
+			get
+			{
+				if (!s_isOreoOrNewer.HasValue)
+					s_isOreoOrNewer = SdkInt >= BuildVersionCodes.O;
+				return s_isOreoOrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -73,8 +73,16 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static BuildVersionCodes SdkInt => Anticipator.SdkInt;
-		
+		internal static BuildVersionCodes SdkInt
+		{
+			get
+			{
+				if (!s_sdkInt.HasValue)
+					s_sdkInt = Build.VERSION.SdkInt;
+				return (BuildVersionCodes)s_sdkInt;
+			}
+		}
+
 		internal static bool Is29OrNewer
 		{
 			get

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -185,6 +185,7 @@ namespace Xamarin.Forms.Platform.Android
 					PowerManager.ActionPowerSaveModeChanged));
 
 				_powerSaveReceiverRegistered = true;
+				_powerSaveModeBroadcastReceiver.CheckAnimationEnabledStatus();
 			}
 
 			OnStateChanged();

--- a/Xamarin.Forms.Platform.Android/PowerSaveModeBroadcastReceiver.cs
+++ b/Xamarin.Forms.Platform.Android/PowerSaveModeBroadcastReceiver.cs
@@ -8,7 +8,12 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public override void OnReceive(Context context, Intent intent)
 		{
-			((AndroidTicker)Ticker.Default).CheckPowerSaveModeStatus();
+			CheckAnimationEnabledStatus();
+		}
+
+		public void CheckAnimationEnabledStatus() 
+		{
+			((AndroidTicker)Ticker.Default).CheckAnimationEnabledStatus();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Modify animation helpers to return `true` (i.e., "canceled") when force-finishing animations because the ticker is system-disabled; this allows users of the animation methods to react accordingly when their awaited looped animations are returning immediately because animations have been disabled by the system (e.g., because of power saving mode).

These changes also add a public method to the Animation class allowing the user to determine if animations have been disabled by the system.

Finally, for newer API levels (26+), the Android power saving mode check no longer just disables the animations; rather, it makes a check with AreAnimationsEnabled; this allows the animations to continue working if the power saving mode doesn't actually disable them (e.g., on Samsung devices with "medium" power saving modes).

See also the discussion [here](https://github.com/xamarin/Xamarin.Forms/issues/7500#issuecomment-552153036)

### Issues Resolved ### 

- fixes #7500
- fixes #8634

### API Changes ###

Added:

`public static bool Animation.IsEnabled { get; }`

### Platforms Affected ### 
- Core/XAML (all platforms)
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Issue 1556 (manual test)

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
