### PR TITLE
[Android] Add dispose check to prevent crash

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9355.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9355.cs
@@ -1,0 +1,62 @@
+using NUnit.Framework;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9355, "ScrollViewRenderer renderer dispose crash", PlatformAffected.Android)]
+	public class Issue9355 : TestNavigationPage
+	{
+		const string TestOk = "Test Ok";
+
+		protected override void Init()
+		{
+			var stacklayout = new StackLayout
+			{
+				Children =
+				{
+					new ScrollView
+					{
+						HorizontalOptions = LayoutOptions.FillAndExpand,
+						VerticalOptions = LayoutOptions.FillAndExpand,
+						Orientation = ScrollOrientation.Both,
+						Content = new Label  
+						{
+							Text = "Label"
+						}
+					}
+				}
+			};
+
+			Forms.CompressedLayout.SetIsHeadless(stacklayout, true);
+
+			var page = new ContentPage
+			{
+				Content = stacklayout
+			};
+
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await Navigation.PushModalAsync(page);
+				await Navigation.PopModalAsync();
+
+				await PushAsync(new ContentPage 
+				{ 
+					Content = new Label
+					{
+						Text = TestOk
+					}
+				});
+			});
+		}
+
+#if UITEST
+		[Test]
+		public void Issue9355Test()
+		{
+			RunningApp.WaitForElement(TestOk);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -165,6 +165,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9087.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9355.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -257,7 +258,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue1724.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3524.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1678.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)Issue7701.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue7701.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2004.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3333.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2338.cs" />

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -263,7 +263,12 @@ namespace Xamarin.Forms.Platform.Android
 			else
 			{
 				_childViews.Remove(renderer);
-				renderer.View.RemoveFromParent();
+
+				if (renderer.View.IsAlive())
+				{
+					renderer.View.RemoveFromParent();
+				}
+
 				renderer.Dispose();
 			}
 		}


### PR DESCRIPTION
### Description of Change ###
PR #8745 introduce a regression which for some page structure cause a crash during dispose.
This PR add a dispose check to prevent the crash.

### Issues Resolved ### 
- fixes #9355 

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Run the UI Test case included in this PR

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
