### PR TITLE
Add intermediate dialog classes to handle legacy/appcompat dialog

### DIFF
--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -7,7 +7,7 @@ using Android.Text;
 using Android.Views;
 using Android.Widget;
 using Xamarin.Forms.Internals;
-using AlertDialog = Android.Support.V7.App.AlertDialog;
+using AppCompatAlertDialog = global::Android.Support.V7.App.AlertDialog;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -90,7 +90,8 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 				}
 
-				var builder = new AlertDialog.Builder(Activity);
+				var builder = new DialogBuilder(Activity);
+
 				builder.SetTitle(arguments.Title);
 				string[] items = arguments.Buttons.ToArray();
 				builder.SetItems(items, (o, args) => arguments.Result.TrySetResult(items[args.Which]));
@@ -101,12 +102,12 @@ namespace Xamarin.Forms.Platform.Android
 				if (arguments.Destruction != null)
 					builder.SetNegativeButton(arguments.Destruction, (o, args) => arguments.Result.TrySetResult(arguments.Destruction));
 
-				AlertDialog dialog = builder.Create();
+				var dialog = builder.Create();
 				builder.Dispose();
 				//to match current functionality of renderer we set cancelable on outside
 				//and return null
 				dialog.SetCanceledOnTouchOutside(true);
-				dialog.CancelEvent += (o, e) => arguments.SetResult(null);
+				dialog.SetCancelEvent((o, e) => arguments.SetResult(null));
 				dialog.Show();
 			}
 
@@ -118,13 +119,13 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 				}
 
-				AlertDialog alert = new AlertDialog.Builder(Activity).Create();
+				var alert = new DialogBuilder(Activity).Create();
 				alert.SetTitle(arguments.Title);
 				alert.SetMessage(arguments.Message);
 				if (arguments.Accept != null)
 					alert.SetButton((int)DialogButtonType.Positive, arguments.Accept, (o, args) => arguments.SetResult(true));
 				alert.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetResult(false));
-				alert.CancelEvent += (o, args) => { arguments.SetResult(false); };
+				alert.SetCancelEvent((o, args) => { arguments.SetResult(false); }); 
 				alert.Show();
 			}
 
@@ -136,7 +137,7 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 				}
 
-				AlertDialog alertDialog = new AlertDialog.Builder(Activity).Create();
+				var alertDialog = new DialogBuilder(Activity).Create();
 				alertDialog.SetTitle(arguments.Title);
 				alertDialog.SetMessage(arguments.Message);
 
@@ -161,7 +162,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				alertDialog.SetButton((int)DialogButtonType.Positive, arguments.Accept, (o, args) => arguments.SetResult(editText.Text));
 				alertDialog.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetResult(null));
-				alertDialog.CancelEvent += (o, args) => { arguments.SetResult(null); };
+				alertDialog.SetCancelEvent((o, args) => { arguments.SetResult(null); });
 
 				alertDialog.Window.SetSoftInputMode(SoftInput.StateVisible);
 				alertDialog.Show();
@@ -207,6 +208,203 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				return renderer.View.Context.Equals(Activity);
+			}
+
+			// This is a proxy dialog builder class to support both pre-appcompat and appcompat dialogs for Alert,
+			// ActionSheet, Prompt, etc. 
+			internal sealed class DialogBuilder
+			{
+				AppCompatAlertDialog.Builder _appcompatBuilder;
+				AlertDialog.Builder _legacyBuilder;
+
+				bool _useAppCompat;
+
+				public DialogBuilder(Activity activity)
+				{
+					if (activity is global::Android.Support.V7.App.AppCompatActivity)
+					{
+						_appcompatBuilder = new AppCompatAlertDialog.Builder(activity);
+						_useAppCompat = true;
+					}
+					else
+					{
+						_legacyBuilder = new AlertDialog.Builder(activity);
+					}
+				}
+
+				public void SetTitle(string title)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatBuilder.SetTitle(title);
+					}
+					else
+					{
+						_legacyBuilder.SetTitle(title);
+					}
+				}
+
+				public void SetItems(string[] items, EventHandler<DialogClickEventArgs> handler)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatBuilder.SetItems(items, handler);
+					}
+					else
+					{
+						_legacyBuilder.SetItems(items, handler);
+					}
+				}
+
+				public void SetPositiveButton(string text, EventHandler<DialogClickEventArgs> handler)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatBuilder.SetPositiveButton(text, handler);
+					}
+					else
+					{
+						_legacyBuilder.SetPositiveButton(text, handler);
+					}
+				}
+
+				public void SetNegativeButton(string text, EventHandler<DialogClickEventArgs> handler)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatBuilder.SetNegativeButton(text, handler);
+					}
+					else
+					{
+						_legacyBuilder.SetNegativeButton(text, handler);
+					}
+				}
+
+				public FlexibleAlertDialog Create()
+				{
+					if (_useAppCompat)
+					{
+						return new FlexibleAlertDialog(_appcompatBuilder.Create());
+					}
+
+					return new FlexibleAlertDialog(_legacyBuilder.Create());
+				}
+
+				public void Dispose()
+				{
+					if (_useAppCompat)
+					{
+						_appcompatBuilder.Dispose();
+					}
+					else
+					{
+						_legacyBuilder.Dispose();
+					}
+				}
+			}
+
+			internal sealed class FlexibleAlertDialog
+			{
+				readonly AppCompatAlertDialog _appcompatAlertDialog;
+				readonly AlertDialog _legacyAlertDialog;
+				bool _useAppCompat;
+
+				public FlexibleAlertDialog(AlertDialog alertDialog)
+				{
+					_legacyAlertDialog = alertDialog;
+				}
+
+				public FlexibleAlertDialog(AppCompatAlertDialog alertDialog)
+				{
+					_appcompatAlertDialog = alertDialog;
+					_useAppCompat = true;
+				}
+
+				public void SetTitle(string title)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.SetTitle(title);
+					}
+					else
+					{
+						_legacyAlertDialog.SetTitle(title);
+					}
+				}
+
+				public void SetMessage(string message)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.SetMessage(message);
+					}
+					else
+					{
+						_legacyAlertDialog.SetMessage(message);
+					}
+				}
+
+				public void SetButton(int whichButton, string text, EventHandler<DialogClickEventArgs> handler)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.SetButton(whichButton, text, handler);
+					}
+					else
+					{
+						_legacyAlertDialog.SetButton(whichButton, text, handler);
+					}
+				}
+
+				public void SetCancelEvent(EventHandler cancel)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.CancelEvent += cancel;
+					}
+					else
+					{
+						_legacyAlertDialog.CancelEvent += cancel;
+					}
+				}
+
+				public void SetCanceledOnTouchOutside(bool canceledOnTouchOutSide)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.SetCanceledOnTouchOutside(canceledOnTouchOutSide);
+					}
+					else
+					{
+						_legacyAlertDialog.SetCanceledOnTouchOutside(canceledOnTouchOutSide);
+					}
+				}
+
+				public void SetView(global::Android.Views.View view)
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.SetView(view);
+					}
+					else
+					{
+						_legacyAlertDialog.SetView(view);
+					}
+				}
+
+				public Window Window => _useAppCompat ? _appcompatAlertDialog.Window : _legacyAlertDialog.Window;
+
+				public void Show()
+				{
+					if (_useAppCompat)
+					{
+						_appcompatAlertDialog.Show();
+					}
+					else
+					{
+						_legacyAlertDialog.Show();
+					}
+				}
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

4.4.0 breaks Alerts, ActionSheets, and Prompts for pre-AppCompat Android (i.e., apps which use `FormsApplicationActivity` instead of `FormsAppCompatActivity`). These changes add proxy classes for dialog building which choose the correct dialog classes based on the activity type being used. This fixes the crashes in legacy apps while allowing AppCompat apps to use the new dialogs.

### Issues Resolved ### 

- fixes #9214

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated tests for AppCompat; for legacy apps, set the `FORMS_APPLICATION_ACTIVITY` compile directive in the Control Gallery on Android, run the gallery, and navigate to the DisplayAlert gallery. f you can display alerts without crashing, the changes have worked.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
