### PR TITLE
[MacOS] Fix NRE with NavigationPage on pre-Mojave

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
@@ -140,9 +140,11 @@ namespace Xamarin.Forms.Platform.MacOS
 				AllowsUserCustomization = false,
 				ShowsBaselineSeparator = true,
 				SizeMode = NSToolbarSizeMode.Regular,
-				Delegate = this,
-				CenteredItemIdentifier = TitleGroupIdentifier
+				Delegate = this
 			};
+
+			if (Forms.IsMojaveOrNewer)
+				toolbar.CenteredItemIdentifier = TitleGroupIdentifier;
 
 			return toolbar;
 		}

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -38,9 +38,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS11OrNewer;
 		static bool? s_isiOS13OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
-#endif
 
-#if __MOBILE__
 		internal static bool IsiOS9OrNewer
 		{
 			get
@@ -91,6 +89,19 @@ namespace Xamarin.Forms
 				return s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden.Value;
 			}
 		}
+#else
+		static bool? s_isMojaveOrNewer;
+
+		internal static bool IsMojaveOrNewer
+		{
+			get
+			{
+				if (!s_isMojaveOrNewer.HasValue)
+					s_isMojaveOrNewer = NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 14, 0));
+				return s_isMojaveOrNewer.Value;
+			}
+		}
+
 #endif
 
 		static IReadOnlyList<string> s_flags;


### PR DESCRIPTION
### Description of Change ###

Fixes NRE when using Xamarin.Forms with Mac OS on pre-Mojave OS versions with a `NavigationPage`

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8261

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Mac OS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

From #6981 we used a property that is available only from Mojave (10.14) and up. This causes an NRE on apps using Xamarin.Forms on OS versions older than that. This change checks the OS version first.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Run the gallery app on a pre-Mojave machine

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
