### PR TITLE
[Core] performance improvements around bindings

### DIFF
--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -276,11 +276,7 @@ namespace Xamarin.Forms
 
 		internal override BindingBase Clone()
 		{
-			return new Binding(Path, Mode) {
-				Converter = Converter,
-				ConverterParameter = ConverterParameter,
-				StringFormat = StringFormat,
-				Source = Source,
+			return new Binding(Path, Mode, Converter, ConverterParameter, StringFormat, Source) {
 				UpdateSourceEventName = UpdateSourceEventName,
 				TargetNullValue = TargetNullValue,
 				FallbackValue = FallbackValue,

--- a/Xamarin.Forms.Core/BindingBase.cs
+++ b/Xamarin.Forms.Core/BindingBase.cs
@@ -87,6 +87,7 @@ namespace Xamarin.Forms
 			SynchronizedCollections.Add(collection, new CollectionSynchronizationContext(context, callback));
 		}
 
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		protected void ThrowIfApplied()
 		{
 			if (IsApplied)

--- a/Xamarin.Forms.Core/BindingBaseExtensions.cs
+++ b/Xamarin.Forms.Core/BindingBaseExtensions.cs
@@ -1,7 +1,10 @@
-﻿namespace Xamarin.Forms
+﻿using System.Runtime.CompilerServices;
+
+namespace Xamarin.Forms
 {
 	static class BindingBaseExtensions
 	{
+		[MethodImpl(MethodImplOptions.AggressiveInlining)]
 		public static BindingMode GetRealizedMode(this BindingBase self, BindableProperty property)
 		{
 			return self.Mode != BindingMode.Default ? self.Mode : property.DefaultBindingMode;


### PR DESCRIPTION
### Description of Change ###

I made most of these changes through the benchmarks here:

https://github.com/jonathanpeppers/Benchmarks/blob/6725a72844c5f18320a31223b6f37abd7b28ece4/Benchmarks/BindingBenchmarks.cs

1. `Clone()` was doing `new Binding()` but then using the property
   setters instead of the ctor parameters. `Clone()` seems to be
   called for `DataTemplate`, `ListView`, etc.

2. `BindingBase.ThrowIfApplied()` is called very frequently, so I
   added `MethodImplOptions.AggressiveInlining`.

3. `BindingBaseExtensions.GetRealizedMode` is called ~3 times per
   binding applied, added `MethodImplOptions.AggressiveInlining`.

4. In `BindingExpression` a `bool isLast` value was always calculated,
   even though it was only sometimes used inside an `if`. It can just
   do this check inside the `if`.

5. `object value = property.DefaultValue;` was defined prior to
   calling `TryGetValue`, which will always overwrite it. I just
   removed the call, since a Roslyn analyzer was showing me this.

6. `BindingExpression` was doing a `string.Split('.')` which always
   allocates a `char[]`. I defined the array as a `static` field
   instead.

7. `BindingExpression.GetPart` used `IEnumerable` and `yield return`.
   In the most common case, this function returned a single item and
   in the rare case two items. I removed this function and a `foreach`
   and moved logic inline within the `ParsePath` method. This avoids
   allocations around `foreach`, when it isn't needed.

These are all small changes, but I was only able to see some
difference after everything came together. If we need to split some of
these up, we can do that.

#### Results ####

Benchmarks running on mono/macOS:

    BenchmarkDotNet=v0.11.3, OS=macOS Mojave 10.14.6 (18G95) [Darwin 18.7.0]
    Intel Core i7-6567U CPU 3.30GHz (Skylake), 1 CPU, 4 logical and 2 physical cores
      [Host]     : Mono 6.6.0.155 (2019-08/296a9afdb24 Thu), 64bit
      DefaultJob : Mono 6.6.0.155 (2019-08/296a9afdb24 Thu), 64bit
             Method |        Mean |      Error |     StdDev |      Median |
    --------------- |------------:|-----------:|-----------:|------------:|
        CtorSingle2 |    355.9 ns |   2.600 ns |   2.432 ns |    356.1 ns |
        CtorSingle1 |    447.0 ns |  28.825 ns |  29.601 ns |    432.4 ns |
      CtorMultiple2 |  1,316.6 ns |   7.092 ns |   6.287 ns |  1,316.6 ns |
      CtorMultiple1 |  1,611.0 ns |  77.914 ns | 109.225 ns |  1,560.9 ns |
             Clone2 |  2,670.6 ns |  38.075 ns |  33.753 ns |  2,655.7 ns |
             Clone1 |  3,154.3 ns |  15.010 ns |  14.040 ns |  3,151.7 ns |
       ApplySingle2 |  8,065.5 ns |  87.537 ns |  77.599 ns |  8,071.3 ns |
       ApplySingle1 |  8,555.2 ns | 183.373 ns | 508.126 ns |  8,268.9 ns |
     ApplyMultiple2 | 28,933.1 ns | 252.589 ns | 236.272 ns | 28,937.1 ns |
     ApplyMultiple1 | 29,388.9 ns | 269.263 ns | 251.868 ns | 29,296.0 ns |

This appears to save 0.5-1ms per binding applied. It is also somewhat
concerning that this shows a complex binding takes ~30ms on mono? I
will look into that further.

Benchmarks running on Windows/.NET framework, allow us to see the
memory usage as well (memory usage not implemented in BDN on mono):

    BenchmarkDotNet=v0.11.3, OS=Windows 10.0.18362
    Intel Core i9-9900K CPU 3.60GHz, 1 CPU, 16 logical and 8 physical cores
      [Host]     : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4075.0
      DefaultJob : .NET Framework 4.7.2 (CLR 4.0.30319.42000), 32bit LegacyJIT-v4.8.4075.0
             Method |       Mean |      Error |     StdDev | Allocated Memory/Op |
    --------------- |-----------:|-----------:|-----------:|--------------------:|
        CtorSingle2 |   122.6 ns |  0.5047 ns |  0.4721 ns |               369 B |
        CtorSingle1 |   156.3 ns |  0.5229 ns |  0.4636 ns |               421 B |
      CtorMultiple2 |   337.7 ns |  2.5286 ns |  2.3652 ns |               857 B |
      CtorMultiple1 |   435.4 ns |  1.0472 ns |  0.9796 ns |              1017 B |
             Clone2 |   667.0 ns |  2.5739 ns |  2.0095 ns |              1715 B |
             Clone1 |   890.6 ns |  9.1459 ns |  8.5551 ns |              2035 B |
       ApplySingle2 | 1,512.4 ns |  9.0686 ns |  7.0802 ns |               521 B |
       ApplySingle1 | 1,655.3 ns | 31.1960 ns | 35.9253 ns |               573 B |
     ApplyMultiple2 | 4,501.1 ns | 21.8014 ns | 20.3930 ns |              1394 B |
     ApplyMultiple1 | 4,510.7 ns | 25.4709 ns | 22.5793 ns |              1554 B |

This looks like it saves ~160 bytes of allocations per binding applied.

I also tested the Blank Forms app template after adding 100 `Label`
with a single binding:

    Before:
    01-13 16:23:09.406  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +746ms
    01-13 16:23:13.103  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +716ms
    01-13 16:23:16.888  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +732ms
    01-13 16:23:20.656  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +728ms
    01-13 16:23:24.390  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +726ms
    01-13 16:23:28.192  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +723ms
    01-13 16:23:31.910  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +725ms
    01-13 16:23:35.660  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +726ms
    01-13 16:23:39.410  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +728ms
    01-13 16:23:43.126  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +724ms
    Average(ms): 727.4
    Std Err(ms): 2.44585817704589
    Std Dev(ms): 7.73448267321236

    After:
    01-13 16:26:21.557  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +732ms
    01-13 16:26:25.294  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +716ms
    01-13 16:26:29.042  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +736ms
    01-13 16:26:32.760  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +721ms
    01-13 16:26:36.490  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +722ms
    01-13 16:26:40.223  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +722ms
    01-13 16:26:43.957  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +724ms
    01-13 16:26:47.726  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +718ms
    01-13 16:26:51.476  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +722ms
    01-13 16:26:55.224  1473  1503 I ActivityTaskManager: Displayed com.xamarin.forms.helloforms/crc6450e568c951913723.MainActivity: +724ms
    Average(ms): 723.7
    Std Err(ms): 1.90933379888262
    Std Dev(ms): 6.0378436180109

In this scenario the changes seems to save ~3.7ms to overall startup.
The code for this project is here:

https://github.com/jonathanpeppers/Xamarin.Forms/commit/a319b6709894379b5d08703f80238e5ef5a92ba0

I timed a Release build running on a Pixel 3 XL.

### Issues Resolved ### 

None

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

CI should be sufficient.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
