### PR TITLE
[CSS] reapply Stylesheet on StyleClass changes

### DIFF
--- a/Xamarin.Forms.Core/Element_StyleSheets.cs
+++ b/Xamarin.Forms.Core/Element_StyleSheets.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms
 		IStyleSelectable IStyleSelectable.Parent => Parent;
 
 		//on parent set, or on parent stylesheet changed, reapply all
-		void ApplyStyleSheetsOnParentSet()
+		internal void ApplyStyleSheetsOnParentSet()
 		{
 			var parent = Parent;
 			if (parent == null)

--- a/Xamarin.Forms.Core/MergedStyle.cs
+++ b/Xamarin.Forms.Core/MergedStyle.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Forms
 				if (_styleClass == value)
 					return;
 
-				if (_styleClass != null && _classStyles != null)
+				if (_styleClass != null && _classStyleProperties != null)
 					foreach (var classStyleProperty in _classStyleProperties)
 						Target.RemoveDynamicResource(classStyleProperty);
 
@@ -67,6 +67,10 @@ namespace Xamarin.Forms
 						_classStyleProperties.Add (classStyleProperty);
 						Target.OnSetDynamicResource (classStyleProperty, Forms.Style.StyleClassPrefix + styleClass);
 					}
+
+					//reapply the css stylesheets
+					if (Target is Element targetelement)
+						targetelement.ApplyStyleSheetsOnParentSet();
 				}
 			}
 		}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2678.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2678.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh2678">
+    <ContentPage.Resources>
+        <StyleSheet>
+            <![CDATA[
+                .one {
+                    background-color: red;
+                }
+
+                .two {
+                    background-color: green;
+                }
+            ]]>
+        </StyleSheet>
+    </ContentPage.Resources>
+    <Label x:Name="label0" class="one" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2678.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh2678.xaml.cs
@@ -1,0 +1,42 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh2678 : ContentPage
+	{
+		public Gh2678() => InitializeComponent();
+		public Gh2678(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+				Xamarin.Forms.Internals.Registrar.RegisterAll(new Type[0]);
+			}
+
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void StyleClassCanBeChanged([Values(false, true)]bool useCompiledXaml)
+			{
+				var layout = new Gh2678(useCompiledXaml);
+				var label = layout.label0;
+				Assert.That(label.BackgroundColor, Is.EqualTo(Color.Red));
+				label.StyleClass = new List<string> { "two" };
+				Assert.That(label.BackgroundColor, Is.EqualTo(Color.Green));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh8936.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh8936.xaml.cs
@@ -39,6 +39,5 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				Assert.That(((Gh8936VM)layout.BindingContext).Data["Key"], Is.EqualTo("Bar"));
 			}
 		}
-
 	}
 }


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2678


### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
