### PR TITLE
Let users override behavior on Navigation Renderer

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -23,7 +23,8 @@ using System.Reflection;
 using Android.Text;
 using Android.Text.Method;
 using Xamarin.Forms.Controls.Issues;
-
+using System.IO;
+using AMenuItemCompat = global::Android.Support.V4.View.MenuItemCompat;
 
 [assembly: ExportRenderer(typeof(Issue5461.ScrollbarFadingEnabledFalseScrollView), typeof(ScrollbarFadingEnabledFalseScrollViewRenderer))]
 [assembly: ExportRenderer(typeof(Issue1942.CustomGrid), typeof(Issue1942GridRenderer))]
@@ -46,6 +47,7 @@ using Xamarin.Forms.Controls.Issues;
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Issues.NoFlashTestNavigationPage), typeof(Xamarin.Forms.ControlGallery.Android.NoFlashTestNavigationPage))]
 [assembly: ExportRenderer(typeof(ShellGestures.TouchTestView), typeof(ShellGesturesTouchTestViewRenderer))]
 [assembly: ExportRenderer(typeof(Issue7249Switch), typeof(Issue7249SwitchRenderer))]
+[assembly: ExportRenderer(typeof(Issue9360.Issue9360NavigationPage), typeof(Issue9360NavigationPageRenderer))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
@@ -54,6 +56,42 @@ using Xamarin.Forms.Controls.Issues;
 #endif
 namespace Xamarin.Forms.ControlGallery.Android
 {
+	public class Issue9360NavigationPageRenderer : Xamarin.Forms.Platform.Android.AppCompat.NavigationPageRenderer
+	{
+		public Issue9360NavigationPageRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
+		{
+			if (toolBarItem.Text == "BAD")
+			{
+				toolBarItem = new ToolbarItem
+				{
+					Text = "OK",
+					IconImageSource = ImageSource.FromFile("heart.xml"),
+					Order = toolBarItem.Order,
+					Priority = toolBarItem.Priority
+				};
+
+				if (toolBarItem.IconImageSource is FileImageSource fileImageSource)
+				{
+					var name = Path.GetFileNameWithoutExtension(fileImageSource.File);
+					var id = Xamarin.Forms.Platform.Android.ResourceManager.GetDrawableByName(name);
+					if (id != 0)
+					{
+						var drawable = context.GetDrawable(id);
+						menuItem.SetIcon(drawable);
+						AMenuItemCompat.SetContentDescription(menuItem, new Java.Lang.String("HEART"));
+						return;
+					}
+				}
+			}
+
+			base.UpdateMenuItemIcon(context, menuItem, toolBarItem);
+		}
+	}
+
 	public class NonAppCompatSwitchRenderer : Xamarin.Forms.Platform.Android.SwitchRenderer
 	{
 		public NonAppCompatSwitchRenderer(Context context) : base(context)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9360.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9360.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Reflection;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9360, "[Bug] Android Icons no longer customizable via NavigationPageRenderer UpdateMenuItemIcon()",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ListView)]
+#endif
+	public class Issue9360 : TestContentPage
+	{
+
+		public class Issue9360NavigationPage : TestNavigationPage
+		{
+			ContentPage CreateNewPage()
+			{
+				string text = "This Test is only Relevant on Android";
+
+				if (Device.RuntimePlatform == Device.Android)
+					text = "Toolbar Item Icon should be a hear";
+
+				ContentPage contentPage = new ContentPage()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label() {
+								Text = text
+							},
+							new Button()
+							{
+								Text = "Push Same Page To see if Icons all load correctly a second time",
+								Command = new Command(async () =>
+								{
+									await PushAsync(CreateNewPage());
+								})
+							}
+						}
+					}
+				};
+
+				contentPage.ToolbarItems.Add(new ToolbarItem() { Text = "BAD" });
+				contentPage.ToolbarItems.Add(new ToolbarItem()
+				{
+					IconImageSource = ImageSource.FromResource("Xamarin.Forms.Controls.GalleryPages.crimson.jpg", typeof(Issue9360NavigationPage).GetTypeInfo().Assembly)
+				});
+
+				contentPage.ToolbarItems.Add(new ToolbarItem()
+				{
+					Text = "second",
+					Command = new Command(() =>
+					{
+						contentPage.ToolbarItems[0].IsEnabled = !contentPage.ToolbarItems[0].IsEnabled;
+						contentPage.ToolbarItems[2].IconImageSource = "coffee.png";
+					})
+				});
+
+				return contentPage;
+			}
+
+			protected override void Init()
+			{
+
+				PushAsync(CreateNewPage());
+			}
+		}
+
+		protected override void Init()
+		{
+			Navigation.PushModalAsync(new Issue9360NavigationPage());
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void NavigationPageRendererMenuItemIconOverrideWorks()
+		{
+			RunningApp.WaitForElement("HEART");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -133,6 +133,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8784.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9360.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -55,6 +55,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		bool _isAttachedToWindow;
 		Platform _platform;
 		string _defaultNavigationContentDescription;
+		List<IMenuItem> _currentMenuItems = new List<IMenuItem>();
 
 		// The following is based on https://android.googlesource.com/platform/frameworks/support.git/+/4a7e12af4ec095c3a53bb8481d8d92f63157c3b7/v4/java/android/support/v4/app/FragmentManager.java#677
 		// Must be overriden in a custom renderer to match durations in XML animation resource files
@@ -169,7 +170,13 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (disposing)
 			{
 				Device.Info.PropertyChanged -= DeviceInfoPropertyChanged;
-			
+
+				if (_currentMenuItems != null)
+				{
+					_currentMenuItems.Clear();
+					_currentMenuItems = null;
+				}
+
 				if (NavigationPageController != null)
 				{
 					var navController = NavigationPageController;
@@ -556,11 +563,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				ResetToolbar();
 		}
 
-		protected virtual void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
-		{
-			_toolbar.OnToolbarItemPropertyChanged(e, _toolbarTracker?.ToolbarItems, Context, null, OnToolbarItemPropertyChanged);
-		}
-
 		void InsertPageBefore(Page page, Page before)
 		{
 			if (!_isAttachedToWindow)
@@ -896,14 +898,22 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void UpdateMenu()
 		{
-			if (_disposed)
+			if (_disposed || _currentMenuItems == null)
 				return;
 
-			_toolbar.UpdateMenuItems(_toolbarTracker?.ToolbarItems, Context, null, OnToolbarItemPropertyChanged);
+			_currentMenuItems.Clear();
+			_currentMenuItems = new List<IMenuItem>();
+			_toolbar.UpdateMenuItems(_toolbarTracker?.ToolbarItems, Context, null, OnToolbarItemPropertyChanged, _currentMenuItems, UpdateMenuItemIcon);
 		}
+
+		protected virtual void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			_toolbar.OnToolbarItemPropertyChanged(e, (ToolbarItem)sender, _toolbarTracker?.ToolbarItems, Context, null, OnToolbarItemPropertyChanged, _currentMenuItems, UpdateMenuItemIcon);
+		}
+
 		protected virtual void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem)
 		{
-			ToolbarExtensions.UpdateMenuItemIcon(context, menuItem, toolBarItem, null);
+			ToolbarExtensions.UpdateMenuItemIcon(context, _toolbar.Menu, _currentMenuItems, menuItem, toolBarItem, null);
 		}
 
 		void UpdateToolbar()

--- a/Xamarin.Forms.Platform.Android/Extensions/JavaObjectExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/JavaObjectExtensions.cs
@@ -15,5 +15,18 @@ namespace Xamarin.Forms.Platform.Android
 
 			return !obj.IsDisposed();
 		}
+
+		public static bool IsDisposed(this global::Android.Runtime.IJavaObject obj)
+		{
+			return obj.Handle == IntPtr.Zero;
+		}
+
+		public static bool IsAlive(this global::Android.Runtime.IJavaObject obj)
+		{
+			if (obj == null)
+				return false;
+
+			return !obj.IsDisposed();
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -5,6 +5,8 @@ using ATextView = global::Android.Widget.TextView;
 using Android.Content;
 using Android.Graphics;
 using System.Collections.Generic;
+using System;
+using System.Linq;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -24,53 +26,100 @@ namespace Xamarin.Forms.Platform.Android
 			IEnumerable<ToolbarItem> sortedToolbarItems, 
 			Context context, 
 			Color? tintColor,
-			PropertyChangedEventHandler toolbarItemChanged
+			PropertyChangedEventHandler toolbarItemChanged,
+			List<IMenuItem> menuItemsCreated,
+			Action<Context, IMenuItem, ToolbarItem> updateMenuItemIcon = null
 			)
 		{
-			if (sortedToolbarItems == null)
+			if (sortedToolbarItems == null || menuItemsCreated == null)
 				return;
 
 			var menu = toolbar.Menu;
 			menu.Clear();
 
+			foreach (var menuItem in menuItemsCreated)
+				menuItem.Dispose();
+
+			menuItemsCreated.Clear();
+
+			int i = 0;
 			foreach (var item in sortedToolbarItems)
 			{
-				item.PropertyChanged -= toolbarItemChanged;
-				item.PropertyChanged += toolbarItemChanged;
+				UpdateMenuItem(toolbar, context, menuItemsCreated, item, tintColor, toolbarItemChanged, null, updateMenuItemIcon);
+				i++;
+			}
+		}
 
-				using (var title = new Java.Lang.String(item.Text))
+		internal static void UpdateMenuItem(
+			AToolbar toolbar,
+			Context context, 
+			List<IMenuItem> menuItemsCreated, 
+			ToolbarItem item, 
+			Color? tintColor,
+			PropertyChangedEventHandler toolbarItemChanged,
+			int? menuItemIndex,
+			Action<Context, IMenuItem, ToolbarItem> updateMenuItemIcon = null)
+		{
+			IMenu menu = toolbar.Menu;
+			item.PropertyChanged -= toolbarItemChanged;
+			item.PropertyChanged += toolbarItemChanged;
+
+			IMenuItem menuitem = null;
+
+			if (menuItemIndex == null)
+			{
+				menuitem = menu.Add(new Java.Lang.String(item.Text));
+				if (menuItemsCreated != null)
+					menuItemsCreated.Add(menuitem);
+			}
+			else
+			{
+				if (menuItemsCreated == null || menuItemsCreated.Count < menuItemIndex.Value)
+					return;
+
+				menuitem = menuItemsCreated[menuItemIndex.Value];
+
+				if (!menuitem.IsAlive())
+					return;
+
+				menuitem.SetTitle(new Java.Lang.String(item.Text));
+			}
+
+			menuitem.SetEnabled(item.IsEnabled);
+			menuitem.SetTitleOrContentDescription(item);
+
+			if (updateMenuItemIcon != null)
+				updateMenuItemIcon(context, menuitem, item);
+			else
+				UpdateMenuItemIcon(context, menu, menuItemsCreated, menuitem, item, tintColor);
+
+			if (item.Order != ToolbarItemOrder.Secondary)
+				menuitem.SetShowAsAction(ShowAsAction.Always);
+
+			menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
+
+			if (tintColor != null && tintColor != Color.Default)
+			{
+				var view = toolbar.FindViewById(menuitem.ItemId);
+				if (view is ATextView textView)
 				{
-					var menuitem = menu.Add(title);
-					menuitem.SetEnabled(item.IsEnabled);
-					menuitem.SetTitleOrContentDescription(item);
-					UpdateMenuItemIcon(context, menuitem, item, tintColor);
-
-					if (item.Order != ToolbarItemOrder.Secondary)
-						menuitem.SetShowAsAction(ShowAsAction.Always);
-
-					menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
-
-					if (tintColor != null && tintColor != Color.Default)
-					{
-						var view = toolbar.FindViewById(menuitem.ItemId);
-						if (view is ATextView textView)
-						{
-							if (item.IsEnabled)
-								textView.SetTextColor(tintColor.Value.ToAndroid());
-							else
-								textView.SetTextColor(tintColor.Value.MultiplyAlpha(0.302).ToAndroid());
-						}
-					}
-
-					menuitem.Dispose();
+					if (item.IsEnabled)
+						textView.SetTextColor(tintColor.Value.ToAndroid());
+					else
+						textView.SetTextColor(tintColor.Value.MultiplyAlpha(0.302).ToAndroid());
 				}
 			}
 		}
 
-		internal static void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
+		internal static void UpdateMenuItemIcon(Context context, IMenu menu, List<IMenuItem> menuItemsCreated, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
 		{
 			_ = context.ApplyDrawableAsync(toolBarItem, ToolbarItem.IconImageSourceProperty, baseDrawable =>
 			{
+				if (menuItem == null || !menuItem.IsAlive())
+				{
+					return;
+				}
+
 				if (baseDrawable != null)
 				{
 					using (var constant = baseDrawable.GetConstantState())
@@ -94,17 +143,37 @@ namespace Xamarin.Forms.Platform.Android
 		public static void OnToolbarItemPropertyChanged(
 			this AToolbar toolbar,
 			PropertyChangedEventArgs e,
+			ToolbarItem toolbarItem,
 			IEnumerable<ToolbarItem> toolbarItems,
 			Context context,
 			Color? tintColor,
-			PropertyChangedEventHandler toolbarItemChanged)
+			PropertyChangedEventHandler toolbarItemChanged,
+			List<IMenuItem> currentMenuItems,
+			Action<Context, IMenuItem, ToolbarItem> updateMenuItemIcon = null)
 		{
 			if (toolbarItems == null)
 				return;
 
 			if (e.IsOneOf(MenuItem.TextProperty, MenuItem.IconImageSourceProperty, MenuItem.IsEnabledProperty))
 			{
-				toolbar.UpdateMenuItems(toolbarItems, context, tintColor, toolbarItemChanged);
+				int index = 0;
+				foreach (var item in toolbarItems)
+				{
+					if(item == toolbarItem)
+					{
+						break;
+					}
+
+					index++;
+				}
+
+				if (index >= currentMenuItems.Count)
+					return;
+
+				if (currentMenuItems[index].IsAlive())
+					UpdateMenuItem(toolbar, context, currentMenuItems, toolbarItem, tintColor, toolbarItemChanged, index, updateMenuItemIcon);
+				else
+					UpdateMenuItems(toolbar, toolbarItems, context, tintColor, toolbarItemChanged, currentMenuItems, updateMenuItemIcon);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -21,6 +21,7 @@ using ATextView = global::Android.Widget.TextView;
 using Android.Support.Design.Widget;
 using AColor = Android.Graphics.Color;
 using Xamarin.Forms.Internals;
+using System.Collections.Generic;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -56,6 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 		AppBarLayout _appBar;
 		float _appBarElevation;
 		GenericGlobalLayoutListener _globalLayoutListener;
+		List<IMenuItem> _currentMenuItems = new List<IMenuItem>();
 
 		public ShellToolbarTracker(IShellContext shellContext, Toolbar toolbar, DrawerLayout drawerLayout)
 		{
@@ -171,9 +173,13 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.Dispose();
 				}
 
+				if (_currentMenuItems != null)
+					_currentMenuItems.Clear();
+
 				_drawerToggle?.Dispose();
 			}
 
+			_currentMenuItems = null;
 			_globalLayoutListener = null;
 			_backButtonBehavior = null;
 			SearchHandler = null;
@@ -492,7 +498,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var menu = toolbar.Menu;
 			var sortedItems = System.Linq.Enumerable.OrderBy(page.ToolbarItems, x => x.Order);
-			toolbar.UpdateMenuItems(sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
+
+			toolbar.UpdateMenuItems(sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged, _currentMenuItems);
 
 			SearchHandler = Shell.GetSearchHandler(page);
 			if (SearchHandler != null && SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Hidden)
@@ -556,7 +563,7 @@ namespace Xamarin.Forms.Platform.Android
 		void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			var sortedItems = System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x => x.Order);
-			_toolbar.OnToolbarItemPropertyChanged(e, sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged);
+			_toolbar.OnToolbarItemPropertyChanged(e, (ToolbarItem)sender, sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged, _currentMenuItems);
 		}
 
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)


### PR DESCRIPTION
### Description of Change ###

- allow navigationpagerenderer to override loading of menu item icons
- when a single item is updated just update the one menuitem opposed to rebuilding the list
- fix a timing issue when loading async drawables which sometimes caused the menuitem to be disposed of and would crash silently with a MenuItemDisposed error

### Issues Resolved ### 
- fixes #9360
- fixes #9278

### Platforms Affected ### 
- Android

### Testing Procedure ###
- UI tests all pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
