### PR TITLE
Rewrite NongreedySnapHelper with older APIs

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Tests/CollectionViewTests.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Tests/CollectionViewTests.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+using NUnit.Framework.Internal;
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.ControlGallery.Android.Tests
+{
+	public class CollectionViewTests : PlatformTestFixture 
+	{
+		[Issue(IssueTracker.Github, 9030, "[Bug] ClassNotFoundException when using snap points on API < 23")]
+		[Test(Description = "CollectionView with SnapPointsType set should not crash")]
+		public void SnapPointsDoNotCrashOnOlderAPIs()
+		{
+			var cv = new CollectionView();
+
+			var itemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Vertical)
+			{
+				SnapPointsType = SnapPointsType.Mandatory
+			};
+			cv.ItemsLayout = itemsLayout;
+
+			// Creating the renderer is enough to cause the ClassNotFoundException on older APIs
+			GetRenderer(cv).Dispose();
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -97,6 +97,7 @@
     <Compile Include="MainApplication.cs" />
     <Compile Include="PerformanceTrackerRenderer.cs" />
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
+    <Compile Include="Tests\CollectionViewTests.cs" />
     <Compile Include="Tests\Issues.cs" />
     <Compile Include="Tests\PlatformTestSettings.cs" />
     <Compile Include="PreApplicationClassActivity.cs" />


### PR DESCRIPTION
### Description of Change ###

The NongreedySnapHelper class uses APIs which aren't available in earlier versions of Android. These changes rewrite that class to use APIs available in earlier versions.

### Issues Resolved ### 

- fixes #9030

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test.

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
