### PR TITLE
Don't attempt to merge UWP resources if they've already been added

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -35,7 +35,10 @@ namespace Xamarin.Forms
 #else
 			Log.Listeners.Add(new DelegateLogListener((c, m) => Trace.WriteLine(m, c)));
 #endif
-			Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(GetTabletResources());
+			if (!Windows.UI.Xaml.Application.Current.Resources.ContainsKey("RootContainerStyle"))
+			{
+				Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(GetTabletResources());
+			}
 
 			try
 			{


### PR DESCRIPTION
### Description of Change ###

If the merged dictionaries already contains the UWP Forms Resources, don't attempt to load them again; this will cause a COM exception.

This is basically just taking the logic from UWP `Platform(Page)` and applying it to `Forms.Init()`.

### Issues Resolved ### 

- fixes #9335

### API Changes ###

None 

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Create a Forms project with a UWP head. Add a separate Forms project with a base class inheriting from `ContentPage`. In the main Forms project, set your main page to a page which derives from your base class in the other project. Run the application.

Without this fix, the application should crash. With this fix, it should run.

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
