### PR TITLE
[Build]Use same counter for all builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -10,7 +10,7 @@ variables:
 - name: SolutionFile
   value: Xamarin.Forms.sln
 - name: BuildVersion
-  value: $[counter(variables['Build.SourceBranch'], 1)]
+  value: $[counter('nuget-counter', 126)]
 - name: BuildVersion42
   value: $[counter('xf-nuget-counter', 992000)]
 - name: BuildVersion43


### PR DESCRIPTION
### Description of Change ###

Use same nuget counter for all builds. Making the counter based on branch didn't work fine with nightly 

### Issues Resolved ### 

- None

### API Changes ###

 None

### Platforms Affected ### 

- Nuget

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
