### PR TITLE
Make CarouselView.IsBounceEnabled work on initialization

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/CarouselViewCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/CarouselViewCoreGalleryPage.cs
@@ -27,12 +27,14 @@ namespace Xamarin.Forms.Controls
 
 			var currentItemContainer = new ValueViewContainer<CarouselView>(Test.CarouselView.CurrentItem, new CarouselView { HeightRequest = 250, ItemsSource = GetCarouselItems(), ItemsLayout = GetCarouselLayout(ItemsLayoutOrientation.Horizontal), ItemTemplate = GetCarouselTemplate(), CurrentItem = _currentItem }, "CurrentItem", value => value.ToString());
 			var isSwipeEnabledContainer = new ValueViewContainer<CarouselView>(Test.CarouselView.IsSwipeEnabled, new CarouselView { IsSwipeEnabled = false, HeightRequest = 250, ItemsSource = GetCarouselItems(), ItemsLayout = GetCarouselLayout(ItemsLayoutOrientation.Horizontal), ItemTemplate = GetCarouselTemplate()}, "IsSwipeEnabled", value => value.ToString());
+			var isBounceEnabledContainer = new ValueViewContainer<CarouselView>(Test.CarouselView.IsBounceEnabled, new CarouselView { IsBounceEnabled = false, HeightRequest = 250, ItemsSource = GetCarouselItems(), ItemsLayout = GetCarouselLayout(ItemsLayoutOrientation.Horizontal), ItemTemplate = GetCarouselTemplate() }, "IsBounceEnabled", value => value.ToString());
 			var isScrollAnimatedContainer = new ValueViewContainer<CarouselView>(Test.CarouselView.IsScrollAnimated, new CarouselView { IsScrollAnimated = false, HeightRequest = 250, ItemsSource = GetCarouselItems(), ItemsLayout = GetCarouselLayout(ItemsLayoutOrientation.Horizontal), ItemTemplate = GetCarouselTemplate() }, "IsScrollAnimated", value => value.ToString());
 			var peekAreaInsetsContainer = new ValueViewContainer<CarouselView>(Test.CarouselView.PeekAreaInsets, new CarouselView { PeekAreaInsets = new Thickness(24, 12, 36, 6), HeightRequest = 250, ItemsSource = GetCarouselItems(), ItemsLayout = GetCarouselLayout(ItemsLayoutOrientation.Horizontal), ItemTemplate = GetCarouselTemplate() }, "PeekAreaInsets", value => value.ToString());
 			var positionContainer = new ValueViewContainer<CarouselView>(Test.CarouselView.Position, new CarouselView { Position = 2, HeightRequest = 250, ItemsSource = GetCarouselItems(), ItemsLayout = GetCarouselLayout(ItemsLayoutOrientation.Horizontal), ItemTemplate = GetCarouselTemplate() }, "Position", value => value.ToString());
 
 			Add(currentItemContainer);
 			Add(isSwipeEnabledContainer);
+			Add(isBounceEnabledContainer);
 			Add(isScrollAnimatedContainer);
 			Add(peekAreaInsetsContainer);
 			Add(positionContainer);

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -882,7 +882,8 @@ namespace Xamarin.Forms.CustomAttributes
 			IsScrollAnimated,
 			NumberOfSideItems, 
 			PeekAreaInsets,
-			Position
+			Position,
+			IsBounceEnabled
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			
 			UpdateIsSwipeEnabled();
+			UpdateIsBounceEnabled();
 			UpdateInitialPosition();
 			UpdateItemSpacing();
 		}


### PR DESCRIPTION
### Description of Change ###

Make control aware of the `IsBounceEnabled` value on initialization on Android.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9159

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

When setting `IsBounceEnabled` from XAML it wouldn't work since the property was not propagated to the native control on initialization, only when the property was set.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Go to CarouselView Core Gallery and find the new IsBounceEnabled option. When swiping from left to right you should not see the Android overscroll animation. On other CarouselView Core Gallery options you should see it.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
