### PR TITLE
[Android] Refresh main page on activity resume if necessary

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -55,6 +55,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool _renderersAdded;
 		bool _activityCreated;
+		bool _needMainPageAssign;
 		bool _powerSaveReceiverRegistered;
 		PowerSaveModeBroadcastReceiver _powerSaveModeBroadcastReceiver;
 
@@ -341,6 +342,13 @@ namespace Xamarin.Forms.Platform.Android
 			_previousState = _currentState;
 			_currentState = AndroidApplicationLifecycleState.OnResume;
 
+			if (_needMainPageAssign)
+			{
+				_needMainPageAssign = false;
+
+				SetMainPage();
+			}
+
 			if (!_powerSaveReceiverRegistered && Forms.IsLollipopOrNewer)
 			{
 				// Start listening for power save mode changes
@@ -397,6 +405,12 @@ namespace Xamarin.Forms.Platform.Android
 			// Activity in pause must not react to application changes
 			if (_currentState >= AndroidApplicationLifecycleState.OnPause)
 			{
+				// If the main page is set after the activity has been paused, delay it to resume step
+				if (args.PropertyName == nameof(_application.MainPage))
+				{
+					_needMainPageAssign = true;
+				}
+
 				return;
 			}
 


### PR DESCRIPTION
Refresh main page on activity resume if main page has been changed when activity was paused

### Description of Change ###
In #4707 I added a condition to protect activity to app state change when activity is in background.
It was to fix some lifecycle and dispose issue which caused invalid app state (navigation out of sync, wrong renderer dispose and other nasty things).
This caused a regression for the persons who changed the main page in the OnPause method or after in the lifecycle.
So this change add a flag for this case, and force a main page change during resume if the flag has been set.

### Issues Resolved ### 
- fixes #9093
- fixes #5236

### API Changes ###
None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Use reproduction case in #9093.

### PR Checklist ###
- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
