### PR TITLE
fixes #6679 [Bug] WebView UWP not displaying

### DIFF
--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		WebNavigationEvent _eventState;
 		bool _updating;
-		private Windows.UI.Xaml.Controls.WebView _internalWebView;
+		Windows.UI.Xaml.Controls.WebView _internalWebView;
 		const string LocalScheme = "ms-appx-web:///";
 
 		// Script to insert a <base> tag into an HTML document

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using Windows.UI.Core;
 using Windows.UI.Xaml.Controls;
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		WebNavigationEvent _eventState;
 		bool _updating;
+		private Windows.UI.Xaml.Controls.WebView _internalWebView;
 		const string LocalScheme = "ms-appx-web:///";
 
 		// Script to insert a <base> tag into an HTML document
@@ -36,10 +37,10 @@ if(bases.length == 0){
 			string htmlWithBaseTag;
 
 			// Set up an internal WebView we can use to load and parse the original HTML string
-			var internalWebView = new Windows.UI.Xaml.Controls.WebView();
+			_internalWebView = new Windows.UI.Xaml.Controls.WebView();
 
 			// When the 'navigation' to the original HTML string is done, we can modify it to include our <base> tag
-			internalWebView.NavigationCompleted += async (sender, args) =>
+			_internalWebView.NavigationCompleted += async (sender, args) =>
 			{
 				// Generate a version of the <base> script with the correct <base> tag
 				var script = BaseInsertionScript.Replace("baseTag", baseTag);
@@ -53,7 +54,7 @@ if(bases.length == 0){
 			};
 
 			// Kick off the initial navigation
-			internalWebView.NavigateToString(html);
+			_internalWebView.NavigateToString(html);
 		}
 
 		public void LoadUrl(string url)

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -51,6 +51,7 @@ if(bases.length == 0){
 
 				// Set the HTML for the 'real' WebView to the updated HTML
 				Control.NavigateToString(!IsNullOrEmpty(htmlWithBaseTag) ? htmlWithBaseTag : html);
+				_internalWebView = null;
 			};
 
 			// Kick off the initial navigation

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -37,6 +37,7 @@ if(bases.length == 0){
 			string htmlWithBaseTag;
 
 			// Set up an internal WebView we can use to load and parse the original HTML string
+			// Make _internalWebView a field instead of local variable to avoid garbage collection
 			_internalWebView = new Windows.UI.Xaml.Controls.WebView();
 
 			// When the 'navigation' to the original HTML string is done, we can modify it to include our <base> tag
@@ -51,6 +52,7 @@ if(bases.length == 0){
 
 				// Set the HTML for the 'real' WebView to the updated HTML
 				Control.NavigateToString(!IsNullOrEmpty(htmlWithBaseTag) ? htmlWithBaseTag : html);
+				// free up memory after we're done with _internalWebView
 				_internalWebView = null;
 			};
 


### PR DESCRIPTION

**If you plan to make service releases for previous versions of Xamarin.Forms, please, apply this fix to all of them, cause this bug is really-really old and exists since version 2.4.0.**

### Description of Change ###
The problem with the WebView appeared because of `var internalWebView` being garbage-collected. This variable is created inside a method, and once the method is done, the variable may be garbage-collected, and may not be (you never know when it happens, but it happens more often on devices with less memory, I guess). 
Putting this `internalWebView` into a private field fixes this bug.

### Issues Resolved ### 

- fixes #6679 [Bug] WebView UWP not displaying

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
If you put `GC.Collect()` right after call to `LoadHtml()` (that is [at this line](https://github.com/xamarin/Xamarin.Forms/blob/bd31e1e9fc8b2f9ad94cc99e0c7ab058174821f3/Xamarin.Forms.Core/HtmlWebViewSource.cs#L29)), you will see that the WebView will stay empty, when an `HtmlWebViewSource` is set as its `Source`.

After applying this fix, `GC.Collect()` doesn't affect the WebView, it displays just fine.


### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
