### PR TITLE
Add Alert Dialog Classes to Proguard.cfg file

### DIFF
--- a/.nuspec/proguard.cfg
+++ b/.nuspec/proguard.cfg
@@ -5,3 +5,6 @@
 -keep class android.support.design.internal.BaselineLayout { *; }
 -dontwarn android.support.design.internal.BaselineLayout
 -keep class com.google.firebase.provider.FirebaseInitProvider { *; }
+-keep class android.support.v7.widget.AlertDialogLayout { *; }
+-keep class android.support.v7.widget.DialogTitle { *; }
+-keep class android.support.v7.widget.ButtonBarLayout { *; }


### PR DESCRIPTION
### Description of Change ###
Tell Proguard to keep classes around related to our Alert Dialog

### Issues Resolved ### 
- fixes #9031

### Platforms Affected ### 
- Android

### Testing Procedure ###
- enable proguard on gallery and full linking
or
- recreate issue in a new project and then add the nuget

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
