### PR TITLE
Set BindingContext for CollectionView cells earlier

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/LinkDescription.xml
+++ b/Xamarin.Forms.ControlGallery.Android/LinkDescription.xml
@@ -2,6 +2,8 @@
 <linker>
   <assembly fullname="Xamarin.Forms.ControlGallery.Android">
     <namespace fullname="Xamarin.Forms.ControlGallery.Android.Tests" />
+    <namespace fullname="Xamarin.Forms.Controls.Issues" />
+    <type fullname="*Renderer" />
   </assembly>
   <assembly fullname="Xamarin.Forms.Controls">
     <namespace fullname="Xamarin.Forms.Controls.Tests" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -50,7 +50,7 @@
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-  </PropertyGroup>  
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>
     <OutputPath>bin\Release\</OutputPath>
@@ -126,6 +126,7 @@
     </Compile>
     <Compile Include="ApiLabelRenderer.cs" />
     <Compile Include="Issue7249SwitchRenderer.cs" />
+    <Compile Include="_9087CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />

--- a/Xamarin.Forms.ControlGallery.Android/_9087CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_9087CustomRenderer.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using Android.Content;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Platform.Android;
+using static Xamarin.Forms.Controls.Issues.Issue9087;
+
+[assembly: ExportRenderer(typeof(_9087Label), typeof(_9087CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _9087CustomRenderer : Platform.Android.FastRenderers.LabelRenderer
+	{
+		public _9087CustomRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null && e.NewElement.Text != "Success")
+			{
+				throw new Exception("Test Failed");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -132,6 +132,7 @@
     <Compile Include="_58406EffectRenderer.cs" />
     <Compile Include="_5886DependencyService.cs" />
     <Compile Include="_60122ImageRenderer.cs" />
+    <Compile Include="_9087CustomRenderer.cs" />
     <Content Include="Assets\coverassets1.jpg" />
     <Content Include="Assets\Fonts\OFL.txt" />
     <Content Include="bank.png" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/_9087CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/_9087CustomRenderer.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Platform.UWP;
+using static Xamarin.Forms.Controls.Issues.Issue9087;
+
+[assembly: ExportRenderer(typeof(_9087Label), typeof(_9087CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class _9087CustomRenderer : LabelRenderer
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null && e.NewElement.Text != "Success")
+			{
+				throw new Exception("Test Failed");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/_9087CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/_9087CustomRenderer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Foundation;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS.CustomRenderers;
+using Xamarin.Forms.Platform.iOS;
+using static Xamarin.Forms.Controls.Issues.Issue9087;
+
+[assembly: ExportRenderer(typeof(_9087Label), typeof(_9087CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS.CustomRenderers
+{
+	public class _9087CustomRenderer : LabelRenderer
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null && e.NewElement.Text != "Success")
+			{
+				throw new Exception("Test Failed");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/LinkDescription.xml
+++ b/Xamarin.Forms.ControlGallery.iOS/LinkDescription.xml
@@ -2,6 +2,7 @@
 <linker>
   <assembly fullname="XamarinFormsControlGalleryiOS">
     <namespace fullname="Xamarin.Forms.ControlGallery.iOS.Tests" />
+    <namespace fullname="Xamarin.Forms.Controls.Issues" />
     <type fullname="*Renderer" />
     <type fullname="*Effect" />
     <type fullname="*Service" />

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -107,6 +107,7 @@
     <Compile Include="AttachedStateEffectRenderer.cs" />
     <Compile Include="BrokenImageSourceHandler.cs" />
     <Compile Include="BrokenNativeControl.cs" />
+    <Compile Include="CustomRenderers\_9087CustomRenderer.cs" />
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
     <Compile Include="SearchbarEffect.cs" />
     <Compile Include="CustomRenderer40251.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9087.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9087.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+using System.ComponentModel;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+using CategoryAttribute = NUnit.Framework.CategoryAttribute;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9087, 
+		"[Bug] Collection View items don't load bindable properties values inside OnElementChanged", PlatformAffected.All)]
+	public class Issue9087 : TestContentPage
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label { Text = $"If you can see the text '{Success}' below, this test has passed." };
+
+			var cv = new CollectionView();
+
+			cv.ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new _9087Label();
+
+				label.SetBinding(Label.TextProperty, new Binding("Name"));
+
+				return label;
+			});
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(cv);
+
+			Content = layout;
+
+			var list = new List<_9087Item>
+			{
+				new _9087Item() { Name = Success }
+			};
+
+			cv.ItemsSource = list;
+		}
+
+		public class _9087Label : Label { }
+
+		public class _9087Item 
+		{ 
+			public string Name { get; set; }
+		}
+
+#if UITEST
+		[Test, Category(UITestCategories.CollectionView)]
+		public void BindablePropertiesAvailableAtOnElementChanged()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -163,6 +163,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8743.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9087.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -43,20 +43,33 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var template = _template.SelectDataTemplate(itemBindingContext, itemsView);
 
-			if(template != _selectedTemplate)
+			var templateChanging = template != _selectedTemplate;
+
+			if(templateChanging)
 			{
+				// Clean up any content we're still holding on to
 				_itemContentView.Recycle();
+
+				// Create the new content
 				View = (View)template.CreateContent();
+
+				// Set the binding context _before_ we create the renderer; that way, the bound data will be 
+				// available during OnElementChanged
+				View.BindingContext = itemBindingContext;
+
+				// Actually create the native renderer
 				_itemContentView.RealizeContent(View);
 				_selectedTemplate = template;
 			}
 
 			_itemContentView.HandleItemSizingStrategy(reportMeasure, size);
 
-			// Set the binding context before we add it as a child of the ItemsView; otherwise, it will
-			// inherit the ItemsView's binding context
-			View.BindingContext = itemBindingContext;
-
+			if (!templateChanging)
+			{
+				// Same template, new data
+				View.BindingContext = itemBindingContext;
+			}
+			
 			itemsView.AddLogicalChild(View);
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
@@ -133,15 +133,13 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			var view = FormsDataTemplate.CreateContent(dataContext, container) as View;
-
+			view.BindingContext = dataContext;
 			_renderer = Platform.CreateRenderer(view);
 			Platform.SetRenderer(view, _renderer);
 
 			Content = _renderer.ContainerElement;
 
 			itemsView?.AddLogicalChild(view);
-			
-			BindableObject.SetInheritedBindingContext(_renderer.Element, dataContext);
 		}
 
 		void ContentLoaded(object sender, RoutedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -84,23 +84,26 @@ namespace Xamarin.Forms.Platform.iOS
 
 				// Create the content and renderer for the view 
 				var view = itemTemplate.CreateContent() as View;
+
+				// Set the binding context _before_ we create the renderer; that way, it's available during OnElementChanged
+				view.BindingContext = bindingContext;
+
 				var renderer = TemplateHelpers.CreateRenderer(view);
 				SetRenderer(renderer);
-			}
 
-			var currentElement = VisualElementRenderer?.Element;
-
-			// Bind the view to the data item
-			if (currentElement != null)
-				currentElement.BindingContext = bindingContext;
-
-			if (itemTemplate != _currentTemplate)
-			{
-				// And make the Element a "child" of the ItemsView
+				// And make the new Element a "child" of the ItemsView
 				// We deliberately do this _after_ setting the binding context for the new element;
 				// if we do it before, the element briefly inherits the ItemsView's bindingcontext and we 
 				// emit a bunch of needless binding errors
-				itemsView.AddLogicalChild(currentElement);
+				itemsView.AddLogicalChild(view);
+			}
+			else 
+			{
+				// Same template, different data
+				var currentElement = VisualElementRenderer?.Element;
+
+				if (currentElement != null)
+					currentElement.BindingContext = bindingContext;
 			}
 
 			_currentTemplate = itemTemplate;


### PR DESCRIPTION
### Description of Change ###

CollectionView implementations are setting the `BindingContext` of their templated views _after_ creating the renderers, which means that

- The bound data is not available to renderers during `OnElementChanged`
- Each renderer is effectively doing at least two layouts (once for empty data and once for actual data)

Theses changes move the setting of the `BindingContext` earlier in the cell binding lifecycle, which addresses both problems.

### Issues Resolved ### 

- fixes #9087

### API Changes ###

None

### Platforms Affected ### 

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
