### PR TITLE
[Android] Fixed SwipeItem tap issue on Android device

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -505,6 +505,31 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 			}
 
+			if (swipeOffset == 0)
+				swipeOffset = GetSwipeContentOffset();
+
+			return swipeOffset;
+		}
+
+		float GetSwipeContentOffset()
+		{
+			float swipeOffset = 0;
+
+			if (_contentView != null)
+			{
+				switch (_swipeDirection)
+				{
+					case SwipeDirection.Left:
+					case SwipeDirection.Right:
+						swipeOffset = _contentView.TranslationX;
+						break;
+					case SwipeDirection.Up:
+					case SwipeDirection.Down:
+						swipeOffset = _contentView.TranslationY;
+						break;
+				}
+			}
+
 			return swipeOffset;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixed SwipeItem tap issue on Android device. When tapping, in certain devices (not happen in emulators) the offset value is validated. Without swipe, just tapping the point when doing touch down and touch up is the same and will break the touch events (execute commands, etc). Added extra validation to verify if the SwipeView is open or closed.

Tested with devices running Android 6, 7.1 and 10.

### Issues Resolved ### 

- fixes #9028

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Test using any SwipeView sample but must be tested using a **device**.

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
