### PR TITLE
Bump Xamarin UI Test packages to fix UI Tests locally

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -360,7 +360,7 @@
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.Insights" Version="1.12.3" />
     <PackageReference Include="Xamarin.iOS.MaterialComponents" Version="72.2.0.1" />
-    <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.21.8" />
+    <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.21.9" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.3" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.6-dev1" />
     <PackageReference Include="NUnit3TestAdapter">
       <Version>3.15.1</Version>
     </PackageReference>

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Selenium.Support" Version="3.14.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.14.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.3" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.6-dev1" />
     <PackageReference Include="NUnit3TestAdapter">
       <Version>3.15.1</Version>
     </PackageReference>

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="NUnit" Version="3.12.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.3" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.6-dev1" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="BaseViewContainerRemoteiOS.cs" />

--- a/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
+++ b/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
     <PackageReference Include="ServiceStack.Text" Version="4.5.12" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.3" />
+    <PackageReference Include="Xamarin.UITest" Version="3.0.6-dev1" />
     <PackageReference Include="Xamarin.UITest.Desktop" Version="0.0.7" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Updated Xamarin.UITest and the Cloud Agent

### Issues Resolved ### 
- fixes #8891

### Testing Procedure ###
- run ui tests locally
- make sure UI tests still run in appcenter

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
