### PR TITLE
[Android] Fix sizing and position on Android of the Indicators

### DIFF
--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -127,7 +127,6 @@ namespace Xamarin.Forms
 			if (IndicatorTemplate != null)
 				return baseRequest;
 
-			var defaultSize = IndicatorSize + DefaultPadding + DefaultPadding;
 			var defaultSize = IndicatorSize + DefaultPadding + DefaultPadding + 1;
 			var items = Count;
 			var sizeRequest = new SizeRequest(new Size(items * defaultSize, IndicatorSize), new Size(10, 10));

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -128,6 +128,7 @@ namespace Xamarin.Forms
 				return baseRequest;
 
 			var defaultSize = IndicatorSize + DefaultPadding + DefaultPadding;
+			var defaultSize = IndicatorSize + DefaultPadding + DefaultPadding + 1;
 			var items = Count;
 			var sizeRequest = new SizeRequest(new Size(items * defaultSize, IndicatorSize), new Size(10, 10));
 			return sizeRequest;

--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -50,6 +50,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public IndicatorViewRenderer(Context context) : base(context)
 		{
+			SetGravity(GravityFlags.Center);
 			_visualElementRenderer = new VisualElementRenderer(this);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Center indicators on IndicatorView by default. 
On Android API 29 the last item get shrank,   

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8911 
- fixes #8934 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
Should center items by default without HorizontalOptions="Center" .
Last indicator shouldn't be smaller.

### Before/After Screenshots ### 
Before
![Screenshot_20200128-160008](https://user-images.githubusercontent.com/1235097/73281775-5b684680-41e8-11ea-9d83-44a492d12b15.png)
![Screenshot_20200128-160338](https://user-images.githubusercontent.com/1235097/73281783-5d320a00-41e8-11ea-843c-4feb297a92df.png)

After
![Screenshot_20200128-161010](https://user-images.githubusercontent.com/1235097/73282030-cc0f6300-41e8-11ea-9205-f9ed3d50280c.png)

![Screenshot_20200128-160600](https://user-images.githubusercontent.com/1235097/73281788-5f946400-41e8-11ea-820a-23b5b3487535.png)


Not applicable

### Testing Procedure ###
Run IndicatorsSample on Android  

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
