### PR TITLE
Remove gitversion from cake and fix UWP nugets

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -29,7 +29,6 @@ PowerShell:
 // TOOLS
 //////////////////////////////////////////////////////////////////////
 #tool nuget:?package=NUnit.ConsoleRunner&version=3.4.0
-#tool nuget:?package=GitVersion.CommandLine&version=4.0.0
 
 //////////////////////////////////////////////////////////////////////
 // ARGUMENTS
@@ -37,12 +36,6 @@ PowerShell:
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
-
-var gitVersion = GitVersion();
-var majorMinorPatch = gitVersion.MajorMinorPatch;
-var informationalVersion = gitVersion.InformationalVersion;
-var buildVersion = gitVersion.FullBuildMetaData;
-var nugetversion = Argument<string>("packageVersion", gitVersion.NuGetVersion);
 
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");

--- a/build.cake
+++ b/build.cake
@@ -220,7 +220,7 @@ Task("Build")
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
                     GetMSBuildSettings()
                         .WithRestore()
-                        .WithProperty("DisableEmbeddedXbf", "true"));
+                        .WithProperty("DisableEmbeddedXbf", "false"));
     }
     catch(Exception)
     {


### PR DESCRIPTION
### Description of Change ###
Versioning the Nuget was moved to msbuild and this code just wasn't deleted when that change was made

### Testing Procedure ###
- make sure cake generates nugets correctly
- make sure build runs

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
