### PR TITLE
[Tizen] Load image synchronously

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/Image.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/Image.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
 	{
 		public static readonly BindableProperty BlendColorProperty = BindableProperty.Create("BlendColor", typeof(Color), typeof(FormsElement), Color.Default);
 
+		public static readonly BindableProperty FileProperty = BindableProperty.Create("File", typeof(string), typeof(FormsElement), default(string));
+
 		public static Color GetBlendColor(BindableObject element)
 		{
 			return (Color)element.GetValue(BlendColorProperty);
@@ -24,6 +26,27 @@ namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetBlendColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
 		{
 			SetBlendColor(config.Element, color);
+			return config;
+		}
+
+		public static string GetFile(BindableObject element)
+		{
+			return (string)element.GetValue(FileProperty);
+		}
+
+		public static void SetFile(BindableObject element, string file)
+		{
+			element.SetValue(FileProperty, file);
+		}
+
+		public static string GetFile(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetFile(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFile(this IPlatformElementConfiguration<Tizen, FormsElement> config, string file)
+		{
+			SetFile(config.Element, file);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/ImageExtensions.cs
@@ -1,8 +1,34 @@
+using EImage = ElmSharp.Image;
+
 namespace Xamarin.Forms.Platform.Tizen
 {
-	internal static class ImageExtensions
+	public static class ImageExtensions
 	{
-		internal static bool IsNullOrEmpty(this ImageSource imageSource) =>
+		public static void ApplyAspect(this EImage image, Aspect aspect)
+		{
+			Aspect _aspect = aspect;
+
+			switch (_aspect)
+			{
+				case Aspect.AspectFit:
+					image.IsFixedAspect = true;
+					image.CanFillOutside = false;
+					break;
+				case Aspect.AspectFill:
+					image.IsFixedAspect = true;
+					image.CanFillOutside = true;
+					break;
+				case Aspect.Fill:
+					image.IsFixedAspect = false;
+					image.CanFillOutside = false;
+					break;
+				default:
+					Log.Warn("Invalid Aspect value: {0}", _aspect);
+					break;
+			}
+		}
+
+		public static bool IsNullOrEmpty(this ImageSource imageSource) =>
 			imageSource == null || imageSource.IsEmpty;
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/Image.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Image.cs
@@ -10,39 +10,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 	/// </summary>
 	public class Image : EImage, IMeasurable
 	{
-		Aspect _aspect;
-
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Xamarin.Forms.Platform.Tizen.Native.Image"/> class.
 		/// </summary>
 		/// <param name="parent">The parent EvasObject.</param>
 		public Image(EvasObject parent) : base(parent)
 		{
-			IsScaling = true;
-			CanScaleUp = true;
-			CanScaleDown = true;
-
-			ApplyAspect(Aspect.AspectFit);
-		}
-
-		/// <summary>
-		/// Gets or sets the image aspect ratio preserving option.
-		/// </summary>
-		/// <value>The aspect option.</value>
-		public Aspect Aspect
-		{
-			get
-			{
-				return _aspect;
-			}
-
-			set
-			{
-				if (_aspect != value)
-				{
-					ApplyAspect(value);
-				}
-			}
 		}
 
 		/// <summary>
@@ -67,6 +40,15 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			return isLoadComplate;
 		}
 
+		public bool LoadFromFile(string file)
+		{
+			if (!string.IsNullOrEmpty(file))
+			{
+				return Load(ResourcePath.GetPath(file));
+			}
+			return false;
+		}
+
 		/// <summary>
 		/// Implements the <see cref="Xamarin.Forms.Platform.Tizen.Native.IMeasurable"/> interface.
 		/// </summary>
@@ -75,7 +57,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		public ESize Measure(int availableWidth, int availableHeight)
 		{
 			var imageSize = ObjectSize;
-
 			var size = new ESize()
 			{
 				Width = imageSize.Width,
@@ -95,37 +76,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 
 			return size;
-		}
-
-		/// <summary>
-		/// Sets the <c>IsFixedAspect</c> and <c>CanFillOutside</c> properties according to the given <paramref name="aspect"/>.
-		/// </summary>
-		/// <param name="aspect">The aspect setting to be applied to the image.</param>
-		void ApplyAspect(Aspect aspect)
-		{
-			_aspect = aspect;
-
-			switch (_aspect)
-			{
-				case Aspect.AspectFit:
-					IsFixedAspect = true;
-					CanFillOutside = false;
-					break;
-
-				case Aspect.AspectFill:
-					IsFixedAspect = true;
-					CanFillOutside = true;
-					break;
-
-				case Aspect.Fill:
-					IsFixedAspect = false;
-					CanFillOutside = false;
-					break;
-
-				default:
-					Log.Warn("Invalid Aspect value: {0}", _aspect);
-					break;
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ImageButtonRenderer.cs
@@ -177,7 +177,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateAspect()
 		{
-			_image.Aspect = Element.Aspect;
+			_image.ApplyAspect(Element.Aspect);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
This PR is about loading local file images on Tizen more efficiently and improving performance. As you know, `Xamarin.Forms.Image` was supposed to load images asynchronously, regardless of the `ImageSource` type. When I measured the performance of loading image files (local file) in Tizen platform, I found that sync loading was about 2~3 times faster than async loading. So, I added the TizenSpecific API - `Image.File` - for this.

 This Tizen platform-specific is used to load local file image synchronously. It can be consumed from XAML and C# as follows. If `Image.ImageSource` is set, `Image.File` is ignored. 

- XAML
```xml

<ContentPage ...
    xmlns:tizen="clr-namespace:Xamarin.Forms.PlatformConfiguration.TizenSpecific;assembly=Xamarin.Forms.Core">
    <StackLayout>
        <Image tizen:Image.File="image.png"/>
    </StackLayout>
</ContentPage>
```

- C#
```cs
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
...

var image = new Xamarin.Forms.Image();
image.On<Tizen>().SetFile("image.png");
```


### Issues Resolved ### 
None

### API Changes ###

`namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific`

Added:
 - string Image.File { get; set; } //Bindable Property

`namespace Xamarin.Forms.Platform.Tizen`

Added:
 - bool ImageExtenstion.IsNullOrEmpty() // internal -> public
 - void ImageExtenstion.ApplyAspect() // moved from Native.Image.Aspect property
 
`namespace Xamarin.Forms.Platform.Tizen.Native`

 Removed:
 - Aspect Image.Aspect {get; set;} // use ImageExtenstion.ApplyAspect() instead


### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
