### PR TITLE
Fix 7257 [UWP] Make Translate in combination with Scale work same as other platforms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7257.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7257.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7257, "[Bug] Scale/Translate works in different order between UWP and Android", PlatformAffected.UWP)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.SearchBar)]
+#endif
+	public class Issue7257 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 7257";
+
+			StackLayout contentSL = new StackLayout();
+
+			Label instructions = new Label
+			{
+				Text = "Look at the layout below. The green and the blue squares should both be at the same vertical position as the red bar to the left, and should be same size. "
+					 + "If the green square is below the blue square, it means there is a problem.",
+				Margin = 10
+			};
+
+			contentSL.Children.Add(instructions);
+
+			AbsoluteLayout testAL = new AbsoluteLayout();
+
+			// Reference red rectangle on left edge 100 from top, 50 high
+			Xamarin.Forms.AbsoluteLayout referenceRectAL = new Xamarin.Forms.AbsoluteLayout();
+			referenceRectAL.BackgroundColor = Xamarin.Forms.Color.Red;
+			Xamarin.Forms.AbsoluteLayout.SetLayoutBounds(referenceRectAL, new Xamarin.Forms.Rectangle(0, 0, 10, 50));
+			Xamarin.Forms.AbsoluteLayout.SetLayoutFlags(referenceRectAL, Xamarin.Forms.AbsoluteLayoutFlags.None);
+			referenceRectAL.TranslationX = 0;
+			referenceRectAL.TranslationY = 100;
+			testAL.Children.Add(referenceRectAL);
+
+			// Problem green rectangle positionned at 100, 100, size 100, 100, scaled 50%.
+			Xamarin.Forms.AbsoluteLayout scaleRectAL = new Xamarin.Forms.AbsoluteLayout();
+			scaleRectAL.BackgroundColor = Xamarin.Forms.Color.Green;
+			Xamarin.Forms.AbsoluteLayout.SetLayoutBounds(scaleRectAL, new Xamarin.Forms.Rectangle(0, 0, 100, 100));
+			Xamarin.Forms.AbsoluteLayout.SetLayoutFlags(scaleRectAL, Xamarin.Forms.AbsoluteLayoutFlags.None);
+			scaleRectAL.AnchorX = 0;
+			scaleRectAL.AnchorY = 0;
+			scaleRectAL.ScaleX = 0.5;
+			scaleRectAL.ScaleY = 0.5;
+			scaleRectAL.TranslationX = 100;
+			scaleRectAL.TranslationY = 100;
+			testAL.Children.Add(scaleRectAL);
+
+			// Blue rectangle positionned at 200, 100, size 100, 100, scaled 50% - rotated invisibly a small amount on X-axis.
+			Xamarin.Forms.AbsoluteLayout scaleRect3DAL = new Xamarin.Forms.AbsoluteLayout();
+			scaleRect3DAL.BackgroundColor = Xamarin.Forms.Color.Blue;
+			Xamarin.Forms.AbsoluteLayout.SetLayoutBounds(scaleRect3DAL, new Xamarin.Forms.Rectangle(0, 0, 100, 100));
+			Xamarin.Forms.AbsoluteLayout.SetLayoutFlags(scaleRect3DAL, Xamarin.Forms.AbsoluteLayoutFlags.None);
+			scaleRect3DAL.AnchorX = 0;
+			scaleRect3DAL.AnchorY = 0;
+			scaleRect3DAL.ScaleX = 0.5;
+			scaleRect3DAL.ScaleY = 0.5;
+			scaleRect3DAL.TranslationX = 200;
+			scaleRect3DAL.TranslationY = 100;
+			scaleRect3DAL.RotationX = 0.001;  //rotate miniscule amount on X-axis, to force 3D projection.
+			testAL.Children.Add(scaleRect3DAL);
+
+			contentSL.Children.Add(testAL);
+			Content = contentSL;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7257.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7257.cs
@@ -30,7 +30,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Label instructions = new Label
 			{
-				Text = "Look at the layout below. The green and the blue squares should both be at the same vertical position as the red bar to the left, and should be same size. "
+				Text = "Look at the layout below.\n\n"
+				     + "The green and the blue squares should both be at the same vertical position as the red bar to the left, and should be same size.\n\n"
 					 + "If the green square is below the blue square, it means there is a problem.",
 				Margin = 10
 			};
@@ -48,7 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 			referenceRectAL.TranslationY = 100;
 			testAL.Children.Add(referenceRectAL);
 
-			// Problem green rectangle positionned at 100, 100, size 100, 100, scaled 50%.
+			// Problem green rectangle positioned at 100, 100, size 100, 100, scaled 50%.
 			Xamarin.Forms.AbsoluteLayout scaleRectAL = new Xamarin.Forms.AbsoluteLayout();
 			scaleRectAL.BackgroundColor = Xamarin.Forms.Color.Green;
 			Xamarin.Forms.AbsoluteLayout.SetLayoutBounds(scaleRectAL, new Xamarin.Forms.Rectangle(0, 0, 100, 100));
@@ -61,7 +62,7 @@ namespace Xamarin.Forms.Controls.Issues
 			scaleRectAL.TranslationY = 100;
 			testAL.Children.Add(scaleRectAL);
 
-			// Blue rectangle positionned at 200, 100, size 100, 100, scaled 50% - rotated invisibly a small amount on X-axis.
+			// Blue rectangle positioned at 200, 100, size 100, 100, scaled 50% - rotated invisibly a small amount on X-axis.
 			Xamarin.Forms.AbsoluteLayout scaleRect3DAL = new Xamarin.Forms.AbsoluteLayout();
 			scaleRect3DAL.BackgroundColor = Xamarin.Forms.Color.Blue;
 			Xamarin.Forms.AbsoluteLayout.SetLayoutBounds(scaleRect3DAL, new Xamarin.Forms.Rectangle(0, 0, 100, 100));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -61,6 +61,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8870.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9428.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9419.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7257.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8787.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8899.cs" />

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -729,8 +729,8 @@ namespace Xamarin.Forms.Platform.UWP
 						Rotation = rotation,
 						ScaleX = scaleX,
 						ScaleY = scaleY,
-						TranslateX = scaleX == 0 ? 0 : translationX / scaleX,
-						TranslateY = scaleY == 0 ? 0 : translationY / scaleY
+						TranslateX = translationX,
+						TranslateY = translationY
 					};
 				}
 			}


### PR DESCRIPTION

### Description of Change ###

Changes the way translate-transforms are applied on FrameworkElements in UWP, when the element is also scaled.

Without this fix, the translate-transform is adjusted so as to neutralize a scaling of the transform that doesn't happen. (Probably because in 3D-projection that apparently _does_ happen, and an [adjustment is necessary](https://github.com/xamarin/Xamarin.Forms/blob/e962467bdd6ce2b612d3e5c97e0992e94bd3dd6c/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs#L553-L555).)

This causes 2D scaling in combination with translating to behave differently on UWP compared to Android/iOS.

With this fix, the translation is not adjusted for scaling in 2D (as there is no need), and therefore behaves the same as on the other platforms.

### Issues Resolved ### 

- fixes #7257

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
2D translate in combination with scaling will behave like it does on Andorid/iOS. Without this fix, if something is scaled to half size, the translation will be doubled.

### Before/After Screenshots ### 
On Android, for comparison:
![Android Before 7257](https://user-images.githubusercontent.com/3807144/72888995-07082700-3d0f-11ea-92e4-114b42a523e0.png)

On UWP, before fix:
![UWP 7257 Before](https://user-images.githubusercontent.com/3807144/72889069-2b640380-3d0f-11ea-80f4-dec87131dca7.png)

On UWP, after fix:
![UWP 7257 After](https://user-images.githubusercontent.com/3807144/72889085-34ed6b80-3d0f-11ea-9381-5e63e777c6b1.png)


### Testing Procedure ###

In UWP to Test Case 7257 in the Control Gallery. Check that the green and blue squares are vertically aligned with the red bar to the left, and that they are the same size. (The green square is the one with a 2D transform. The blue square is rotated an imperceptible amount in 3D, and therefore uses FrameworkElement.Projection instead of FrameworkElement.RenderTransform.)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
