### PR TITLE
[Android, iOS] Improve the swipe threshold used in Execute Mode

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -909,7 +909,7 @@ namespace Xamarin.Forms.Platform.Android
 			else
 			{
 				if (isHorizontal)
-					swipeThreshold = SwipeThreshold;
+					swipeThreshold = CalculateSwipeThreshold();
 				else
 				{
 					var contentHeight = (float)_context.FromPixels(_contentView.Height);
@@ -918,6 +918,18 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			return ValidateSwipeThreshold(swipeThreshold);
+		}
+
+		float CalculateSwipeThreshold()
+		{
+			if (_contentView != null)
+			{
+				var swipeThreshold = (float)(_contentView.Width * 0.8);
+
+				return swipeThreshold;
+			}
+
+			return SwipeThreshold;
 		}
 
 		float ValidateSwipeThreshold(float swipeThreshold)

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -838,7 +838,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				if (isHorizontal)
-					swipeThreshold = SwipeThreshold;
+					swipeThreshold = CalculateSwipeThreshold();
 				else
 				{
 					var contentHeight = _contentView.Frame.Height;
@@ -847,6 +847,18 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return ValidateSwipeThreshold(swipeThreshold);
+		}
+
+		double CalculateSwipeThreshold()
+		{
+			if (_contentView != null)
+			{
+				var swipeThreshold = _contentView.Frame.Width * 0.8;
+
+				return swipeThreshold;
+			}
+
+			return SwipeThreshold;
 		}
 
 		double ValidateSwipeThreshold(double swipeThreshold)


### PR DESCRIPTION
### Description of Change ###

The swipe **threshold** set how far the user must swipe before execute a SwipeItem command (Execute Mode).

We used a fixed value to set the swipe threshold which is not correct in all cases. This PR applies changes to set the swipe threshold to the 80% of the SwipeView size. 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use any SwipeView sample in a simulator device with large screen.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
