### PR TITLE
Fix 8586 8587 - [Tizen] Added guard for CollectionView

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
@@ -495,6 +495,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		void RequestLayoutItems()
 		{
+			if (AllocatedSize.Width <= 0 || AllocatedSize.Height <= 0)
+				return;
+
 			if (!_requestLayoutItems)
 			{
 				_requestLayoutItems = true;

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/GridLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/GridLayoutManager.cs
@@ -115,6 +115,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		public void LayoutItems(Rect bound, bool force)
 		{
+			if (_allocatedSize.Width <= 0 || _allocatedSize.Height <= 0)
+				return;
+
 			// TODO : need to optimization. it was frequently called with similar bound value.
 			if (!ShouldRearrange(bound) && !force)
 			{

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ItemTemplateAdaptor.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ItemTemplateAdaptor.cs
@@ -104,9 +104,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		public override void RemoveNativeView(EvasObject native)
 		{
+			UnBinding(native);
 			if (_nativeFormsTable.TryGetValue(native, out View view))
 			{
-				ResetBindedView(view);
 				Platform.GetRenderer(view)?.Dispose();
 				_nativeFormsTable.Remove(native);
 			}
@@ -178,7 +178,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			int index = GetItemIndex(data);
 			if (index != -1)
 			{
-				CollectionView.ItemMeasureInvalidated(index);
+				CollectionView?.ItemMeasureInvalidated(index);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
@@ -110,6 +110,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		public void LayoutItems(Rect bound, bool force)
 		{
+			if (_allocatedSize.Width <= 0 || _allocatedSize.Height <= 0)
+				return;
+
 			// TODO : need to optimization. it was frequently called with similar bound value.
 			if (!ShouldRearrange(bound) && !force)
 			{


### PR DESCRIPTION
### Description of Change ###

Resolves bug #8586
To prevent sizeless layout requests when the CollectionView is in a hiding state.

Resolves bug #8587
Remove events on unbinding in CollectionView

### Issues Resolved ### 

- fixes #8586 #8587 

### Platforms Affected ### 

- Tizen

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
