### PR TITLE
[Core] Allow CarouselView to specify IndicatorView 

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -45,7 +45,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8693.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8693.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Margin = new Thickness(0, 0, 0, 24)
 			};
 
-			indicatorView.ItemsSourceBy = carouselView;
+			carouselView.IndicatorView = indicatorView;
 
 			layout.Children.Add(instructions);
 			layout.Children.Add(updateButton);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8693.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8693.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Margin = new Thickness(0, 0, 0, 24)
 			};
 
-			IndicatorView.SetItemsSourceBy(indicatorView, carouselView);
+			indicatorView.ItemsSourceBy = carouselView;
 
 			layout.Children.Add(instructions);
 			layout.Children.Add(updateButton);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1776,17 +1776,17 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue3228.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2172.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8902.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -50,9 +50,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				Margin = new Thickness(15, 20),
 				IndicatorColor = Color.Gray,
 				SelectedIndicatorColor = Color.Black,
-				IndicatorsShape = IndicatorShape.Square,
-				ItemsSourceBy = carouselView
+				IndicatorsShape = IndicatorShape.Square
 			};
+
+			carouselView.IndicatorView = indicators;
 
 			absolute.Children.Add(indicators, new Rectangle(.5, 1, -1, -1), AbsoluteLayoutFlags.PositionProportional);
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -50,10 +50,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				Margin = new Thickness(15, 20),
 				IndicatorColor = Color.Gray,
 				SelectedIndicatorColor = Color.Black,
-				IndicatorsShape = IndicatorShape.Square
+				IndicatorsShape = IndicatorShape.Square,
+				ItemsSourceBy = carouselView
 			};
-
-			IndicatorView.SetItemsSourceBy(indicators, carouselView);
 
 			absolute.Children.Add(indicators, new Rectangle(.5, 1, -1, -1), AbsoluteLayoutFlags.PositionProportional);
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -12,7 +12,7 @@
             <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Slider Margin="5" Value="{Binding Position, Mode=TwoWay}" Maximum="{Binding Count}" />
-        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="1" HeightRequest="400">
+        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="1" HeightRequest="400" IndicatorView="indicator">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <gallery:ExampleTemplateCarousel />
@@ -30,6 +30,6 @@
                 </CarouselView>
             </Grid>
         </Frame>
-        <IndicatorView ItemsSourceBy="carouselNormal" IndicatorColor="Gray" SelectedIndicatorColor="Black" Grid.Row="4"></IndicatorView>
+        <IndicatorView x:Name="indicator" IndicatorColor="Gray" SelectedIndicatorColor="Black" Grid.Row="4"></IndicatorView>
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -30,5 +30,6 @@
                 </CarouselView>
             </Grid>
         </Frame>
+        <IndicatorView ItemsSourceBy="carouselNormal" IndicatorColor="Gray" SelectedIndicatorColor="Black" Grid.Row="4"></IndicatorView>
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -59,9 +59,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				IndicatorColor = Color.Gray,
 				SelectedIndicatorColor = Color.Black,
 				IndicatorsShape = IndicatorShape.Square,
-				AutomationId = "TheIndicatorView",
-				ItemsSourceBy = carouselView
+				AutomationId = "TheIndicatorView"
 			};
+
+			carouselView.IndicatorView = indicatorView;
 
 			layout.Children.Add(indicatorView);
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -59,10 +59,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				IndicatorColor = Color.Gray,
 				SelectedIndicatorColor = Color.Black,
 				IndicatorsShape = IndicatorShape.Square,
-				AutomationId = "TheIndicatorView"
+				AutomationId = "TheIndicatorView",
+				ItemsSourceBy = carouselView
 			};
-
-			IndicatorView.SetItemsSourceBy(indicatorView, carouselView);
 
 			layout.Children.Add(indicatorView);
 

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml
@@ -19,7 +19,7 @@
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
         </Grid.RowDefinitions>
-        <CarouselView x:Name="carousel" ItemsSource="{Binding Items}" Grid.Row="0" Grid.RowSpan="3">
+        <CarouselView x:Name="carousel" ItemsSource="{Binding Items}" Grid.Row="0" Grid.RowSpan="3" IndicatorView="indicators">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <Frame BackgroundColor="{Binding Color}">
@@ -31,16 +31,5 @@
             </CarouselView.ItemTemplate>
         </CarouselView>
         <IndicatorView x:Name="indicators" Grid.Row="1" IndicatorColor="Gray" SelectedIndicatorColor="White" HorizontalOptions="Center" />
-        <IndicatorView x:Name="indicatorsForms" Grid.Row="2" ItemsSourceBy="carousel" IndicatorColor="Transparent" SelectedIndicatorColor="Gray" HorizontalOptions="Center"  Margin="0,20,0,20" Visual="Forms" >
-            <IndicatorView.IndicatorTemplate>
-                <DataTemplate>
-                    <Image>
-                        <Image.Source>
-                            <FontImageSource Glyph="{StaticResource Indicator}" FontFamily="{StaticResource IonicsFontFamily}" Color="Pink"></FontImageSource>
-                        </Image.Source>
-                    </Image>
-                </DataTemplate>
-            </IndicatorView.IndicatorTemplate>
-        </IndicatorView>
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
@@ -18,7 +18,6 @@ namespace Xamarin.Forms.Controls
 			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
 			InitializeComponent();
 			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel();
-			indicators.ItemsSourceBy = carousel;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Controls
 			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
 			InitializeComponent();
 			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel();
-			IndicatorView.SetItemsSourceBy(indicators, carousel);
+			indicators.ItemsSourceBy = carousel;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -107,23 +107,6 @@ namespace Xamarin.Forms
 		}
 
 
-		[TypeConverter(typeof(ReferenceTypeConverter))]
-		public ItemsView ItemsSourceBy
-		{
-			get => (ItemsView)GetValue(ItemsSourceByProperty);
-			set => SetValue(ItemsSourceByProperty, value);
-		}
-
-		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create(nameof(ItemsSourceBy), typeof(ItemsView), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
-		 => ((IndicatorView)bindable).LinkToItemsView(newValue as ItemsView));
-
-
-		public virtual void LinkToItemsView(ItemsView itemsView)
-		{
-			if (itemsView is CarouselView carouselView)
-				LinkToCarouselView(this, carouselView);
-		}
-
 		protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 		{
 			var baseRequest = base.OnMeasure(widthConstraint, heightConstraint);
@@ -148,24 +131,6 @@ namespace Xamarin.Forms
 				(indicatorView.IndicatorLayout as IndicatorStackLayout).Remove();
 				indicatorView.IndicatorLayout = null;
 			}
-		}
-
-		static void LinkToCarouselView(IndicatorView indicatorView, CarouselView carouselView)
-		{
-			if (carouselView == null || indicatorView == null)
-				return;
-
-			indicatorView.SetBinding(PositionProperty, new Binding
-			{
-				Path = nameof(CarouselView.Position),
-				Source = carouselView
-			});
-
-			indicatorView.SetBinding(ItemsSourceProperty, new Binding
-			{
-				Path = nameof(ItemsView.ItemsSource),
-				Source = carouselView
-			});
 		}
 
 		void ResetItemsSource(IEnumerable oldItemsSource)

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -108,14 +108,14 @@ namespace Xamarin.Forms
 
 
 		[TypeConverter(typeof(ReferenceTypeConverter))]
-		public VisualElement ItemsSourceBy
+		public ItemsView ItemsSourceBy
 		{
-			get => (VisualElement)GetValue(ItemsSourceByProperty);
+			get => (ItemsView)GetValue(ItemsSourceByProperty);
 			set => SetValue(ItemsSourceByProperty, value);
 		}
 
-		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create(nameof(ItemsSourceBy), typeof(VisualElement), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
-		 => (bindable as IndicatorView)?.LinkToVisualElement(newValue as VisualElement));
+		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create(nameof(ItemsSourceBy), typeof(ItemsView), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
+		 => ((IndicatorView)bindable).LinkToVisualElement(newValue as ItemsView));
 
 
 		public virtual void LinkToVisualElement(VisualElement visualElement)

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -115,12 +115,12 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create(nameof(ItemsSourceBy), typeof(ItemsView), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
-		 => ((IndicatorView)bindable).LinkToVisualElement(newValue as ItemsView));
+		 => ((IndicatorView)bindable).LinkToItemsView(newValue as ItemsView));
 
 
-		public virtual void LinkToVisualElement(VisualElement visualElement)
+		public virtual void LinkToItemsView(ItemsView itemsView)
 		{
-			if (visualElement is CarouselView carouselView)
+			if (itemsView is CarouselView carouselView)
 				LinkToCarouselView(this, carouselView);
 		}
 

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -106,19 +106,17 @@ namespace Xamarin.Forms
 			set => SetValue(ItemsSourceProperty, value);
 		}
 
-		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create("ItemsSourceBy", typeof(VisualElement), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
-		 => (bindable as IndicatorView)?.LinkToVisualElement(newValue as VisualElement));
 
 		[TypeConverter(typeof(ReferenceTypeConverter))]
-		public static VisualElement GetItemsSourceBy(BindableObject bindable)
+		public VisualElement ItemsSourceBy
 		{
-			return (VisualElement)bindable.GetValue(ItemsSourceByProperty);
+			get => (VisualElement)GetValue(ItemsSourceByProperty);
+			set => SetValue(ItemsSourceByProperty, value);
 		}
 
-		public static void SetItemsSourceBy(BindableObject bindable, VisualElement value)
-		{
-			bindable.SetValue(ItemsSourceByProperty, value);
-		}
+		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create(nameof(ItemsSourceBy), typeof(VisualElement), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
+		 => (bindable as IndicatorView)?.LinkToVisualElement(newValue as VisualElement));
+
 
 		public virtual void LinkToVisualElement(VisualElement visualElement)
 		{

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -107,7 +107,7 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly BindableProperty ItemsSourceByProperty = BindableProperty.Create("ItemsSourceBy", typeof(VisualElement), typeof(IndicatorView), default(VisualElement), propertyChanged: (bindable, oldValue, newValue)
-		 => LinkToCarouselView(bindable as IndicatorView, newValue as CarouselView));
+		 => (bindable as IndicatorView)?.LinkToVisualElement(newValue as VisualElement));
 
 		[TypeConverter(typeof(ReferenceTypeConverter))]
 		public static VisualElement GetItemsSourceBy(BindableObject bindable)
@@ -118,6 +118,12 @@ namespace Xamarin.Forms
 		public static void SetItemsSourceBy(BindableObject bindable, VisualElement value)
 		{
 			bindable.SetValue(ItemsSourceByProperty, value);
+		}
+
+		public virtual void LinkToVisualElement(VisualElement visualElement)
+		{
+			if (visualElement is CarouselView carouselView)
+				LinkToCarouselView(this, carouselView);
 		}
 
 		protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -168,21 +168,15 @@ namespace Xamarin.Forms
 			set => SetValue(ItemsLayoutProperty, value);
 		}
 
-
 		[TypeConverter(typeof(ReferenceTypeConverter))]
 		public IndicatorView IndicatorView
 		{
-			get => (IndicatorView)GetValue(IndicatorViewProperty);
-			set => SetValue(IndicatorViewProperty, value);
+			set => LinkToIndicatorView(this, value);
 		}
 
-		public static readonly BindableProperty IndicatorViewProperty = BindableProperty.Create(nameof(IndicatorView), typeof(IndicatorView), typeof(CarouselView), default(IndicatorView), propertyChanged: (bindable, oldValue, newValue)
-		 => LinkToIndicatorView(newValue as IndicatorView, bindable as CarouselView));
-
-
-		static void LinkToIndicatorView(IndicatorView indicatorView, CarouselView carouselView)
+		static void LinkToIndicatorView(CarouselView carouselView, IndicatorView indicatorView)
 		{
-			if (carouselView == null || indicatorView == null)
+			if (indicatorView == null)
 				return;
 
 			indicatorView.SetBinding(IndicatorView.PositionProperty, new Binding
@@ -198,11 +192,9 @@ namespace Xamarin.Forms
 			});
 		}
 
-
-
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public bool IsScrolling { get; set; }
-		
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public Queue<Action> ScrollToActions = new Queue<Action>();
 

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -158,6 +158,38 @@ namespace Xamarin.Forms
 			set => SetValue(ItemsLayoutProperty, value);
 		}
 
+
+		[TypeConverter(typeof(ReferenceTypeConverter))]
+		public IndicatorView IndicatorView
+		{
+			get => (IndicatorView)GetValue(IndicatorViewProperty);
+			set => SetValue(IndicatorViewProperty, value);
+		}
+
+		public static readonly BindableProperty IndicatorViewProperty = BindableProperty.Create(nameof(IndicatorView), typeof(IndicatorView), typeof(CarouselView), default(IndicatorView), propertyChanged: (bindable, oldValue, newValue)
+		 => LinkToIndicatorView(newValue as IndicatorView, bindable as CarouselView));
+
+
+		static void LinkToIndicatorView(IndicatorView indicatorView, CarouselView carouselView)
+		{
+			if (carouselView == null || indicatorView == null)
+				return;
+
+			indicatorView.SetBinding(IndicatorView.PositionProperty, new Binding
+			{
+				Path = nameof(CarouselView.Position),
+				Source = carouselView
+			});
+
+			indicatorView.SetBinding(IndicatorView.ItemsSourceProperty, new Binding
+			{
+				Path = nameof(ItemsView.ItemsSource),
+				Source = carouselView
+			});
+		}
+
+
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public bool IsScrolling { get; set; }
 


### PR DESCRIPTION
### Description of Change ###

CarouselView should provide a way to link to a IndicatorView. 
 
fixes #8992 

### API Changes ###

Added:
 - `public IndicatorView IndicatorView`

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Try create a custom IndicatorView and provide an override to link to other control.

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
