### PR TITLE
Anticipator

### DIFF
--- a/.create-stubs.bat
+++ b/.create-stubs.bat
@@ -135,10 +135,14 @@ echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\TabbedPageStyle.xbf
 echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\FormsEmbeddedPageWrapper.xbf
 echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\StepperControl.xbf
 echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\FormsCheckBoxStyle.xbf
+echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\PickerStyle.xbf
 
 mkdir Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Microsoft.UI.Xaml
 mkdir Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Microsoft.UI.Xaml\DensityStyles
 echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Microsoft.UI.Xaml\DensityStyles\Compact.xbf
+
+mkdir Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Microsoft.UI.Xaml\themes
+echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Microsoft.UI.Xaml\themes\generic.xbf
 
 mkdir Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Shell
 echo foo > Xamarin.Forms.Platform.UAP\bin\%CONFIG%\Shell\ShellStyles.xbf

--- a/.create-stubs.bat
+++ b/.create-stubs.bat
@@ -110,6 +110,12 @@ echo foo > Xamarin.Forms.Platform.MacOS\bin\%CONFIG%\Xamarin.forms.Platform.macO
 echo foo > Xamarin.Forms.Platform.MacOS\bin\%CONFIG%\Xamarin.forms.Platform.dll
 echo foo > Xamarin.Forms.Maps.MacOS\bin\%CONFIG%\Xamarin.Forms.Maps.macOS.dll
 
+mkdir Xamarin.Forms.Platform.MacOS\bin\%CONFIG%\2017
+echo foo > Xamarin.Forms.Platform.MacOS\bin\%CONFIG%\2017\Xamarin.Forms.Platform.macOS.dll
+
+mkdir Xamarin.Forms.Platform.iOS\bin\%CONFIG%\2017
+echo foo > Xamarin.Forms.Platform.iOS\bin\%CONFIG%\2017\Xamarin.Forms.Platform.iOS.dll
+
 mkdir Stubs\Xamarin.Forms.Platform.Tizen\bin\%CONFIG%\tizen40
 echo foo > Stubs\Xamarin.Forms.Platform.Tizen\bin\%CONFIG%\tizen40\Xamarin.Forms.Platform.dll
 echo foo > Xamarin.Forms.Maps.Tizen\bin\%CONFIG%\Tizen40\Xamarin.Forms.Maps.Tizen.dll

--- a/Xamarin.Forms.ControlGallery.Android/MainApplication.cs
+++ b/Xamarin.Forms.ControlGallery.Android/MainApplication.cs
@@ -5,6 +5,7 @@ using Android.OS;
 using Android.Runtime;
 using Plugin.CurrentActivity;
 using Xamarin.Forms.DualScreen;
+using Xamarin.Forms.Platform.Android;
 
 namespace Xamarin.Forms.ControlGallery.Android
 {
@@ -23,10 +24,12 @@ namespace Xamarin.Forms.ControlGallery.Android
         {
             base.OnCreate();
             RegisterActivityLifecycleCallbacks(this);
-            //A great place to initialize Xamarin.Insights and Dependency Services!
-        }
 
-        public override void OnTerminate()
+			AndroidAnticipator.Initialize(this);
+			//A great place to initialize Xamarin.Insights and Dependency Services!
+		}
+
+		public override void OnTerminate()
         {
             base.OnTerminate();
             UnregisterActivityLifecycleCallbacks(this);

--- a/Xamarin.Forms.Core/DependencyResolver.cs
+++ b/Xamarin.Forms.Core/DependencyResolver.cs
@@ -38,28 +38,48 @@ namespace Xamarin.Forms.Internals
 
 		internal static object ResolveOrCreate(Type type, object source, Type visualType, params object[] args)
 		{
+			Profile.FrameBegin(type.Name);
 			visualType = visualType ?? _defaultVisualType;
 
 			var result = Resolve(type, args);
 
-			if (result != null) return result;
-
-			if (args.Length > 0)
+			if (result == null && args.Length > 0)
 			{
 				if(visualType != _defaultVisualType)
+				{
+					Profile.FramePartition("Activate 2 Info");
 					if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == 2))
-						return Activator.CreateInstance(type, new[] { args[0], source });
+					{
+						Profile.FramePartition("Activate 2");
+						result = Activator.CreateInstance(type, new[] { args[0], source });
+					}
+				}
 
 				// This is by no means a general solution to matching with the correct constructor, but it'll
 				// do for finding Android renderers which need Context (vs older custom renderers which may still use
 				// parameterless constructors)
-				if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == args.Length))
+				if (result == null)
 				{
-					return Activator.CreateInstance(type, args);
+					Profile.FramePartition("Activate L Info");
+					if (type.GetTypeInfo().DeclaredConstructors.Any(info => info.GetParameters().Length == args.Length))
+					{
+						Profile.FramePartition("Activate L");
+						result = Activator.CreateInstance(type, args);
+						if (result == null)
+							throw new Exception($"Failed to find matching .ctor for {type}");
+					}
 				}
 			}
 			
-			return Activator.CreateInstance(type);
+			if (result == null)
+			{
+				Profile.FramePartition("Activate");
+				result = Activator.CreateInstance(type);
+			}
+
+			Profile.FrameEnd(type.Name);
+
+			return result;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Internals/ProfilePage.cs
+++ b/Xamarin.Forms.Core/Internals/ProfilePage.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 using Xamarin.Forms;
 using Xamarin.Forms.Internals;
@@ -54,6 +55,12 @@ namespace Xamarin.Forms.Internals
 
 			return total;
 		}
+
+		private static void AppendLog(StringBuilder sb)
+		{
+			sb.AppendLine("---LOG---");
+			sb.AppendLine(Profile.Log.Aggregate(string.Empty, (a, o) => a + o + Environment.NewLine));
+		} 
 
 		private static void AppendProfile(StringBuilder sb, long profiledMs, bool showZeros)
 		{
@@ -127,6 +134,7 @@ namespace Xamarin.Forms.Internals
 				var sb = new StringBuilder();
 				sb.AppendLine($"Profiled: {profiledMs}ms");
 				AppendProfile(sb, profiledMs, showZeros);
+				AppendLog(sb);
 				label.Text = sb.ToString();
 			};
 			buttonA.Clicked += delegate { showZeros = !showZeros; update(); };

--- a/Xamarin.Forms.Core/Profiler.cs
+++ b/Xamarin.Forms.Core/Profiler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.IO;
+using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Runtime.InteropServices;
@@ -15,6 +16,29 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public struct Profile : IDisposable
 	{
+		public struct LogEntry
+		{
+			public string Format;
+			public object[] Arguments;
+
+			public LogEntry(string format, params object[] arguments)
+			{
+				Format = format;
+				Arguments = arguments;
+			}
+
+			public override string ToString()
+				=> string.Format(Format, Arguments?.Select(o => (o as Lazy<string>)?.Value ?? o).ToArray());
+		}
+
+		public static List<LogEntry> Log = new List<LogEntry>();
+		public static void WriteLog(string format, params object[] arguments)
+		{
+			var entry = new LogEntry(format, arguments);
+			lock(Log)
+				Log.Add(entry);
+		}
+
 		const int Capacity = 1000;
 
 		[DebuggerDisplay("{Name,nq} {Id} {Ticks}")]
@@ -26,7 +50,7 @@ namespace Xamarin.Forms.Internals
 			public int Depth;
 			public int Line;
 		}
-		public static List<Datum> Data = new List<Datum>(Capacity);
+		public readonly static List<Datum> Data = new List<Datum>(Capacity);
 
 		static Stack<Profile> Stack = new Stack<Profile>(Capacity);
 		static int Depth = 0;
@@ -44,7 +68,6 @@ namespace Xamarin.Forms.Internals
 
 		public static void Stop()
 		{
-			// unwind stack
 			Running = false;
 			while (Stack.Count > 0)
 				Stack.Pop();

--- a/Xamarin.Forms.Platform.Android/Anticipator.cs
+++ b/Xamarin.Forms.Platform.Android/Anticipator.cs
@@ -1,135 +1,518 @@
 ﻿using System;
-using System.Collections.Concurrent;
-using System.Runtime.CompilerServices;
-using System.Threading;
+using System.Collections.Generic;
+using System.Reflection;
+using Android.Content;
+using Android.Views;
+using Android.Util;
+using Android.App;
 using ABuildVersionCodes = Android.OS.BuildVersionCodes;
 using ABuild = Android.OS.Build;
+using AView = Android.Views.View;
+using ARelativeLayout = Android.Widget.RelativeLayout;
+using FLabelRenderer = Xamarin.Forms.Platform.Android.FastRenderers.LabelRenderer;
+#if __ANDROID_29__
+using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
+#else
+using AToolbar = Android.Support.V7.Widget.Toolbar;
+# endif
+using System.Threading;
+using System.Collections.Concurrent;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.Internals;
+using System.Diagnostics;
+using Android.Content.Res;
+using Android.Widget;
+using Orientation = Android.Content.Res.Orientation;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	/// <summary>
-	/// 
-	/// Anticipator is a hand-rolled threadpool that exists to speedup startup by activating
-	/// threads that can be used to race ahead of the UIThread in order to compute and cache results 
-	/// that the UIThread would otherwise have to compute as part of startup. This requires
-	/// making some startup code re-entrant. 
-	/// 
-	/// So developers don't need to wonder if the startup code they're writing is re-entrant we 
-	/// isolate all re-entrant code here in the static members of Anticipator.
-	/// 
-	/// Computing the results that need to be cached often require calling into the Android OS. 
-	/// Calling into the Android OS off the UIThread is a "gray" operation. E.g. we know not to 
-	/// update UI elements off the UIThread, but what about getting the SdkInt version? Likely
-	/// ok but just the same we want to track ALL Android OS APIs we call off the UIThread.
-	/// Isolating all re-entrant code in static Anticipator members simplifies accounting of
-	/// all Android OS calls potentially made off the UIThread.
-	/// 
-	/// </summary>
-	internal partial class Anticipator
+	interface IPreBuildable
 	{
-		static Anticipator s_singleton;
-		static ABuildVersionCodes? s_sdkInt;
+		object Build();
+	}
 
-		static Anticipator()
+	interface IPreComputable
+	{
+		object Compute();
+	}
+
+	public static class AndroidAnticipator
+	{
+		static class Key
 		{
-			s_singleton = new Anticipator();
+			internal struct SdkVersion : IPreComputable
+			{
+				object IPreComputable.Compute()
+					=> ABuild.VERSION.SdkInt;
 
-			s_singleton.AnticipateClassConstruction(typeof(Resource.Layout));
-			s_singleton.AnticipateClassConstruction(typeof(Resource.Attribute));
-			s_singleton.AnticipateGetter(() => Forms.SdkInt);
+				public override string ToString()
+					=> $"{nameof(SdkVersion)}";
+			}
+
+			internal struct IdedResourceExists : IPreComputable
+			{
+				readonly internal Context Context;
+				readonly internal int Id;
+
+				internal IdedResourceExists(Context context, int id)
+				{
+					Context = context;
+					Id = id;
+				}
+
+				object IPreComputable.Compute()
+				{
+					if (Id == 0)
+						return false;
+
+					using (var value = new TypedValue())
+						return Context.Theme.ResolveAttribute(Id, value, true);
+				}
+
+				public override string ToString()
+					=> $"{nameof(IdedResourceExists)}, '{ResourceName(Id)}'";
+			}
+
+			internal struct NamedResourceExists : IPreComputable
+			{
+				readonly internal Context Context;
+				readonly internal string Name;
+				readonly internal string Type;
+
+				internal NamedResourceExists(Context context, string name, string type)
+				{
+					Context = context;
+					Name = name;
+					Type = type;
+				}
+
+				object IPreComputable.Compute()
+				{
+					var id = Context.Resources.GetIdentifier(Name, Type, Context.PackageName);
+					if (id == 0)
+						return false;
+
+					using (var value = new TypedValue())
+						return Context.Theme.ResolveAttribute(id, value, true);
+				}
+
+				public override string ToString()
+					=> $"{nameof(NamedResourceExists)}, {Name}";
+			}
+
+			internal struct InflateResource : IPreBuildable
+			{
+				readonly internal Context Context;
+				readonly internal int Id;
+
+				internal InflateResource(Context context, int id)
+				{
+					if (id == 0)
+						throw new ArgumentException("id cannot be zero");
+
+					Context = context;
+					Id = id;
+				}
+
+				object IPreBuildable.Build()
+				{
+					var layoutInflator = (Context as Activity)?.LayoutInflater ?? 
+						LayoutInflater.FromContext(Context);
+
+					return layoutInflator.Inflate(Id, null);
+				}
+
+				public override string ToString()
+					=> $"{nameof(InflateResource)}, {ResourceName(Id)}";
+			}
+
+			internal struct ActivateView :
+				IPreBuildable, IEquatable<ActivateView>
+			{
+				readonly internal Context Context;
+				readonly internal Type Type;
+				readonly internal Func<Context, object> Factory;
+
+				internal ActivateView(Context context, Type type, Func<Context, object> activator = null)
+				{
+					Context = context;
+					Type = type;
+					Factory = activator;
+				}
+
+				object IPreBuildable.Build()
+				{
+					if (Factory == null)
+						return Activator.CreateInstance(Type, Context);
+
+					return Factory(Context);
+				}
+
+				public override int GetHashCode()
+					=> Context.GetHashCode() ^ Type.GetHashCode();
+				public bool Equals(ActivateView other)
+					=> other.Context == Context && other.Type == Type;
+				public override bool Equals(object other)
+					=> other is ActivateView ? Equals((ActivateView)other) : false;
+				public override string ToString()
+					=> $"{nameof(ActivateView)}, {Type.GetTypeInfo().Name}";
+			}
 		}
 
-		internal static ABuildVersionCodes SdkInt
+		public static void Initialize(ContextWrapper context)
 		{
-			get
+			Profile.FrameBegin();
+
+			if (context == null)
+				throw new ArgumentNullException(nameof(context));
+
+			s_scheduler.Value.Schedule(() =>
 			{
-				if (!s_sdkInt.HasValue)
-					s_sdkInt = ABuild.VERSION.SdkInt;
-				return (ABuildVersionCodes)s_sdkInt;
-			}
+				s_anticipator.AnticipateAllocation(new Key.ActivateView(context, typeof(AToolbar), o => new AToolbar(o)));
+
+				s_scheduler.Value.Schedule(() =>
+				{
+					s_anticipator.AnticipateAllocation(new Key.ActivateView(context.BaseContext, typeof(ARelativeLayout), o => new ARelativeLayout(o)));
+
+					s_scheduler.Value.Schedule(() =>
+					{
+						s_anticipator.AnticipateValue(new Key.SdkVersion());
+
+						s_anticipator.AnticipateValue(new Key.IdedResourceExists(context, global::Android.Resource.Attribute.ColorAccent));
+						s_anticipator.AnticipateValue(new Key.NamedResourceExists(context, "colorAccent", "attr"));
+
+						if (FormsAppCompatActivity.ToolbarResource != 0)
+							s_anticipator.AnticipateAllocation(new Key.InflateResource(context, FormsAppCompatActivity.ToolbarResource));
+						if (Resource.Layout.FlyoutContent != 0)
+							s_anticipator.AnticipateAllocation(new Key.InflateResource(context, Resource.Layout.FlyoutContent));
+
+						s_scheduler.Value.Schedule(() =>
+						{
+							new PageRenderer(context);
+							new FLabelRenderer(context);
+							new ListViewRenderer(context);
+						});
+					});
+				});
+			});
+
+			Profile.FrameEnd();
+		}
+
+		public static void ReportUnused()
+		{
+			s_anticipator.ReportUnused();
+		}
+
+		internal static ABuildVersionCodes SdkVersion
+			=> (ABuildVersionCodes)s_anticipator.Compute(new Key.SdkVersion());
+
+		internal static bool IdedResourceExists(Context context, int id)
+			=> (bool)s_anticipator.Compute(new Key.IdedResourceExists(context, id));
+
+		internal static bool NamedResourceExists(Context context, string name, string type)
+			=> (bool)s_anticipator.Compute(new Key.NamedResourceExists(context, name, type));
+
+		internal static AView InflateResource(Context context, int id)
+			=> (AView)s_anticipator.Allocate(new Key.InflateResource(context, id));
+
+		internal static AView ActivateView(Context context, Type type)
+			=> (AView)s_anticipator.Allocate(new Key.ActivateView(context, type));
+
+		static string ResourceName(int id)
+			=> id != 0 && s_resourceNames.Value.TryGetValue(id, out var name) ? name : id.ToString();
+
+		static Lazy<Scheduler> s_scheduler;
+		static Lazy<Dictionary<int, string>> s_resourceNames;
+		static Anticipator s_anticipator;
+
+		static AndroidAnticipator()
+		{
+			Profile.FrameBegin("AndroidAnticipator");
+
+			Profile.FramePartition("Scheduler");
+			s_scheduler = new Lazy<Scheduler>(() => new Scheduler());
+
+			Profile.FramePartition("Anticipator");
+			s_anticipator = new Anticipator(s_scheduler);
+
+			Profile.FramePartition("Resource Names");
+			s_resourceNames = new Lazy<Dictionary<int, string>>(() => new Dictionary<int, string>
+			{
+				[FormsAppCompatActivity.ToolbarResource] = nameof(FormsAppCompatActivity.ToolbarResource),
+				[global::Android.Resource.Attribute.ColorAccent] = nameof(global::Android.Resource.Attribute.ColorAccent),
+				[Resource.Layout.FlyoutContent] = nameof(Resource.Layout.FlyoutContent),
+			});
+
+			Profile.FrameEnd("AndroidAnticipator");
 		}
 	}
 
-	/// <summary>
-	/// A carve out of the the private instance members of Anticipator used to access the thread
-	/// pool. The thread pool should only ever be accessed by static members of Anticipator. 
-	/// </summary>
-	internal partial class Anticipator
+	sealed class Anticipator
 	{
-		const int ThreadLifeTimeSeconds = 5;
-		readonly static TimeSpan LoopTimeOut = TimeSpan.FromSeconds(ThreadLifeTimeSeconds);
-
-		readonly Thread[] _threads;
-		readonly AutoResetEvent[] _signals;
-		readonly ConcurrentQueue<Action> _actions;
-
-		internal Anticipator()
+		sealed class Warehouse
 		{
-			_actions = new ConcurrentQueue<Action>();
+			static ConcurrentBag<object> ActivateBag(object key)
+				=> new ConcurrentBag<object>();
 
-			_threads = new Thread[Environment.ProcessorCount];
-			_signals = new AutoResetEvent[Environment.ProcessorCount];
+			readonly ConcurrentDictionary<object, object> _dictionary;
+			readonly Func<object, ConcurrentBag<object>> _activateBag;
+			readonly ConcurrentDictionary<object, int> _timeToActivate;
+			readonly Lazy<Scheduler> _scheduler;
 
-			_signals[0] = new AutoResetEvent(true);
-			_threads[0] = new Thread(Loop);
-			_threads[0].Start(_signals[0]);
-
-			Anticipate(() =>
+			internal Warehouse(Lazy<Scheduler> scheduler)
 			{
-				for (var i = 1; i < _threads.Length; i++)
+				_activateBag = ActivateBag;
+				_dictionary = new ConcurrentDictionary<object, object>();
+				_timeToActivate = new ConcurrentDictionary<object, int>();
+				_scheduler = scheduler;
+			}
+
+			ConcurrentBag<object> Get(object key)
+				=> (ConcurrentBag<object>)_dictionary.GetOrAdd(key, _activateBag);
+
+			void Set(object key, object value)
+				=> Get(key).Add(value);
+
+			bool TryGet(object key, out object value)
+			{
+				var result = Get(key).TryTake(out value);
+
+				if (result)
 				{
-					_signals[i] = new AutoResetEvent(true);
-					_threads[i] = new Thread(Loop);
-					_threads[i].Start(_signals[i]);
+					_timeToActivate.TryRemove(value, out var ms);
+					s_savings += ms;
+					Profile.WriteLog("WAREHOUSE HIT: {0}, ms={1}", key, ms);
 				}
-			});
-		}
-
-		void Loop(object argument)
-		{
-			var signal = (AutoResetEvent)argument;
-
-			while (signal.WaitOne(LoopTimeOut))
-			{
-				// process actions
-				while (_actions.Count > 0)
+				else
 				{
-					if (!_actions.TryDequeue(out Action action))
-						continue; // lost race to dequeue
+					Profile.WriteLog("WAREHOUSE MISS: {0}", key);
+				}
 
-					action();
+				return result;
+			}
+
+			public object Get<T>(T key = default)
+				where T : IPreBuildable
+			{
+				if (!TryGet(key, out var value))
+					return key.Build();
+
+				return value;
+			}
+
+			public void Anticipate<T>(T key = default)
+				where T : IPreBuildable
+			{
+				_scheduler.Value.Schedule(() =>
+				{
+					try
+					{
+						var stopwatch = new Stopwatch();
+						stopwatch.Start();
+						var value = key.Build();
+						if (value == null)
+						{
+							Profile.WriteLog("WEARHOUSED NULL BUILD: {0}", key);
+							return;
+						}
+						var ticks = stopwatch.ElapsedTicks;
+						var ms = TimeSpan.FromTicks(ticks).Milliseconds;
+
+						_timeToActivate.TryAdd(value, ms);
+						Set(key, value);
+						Profile.WriteLog("Wearhoused: {0}, ms={1}", key, ms);
+					}
+					catch (Exception ex)
+					{
+						Profile.WriteLog("WEARHOUSE EXCEPTION: {0}: {1}", key, ex);
+					}
+				});
+			}
+
+			public void ReportUnused()
+			{
+				foreach (var pair in _dictionary)
+				{
+					foreach (var value in ((ConcurrentBag<object>)pair.Value))
+					{
+						_timeToActivate.TryRemove(value, out var ms);
+						Profile.WriteLog("WEARHOUSE UNUSED: {0}, ms={1}", pair.Key, ms);
+						(value as IDisposable)?.Dispose();
+					}
 				}
 			}
 		}
 
-		void Signal()
+		sealed class Cache
 		{
-			for (var i = 0; i < _signals.Length; i++)
+			readonly ConcurrentDictionary<object, object> _dictionary;
+			readonly ConcurrentDictionary<object, int> _timeToCompute;
+			readonly Lazy<Scheduler> _scheduler;
+
+			internal Cache(Lazy<Scheduler> scheduler)
 			{
-				if (_signals[i] != null)
-					_signals[i].Set();
+				_scheduler = scheduler;
+				_timeToCompute = new ConcurrentDictionary<object, int>();
+				_dictionary = new ConcurrentDictionary<object, object>();
+			}
+
+			void Set(object key, object value)
+				=> _dictionary.TryAdd(key, value);
+
+			bool TryGet(object key, out object value)
+			{
+				var result = _dictionary.TryGetValue(key, out value);
+				if (!result)
+					return false;
+
+				if (!_timeToCompute.TryRemove(key, out var ms))
+					return true;
+
+				s_savings += ms;
+				Profile.WriteLog("CACHE HIT: {0}, ms={1}", key, ms);
+				return true;
+			}
+
+			public object Get<T>(T key = default)
+				where T : IPreComputable
+			{
+				if (!TryGet(key, out var value))
+					return key.Compute();
+
+				return value;
+			}
+
+			public void Anticipate<T>(T key = default)
+				where T : IPreComputable
+			{
+				_scheduler.Value.Schedule(() =>
+				{
+					try
+					{
+						var stopwatch = new Stopwatch();
+						stopwatch.Start();
+						var value = key.Compute();
+						var ticks = stopwatch.ElapsedTicks;
+						var ms = TimeSpan.FromTicks(ticks).Milliseconds;
+
+						_timeToCompute.TryAdd(key, ms);
+						Set(key, value);
+						Profile.WriteLog("Cashed: {0}, ms={1}", key, ms);
+					}
+					catch (Exception ex)
+					{
+						Profile.WriteLog("CACHE EXCEPTION: {0}: {1}", key, ex);
+					}
+				});
+			}
+
+			public void ReportUnused()
+			{
+				foreach (var pair in _dictionary)
+				{
+					if (_timeToCompute.ContainsKey(pair.Key))
+						Profile.WriteLog("CACHE UNUSED: {0}", pair.Key);
+				}
 			}
 		}
 
-		void Anticipate(Action action)
+		static int s_savings = 0;
+
+		readonly Lazy<Scheduler> _scheduler;
+		readonly Lazy<Cache> _cache;
+		readonly Lazy<Warehouse> _heap;
+
+		internal Anticipator(Lazy<Scheduler> scheduler)
+		{
+			Profile.FrameBegin("Anticipator .ctor");
+
+			_scheduler = scheduler;
+
+			Profile.FramePartition("Warehouse");
+			_heap = new Lazy<Warehouse>(() => new Warehouse(_scheduler));
+
+			Profile.FramePartition("Cache");
+			_cache = new Lazy<Cache>(() => new Cache(_scheduler));
+
+			Profile.FrameEnd("Anticipator .ctor");
+		}
+
+		internal void AnticipateAllocation<T>(T key = default)
+			where T : IPreBuildable
+			=> _heap.Value.Anticipate(key);
+
+		internal object Allocate<T>(T key = default)
+			where T : IPreBuildable
+			=> _heap.Value.Get(key);
+
+		internal void AnticipateValue<T>(T key = default)
+			where T : IPreComputable
+			=> _cache.Value.Anticipate(key);
+
+		internal object Compute<T>(T key = default)
+			where T : IPreComputable
+			=> _cache.Value.Get(key);
+
+		public void ReportUnused()
+		{
+			_cache.Value.ReportUnused();
+			_heap.Value.ReportUnused();
+
+			Profile.WriteLog("ANTICIPATOR: SAVINGS {0}ms", s_savings);
+		}
+	}
+
+	sealed class Scheduler
+	{
+		private static readonly TimeSpan LoopTimeOut = TimeSpan.FromSeconds(5.0);
+		private readonly Thread _thread;
+		private readonly AutoResetEvent _work;
+		private readonly Lazy<ConcurrentQueue<Action>> _actions;
+
+		internal Scheduler()
+		{
+			Profile.FrameBegin("Scheduler .ctor");
+			_actions = new Lazy<ConcurrentQueue<Action>>(() =>
+				new ConcurrentQueue<Action>());
+
+			_work = new AutoResetEvent(false);
+
+			Profile.FramePartition("ParameterizedThreadStart");
+			_thread = new Thread(new ParameterizedThreadStart(Loop));
+			_thread.Start(_work);
+			Profile.FrameEnd("Scheduler .ctor");
+		}
+
+		private void Loop(object argument)
+		{
+			var autoResetEvent = (AutoResetEvent)argument;
+
+			while (autoResetEvent.WaitOne(LoopTimeOut))
+			{
+				while (_actions.Value.Count > 0)
+				{
+					Action action;
+					if (_actions.Value.TryDequeue(out action))
+					{
+						if (action == null)
+							return;
+
+						action();
+					}
+				}
+			}
+		}
+
+
+		internal void Schedule(Action action)
 		{
 			if (action == null)
 				throw new ArgumentNullException(nameof(action));
 
-			_actions.Enqueue(action);
-
-			Signal();
+			_actions.Value.Enqueue(action);
+			_work.Set();
 		}
-
-		void AnticipateClassConstruction(Type type)
-		{
-			Anticipate(() => RuntimeHelpers.RunClassConstructor(type.TypeHandle));
-		}
-
-		void AnticipateGetter<T>(Func<T> getter)
-		{
-			Anticipate(() => getter());
-		}
-
 	}
 }
+ 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -795,7 +795,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			AToolbar bar;
 			if (FormsAppCompatActivity.ToolbarResource != 0)
-				bar = activity.LayoutInflater.Inflate(FormsAppCompatActivity.ToolbarResource, null).JavaCast<AToolbar>();
+				bar = AndroidAnticipator.InflateResource(activity, FormsAppCompatActivity.ToolbarResource).JavaCast<AToolbar>();
 			else
 				bar = new AToolbar(context);
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -12,6 +12,7 @@ using Android.Text;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using Xamarin.Forms.Internals;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
@@ -33,25 +34,34 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		float _lineSpacingMultiplierDefault = -1.0f;
 		VisualElementTracker _visualElementTracker;
 		VisualElementRenderer _visualElementRenderer;
-		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
+		readonly MotionEventHelper _motionEventHelper;
 		SpannableString _spannableString;
 
 		bool _wasFormatted;
 
 		public LabelRenderer(Context context) : base(context)
 		{
+			Profile.FrameBegin(nameof(LabelRenderer));
+
+			_motionEventHelper = new MotionEventHelper();
 			_labelTextColorDefault = TextColors;
 			_visualElementRenderer = new VisualElementRenderer(this);
 			BackgroundManager.Init(this);
+
+			Profile.FrameEnd(nameof(LabelRenderer));
 		}
 
 		[Obsolete("This constructor is obsolete as of version 2.5. Please use LabelRenderer(Context) instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public LabelRenderer() : base(Forms.Context)
 		{
+			Profile.FrameBegin(nameof(LabelRenderer));
+			
 			_labelTextColorDefault = TextColors;
 			_visualElementRenderer = new VisualElementRenderer(this);
 			BackgroundManager.Init(this);
+
+			Profile.FrameEnd(nameof(LabelRenderer));
 		}
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -62,7 +62,8 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			var coordinator = LayoutInflater.FromContext(context).Inflate(Resource.Layout.FlyoutContent, null);
+			Profile.FramePartition("Inflate FlyoutContent");
+			var coordinator = AndroidAnticipator.InflateResource(context, Resource.Layout.FlyoutContent);
 
 			Profile.FramePartition("Find Recycler");
 			_recycler = coordinator.FindViewById<RecyclerView>(Resource.Id.flyoutcontent_recycler);

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -22,7 +22,6 @@
     <AndroidResource Include="Resources\anim\**\*" />
     <AndroidResource Include="Resources\values\**\*" />
     <Compile Remove="Resources\Layout\**\*" />
-    <Compile Remove="Anticipator.cs" />
     <None Include="Resources\Layout\**\*" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">


### PR DESCRIPTION
_Opened a PR to provide somewhere to dump documentation._

### Ex Summary
* ~10% improvement in XF code startup path.
* Exploits parallelism  in startup by caching and allocating on a non-UI thread
* Isolates multi-threaded code via `IAnticipatable` 
* Logs cache population times, hits, misses, and unused members
* Disposes allocation
* Enabled/Disabled by developer; Useful to determine if a race has introduced a bug
* Abstracted common logic for use in Mac and UWP if/when we optimize those paths
* Documented here 👍 

### Overview

The Anticipator feature reduces startup time by running startup logic in parallel where possible. The feature consists of a thread, a warehouse, and a cache. The thread pre-allocates and pre-computes types and value and stores them in the warehouse and cache respectively. The UIThread then pulls the pre-allocated and pre-computed values from warehouse and cache. After a fixed period, the UIThread joins with the thread, disposes any unused heap objects, and releases the thread, heap, and cache for collection.

Anticipator logs information using the `Profiler` feature. The logs include: 
* how long it took to compute or allocate a given type or value
* whether the UIThread hit or missed when accessing the heap or cache
* and how long the UIThread waited to join with the anticipator thread. 

### App Developers

All app developers need do to enable the optimization is call `Anticipator.Initialize` in `OnCreate`. Eventually this logic call will be included in the XF VS project template. 

If the Anticipator is suspected to cause periodic startup failures, then the developer may comment out the initialization call and try again.

### Forms Developers (clients)

Callsites that can be run in parallel are replaced with a call to a corresponding static method on `Anticipator` or one of its derivations. As of now, these are the supported anticipations:

* `AndroidAnticipator`
  * `SdkVersion`
  * `NamedResourceExists`
  * `InflateResource`
  * `ActivateView`
  * `ResourceName`
