### PR TITLE
7856 - Shell BackButtonBehaviour TextOverride breaks back navigation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856.cs
@@ -1,11 +1,20 @@
 ﻿using System;
 using Xamarin.Forms.CustomAttributes;
 
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Issue(IssueTracker.Github, 7856,
 		"[Bug]  Shell BackButtonBehaviour TextOverride breaks back",
 		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
 	public class Issue7856 : TestShell
 	{
 
@@ -33,5 +42,22 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			_ = Shell.Current.Navigation.PushAsync(new Issue7856_1());
 		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void BackButtonBehaviorTest()
+		{
+			RunningApp.Tap(x => x.Text("Tap to Navigate To the Page With BackButtonBehavior"));
+
+			RunningApp.WaitForElement(x => x.Text("Navigate again"));
+
+			RunningApp.Tap(x => x.Text("Navigate again"));
+
+			RunningApp.WaitForElement(x => x.Text("Test"));
+
+			RunningApp.Tap(x => x.Text("Test"));
+
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 7856,
+		"[Bug]  Shell BackButtonBehaviour TextOverride breaks back",
+		PlatformAffected.iOS)]
+	public class Issue7856 : TestShell
+	{
+
+		const string ContentPageTitle = "Item1";
+		const string ButtonId = "ButtonId";
+
+		protected override void Init()
+		{
+			CreateContentPage(ContentPageTitle).Content =
+				new StackLayout
+				{
+					Children =
+					{
+						new Button
+						{
+							AutomationId = ButtonId,
+							Text = "Tap to Navigate To the Page With BackButtonBehavior",
+							Command = new Command(NavToBackButtonBehaviorPage)
+						}
+					}
+				};
+		}
+
+		private void NavToBackButtonBehaviorPage()
+		{
+			_ = Shell.Current.Navigation.PushAsync(new Issue7856_1());
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856_1.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856_1.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.Issues.Issue7856_1" Title="7856">
+    <ContentPage.Content>
+        <StackLayout Padding="10">
+            <Label Text="Hello"/>
+            <Button Text="Navigate again" Clicked="Navigate_Clicked" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856_1.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856_1.xaml.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	public partial class Issue7856_1 : ContentPage
+	{
+		public Issue7856_1()
+		{
+			InitializeComponent();
+
+			Shell.SetBackButtonBehavior(this, new BackButtonBehavior
+			{
+				TextOverride = "Test"
+			});
+		}
+
+		private void Navigate_Clicked(object sender, EventArgs e)
+		{
+			_ = Shell.Current.Navigation.PushAsync(new Issue7856_1());
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856_1.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7856_1.xaml.cs
@@ -9,7 +9,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue7856_1()
 		{
+#if APP
 			InitializeComponent();
+#endif
 
 			Shell.SetBackButtonBehavior(this, new BackButtonBehavior
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -120,9 +120,27 @@ namespace Xamarin.Forms.Controls.Issues
 					AutomationId = PushPageId
 				});
 
-				
-				Content = layout;
+				layout.Children.Add(new Button()
+				{
+					Text = "Toggle Flyout Behavior",
+					Command = new Command(ToggleFlyoutBehavior)
+				});
+
+
+				Content = new ScrollView() { Content = layout };
 				ToggleBehavior();
+			}
+
+			void ToggleFlyoutBehavior(object obj)
+			{
+				var behavior = (int)(Shell.Current.FlyoutBehavior);
+				behavior++;
+
+				if (Enum.GetValues(typeof(FlyoutBehavior)).Length <= behavior)
+					behavior = 0;
+
+				Shell.Current.FlyoutBehavior = (FlyoutBehavior)behavior;
+
 			}
 
 			async void PushPage(object obj)
@@ -181,7 +199,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 
-#if UITEST && (__IOS__ || __ANDROID__)
+#if UITEST && (__SHELL__)
 		[Test]
 		public void CommandTest()
 		{
@@ -196,6 +214,18 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(ToggleCommandCanExecuteId);
 
 			commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
+			Assert.AreEqual(commandResult, "parameter");
+		}
+
+		[Test]
+		public void CommandWorksWhenItsTheOnlyThingSet()
+		{
+			RunningApp.Tap(PushPageId);
+			RunningApp.Tap(ToggleCommandId);
+			RunningApp.EnterText(EntryCommandParameter, "parameter");
+			TapBackArrow();
+
+			var commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
 			Assert.AreEqual(commandResult, "parameter");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1342,6 +1342,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9735.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9305.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9767.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7856.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7856_1.xaml.cs">
+      <DependentUpon>Issue7856_1.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9054.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9326.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8689.xaml.cs" />
@@ -1514,6 +1518,10 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8326.xaml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8449.xaml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7924.xaml" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7856_1.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9734.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -234,7 +234,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var image = behavior.GetPropertyIfSet<ImageSource>(BackButtonBehavior.IconOverrideProperty, null);
 			var enabled = behavior.GetPropertyIfSet(BackButtonBehavior.IsEnabledProperty, true);
-			var text = behavior.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
+			var text = behavior.GetPropertyIfSet<string>(BackButtonBehavior.TextOverrideProperty, null);
+			var command = behavior.GetPropertyIfSet<object>(BackButtonBehavior.CommandProperty, null);
 			
 			UIImage icon = null;
 
@@ -260,29 +261,50 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (image != null)
 					icon = await image.GetNativeImageAsync();
-				else if (String.IsNullOrWhiteSpace(text))
+				else if (text == null)
 					icon = DrawHamburger();
 
-				if (icon == null)
+				if (text != null || image != null)
 				{
-					NavigationItem.LeftBarButtonItem =
-						new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
-				}
-				else
-				{
-					NavigationItem.LeftBarButtonItem =
-						new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+
+					var backButton = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
+
+					if (text != null)
+					{
+						backButton.Title = text;
+					}
+
+					if (image != null)
+					{
+						backButton.Image = icon;
+					}
+
+					NavigationItem.BackBarButtonItem = backButton;
 				}
 
-				if (String.IsNullOrWhiteSpace(image?.AutomationId))
-					NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
-				else
-					NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = image.AutomationId;
-
-				if (image != null)
+				if (IsRootPage)
 				{
-					NavigationItem.LeftBarButtonItem.SetAccessibilityHint(image);
-					NavigationItem.LeftBarButtonItem.SetAccessibilityLabel(image);
+					if (icon == null)
+					{
+						NavigationItem.LeftBarButtonItem =
+							new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+					}
+					else
+					{
+						NavigationItem.LeftBarButtonItem =
+							new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+					}
+
+					if (String.IsNullOrWhiteSpace(image?.AutomationId))
+						NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
+					else
+						NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = image.AutomationId;
+
+					if (image != null)
+					{
+						NavigationItem.LeftBarButtonItem.SetAccessibilityHint(image);
+						NavigationItem.LeftBarButtonItem.SetAccessibilityLabel(image);
+					}
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -266,7 +266,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 
 
-				if (text != null)
+				if (text != null && !IsRootPage)
 				{
 					var backButton = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
 					backButton.Title = text;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					await UpdateToolbarItems().ConfigureAwait(false);
 				}
-				catch(Exception exc)
+				catch (Exception exc)
 				{
 					Internals.Log.Warning(nameof(ShellPageRendererTracker), $"Failed to update toolbar items: {exc}");
 				}
@@ -236,7 +236,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var enabled = behavior.GetPropertyIfSet(BackButtonBehavior.IsEnabledProperty, true);
 			var text = behavior.GetPropertyIfSet<string>(BackButtonBehavior.TextOverrideProperty, null);
 			var command = behavior.GetPropertyIfSet<object>(BackButtonBehavior.CommandProperty, null);
-			
+
 			UIImage icon = null;
 
 			if (image == null && String.IsNullOrWhiteSpace(text) && (!IsRootPage || _flyoutBehavior != FlyoutBehavior.Flyout))
@@ -264,37 +264,28 @@ namespace Xamarin.Forms.Platform.iOS
 				else if (text == null)
 					icon = DrawHamburger();
 
-				if (text != null || image != null)
+
+
+				if (text != null)
 				{
-
 					var backButton = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
-
-					if (text != null)
-					{
-						backButton.Title = text;
-					}
-
-					if (image != null)
-					{
-						backButton.Image = icon;
-					}
+					backButton.Title = text;
 
 					NavigationItem.BackBarButtonItem = backButton;
 				}
-
-				if (IsRootPage)
+				else if (icon == null)
 				{
-					if (icon == null)
-					{
-						NavigationItem.LeftBarButtonItem =
-							new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
-					}
-					else
-					{
-						NavigationItem.LeftBarButtonItem =
-							new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
-					}
+					NavigationItem.LeftBarButtonItem =
+						new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+				}
+				else
+				{
+					NavigationItem.LeftBarButtonItem =
+						new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+				}
 
+				if (NavigationItem.LeftBarButtonItem != null)
+				{
 					if (String.IsNullOrWhiteSpace(image?.AutomationId))
 						NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
 					else

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -243,13 +243,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UIImage icon = null;
 
-			/*if (image == null &&
-				String.IsNullOrWhiteSpace(text) &&
-				(!IsRootPage || _flyoutBehavior != FlyoutBehavior.Flyout))
-			{
-				NavigationItem.LeftBarButtonItem = null;
-			}
-			else*/
 			if(IsRootPage && _flyoutBehavior != FlyoutBehavior.Flyout)
 			{
 				NavigationItem.LeftBarButtonItem = null;
@@ -275,46 +268,19 @@ namespace Xamarin.Forms.Platform.iOS
 				else if (String.IsNullOrWhiteSpace(text) && IsRootPage)
 					icon = DrawHamburger();
 
-				/*if (!IsRootPage)
-				{
-					var backButton = new UIBarButtonItem { Style = UIBarButtonItemStyle.Plain };
-					backButton.Title = text;
-					NavigationItem.BackBarButtonItem = backButton;
-				}
-				else*/
-				if (icon == null)
-				{
-					if (IsRootPage)
-					{
-						NavigationItem.LeftBarButtonItem =
-							new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
-					}
-					else
-					{
-						//NavigationItem.LeftBarButtonItem = null;
-						UIBarButtonItem backButton;
-
-						if (text == null)
-						{
-							backButton = new UIBarButtonItem((string)null, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
-						}
-						else
-						{
-							backButton = new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
-						}
-
-						if(ViewController.ParentViewController is UINavigationController nc)
-						{
-							var viewControllers = nc.ViewControllers;
-							var previousVC = viewControllers[viewControllers.Length - 2];
-							previousVC.NavigationItem.BackBarButtonItem = backButton;
-						}
-					}
-				}
-				else
+				if (icon != null)
 				{
 					NavigationItem.LeftBarButtonItem =
 						new UIBarButtonItem(icon, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+				}
+				else if (!String.IsNullOrWhiteSpace(text))
+				{
+					NavigationItem.LeftBarButtonItem =
+						new UIBarButtonItem(text, UIBarButtonItemStyle.Plain, (s, e) => LeftBarButtonItemHandler(ViewController, IsRootPage)) { Enabled = enabled };
+				}
+				else
+				{
+					NavigationItem.LeftBarButtonItem = null;
 				}
 
 				if (NavigationItem.LeftBarButtonItem != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
+using System.Windows.Input;
 using UIKit;
 using Xamarin.Forms.Internals;
 
@@ -81,6 +82,28 @@ namespace Xamarin.Forms.Platform.iOS
 			// this means the pop is already done, nothing we can do
 			if (ViewControllers.Length < NavigationBar.Items.Length)
 				return true;
+
+			foreach(var tracker in _trackers)
+			{
+				if(tracker.Value.ViewController == TopViewController)
+				{
+					var behavior = Shell.GetBackButtonBehavior(tracker.Value.Page);
+					var command = behavior.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
+					var commandParameter = behavior.GetPropertyIfSet<object>(BackButtonBehavior.CommandParameterProperty, null);
+
+					if (command != null)
+					{
+						if(command.CanExecute(commandParameter))
+						{
+							command.Execute(commandParameter);
+						}
+
+						return false;
+					}
+
+					break;
+				}
+			}
 
 			bool allowPop = ShouldPop();
 


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
- fixes #7856

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
It now shows back button behaviours as it should.

### Testing Procedure ###
Create a Shell and with one page and set BackButton Override. Navigate to another page and check that the back button is shown as you overrode it.

Video:
[7856.mp4.zip](https://github.com/xamarin/Xamarin.Forms/files/3978657/7856.mp4.zip)


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
