### PR TITLE
Fix cross-thread exception when finalizing ButtonRenderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -54,16 +54,20 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (_isDisposed)
 				return;
-			if (Control != null)
-			{
-				Control.TouchUpInside -= OnButtonTouchUpInside;
-				Control.TouchDown -= OnButtonTouchDown;
-				BorderElementManager.Dispose(this);
-				_buttonLayoutManager?.Dispose();
-				_buttonLayoutManager = null;
-			}
 
 			_isDisposed = true;
+
+			if (disposing)
+			{
+				if (Control != null)
+				{
+					Control.TouchUpInside -= OnButtonTouchUpInside;
+					Control.TouchDown -= OnButtonTouchDown;
+					BorderElementManager.Dispose(this);
+					_buttonLayoutManager?.Dispose();
+					_buttonLayoutManager = null;
+				}
+			}
 
 			base.Dispose(disposing);
 		}


### PR DESCRIPTION
### Description of Change ###

ButtonRenderer on iOS is not following the Dispose pattern, which means that deterministic disposal operations can happen from the finalizer, which may not be run on the UI thread; this results in cross-thread exceptions that are very difficult to reproduce.

### Issues Resolved ### 
Seemingly random application crashes.

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Nope

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
