### PR TITLE
Registrar frame profile matchup fix

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -343,7 +343,11 @@ namespace Xamarin.Forms.Internals
 
 				object[] effectAttributes = assembly.GetCustomAttributesSafe(typeof (ExportEffectAttribute));
 				if (effectAttributes == null || effectAttributes.Length == 0)
+				{
+					Profile.FrameEnd();
 					continue;
+				}
+
 				string resolutionName = assembly.FullName;
 				var resolutionNameAttribute = (ResolutionGroupNameAttribute)assembly.GetCustomAttribute(typeof(ResolutionGroupNameAttribute));
 				if (resolutionNameAttribute != null)


### PR DESCRIPTION
### Description of Change ###

When the for loop on the registrar exits early it needs to close the profiler frame

### Testing Procedure ###
- make sure you can launch Android control gallery and run a ui test

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
