### PR TITLE
[Bug] Fix ClearButtonVisibility.Never does not take effect on UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8836.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8836.cs
@@ -1,0 +1,48 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8836, "[Bug] ClearButtonVisibility.Never does not take effect on UWP", PlatformAffected.UWP)]
+	public class Issue8836 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stack = new StackLayout();
+
+			stack.Children.Add(new Label {Text = "Click the button to toggle the clear button visibility."});
+
+			Entry = new Entry
+			{
+				Text = "Clear Button: While Editing",
+				ClearButtonVisibility = ClearButtonVisibility.WhileEditing
+			};
+			stack.Children.Add(Entry);
+
+			var button = new Button { Text = "Toggle Clear Button State" };
+			button.Clicked += Button_Clicked;
+			stack.Children.Add(button);
+
+			Content = stack;
+		}
+
+		private void Button_Clicked(object sender, System.EventArgs e)
+		{
+			if (Entry.ClearButtonVisibility == ClearButtonVisibility.Never)
+			{
+				Entry.ClearButtonVisibility = ClearButtonVisibility.WhileEditing;
+				Entry.Text = "Clear Button: While Editing";
+			}
+			else
+			{
+				Entry.ClearButtonVisibility = ClearButtonVisibility.Never;
+				Entry.Text = "Clear Button: Never";
+			}
+			Entry.Focus();
+		}
+
+		public Entry Entry { get; set; }
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -39,6 +39,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8899.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8551.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8836.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8902.xaml.cs">
       <DependentUpon>Issue8902.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/EntryRenderer.cs
@@ -66,6 +66,9 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateReturnType();
 				UpdateIsReadOnly();
 				UpdateInputScope();
+				UpdateClearButtonVisibility();
+
+
 
 				if (_cursorPositionChangePending)
 					UpdateCursorPosition();
@@ -148,6 +151,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateSelectionLength();
 			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
 				UpdateIsReadOnly();
+			else if (e.PropertyName == Entry.ClearButtonVisibilityProperty.PropertyName)
+				UpdateClearButtonVisibility();
 		}
 
 		protected override void UpdateBackgroundColor()
@@ -234,6 +239,11 @@ namespace Xamarin.Forms.Platform.UWP
 		void UpdateCharacterSpacing()
 		{
 			Control.CharacterSpacing = Element.CharacterSpacing.ToEm();
+		}
+
+		void UpdateClearButtonVisibility()
+		{
+			Control.ClearButtonVisible = Element.ClearButtonVisibility == ClearButtonVisibility.WhileEditing;
 		}
 
 		void UpdateInputScope()

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -26,7 +26,7 @@
 		<Setter Property="Template">
 			<Setter.Value>
 				<ControlTemplate TargetType="uwp:FormsTextBox">
-					<Grid>
+					<Grid x:Name="RootGrid">
 						<Grid.Resources>
 							<Style x:Name="DeleteButtonStyle" TargetType="Button">
 								<Setter Property="Template">


### PR DESCRIPTION
### Description of Change ###

Modifies the UWP EntryRenderer, FormsTextBox and FormsTextBoxTemplate to support optionally hiding the Delete Button as support by the other platforms.

Method used to implement this is to extract the ButtonVisible visual state and remove it from the control template when the entry is set to not display the delete button.  If it is changed back the ButtonVisible state is added back to the control template.

### Issues Resolved ### 
 - Fixes #8836

### API Changes ###
None
 
### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Delete button will be shown or not shown based on the Entry's ClearButtonVisibility value.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Default Behavior
![image](https://user-images.githubusercontent.com/15127788/72667478-3d316800-39ea-11ea-8013-1298d1f58428.png)

Updated behavior when clear button is set to never
![image](https://user-images.githubusercontent.com/15127788/72667486-46223980-39ea-11ea-90b3-b1cab5b4cfb6.png)


### Testing Procedure ###
Open the issue 8836 page in the control gallery and follow the instructions.  Just clicking the toggle button will flip the state back and forth.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
