### PR TITLE
[core] perf improvements for Assembly attributes reflection

### DIFF
--- a/Xamarin.Forms.Core/DependencyService.cs
+++ b/Xamarin.Forms.Core/DependencyService.cs
@@ -109,33 +109,15 @@ namespace Xamarin.Forms
 				if (s_initialized)
 					return;
 
-				Type targetAttrType = typeof(DependencyAttribute);
-
 				// Don't use LINQ for performance reasons
 				// Naive implementation can easily take over a second to run
 				foreach (Assembly assembly in assemblies)
 				{
-					object[] attributes;
-					try
-					{
-#if NETSTANDARD2_0
-						attributes = assembly.GetCustomAttributes(targetAttrType, true);
-#else
-						attributes = assembly.GetCustomAttributes(targetAttrType).ToArray();
-#endif
-					}
-					catch (System.IO.FileNotFoundException)
-					{
-						// Sometimes the previewer doesn't actually have everything required for these loads to work
-						Log.Warning(nameof(Registrar), "Could not load assembly: {0} for Attibute {1} | Some renderers may not be loaded", assembly.FullName, targetAttrType.FullName);
-						continue;
-					}
-
-					var length = attributes.Length;
-					if (length == 0)
+					object[] attributes = assembly.GetCustomAttributesSafe(typeof(DependencyAttribute));
+					if (attributes == null)
 						continue;
 
-					for (int i = 0; i < length; i++)
+					for (int i = 0; i < attributes.Length; i++)
 					{
 						DependencyAttribute attribute = (DependencyAttribute)attributes[i];
 						if (!DependencyTypes.Contains(attribute.Implementor))

--- a/Xamarin.Forms.Core/ReflectionExtensions.cs
+++ b/Xamarin.Forms.Core/ReflectionExtensions.cs
@@ -47,13 +47,12 @@ namespace Xamarin.Forms.Internals
 
 		internal static object[] GetCustomAttributesSafe(this Assembly assembly,  Type attrType)
 		{
-			object[] attributes = null;
 			try
 			{
 #if NETSTANDARD2_0
-				attributes = assembly.GetCustomAttributes(attrType, true);
+				return assembly.GetCustomAttributes(attrType, true);
 #else
-				attributes = assembly.GetCustomAttributes(attrType).ToArray();
+				return assembly.GetCustomAttributes(attrType).ToArray();
 #endif
 			}
 			catch (System.IO.FileNotFoundException)
@@ -62,7 +61,7 @@ namespace Xamarin.Forms.Internals
 				Log.Warning(nameof(Registrar), "Could not load assembly: {0} for Attribute {1} | Some renderers may not be loaded", assembly.FullName, attrType.FullName);
 			}
 
-			return attributes;
+			return null;
 		}
 
 		public static Type[] GetExportedTypes(this Assembly assembly)

--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -335,40 +335,20 @@ namespace Xamarin.Forms.Internals
 
 				foreach (Type attrType in attrTypes)
 				{
-					object[] attributes;
-					try
-					{
-#if NETSTANDARD2_0
-						attributes = assembly.GetCustomAttributes(attrType, true);
-#else
-						attributes = assembly.GetCustomAttributes(attrType).ToArray();
-#endif
-					}
-					catch (System.IO.FileNotFoundException)
-					{
-						// Sometimes the previewer doesn't actually have everything required for these loads to work
-						Log.Warning(nameof(Registrar), "Could not load assembly: {0} for Attibute {1} | Some renderers may not be loaded", assembly.FullName, attrType.FullName);
+					object[] attributes = assembly.GetCustomAttributesSafe(attrType);
+					if (attributes == null || attributes.Length == 0)
 						continue;
-					}
-
-					var handlerAttributes = new HandlerAttribute[attributes.Length];
-					Array.Copy(attributes, handlerAttributes, attributes.Length);
-					RegisterRenderers(handlerAttributes);
+					RegisterRenderers((HandlerAttribute[])attributes);
 				}
 
+				object[] effectAttributes = assembly.GetCustomAttributesSafe(typeof (ExportEffectAttribute));
+				if (effectAttributes == null || effectAttributes.Length == 0)
+					continue;
 				string resolutionName = assembly.FullName;
 				var resolutionNameAttribute = (ResolutionGroupNameAttribute)assembly.GetCustomAttribute(typeof(ResolutionGroupNameAttribute));
 				if (resolutionNameAttribute != null)
 					resolutionName = resolutionNameAttribute.ShortName;
-
-#if NETSTANDARD2_0
-				object[] effectAttributes = assembly.GetCustomAttributes(typeof(ExportEffectAttribute), true);
-#else
-				object[] effectAttributes = assembly.GetCustomAttributes(typeof(ExportEffectAttribute)).ToArray();
-#endif
-				var typedEffectAttributes = new ExportEffectAttribute[effectAttributes.Length];
-				Array.Copy(effectAttributes, typedEffectAttributes, effectAttributes.Length);
-				RegisterEffects(resolutionName, typedEffectAttributes);
+				RegisterEffects(resolutionName, (ExportEffectAttribute[])effectAttributes);
 
 				Profile.FrameEnd();
 			}


### PR DESCRIPTION
### Description of Change ###

When profiling startup, I started looking into the number of calls
retrieving custom attributes from assemblies:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
          24        0         301 System.Reflection.RuntimeAssembly:GetCustomAttributes (System.Type,bool)

I saw a pattern such as:

    object[] attributes = assembly.GetCustomAttributes(attrType, true);
    var handlerAttributes = new HandlerAttribute[attributes.Length];
    Array.Copy(attributes, handlerAttributes, attributes.Length);
    RegisterRenderers(handlerAttributes);

We can avoid the allocation and copying of the array completely here.
We can simply cast `attributes` to `HandlerAttribute[]`.

The other thing I saw was:

    string resolutionName = assembly.FullName;
    var resolutionNameAttribute = (ResolutionGroupNameAttribute)assembly.GetCustomAttribute(typeof(ResolutionGroupNameAttribute));
    if (resolutionNameAttribute != null)
        resolutionName = resolutionNameAttribute.ShortName;

This was happening even if the assembly had no `[assembly:Effect]`.

I reordered the code to not look for `[assembly: ResolutionGroupName]`
unless there was an `[assembly: Export]`.

This reduced the calls to `GetCustomAttributes` to:

    Method call summary
    Total(ms) Self(ms)      Calls Method name
          21        0         251 System.Reflection.RuntimeAssembly:GetCustomAttributes (System.Type,bool)

I also did a small amount of refactoring:

* `ReflectionExtensions.GetCustomAttributesSafe` had a variable
  declaration that could be removed.
* `ReflectionExtensions.GetCustomAttributesSafe` was a nice wrapper to
  avoid `#if` and also has a `try-catch` for the previewer. I used
  this in places where there was duplicated code.

#### Results ####

    Before:
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    12-17 13:08:57.119  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +588ms
    12-17 13:09:00.852  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +583ms
    12-17 13:09:04.602  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +573ms
    12-17 13:09:08.388  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +581ms
    12-17 13:09:12.137  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    12-17 13:09:15.887  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +583ms
    12-17 13:09:19.621  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +578ms
    12-17 13:09:23.388  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +588ms
    12-17 13:09:27.123  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +587ms
    12-17 13:09:30.892  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    Average(ms): 580.8
    Std Err(ms): 1.94250697124446
    Std Dev(ms): 6.1427463998877

    After:
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    Launching: com.xamarin.forms.helloforms
    12-17 13:10:29.762  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +579ms
    12-17 13:10:33.514  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +572ms
    12-17 13:10:37.263  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +564ms
    12-17 13:10:40.996  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +572ms
    12-17 13:10:44.748  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +569ms
    12-17 13:10:48.467  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +573ms
    12-17 13:10:52.231  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +577ms
    12-17 13:10:55.981  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +558ms
    12-17 13:10:59.765  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +574ms
    12-17 13:11:03.499  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +569ms
    Average(ms): 570.7
    Std Err(ms): 1.94393644157644
    Std Dev(ms): 6.1472667819844

I think this saves ~10ms on startup on Android, but this should help
all platforms.

These numbers were taken running on a Pixel 3 XL, a Blank
Xamarin.Forms app template using Xamarin.Forms/master.

Using: https://github.com/xamarin/Xamarin.Forms/pull/8867

### Issues Resolved ### 

None

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
