### PR TITLE
Fix UWP Platform project so that it doesn't try to load on VS MAC

### DIFF
--- a/UWP.Build.props
+++ b/UWP.Build.props
@@ -1,0 +1,9 @@
+<PropertyGroup>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
+</PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
+    <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
+  </PropertyGroup>

--- a/UWP.Build.props
+++ b/UWP.Build.props
@@ -1,9 +1,11 @@
-<PropertyGroup>
+<Project>
+  <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
     <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
-</PropertyGroup>
+  </PropertyGroup>
   <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
   </PropertyGroup>
+</Project>

--- a/UWP.Build.targets
+++ b/UWP.Build.targets
@@ -1,18 +1,20 @@
-<ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT' ">
+<Project>
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-        <Name>Windows Mobile Extensions for the UWP</Name>
+      <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
-</ItemGroup>
-<ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT' ">
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT' ">
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-        <Name>Windows Mobile Extensions for the UWP</Name>
+      <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
-</ItemGroup>
-<ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
     <Compile Remove="**\*.*" />
     <None Include="**\*.*" />
-</ItemGroup>
-<ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
-</ItemGroup>
+  </ItemGroup>
+</Project>

--- a/UWP.Build.targets
+++ b/UWP.Build.targets
@@ -1,0 +1,18 @@
+<ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT' ">
+    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+        <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+</ItemGroup>
+<ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT' ">
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+        <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+</ItemGroup>
+<ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
+    <Compile Remove="**\*.*" />
+    <None Include="**\*.*" />
+</ItemGroup>
+<ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
+</ItemGroup>

--- a/Xamarin.Forms.Maps.UWP/Directory.Build.Props
+++ b/Xamarin.Forms.Maps.UWP/Directory.Build.Props
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="../Directory.Build.props" />
   <Import Project="../UWP.Build.props" />
 </Project>

--- a/Xamarin.Forms.Maps.UWP/Directory.Build.Props
+++ b/Xamarin.Forms.Maps.UWP/Directory.Build.Props
@@ -1,1 +1,3 @@
-<Import Project="../UWP.build.props" />
+<Project>
+  <Import Project="../UWP.Build.props" />
+</Project>

--- a/Xamarin.Forms.Maps.UWP/Directory.Build.Props
+++ b/Xamarin.Forms.Maps.UWP/Directory.Build.Props
@@ -1,0 +1,1 @@
+<Import Project="../UWP.build.props" />

--- a/Xamarin.Forms.Maps.UWP/Directory.Build.targets
+++ b/Xamarin.Forms.Maps.UWP/Directory.Build.targets
@@ -1,1 +1,3 @@
-<Import Project="../UWP.build.targets" />
+<Project>
+  <Import Project="../UWP.Build.targets" />
+</Project>

--- a/Xamarin.Forms.Maps.UWP/Directory.Build.targets
+++ b/Xamarin.Forms.Maps.UWP/Directory.Build.targets
@@ -1,0 +1,1 @@
+<Import Project="../UWP.build.targets" />

--- a/Xamarin.Forms.Maps.UWP/Directory.Build.targets
+++ b/Xamarin.Forms.Maps.UWP/Directory.Build.targets
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="../Directory.Build.targets" />
   <Import Project="../UWP.Build.targets" />
 </Project>

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -1,8 +1,5 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.14393;uap10.0.16299</TargetFrameworks>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
     <RootNamespace>Xamarin.Forms.Maps.UWP</RootNamespace>
     <AssemblyName>Xamarin.Forms.Maps.UWP</AssemblyName>
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
@@ -17,33 +14,15 @@
     <OutputPath>bin\Release\</OutputPath>
     <DefineConstants>TRACE;NETFX_CORE;WINDOWS_UWP</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299'">
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
     <EmbeddedResource Include="Properties\Xamarin.Forms.Maps.UWP.rd.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.15</Version>
-    </PackageReference>
-  </ItemGroup>
-  <ItemGroup>
-    <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
-    
+    <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">    
     </ProjectReference>
-    <ProjectReference Include="..\Xamarin.Forms.Maps\Xamarin.Forms.Maps.csproj">
-   
+    <ProjectReference Include="..\Xamarin.Forms.Maps\Xamarin.Forms.Maps.csproj">   
     </ProjectReference>
-    <ProjectReference Include="..\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj">
-    
+    <ProjectReference Include="..\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj">    
     </ProjectReference>
   </ItemGroup>
  

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -1,4 +1,13 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
+  <PropertyGroup Condition="$(MSBuildAssemblyVersion)' != '16.0'">
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND $(MSBuildAssemblyVersion)' != '16.0'">
+    <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup>
     <RootNamespace>Xamarin.Forms.Maps.UWP</RootNamespace>
     <AssemblyName>Xamarin.Forms.Maps.UWP</AssemblyName>
@@ -24,6 +33,24 @@
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj">    
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
+    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
+    <Compile Remove="**\*.*" />
+    <None Include="**\*.*" />
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
  
 </Project>

--- a/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
+++ b/Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
-  <PropertyGroup Condition="$(MSBuildAssemblyVersion)' != '16.0'">
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND $(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -34,23 +28,4 @@
     <ProjectReference Include="..\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj">    
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
-    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
-    <Compile Remove="**\*.*" />
-    <None Include="**\*.*" />
-  </ItemGroup>
-  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
-  </ItemGroup>
- 
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Directory.Build.Props
+++ b/Xamarin.Forms.Platform.UAP/Directory.Build.Props
@@ -1,3 +1,4 @@
 <Project>
-  <Import Project="../UWP.Build.props" />
+    <Import Project="../Directory.Build.props" />
+    <Import Project="../UWP.Build.props" />
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Directory.Build.Props
+++ b/Xamarin.Forms.Platform.UAP/Directory.Build.Props
@@ -1,1 +1,3 @@
-<Import Project="../UWP.build.props" />
+<Project>
+  <Import Project="../UWP.Build.props" />
+</Project>

--- a/Xamarin.Forms.Platform.UAP/Directory.Build.Props
+++ b/Xamarin.Forms.Platform.UAP/Directory.Build.Props
@@ -1,0 +1,1 @@
+<Import Project="../UWP.build.props" />

--- a/Xamarin.Forms.Platform.UAP/Directory.Build.targets
+++ b/Xamarin.Forms.Platform.UAP/Directory.Build.targets
@@ -1,1 +1,3 @@
-<Import Project="../UWP.build.targets" />
+<Project>
+  <Import Project="../UWP.Build.targets" />
+</Project>

--- a/Xamarin.Forms.Platform.UAP/Directory.Build.targets
+++ b/Xamarin.Forms.Platform.UAP/Directory.Build.targets
@@ -1,0 +1,1 @@
+<Import Project="../UWP.build.targets" />

--- a/Xamarin.Forms.Platform.UAP/Directory.Build.targets
+++ b/Xamarin.Forms.Platform.UAP/Directory.Build.targets
@@ -1,3 +1,4 @@
 <Project>
+  <Import Project="../Directory.Build.targets" />
   <Import Project="../UWP.Build.targets" />
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -1,11 +1,5 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
-  <PropertyGroup Condition="$(MSBuildAssemblyVersion)' != '16.0'">
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
-  </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND $(MSBuildAssemblyVersion)' != '16.0'">
+  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
   </PropertyGroup>
   <PropertyGroup>
@@ -116,23 +110,5 @@
     <PackageReference Include="Win2D.uwp">
       <Version>1.20.0</Version>
     </PackageReference>
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
-    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
-    <Compile Remove="**\*.*" />
-    <None Include="**\*.*" />
-  </ItemGroup>
-  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -1,4 +1,13 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
+  <PropertyGroup Condition="$(MSBuildAssemblyVersion)' != '16.0'">
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
+    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND $(MSBuildAssemblyVersion)' != '16.0'">
+    <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
+  </PropertyGroup>
   <PropertyGroup>
     <AssemblyName>Xamarin.Forms.Platform.UAP</AssemblyName>
     <RootNamespace>Xamarin.Forms.Platform.UAP</RootNamespace>
@@ -107,5 +116,23 @@
     <PackageReference Include="Win2D.uwp">
       <Version>1.20.0</Version>
     </PackageReference>
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
+    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
+    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
+      <Name>Windows Mobile Extensions for the UWP</Name>
+    </SDKReference>
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
+    <Compile Remove="**\*.*" />
+    <None Include="**\*.*" />
+  </ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT'  AND $(MSBuildAssemblyVersion)' != '16.0' ">
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
     <TargetFrameworks>uap10.0.14393;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
     <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
     <AssemblyName>Xamarin.Forms.Platform.UAP</AssemblyName>
@@ -43,7 +44,7 @@
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
-  <ItemGroup>
+  <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <Page Include="AutoSuggestStyle.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
@@ -111,13 +112,19 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
+
+  <ItemGroup>
+    <Compile Remove="**\*.*" />
+    <None Include="**\*.*" />
+  </ItemGroup>
+
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj">
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup>
+  <!-- <ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.1.190606001</Version>
     </PackageReference>
@@ -125,5 +132,5 @@
       <Version>1.20.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
-  </ItemGroup>
+  </ItemGroup> -->
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -1,9 +1,5 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
-    <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
     <AssemblyName>Xamarin.Forms.Platform.UAP</AssemblyName>
     <RootNamespace>Xamarin.Forms.Platform.UAP</RootNamespace>
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
@@ -30,20 +26,6 @@
     <NoWarn>
     </NoWarn>
   </PropertyGroup>
-  <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
-    <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
-  </PropertyGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT' ">
-    <PackageReference Include="NETStandard.Library" Version="2.0.1" />
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT' ">
-    <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
-      <Name>Windows Mobile Extensions for the UWP</Name>
-    </SDKReference>
-  </ItemGroup>
   <ItemGroup Condition=" '$(OS)' == 'Windows_NT' ">
     <Page Include="AutoSuggestStyle.xaml">
       <SubType>Designer</SubType>
@@ -112,12 +94,6 @@
       <Generator>MSBuild:Compile</Generator>
     </Page>
   </ItemGroup>
-
-  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
-    <Compile Remove="**\*.*" />
-    <None Include="**\*.*" />
-  </ItemGroup>
-
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
     </ProjectReference>
@@ -131,6 +107,5 @@
     <PackageReference Include="Win2D.uwp">
       <Version>1.20.0</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="MSBuild.Sdk.Extras">
   <PropertyGroup>
-    <TargetFrameworks>uap10.0.14393;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>    
     <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.14393'">10.0.16299.0</TargetPlatformVersion>
     <TargetPlatformVersion Condition="$(TargetFramework) == 'uap10.0.16299'">10.0.16299.0</TargetPlatformVersion>
@@ -33,13 +33,13 @@
   <PropertyGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
     <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
   </PropertyGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393'">
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.14393' AND  '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="NETStandard.Library" Version="2.0.1" />
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
   </ItemGroup>
-  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299'">
+  <ItemGroup Condition="$(TargetFramework) == 'uap10.0.16299' AND  '$(OS)' == 'Windows_NT' ">
     <SDKReference Include="WindowsMobile, Version=10.0.16299.0">
       <Name>Windows Mobile Extensions for the UWP</Name>
     </SDKReference>
@@ -113,7 +113,7 @@
     </Page>
   </ItemGroup>
 
-  <ItemGroup>
+  <ItemGroup  Condition=" '$(OS)' != 'Windows_NT' ">
     <Compile Remove="**\*.*" />
     <None Include="**\*.*" />
   </ItemGroup>
@@ -124,7 +124,7 @@
     <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj">
     </ProjectReference>
   </ItemGroup>
-  <!-- <ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
+  <ItemGroup  Condition=" '$(OS)' == 'Windows_NT' ">
     <PackageReference Include="Microsoft.UI.Xaml">
       <Version>2.1.190606001</Version>
     </PackageReference>
@@ -132,5 +132,5 @@
       <Version>1.20.0</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
-  </ItemGroup> -->
+  </ItemGroup>
 </Project>


### PR DESCRIPTION
### Description of Change ###

Setup conditionals on the UWP Platform project so that it's basically an empty netstandard2.0 project when built on mac

### Testing Procedure ###
- No popup warnings on VSMAC
- Make sure everything is building correctly on the windows/mac CI

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
