### PR TITLE
[core] lazy load Assembly-level attributes for CSS

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -254,7 +254,10 @@ namespace Xamarin.Forms.Internals
 		}
 
 		internal static Dictionary<string, Type> Effects { get; } = new Dictionary<string, Type>();
-		internal static Dictionary<string, IList<StyleSheets.StylePropertyAttribute>> StyleProperties { get; } = new Dictionary<string, IList<StyleSheets.StylePropertyAttribute>>();
+		internal static Dictionary<string, IList<StylePropertyAttribute>> StyleProperties => LazyStyleProperties.Value;
+
+		static bool DisableCSS = false;
+		static readonly Lazy<Dictionary<string, IList<StylePropertyAttribute>>> LazyStyleProperties = new Lazy<Dictionary<string, IList<StylePropertyAttribute>>>(LoadStyleSheets);
 
 		public static IEnumerable<Assembly> ExtraAssemblies { get; set; }
 
@@ -275,24 +278,29 @@ namespace Xamarin.Forms.Internals
 			}
 		}
 
-		public static void RegisterStylesheets()
+		public static void RegisterStylesheets(InitializationFlags flags)
 		{
-			var assembly = typeof(StylePropertyAttribute).GetTypeInfo().Assembly;
+			if ((flags & InitializationFlags.DisableCss) == InitializationFlags.DisableCss)
+				DisableCSS = true;
+		}
 
-#if NETSTANDARD2_0
-			object[] styleAttributes = assembly.GetCustomAttributes(typeof(StylePropertyAttribute), true);
-#else
-			object[] styleAttributes = assembly.GetCustomAttributes(typeof(StyleSheets.StylePropertyAttribute)).ToArray();
-#endif
-			var stylePropertiesLength = styleAttributes.Length;
+		static Dictionary<string, IList<StylePropertyAttribute>> LoadStyleSheets()
+		{
+			var properties = new Dictionary<string, IList<StylePropertyAttribute>>();
+			if (DisableCSS)
+				return properties;
+			var assembly = typeof(StylePropertyAttribute).GetTypeInfo().Assembly;
+			var styleAttributes = assembly.GetCustomAttributesSafe(typeof(StylePropertyAttribute));
+			var stylePropertiesLength = styleAttributes?.Length ?? 0;
 			for (var i = 0; i < stylePropertiesLength; i++)
 			{
 				var attribute = (StylePropertyAttribute)styleAttributes[i];
-				if (StyleProperties.TryGetValue(attribute.CssPropertyName, out var attrList))
+				if (properties.TryGetValue(attribute.CssPropertyName, out var attrList))
 					attrList.Add(attribute);
 				else
-					StyleProperties[attribute.CssPropertyName] = new List<StylePropertyAttribute> { attribute };
+					properties[attribute.CssPropertyName] = new List<StylePropertyAttribute> { attribute };
 			}
+			return properties;
 		}
 
 		public static void RegisterEffects(string resolutionName, ExportEffectAttribute[] effectAttributes)
@@ -377,9 +385,7 @@ namespace Xamarin.Forms.Internals
 				Profile.FrameEnd(assemblyName);
 			}
 
-			if ((flags & InitializationFlags.DisableCss) == 0)
-				RegisterStylesheets();
-
+			RegisterStylesheets(flags);
 			Profile.FramePartition("DependencyService.Initialize");
 			DependencyService.Initialize(assemblies);
 

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -342,9 +342,7 @@ namespace Xamarin.Forms
 					}
 
 					// css
-					var noCss = (flags & InitializationFlags.DisableCss) != 0;
-					if (!noCss)
-						Registrar.RegisterStylesheets();
+					Registrar.RegisterStylesheets(flags);
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -425,10 +425,7 @@ namespace Xamarin.Forms
 					}
 
 					// css
-					var flags = options.Flags;
-					var noCss = (flags & InitializationFlags.DisableCss) != 0;
-					if (!noCss)
-						Registrar.RegisterStylesheets();
+					Registrar.RegisterStylesheets(options.Flags);
 				}
 				else
 				{


### PR DESCRIPTION
### Description of Change ###

There is code that uses System.Reflection over a big list of these:

    [assembly: StyleProperty("background-color", typeof(VisualElement), nameof(VisualElement.BackgroundColorProperty))]

Two changes here:

1. Let's make sure nothing happens at all if your app isn't using CSS.
2. I refactored a smidge to take advantage of `GetCustomAttributesSafe`.

#### Results ####

Testing a Blank Forms app template on a Pixel 3 XL:

    Before:
    12-20 17:04:36.397  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +590ms
    12-20 17:04:40.129  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +585ms
    12-20 17:04:43.844  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-20 17:04:47.645  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    12-20 17:04:51.377  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +578ms
    12-20 17:04:55.129  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +580ms
    12-20 17:04:58.927  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +594ms
    12-20 17:05:02.695  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +601ms
    12-20 17:05:06.394  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +587ms
    12-20 17:05:10.160  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +584ms
    Average(ms): 584.6
    Std Err(ms): 2.82134719593318
    Std Dev(ms): 8.92188320927819

    After:
    12-20 17:06:32.214  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +583ms
    12-20 17:06:35.931  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +570ms
    12-20 17:06:39.664  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +572ms
    12-20 17:06:43.448  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +584ms
    12-20 17:06:47.165  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +565ms
    12-20 17:06:50.897  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +576ms
    12-20 17:06:54.631  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +572ms
    12-20 17:06:58.398  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +580ms
    12-20 17:07:02.149  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +571ms
    12-20 17:07:05.897  1490  1517 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +577ms
    Average(ms): 575
    Std Err(ms): 1.92642443690665
    Std Dev(ms): 6.09188896083235

As the comment in `Xamarin.Forms.Platform.Tizen/Forms.cs` suggests, it
does seem to help by 10ms.

### Issues Resolved ### 

None

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###



### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
