### PR TITLE
Apply cecil fixes to make packages 2017 compatible

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -36,6 +36,6 @@
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -36,6 +36,6 @@
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.3" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -19,7 +19,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
-  </ProjectReference>
+    </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Forms.Platform.Android.FormsViewGroup\Xamarin.Forms.Platform.Android.FormsViewGroup.csproj">
     </ProjectReference>
     <ProjectReference Include="..\..\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android.csproj">
@@ -34,5 +34,8 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid90'">
     <PackageReference Include="Xamarin.Android.Support.v4" Version="28.0.0.3" />
     <PackageReference Include="Xamarin.Android.Support.v7.RecyclerView" Version="28.0.0.3" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -58,6 +58,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -58,6 +58,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -57,4 +57,7 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.ControlGallery.iOS/PlatformSpecificCoreGalleryFactory.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/PlatformSpecificCoreGalleryFactory.cs
@@ -3,11 +3,13 @@ using System.Collections.Generic;
 using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.iOS;
 using Xamarin.Forms.Controls;
+using Xamarin.Forms.Internals;
 
 [assembly: Dependency(typeof(PlatformSpecificCoreGalleryFactory))]
 
 namespace Xamarin.Forms.ControlGallery.iOS
 {
+	[Preserve(AllMembers = true)]
 	public class PlatformSpecificCoreGalleryFactory : IPlatformSpecificCoreGalleryFactory
 	{
 		public string Title => "iOS Core Gallery";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1753,7 +1753,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4744.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -35,6 +35,6 @@
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="71.1610.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -35,6 +35,6 @@
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="71.1610.0" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -34,4 +34,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="71.1610.0" />
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -66,6 +66,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -66,6 +66,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -65,4 +65,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -35,6 +35,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -35,6 +35,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -31,7 +31,10 @@
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Platform.Android.FormsViewGroup\Xamarin.Forms.Platform.Android.FormsViewGroup.csproj">
     </ProjectReference>
-    <ProjectReference PrivateAssets="All" Include="..\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android.csproj">
+    <ProjectReference Include="..\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android.csproj">
     </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -95,6 +95,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -95,6 +95,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -94,4 +94,7 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -37,6 +37,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -37,6 +37,6 @@
     </PackageReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -36,4 +36,5 @@
       <Version>1.0.0-rc1</Version>
     </PackageReference>
   </ItemGroup>
+  <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -36,5 +36,7 @@
       <Version>1.0.0-rc1</Version>
     </PackageReference>
   </ItemGroup>
-  <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -59,7 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -59,7 +59,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
   
 </Project>

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -58,5 +58,8 @@
     <ProjectReference Include="..\Xamarin.Forms.Platform.Android.FormsViewGroup\Xamarin.Forms.Platform.Android.FormsViewGroup.csproj">
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
   
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -12,7 +12,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
+					if(Forms.IsiOS13OrNewer)
+						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium });
+					else
+						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
 				}
 
 				UpdateColor();

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -295,6 +295,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -295,6 +295,6 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -294,5 +294,7 @@
       <Name>Xamarin.Forms.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Build.TypeRedirector" Version="0.1.1-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -18,11 +18,11 @@ variables:
 - name: BuildVersion44
   value: $[counter('xf-nuget-counter', 992000)]
 - name: NUGET_VERSION
-  value: 5.0.2
+  value: 5.4.0
 - name: DOTNET_SKIP_FIRST_TIME_EXPERIENCE
   value: true
 - name: DOTNET_VERSION
-  value: 3.0.100
+  value: 3.1.100
 
 resources:
   repositories:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,8 +123,6 @@ jobs:
   displayName: Nuget Phase
   dependsOn:
    - win
-   - win_2019
-   - win_2019_android
   condition: succeeded()
   pool:
     name: $(winVmImage)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -64,42 +64,11 @@ jobs:
   parameters:
     name: win
     displayName: Build Windows Phase
-    vmImage: $(winVmImage)
-    targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
-    msbuildExtraArguments: '/nowarn:VSX1000 /p:AndroidTargetFrameworks=MonoAndroid90'
-    buildConfiguration: $(DefaultBuildConfiguration)
-    buildPlatform: $(DefaultBuildPlatform)
-    provisionatorPath : 'build/provisioning/provisioning.csx'
-    includeUwp: 'false'
-
-- template: build/steps/build-windows.yml
-  parameters:
-    name: win_2019_android
-    displayName: Build Android 10.0
     vmImage: $(win2019VmImage)
-    targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
-    msbuildExtraArguments: '/nowarn:VSX1000 /p:AndroidTargetFrameworks=MonoAndroid10.0'
-    buildConfiguration: $(DefaultBuildConfiguration)
-    buildPlatform: $(DefaultBuildPlatform)
-    provisionatorPath : 'build/provisioning/provisioning.csx'
-    slnPath: '.Xamarin.Forms.Android.nuget.sln'
-    includeUwp: 'false'
-    includeNonUwpAndNonAndroid: 'false'
-
-- template: build/steps/build-windows.yml
-  parameters:
-    name: win_2019
-    displayName: Build UWP Phase
-    vmImage: $(win2019VmImage)
-    targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
     msbuildExtraArguments: '/nowarn:VSX1000'
     buildConfiguration: $(DefaultBuildConfiguration)
     buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
-    slnPath: '.Xamarin.Forms.UAP.nuget.sln'
-    includeNonUwpAndNonAndroid: 'false'
-    includeAndroid: 'false'
-
 
 - template: build/steps/build-android.yml
   parameters:

--- a/build.cake
+++ b/build.cake
@@ -56,14 +56,17 @@ string androidSDK_windows = "";//"https://aka.ms/xamarin-android-commercial-d15-
 string iOSSDK_windows = "";//"https://download.visualstudio.microsoft.com/download/pr/71f33151-5db4-49cc-ac70-ba835a9f81e2/d256c6c50cd80ec0207783c5c7a4bc2f/xamarin.visualstudio.apple.sdk.4.12.3.83.vsix";
 string macSDK_windows = "";
 
-monoMajorVersion = "6.4.0";
-monoPatchVersion = "198";
-monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
-
-string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-3-macos";
+monoMajorVersion = "6.8.0";
+monoPatchVersion = "";
+if(String.IsNullOrWhiteSpace(monoPatchVersion))
+    monoVersion = $"{monoMajorVersion}";
+else
+    monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
+    
+string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-4-macos";
 string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
-string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
+string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-4/0d8fe219c727fc68d495c26823070b510a4aa474/36/package/notarized/xamarin.ios-13.8.3.0.pkg";
+string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-4/0d8fe219c727fc68d495c26823070b510a4aa474/36/package/notarized/xamarin.mac-6.8.3.0.pkg";
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -56,6 +56,7 @@ steps:
     inputs:
       solutionFile: $(slnPath)
       configuration: $(buildConfiguration)
+      args: /bl:$(Build.ArtifactStagingDirectory)/ios.binlog
 
 
   - task: CopyFiles@2


### PR DESCRIPTION
### Description of Change ###
This will allow us to build our nuget packages on vs 2019 but they will still work on VS2017

### Platforms Affected ### 
- iOS
- Android


### Testing Procedure ###
- download the nuget packages and try to run/build android/ios projects on vs2017

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
