### PR TITLE
Embedded fonts. Fixes #9190

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FontExtensions.cs
@@ -174,8 +174,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				var style = ToTypefaceStyle(fontAttribute);
-				result = Typeface.Create(fontFamily, style);
+				result = fontFamily.ToTypeFace(fontAttribute);
 			}
 
 			return result;

--- a/Xamarin.Forms.Platform.iOS/EmbeddedFontLoader.cs
+++ b/Xamarin.Forms.Platform.iOS/EmbeddedFontLoader.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Diagnostics;
+using System.Linq;
 using CoreGraphics;
 using CoreText;
 using Foundation;
@@ -14,11 +15,16 @@ namespace Xamarin.Forms.Platform.iOS
 			try
 			{
 				var data = NSData.FromStream(font.ResourceStream);
-
+				var fonts = UIKit.UIFont.FamilyNames.ToList();
 				var provider = new CGDataProvider(data);
 				var cGFont = CGFont.CreateFromProvider(provider);
 				if (CTFontManager.RegisterGraphicsFont(cGFont, out var error))
-					return (true, null);
+				{
+
+					var newFonts = UIKit.UIFont.FamilyNames.ToList();
+					var diff = newFonts.Except(fonts).ToList();
+					return (true, diff.FirstOrDefault());
+				}
 				Debug.WriteLine(error.Description);
 			}
 			catch (Exception ex)

--- a/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
@@ -59,8 +59,8 @@ namespace Xamarin.Forms.Platform.iOS
 						result = UIFont.SystemFontOfSize(size, UIFontWeight.Regular);
 						return result;
 					}
-					
-					result = UIFont.FromName(family, size);
+					if(result == null)
+						result = UIFont.FromName(family, size);
 					if (result != null)
 						return result;
 				}
@@ -94,9 +94,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!string.IsNullOrWhiteSpace(fontFile.Extension))
 			{
-				var (hasFont, _) = FontRegistrar.HasFont(fontFile.FileNameWithExtension());
+				var (hasFont, filePath) = FontRegistrar.HasFont(fontFile.FileNameWithExtension());
 				if (hasFont)
-					return fontFile.PostScriptName;
+					return filePath ?? fontFile.PostScriptName;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

iOS and android had times when the emebedded font's were not loaded

### Issues Resolved ### 

- fixes #9190

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
