### PR TITLE
Replacement ActivityIndicator for WPF

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml
+++ b/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml
@@ -2,7 +2,10 @@
 	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
 	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
 	x:Class="Xamarin.Forms.Platform.WPF.Controls.FormsProgressRing"
-    x:Name="Control">
+    x:Name="Control"
+    Foreground="Black"
+    MinWidth="50"
+    MinHeight="50">
     <UserControl.Resources>
         <Style x:Key="ProgressRingEllipseStyle" TargetType="Ellipse">
             <Setter Property="Opacity" Value="0"/>

--- a/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml
+++ b/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml
@@ -1,0 +1,134 @@
+﻿<UserControl
+	xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+	xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+	x:Class="Xamarin.Forms.Platform.WPF.Controls.FormsProgressRing"
+    x:Name="Control">
+    <UserControl.Resources>
+        <Style x:Key="ProgressRingEllipseStyle" TargetType="Ellipse">
+            <Setter Property="Opacity" Value="0"/>
+            <Setter Property="HorizontalAlignment" Value="Left"/>
+            <Setter Property="VerticalAlignment" Value="Top"/>
+            <Setter Property="Margin" Value="8"/>
+            <Setter Property="Height" Value="5"/>
+            <Setter Property="Width" Value="5"/>
+            <Setter Property="StrokeThickness" Value="0"/>
+        </Style>
+        <Storyboard x:Key="ProgressRingStoryboard" RepeatBehavior="Forever">
+            <ObjectAnimationUsingKeyFrames Duration="0" Storyboard.TargetProperty="Visibility" Storyboard.TargetName="Ring">
+                <DiscreteObjectKeyFrame KeyTime="0">
+                    <DiscreteObjectKeyFrame.Value>
+                        <Visibility>Visible</Visibility>
+                    </DiscreteObjectKeyFrame.Value>
+                </DiscreteObjectKeyFrame>
+            </ObjectAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="0" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="E1">
+                <DiscreteDoubleKeyFrame KeyTime="0" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.21" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.22" Value="0"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.47" Value="0"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.167" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="E2">
+                <DiscreteDoubleKeyFrame KeyTime="0" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.21" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.22" Value="0"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.47" Value="0"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.334" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="E3">
+                <DiscreteDoubleKeyFrame KeyTime="0" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.21" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.22" Value="0"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.47" Value="0"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.501" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="E4">
+                <DiscreteDoubleKeyFrame KeyTime="0" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.21" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.22" Value="0"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.47" Value="0"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.668" Storyboard.TargetProperty="Opacity" Storyboard.TargetName="E5">
+                <DiscreteDoubleKeyFrame KeyTime="0" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.21" Value="1"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.22" Value="0"/>
+                <DiscreteDoubleKeyFrame KeyTime="0:0:3.47" Value="0"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="0" Storyboard.TargetProperty="Angle" Storyboard.TargetName="E1R">
+                <SplineDoubleKeyFrame KeySpline="0.13,0.21,0.1,0.7" KeyTime="0" Value="-110"/>
+                <SplineDoubleKeyFrame KeySpline="0.02,0.33,0.38,0.77" KeyTime="0:0:0.433" Value="10"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:1.2" Value="93"/>
+                <SplineDoubleKeyFrame KeySpline="0.57,0.17,0.95,0.75" KeyTime="0:0:1.617" Value="205"/>
+                <SplineDoubleKeyFrame KeySpline="0,0.19,0.07,0.72" KeyTime="0:0:2.017" Value="357"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:2.783" Value="439"/>
+                <SplineDoubleKeyFrame KeySpline="0,0,0.95,0.37" KeyTime="0:0:3.217" Value="585"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.167" Storyboard.TargetProperty="Angle" Storyboard.TargetName="E2R">
+                <SplineDoubleKeyFrame KeySpline="0.13,0.21,0.1,0.7" KeyTime="0" Value="-116"/>
+                <SplineDoubleKeyFrame KeySpline="0.02,0.33,0.38,0.77" KeyTime="0:0:0.433" Value="4"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:1.2" Value="87"/>
+                <SplineDoubleKeyFrame KeySpline="0.57,0.17,0.95,0.75" KeyTime="0:0:1.617" Value="199"/>
+                <SplineDoubleKeyFrame KeySpline="0,0.19,0.07,0.72" KeyTime="0:0:2.017" Value="351"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:2.783" Value="433"/>
+                <SplineDoubleKeyFrame KeySpline="0,0,0.95,0.37" KeyTime="0:0:3.217" Value="579"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.334" Storyboard.TargetProperty="Angle" Storyboard.TargetName="E3R">
+                <SplineDoubleKeyFrame KeySpline="0.13,0.21,0.1,0.7" KeyTime="0" Value="-122"/>
+                <SplineDoubleKeyFrame KeySpline="0.02,0.33,0.38,0.77" KeyTime="0:0:0.433" Value="-2"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:1.2" Value="81"/>
+                <SplineDoubleKeyFrame KeySpline="0.57,0.17,0.95,0.75" KeyTime="0:0:1.617" Value="193"/>
+                <SplineDoubleKeyFrame KeySpline="0,0.19,0.07,0.72" KeyTime="0:0:2.017" Value="345"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:2.783" Value="427"/>
+                <SplineDoubleKeyFrame KeySpline="0,0,0.95,0.37" KeyTime="0:0:3.217" Value="573"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.501" Storyboard.TargetProperty="Angle" Storyboard.TargetName="E4R">
+                <SplineDoubleKeyFrame KeySpline="0.13,0.21,0.1,0.7" KeyTime="0" Value="-128"/>
+                <SplineDoubleKeyFrame KeySpline="0.02,0.33,0.38,0.77" KeyTime="0:0:0.433" Value="-8"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:1.2" Value="75"/>
+                <SplineDoubleKeyFrame KeySpline="0.57,0.17,0.95,0.75" KeyTime="0:0:1.617" Value="187"/>
+                <SplineDoubleKeyFrame KeySpline="0,0.19,0.07,0.72" KeyTime="0:0:2.017" Value="339"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:2.783" Value="421"/>
+                <SplineDoubleKeyFrame KeySpline="0,0,0.95,0.37" KeyTime="0:0:3.217" Value="567"/>
+            </DoubleAnimationUsingKeyFrames>
+            <DoubleAnimationUsingKeyFrames BeginTime="00:00:00.668" Storyboard.TargetProperty="Angle" Storyboard.TargetName="E5R">
+                <SplineDoubleKeyFrame KeySpline="0.13,0.21,0.1,0.7" KeyTime="0" Value="-134"/>
+                <SplineDoubleKeyFrame KeySpline="0.02,0.33,0.38,0.77" KeyTime="0:0:0.433" Value="-14"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:1.2" Value="69"/>
+                <SplineDoubleKeyFrame KeySpline="0.57,0.17,0.95,0.75" KeyTime="0:0:1.617" Value="181"/>
+                <SplineDoubleKeyFrame KeySpline="0,0.19,0.07,0.72" KeyTime="0:0:2.017" Value="331"/>
+                <SplineDoubleKeyFrame KeyTime="0:0:2.783" Value="415"/>
+                <SplineDoubleKeyFrame KeySpline="0,0,0.95,0.37" KeyTime="0:0:3.217" Value="561"/>
+            </DoubleAnimationUsingKeyFrames>
+        </Storyboard>
+    </UserControl.Resources>
+
+    <Grid x:Name="Ring" RenderTransformOrigin=".5,.5" VerticalAlignment="Center" HorizontalAlignment="Center" Visibility="Collapsed">
+        <Canvas RenderTransformOrigin=".5,.5">
+            <Canvas.RenderTransform>
+                <RotateTransform x:Name="E1R"/>
+            </Canvas.RenderTransform>
+            <Ellipse x:Name="E1" Fill="{Binding Foreground, ElementName=Control}" Style="{StaticResource ProgressRingEllipseStyle}" />
+        </Canvas>
+        <Canvas RenderTransformOrigin=".5,.5">
+            <Canvas.RenderTransform>
+                <RotateTransform x:Name="E2R"/>
+            </Canvas.RenderTransform>
+            <Ellipse x:Name="E2" Fill="{Binding Foreground, ElementName=Control}" Style="{StaticResource ProgressRingEllipseStyle}" />
+        </Canvas>
+        <Canvas RenderTransformOrigin=".5,.5">
+            <Canvas.RenderTransform>
+                <RotateTransform x:Name="E3R"/>
+            </Canvas.RenderTransform>
+            <Ellipse x:Name="E3" Fill="{Binding Foreground, ElementName=Control}" Style="{StaticResource ProgressRingEllipseStyle}" />
+        </Canvas>
+        <Canvas RenderTransformOrigin=".5,.5">
+            <Canvas.RenderTransform>
+                <RotateTransform x:Name="E4R"/>
+            </Canvas.RenderTransform>
+            <Ellipse x:Name="E4" Fill="{Binding Foreground, ElementName=Control}" Style="{StaticResource ProgressRingEllipseStyle}" />
+        </Canvas>
+        <Canvas RenderTransformOrigin=".5,.5">
+            <Canvas.RenderTransform>
+                <RotateTransform x:Name="E5R"/>
+            </Canvas.RenderTransform>
+            <Ellipse x:Name="E5" Fill="{Binding Foreground, ElementName=Control}" Style="{StaticResource ProgressRingEllipseStyle}" />
+        </Canvas>
+    </Grid>
+</UserControl>

--- a/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml.cs
+++ b/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml.cs
@@ -31,12 +31,12 @@ namespace Xamarin.Forms.Platform.WPF.Controls
 			}
 		}
 
-		private static void IsActiveChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+		static void IsActiveChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
 		{
 			((FormsProgressRing)sender).OnIsActiveChanged(Convert.ToBoolean(e.NewValue));
 		}
 
-		private void OnIsActiveChanged(bool newValue)
+		void OnIsActiveChanged(bool newValue)
 		{
 			if (newValue)
 			{

--- a/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml.cs
+++ b/Xamarin.Forms.Platform.WPF/Controls/FormsProgressRing.xaml.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Animation;
+
+namespace Xamarin.Forms.Platform.WPF.Controls
+{
+	public partial class FormsProgressRing : UserControl
+	{
+		public static readonly DependencyProperty IsActiveProperty = DependencyProperty.Register("IsActive", typeof(bool), typeof(FormsProgressRing), new PropertyMetadata(false, new PropertyChangedCallback(IsActiveChanged)));
+
+		Storyboard animation;
+
+		public FormsProgressRing()
+		{
+			InitializeComponent();
+
+			animation = (Storyboard)Resources["ProgressRingStoryboard"];
+		}
+
+		public bool IsActive
+		{
+			get
+			{
+				return (bool)GetValue(IsActiveProperty);
+			}
+
+			set
+			{
+				SetValue(IsActiveProperty, value);
+			}
+		}
+
+		private static void IsActiveChanged(DependencyObject sender, DependencyPropertyChangedEventArgs e)
+		{
+			((FormsProgressRing)sender).OnIsActiveChanged(Convert.ToBoolean(e.NewValue));
+		}
+
+		private void OnIsActiveChanged(bool newValue)
+		{
+			if (newValue)
+			{
+				animation.Begin();
+			}
+			else
+			{
+				animation.Stop();
+			}
+		}
+
+		protected override void OnRenderSizeChanged(SizeChangedInfo sizeInfo)
+		{
+			// force the ring to the largest square which is fully visible in the control
+			Ring.Width = Math.Min(ActualWidth, ActualHeight);
+			Ring.Height = Math.Min(ActualWidth, ActualHeight);
+			base.OnRenderSizeChanged(sizeInfo);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.WPF/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ActivityIndicatorRenderer.cs
@@ -24,12 +24,12 @@ namespace Xamarin.Forms.Platform.WPF
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			base.OnElementPropertyChanged(sender, e);
-
 			if (e.PropertyName == ActivityIndicator.IsRunningProperty.PropertyName)
 				UpdateIsActive();
 			else if (e.PropertyName == ActivityIndicator.ColorProperty.PropertyName)
 				UpdateColor();
+
+			base.OnElementPropertyChanged(sender, e);
 		}
 
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void UpdateColor()
 		{
-			Control.UpdateDependencyColor(FormsProgressRing.ForegroundProperty, Element.Color);
+			Control.UpdateDependencyColor(FormsProgressRing.ForegroundProperty, Element.Color != Color.Default ? Element.Color : Color.Accent);
 		}
 
 		void UpdateIsActive()

--- a/Xamarin.Forms.Platform.WPF/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ActivityIndicatorRenderer.cs
@@ -1,14 +1,10 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using WProgressBar = System.Windows.Controls.ProgressBar;
+using Xamarin.Forms.Platform.WPF.Controls;
 
 namespace Xamarin.Forms.Platform.WPF
 {
-	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, WProgressBar>
+	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, FormsProgressRing>
 	{
 		protected override void OnElementChanged(ElementChangedEventArgs<ActivityIndicator> e)
 		{
@@ -16,10 +12,10 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				if (Control == null) // construct and SetNativeControl and suscribe control event
 				{
-					SetNativeControl(new WProgressBar());
+					SetNativeControl(new FormsProgressRing());
 				}
 
-				UpdateIsIndeterminate();
+				UpdateIsActive();
 				UpdateColor();
 			}
 
@@ -31,19 +27,35 @@ namespace Xamarin.Forms.Platform.WPF
 			base.OnElementPropertyChanged(sender, e);
 
 			if (e.PropertyName == ActivityIndicator.IsRunningProperty.PropertyName)
-				UpdateIsIndeterminate();
+				UpdateIsActive();
 			else if (e.PropertyName == ActivityIndicator.ColorProperty.PropertyName)
 				UpdateColor();
 		}
 
-		void UpdateColor()
+		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			Control.UpdateDependencyColor(WProgressBar.ForegroundProperty, Element.Color);
+			// Restrict control to a square
+			return base.GetDesiredSize(Math.Min(widthConstraint, heightConstraint), Math.Min(widthConstraint, heightConstraint));
 		}
 
-		void UpdateIsIndeterminate()
+		protected override void Dispose(bool disposing)
 		{
-			Control.IsIndeterminate = Element.IsRunning;
+			if (Element is object)
+			{
+				Element.IsRunning = false;
+			}
+
+			base.Dispose(disposing);
+		}
+
+		void UpdateColor()
+		{
+			Control.UpdateDependencyColor(FormsProgressRing.ForegroundProperty, Element.Color);
+		}
+
+		void UpdateIsActive()
+		{
+			Control.IsActive = Element.IsRunning;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
+++ b/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
@@ -74,6 +74,9 @@
     <Compile Include="Controls\FormsPage.cs" />
     <Compile Include="Controls\FormsNavigationPage.cs" />
     <Compile Include="Controls\FormsPathIcon.cs" />
+    <Compile Include="Controls\FormsProgressRing.xaml.cs">
+      <DependentUpon>FormsProgressRing.xaml</DependentUpon>
+    </Compile>
     <Compile Include="Controls\FormsSymbolIcon.cs" />
     <Compile Include="Controls\FormsTabbedPage.cs" />
     <Compile Include="Controls\FormsTransitioningContentControl.cs" />
@@ -226,6 +229,9 @@
     <Page Include="Assets\Default.xaml">
       <Generator>MSBuild:Compile</Generator>
       <SubType>Designer</SubType>
+    </Page>
+    <Page Include="Controls\FormsProgressRing.xaml">
+      <Generator>MSBuild:Compile</Generator>
     </Page>
     <Page Include="Themes\Generic.xaml">
       <Generator>MSBuild:Compile</Generator>


### PR DESCRIPTION
### Description of Change ###

Replaces the default ProgressBar with a proper Activity spinner to show indeterminate activity. Style is consistent with Windows features and is the same as used throughout Windows 8 and above.

### Issues Resolved ### 
- fixes #9372 

### API Changes ###
 None

### Platforms Affected ### 
- WPF

### Behavioral/Visual Changes ###
Before the change an ActivityIndicator is rendered as a progress bar with indeterminate style which doesn't fit with the look across multiple platforms or the control used in various Windows components. After the change the ActivityIndicator is rendered as a circular animated control with multiple dots chasing around. This is similar to the control used on UWP but works on any WPF platform.

### Before/After Screenshots ### 
Before:-
![activityindicator-before](https://user-images.githubusercontent.com/3985053/73596354-532a4700-4519-11ea-81d1-76ee6a6b2bc5.png)

After:-
![activityindicator-after](https://user-images.githubusercontent.com/3985053/73596357-56bdce00-4519-11ea-9d95-f79b95816d8d.png)

### Testing Procedure ###
The new behaviour can be tested on the existing control gallery project.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
