### PR TITLE
Package up everything into the PRI file for debug and release builds

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -204,7 +204,7 @@
     <file src="..\Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.iOS10" />
 
     <!--UWP-->
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Plfuwpatform.UAP.dll" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -206,10 +206,10 @@
     <!--UWP-->
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Properties" />
+    <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0\Properties" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.pri" target="lib\uap10.0" />
 
     <!--Mac-->

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -206,50 +206,11 @@
     <!--UWP-->
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.pri" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Properties" />
-
-    
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsFlyout.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCommandBarStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsProgressBarStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Resources.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsTextBoxStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\AutoSuggestStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\SliderStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\MasterDetailControlStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PageControlStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\TabbedPageStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsEmbeddedPageWrapper.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\StepperControl.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\CollectionView\ItemsViewStyles.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\CollectionView" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCheckBoxStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\Compact.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Shell\ShellStyles.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Shell" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PickerStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\generic.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\" />
-
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsFlyout.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCommandBarStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsProgressBarStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Resources.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsTextBoxStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\AutoSuggestStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\SliderStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\MasterDetailControlStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PageControlStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\TabbedPageStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsEmbeddedPageWrapper.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\StepperControl.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\CollectionView\ItemsViewStyles.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\CollectionView" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCheckBoxStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\Compact.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Shell\ShellStyles.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Shell" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PickerStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\generic.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.pri" target="lib\uap10.0" />
 
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -204,9 +204,9 @@
     <file src="..\Stubs\Xamarin.Forms.Platform.iOS\bin\iPhone\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.iOS10" />
 
     <!--UWP-->
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.dll" target="lib\uap10.0" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Plfuwpatform.UAP.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.*pdb" target="lib\uap10.0" />
-    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.xr.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.dll" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0\Properties" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -212,6 +212,7 @@
     <file src="..\Xamarin.Forms.Platform\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Platform.*pdb" target="lib\uap10.0" />
     <file src="..\Xamarin.Forms.Platform.UAP\Properties\Xamarin.Forms.Platform.UAP.rd.xml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Properties" />
 
+    
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsFlyout.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCommandBarStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsProgressBarStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
@@ -230,6 +231,25 @@
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Shell\ShellStyles.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Shell" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PickerStyle.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
     <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\generic.xbf" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\" />
+
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsFlyout.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCommandBarStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsProgressBarStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Resources.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsTextBoxStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\AutoSuggestStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\SliderStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\MasterDetailControlStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PageControlStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\TabbedPageStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsEmbeddedPageWrapper.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\StepperControl.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\CollectionView\ItemsViewStyles.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\CollectionView" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\FormsCheckBoxStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\Compact.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\DensityStyles\" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Shell\ShellStyles.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Shell" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\PickerStyle.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP" />
+    <file src="..\Xamarin.Forms.Platform.UAP\bin\$Configuration$\uap10.0.14393\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\generic.xaml" target="lib\uap10.0\Xamarin.Forms.Platform.UAP\Microsoft.UI.Xaml\Themes\" />
 
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -8,7 +8,6 @@
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DefineConstants>DEBUG;TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -129,12 +129,35 @@
   <Target Name="UpdateLayoutFiles"
     AfterTargets="PrepareLibraryLayout"
     Condition="'$(CI)' == 'true'">
+
     <ItemGroup>
-        <MySourceFiles Include="obj\$(Configuration)\embed\**\*.xbf"/>
+        <XbfFiles Include="obj\$(Configuration)\**\*.xbf"/>
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(XbfFiles)"
+        DestinationFiles="@(XbfFiles->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+    <ItemGroup>
+        <MySourceFiles Include="obj\$(Configuration)\**\*.xaml"/>
     </ItemGroup>
     <Copy
         SourceFiles="@(MySourceFiles)"
         DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+
+    <ItemGroup>
+        <XbfFilesEmbed Include="obj\$(Configuration)\embed\**\*.xbf"/>
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(XbfFilesEmbed)"
+        DestinationFiles="@(XbfFilesEmbed->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+    <ItemGroup>
+        <MySourceFilesEmbed Include="obj\$(Configuration)\embed\**\*.xaml"/>
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(MySourceFilesEmbed)"
+        DestinationFiles="@(MySourceFilesEmbed->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
   </Target>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -135,14 +135,14 @@
     </ItemGroup>
     <Copy
         SourceFiles="@(XbfFiles)"
-        DestinationFiles="@(XbfFiles->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(XbfFiles->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
     <ItemGroup>
         <MySourceFiles Include="obj\$(Configuration)\**\*.xaml"/>
     </ItemGroup>
     <Copy
         SourceFiles="@(MySourceFiles)"
-        DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
 
     <ItemGroup>
@@ -150,14 +150,14 @@
     </ItemGroup>
     <Copy
         SourceFiles="@(XbfFilesEmbed)"
-        DestinationFiles="@(XbfFilesEmbed->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(XbfFilesEmbed->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
     <ItemGroup>
         <MySourceFilesEmbed Include="obj\$(Configuration)\embed\**\*.xaml"/>
     </ItemGroup>
     <Copy
         SourceFiles="@(MySourceFilesEmbed)"
-        DestinationFiles="@(MySourceFilesEmbed->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(MySourceFilesEmbed->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
   </Target>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -32,6 +32,10 @@
   <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
   </PropertyGroup>
+  <PropertyGroup>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
+  </PropertyGroup>
   <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
@@ -126,4 +130,15 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
+  <Target Name="UpdateLayoutFiles"
+    AfterTargets="PrepareLibraryLayout"
+    Condition="'$(CI)' == 'true'">
+    <ItemGroup>
+        <MySourceFiles Include="obj\$(Configuration)\embed\**\*.xbf"/>
+    </ItemGroup>
+    <Copy
+        SourceFiles="@(MySourceFiles)"
+        DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
+    />
+  </Target>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -32,10 +32,6 @@
   <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
   </PropertyGroup>
-  <PropertyGroup>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <OutputPath>bin\$(Configuration)\$(TargetFramework)</OutputPath>
-  </PropertyGroup>
   <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -126,30 +126,4 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
- <!-- <Target Name="AfterBuild" AfterTargets="PrepareForRun">
-
-     <ItemGroup>
-        <XbfFiles Include="obj\$(Configuration)\**\*.xbf"/>
-    </ItemGroup>
-    <Copy
-        SourceFiles="@(XbfFiles)"
-        DestinationFiles="@(XbfFiles->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
-
-    <ItemGroup>
-        <MySourceFiles Include="obj\$(Configuration)\$(TargetFramework)\**\*.xaml"/>
-    </ItemGroup>
-    <Copy
-        SourceFiles="@(MySourceFiles)"
-        DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\$(TargetFramework)\Xamarin.Forms.Platform.UAP\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
-
-    <ItemGroup>
-        <XbfFilesEmbed Include="obj\$(Configuration)\$(TargetFramework)\embed\**\*.xbf"/>
-    </ItemGroup>
-    <Copy
-        SourceFiles="@(XbfFilesEmbed)"
-        DestinationFiles="@(XbfFilesEmbed->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
-  </Target> -->
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -8,7 +8,7 @@
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <GenerateLibraryLayout>true</GenerateLibraryLayout>
+    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
@@ -126,38 +126,30 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
-  <Target Name="UpdateLayoutFiles"
-    AfterTargets="PrepareLibraryLayout"
-    Condition="'$(CI)' == 'true'">
+ <!-- <Target Name="AfterBuild" AfterTargets="PrepareForRun">
 
-    <ItemGroup>
+     <ItemGroup>
         <XbfFiles Include="obj\$(Configuration)\**\*.xbf"/>
     </ItemGroup>
     <Copy
         SourceFiles="@(XbfFiles)"
         DestinationFiles="@(XbfFiles->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
+
     <ItemGroup>
-        <MySourceFiles Include="obj\$(Configuration)\**\*.xaml"/>
+        <MySourceFiles Include="obj\$(Configuration)\$(TargetFramework)\**\*.xaml"/>
     </ItemGroup>
     <Copy
         SourceFiles="@(MySourceFiles)"
-        DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(MySourceFiles->'bin\$(Configuration)\$(TargetFramework)\Xamarin.Forms.Platform.UAP\%(RecursiveDir)%(Filename)%(Extension)')"
     />
 
     <ItemGroup>
-        <XbfFilesEmbed Include="obj\$(Configuration)\embed\**\*.xbf"/>
+        <XbfFilesEmbed Include="obj\$(Configuration)\$(TargetFramework)\embed\**\*.xbf"/>
     </ItemGroup>
     <Copy
         SourceFiles="@(XbfFilesEmbed)"
-        DestinationFiles="@(XbfFilesEmbed->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
+        DestinationFiles="@(XbfFilesEmbed->'bin\$(Configuration)\$(TargetFramework)\%(RecursiveDir)%(Filename)%(Extension)')"
     />
-    <ItemGroup>
-        <MySourceFilesEmbed Include="obj\$(Configuration)\embed\**\*.xaml"/>
-    </ItemGroup>
-    <Copy
-        SourceFiles="@(MySourceFilesEmbed)"
-        DestinationFiles="@(MySourceFilesEmbed->'bin\$(Configuration)\%(RecursiveDir)%(Filename)%(Extension)')"
-    />
-  </Target>
+  </Target> -->
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -8,7 +8,7 @@
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <DisableEmbeddedXbf>false</DisableEmbeddedXbf>
+    <GenerateLibraryLayout Condition="'$(MSBuildAssemblyVersion)' != '16.0'">true</GenerateLibraryLayout>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -71,6 +71,19 @@ jobs:
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
 
+jobs:
+- template: build/steps/build-windows.yml
+  parameters:
+    name: win_2019
+    displayName: Build UWP Phase
+    vmImage: $(win2019VmImage)
+    targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
+    msbuildExtraArguments: '/nowarn:VSX1000 /p:CreateAllAndroidTargets=true'
+    buildConfiguration: $(DefaultBuildConfiguration)
+    buildPlatform: $(DefaultBuildPlatform)
+    provisionatorPath : 'build/provisioning/provisioning.csx'
+    slnPath: '.Xamarin.Forms.UAP.nuget.sln'
+
 - template: build/steps/build-android.yml
   parameters:
     name: android_legacy
@@ -125,6 +138,7 @@ jobs:
   displayName: Nuget Phase
   dependsOn:
    - win
+   - win_2019
   condition: succeeded()
   pool:
     name: $(winVmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,8 +70,7 @@ jobs:
     buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-
-jobs:
+    
 - template: build/steps/build-windows.yml
   parameters:
     name: win_2019

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,7 +70,8 @@ jobs:
     buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-    
+    includeUwp: 'false'
+
 - template: build/steps/build-windows.yml
   parameters:
     name: win_2019
@@ -82,6 +83,8 @@ jobs:
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
     slnPath: '.Xamarin.Forms.UAP.nuget.sln'
+    includeNonUwp: 'false'
+
 
 - template: build/steps/build-android.yml
   parameters:

--- a/build.cake
+++ b/build.cake
@@ -36,7 +36,7 @@ PowerShell:
 //////////////////////////////////////////////////////////////////////
 
 var target = Argument("target", "Default");
-var configuration = Argument("configuration", "Release");
+var configuration = Argument("configuration", "Debug");
 
 var gitVersion = GitVersion();
 var majorMinorPatch = gitVersion.MajorMinorPatch;

--- a/build.cake
+++ b/build.cake
@@ -36,7 +36,7 @@ PowerShell:
 //////////////////////////////////////////////////////////////////////
 
 var target = Argument("target", "Default");
-var configuration = Argument("configuration", "Debug");
+var configuration = Argument("configuration", "Release");
 
 var gitVersion = GitVersion();
 var majorMinorPatch = gitVersion.MajorMinorPatch;
@@ -223,6 +223,11 @@ Task("Build")
 {
     try{
         MSBuild("./Xamarin.Forms.sln", GetMSBuildSettings().WithRestore());
+
+        MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
+                    GetMSBuildSettings()
+                        .WithRestore()
+                        .WithProperty("DisableEmbeddedXbf", "true"));
     }
     catch(Exception)
     {

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -51,7 +51,7 @@ steps:
        }
     failOnStderr: true
     displayName: 'Update nuspecs'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: succeeded()
 
   - task: NuGetCommand@2
     displayName: 'Make NuGet Package Release'
@@ -62,7 +62,7 @@ steps:
       packDestination: '$(Build.ArtifactStagingDirectory)/nuget/release'
       versioningScheme: byEnvVar
       versionEnvVar: nugetPackageVersion
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: succeeded()
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -51,7 +51,7 @@ steps:
        }
     failOnStderr: true
     displayName: 'Update nuspecs'
-    condition: succeeded()
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: NuGetCommand@2
     displayName: 'Make NuGet Package Release'
@@ -62,7 +62,7 @@ steps:
       packDestination: '$(Build.ArtifactStagingDirectory)/nuget/release'
       versioningScheme: byEnvVar
       versionEnvVar: nugetPackageVersion
-    condition: succeeded()
+    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -84,7 +84,6 @@ jobs:
         codeCoverageEnabled: true
         testRunTitle: '$(BuildConfiguration)_UnitTests'
         configuration: '$(BuildConfiguration)'
-        vsTestVersion: '15.0'
         diagnosticsEnabled: true
 
     - task: CopyFiles@2

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -17,6 +17,8 @@ parameters:
   artifactsName: 'win_build'
   nunitTestAdapterFolder: 'packages/NUnitTestAdapter.AnyVersion/build/'
   nunitTestFolder: '$(build.sourcesdirectory)'
+  includeUwp: 'true'
+  includeNonUwp: 'true'
 
 jobs:
   - job: ${{ parameters.name }}
@@ -97,6 +99,7 @@ jobs:
 
     - task: CopyFiles@2
       displayName: 'Copy Files dlls'
+      condition: eq(${{ parameters.includeNonUwp }}, 'true')
       inputs:
         Contents: |
           Stubs/**/bin/**/*.dll
@@ -131,12 +134,6 @@ jobs:
           Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.pdb
           Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Platform.WP8/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
-          Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
           Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.mdb
           Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.dll
@@ -145,11 +142,6 @@ jobs:
           Xamarin.Forms.Maps.Android/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Maps.iOS/bin/iPhoneSimulator/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Maps.MacOS/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.WP8/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
           Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.pdb
           Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.mdb
@@ -189,6 +181,23 @@ jobs:
           **/*.binlog
 
         TargetFolder: ${{ parameters.artifactsTargetFolder }}
+
+      - task: CopyFiles@2
+        displayName: 'Copy UWP'
+        condition: eq(${{ parameters.includeUwp }}, 'true')
+        inputs:
+          Contents: |
+            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
+            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
+            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
+            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
+            Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
+            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
+            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
+            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
+            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
+
+          TargetFolder: ${{ parameters.artifactsTargetFolder }}
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: ${{ parameters.artifactsName }}'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -80,7 +80,7 @@ jobs:
       inputs:
         solution: ${{ parameters.csprojPath }}
         configuration: '$(BuildConfiguration)'
-        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /p:DisableEmbeddedXbf=false /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration)-csproj.binlog
+        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /t:rebuild /p:DisableEmbeddedXbf=false /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration)-csproj.binlog
   
     - task: VSTest@2
       displayName: 'Unit Tests'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -100,7 +100,6 @@ jobs:
       inputs:
         Contents: |
           Stubs/**/bin/**/*.dll
-          Xamarin.Forms.Platform.UAP/obj/**/*.*
           Microsoft.XamlStandard/bin/**/*.dll
           Microsoft.XamlStandard.Design/bin/**/*.dll
           Xamarin.Forms.Core/bin/**/*.dll
@@ -137,8 +136,6 @@ jobs:
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xbf
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xaml
           Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
           Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.mdb

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -78,6 +78,7 @@ jobs:
 
     - task: MSBuild@1
       displayName: 'Embed XBF into PRI'
+      condition: eq(${{ parameters.includeUwp }}, 'true')
       name: winbuild_pri_embed
       inputs:
         solution: ${{ parameters.csprojPath }}

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -182,22 +182,22 @@ jobs:
 
         TargetFolder: ${{ parameters.artifactsTargetFolder }}
 
-      - task: CopyFiles@2
-        displayName: 'Copy UWP'
-        condition: eq(${{ parameters.includeUwp }}, 'true')
-        inputs:
-          Contents: |
-            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
-            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
-            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
-            Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
-            Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
-            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
-            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
-            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
-            Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
+    - task: CopyFiles@2
+      displayName: 'Copy UWP'
+      condition: eq(${{ parameters.includeUwp }}, 'true')
+      inputs:
+        Contents: |
+          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
+          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
+          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
+          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
+          Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
+          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
+          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
+          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
+          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
 
-          TargetFolder: ${{ parameters.artifactsTargetFolder }}
+        TargetFolder: ${{ parameters.artifactsTargetFolder }}
 
     - task: PublishBuildArtifacts@1
       displayName: 'Publish Artifact: ${{ parameters.artifactsName }}'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -91,6 +91,7 @@ jobs:
       inputs:
         Contents: |
           Stubs/**/bin/**/*.dll
+          Xamarin.Forms.Platform.UAP/obj/**/*.*
           Microsoft.XamlStandard/bin/**/*.dll
           Microsoft.XamlStandard.Design/bin/**/*.dll
           Xamarin.Forms.Core/bin/**/*.dll
@@ -128,6 +129,7 @@ jobs:
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
           Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xbf
+          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xaml
           Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
           Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.dll
           Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.mdb

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -8,6 +8,7 @@ parameters:
   preBuildSteps: []   # any steps to run before the build
   postBuildSteps: []  # any additional steps to run after the build
   slnPath : 'Xamarin.Forms.sln'
+  csprojPath : 'Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj'
   buildConfiguration : 'Debug'
   releaseBuildConfiguration : 'Release'
   buildPlatform : 'any cpu'
@@ -73,6 +74,14 @@ jobs:
         configuration: '$(BuildConfiguration)'
         msbuildArguments: ${{ parameters.msbuildExtraArguments }} /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration).binlog
 
+    - task: MSBuild@1
+      displayName: 'Embed XBF into PRI'
+      name: winbuild_pri_embed
+      inputs:
+        solution: ${{ parameters.csprojPath }}
+        configuration: '$(BuildConfiguration)'
+        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /p:DisableEmbeddedXbf=false /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration)-csproj.binlog
+  
     - task: VSTest@2
       displayName: 'Unit Tests'
       inputs:


### PR DESCRIPTION
### Description of Change ###
- removed all the xbf files from the nuspec and used */p:DisableEmbeddedXbf=false* to ensure that everything gets embedded into the pri file for debug/release builds
- I moved the UWP platform builds to VS 2019 because that's the only way I could produce a nuget tthat worked with VS 2017.  If I build the nuget on our VS 2017 server then use it with VS 2017 it would throw exceptions about a missing XAML file

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- Maser builds and you can use the nuget

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
