### PR TITLE
[core] Profile is off by default, save 56KB of allocations

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -331,8 +331,8 @@ namespace Xamarin.Forms.Internals
 			Profile.FramePartition("Reflect");
 			foreach (Assembly assembly in assemblies)
 			{
-				var assemblyName = assembly.GetName().Name;
-				Profile.FrameBegin(assemblyName);
+				string frameName = Profile.IsEnabled ? assembly.GetName().Name : "Assembly";
+				Profile.FrameBegin(frameName);
 
 				foreach (Type attrType in attrTypes)
 				{
@@ -360,7 +360,7 @@ namespace Xamarin.Forms.Internals
 				object[] effectAttributes = assembly.GetCustomAttributesSafe(typeof (ExportEffectAttribute));
 				if (effectAttributes == null || effectAttributes.Length == 0)
 				{
-					Profile.FrameEnd(assemblyName);
+					Profile.FrameEnd(frameName);
 					continue;
 				}
 
@@ -370,7 +370,7 @@ namespace Xamarin.Forms.Internals
 					resolutionName = resolutionNameAttribute.ShortName;
 				RegisterEffects(resolutionName, (ExportEffectAttribute[])effectAttributes);
 
-				Profile.FrameEnd(assemblyName);
+				Profile.FrameEnd(frameName);
 			}
 
 			if ((flags & InitializationFlags.DisableCss) == 0)

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -369,7 +369,7 @@ namespace Xamarin.Forms
 		}
 
 		static IReadOnlyList<string> s_flags;
-		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new string[0]);
 
 		public static void SetFlags(params string[] flags)
 		{
@@ -385,7 +385,9 @@ namespace Xamarin.Forms
 				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
 			}
 
-			s_flags = flags.ToList().AsReadOnly();
+			s_flags = (string[])flags.Clone();
+			if (s_flags.Contains ("Profile"))
+				Profile.Enable();
 			FlagsSet = true;
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -236,7 +236,7 @@ namespace Xamarin.Forms
 		}
 
 		static IReadOnlyList<string> s_flags;
-		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new string[0]);
 
 		public static void SetFlags(params string[] flags)
 		{
@@ -245,7 +245,9 @@ namespace Xamarin.Forms
 				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
 			}
 
-			s_flags = flags.ToList().AsReadOnly();
+			s_flags = (string[])flags.Clone();
+			if (s_flags.Contains ("Profile"))
+				Profile.Enable();
 		}
 
 		public static void SetTitleBarVisibility(TizenTitleBarVisibility visibility)

--- a/Xamarin.Forms.Platform.UAP/FormsUWP.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsUWP.cs
@@ -3,13 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms
 {
 	public static partial class Forms
 	{
 		static IReadOnlyList<string> s_flags;
-		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new string [0]);
 
 		public static void SetFlags(params string[] flags)
 		{
@@ -18,7 +19,9 @@ namespace Xamarin.Forms
 				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
 			}
 
-			s_flags = flags.ToList().AsReadOnly();
+			s_flags = (string[])flags.Clone();
+			if (s_flags.Contains ("Profile"))
+				Profile.Enable();
 		}
 
 	}

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms
 #endif
 
 		static IReadOnlyList<string> s_flags;
-		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new List<string>().AsReadOnly());
+		public static IReadOnlyList<string> Flags => s_flags ?? (s_flags = new string[0]);
 
 		public static void SetFlags(params string[] flags)
 		{
@@ -114,7 +114,9 @@ namespace Xamarin.Forms
 				throw new InvalidOperationException($"{nameof(SetFlags)} must be called before {nameof(Init)}");
 			}
 
-			s_flags = flags.ToList().AsReadOnly();
+			s_flags = (string[])flags.Clone();
+			if (s_flags.Contains ("Profile"))
+				Profile.Enable();
 		}
 
 		public static void Init()


### PR DESCRIPTION
### Description of Change ###

Profiling a Blank Forms app template with allocations on Android:

    adb shell setprop debug.mono.profile log:calls,alloc

I saw something worrying:

    Allocation summary
         Bytes      Count  Average Type name
         32064          2    16032 Xamarin.Forms.Internals.Profile.Datum[]
         24032          1    24032 Xamarin.Forms.Internals.Profile[]

This appears to be ~56KB of objects that are allocated at startup.
`Profile` in general looks like it should be useful, but it shouldn't
impact startup in customer's apps!

The `Profile` struct is a public API, so we can't use `#if` or
`[Conditional]`. I'm thinking a new flag is need to enable the
`Profile` class:

    Forms.SetFlags("Profile");

To make everything work, I had to add two public members to `Profile`:

* Profile.Enable()
* Profile.IsEnabled

They can't be `internal`, since `Forms` is in each platform-specific
assembly. I added `[EditorBrowsable(EditorBrowsableState.Never)]`.

Additionally, there was one place in `Registrar.cs`:

    Profile.FrameBegin(assembly.GetName().Name);

`Assembly.GetName()` for every assembly would be expensive, so I check
if `Profile.IsEnabled` is False and use "Assembly" instead.

One last improvement was the handling of:

    public static partial class Forms
    {
        public static IReadOnlyList<string> Flags
        ...

There were some weird `.ToList().AsReadonly()` calls. `string[]`
implements `IReadOnlyList`, so we can just `Clone()` the input or use
`new string[0]` by default.

#### Results ####

I saw a small improvement to startup on a Pixel 3 XL:

    Before:
    12-18 16:51:16.427  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +586ms
    12-18 16:51:20.133  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +567ms
    12-18 16:51:23.863  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +573ms
    12-18 16:51:27.581  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-18 16:51:31.362  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +577ms
    12-18 16:51:35.095  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +575ms
    12-18 16:51:38.846  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +578ms
    12-18 16:51:42.576  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +570ms
    12-18 16:51:46.324  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +569ms
    12-18 16:51:50.056  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    Average(ms): 574.2
    Std Err(ms): 1.74355957741627
    Std Dev(ms): 5.51361950083609

    After:
    12-18 16:55:04.122  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-18 16:55:07.805  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +570ms
    12-18 16:55:11.553  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +569ms
    12-18 16:55:15.303  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +574ms
    12-18 16:55:19.020  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +572ms
    12-18 16:55:22.766  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    12-18 16:55:26.500  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +573ms
    12-18 16:55:30.264  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +582ms
    12-18 16:55:33.981  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-18 16:55:37.697  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    Average(ms): 572.9
    Std Err(ms): 1.19675487140108
    Std Dev(ms): 3.78447119452933

### Issues Resolved ### 

None

### API Changes ###

`Profile.Enable()` and `Profile.IsEnabled` are added, but with `[EditorBrowsable(EditorBrowsableState.Never)]`.

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Going forward you will have to add this to your app:

    Xamarin.Forms.Forms.SetFlags("Profile");

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
