### PR TITLE
Avoid NRE removing WeakReferences (and remove null ones)

### DIFF
--- a/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
+++ b/Xamarin.Forms.Core/Interactivity/AttachedCollection.cs
@@ -135,7 +135,7 @@ namespace Xamarin.Forms
 				return;
 			}
 
-			_associatedObjects.RemoveAll(t => !t.IsAlive);
+			_associatedObjects.RemoveAll(t => t == null || !t.IsAlive);
 			_cleanupThreshold = _associatedObjects.Count + CleanupTrigger;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Add a null check when removing dead WeakReferences.

### Issues Resolved ### 

- fixes #9183

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

None, unable to repro.

### PR Checklist ###
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
