### PR TITLE
Change build output on 2017 to match 2019

### DIFF
--- a/.nuspec/Xamarin.Forms.AppLinks.nuspec
+++ b/.nuspec/Xamarin.Forms.AppLinks.nuspec
@@ -25,6 +25,6 @@
     </references>
   </metadata>
   <files>
-    <file src="..\Xamarin.Forms.Platform.Android.AppLinks\bin\$Configuration$\MonoAndroid90\90\Xamarin.Forms.Platform.Android.AppLinks.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Platform.Android.AppLinks\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.Android.AppLinks.dll" target="lib\MonoAndroid90" />
   </files>
 </package>

--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -34,7 +34,7 @@
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\netstandard2.0" />
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\netstandard2.0" />
 
-    <file src="..\Xamarin.Forms.Maps.Android\bin\$Configuration$\MonoAndroid90\90\Xamarin.Forms.Maps.Android.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Maps.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Maps.Android.dll" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\MonoAndroid90" />
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\MonoAndroid90" />
 

--- a/.nuspec/Xamarin.Forms.Visual.Material.nuspec
+++ b/.nuspec/Xamarin.Forms.Visual.Material.nuspec
@@ -43,9 +43,9 @@
     <file src="Xamarin.Forms.Visual.Material.targets" target="build\MonoAndroid10\Xamarin.Forms.Visual.Material.targets" />
 
     <!--Android 90-->
-    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid90\90\Xamarin.Forms.Material.dll" target="lib\MonoAndroid90" />
-    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid90\90\Xamarin.Forms.Material.*pdb" target="lib\MonoAndroid90" />
-    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid90\90\Xamarin.Forms.Material.*mdb" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid90\Xamarin.Forms.Material.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid90\Xamarin.Forms.Material.*pdb" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid90\Xamarin.Forms.Material.*mdb" target="lib\MonoAndroid90" />
 
     <!--iOS-->
     <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.dll" target="lib\Xamarin.iOS10" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -149,8 +149,8 @@
     <file src="proguard.cfg" target="build\MonoAndroid10\proguard.cfg" />
     
     <!--Android 90-->
-    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\90\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid90" />
-    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\90\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid90" />
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.dll" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.*pdb" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid90" />
@@ -161,7 +161,7 @@
     <file src="..\docs\**\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid90" />
-    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\90\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid90" />
+    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid90" />
 
     <!--iPhone Unified-->
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="lib\Xamarin.iOS10" />

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -10,6 +10,10 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <Compile Include="..\Xamarin.Forms.Platform.cs" Link="Xamarin.Forms.Platform.cs" />
   </ItemGroup>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -9,7 +9,10 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
-
+  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
     </ProjectReference>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -11,6 +11,10 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\**\*" />
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -12,6 +12,10 @@
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
   </PropertyGroup>
+  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
+  </PropertyGroup>
   <ItemGroup>
     <None Remove="Resources\values\Strings.xml" />
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -6,10 +6,14 @@
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <RootNamespace>Xamarin.Forms.Platform.Android</RootNamespace>
-    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>    
+    <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)'=='Debug' ">
     <DebugSymbols>true</DebugSymbols>
+  </PropertyGroup>
+  <PropertyGroup  Condition="'$(MSBuildAssemblyVersion)' != '16.0'">
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="AppCompat\Resource.cs" />
@@ -34,4 +38,5 @@
     <ProjectReference Include="..\Xamarin.Forms.Platform.Android.FormsViewGroup\Xamarin.Forms.Platform.Android.FormsViewGroup.csproj">
     </ProjectReference>
   </ItemGroup>
+  
 </Project>


### PR DESCRIPTION
### Description of Change ###

VS2017 places the binary files into *MonoAndroid90\90\*
VS2019 places the binary files into *MonoAndroid90\*

This PR makes VS2017 like VS2019 so that the nuspecs can just stay the same regardless if you're building on vs2017 or vs2019


### Testing Procedure ###
- test generated nugets

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
