### PR TITLE
Fix ResolveLayoutChanges crash

### DIFF
--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -355,7 +355,8 @@ namespace Xamarin.Forms
 				InvalidateMeasureInternal(InvalidationTrigger.MeasureChanged);
 			}
 
-			s_resolutionList.Add(new KeyValuePair<Layout, int>(this, GetElementDepth(this)));
+			var kvp = new KeyValuePair<Layout, int>(this, GetElementDepth(this));
+			s_resolutionList.Add(kvp);
 			if (!s_relayoutInProgress)
 			{
 				s_relayoutInProgress = true;


### PR DESCRIPTION
### Description of Change ###

By un-inlining the kvp to add to `s_resolutionList`, it is dereferenced later, vastly reducing the likelihood that `s_resolutionList` is an older instance that is currently being enumerated in `ResolveLayoutChanges`.

### Issues Resolved ### 

- fixes #9062

### API Changes ### 
 None

### Platforms Affected ### 
- Android
(although other platforms should be regression tested)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Unfortunately because this is a rare race condition, this is hard. We are working on getting a much more reliable recreation, but this may take some time.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
