### PR TITLE
fix: ios image loader should consider scale

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -148,6 +148,11 @@ namespace Xamarin.Forms.Platform.iOS
 				Log.Warning(nameof(FileImageSourceHandler), "Could not find image: {0}", imagesource);
 			}
 
+			if (image != null && scale > 1)
+			{
+				image = new UIImage(image.CGImage, scale, UIImageOrientation.Up);
+			}
+
 			return Task.FromResult(image);
 		}
 
@@ -267,7 +272,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var iconcolor = fontsource.Color.IsDefault ? _defaultColor : fontsource.Color;
 				var attString = new NSAttributedString(fontsource.Glyph, font: font, foregroundColor: iconcolor.ToUIColor());
 				var imagesize = ((NSString)fontsource.Glyph).GetSizeUsingAttributes(attString.GetUIKitAttributes(0, out _));
-				
+
 				UIGraphics.BeginImageContextWithOptions(imagesize, false, 0f);
 				var ctx = new NSStringDrawingContext();
 				var boundingRect = attString.GetBoundingRect(imagesize, (NSStringDrawingOptions)0, ctx);


### PR DESCRIPTION
### Description of Change ###
`Xamarin.Forms.Platform.iOS.FileImageSourceHandler.LoadImageAsync` doesn't use the `scale` parameter, so fix it.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- iOS
