### PR TITLE
[Tizen] Add material renderers for Editor and Picker

### DIFF
--- a/Xamarin.Forms.Material.Tizen/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialDatePickerRenderer.cs
@@ -3,10 +3,10 @@ using Xamarin.Forms.Material.Tizen;
 using Xamarin.Forms.Material.Tizen.Native;
 using Xamarin.Forms.Platform.Tizen;
 
-[assembly: ExportRenderer(typeof(DatePicker), typeof(MaterialDatePckerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+[assembly: ExportRenderer(typeof(DatePicker), typeof(MaterialDatePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
 namespace Xamarin.Forms.Material.Tizen
 {
-	public class MaterialDatePckerRenderer : DatePickerRenderer
+	public class MaterialDatePickerRenderer : DatePickerRenderer
 	{
 		Color _defaultTitleColor = Color.Black;
 

--- a/Xamarin.Forms.Material.Tizen/MaterialDatePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialDatePickerRenderer.cs
@@ -1,0 +1,50 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Material.Tizen;
+using Xamarin.Forms.Material.Tizen.Native;
+using Xamarin.Forms.Platform.Tizen;
+
+[assembly: ExportRenderer(typeof(DatePicker), typeof(MaterialDatePckerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+namespace Xamarin.Forms.Material.Tizen
+{
+	public class MaterialDatePckerRenderer : DatePickerRenderer
+	{
+		Color _defaultTitleColor = Color.Black;
+
+		protected override ElmSharp.Entry CreateNativeControl()
+		{
+			return new MPicker(Forms.NativeParent);
+		}
+
+		protected override void OnDateTimeChanged(object sender, Platform.Tizen.Native.DateChangedEventArgs dcea)
+		{
+			Element.Date = dcea.NewDate;
+			if (Control is MPicker mp)
+			{
+				mp.Placeholder = dcea.NewDate.ToString(Element.Format);
+			}
+		}
+
+		protected override void UpdateDate()
+		{
+			if (Control is MPicker mp)
+			{
+				mp.Placeholder = Element.Date.ToString(Element.Format);
+			}
+		}
+
+		protected override void UpdateTextColor()
+		{
+			if (Control is MPicker mp)
+			{
+				if (Element.TextColor.IsDefault)
+				{
+					mp.PlaceholderColor = _defaultTitleColor.ToNative();
+				}
+				else
+				{
+					mp.PlaceholderColor = Element.TextColor.ToNative();
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Material.Tizen/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialEditorRenderer.cs
@@ -1,0 +1,33 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Material.Tizen;
+using Xamarin.Forms.Material.Tizen.Native;
+using Xamarin.Forms.Platform.Tizen;
+using Xamarin.Forms.Platform.Tizen.Native;
+
+[assembly: ExportRenderer(typeof(Editor), typeof(MaterialEditorRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+namespace Xamarin.Forms.Material.Tizen
+{
+	public class MaterialEditorRenderer : EditorRenderer
+	{
+		protected override ElmSharp.Entry CreateNativeControl()
+		{
+			return new MEditor(Forms.NativeParent)
+			{
+				IsSingleLine = false,
+				LineWrapType = ElmSharp.WrapType.Mixed
+			};
+		}
+
+		protected override void UpdateTextColor()
+		{
+			if (Control is MEditor me)
+			{
+				me.TextColor = Element.TextColor.ToNative();
+				me.TextFocusedColor = Element.TextColor.ToNative();
+				me.UnderlineColor = Element.TextColor.ToNative();
+				me.UnderlineFocusedColor = Element.TextColor.ToNative();
+				me.CursorColor = Element.TextColor.ToNative();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Material.Tizen/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialPickerRenderer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using Xamarin.Forms;
+using Xamarin.Forms.Material.Tizen;
+using Xamarin.Forms.Material.Tizen.Native;
+using Xamarin.Forms.Platform.Tizen;
+
+[assembly: ExportRenderer(typeof(Picker), typeof(MaterialPckerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+namespace Xamarin.Forms.Material.Tizen
+{
+	public class MaterialPckerRenderer : PickerRenderer
+	{
+		Color _defaultTitleColor = Color.Black;
+
+		protected override ElmSharp.Entry CreateNativeControl()
+		{
+			return new MPicker(Forms.NativeParent);
+		}
+
+		protected override void UpdateSelectedIndex()
+		{
+			if (Control is MPicker mp)
+			{
+				mp.Placeholder = (Element.SelectedIndex == -1 || Element.Items == null ?
+				"" : Element.Items[Element.SelectedIndex]);
+			}
+		}
+
+		protected override void UpdateTitleColor()
+		{
+			if (Control is MPicker mp)
+			{
+				if (Element.TitleColor.IsDefault)
+				{
+					mp.PlaceholderColor = _defaultTitleColor.ToNative();
+				}
+				else
+				{
+					mp.PlaceholderColor = Element.TitleColor.ToNative();
+				}
+			}
+		}
+
+		protected override void UpdateTextColor()
+		{
+			if (Control is MPicker mp)
+			{
+				if (Element.TextColor.IsDefault)
+				{
+					mp.TextColor = _defaultTitleColor.ToNative();
+				}
+				else
+				{
+					mp.TextColor = Element.TextColor.ToNative();
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Material.Tizen/MaterialPickerRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialPickerRenderer.cs
@@ -4,10 +4,10 @@ using Xamarin.Forms.Material.Tizen;
 using Xamarin.Forms.Material.Tizen.Native;
 using Xamarin.Forms.Platform.Tizen;
 
-[assembly: ExportRenderer(typeof(Picker), typeof(MaterialPckerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+[assembly: ExportRenderer(typeof(Picker), typeof(MaterialPickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
 namespace Xamarin.Forms.Material.Tizen
 {
-	public class MaterialPckerRenderer : PickerRenderer
+	public class MaterialPickerRenderer : PickerRenderer
 	{
 		Color _defaultTitleColor = Color.Black;
 

--- a/Xamarin.Forms.Material.Tizen/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialTimePickerRenderer.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms;
+using Xamarin.Forms.Material.Tizen;
+using Xamarin.Forms.Material.Tizen.Native;
+using Xamarin.Forms.Platform.Tizen;
+
+[assembly: ExportRenderer(typeof(TimePicker), typeof(MaterialTimePckerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+namespace Xamarin.Forms.Material.Tizen
+{
+	public class MaterialTimePckerRenderer : TimePickerRenderer
+	{
+		Color _defaultTitleColor = Color.Black;
+		static readonly string _defaultFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern;
+
+		protected override ElmSharp.Entry CreateNativeControl()
+		{
+			return new MPicker(Forms.NativeParent);
+		}
+
+		protected override void UpdateTimeAndFormat()
+		{
+			if (Control is MPicker mp)
+			{
+				// Xamarin using DateTime formatting (https://developer.xamarin.com/api/property/Xamarin.Forms.TimePicker.Format/)
+				mp.Placeholder = new DateTime(Time.Ticks).ToString(Element.Format ?? _defaultFormat);
+			}
+		}
+
+		protected override void UpdateTextColor()
+		{
+			if (Control is MPicker mp)
+			{
+				if (Element.TextColor.IsDefault)
+				{
+					mp.PlaceholderColor = _defaultTitleColor.ToNative();
+				}
+				else
+				{
+					mp.PlaceholderColor = Element.TextColor.ToNative();
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Material.Tizen/MaterialTimePickerRenderer.cs
+++ b/Xamarin.Forms.Material.Tizen/MaterialTimePickerRenderer.cs
@@ -5,10 +5,10 @@ using Xamarin.Forms.Material.Tizen;
 using Xamarin.Forms.Material.Tizen.Native;
 using Xamarin.Forms.Platform.Tizen;
 
-[assembly: ExportRenderer(typeof(TimePicker), typeof(MaterialTimePckerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
+[assembly: ExportRenderer(typeof(TimePicker), typeof(MaterialTimePickerRenderer), new[] { typeof(VisualMarker.MaterialVisual) }, Priority = short.MinValue)]
 namespace Xamarin.Forms.Material.Tizen
 {
-	public class MaterialTimePckerRenderer : TimePickerRenderer
+	public class MaterialTimePickerRenderer : TimePickerRenderer
 	{
 		Color _defaultTitleColor = Color.Black;
 		static readonly string _defaultFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern;

--- a/Xamarin.Forms.Material.Tizen/Native/MEditor.cs
+++ b/Xamarin.Forms.Material.Tizen/Native/MEditor.cs
@@ -1,0 +1,86 @@
+using System;
+using ElmSharp;
+using Tizen.NET.MaterialComponents;
+using Xamarin.Forms.Platform.Tizen.Native;
+
+namespace Xamarin.Forms.Material.Tizen.Native
+{
+	public class MEditor : MaterialEntry
+	{
+		bool _isTexstBlockFocused = false;
+		int _heightPadding = 0;
+
+		public MEditor(EvasObject parent) : base(parent)
+		{
+			Initialize();
+		}
+
+		public override ElmSharp.Size Measure(int availableWidth, int availableHeight)
+		{
+			var textBlockSize = base.Measure(availableWidth, availableHeight);
+
+			textBlockSize.Width += Layout.MinimumWidth;
+
+			if (textBlockSize.Height < Layout.MinimumHeight)
+				textBlockSize.Height = Layout.MinimumHeight;
+			else
+				textBlockSize.Height += _heightPadding;
+
+			return textBlockSize;
+		}
+
+		protected override void OnFocused(object sender, EventArgs args)
+		{
+			//To prevent enabling Label
+		}
+
+		protected override void OnUnfocused(object sender, EventArgs args)
+		{
+			//To prevent enabling Label
+		}
+
+		protected override void OnLayoutFocused(object sender, EventArgs args)
+		{
+			Layout.SignalEmit(States.Focused, "");
+		}
+
+		protected override void OnLayoutUnFocused(object sender, EventArgs args)
+		{
+			_isTexstBlockFocused = false;
+			Layout.SignalEmit(States.Unfocused, "");
+		}
+
+		void Initialize()
+		{
+			Layout.KeyDown += (s, e) =>
+			{
+				if (e.KeyName == "Return")
+				{
+					if (!_isTexstBlockFocused)
+					{
+						SetFocusOnTextBlock(true);
+						e.Flags |= EvasEventFlag.OnHold;
+					}
+				}
+			};
+
+			var gesture = new GestureLayer(Layout);
+			gesture.Attach(Layout);
+			gesture.SetTapCallback(GestureLayer.GestureType.Tap, GestureLayer.GestureState.End, (data) => SetFocusOnTextBlock(true));
+
+			Clicked += (s, e) => SetFocusOnTextBlock(true);
+		}
+
+		void SetFocusOnTextBlock(bool isFocused)
+		{
+			AllowFocus(isFocused);
+			SetFocus(isFocused);
+			_isTexstBlockFocused = isFocused;
+
+			if (isFocused)
+				InvokeTextBlockFocused();
+			else
+				InvokeTextBlcokUnfocused();
+		}
+	}
+}

--- a/Xamarin.Forms.Material.Tizen/Native/MEditor.cs
+++ b/Xamarin.Forms.Material.Tizen/Native/MEditor.cs
@@ -78,9 +78,9 @@ namespace Xamarin.Forms.Material.Tizen.Native
 			_isTexstBlockFocused = isFocused;
 
 			if (isFocused)
-				InvokeTextBlockFocused();
+				OnTextBlockFocused();
 			else
-				InvokeTextBlcokUnfocused();
+				OnTextBlcokUnfocused();
 		}
 	}
 }

--- a/Xamarin.Forms.Material.Tizen/Native/MPicker.cs
+++ b/Xamarin.Forms.Material.Tizen/Native/MPicker.cs
@@ -1,0 +1,18 @@
+using System;
+using ElmSharp;
+using Tizen.NET.MaterialComponents;
+
+namespace Xamarin.Forms.Material.Tizen.Native
+{
+	public class MPicker : MEditor
+	{
+		public MPicker(EvasObject parent) : base(parent)
+		{
+			IsSingleLine = true;
+			IsEditable = false;
+			InputPanelShowByOnDemand = true;
+			HorizontalTextAlignment = Platform.Tizen.Native.TextAlignment.Center;
+			SetVerticalTextAlignment(Parts.Entry.TextEdit, 0.5);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
@@ -22,12 +22,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				_editfieldLayout.SetTheme("layout", "editfield", style);
 		}
 
-		public event EventHandler TextBlockFocused;
-		public event EventHandler TextBlockUnfocused;
-
-		public event EventHandler LayoutFocused;
-		public event EventHandler LayoutUnfocused;
-
 		public bool IsTextBlockFocused { get; private set; }
 
 		public override EColor BackgroundColor
@@ -71,9 +65,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			IsTextBlockFocused = isFocused;
 
 			if (isFocused)
-				TextBlockFocused?.Invoke(this, EventArgs.Empty);
+				InvokeTextBlockFocused();
 			else
-				TextBlockUnfocused?.Invoke(this, EventArgs.Empty);
+				InvokeTextBlcokUnfocused();
 		}
 
 		public override ElmSharp.Size Measure(int availableWidth, int availableHeight)
@@ -136,12 +130,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				SetFocusOnTextBlock(false);
 				layout.SignalEmit("elm,state,unfocused", "");
-				LayoutUnfocused?.Invoke(this, EventArgs.Empty);
+				InvokeLayoutUnfocused();
 			};
 			layout.Focused += (s, e) =>
 			{
 				layout.SignalEmit("elm,state,focused", "");
-				LayoutFocused?.Invoke(this, EventArgs.Empty);
+				InvokeLayoutFocused();
 			};
 
 			layout.KeyDown += (s, e) =>

--- a/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
@@ -65,9 +65,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			IsTextBlockFocused = isFocused;
 
 			if (isFocused)
-				InvokeTextBlockFocused();
+				OnTextBlockFocused();
 			else
-				InvokeTextBlcokUnfocused();
+				OnTextBlcokUnfocused();
 		}
 
 		public override ElmSharp.Size Measure(int availableWidth, int availableHeight)
@@ -130,12 +130,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				SetFocusOnTextBlock(false);
 				layout.SignalEmit("elm,state,unfocused", "");
-				InvokeLayoutUnfocused();
+				OnEntryLayoutUnfocused();
 			};
 			layout.Focused += (s, e) =>
 			{
 				layout.SignalEmit("elm,state,focused", "");
-				InvokeLayoutFocused();
+				OnEntryLayoutFocused();
 			};
 
 			layout.KeyDown += (s, e) =>

--- a/Xamarin.Forms.Platform.Tizen/Native/Entry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Entry.cs
@@ -79,12 +79,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <summary>
 		/// Occurs when the layout of entry get focused.
 		/// </summary>
-		public event EventHandler LayoutFocused;
+		public event EventHandler EntryLayoutFocused;
 
 		/// <summary>
 		/// Occurs when the layout of entry loses focus
 		/// </summary>
-		public event EventHandler LayoutUnfocused;
+		public event EventHandler EntryLayoutUnfocused;
 
 		/// <summary>
 		/// Gets or sets the text.
@@ -385,24 +385,24 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		}
 
-		protected virtual void InvokeTextBlockFocused()
+		protected virtual void OnTextBlockFocused()
 		{
 			TextBlockFocused?.Invoke(this, EventArgs.Empty);
 		}
 
-		protected virtual void InvokeTextBlcokUnfocused()
+		protected virtual void OnTextBlcokUnfocused()
 		{
 			TextBlockUnfocused?.Invoke(this, EventArgs.Empty);
 		}
 
-		protected virtual void InvokeLayoutFocused()
+		protected virtual void OnEntryLayoutFocused()
 		{
-			LayoutFocused?.Invoke(this, EventArgs.Empty);
+			EntryLayoutFocused?.Invoke(this, EventArgs.Empty);
 		}
 
-		protected virtual void InvokeLayoutUnfocused()
+		protected virtual void OnEntryLayoutUnfocused()
 		{
-			LayoutUnfocused?.Invoke(this, EventArgs.Empty);
+			EntryLayoutUnfocused?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected virtual void OnTextChanged(string oldValue, string newValue)

--- a/Xamarin.Forms.Platform.Tizen/Native/Entry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Entry.cs
@@ -67,6 +67,26 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		public event EventHandler<TextChangedEventArgs> TextChanged;
 
 		/// <summary>
+		/// Occurs when the text block get focused.
+		/// </summary>
+		public event EventHandler TextBlockFocused;
+
+		/// <summary>
+		/// Occurs when the text block loses focus
+		/// </summary>
+		public event EventHandler TextBlockUnfocused;
+
+		/// <summary>
+		/// Occurs when the layout of entry get focused.
+		/// </summary>
+		public event EventHandler LayoutFocused;
+
+		/// <summary>
+		/// Occurs when the layout of entry loses focus
+		/// </summary>
+		public event EventHandler LayoutUnfocused;
+
+		/// <summary>
 		/// Gets or sets the text.
 		/// </summary>
 		/// <value>The text.</value>
@@ -79,6 +99,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 			set
 			{
+
 				if (value != _span.Text)
 				{
 					var old = _span.Text;
@@ -362,6 +383,26 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 #endif
 			return size;
 
+		}
+
+		protected virtual void InvokeTextBlockFocused()
+		{
+			TextBlockFocused?.Invoke(this, EventArgs.Empty);
+		}
+
+		protected virtual void InvokeTextBlcokUnfocused()
+		{
+			TextBlockUnfocused?.Invoke(this, EventArgs.Empty);
+		}
+
+		protected virtual void InvokeLayoutFocused()
+		{
+			LayoutFocused?.Invoke(this, EventArgs.Empty);
+		}
+
+		protected virtual void InvokeLayoutUnfocused()
+		{
+			LayoutUnfocused?.Invoke(this, EventArgs.Empty);
 		}
 
 		protected virtual void OnTextChanged(string oldValue, string newValue)

--- a/Xamarin.Forms.Platform.Tizen/Native/IEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/IEntry.cs
@@ -25,5 +25,13 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		Keyboard Keyboard { get; set; }
 
 		event EventHandler<TextChangedEventArgs> TextChanged;
+
+		event EventHandler TextBlockFocused;
+
+		event EventHandler TextBlockUnfocused;
+
+		event EventHandler LayoutFocused;
+
+		event EventHandler LayoutUnfocused;
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/IEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/IEntry.cs
@@ -30,8 +30,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		event EventHandler TextBlockUnfocused;
 
-		event EventHandler LayoutFocused;
+		event EventHandler EntryLayoutFocused;
 
-		event EventHandler LayoutUnfocused;
+		event EventHandler EntryLayoutUnfocused;
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
@@ -43,6 +43,7 @@ namespace Xamarin.Forms.Platform.Tizen
 					InputPanelShowByOnDemand = true,
 				};
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
+				entry.IsEditable = false;
 				entry.TextBlockFocused += OnTextBlockFocused;
 				SetNativeControl(entry);
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
@@ -1,10 +1,11 @@
 using System;
 using Xamarin.Forms.Platform.Tizen.Native;
 using WatchDataTimePickerDialog = Xamarin.Forms.Platform.Tizen.Native.Watch.WatchDataTimePickerDialog;
+using EEntry = ElmSharp.Entry;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public class DatePickerRenderer : ViewRenderer<DatePicker, EditfieldEntry>
+	public class DatePickerRenderer : ViewRenderer<DatePicker, EEntry>
 	{
 		//TODO need to add internationalization support
 		const string DialogTitle = "Choose Date";
@@ -36,16 +37,14 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				var entry = new Native.EditfieldEntry(Forms.NativeParent)
-				{
-					IsSingleLine = true,
-					HorizontalTextAlignment = Native.TextAlignment.Center,
-					InputPanelShowByOnDemand = true,
-				};
+				var entry = CreateNativeControl();
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
-				entry.IsEditable = false;
-				entry.TextBlockFocused += OnTextBlockFocused;
 				SetNativeControl(entry);
+
+				if (entry is IEntry ie)
+				{
+					ie.TextBlockFocused += OnTextBlockFocused;
+				}
 
 				_lazyDialog = new Lazy<IDateTimeDialog>(() =>
 				{
@@ -58,9 +57,27 @@ namespace Xamarin.Forms.Platform.Tizen
 			base.OnElementChanged(e);
 		}
 
+		protected virtual EEntry CreateNativeControl()
+		{
+			return new Native.EditfieldEntry(Forms.NativeParent)
+			{
+				IsSingleLine = true,
+				HorizontalTextAlignment = Native.TextAlignment.Center,
+				InputPanelShowByOnDemand = true,
+				IsEditable = false
+			};
+		}
+
 		protected override Size MinimumSize()
 		{
-			return Control.Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
+			if (Control is IMeasurable im)
+			{
+				return im.Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
+			}
+			else
+			{
+				return base.MinimumSize();
+			}
 		}
 
 		protected override void Dispose(bool disposing)
@@ -69,7 +86,10 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				if (Control != null)
 				{
-					Control.TextBlockFocused -= OnTextBlockFocused;
+					if (Control is IEntry ie)
+					{
+						ie.TextBlockFocused -= OnTextBlockFocused;
+					}
 				}
 				if (_lazyDialog.IsValueCreated)
 				{
@@ -96,35 +116,47 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
-		void OnDateTimeChanged(object sender, Native.DateChangedEventArgs dcea)
+		protected virtual void OnDateTimeChanged(object sender, Native.DateChangedEventArgs dcea)
 		{
 			Element.Date = dcea.NewDate;
 			Control.Text = dcea.NewDate.ToString(Element.Format);
 		}
 
-		void UpdateDate()
+		protected virtual void UpdateDate()
 		{
 			Control.Text = Element.Date.ToString(Element.Format);
 		}
 
-		void UpdateTextColor()
+		protected virtual void UpdateTextColor()
 		{
-			Control.TextColor = Element.TextColor.ToNative();
+			if (Control is IEntry ie)
+			{
+				ie.TextColor = Element.TextColor.ToNative();
+			}
 		}
 
 		void UpdateFontSize()
 		{
-			Control.FontSize = Element.FontSize;
+			if (Control is IEntry ie)
+			{
+				ie.FontSize = Element.FontSize;
+			}
 		}
 
 		void UpdateFontFamily()
 		{
-			Control.FontFamily = Element.FontFamily.ToNativeFontFamily();
+			if (Control is IEntry ie)
+			{
+				ie.FontFamily = Element.FontFamily;
+			}
 		}
 
 		void UpdateFontAttributes()
 		{
-			Control.FontAttributes = Element.FontAttributes;
+			if (Control is IEntry ie)
+			{
+				ie.FontAttributes = Element.FontAttributes;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -1,8 +1,10 @@
 using System;
+using Xamarin.Forms.Platform.Tizen.Native;
+using EEntry = ElmSharp.Entry;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public class EditorRenderer : ViewRenderer<Editor, Native.Entry>
+	public class EditorRenderer : ViewRenderer<Editor, EEntry>
 	{
 		public EditorRenderer()
 		{
@@ -23,20 +25,29 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				// Multiline EditField style is only available on Mobile and TV profile
-				var entry = Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.TV ? new Native.EditfieldEntry(Forms.NativeParent, "multiline") : new Native.Entry(Forms.NativeParent)
-				{
-					IsSingleLine = false,
-				};
+				var entry = CreateNativeControl();
 				entry.Focused += OnEntryFocused;
 				entry.Unfocused += OnEntryUnfocused;
-				entry.TextChanged += OnTextChanged;
 				entry.Unfocused += OnCompleted;
 				entry.PrependMarkUpFilter(MaxLengthFilter);
-
+				if (entry is IEntry ie)
+				{
+					ie.TextChanged += OnTextChanged;
+				}
 				SetNativeControl(entry);
 			}
 			base.OnElementChanged(e);
+		}
+
+		protected virtual EEntry CreateNativeControl()
+		{
+			// Multiline EditField style is only available on Mobile and TV profile
+			var entry = Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.TV ? new Native.EditfieldEntry(Forms.NativeParent, "multiline") : new Native.Entry(Forms.NativeParent)
+			{
+				IsSingleLine = false,
+			};
+
+			return entry;
 		}
 
 		protected override void Dispose(bool disposing)
@@ -45,10 +56,13 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				if (null != Control)
 				{
-					Control.TextChanged -= OnTextChanged;
 					Control.BackButtonPressed -= OnCompleted;
 					Control.Unfocused -= OnEntryUnfocused;
 					Control.Focused -= OnEntryFocused;
+					if (Control is IEntry ie)
+					{
+						ie.TextChanged -= OnTextChanged;
+					}
 				}
 			}
 			base.Dispose(disposing);
@@ -59,9 +73,17 @@ namespace Xamarin.Forms.Platform.Tizen
 			return (Control as Native.IMeasurable).Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
 		}
 
+		protected virtual void UpdateTextColor()
+		{
+			if (Control is IEntry ie)
+			{
+				ie.TextColor = Element.TextColor.ToNative();
+			}
+		}
+
 		void OnTextChanged(object sender, EventArgs e)
 		{
-			Element.SetValueFromRenderer(Editor.TextProperty, ((Native.Entry)sender).Text);
+			Element.SetValueFromRenderer(Editor.TextProperty, Control.Text);
 		}
 
 		bool _isSendComplate = false;
@@ -99,31 +121,39 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 		}
 
-		void UpdateTextColor()
-		{
-			Control.TextColor = Element.TextColor.ToNative();
-		}
-
 		void UpdateFontSize()
 		{
-			Control.FontSize = Element.FontSize;
+			if (Control is IEntry ie)
+			{
+				ie.FontSize = Element.FontSize;
+			}
 		}
 
 		void UpdateFontFamily()
 		{
-			Control.FontFamily = Element.FontFamily.ToNativeFontFamily();
+			if (Control is IEntry ie)
+			{
+				ie.FontFamily = Element.FontFamily.ToNativeFontFamily();
+			}
 		}
 
 		void UpdateFontAttributes()
 		{
-			Control.FontAttributes = Element.FontAttributes;
+			if (Control is IEntry ie)
+			{
+				ie.FontAttributes = Element.FontAttributes;
+			}
 		}
 
 		void UpdateKeyboard(bool initialize)
 		{
 			if (initialize && Element.Keyboard == Keyboard.Default)
 				return;
-			Control.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled, true);
+
+			if (Control is IEntry ie)
+			{
+				ie.UpdateKeyboard(Element.Keyboard, Element.IsSpellCheckEnabled, true);
+			}
 		}
 
 		void UpdateIsSpellCheckEnabled()
@@ -139,12 +169,18 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdatePlaceholder()
 		{
-			Control.Placeholder = Element.Placeholder;
+			if (Control is IEntry ie)
+			{
+				ie.Placeholder = Element.Placeholder;
+			}
 		}
 
 		void UpdatePlaceholderColor()
 		{
-			Control.PlaceholderColor = Element.PlaceholderColor.ToNative();
+			if (Control is IEntry ie)
+			{
+				ie.PlaceholderColor = Element.PlaceholderColor.ToNative();
+			}
 		}
 
 		string MaxLengthFilter(ElmSharp.Entry entry, string s)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				};
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
 				entry.HorizontalTextAlignment = Native.TextAlignment.Center;
+				entry.IsEditable = false;
 				entry.TextBlockFocused += OnTextBlockFocused;
 
 				if (Device.Idiom == TargetIdiom.TV)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
@@ -35,8 +35,8 @@ namespace Xamarin.Forms.Platform.Tizen
 						ie.TextBlockFocused -= OnTextBlockFocused;
 						if (Device.Idiom == TargetIdiom.TV)
 						{
-							ie.LayoutFocused -= OnLayoutFocused;
-							ie.LayoutUnfocused -= OnLayoutUnfocused;
+							ie.EntryLayoutFocused -= OnLayoutFocused;
+							ie.EntryLayoutUnfocused -= OnLayoutUnfocused;
 						}
 					}
 					CleanView();
@@ -57,8 +57,8 @@ namespace Xamarin.Forms.Platform.Tizen
 
 					if (Device.Idiom == TargetIdiom.TV)
 					{
-						ie.LayoutFocused += OnLayoutFocused;
-						ie.LayoutUnfocused += OnLayoutUnfocused;
+						ie.EntryLayoutFocused += OnLayoutFocused;
+						ie.EntryLayoutUnfocused += OnLayoutUnfocused;
 					}
 				}
 				SetNativeControl(entry);

--- a/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using Xamarin.Forms.Platform.Tizen.Native;
 using Xamarin.Forms.Platform.Tizen.Native.Watch;
 using ElmSharp;
+using EEntry = ElmSharp.Entry;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public class PickerRenderer : ViewRenderer<Picker, EditfieldEntry>
+	public class PickerRenderer : ViewRenderer<Picker, EEntry>
 	{
 		List _list;
 		Dialog _dialog;
@@ -29,11 +30,14 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				if (Control != null)
 				{
-					Control.TextBlockFocused -= OnTextBlockFocused;
-					if (Device.Idiom == TargetIdiom.TV)
+					if (Control is IEntry ie)
 					{
-						Control.LayoutFocused -= OnLayoutFocused;
-						Control.LayoutUnfocused -= OnLayoutUnfocused;
+						ie.TextBlockFocused -= OnTextBlockFocused;
+						if (Device.Idiom == TargetIdiom.TV)
+						{
+							ie.LayoutFocused -= OnLayoutFocused;
+							ie.LayoutUnfocused -= OnLayoutUnfocused;
+						}
 					}
 					CleanView();
 				}
@@ -45,71 +49,102 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				var entry = new EditfieldEntry(Forms.NativeParent)
-				{
-					IsSingleLine = true,
-					InputPanelShowByOnDemand = true,
-				};
+				var entry = CreateNativeControl();
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
-				entry.HorizontalTextAlignment = Native.TextAlignment.Center;
-				entry.IsEditable = false;
-				entry.TextBlockFocused += OnTextBlockFocused;
-
-				if (Device.Idiom == TargetIdiom.TV)
+				if (entry is IEntry ie)
 				{
-					entry.LayoutFocused += OnLayoutFocused;
-					entry.LayoutUnfocused += OnLayoutUnfocused;
-				}
+					ie.TextBlockFocused += OnTextBlockFocused;
 
+					if (Device.Idiom == TargetIdiom.TV)
+					{
+						ie.LayoutFocused += OnLayoutFocused;
+						ie.LayoutUnfocused += OnLayoutUnfocused;
+					}
+				}
 				SetNativeControl(entry);
 			}
 			base.OnElementChanged(e);
 		}
 
-		void UpdateSelectedIndex()
+		protected virtual EEntry CreateNativeControl()
+		{
+			return new EditfieldEntry(Forms.NativeParent)
+			{
+				IsSingleLine = true,
+				InputPanelShowByOnDemand = true,
+				IsEditable = false,
+				HorizontalTextAlignment = Native.TextAlignment.Center
+			};
+		}
+
+		protected virtual void UpdateSelectedIndex()
 		{
 			Control.Text = (Element.SelectedIndex == -1 || Element.Items == null ?
 				"" : Element.Items[Element.SelectedIndex]);
 		}
 
-		void UpdateTextColor()
+		protected virtual void UpdateTitleColor()
 		{
-			Control.TextColor = Element.TextColor.ToNative();
+			if (Control is IEntry ie)
+			{
+				ie.PlaceholderColor = Element.TitleColor.ToNative();
+			}
+		}
+
+		protected virtual void UpdateTextColor()
+		{
+			if (Control is IEntry ie)
+			{
+				ie.TextColor = Element.TextColor.ToNative();
+			}
 		}
 
 		void UpdateFontSize()
 		{
-			Control.FontSize = Element.FontSize;
+			if (Control is IEntry ie)
+			{
+				ie.FontSize = Element.FontSize;
+			}
 		}
 
 		void UpdateFontFamily()
 		{
-			Control.FontFamily = Element.FontFamily;
+			if (Control is IEntry ie)
+			{
+				ie.FontFamily = Element.FontFamily;
+			}
 		}
 
 		void UpdateFontAttributes()
 		{
-			Control.FontAttributes = Element.FontAttributes;
+			if (Control is IEntry ie)
+			{
+				ie.FontAttributes = Element.FontAttributes;
+			}
 		}
 
 		void UpdateTitle()
 		{
-			Control.Placeholder = Element.Title;
-		}
-
-		void UpdateTitleColor()
-		{
-			Control.PlaceholderColor = Element.TitleColor.ToNative();
+			if (Control is IEntry ie)
+			{
+				ie.Placeholder = Element.Title;
+			}
 		}
 
 		void OnLayoutFocused(object sender, EventArgs e)
 		{
-			Control.FontSize = Control.FontSize * 1.5;
+			if (Control is IEntry ie)
+			{
+				ie.FontSize = ie.FontSize * 1.5;
+			}
 		}
 
 		void OnLayoutUnfocused(object sender, EventArgs e)
 		{
-			Control.FontSize = Control.FontSize / 1.5;
+			if (Control is IEntry ie)
+			{
+				ie.FontSize = ie.FontSize / 1.5;
+			}
 		}
 
 		void OnTextBlockFocused(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/TimePickerRenderer.cs
@@ -2,17 +2,19 @@ using System;
 using System.Globalization;
 using Xamarin.Forms.Platform.Tizen.Native;
 using WatchDataTimePickerDialog = Xamarin.Forms.Platform.Tizen.Native.Watch.WatchDataTimePickerDialog;
+using EEntry = ElmSharp.Entry;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public class TimePickerRenderer : ViewRenderer<TimePicker, EditfieldEntry>
+	public class TimePickerRenderer : ViewRenderer<TimePicker, EEntry>
 	{
 		//TODO need to add internationalization support
 		const string DialogTitle = "Choose Time";
 		static readonly string s_defaultFormat = CultureInfo.CurrentCulture.DateTimeFormat.ShortTimePattern;
 
-		TimeSpan _time = DateTime.Now.TimeOfDay;
 		Lazy<IDateTimeDialog> _lazyDialog;
+
+		protected TimeSpan Time = DateTime.Now.TimeOfDay;
 
 		public TimePickerRenderer()
 		{
@@ -40,16 +42,14 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Control == null)
 			{
-				var entry = new Native.EditfieldEntry(Forms.NativeParent)
-				{
-					IsSingleLine = true,
-					HorizontalTextAlignment = Native.TextAlignment.Center,
-					InputPanelShowByOnDemand = true,
-				};
+				var entry = CreateNativeControl();
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
-				entry.IsEditable = false;
-				entry.TextBlockFocused += OnTextBlockFocused;
 				SetNativeControl(entry);
+
+				if (entry is IEntry ie)
+				{
+					ie.TextBlockFocused += OnTextBlockFocused;
+				}
 
 				_lazyDialog = new Lazy<IDateTimeDialog>(() => {
 					var dialog = CreateDialog();
@@ -62,13 +62,27 @@ namespace Xamarin.Forms.Platform.Tizen
 			base.OnElementChanged(e);
 		}
 
+		protected virtual EEntry CreateNativeControl()
+		{
+			return new Native.EditfieldEntry(Forms.NativeParent)
+			{
+				IsSingleLine = true,
+				HorizontalTextAlignment = Native.TextAlignment.Center,
+				InputPanelShowByOnDemand = true,
+				IsEditable = false
+			};
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
 			{
 				if (Control != null)
 				{
-					Control.TextBlockFocused -= OnTextBlockFocused;
+					if (Control is IEntry ie)
+					{
+						ie.TextBlockFocused -= OnTextBlockFocused;
+					}
 				}
 				if (_lazyDialog.IsValueCreated)
 				{
@@ -82,7 +96,14 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		protected override Size MinimumSize()
 		{
-			return Control.Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
+			if ( Control is IMeasurable im)
+			{
+				return im.Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
+			}
+			else
+			{
+				return base.MinimumSize();
+			}
 		}
 
 		void OnTextBlockFocused(object o, EventArgs e)
@@ -110,36 +131,48 @@ namespace Xamarin.Forms.Platform.Tizen
 			UpdateTimeAndFormat();
 		}
 
-		void UpdateTextColor()
+		protected virtual void UpdateTextColor()
 		{
-			Control.TextColor = Element.TextColor.ToNative();
+			if (Control is IEntry ie)
+			{
+				ie.TextColor = Element.TextColor.ToNative();
+			}
 		}
 
 		void UpdateTime()
 		{
-			_time = Element.Time;
+			Time = Element.Time;
 			UpdateTimeAndFormat();
 		}
 
 		void UpdateFontSize()
 		{
-			Control.FontSize = Element.FontSize;
+			if (Control is IEntry ie)
+			{
+				ie.FontSize = Element.FontSize;
+			}
 		}
 
 		void UpdateFontFamily()
 		{
-			Control.FontFamily = Element.FontFamily.ToNativeFontFamily();
+			if (Control is IEntry ie)
+			{
+				ie.FontFamily = Element.FontFamily;
+			}
 		}
 
 		void UpdateFontAttributes()
 		{
-			Control.FontAttributes = Element.FontAttributes;
+			if (Control is IEntry ie)
+			{
+				ie.FontAttributes = Element.FontAttributes;
+			}
 		}
 
-		void UpdateTimeAndFormat()
+		protected virtual void UpdateTimeAndFormat()
 		{
 			// Xamarin using DateTime formatting (https://developer.xamarin.com/api/property/Xamarin.Forms.TimePicker.Format/)
-			Control.Text = new DateTime(_time.Ticks).ToString(Element.Format ?? s_defaultFormat);
+			Control.Text = new DateTime(Time.Ticks).ToString(Element.Format ?? s_defaultFormat);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/TimePickerRenderer.cs
@@ -47,6 +47,7 @@ namespace Xamarin.Forms.Platform.Tizen
 					InputPanelShowByOnDemand = true,
 				};
 				entry.SetVerticalTextAlignment("elm.text", 0.5);
+				entry.IsEditable = false;
 				entry.TextBlockFocused += OnTextBlockFocused;
 				SetNativeControl(entry);
 


### PR DESCRIPTION
<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

This PR includes two commits. The one is to add material renderers for `Editor`, `Picker`, `DatePicker`, `TimePicker`, and the other one is to fix the renderes for picker to hide a cursor.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

 None

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
The APIs in Tizen backend has been changed as follows:
 (`Xamarin.Forms.Platform.Tizen` and `Xamarin.Forms.Material.Tizen`)

Added:
  - Entry
    protected virtual OnTextBlockFocused();
    protected virtual OnTextBlockUnfocused();
    protected virtual OnEntryLayoutFocused();
    protected virtual OnEntryLayoutUnfocused(); 

  - IEntry
    event EventHandler TextBlockFocused
    event EventHandler TextBlockUnfocused
    event EventHandler EntryLayoutFocused
    event EventHandler EntryLayoutUnfocused
	
  - EditorRenderer
    protected virtual EEntry CreateNativeControl()

  - TimePickerRenderer
    protected virtual EEntry CreateNativeControl()

  - DatePickerRenderer
    protected virtual EEntry CreateNativeControl()
	
  - PickerRenderer
    protected virtual EEntry CreateNativeControl()

  - TimePickerRenderer
    protected TimeSpan Time

  - MEditor : MaterialEntry
  - MPicker : MEditor
  
  - MaterialEntryRenderer : EntryRenderer
  - MaterialPckerRenderer : PickerRenderer
  - MaterialDatePckerRenderer : DatePickerRenderer
  - MaterialTimePickerRenderer : TimePickerRenderer

Changed :
  - EditorRenderer
    void UpdateTextColor() => protected virtual void UpdateTextColor()

  - PickerRenderer
    void UpdateTitleColor() => protected virtual void UpdateTitleColor()
	
  - DatePickerRenderer
    void OnDateTimeChanged() => protected virtual void OnDateTimeChanged()
    void UpdateDate() => protected virtual void UpdateDate()
    void UpdateTextColor() => protected virtual void UpdateTextColor()

  - TimePickerRenderer
    void UpdateTextColor() => protected virtual void UpdateTextColor()
    void UpdateTimeAndFormat() =>protected virtual void UpdateTimeAndFormat()

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

- Before
![editor_before_gif](https://user-images.githubusercontent.com/20968023/73537725-7d71fb00-446c-11ea-8fdb-14e17c625460.gif)
![picker_before](https://user-images.githubusercontent.com/20968023/73537747-8d89da80-446c-11ea-9597-a1aceb14c27a.gif)


- After
![editor_after_gif](https://user-images.githubusercontent.com/20968023/73537752-9084cb00-446c-11ea-9714-fb542743f47b.gif)
![picker_after](https://user-images.githubusercontent.com/20968023/73537758-97134280-446c-11ea-9dde-49b89c7ac416.gif)


- Fixed `Picker` to hide a cursor on TV
  - Before
![tv_picker_before](https://user-images.githubusercontent.com/20968023/73537854-d93c8400-446c-11ea-8cf5-6c2412e7c134.gif)
  - After
![tv_picker_after](https://user-images.githubusercontent.com/20968023/73537860-db9ede00-446c-11ea-98c1-6bfb1ff44e33.gif)



### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
