### PR TITLE
Stop linker removing custom renderers, services, and effects in Control Gallery

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/LinkDescription.xml
+++ b/Xamarin.Forms.ControlGallery.iOS/LinkDescription.xml
@@ -2,6 +2,9 @@
 <linker>
   <assembly fullname="XamarinFormsControlGalleryiOS">
     <namespace fullname="Xamarin.Forms.ControlGallery.iOS.Tests" />
+    <type fullname="*Renderer" />
+    <type fullname="*Effect" />
+    <type fullname="*Service" />
   </assembly>
   <assembly fullname="Xamarin.Forms.Controls">
     <namespace fullname="Xamarin.Forms.Controls.Tests" />

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -91,12 +91,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 		static IList<GestureElement> GetChildGestures(
-
-#if __MOBILE__
-			UIGestureRecognizer sender,
-#else
-			NSGestureRecognizer sender,
-#endif
+			NativeGestureRecognizer sender,
 			WeakReference weakEventTracker, WeakReference weakRecognizer, EventTracker eventTracker, View view)
 		{
 			if (!weakRecognizer.IsAlive)
@@ -105,14 +100,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (eventTracker._disposed || view == null)
 				return null;
 
-#if __MOBILE__
-			var originPoint = sender.LocationInView(UIApplication.SharedApplication.KeyWindow.RootViewController.View);
-			originPoint = UIApplication.SharedApplication.KeyWindow.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
-#else
-			var originPoint = sender.LocationInView(null);
-			originPoint = NSApplication.SharedApplication.KeyWindow.ContentView.ConvertPointToView(originPoint, eventTracker._renderer.NativeView);
-#endif
-
+			var originPoint = sender.LocationInView(eventTracker._renderer.NativeView);
 			var childGestures = view.GetChildElements(new Point(originPoint.X, originPoint.Y));
 			return childGestures;
 		}

--- a/Xamarin.Forms.Platform.iOS/ShadowEffect.cs
+++ b/Xamarin.Forms.Platform.iOS/ShadowEffect.cs
@@ -1,11 +1,13 @@
 ﻿using System;
 using System.ComponentModel;
 using UIKit;
+using Xamarin.Forms.Internals;
 using PlatformElement = Xamarin.Forms.PlatformConfiguration.iOSSpecific.VisualElement;
 
 
 namespace Xamarin.Forms.Platform.iOS
 {
+	[Preserve(AllMembers = true)]
 	internal class ShadowEffect : PlatformEffect
 	{
 		UIView ShadowView => Control ?? Container;


### PR DESCRIPTION
### Description of Change ###

Stop linker removing custom renderers, services, and effects in Control Gallery.

As a bonus, this also fixes TapGestures in Spans on iOS.

