### PR TITLE
[platform] improve perf of PropertyChangedEventArgsExtensions

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/PropertyChangedEventArgsExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/PropertyChangedEventArgsExtensions.cs
@@ -1,25 +1,48 @@
 using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Platform.Android
 {
 	internal static class PropertyChangedEventArgsExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool Is(this PropertyChangedEventArgs args, BindableProperty property)
 		{
 			return args.PropertyName == property.PropertyName;
 		}
 
-		public static bool IsOneOf(this PropertyChangedEventArgs args, params BindableProperty[] properties)
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1)
 		{
-			foreach (BindableProperty property in properties)
-			{
-				if (args.PropertyName == property.PropertyName)
-				{
-					return true;
-				}
-			}
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName;
+		}
 
-			return false;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName ||
+				args.PropertyName == p3.PropertyName;
+		}
+		
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3, BindableProperty p4)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName ||
+				args.PropertyName == p3.PropertyName ||
+				args.PropertyName == p4.PropertyName;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ImageRenderer.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.Platform.Android
 				await TryUpdateBitmap();
 			else if (e.PropertyName == Image.AspectProperty.PropertyName)
 				UpdateAspect();
-			else if (e.IsOneOf(Image.IsAnimationPlayingProperty))
+			else if (e.Is(Image.IsAnimationPlayingProperty))
 				UpdateAnimations();
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateTextColor();
 			}
-			else if (e.IsOneOf(SearchHandler.PlaceholderColorProperty))
+			else if (e.Is(SearchHandler.PlaceholderColorProperty))
 			{
 				UpdatePlaceholderColor();
 			}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected override void HandleLayoutPropertyChanged(PropertyChangedEventArgs property)
 		{
-			if (property.IsOneOf(LinearItemsLayout.ItemSpacingProperty))
+			if (property.Is(LinearItemsLayout.ItemSpacingProperty))
 				UpdateItemSpacing();
 			else if (property.Is(ItemsLayout.SnapPointsTypeProperty))
 				UpdateSnapPointsType();

--- a/Xamarin.Forms.Platform.UAP/PropertyChangedEventArgsExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/PropertyChangedEventArgsExtensions.cs
@@ -1,25 +1,48 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Platform.UWP
 {
 	internal static class PropertyChangedEventArgsExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool Is(this PropertyChangedEventArgs args, BindableProperty property)
 		{
 			return args.PropertyName == property.PropertyName;
 		}
 
-		public static bool IsOneOf(this PropertyChangedEventArgs args, params BindableProperty[] properties)
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1)
 		{
-			foreach (BindableProperty property in properties)
-			{
-				if (args.PropertyName == property.PropertyName)
-				{
-					return true;
-				}
-			}
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName;
+		}
 
-			return false;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName ||
+				args.PropertyName == p3.PropertyName;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3, BindableProperty p4)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName ||
+				args.PropertyName == p3.PropertyName ||
+				args.PropertyName == p4.PropertyName;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/PropertyChangedEventArgsExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/PropertyChangedEventArgsExtensions.cs
@@ -1,25 +1,48 @@
 ﻿using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Platform.iOS
 {
 	internal static class PropertyChangedEventArgsExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static bool Is(this PropertyChangedEventArgs args, BindableProperty property)
 		{
 			return args.PropertyName == property.PropertyName;
 		}
 
-		public static bool IsOneOf(this PropertyChangedEventArgs args, params BindableProperty[] properties)
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1)
 		{
-			foreach (BindableProperty property in properties)
-			{
-				if (args.PropertyName == property.PropertyName)
-				{
-					return true;
-				}
-			}
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName;
+		}
 
-			return false;
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName ||
+				args.PropertyName == p3.PropertyName;
+		}
+
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
+		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3, BindableProperty p4)
+		{
+			return args.PropertyName == p0.PropertyName ||
+				args.PropertyName == p1.PropertyName ||
+				args.PropertyName == p2.PropertyName ||
+				args.PropertyName == p3.PropertyName ||
+				args.PropertyName == p4.PropertyName;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

When reviewing code in Xamarin.Forms I noticed the method:

    public static bool IsOneOf(this PropertyChangedEventArgs args, params BindableProperty[] properties)
    {
        foreach (BindableProperty property in properties)
        {
            if (args.PropertyName == property.PropertyName)
            {
                return true;
            }
        }
    }

Which is used such as:

    else if (e.IsOneOf(Label.TextProperty, Label.FormattedTextProperty, Label.TextTypeProperty))
        UpdateText();

The readability is nice, it is an improvement to:

    else if (e.PropertyName == Label.TextProperty.PropertyName || e.PropertyName == Label.FormattedTextProperty.PropertyName || e.PropertyName == Label.TextTypeProperty.PropertyName))
        UpdateText();

I mean that is so long it goes off the end of my screen!

Unfortunately, the `IsOneOf` method has some impact to performance:

1. A `BindableProperty[]` is always allocated on the heap.
2. In this simple case, the compiler should swap the `foreach` loop to
   a `for` loop. A for-loop is still slower than the long `if`
   statement.

Since `IsOneOf` is used in `OnElementPropertyChanged` throughout
Xamarin.Forms for even basic renderers, like `LabelRenderer` it's
worth making an optimization here. I would suspect most apps
experience 1000's of property changes.

I improved `Is` and `IsOneOf`:

* Use `MethodImplOptions.AggressiveInlining`
* Remove the `params[]` and manually define up to 5 parameters. If you
  need more, please reexamine your life choices.

I wrote a benchmark here:

https://github.com/jonathanpeppers/Benchmarks/blob/7f9ea6950bbea6b6dcc22b2fa7261d2415bb7829/Benchmarks/PropertyChangedExtensions.cs

The results running on mono/macOS:

    // * Summary *
    BenchmarkDotNet=v0.11.3, OS=macOS Mojave 10.14.6 (18G95) [Darwin 18.7.0]
    Intel Core i7-6567U CPU 3.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
      [Host]     : Mono 6.8.0.53 (2019-10/e9b5aec5ec7 Thu), 64bit
      DefaultJob : Mono 6.8.0.53 (2019-10/e9b5aec5ec7 Thu), 64bit
       Method |     Mean |     Error |    StdDev |   Median |
    --------- |---------:|----------:|----------:|---------:|
     IsOneOf2 | 32.98 ns | 0.7876 ns | 0.9960 ns | 32.89 ns |
          Is2 | 33.22 ns | 0.9209 ns | 2.7152 ns | 32.18 ns |
          Is1 | 42.70 ns | 1.2682 ns | 3.6793 ns | 42.31 ns |
     IsOneOf1 | 75.29 ns | 1.8637 ns | 5.4953 ns | 73.64 ns |

It seems `IsOneOf` is now more 2x faster and `Is` is now ~33% better.

I also found a couple places where `IsOneOf` was called with one
parameter. I think calling `Is` instead makes sense?

### Issues Resolved ### 

None

### API Changes ###

None - everything should be `internal`

### Platforms Affected ### 

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

CI should be good enough?

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
