### PR TITLE
[iOS] Reduce casting and repeat math during BoxView drawing

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
@@ -16,9 +16,9 @@ namespace Xamarin.Forms.Platform.iOS
 		nfloat _bottomRight;
 
 		const float PI = (float)Math.PI;
-		const float PIAndAHalf = (float)(Math.PI * 1.5);
-		const float HalfPI = (float)(Math.PI * .5);
-		const float TwoPI = (float)Math.PI * 2;
+		const float PIAndAHalf = PI * 1.5f;
+		const float HalfPI = PI * .5f;
+		const float TwoPI = PI * 2;
 
 		public override void Draw(RectangleF rect)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
@@ -15,14 +15,19 @@ namespace Xamarin.Forms.Platform.iOS
 		nfloat _bottomLeft;
 		nfloat _bottomRight;
 
+		const float PI = (float)Math.PI;
+		const float PIAndAHalf = (float)(Math.PI * 1.5);
+		const float HalfPI = (float)(Math.PI * .5);
+		const float TwoPI = (float)Math.PI * 2;
+
 		public override void Draw(RectangleF rect)
 		{
 			UIBezierPath bezierPath = new UIBezierPath();
 
-			bezierPath.AddArc(new CoreGraphics.CGPoint((float)Bounds.X + Bounds.Width - _topRight, (float)Bounds.Y + _topRight), _topRight, (float)(Math.PI * 1.5), (float)Math.PI * 2, true);
-			bezierPath.AddArc(new CoreGraphics.CGPoint((float)Bounds.X + Bounds.Width - _bottomRight, (float)Bounds.Y + Bounds.Height - _bottomRight), _bottomRight, 0, (float)(Math.PI * .5), true);
-			bezierPath.AddArc(new CoreGraphics.CGPoint((float)Bounds.X + _bottomLeft, (float)Bounds.Y + Bounds.Height - _bottomLeft), _bottomLeft, (float)(Math.PI * .5), (float)Math.PI, true);
-			bezierPath.AddArc(new CoreGraphics.CGPoint((float)Bounds.X + _topLeft, (float)Bounds.Y + _topLeft), (float)_topLeft, (float)Math.PI, (float)(Math.PI * 1.5), true);
+			bezierPath.AddArc(new CoreGraphics.CGPoint(Bounds.X + Bounds.Width - _topRight, Bounds.Y + _topRight), _topRight, PIAndAHalf, TwoPI, true);
+			bezierPath.AddArc(new CoreGraphics.CGPoint(Bounds.X + Bounds.Width - _bottomRight, Bounds.Y + Bounds.Height - _bottomRight), _bottomRight, 0, HalfPI, true);
+			bezierPath.AddArc(new CoreGraphics.CGPoint(Bounds.X + _bottomLeft, Bounds.Y + Bounds.Height - _bottomLeft), _bottomLeft, HalfPI, PI, true);
+			bezierPath.AddArc(new CoreGraphics.CGPoint(Bounds.X + _topLeft, Bounds.Y + _topLeft), _topLeft, PI, PIAndAHalf, true);
 
 			_colorToRenderer.SetFill();
 			bezierPath.Fill();
@@ -83,10 +88,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var elementCornerRadius = Element.CornerRadius;
 
-			_topLeft = (float)elementCornerRadius.TopLeft;
-			_topRight = (float)elementCornerRadius.TopRight;
-			_bottomLeft = (float)elementCornerRadius.BottomLeft;
-			_bottomRight = (float)elementCornerRadius.BottomRight;
+			_topLeft = (nfloat)elementCornerRadius.TopLeft;
+			_topRight = (nfloat)elementCornerRadius.TopRight;
+			_bottomLeft = (nfloat)elementCornerRadius.BottomLeft;
+			_bottomRight = (nfloat)elementCornerRadius.BottomRight;
 
 			SetNeedsDisplay();
 		}


### PR DESCRIPTION
### Description of Change ###

BoxRenderer's drawing method is constantly recomputing some multiples of pi and casting back and forth between float/nfloat unnecessarily. These changes eliminate some of the unnecessary effort.

### Issues Resolved ### 
None

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
