### PR TITLE
[Enhancement] Add Asynchronous Callback to Device.StartTimer

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
@@ -120,14 +120,13 @@ namespace Xamarin.Forms.Core.UnitTests
 		public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
 		{
 			Timer timer = null;
-			TimerCallback onTimeout = o => BeginInvokeOnMainThread(() => {
-				callback().ContinueWith(completedTask =>
-				{
-					if (!completedTask.IsFaulted && !completedTask.Result)
-						return;
+			TimerCallback onTimeout = o => BeginInvokeOnMainThread(async () =>
+			{
+				var result = await callback();
+				if (result)
+					return;
 
-					timer.Dispose();
-				});					
+				timer.Dispose();
 			});
 			timer = new Timer(onTimeout, null, interval, interval);
 		}

--- a/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
@@ -117,6 +117,21 @@ namespace Xamarin.Forms.Core.UnitTests
 			timer = new Timer (onTimeout, null, interval, interval);
 		}
 
+		public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+		{
+			Timer timer = null;
+			TimerCallback onTimeout = o => BeginInvokeOnMainThread(() => {
+				callback().ContinueWith(completedTask =>
+				{
+					if (!completedTask.IsFaulted && !completedTask.Result)
+						return;
+
+					timer.Dispose();
+				});					
+			});
+			timer = new Timer(onTimeout, null, interval, interval);
+		}
+
 		public Task<Stream> GetStreamAsync (Uri uri, CancellationToken cancellationToken)
 		{
 			if (getStreamAsync == null)

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -235,6 +235,11 @@ namespace Xamarin.Forms
 			PlatformServices.StartTimer(interval, callback);
 		}
 
+		public static void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+		{
+			PlatformServices.StartTimer(interval, callback);
+		}
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static Assembly[] GetAssemblies()
 		{

--- a/Xamarin.Forms.Core/IPlatformServices.cs
+++ b/Xamarin.Forms.Core/IPlatformServices.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Forms.Internals
 
 		void StartTimer(TimeSpan interval, Func<bool> callback);
 
+		void StartTimer(TimeSpan interval, Func<Task<bool>> callback);
+
 		string RuntimePlatform { get; }
 
 		void QuitApplication();

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -755,6 +755,25 @@ namespace Xamarin.Forms
 				}, (long)interval.TotalMilliseconds);
 			}
 
+			public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+			{
+				var handler = new Handler(Looper.MainLooper);
+				handler.PostDelayed(() =>
+				{
+					callback().ContinueWith(completedTask =>
+					{
+						if (completedTask.IsFaulted
+							|| (completedTask.IsCompleted && !completedTask.Result))
+						{
+							StartTimer(interval, callback);
+						}
+
+						handler.Dispose();
+						handler = null;
+					});
+				}, (long)interval.TotalMilliseconds);
+			}
+
 			double ConvertTextAppearanceToSize(int themeDefault, int deviceDefault, double defaultValue)
 			{
 				double myValue;

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -758,19 +758,14 @@ namespace Xamarin.Forms
 			public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
 			{
 				var handler = new Handler(Looper.MainLooper);
-				handler.PostDelayed(() =>
+				handler.PostDelayed(async () =>
 				{
-					callback().ContinueWith(completedTask =>
-					{
-						if (completedTask.IsFaulted
-							|| (completedTask.IsCompleted && !completedTask.Result))
-						{
-							StartTimer(interval, callback);
-						}
+					var result = await callback();
+					if (result)
+						StartTimer(interval, callback);
 
-						handler.Dispose();
-						handler = null;
-					});
+					handler.Dispose();
+					handler = null;
 				}, (long)interval.TotalMilliseconds);
 			}
 

--- a/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
@@ -107,6 +107,19 @@ namespace Xamarin.Forms.Platform.GTK
 			});
 		}
 
+		public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+		{
+			bool callbackResult = true;
+
+			GLib.Timeout.Add((uint)interval.TotalMilliseconds, () =>
+			{
+				ExecuteCallBack();
+				return callbackResult;
+			});
+
+			async void ExecuteCallBack() => callbackResult = await callback();
+		}
+
 		private static int Hex(int v)
 		{
 			if (v < 10)

--- a/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
@@ -113,7 +113,9 @@ namespace Xamarin.Forms.Platform.GTK
 
 			GLib.Timeout.Add((uint)interval.TotalMilliseconds, () =>
 			{
-				ExecuteCallBack();
+				if (callbackResult)
+					ExecuteCallBack();
+
 				return callbackResult;
 			});
 

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -151,15 +151,15 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (!invoking)
 				{
 					invoking = true;
-					BeginInvokeOnMainThread( async () =>
-					{
-						var callbackResult = await callback();
-						if (!callbackResult)
+					BeginInvokeOnMainThread(async () =>
 						{
-							timer.Dispose();
+							var result = await callback();
+							if (!result)
+							{
+								timer.Dispose();
+							}
+							invoking = false;
 						}
-						invoking = false;
-					}
 					);
 				}
 			};

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -8,6 +8,7 @@ using System.Reflection;
 using System.Security.Cryptography;
 using System.Threading;
 using System.Threading.Tasks;
+using Tizen.Telephony;
 using Xamarin.Forms.Internals;
 using TAppControl = Tizen.Applications.AppControl;
 
@@ -133,6 +134,32 @@ namespace Xamarin.Forms.Platform.Tizen
 							}
 							invoking = false;
 						}
+					);
+				}
+			};
+			timer = new Timer(onTimeout, null, Timeout.Infinite, Timeout.Infinite);
+			// set interval separarately to prevent calling onTimeout before `timer' is assigned
+			timer.Change(interval, interval);
+		}
+
+		public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+		{
+			Timer timer = null;
+			bool invoking = false;
+			TimerCallback onTimeout = o =>
+			{
+				if (!invoking)
+				{
+					invoking = true;
+					BeginInvokeOnMainThread( async () =>
+					{
+						var callbackResult = await callback();
+						if (!callbackResult)
+						{
+							timer.Dispose();
+						}
+						invoking = false;
+					}
 					);
 				}
 			};

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -152,6 +152,25 @@ namespace Xamarin.Forms.Platform.UWP
 			CompositionTarget.Rendering += renderingFrameEventHandler;
 		}
 
+		public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+		{
+			var timerTick = 0L;
+			var stopWatch = new Stopwatch();
+			stopWatch.Start();
+			async void renderingFrameEventHandler(object sender, object args)
+			{
+				var newTimerTick = stopWatch.ElapsedMilliseconds / (long)interval.TotalMilliseconds;
+				if (newTimerTick == timerTick)
+					return;
+				timerTick = newTimerTick;
+				bool result = await callback();
+				if (result)
+					return;
+				CompositionTarget.Rendering -= renderingFrameEventHandler;
+			}
+			CompositionTarget.Rendering += renderingFrameEventHandler;
+		}
+
 		public void QuitApplication()
 		{
 			Log.Warning(nameof(WindowsBasePlatformServices), "Platform doesn't implement QuitApp");

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -145,9 +145,8 @@ namespace Xamarin.Forms.Platform.UWP
 					return;
 				timerTick = newTimerTick;
 				bool result = callback();
-				if (result)
-					return;
-				CompositionTarget.Rendering -= renderingFrameEventHandler;
+				if (!result)
+					CompositionTarget.Rendering -= renderingFrameEventHandler;
 			}
 			CompositionTarget.Rendering += renderingFrameEventHandler;
 		}
@@ -164,9 +163,8 @@ namespace Xamarin.Forms.Platform.UWP
 					return;
 				timerTick = newTimerTick;
 				bool result = await callback();
-				if (result)
-					return;
-				CompositionTarget.Rendering -= renderingFrameEventHandler;
+				if (!result)
+					CompositionTarget.Rendering -= renderingFrameEventHandler;
 			}
 			CompositionTarget.Rendering += renderingFrameEventHandler;
 		}

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -151,6 +151,18 @@ namespace Xamarin.Forms.Platform.WPF
 			};
 		}
 
+		public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+		{
+			var timer = new DispatcherTimer(DispatcherPriority.Background, System.Windows.Application.Current.Dispatcher) { Interval = interval };
+			timer.Start();
+			timer.Tick += async (sender, args) =>
+			{
+				bool result = await callback();
+				if (!result)
+					timer.Stop();
+			};
+		}
+
 		public void QuitApplication()
 		{
 			System.Windows.Application.Current.Shutdown();

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -334,6 +334,22 @@ namespace Xamarin.Forms
 				NSRunLoop.Main.AddTimer(timer, NSRunLoopMode.Common);
 			}
 
+			public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
+			{
+				NSTimer timer = NSTimer.CreateRepeatingTimer(interval, t =>
+				{
+					callback().ContinueWith(completedTask =>
+					{
+						if (completedTask.IsFaulted
+							|| (completedTask.IsCompleted && !completedTask.Result))
+						{
+							t.Invalidate();
+						}
+					});
+				});
+				NSRunLoop.Main.AddTimer(timer, NSRunLoopMode.Common);
+			}
+
 			HttpClient GetHttpClient()
 			{
 				var proxy = CoreFoundation.CFNetwork.GetSystemProxySettings();

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -336,16 +336,11 @@ namespace Xamarin.Forms
 
 			public void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
 			{
-				NSTimer timer = NSTimer.CreateRepeatingTimer(interval, t =>
+				NSTimer timer = NSTimer.CreateRepeatingTimer(interval, async t =>
 				{
-					callback().ContinueWith(completedTask =>
-					{
-						if (completedTask.IsFaulted
-							|| (completedTask.IsCompleted && !completedTask.Result))
-						{
-							t.Invalidate();
-						}
-					});
+					var result = await callback();
+					if (result)
+						t.Invalidate();
 				});
 				NSRunLoop.Main.AddTimer(timer, NSRunLoopMode.Common);
 			}


### PR DESCRIPTION
### Description of Change ###

Implements an asynchronous callback to `Device.StartTimer`

This will enable devs to use `StartTime` to execute asynchronous tasks, e.g. calls to web APIs, saving/retrieving items from disk, getting device sensor information like GPS coordinates.

```csharp
class App : Application
{
    protected override void OnStart()
    {
        Device.StartTime(TimeSpan.FromSeconds(5), SendUpdate);
    }

    async Task<bool> SendUpdate()
    {
        var isSuccessful = await DataServices.PostData();
        return isSuccessful;
    }
}
```

### Issues Resolved ### 

- fixes #9131 

### API Changes ###

```csharp
interface IPlatformServices
{
    //Add New API
    void StartTimer(TimeSpan interval, Func<Task<bool>> callback)
}
```
 
 None

### Platforms Affected ###

- Core/XAML (all platforms)
- iOS
- Android
- UWP
- WPF
- Tizen
- macOS
- GTK

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

The following tests will be created for each platform:
- [ ] Call `StartTimer(TimeSpan interval, Func<Task<bool>> callback)` with a successful Task that returns `true`; confirm timer executes again
- [ ] Call `StartTimer(TimeSpan interval, Func<Task<bool>> callback)` with a successful Task that returns `false`; confirm timer does not execute again
- [ ] Call `StartTimer(TimeSpan interval, Func<Task<bool>> callback)` with a Task that throws an exception before `await` is called in that `Task`; confirm timer does not execute again at the scheduled interval
- [ ] Call `StartTimer(TimeSpan interval, Func<Task<bool>> callback)` with a Task that throws an exception after `await` is called in that `Task`; confirm timer does not execute again at the scheduled interval

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ x ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
