### PR TITLE
[iOS] Update CollectionView constrains when Bounds changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8902.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8902.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"  
+             x:Class="Xamarin.Forms.Controls.Issues.Issue8902">
+    <controls:TestContentPage.Content>
+        <CarouselView ItemsSource="{Binding Persons}">
+            <CarouselView.ItemsLayout>
+                <LinearItemsLayout Orientation="Horizontal"
+                         SnapPointsType="MandatorySingle" />
+            </CarouselView.ItemsLayout>
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Frame>
+                        <StackLayout>
+                            <ContentView Margin="30"
+                         BackgroundColor="Gray"
+                         HorizontalOptions="Fill">
+                                <Label FontSize="Large"
+                     Text="{Binding Name}" />
+                            </ContentView>
+                            <Label HorizontalOptions="Center"
+                   Text="{Binding Age}"
+                   VerticalOptions="Center" />
+                        </StackLayout>
+                    </Frame>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+    </controls:TestContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8902.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8902.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 8902, "CarouselView Layout on orientation change", PlatformAffected.iOS)]
+	public partial class Issue8902 : TestContentPage
+    {
+        public Issue8902()
+        {
+#if APP
+            InitializeComponent();
+#endif
+        }
+
+		protected override void Init()
+		{
+			BindingContext = new Issue8902ViewModel();
+		}
+
+		public class Issue8902ViewModel
+		{
+			public Issue8902ViewModel()
+			{
+				Persons = new List<Issue8902Person>();
+				Persons.Add(new Issue8902Person()
+				{
+					Age = 38,
+					Name = "User 1"
+				});
+				Persons.Add(new Issue8902Person()
+				{
+					Age = 22,
+					Name = "User 2"
+				});
+				Persons.Add(new Issue8902Person()
+				{
+					Age = 51,
+					Name = "User 3"
+				});
+			}
+			public List<Issue8902Person> Persons { get; set; }
+		}
+
+		public class Issue8902Person
+		{
+			public string Name { get; set; }
+			public int Age { get; set; }
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -11,6 +11,10 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8262.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8902.xaml.cs">
+      <DependentUpon>Issue8902.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9006.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8207.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6362.cs" />
@@ -1686,6 +1690,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8508.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8902.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -22,6 +22,8 @@ namespace Xamarin.Forms.Platform.iOS
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
 
+		CoreGraphics.CGRect _boundsSize;
+
 		protected UICollectionViewDelegateFlowLayout Delegator { get; set; }
 
 		protected ItemsViewController(TItemsView itemsView, ItemsViewLayout layout) : base(layout)
@@ -143,6 +145,13 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewWillLayoutSubviews();
 
+			//We are possibliy changing orientation, we need to tell our layout and cells
+			//to update based on new size constrains
+			if(!_boundsSize.IsEmpty && _boundsSize != CollectionView.Bounds)
+			{
+				_initialConstraintsSet = false;
+				CollectionView.ReloadData();
+			}
 			// We can't set this constraint up on ViewDidLoad, because Forms does other stuff that resizes the view
 			// and we end up with massive layout errors. And View[Will/Did]Appear do not fire for this controller
 			// reliably. So until one of those options is cleared up, we set this flag so that the initial constraints
@@ -157,6 +166,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				ResizeEmptyView();
 			}
+
+			_boundsSize = CollectionView.Bounds;
 		}
   
 		protected virtual UICollectionViewDelegateFlowLayout CreateDelegator()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -164,7 +164,7 @@ namespace Xamarin.Forms.Platform.iOS
 			//We are changing orientation and we need to tell our layout
 			//to update based on new size constrains
 			ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
-			//We call ReloadData so our VisibleCells also update there eize
+			//We call ReloadData so our VisibleCells also update their size
 			CollectionView.ReloadData();
 
 			base.WillAnimateRotation(toInterfaceOrientation, duration);


### PR DESCRIPTION
### Description of Change ###

We need to makse sure that if the bounds of the UICollectionView changes, for example on orientation changes we need to tell our layout and our cells to update base on the new size.

### Issues Resolved ### 

- fixes #8902 

### API Changes ###

None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###

CollectionView layouts should update on rotation changes

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Check the issue 8902 rotate the device check the UI for the Items on the CarouselView updates to the correct size. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
