### PR TITLE
Make create shell table view controller virtual

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		}
 
-		protected ShellTableViewController CreateShellTableViewController()
+		protected virtual ShellTableViewController CreateShellTableViewController()
 		{
 			return new ShellTableViewController(_shellContext, _headerView, OnElementSelected);
 		}


### PR DESCRIPTION

### Description of Change ###

Make create shell table view controller virtual on the ShellFlyoutContentRenderer so users can override and supply their own

### API Changes ###
Changed:
Make CreateShellTableViewController virtual

```C#
class ShellFlyoutContentRenderer
{
     protected virtual ShellTableViewController CreateShellTableViewController()
```


### Platforms Affected ### 
- iOS


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
