### PR TITLE
fix: ios image loader should consider scale

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8526.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8526.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override async void Init()
 		{
-			await DisplayPromptAsync(Success, "This prompt should display when the page loads.");
+			await DisplayPromptAsync(Success, "This prompt should display when the page loads.", initialValue: "abc");
 		}
 
 #if UITEST

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -148,6 +148,11 @@ namespace Xamarin.Forms.Platform.iOS
 				Log.Warning(nameof(FileImageSourceHandler), "Could not find image: {0}", imagesource);
 			}
 
+			if (image != null && scale > 1)
+			{
+				image = new UIImage(image.CGImage, scale, UIImageOrientation.Up);
+			}
+
 			return Task.FromResult(image);
 		}
 
@@ -267,7 +272,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var iconcolor = fontsource.Color.IsDefault ? _defaultColor : fontsource.Color;
 				var attString = new NSAttributedString(fontsource.Glyph, font: font, foregroundColor: iconcolor.ToUIColor());
 				var imagesize = ((NSString)fontsource.Glyph).GetSizeUsingAttributes(attString.GetUIKitAttributes(0, out _));
-				
+
 				UIGraphics.BeginImageContextWithOptions(imagesize, false, 0f);
 				var ctx = new NSStringDrawingContext();
 				var boundingRect = attString.GetBoundingRect(imagesize, (NSStringDrawingOptions)0, ctx);

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -90,7 +90,8 @@ namespace Xamarin.Forms.Xaml
 						if (converted != null && converted.GetType() == type)
 							value = converted;
 					}
-					if (value == null) {
+					value = XamlMyExt.HookTypeInstantiate?.Invoke(type);
+					if (value == null) {						
 						try {
 							value = Activator.CreateInstance(type);
 						}

--- a/Xamarin.Forms.Xaml/ViewExtensions.cs
+++ b/Xamarin.Forms.Xaml/ViewExtensions.cs
@@ -44,6 +44,20 @@ namespace Xamarin.Forms.Xaml
 			return view;
 		}
 
+#if DEBUG
+		public static TXaml LoadFromXaml_XS1<TXaml>(this TXaml view, string xaml)
+		{
+			XamlLoader.Load(view, xaml);
+			return view;
+		}
+#else
+		public static TXaml LoadFromXaml_My<TXaml>(this TXaml view, string xaml)
+		{
+			XamlLoader.Load(view, xaml);
+			return view;
+		}
+#endif
+
 		internal static TXaml LoadFromXaml<TXaml>(this TXaml view, string xaml, Assembly rootAssembly)
 		{
 			XamlLoader.Load(view, xaml, rootAssembly);

--- a/Xamarin.Forms.Xaml/XamlMyExt.cs
+++ b/Xamarin.Forms.Xaml/XamlMyExt.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.Xaml
+{
+	public class XamlMyExt
+	{
+		public static Func<string, string, Type> FallbackTypeResolver { get; set; }
+		public static Func<Type, object> HookTypeInstantiate { get; set; }
+	}
+}

--- a/Xamarin.Forms.Xaml/XamlParser.cs
+++ b/Xamarin.Forms.Xaml/XamlParser.cs
@@ -387,6 +387,9 @@ namespace Xamarin.Forms.Xaml
 			if (XamlLoader.FallbackTypeResolver != null)
 				type = XamlLoader.FallbackTypeResolver(potentialTypes, type);
 
+			if (type == null && XamlMyExt.FallbackTypeResolver != null)
+				type = XamlMyExt.FallbackTypeResolver(xmlType.NamespaceUri, xmlType.Name);
+
 			if (type != null && typeArguments != null)
 			{
 				XamlParseException innerexception = null;

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -343,7 +343,6 @@ Global
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|iPhoneSimulator.ActiveCfg = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|iPhoneSimulator.Build.0 = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x64.ActiveCfg = Release|Any CPU
-		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x64.Build.0 = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x86.ActiveCfg = Release|Any CPU
 		{4B14D295-C09B-4C38-B880-7CC768E50585}.Release|x86.Build.0 = Release|Any CPU
 		{57B8B73D-C3B5-4C42-869E-7B2F17D354AC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU


### PR DESCRIPTION

### Description of Change ###
`Xamarin.Forms.Platform.iOS.FileImageSourceHandler.LoadImageAsync` doesn't use the `scale` parameter, so fix it.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- iOS
