### PR TITLE
Query parameters were not being applied during simple navigation

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -284,32 +284,41 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsFalse(page1.Appearing);
 			Assert.IsTrue(page2.Appearing);
 		}
-		
 
-		public class ModalTestPage : ShellLifeCycleTests.LifeCyclePage
+		[Test]
+		public async Task BasicQueryStringTest()
 		{
-			public ModalTestPage()
+			var shell = new Shell();
+
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			shell.Items.Add(item);
+			await shell.GoToAsync(new ShellNavigationState($"ModalTestPage?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ModalTestPageBase;
+			Assert.AreEqual("1234", testPage.SomeQueryParameter);
+		}
+
+
+		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
+		public class ModalTestPageBase : ShellLifeCycleTests.LifeCyclePage
+		{
+			public string SomeQueryParameter
 			{
-				Shell.SetPresentationMode(this, PresentationMode.Modal);
+				get;
+				set;
 			}
 
-			protected override void OnAppearing()
+			public ModalTestPageBase()
 			{
-				base.OnAppearing();
+				Shell.SetPresentationMode(this, PresentationMode.Modal);
 			}
 		}
 
-		public class ModalTestPage2 : ShellLifeCycleTests.LifeCyclePage
+		public class ModalTestPage : ModalTestPageBase
 		{
-			public ModalTestPage2()
-			{
-				Shell.SetPresentationMode(this, PresentationMode.Modal);
-			}
+		}
 
-			protected override void OnAppearing()
-			{
-				base.OnAppearing();
-			}
+		public class ModalTestPage2 : ModalTestPageBase
+		{
 		}
 
 		public class ModalNavigationTestPage : NavigationPage
@@ -317,11 +326,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			public ModalNavigationTestPage() : base(new ModalTestPage())
 			{
 				Shell.SetPresentationMode(this, PresentationMode.Modal);
-			}
-
-			protected override void OnAppearing()
-			{
-				base.OnAppearing();
 			}
 		}
 

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -391,6 +391,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("4321", testPage.SomeQueryParameter);
 		}
 
+		[Test]
+		public async Task BasicQueryStringTest()
+		{
+			var shell = new Shell();
+
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			Routing.RegisterRoute("details", typeof(ShellTestPage));
+			shell.Items.Add(item);
+			await shell.GoToAsync(new ShellNavigationState($"details?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			var testPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ShellTestPage;
+			Assert.AreEqual("1234", testPage.SomeQueryParameter);
+		}
+
 
 		[Test]
 		public async Task NavigationWithQueryStringAndNoDataTemplate()

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -406,6 +406,7 @@ namespace Xamarin.Forms
 
 				var isModal = (Shell.GetPresentationMode(content) & PresentationMode.Modal) == PresentationMode.Modal;
 
+				Shell.ApplyQueryAttributes(content, queryData, isLast);
 				if (isModal)
 				{
 					modalPageStacks.Add(content);


### PR DESCRIPTION
### Description of Change ###
During the restructuring of navigation to handle modals the code that applies query string parameters during basing navigation was lost

### Issues Resolved ### 
- fixes #9344 


### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
