### PR TITLE
[Core] remove array covariant cast for UWP

### DIFF
--- a/Xamarin.Forms.Core/Registrar.cs
+++ b/Xamarin.Forms.Core/Registrar.cs
@@ -338,7 +338,10 @@ namespace Xamarin.Forms.Internals
 					object[] attributes = assembly.GetCustomAttributesSafe(attrType);
 					if (attributes == null || attributes.Length == 0)
 						continue;
-					RegisterRenderers((HandlerAttribute[])attributes);
+					//NOTE: a simple cast to HandlerAttribute[] failed on UWP, hence the Array.Copy
+					var handlerAttributes = new HandlerAttribute[attributes.Length];
+					Array.Copy(attributes, handlerAttributes, attributes.Length);
+					RegisterRenderers(handlerAttributes);
 				}
 
 				object[] effectAttributes = assembly.GetCustomAttributesSafe(typeof (ExportEffectAttribute));
@@ -352,7 +355,10 @@ namespace Xamarin.Forms.Internals
 				var resolutionNameAttribute = (ResolutionGroupNameAttribute)assembly.GetCustomAttribute(typeof(ResolutionGroupNameAttribute));
 				if (resolutionNameAttribute != null)
 					resolutionName = resolutionNameAttribute.ShortName;
-				RegisterEffects(resolutionName, (ExportEffectAttribute[])effectAttributes);
+				//NOTE: a simple cast to ExportEffectAttribute[] failed on UWP, hence the Array.Copy
+				var typedEffectAttributes = new ExportEffectAttribute[effectAttributes.Length];
+				Array.Copy(effectAttributes, typedEffectAttributes, effectAttributes.Length);
+				RegisterEffects(resolutionName, typedEffectAttributes);
 
 				Profile.FrameEnd();
 			}


### PR DESCRIPTION
### Description of Change ###

Fixes #9134

A reported failure of:

    System.InvalidCastException: 'Unable to cast object of type 'System.Attribute[]' to type 'Xamarin.Forms.HandlerAttribute[]'.'

was happening on UWP, @PureWeen also could repro with a new app.

What is weird about this:

* It appears to work with .NET Framework & Mono
* It appears to work for me locally if I just launch the Control
  Gallery on UWP.

I suspect something is happening with how Xamarin.Forms is built
(using 2017 and older UWP SDKs), but not really sure?

I think we should just fix this quickly and I will revisit later.

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/9134

### API Changes ###
 
 None

### Platforms Affected ### 
- Core/XAML (all platforms)
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

We should perhaps manually test the NuGet package on UWP?

It is really weird this works for me locally on the 4.4.0 branch running the UWP ControlGallery:

![image](https://user-images.githubusercontent.com/840039/72036554-c913f900-3260-11ea-8884-fe4bef07addd.png)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
