### PR TITLE
[Core] Rework navigation task handling

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/NavigationUnitTest.cs
@@ -25,6 +25,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreSame(childRoot, nav.RootPage);
 			Assert.AreSame(childRoot, nav.CurrentPage);
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
+			Assert.IsNull(nav.CurrentNavigationTask);
 		}
 
 		[Test]
@@ -55,6 +56,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreSame(childRoot, nav.CurrentPage);
 			Assert.AreSame(nav.RootPage, nav.CurrentPage);
 			Assert.AreEqual (childRoot2, popped);
+			Assert.IsNull(nav.CurrentNavigationTask);
 
 			await nav.PopAsync ();
 			var last = await nav.Navigation.PopAsync ();


### PR DESCRIPTION
### Description of Change ###
To synchronize navigation actions, the variable CurrentNavigationTask is used to track the current navigation and await it if necessary.
But this variable is never reset and can cause a memory leak.
So I added a new variable in the navigation methods which contains the navigation task created by the method. At the end I compare it with the CurrentNavigationTask, if it is equal we can reset it, if not, it is that another navigation overwritten it, in this case it's this method which will do the reset.

I removed the try catch introduced in 2873, because I don't know if it is still necessary and I can't test on iOS. If the tests fails I will re-add it.

### Issues Resolved ### 
- fixes #1429

### API Changes ###
- None

### Platforms Affected ### 
- Core (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
- Run the NavigationUnitTest
- Run the reproduction case in #1429 with the profiler, then :
   - Go to Page2
   - Go back
   - Make a snapshot
   - Go to Live Objects
   - Search for Page2
   - If it succeed no Page2 should be present

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
