### PR TITLE
[iOS] Verify first group exists before measuring its header

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8899.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8899.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8899, "Clearing CollectionView IsGrouped=\"True\" crashes application iOS ")]
+	public class Issue8899 : TestContentPage
+	{
+		const string Go = "Go";
+		const string Success = "Success";
+		const string Running = "Running...";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label { Text = $"Tap the button marked '{Go}'. The CollectionView below should clear," +
+				$" and the '{Running}' label should change to {Success}. If this does not happen, the test has failed."};
+			var result = new Label { Text = "running..." };
+
+			var viewModel = new _8899ViewModel();
+
+			var button = new Button { Text = Go, AutomationId = Go };
+			button.Clicked += (obj, args) => {
+				viewModel.Groups.Clear();
+				result.Text = Success;
+			};
+
+			var cv = new CollectionView { };
+			cv.GroupHeaderTemplate = new DataTemplate(() => {
+				var label = new Label { };
+				label.SetBinding(Label.TextProperty, new Binding("GroupName"));
+				return label;
+			});
+			cv.ItemTemplate = new DataTemplate(() => {
+				var label = new Label { };
+				label.SetBinding(Label.TextProperty, new Binding("Text"));
+				return label;
+			});
+			cv.IsGrouped = true;
+			cv.ItemsSource = viewModel.Groups;
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(result);
+			layout.Children.Add(button);
+			layout.Children.Add(cv);
+
+			Content = layout;
+		}
+
+		public class _8899ViewModel
+		{ 
+			public ObservableCollection<_8899Group> Groups { get; set; }
+
+			public _8899ViewModel() 
+			{
+				Groups = new ObservableCollection<_8899Group>();
+				for (int n = 0; n < 3; n++)
+				{
+					Groups.Add(new _8899Group(n));
+				}
+			}
+		}
+
+		public class _8899Group : List<_8899Item>
+		{ 
+			public string GroupName { get; set; }
+
+			public _8899Group(int n) 
+			{
+				GroupName = $"Group {n}";
+
+				Add(new _8899Item { Text = $"Group {n} Item" });
+			}
+		}
+
+		public class _8899Item
+		{ 
+			public string Text { get; set; }
+		}
+
+#if UITEST
+		[Test, Category(UITestCategories.CollectionView)]
+		public void ClearingGroupedCollectionViewShouldNotCrash()
+		{
+			RunningApp.WaitForElement(Go);
+			RunningApp.Tap(Go);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8899.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8899.cs
@@ -59,6 +59,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = layout;
 		}
 
+		[Preserve(AllMembers = true)]
 		public class _8899ViewModel
 		{ 
 			public ObservableCollection<_8899Group> Groups { get; set; }
@@ -73,6 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
+		[Preserve(AllMembers = true)]
 		public class _8899Group : List<_8899Item>
 		{ 
 			public string GroupName { get; set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -15,6 +15,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8262.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8899.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8902.xaml.cs">
       <DependentUpon>Issue8902.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/GroupedItemTemplateCollection.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/GroupedItemTemplateCollection.cs
@@ -52,9 +52,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void GroupsChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
-			if (Device.IsInvokeRequired)
+			if (_container.Dispatcher.IsInvokeRequired)
 			{
-				Device.BeginInvokeOnMainThread(() => GroupsChanged(args));
+				_container.Dispatcher.BeginInvokeOnMainThread(() => GroupsChanged(args));
 			}
 			else
 			{
@@ -163,12 +163,10 @@ namespace Xamarin.Forms.Platform.UWP
 		void Reset()
 		{
 			Items.Clear();
-			_groupList.Clear();
 
 			foreach (var group in _itemsSource)
 			{
 				var groupTemplateContext = CreateGroupTemplateContext(group);
-				_groupList.Add(group);
 				Items.Add(groupTemplateContext);
 			}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -143,9 +143,14 @@ namespace Xamarin.Forms.Platform.iOS
 			return GetReferenceSizeForheaderOrFooter(collectionView, ItemsView.GroupFooterTemplate, UICollectionElementKindSectionKey.Footer, section);
 		}
 
-		internal CGSize GetReferenceSizeForheaderOrFooter(UICollectionView collectionView,DataTemplate template, NSString elementKind, nint section)
+		internal CGSize GetReferenceSizeForheaderOrFooter(UICollectionView collectionView, DataTemplate template, NSString elementKind, nint section)
 		{
 			if (!_isGrouped || template == null)
+			{
+				return CGSize.Empty;
+			}
+
+			if (ItemsSource.GroupCount < 1)
 			{
 				return CGSize.Empty;
 			}


### PR DESCRIPTION
### Description of Change ###

Clearing out the groups in an ObservableCollection which is the source for a grouped CollectionView throws an exception on iOS and UWP.

These changes fix the issue on iOS by verifying the existence of a group before attempting to measure the group header or footer.

These changes fix the issue on UWP by not manually resetting the internal group list while handling its Reset action.

### Issues Resolved ### 

- fixes #8899

### API Changes ###

None

### Platforms Affected ### 

- iOS
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test for iOS; for UWP, run Issue 8899 in the Control Gallery.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
