### PR TITLE
Add null check to GetIconColor

### DIFF
--- a/Xamarin.Forms.Core/NavigationPage.cs
+++ b/Xamarin.Forms.Core/NavigationPage.cs
@@ -163,6 +163,11 @@ namespace Xamarin.Forms
 
 		public static Color GetIconColor(BindableObject bindable)
 		{
+			if (bindable == null)
+			{
+				return Color.Default;		
+			}
+
 			return (Color)bindable.GetValue(IconColorProperty);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Adds a null check to GetIconColor to avoid a possible NRE.

### Issues Resolved ### 
- fixes: Can't launch Control Gallery (and possibly anything else with a NavigationPage)

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

Launch Control Gallery on iOS. If this works, it won't crash with a NullReferenceException.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
