### PR TITLE
[android] use Type.GetType() to load AppLinks

### DIFF
--- a/Xamarin.Forms.Platform.Android/AndroidAppIndexProvider.cs
+++ b/Xamarin.Forms.Platform.Android/AndroidAppIndexProvider.cs
@@ -1,9 +1,5 @@
 ﻿using Android.Content;
 using System;
-using System.Reflection;
-using System.Linq;
-using System.Globalization;
-using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -11,30 +7,15 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public AndroidAppIndexProvider(Context context)
 		{
-			var assemblyAppLinks = GetAssemblyForAppLinks(AppLinksAssemblyName);
-
-			if (assemblyAppLinks != null)
+			var fullyQualifiedName = $"{AppLinksAssemblyName}.{AppLinksClassName}, {AppLinksAssemblyName}";
+			var type = Type.GetType(fullyQualifiedName, throwOnError: false);
+			if (type != null)
 			{
-				Type type = assemblyAppLinks.GetType($"{AppLinksAssemblyName}.{AppLinksClassName}");
-
-				if (type != null)
-				{
-					var applink = Activator.CreateInstance(type, new object[] { context }, null);
-
-					if (applink != null)
-					{
-						AppLinks = applink as IAppLinks;
-					}
-				}
+				AppLinks = Activator.CreateInstance(type, new object[] { context }, null) as IAppLinks;
 			}
 		}
 
 		public IAppLinks AppLinks { get; }
-
-		private Assembly GetAssemblyForAppLinks(string assemblyName)
-		{
-			return Device.GetAssemblies().FirstOrDefault(assembly => assembly.GetName().Name == assemblyName);
-		}
 
 		const string AppLinksAssemblyName = "Xamarin.Forms.Platform.Android.AppLinks";
 		const string AppLinksClassName = "AndroidAppLinks";


### PR DESCRIPTION
### Description of Change ###

Reviewing the memory report from the Mono profiler:

    Allocation summary
         Bytes      Count  Average Type name
         13776        123      112 System.Reflection.AssemblyName

That is a lot of `AssemblyName` objects!

I found part of the culprit to be in `AndroidAppIndexProvider`:

    private Assembly GetAssemblyForAppLinks(string assemblyName)
    {
        return Device.GetAssemblies().FirstOrDefault(assembly => assembly.GetName().Name == assemblyName);
    }

Instead of using `System.Linq` to create an `AssemblyName` for every
.NET assembly, we can just use a fully-qualified name with
`Type.GetType`.

The memory results were a bit better:

    Allocation summary
         Bytes      Count  Average Type name
          8176         73      112 System.Reflection.AssemblyName

Since this avoids a bit of System.Reflection & System.Linq, I was able
to see a performance improvement in a Blank Forms app template on a
Pixel 3 XL:

    Before:
    12-18 16:51:16.427  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +586ms
    12-18 16:51:20.133  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +567ms
    12-18 16:51:23.863  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +573ms
    12-18 16:51:27.581  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-18 16:51:31.362  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +577ms
    12-18 16:51:35.095  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +575ms
    12-18 16:51:38.846  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +578ms
    12-18 16:51:42.576  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +570ms
    12-18 16:51:46.324  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +569ms
    12-18 16:51:50.056  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    Average(ms): 574.2
    Std Err(ms): 1.74355957741627
    Std Dev(ms): 5.51361950083609

    After:
    12-18 16:55:04.122  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-18 16:55:07.805  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +570ms
    12-18 16:55:11.553  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +569ms
    12-18 16:55:15.303  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +574ms
    12-18 16:55:19.020  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +572ms
    12-18 16:55:22.766  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    12-18 16:55:26.500  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +573ms
    12-18 16:55:30.264  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +582ms
    12-18 16:55:33.981  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-18 16:55:37.697  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    Average(ms): 572.9
    Std Err(ms): 1.19675487140108
    Std Dev(ms): 3.78447119452933

I also manually tested adding a reference to
`Xamarin.Forms.Platform.Android.AppLinks` and the code here was still
able to create the `AndroidAppLinks` object.

### Issues Resolved ### 

None

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

If there is a sample that tests AppLinks that might be good 👍 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
