### PR TITLE
[android] remove the Anticipator for 4.5.0 and master

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Forms
 
 		const int TabletCrossover = 600;
 
+		static BuildVersionCodes? s_sdkInt;
 		static bool? s_isLollipopOrNewer;
 		static bool? s_is29OrNewer;
 		static bool? s_isMarshmallowOrNewer;
@@ -72,7 +73,13 @@ namespace Xamarin.Forms
 		static Color _ColorButtonNormal = Color.Default;
 		public static Color ColorButtonNormalOverride { get; set; }
 
-		internal static BuildVersionCodes SdkInt => Anticipator.SdkInt;
+		internal static BuildVersionCodes SdkInt {
+			get {
+				if (!s_sdkInt.HasValue)
+					s_sdkInt = Build.VERSION.SdkInt;
+				return (BuildVersionCodes)s_sdkInt;
+			}
+		}
 
 		internal static bool Is29OrNewer
 		{

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -22,6 +22,7 @@
     <AndroidResource Include="Resources\anim\**\*" />
     <AndroidResource Include="Resources\values\**\*" />
     <Compile Remove="Resources\Layout\**\*" />
+    <Compile Remove="Anticipator.cs" />
     <None Include="Resources\Layout\**\*" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">


### PR DESCRIPTION
### Description of Change ###

Context: https://github.com/xamarin/Xamarin.Forms/pull/8858

After merging from 4.4.0, etc. this class came back.

@kingces95 did not want to remove the `Anticipator.cs` file. Since
`Xamarin.Forms.Platform.Android.csproj` is now a short-form MSBuild
project, you have to add an explicit:

`<Compile Remove="Anticipator.cs"/>` to remove it.

### Issues Resolved ### 

None

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

CI should be OK

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
