### PR TITLE
[GTK] Fix button shrinking

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9092.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9092.cs
@@ -1,0 +1,85 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9092, "[Bug] GTK: reenabling button doesn't work if page is a not-initial NavigationPage", PlatformAffected.Gtk)]
+	public class Issue9092 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			var page = new ContentPage9092();
+			NavigationPage.SetHasNavigationBar(page, false);
+
+			var navigationPage = new NavigationPage(page);
+			NavigationPage.SetHasNavigationBar(navigationPage, false);
+
+			Navigation.PushAsync(navigationPage);
+		}
+
+#if UITEST
+		[Test]
+		public void Issue9092Test()
+		{
+			RunningApp.Screenshot("I see button");
+			RunningApp.Tap(q => q.Marked("AddButton"));
+			RunningApp.Screenshot("I see button with added text");
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ContentPage9092 : ContentPage
+	{
+		public ContentPage9092()
+		{
+			var button = new Button()
+			{
+				Text = "Add +",
+				HorizontalOptions = LayoutOptions.Center,
+				AutomationId = "AddButton"
+			};
+
+			button.Command = new Command(o =>
+			{
+				button.Text += " +";
+			});
+
+			var stackLayoutWithButton = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.Center,
+				Children =
+				{
+					button
+				}
+			};
+
+			var grid = new Grid()
+			{
+				RowSpacing = 0,
+				RowDefinitions =
+				{
+					new RowDefinition() { Height = 30 },
+					new RowDefinition() { Height = GridLength.Star },
+					new RowDefinition() { Height = 30 }
+				}
+			};
+
+			grid.AddChild(new Grid { BackgroundColor = Color.Green }, 0, 0);
+			grid.AddChild(stackLayoutWithButton, 0, 1);
+			grid.AddChild(new Grid { BackgroundColor = Color.Green }, 0, 2);
+
+			Content = grid;
+
+			Title = "Page Title";
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -158,6 +158,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8743.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9092.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.GTK/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ButtonRenderer.cs
@@ -13,6 +13,19 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		protected override bool PreventGestureBubbling { get; set; } = true;
 
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
+		{
+			var req = Control.SizeRequest();
+
+			var widthFits = widthConstraint >= req.Width;
+			var heightFits = heightConstraint >= req.Height;
+
+			var size = new Size(widthFits ? req.Width : (int)widthConstraint,
+				heightFits ? req.Height : (int)heightConstraint);
+
+			return new SizeRequest(size);
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (Control != null)


### PR DESCRIPTION
### Description of Change ###

Using buttons on page without navbar causes them to shrink to 1px width on GTK. Two things leading to this:

If a button desired size is bigger than available space, button [would shrink to width constraint](https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.Platform.GTK/Extensions/WidgetExtensions.cs#L39) and would stay this way on next cycles, even if it could get more space;

Each page starts to allocate children sizes with its initial size 1px X 1px, on next cycles getting real window size. Pages with navbar would subtract navbar height from available size and get negative number, so they won't ask children to allocate space on this cycle. Pages without any navbar would calculate its children sizes on page 1px wide, stucking buttons with width=1px for all next cycles.

Overriding ButtonRendered.GetDesiredSize method to remove button size mutation fixed this behavior.

### Issues Resolved ### 

- fixes #9092 (this is the real reason behind the bug, not disabling button or changing navigation pages)

### API Changes ###

 None

### Platforms Affected ### 

- GTK

### Behavioral/Visual Changes ###

Buttons should stop to shrink

### Before/After Screenshots ### 

No navbar, green row on the top of the page

Before:
![Xamarin Forms GTK# Backend 13-Jan-20 22_19_32](https://user-images.githubusercontent.com/24920435/72338451-8d03ec80-36d5-11ea-9fd0-febe256d2705.png)

After:
![Xamarin Forms GTK# Backend 13-Jan-20 22_20_13](https://user-images.githubusercontent.com/24920435/72338463-91300a00-36d5-11ea-8c20-811a25af9276.png)

### Testing Procedure ###

[GTK] Add button on page without navbars. Confirm that button has right width. Change button text and WidthRequest to check size changing and constraint fitting.

Tested this behavior on Windows 10 and Kubuntu 19.04

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
