### PR TITLE
Propagate CollectionView BindingContext to Header/Footer on Android

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml
@@ -7,13 +7,13 @@
              x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries.HeaderFooterView">
     <ContentPage.Content>
 
-        <CollectionView x:Name="CollectionView">
+        <CollectionView x:Name="CollectionView" ItemsSource="{Binding Items}">
             
             <CollectionView.Header>
 
                 <Grid>
                     <Image Source="oasis.jpg" Aspect="AspectFill" HeightRequest="100"></Image>
-                    <Label Text="This Is A Header" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" 
+                    <Label Text="{Binding HeaderText}" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" 
                            FontAttributes="Bold" FontSize="36" />
                 </Grid>
 
@@ -23,7 +23,7 @@
 
                 <Grid>
                     <Image Source="cover1.jpg" Aspect="AspectFill" HeightRequest="80"></Image>
-                    <Label Text="This Is A Footer" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
+                    <Label Text="{Binding FooterText}" TextColor="AntiqueWhite" HorizontalTextAlignment="Center" Rotation="10" 
                            FontAttributes="Bold" FontSize="20" />
                 </Grid>
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/HeaderFooterGalleries/HeaderFooterView.xaml.cs
@@ -1,18 +1,30 @@
-﻿using Xamarin.Forms.Xaml;
+﻿using System;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.HeaderFooterGalleries
 {
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class HeaderFooterView : ContentPage
 	{
-		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource(3);
+		readonly HeaderFooterViewModel _viewModel = new HeaderFooterViewModel(3);
 
 		public HeaderFooterView()
 		{
 			InitializeComponent();
 
 			CollectionView.ItemTemplate = ExampleTemplates.PhotoTemplate();
-			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+			CollectionView.BindingContext = _viewModel;
 		}
+	}
+
+	internal class HeaderFooterViewModel : DemoFilteredItemSource
+	{
+		public HeaderFooterViewModel(int count = 50, Func<string, CollectionViewGalleryTestItem, bool> filter = null) : base(count, filter)
+		{
+		}
+
+		public string HeaderText => "This Is A Header";
+
+		public string FooterText => "This Is A Footer";
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
@@ -141,8 +141,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var viewHolder = SimpleViewHolder.FromFormsView(formsView, context);
 
-				// Propagate the binding context from the ItemsView to the header/footer
-				viewHolder.View.BindingContext = ItemsView.BindingContext;
+				// Propagate the binding context, visual, etc. from the ItemsView to the header/footer
+				ItemsView.AddLogicalChild(viewHolder.View);
 
 				return viewHolder;
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
@@ -139,7 +139,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (content is View formsView)
 			{
-				return SimpleViewHolder.FromFormsView(formsView, context);
+				var viewHolder = SimpleViewHolder.FromFormsView(formsView, context);
+
+				// Propagate the binding context from the ItemsView to the header/footer
+				viewHolder.View.BindingContext = ItemsView.BindingContext;
+
+				return viewHolder;
 			}
 
 			// No template, Footer is not a Forms View, so just display Footer.ToString


### PR DESCRIPTION
### Description of Change ###

When creating a simple Forms view (non-template) header/footer for a CollectionView on Android, the header/footer do not inherit the binding context of the CollectionView. These changes fix that issue, so that bindings in the header/footer have a context.

### Issues Resolved ### 

- fixes #8700

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Repurposing an existing automated test.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
