### PR TITLE
Add null check in UpdateFlowDirection

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -146,7 +146,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateFlowDirection()
 		{
-			if (Superview == null || _requestedScroll != null || _checkedForRtlScroll)
+			if (Superview == null || ScrollView.Content == null || _requestedScroll != null || _checkedForRtlScroll)
 				return;
 
 			if (Element is IVisualElementController controller && ScrollView.Orientation != ScrollOrientation.Vertical)


### PR DESCRIPTION
### Description of Change ###
Before this fix, when I use ScrollView with no Content and RightToLeft FlowDirection application crashes after page is loaded. So I added null check for ScrollView.Content in UpdateFlowDirection method in ScrollViewRenderer for iOS.
 
### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
The application will no longer crash with  with changed flow dirrection to RtL and null Content of ScrollView.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Try use ScroolView with any content on iOS with changed flow dirrection to RtL.