### PR TITLE
fix for #8564 exception "Delegate to an instance method cannot have null 'this'"

### DIFF
--- a/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
+++ b/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -13,16 +13,23 @@ namespace Xamarin.Forms.Platform.UWP
 		readonly ITitleViewRendererController _titleViewRendererController;
 
 		View TitleView => _titleViewRendererController.TitleView;
-		CommandBar CommandBar =>  _titleViewRendererController.CommandBar;
+		CommandBar CommandBar => _titleViewRendererController.CommandBar;
 		FrameworkElement TitleViewPresenter => _titleViewRendererController.TitleViewPresenter;
 
 		public TitleViewManager(ITitleViewRendererController titleViewRendererController)
 		{
 			_titleViewRendererController = titleViewRendererController;
-			_titleViewRendererController.TitleViewPresenter.Loaded += OnTitleViewPresenterLoaded;
 
-			CommandBar.LayoutUpdated += commandLayoutUpdated;
-			CommandBar.Unloaded += commandBarUnloaded;
+			if (TitleViewPresenter != null)
+			{
+				TitleViewPresenter.Loaded += OnTitleViewPresenterLoaded;
+			}
+
+			if (CommandBar != null)
+			{
+				CommandBar.LayoutUpdated += commandLayoutUpdated;
+				CommandBar.Unloaded += commandBarUnloaded;
+			}
 		}
 
 		internal void OnTitleViewPropertyChanged()
@@ -33,13 +40,19 @@ namespace Xamarin.Forms.Platform.UWP
 		void OnTitleViewPresenterLoaded(object sender, RoutedEventArgs e)
 		{
 			UpdateTitleViewWidth();
-			TitleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;
+			if (TitleViewPresenter != null)
+			{
+				TitleViewPresenter.Loaded -= OnTitleViewPresenterLoaded;
+			}
 		}
 
 		void commandBarUnloaded(object sender, RoutedEventArgs e)
 		{
-			CommandBar.LayoutUpdated -= commandLayoutUpdated;
-			CommandBar.Unloaded -= commandBarUnloaded;
+			if (CommandBar != null)
+			{
+				CommandBar.LayoutUpdated -= commandLayoutUpdated;
+				CommandBar.Unloaded -= commandBarUnloaded;
+			}
 		}
 
 		void commandLayoutUpdated(object sender, object e)
@@ -52,7 +65,8 @@ namespace Xamarin.Forms.Platform.UWP
 			if (TitleView == null || TitleViewPresenter == null || CommandBar == null)
 				return;
 
-			if (CommandBar.ActualWidth <= 0) return;
+			if (CommandBar.ActualWidth <= 0)
+				return;
 
 			double buttonWidth = 0;
 			foreach (var item in CommandBar.GetDescendantsByName<Windows.UI.Xaml.Controls.Button>("MoreButton"))


### PR DESCRIPTION
<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###
Added null-checks for _titleViewRendererController.TitleViewPresenter and _titleViewRendererController.CommandBar that can be null if there is no corresponding part of the MasterDetailControl template

### Issues Resolved ### 
- fixes #8564 

### API Changes ###
None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

set _titleViewRendererController.TitleViewPresenter and _titleViewRendererController.CommandBar to null and see that exception goes away

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
