### PR TITLE
Don't use priority parameter with menu parameter

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Tests/Issues.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Tests/Issues.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.ControlGallery.Android.Tests
 
 		[Test(Description = "No exceptions should be thrown")]
 		[Issue(IssueTracker.Github, 9185, "[Bug] Java.Lang.IllegalArgumentException: 'order does not contain a valid category.'")]
-		public void ToolbarItemWithReallyHighPriortyDoesntCrash()
+		public void ToolbarItemWithReallyHighPriorityDoesntCrash()
 		{
 			try
 			{

--- a/Xamarin.Forms.ControlGallery.Android/Tests/Issues.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Tests/Issues.cs
@@ -1,4 +1,5 @@
-﻿using Android.Views;
+﻿using System;
+using Android.Views;
 using NUnit.Framework;
 using NUnit.Framework.Internal;
 using Xamarin.Forms.CustomAttributes;
@@ -23,7 +24,7 @@ namespace Xamarin.Forms.ControlGallery.Android.Tests
 				var entry1 = new Entry { Text = "foo", HorizontalTextAlignment = TextAlignment.Center };
 				using (var editText = GetNativeControl(entry1))
 				{
-					var centeredHorizontal = 
+					var centeredHorizontal =
 					(editText.Gravity & GravityFlags.HorizontalGravityMask) == GravityFlags.CenterHorizontal;
 
 					Assert.That(centeredHorizontal, Is.True);
@@ -38,10 +39,33 @@ namespace Xamarin.Forms.ControlGallery.Android.Tests
 					Assert.That(editText.TextAlignment, Is.EqualTo(global::Android.Views.TextAlignment.Center));
 				}
 			}
-			finally 
+			finally
 			{
 				// If something went wrong, make sure we leave the Context as it was when we started
 				ToggleRTLSupport(Context, supportsRTL);
+			}
+		}
+
+		[Test(Description = "No exceptions should be thrown")]
+		[Issue(IssueTracker.Github, 9185, "[Bug] Java.Lang.IllegalArgumentException: 'order does not contain a valid category.'")]
+		public void ToolbarItemWithReallyHighPriortyDoesntCrash()
+		{
+			try
+			{
+				ContentPage page = new ContentPage()
+				{
+					ToolbarItems =
+					{
+						new ToolbarItem() { Text = "2", Priority = int.MaxValue },
+						new ToolbarItem() { Text = "1", Priority = int.MaxValue - 1 }
+					}
+				};
+
+				GetRenderer(new NavigationPage(page));
+			}
+			catch (Exception exc)
+			{
+				Assert.Fail($"{exc}");
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -21,26 +21,26 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 		public static void UpdateMenuItems(this AToolbar toolbar,
-			IEnumerable<ToolbarItem> toolbarItems, 
+			IEnumerable<ToolbarItem> sortedToolbarItems, 
 			Context context, 
 			Color? tintColor,
 			PropertyChangedEventHandler toolbarItemChanged
 			)
 		{
-			if (toolbarItems == null)
+			if (sortedToolbarItems == null)
 				return;
 
 			var menu = toolbar.Menu;
 			menu.Clear();
 
-			foreach (var item in toolbarItems)
+			foreach (var item in sortedToolbarItems)
 			{
 				item.PropertyChanged -= toolbarItemChanged;
 				item.PropertyChanged += toolbarItemChanged;
 
 				using (var title = new Java.Lang.String(item.Text))
 				{
-					var menuitem = menu.Add(global::Android.Views.Menu.None, 0, item.Priority, title);
+					var menuitem = menu.Add(title);
 					menuitem.SetEnabled(item.IsEnabled);
 					menuitem.SetTitleOrContentDescription(item);
 					UpdateMenuItemIcon(context, menuitem, item, tintColor);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -491,7 +491,8 @@ namespace Xamarin.Forms.Platform.Android
 		protected virtual void UpdateToolbarItems(Toolbar toolbar, Page page)
 		{
 			var menu = toolbar.Menu;
-			toolbar.UpdateMenuItems(page.ToolbarItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
+			var sortedItems = System.Linq.Enumerable.OrderBy(page.ToolbarItems, x => x.Order);
+			toolbar.UpdateMenuItems(sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
 
 			SearchHandler = Shell.GetSearchHandler(page);
 			if (SearchHandler != null && SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Hidden)
@@ -554,7 +555,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			_toolbar.OnToolbarItemPropertyChanged(e, Page.ToolbarItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
+			var sortedItems = System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x => x.Order);
+			_toolbar.OnToolbarItemPropertyChanged(e, sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
 		}
 
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Revert to always presorting MenuItems and just adding them in sorted order. Android doesn't react very will when you use a really high priority number

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9185


### Platforms Affected ### 
- Android


### Testing Procedure ###
- ui test included
- test a few CG pages with toolbar items make sure the display/sort correctly

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
