### PR TITLE
Stop the linker from killing off the Deserializer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Deserializer.cs
+++ b/Xamarin.Forms.Platform.iOS/Deserializer.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Platform.iOS
 namespace Xamarin.Forms.Platform.MacOS
 #endif
 {
+	[Preserve(AllMembers = true)]
 	internal class Deserializer : IDeserializer
 	{
 		const string PropertyStoreFile = "PropertyStore.forms";

--- a/Xamarin.Forms.Platform.iOS/NativeBindingService.cs
+++ b/Xamarin.Forms.Platform.iOS/NativeBindingService.cs
@@ -1,11 +1,13 @@
 using System;
 using UIKit;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml.Internals;
 
 [assembly: Xamarin.Forms.Dependency(typeof(Xamarin.Forms.Platform.iOS.NativeBindingService))]
 
 namespace Xamarin.Forms.Platform.iOS
 {
+	[Preserve(AllMembers = true)]
 	class NativeBindingService : INativeBindingService
 	{
 		public bool TrySetBinding(object target, string propertyName, BindingBase binding)

--- a/Xamarin.Forms.Platform.iOS/NativeValueConverterService.cs
+++ b/Xamarin.Forms.Platform.iOS/NativeValueConverterService.cs
@@ -14,6 +14,7 @@ using UIView = AppKit.NSView;
 namespace Xamarin.Forms.Platform.MacOS
 #endif
 {
+	[Preserve(AllMembers = true)]
 	class NativeValueConverterService : INativeValueConverterService
 	{
 		public bool ConvertTo(object value, Type toType, out object nativeValue)


### PR DESCRIPTION
### Description of Change ###

Now the iOS platform is marked as "linker safe", the linker can (and will) link out the Deserializer dependency. This change adds a Preserve attribute to avoid that.

### Issues Resolved ### 
- fixes crash in SaveProperties on iOS

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Automated test 28709 - if it doesn't crash, this worked.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
