### PR TITLE
Fixes TPV so it works anywhere on the screen

### DIFF
--- a/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewNotSpannedTests.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewNotSpannedTests.cs
@@ -9,7 +9,7 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.DualScreen.UnitTests
 {
 	[TestFixture]
-	public class TwoPaneViewTests : BaseTestFixture
+	public class TwoPaneViewNotSpannedTests : BaseTestFixture
 	{
 		[SetUp]
 		public override void Setup()

--- a/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewNotSpannedTests.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewNotSpannedTests.cs
@@ -16,12 +16,15 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 		{
 			base.Setup();
 			Device.PlatformServices = new MockPlatformServices();
-			Device.info = new TestDeviceInfo();
 		}
 
-		TwoPaneView CreateTwoPaneView(View pane1 = null, View pane2 = null)
+		TwoPaneView CreateTwoPaneView(View pane1 = null, View pane2 = null, IDualScreenService dualScreenService = null)
 		{
-			TwoPaneView view = new TwoPaneView()
+			dualScreenService = dualScreenService ?? new TestDualScreenServicePortrait();
+			pane1 = pane1 ?? new BoxView();
+			pane2 = pane2 ?? new BoxView();
+
+			TwoPaneView view = new TwoPaneView(dualScreenService)
 			{
 				IsPlatformEnabled = true,
 				Pane1 = pane1,
@@ -46,16 +49,16 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			var Pane1 = new StackLayout();
 			var Pane2 = new Grid();
 
-			TwoPaneView twoPaneView = new TwoPaneView()
-			{
-				TallModeConfiguration = TwoPaneViewTallModeConfiguration.SinglePane,
-				WideModeConfiguration = TwoPaneViewWideModeConfiguration.SinglePane,
-				Pane1 = Pane1,
-				Pane2 = Pane2,
-				PanePriority = TwoPaneViewPriority.Pane2,
-				MinTallModeHeight = 1000,
-				MinWideModeWidth = 2000,
-			};
+			TwoPaneView twoPaneView = CreateTwoPaneView(Pane1, Pane2);
+
+			twoPaneView.TallModeConfiguration = TwoPaneViewTallModeConfiguration.SinglePane;
+			twoPaneView.WideModeConfiguration = TwoPaneViewWideModeConfiguration.SinglePane;
+			twoPaneView.Pane1 = Pane1;
+			twoPaneView.Pane2 = Pane2;
+			twoPaneView.PanePriority = TwoPaneViewPriority.Pane2;
+			twoPaneView.MinTallModeHeight = 1000;
+			twoPaneView.MinWideModeWidth = 2000;
+
 
 			Assert.AreEqual(TwoPaneViewTallModeConfiguration.SinglePane, twoPaneView.TallModeConfiguration);
 			Assert.AreEqual(TwoPaneViewWideModeConfiguration.SinglePane, twoPaneView.WideModeConfiguration);
@@ -67,19 +70,55 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 		}
 
 		[Test]
-		public void BasicLayoutTest()
+		public void BasicLayoutTestPortrait()
 		{
-			TwoPaneView twoPaneView = new TwoPaneView();
-			twoPaneView.Layout(new Rectangle(0, 0, 300, 300));
+			TwoPaneView twoPaneView = CreateTwoPaneView();
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
 
-			Assert.AreEqual(300, twoPaneView.Height);
+			Assert.AreEqual(300, twoPaneView.Pane1.Width);
+			Assert.AreEqual(500, twoPaneView.Pane1.Height);
+
+		}
+
+		[Test]
+		public void BasicLayoutTestLandscape()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView(dualScreenService: new TestDualScreenServiceLandscape());
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+
 			Assert.AreEqual(300, twoPaneView.Width);
+			Assert.AreEqual(500, twoPaneView.Height);
+		}
+
+		[Test]
+		public void BasicLayoutTestSinglePanePortrait()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView();
+			twoPaneView.MinWideModeWidth = 1000;
+			twoPaneView.MinTallModeHeight = 1000;
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+
+			Assert.AreEqual(300, twoPaneView.Pane1.Width);
+			Assert.AreEqual(500, twoPaneView.Pane1.Height);
+
+		}
+
+		[Test]
+		public void BasicLayoutTestSinglePaneLandscape()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView(dualScreenService: new TestDualScreenServiceLandscape());
+			twoPaneView.MinWideModeWidth = 1000;
+			twoPaneView.MinTallModeHeight = 1000;
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+
+			Assert.AreEqual(300, twoPaneView.Pane1.Width);
+			Assert.AreEqual(500, twoPaneView.Pane1.Height);
 		}
 
 		[Test]
 		public void ModeSwitchesWithMinWideModeWidth()
 		{
-			TwoPaneView twoPaneView = new TwoPaneView();
+			TwoPaneView twoPaneView = CreateTwoPaneView();
 			twoPaneView.Layout(new Rectangle(0, 0, 300, 300));
 
 			twoPaneView.MinWideModeWidth = 400;
@@ -91,7 +130,7 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 		[Test]
 		public void ModeSwitchesWithMinTallModeHeight()
 		{
-			TwoPaneView twoPaneView = new TwoPaneView();
+			TwoPaneView twoPaneView = CreateTwoPaneView();
 			twoPaneView.Layout(new Rectangle(0, 0, 300, 300));
 
 			twoPaneView.MinTallModeHeight = 400;
@@ -258,9 +297,9 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 		}
 
 
-		internal class TestDeviceInfo : DeviceInfo
+		internal class TestDeviceInfoPortrait : DeviceInfo
 		{
-			public TestDeviceInfo()
+			public TestDeviceInfoPortrait()
 			{
 				CurrentOrientation = DeviceOrientation.Portrait;
 			}
@@ -278,6 +317,97 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			{
 				get { return 2; }
 			}
+		}
+
+		internal class TestDeviceInfoLandscape : DeviceInfo
+		{
+			public TestDeviceInfoLandscape()
+			{
+				CurrentOrientation = DeviceOrientation.Landscape;
+			}
+			public override Size PixelScreenSize
+			{
+				get { return new Size(2000, 1000); }
+			}
+
+			public override Size ScaledScreenSize
+			{
+				get { return new Size(1000, 500); }
+			}
+
+			public override double ScalingFactor
+			{
+				get { return 2; }
+			}
+		}
+
+
+		internal class TestDualScreenServiceLandscape : IDualScreenService
+		{
+			Point _location;
+			Rectangle _hinge;
+			public TestDualScreenServiceLandscape()
+			{
+				DeviceInfo = new TestDeviceInfoLandscape();
+				_hinge = Rectangle.Zero;
+				IsSpanned = false;
+				IsLandscape = true;
+				_location = Point.Zero;
+			}
+
+			public bool IsSpanned { get; set; }
+
+			public bool IsLandscape { get; set; }
+
+			public DeviceInfo DeviceInfo { get; set; }
+
+			public event EventHandler OnScreenChanged;
+
+			public void Dispose()
+			{
+			}
+
+			public Rectangle GetHinge() => _hinge;
+
+			public void SetHinge(Rectangle rectangle) => _hinge = rectangle;
+
+			public Point? GetLocationOnScreen(VisualElement visualElement) => _location;
+
+			public Point? SetLocationOnScreen(Point point) => _location = point;
+		}
+
+		internal class TestDualScreenServicePortrait : IDualScreenService
+		{
+			Point _location;
+			Rectangle _hinge;
+			public TestDualScreenServicePortrait()
+			{
+				DeviceInfo = new TestDeviceInfoPortrait();
+				_hinge = Rectangle.Zero;
+				IsSpanned = false;
+				IsLandscape = false;
+				_location = Point.Zero;
+			}
+
+			public bool IsSpanned { get; set; }
+
+			public bool IsLandscape { get; set; }
+
+			public DeviceInfo DeviceInfo { get; set; }
+
+			public event EventHandler OnScreenChanged;
+
+			public void Dispose()
+			{
+			}
+
+			public Rectangle GetHinge() => _hinge;
+
+			public void SetHinge(Rectangle rectangle) => _hinge = rectangle;
+
+			public Point? GetLocationOnScreen(VisualElement visualElement) => _location;
+
+			public Point? SetLocationOnScreen(Point point) => _location = point;
 		}
 
 	}

--- a/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewSpannedTests.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewSpannedTests.cs
@@ -57,6 +57,12 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			Assert.AreEqual(490, result.Children[0].Width);
 			Assert.AreEqual(490, result.Children[1].Width);
 			Assert.AreEqual(510, result.Children[1].X);
+
+			Assert.AreEqual(490, result.Pane1.Width);
+			Assert.AreEqual(490, result.Pane2.Width);
+
+			Assert.AreEqual(deviceInfo.ScaledScreenSize.Height, result.Pane1.Height);
+			Assert.AreEqual(deviceInfo.ScaledScreenSize.Height, result.Pane2.Height);
 		}
 
 		[Test]

--- a/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewSpannedTests.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewSpannedTests.cs
@@ -1,0 +1,286 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.DualScreen.UnitTests
+{
+	[TestFixture]
+	public class TwoPaneViewSpannedTests : BaseTestFixture
+	{
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			Device.PlatformServices = new MockPlatformServices();
+		}
+
+		TwoPaneView CreateTwoPaneView(IDualScreenService dualScreenService, View pane1 = null, View pane2 = null)
+		{
+			pane1 = pane1 ?? new BoxView();
+			pane2 = pane2 ?? new BoxView();
+
+			TwoPaneView view = new TwoPaneView(dualScreenService)
+			{
+				IsPlatformEnabled = true,
+				Pane1 = pane1,
+				Pane2 = pane2
+			};
+
+			view.MinTallModeHeight = 4000;
+			view.MinWideModeWidth = 4000;
+
+			if (pane1 != null)
+				pane1.IsPlatformEnabled = true;
+
+			if (pane2 != null)
+				pane2.IsPlatformEnabled = true;
+
+			view.Children[0].IsPlatformEnabled = true;
+			view.Children[1].IsPlatformEnabled = true;
+
+			return view;
+		}
+
+		[Test]
+		public void BasicSpanTest()
+		{
+			var deviceInfo = new TestDeviceInfoPortrait();
+			TestDualScreenServicePortrait testDualScreenService = new TestDualScreenServicePortrait(deviceInfo);
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(Point.Zero, deviceInfo.ScaledScreenSize));
+
+			Assert.AreEqual(490, result.Children[0].Width);
+			Assert.AreEqual(490, result.Children[1].Width);
+			Assert.AreEqual(510, result.Children[1].X);
+		}
+
+		[Test]
+		public void DeviceWithoutSpanSupport()
+		{
+			var deviceInfo = new TestDeviceInfoPortrait();
+			TestDualScreenServicePortrait testDualScreenService = new TestDualScreenServicePortrait(deviceInfo);
+			testDualScreenService.IsSpanned = false;
+			testDualScreenService.SetHinge(Rectangle.Zero);
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(100, 100 ,200, 200));
+
+			Assert.AreEqual(200, result.Children[0].Width);
+			Assert.AreEqual(200, result.Children[0].Height);
+		}
+
+		[Test]
+		public void LayoutShiftedOffCenterWideMode()
+		{
+			var deviceInfo = new TestDeviceInfoPortrait();
+			TestDualScreenServicePortrait testDualScreenService = new TestDualScreenServicePortrait(deviceInfo);
+			testDualScreenService.SetLocationOnScreen(new Point(400, 0));
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(400, 0, 500, deviceInfo.ScaledScreenSize.Height));
+
+			Assert.AreEqual(90, result.Children[0].Width);
+			Assert.AreEqual(400, result.Bounds.X);
+			Assert.AreEqual(390, result.Children[1].Width);
+			Assert.AreEqual(110, result.Children[1].X);
+		}
+
+
+		[Test]
+		public void PortraitLayoutStartUnderneathHinge()
+		{
+			var deviceInfo = new TestDeviceInfoPortrait();
+			TestDualScreenServicePortrait testDualScreenService = new TestDualScreenServicePortrait(deviceInfo);
+			testDualScreenService.SetLocationOnScreen(new Point(500, 0));
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(500, 0, 400, deviceInfo.ScaledScreenSize.Height));
+
+			Assert.AreEqual(390, result.Pane1.Width);
+			Assert.AreEqual(10, result.Pane1.X);
+			Assert.IsFalse(result.Children[1].IsVisible);
+		}
+
+		[Test]
+		public void PortraitLayoutEndsUnderneathHinge()
+		{
+			var deviceInfo = new TestDeviceInfoPortrait();
+			TestDualScreenServicePortrait testDualScreenService = new TestDualScreenServicePortrait(deviceInfo);
+			testDualScreenService.SetLocationOnScreen(new Point(100, 0));
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(100, 0, 400, deviceInfo.ScaledScreenSize.Height));
+
+			Assert.AreEqual(390, result.Pane1.Width);
+			Assert.AreEqual(0, result.Pane1.X);
+			Assert.IsFalse(result.Children[1].IsVisible);
+		}
+
+
+		[Test]
+		public void LandscapeLayoutStartUnderneathHinge()
+		{
+			var deviceInfo = new TestDeviceInfoLandscape();
+			var testDualScreenService = new TestDualScreenServiceLandscape(deviceInfo);
+			testDualScreenService.SetLocationOnScreen(new Point(0, 500));
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(0, 500, deviceInfo.ScaledScreenSize.Width, 400));
+
+			Assert.AreEqual(390, result.Pane1.Height);
+			Assert.AreEqual(10, result.Pane1.Y);
+			Assert.IsFalse(result.Children[1].IsVisible);
+		}
+
+		[Test]
+		public void LandscapeLayoutEndsUnderneathHinge()
+		{
+			var deviceInfo = new TestDeviceInfoPortrait();
+			var testDualScreenService = new TestDualScreenServiceLandscape(deviceInfo);
+			testDualScreenService.SetLocationOnScreen(new Point(0, 100));
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(0, 100, deviceInfo.ScaledScreenSize.Width, 400));
+
+			Assert.AreEqual(390, result.Pane1.Height);
+			Assert.AreEqual(0, result.Pane1.Y);
+			Assert.IsFalse(result.Children[1].IsVisible);
+		}
+
+
+		[Test]
+		public void LayoutShiftedOffCenterTallMode()
+		{
+			var deviceInfo = new TestDeviceInfoLandscape();
+			var testDualScreenService = new TestDualScreenServiceLandscape(deviceInfo);
+			testDualScreenService.SetLocationOnScreen(new Point(0, 400));
+			var result = CreateTwoPaneView(testDualScreenService);
+
+			result.Layout(new Rectangle(0, 400, deviceInfo.ScaledScreenSize.Width, 500));
+
+			Assert.AreEqual(90, result.Children[0].Height);
+			Assert.AreEqual(400, result.Bounds.Y);
+			Assert.AreEqual(390, result.Children[1].Height);
+			Assert.AreEqual(110, result.Children[1].Y);
+		}
+
+		internal class TestDualScreenServiceLandscape : IDualScreenService
+		{
+			Point _location;
+			Rectangle _hinge;
+			public TestDualScreenServiceLandscape(DeviceInfo deviceInfo)
+			{
+				DeviceInfo = deviceInfo;
+				_hinge = new Rectangle(0, 490, DeviceInfo.ScaledScreenSize.Width, 20);
+				IsSpanned = true;
+				IsLandscape = true;
+				_location = Point.Zero;
+			}
+
+			public bool IsSpanned { get; set; }
+
+			public bool IsLandscape { get; set; }
+
+			public DeviceInfo DeviceInfo { get; set; }
+
+			public event EventHandler OnScreenChanged;
+
+			public void Dispose()
+			{
+			}
+
+			public Rectangle GetHinge() => _hinge;
+
+			public void SetHinge(Rectangle rectangle) => _hinge = rectangle;
+
+			public Point? GetLocationOnScreen(VisualElement visualElement) => _location;
+
+			public Point? SetLocationOnScreen(Point point) => _location = point;
+		}
+
+		internal class TestDualScreenServicePortrait : IDualScreenService
+		{
+			Point _location;
+			Rectangle _hinge;
+			public TestDualScreenServicePortrait(DeviceInfo deviceInfo)
+			{
+				DeviceInfo = deviceInfo;
+				_hinge = new Rectangle(490, 0, 20, DeviceInfo.ScaledScreenSize.Height);
+				IsSpanned = true;
+				IsLandscape = false;
+				_location = Point.Zero;
+			}
+
+			public bool IsSpanned { get; set; }
+
+			public bool IsLandscape { get; set; }
+
+			public DeviceInfo DeviceInfo { get; set; }
+
+			public event EventHandler OnScreenChanged;
+
+			public void Dispose()
+			{
+			}
+
+			public Rectangle GetHinge() => _hinge;
+
+			public void SetHinge(Rectangle rectangle) => _hinge = rectangle;
+
+			public Point? GetLocationOnScreen(VisualElement visualElement) => _location;
+
+			public Point? SetLocationOnScreen(Point point) => _location = point;
+		}
+
+		internal class TestDeviceInfoLandscape : DeviceInfo
+		{
+			public TestDeviceInfoLandscape()
+			{
+				CurrentOrientation = DeviceOrientation.Landscape;
+			}
+
+			public override Size PixelScreenSize
+			{
+				get { return new Size(1000, 2000); }
+			}
+
+			public override Size ScaledScreenSize
+			{
+				get { return new Size(500, 1000); }
+			}
+
+			public override double ScalingFactor
+			{
+				get { return 2; }
+			}
+		}
+
+		internal class TestDeviceInfoPortrait : DeviceInfo
+		{
+			public TestDeviceInfoPortrait()
+			{
+				CurrentOrientation = DeviceOrientation.Portrait;
+			}
+
+			public override Size PixelScreenSize
+			{
+				get { return new Size(2000, 1000); }
+			}
+
+			public override Size ScaledScreenSize
+			{
+				get { return new Size(1000, 500); }
+			}
+
+			public override double ScalingFactor
+			{
+				get { return 2; }
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.DualScreen.UnitTests/Xamarin.Forms.DualScreen.UnitTests.csproj
+++ b/Xamarin.Forms.DualScreen.UnitTests/Xamarin.Forms.DualScreen.UnitTests.csproj
@@ -4,6 +4,7 @@
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">net47;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp2.1</TargetFrameworks>
     <IsPackable>false</IsPackable>
+    <NoWarn>0114;0672;0108;0067;0168;0169;0219;0612;0618;1998;4014</NoWarn>
   </PropertyGroup>
 
 

--- a/Xamarin.Forms.DualScreen/DualScreenInfo.shared.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenInfo.shared.cs
@@ -15,9 +15,23 @@ namespace Xamarin.Forms.DualScreen
         Rectangle _hingeBounds;
         bool _isLandscape;
         TwoPaneViewMode _spanMode;
+		TwoPaneViewLayoutGuide _twoPaneViewLayoutGuide;
+		public static DualScreenInfo Current => _dualScreenInfo.Value;
 
-        public static DualScreenInfo Current => _dualScreenInfo.Value;
-        public Rectangle[] SpanningBounds
+		public DualScreenInfo(Layout layout)
+		{
+			if(layout == null)
+			{
+				_twoPaneViewLayoutGuide = TwoPaneViewLayoutGuide.Instance;
+			}
+			else
+			{
+				_twoPaneViewLayoutGuide = new TwoPaneViewLayoutGuide(layout);
+				_twoPaneViewLayoutGuide.PropertyChanged += OnTwoPaneViewLayoutGuideChanged;
+			}
+		}
+
+		public Rectangle[] SpanningBounds
         {
             get => GetSpanningBounds();
             set
@@ -56,7 +70,7 @@ namespace Xamarin.Forms.DualScreen
 
         Rectangle[] GetSpanningBounds()
         {
-            var guide = TwoPaneViewLayoutGuide.Instance;
+            var guide = _twoPaneViewLayoutGuide;
             var hinge = guide.Hinge;
             guide.UpdateLayouts();
 
@@ -71,19 +85,19 @@ namespace Xamarin.Forms.DualScreen
 
         Rectangle GetHingeBounds()
         {
-            var guide = TwoPaneViewLayoutGuide.Instance;
+            var guide = _twoPaneViewLayoutGuide;
             guide.UpdateLayouts();
             return guide.Hinge;
         }
 
-        bool GetIsLandscape() => TwoPaneViewLayoutGuide.Instance.IsLandscape;
+        bool GetIsLandscape() => _twoPaneViewLayoutGuide.IsLandscape;
 
-        TwoPaneViewMode GetSpanMode() => TwoPaneViewLayoutGuide.Instance.Mode;
+        TwoPaneViewMode GetSpanMode() => _twoPaneViewLayoutGuide.Mode;
 
         static DualScreenInfo OnCreate()
         {
-            DualScreenInfo dualScreenInfo = new DualScreenInfo();
-            TwoPaneViewLayoutGuide.Instance.PropertyChanged += dualScreenInfo.OnTwoPaneViewLayoutGuideChanged;
+            DualScreenInfo dualScreenInfo = new DualScreenInfo(null);
+			dualScreenInfo._twoPaneViewLayoutGuide.PropertyChanged += dualScreenInfo.OnTwoPaneViewLayoutGuideChanged;
             return dualScreenInfo;
         }
 

--- a/Xamarin.Forms.DualScreen/DualScreenService.android.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenService.android.cs
@@ -7,6 +7,7 @@ using Android.Views;
 using Microsoft.Device.Display;
 using Xamarin.Forms;
 using Xamarin.Forms.DualScreen;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android;
 
 [assembly: Dependency(typeof(DualScreenService.DualScreenServiceImpl))]
@@ -101,6 +102,7 @@ namespace Xamarin.Forms.DualScreen
 
 			public bool IsSpanned
 				=> _isDuo && (_helper?.IsDualMode ?? false);
+			public DeviceInfo DeviceInfo => Device.info;
 
 			public Rectangle GetHinge()
 			{

--- a/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
@@ -12,6 +12,7 @@ using Windows.UI.Xaml;
 using Windows.UI.Xaml.Hosting;
 using Xamarin.Forms;
 using Xamarin.Forms.DualScreen;
+using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.UWP;
 
 [assembly: Dependency(typeof(DualScreenService))]
@@ -39,9 +40,10 @@ namespace Xamarin.Forms.DualScreen
 
                 return false;
             }
-        }
+		}
+		public DeviceInfo DeviceInfo => Device.info;
 
-        public bool IsLandscape
+		public bool IsLandscape
         {
             get
             {

--- a/Xamarin.Forms.DualScreen/IDualScreenService.shared.cs
+++ b/Xamarin.Forms.DualScreen/IDualScreenService.shared.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using System.Threading.Tasks;
 using Xamarin.Forms;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.DualScreen
 {
@@ -12,5 +13,6 @@ namespace Xamarin.Forms.DualScreen
 		bool IsLandscape { get; }
 		Rectangle GetHinge();
 		Point? GetLocationOnScreen(VisualElement visualElement);
+		DeviceInfo DeviceInfo { get; }
 	}
 }

--- a/Xamarin.Forms.DualScreen/NoDualScreenServiceImpl.shared.cs
+++ b/Xamarin.Forms.DualScreen/NoDualScreenServiceImpl.shared.cs
@@ -19,7 +19,9 @@ namespace Xamarin.Forms.DualScreen
 
         public bool IsLandscape => Device.info.CurrentOrientation.IsLandscape();
 
-        public event EventHandler OnScreenChanged
+		public DeviceInfo DeviceInfo => Device.info;
+
+		public event EventHandler OnScreenChanged
         {
             add
             {

--- a/Xamarin.Forms.DualScreen/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.DualScreen/Properties/AssemblyInfo.cs
@@ -1,0 +1,3 @@
+using System.Runtime.CompilerServices;
+
+[assembly: InternalsVisibleTo("Xamarin.Forms.DualScreen.UnitTests")]

--- a/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
@@ -368,7 +368,7 @@ namespace Xamarin.Forms.DualScreen
 				}
 				else
 				{
-					InvalidateLayout();
+					Device.BeginInvokeOnMainThread(InvalidateLayout);
 				}
 			}
 			finally
@@ -394,28 +394,6 @@ namespace Xamarin.Forms.DualScreen
 			columnMiddle.Width = new GridLength(0, GridUnitType.Absolute);
 			rowMiddle.Height = new GridLength(0, GridUnitType.Absolute);
 
-			if (newMode == ViewMode.LeftRight || newMode == ViewMode.RightLeft)
-			{
-				columnLeft.Width = ((newMode == ViewMode.LeftRight) ? Pane1Length : Pane2Length);
-				columnRight.Width = ((newMode == ViewMode.LeftRight) ? Pane2Length : Pane1Length);
-			}
-			else
-			{
-				columnLeft.Width = new GridLength(1, GridUnitType.Star);
-				columnRight.Width = new GridLength(0, GridUnitType.Absolute);
-			}
-
-			if (newMode == ViewMode.TopBottom || newMode == ViewMode.BottomTop)
-			{
-				rowTop.Height = ((newMode == ViewMode.TopBottom) ? Pane1Length : Pane2Length);
-				rowBottom.Height = ((newMode == ViewMode.TopBottom) ? Pane2Length : Pane1Length);
-			}
-			else
-			{
-				rowTop.Height = new GridLength(1, GridUnitType.Star);
-				rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
-			}
-
 			if (TwoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane && newMode != ViewMode.Pane1Only && newMode != ViewMode.Pane2Only)
 			{
 				Rectangle hinge = _twoPaneViewLayoutGuide.Hinge;
@@ -423,14 +401,44 @@ namespace Xamarin.Forms.DualScreen
 				if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Wide)
 				{
 					columnMiddle.Width = new GridLength(hinge.Width, GridUnitType.Absolute);
+
 					columnLeft.Width = new GridLength(pane1.Width, GridUnitType.Absolute);
 					columnRight.Width = new GridLength(pane2.Width, GridUnitType.Absolute);
+					rowTop.Height = GridLength.Star;
+					rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
 				}
 				else
 				{
 					rowMiddle.Height = new GridLength(hinge.Height, GridUnitType.Absolute);
+
 					rowTop.Height = new GridLength(pane1.Height, GridUnitType.Absolute);
 					rowBottom.Height = new GridLength(pane2.Height, GridUnitType.Absolute);
+					columnLeft.Width = GridLength.Star;
+					columnRight.Width = new GridLength(0, GridUnitType.Absolute);
+				}
+			}
+			else
+			{
+				if (newMode == ViewMode.LeftRight || newMode == ViewMode.RightLeft)
+				{
+					columnLeft.Width = ((newMode == ViewMode.LeftRight) ? Pane1Length : Pane2Length);
+					columnRight.Width = ((newMode == ViewMode.LeftRight) ? Pane2Length : Pane1Length);
+				}
+				else
+				{
+					columnLeft.Width = new GridLength(1, GridUnitType.Star);
+					columnRight.Width = new GridLength(0, GridUnitType.Absolute);
+				}
+
+				if (newMode == ViewMode.TopBottom || newMode == ViewMode.BottomTop)
+				{
+					rowTop.Height = ((newMode == ViewMode.TopBottom) ? Pane1Length : Pane2Length);
+					rowBottom.Height = ((newMode == ViewMode.TopBottom) ? Pane2Length : Pane1Length);
+				}
+				else
+				{
+					rowTop.Height = new GridLength(1, GridUnitType.Star);
+					rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
 				}
 			}
 

--- a/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
@@ -368,7 +368,7 @@ namespace Xamarin.Forms.DualScreen
 				}
 				else
 				{
-					Device.BeginInvokeOnMainThread(InvalidateLayout);
+					InvalidateLayout();
 				}
 			}
 			finally

--- a/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
@@ -394,6 +394,28 @@ namespace Xamarin.Forms.DualScreen
 			columnMiddle.Width = new GridLength(0, GridUnitType.Absolute);
 			rowMiddle.Height = new GridLength(0, GridUnitType.Absolute);
 
+			if (newMode == ViewMode.LeftRight || newMode == ViewMode.RightLeft)
+			{
+				columnLeft.Width = ((newMode == ViewMode.LeftRight) ? Pane1Length : Pane2Length);
+				columnRight.Width = ((newMode == ViewMode.LeftRight) ? Pane2Length : Pane1Length);
+			}
+			else
+			{
+				columnLeft.Width = new GridLength(1, GridUnitType.Star);
+				columnRight.Width = new GridLength(0, GridUnitType.Absolute);
+			}
+
+			if (newMode == ViewMode.TopBottom || newMode == ViewMode.BottomTop)
+			{
+				rowTop.Height = ((newMode == ViewMode.TopBottom) ? Pane1Length : Pane2Length);
+				rowBottom.Height = ((newMode == ViewMode.TopBottom) ? Pane2Length : Pane1Length);
+			}
+			else
+			{
+				rowTop.Height = new GridLength(1, GridUnitType.Star);
+				rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
+			}
+
 			if (TwoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane && newMode != ViewMode.Pane1Only && newMode != ViewMode.Pane2Only)
 			{
 				Rectangle hinge = _twoPaneViewLayoutGuide.Hinge;
@@ -401,44 +423,14 @@ namespace Xamarin.Forms.DualScreen
 				if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Wide)
 				{
 					columnMiddle.Width = new GridLength(hinge.Width, GridUnitType.Absolute);
-
 					columnLeft.Width = new GridLength(pane1.Width, GridUnitType.Absolute);
 					columnRight.Width = new GridLength(pane2.Width, GridUnitType.Absolute);
-					rowTop.Height = GridLength.Star;
-					rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
 				}
 				else
 				{
 					rowMiddle.Height = new GridLength(hinge.Height, GridUnitType.Absolute);
-
 					rowTop.Height = new GridLength(pane1.Height, GridUnitType.Absolute);
 					rowBottom.Height = new GridLength(pane2.Height, GridUnitType.Absolute);
-					columnLeft.Width = GridLength.Star;
-					columnRight.Width = new GridLength(0, GridUnitType.Absolute);
-				}
-			}
-			else
-			{
-				if (newMode == ViewMode.LeftRight || newMode == ViewMode.RightLeft)
-				{
-					columnLeft.Width = ((newMode == ViewMode.LeftRight) ? Pane1Length : Pane2Length);
-					columnRight.Width = ((newMode == ViewMode.LeftRight) ? Pane2Length : Pane1Length);
-				}
-				else
-				{
-					columnLeft.Width = new GridLength(1, GridUnitType.Star);
-					columnRight.Width = new GridLength(0, GridUnitType.Absolute);
-				}
-
-				if (newMode == ViewMode.TopBottom || newMode == ViewMode.BottomTop)
-				{
-					rowTop.Height = ((newMode == ViewMode.TopBottom) ? Pane1Length : Pane2Length);
-					rowBottom.Height = ((newMode == ViewMode.TopBottom) ? Pane2Length : Pane1Length);
-				}
-				else
-				{
-					rowTop.Height = new GridLength(1, GridUnitType.Star);
-					rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
 				}
 			}
 

--- a/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
@@ -2,33 +2,33 @@
 
 namespace Xamarin.Forms.DualScreen
 {
-    public enum TwoPaneViewMode
-    {
-        SinglePane, Wide, Tall
-    }
+	public enum TwoPaneViewMode
+	{
+		SinglePane, Wide, Tall
+	}
 
-    public enum TwoPaneViewTallModeConfiguration
-    {
-        SinglePane,
-        TopBottom,
-        BottomTop,
-    }
+	public enum TwoPaneViewTallModeConfiguration
+	{
+		SinglePane,
+		TopBottom,
+		BottomTop,
+	}
 
-    public enum TwoPaneViewWideModeConfiguration
-    {
-        SinglePane,
-        LeftRight,
-        RightLeft,
-    }
+	public enum TwoPaneViewWideModeConfiguration
+	{
+		SinglePane,
+		LeftRight,
+		RightLeft,
+	}
 
-    public enum TwoPaneViewPriority
-    {
-        Pane1,
-        Pane2
-    }
+	public enum TwoPaneViewPriority
+	{
+		Pane1,
+		Pane2
+	}
 
-    [ContentProperty("")]
-    public partial class TwoPaneView : Grid
+	[ContentProperty("")]
+	public partial class TwoPaneView : Grid
 	{
 
 		static TwoPaneView()
@@ -41,171 +41,178 @@ namespace Xamarin.Forms.DualScreen
 		}
 
 		enum ViewMode
-        {
-            Pane1Only,
-            Pane2Only,
-            LeftRight,
-            RightLeft,
-            TopBottom,
-            BottomTop,
-            None
-        };
+		{
+			Pane1Only,
+			Pane2Only,
+			LeftRight,
+			RightLeft,
+			TopBottom,
+			BottomTop,
+			None
+		};
 
 		TwoPaneViewLayoutGuide _twoPaneViewLayoutGuide;
 		VisualStateGroup _modeStates;
 		ContentView _content1;
 		ContentView _content2;
-        ViewMode _currentMode;
-        bool _hasMeasured = false;
-        bool _updatingMode = false;
-        bool _performingLayout = false;
-        bool _processPendingChange = false;
+		ViewMode _currentMode;
+		bool _hasMeasured = false;
+		bool _updatingMode = false;
+		bool _performingLayout = false;
+		bool _processPendingChange = false;
 
-        public static readonly BindableProperty TallModeConfigurationProperty
-            = BindableProperty.Create("TallModeConfiguration", typeof(TwoPaneViewTallModeConfiguration), typeof(TwoPaneView), defaultValue: TwoPaneViewTallModeConfiguration.TopBottom, propertyChanged: OnJustInvalidateLayout);
+		public static readonly BindableProperty TallModeConfigurationProperty
+			= BindableProperty.Create("TallModeConfiguration", typeof(TwoPaneViewTallModeConfiguration), typeof(TwoPaneView), defaultValue: TwoPaneViewTallModeConfiguration.TopBottom, propertyChanged: OnJustInvalidateLayout);
 
-        public static readonly BindableProperty WideModeConfigurationProperty
-            = BindableProperty.Create("WideModeConfiguration", typeof(TwoPaneViewWideModeConfiguration), typeof(TwoPaneView), defaultValue: TwoPaneViewWideModeConfiguration.LeftRight, propertyChanged: OnJustInvalidateLayout);
+		public static readonly BindableProperty WideModeConfigurationProperty
+			= BindableProperty.Create("WideModeConfiguration", typeof(TwoPaneViewWideModeConfiguration), typeof(TwoPaneView), defaultValue: TwoPaneViewWideModeConfiguration.LeftRight, propertyChanged: OnJustInvalidateLayout);
 
-        public static readonly BindableProperty Pane1Property
-            = BindableProperty.Create("Pane1", typeof(View), typeof(TwoPaneView), propertyChanged: (b, o, n) => OnPanePropertyChanged(b, o, n, 0));
+		public static readonly BindableProperty Pane1Property
+			= BindableProperty.Create("Pane1", typeof(View), typeof(TwoPaneView), propertyChanged: (b, o, n) => OnPanePropertyChanged(b, o, n, 0));
 
-        public static readonly BindableProperty Pane2Property
-            = BindableProperty.Create("Pane2", typeof(View), typeof(TwoPaneView), propertyChanged: (b, o, n) => OnPanePropertyChanged(b, o, n, 1));
+		public static readonly BindableProperty Pane2Property
+			= BindableProperty.Create("Pane2", typeof(View), typeof(TwoPaneView), propertyChanged: (b, o, n) => OnPanePropertyChanged(b, o, n, 1));
 
-        public static readonly BindablePropertyKey ModePropertyKey
-            = BindableProperty.CreateReadOnly("Mode", typeof(TwoPaneViewMode), typeof(TwoPaneView), defaultValue: TwoPaneViewMode.SinglePane, propertyChanged: OnModePropertyChanged);
-        
-        public static readonly BindableProperty ModeProperty = ModePropertyKey.BindableProperty;
+		public static readonly BindablePropertyKey ModePropertyKey
+			= BindableProperty.CreateReadOnly("Mode", typeof(TwoPaneViewMode), typeof(TwoPaneView), defaultValue: TwoPaneViewMode.SinglePane, propertyChanged: OnModePropertyChanged);
 
-        public static readonly BindableProperty PanePriorityProperty
-            = BindableProperty.Create("PanePriority", typeof(TwoPaneViewPriority), typeof(TwoPaneView), defaultValue: TwoPaneViewPriority.Pane1, propertyChanged: OnJustInvalidateLayout);
+		public static readonly BindableProperty ModeProperty = ModePropertyKey.BindableProperty;
 
-        public static readonly BindableProperty MinTallModeHeightProperty
-            = BindableProperty.Create("MinTallModeHeight", typeof(double), typeof(TwoPaneView), defaultValueCreator:OnMinModePropertyCreate, propertyChanged: OnJustInvalidateLayout);
+		public static readonly BindableProperty PanePriorityProperty
+			= BindableProperty.Create("PanePriority", typeof(TwoPaneViewPriority), typeof(TwoPaneView), defaultValue: TwoPaneViewPriority.Pane1, propertyChanged: OnJustInvalidateLayout);
+
+		public static readonly BindableProperty MinTallModeHeightProperty
+			= BindableProperty.Create("MinTallModeHeight", typeof(double), typeof(TwoPaneView), defaultValueCreator: OnMinModePropertyCreate, propertyChanged: OnJustInvalidateLayout);
 
 		public static readonly BindableProperty MinWideModeWidthProperty
-            = BindableProperty.Create("MinWideModeWidth", typeof(double), typeof(TwoPaneView), defaultValueCreator: OnMinModePropertyCreate, propertyChanged: OnJustInvalidateLayout);
+			= BindableProperty.Create("MinWideModeWidth", typeof(double), typeof(TwoPaneView), defaultValueCreator: OnMinModePropertyCreate, propertyChanged: OnJustInvalidateLayout);
 
-        public static readonly BindableProperty Pane1LengthProperty
-            = BindableProperty.Create("Pane1Length", typeof(GridLength), typeof(TwoPaneView), defaultValue: GridLength.Star, propertyChanged: OnJustInvalidateLayout);
+		public static readonly BindableProperty Pane1LengthProperty
+			= BindableProperty.Create("Pane1Length", typeof(GridLength), typeof(TwoPaneView), defaultValue: GridLength.Star, propertyChanged: OnJustInvalidateLayout);
 
-        public static readonly BindableProperty Pane2LengthProperty
-            = BindableProperty.Create("Pane2Length", typeof(GridLength), typeof(TwoPaneView), defaultValue: GridLength.Star, propertyChanged: OnJustInvalidateLayout);
+		public static readonly BindableProperty Pane2LengthProperty
+			= BindableProperty.Create("Pane2Length", typeof(GridLength), typeof(TwoPaneView), defaultValue: GridLength.Star, propertyChanged: OnJustInvalidateLayout);
 
-        public event EventHandler ModeChanged;
+		public event EventHandler ModeChanged;
 
 		static object OnMinModePropertyCreate(BindableObject bindable)
 		{
+			double returnValue = 641d;
 			if (Device.info == null)
-				return 641;
+				return returnValue;
 
-			return 641 / Device.info.ScalingFactor;
+			returnValue = 641d / Device.info.ScalingFactor;
+			return returnValue;
 		}
 
 
 		static void OnModePropertyChanged(BindableObject bindable, object oldValue, object newValue)
-        {
-            ((TwoPaneView)bindable).ModeChanged?.Invoke(bindable, EventArgs.Empty);
-        }
+		{
+			((TwoPaneView)bindable).ModeChanged?.Invoke(bindable, EventArgs.Empty);
+		}
 
-        static void OnJustInvalidateLayout(BindableObject bindable, object oldValue, object newValue)
-        {
-            var b = (TwoPaneView)bindable;
-            if (!b._performingLayout && !b._updatingMode)
-            {
-                b.UpdateMode();
-            }
-            else
-            {
-                b._processPendingChange = true;
-            }
-        }
+		static void OnJustInvalidateLayout(BindableObject bindable, object oldValue, object newValue)
+		{
+			var b = (TwoPaneView)bindable;
+			if (!b._performingLayout && !b._updatingMode)
+			{
+				b.UpdateMode();
+			}
+			else
+			{
+				b._processPendingChange = true;
+			}
+		}
 
-        static void OnPanePropertyChanged(BindableObject bindable, object oldValue, object newValue, int paneIndex)
-        {
-            TwoPaneView twoPaneView = (TwoPaneView)bindable;
+		static void OnPanePropertyChanged(BindableObject bindable, object oldValue, object newValue, int paneIndex)
+		{
+			TwoPaneView twoPaneView = (TwoPaneView)bindable;
 			var newView = (View)newValue;
 
-            if (paneIndex == 0)
-                twoPaneView._content1.Content = newView;
-            else
-                twoPaneView._content2.Content = newView;
+			if (paneIndex == 0)
+				twoPaneView._content1.Content = newView;
+			else
+				twoPaneView._content2.Content = newView;
 
-            OnJustInvalidateLayout(bindable, null, null);
-        }
+			OnJustInvalidateLayout(bindable, null, null);
+		}
 
-        public double MinTallModeHeight
-        {
-            get { return (double)GetValue(MinTallModeHeightProperty); }
-            set { SetValue(MinTallModeHeightProperty, value); }
-        }
-        public double MinWideModeWidth
-        {
-            get { return (double)GetValue(MinWideModeWidthProperty); }
-            set { SetValue(MinWideModeWidthProperty, value); }
-        }
+		public double MinTallModeHeight
+		{
+			get { return (double)GetValue(MinTallModeHeightProperty); }
+			set { SetValue(MinTallModeHeightProperty, value); }
+		}
+		public double MinWideModeWidth
+		{
+			get { return (double)GetValue(MinWideModeWidthProperty); }
+			set { SetValue(MinWideModeWidthProperty, value); }
+		}
 
-        public GridLength Pane1Length
-        {
-            get { return (GridLength)GetValue(Pane1LengthProperty); }
-            set { SetValue(Pane1LengthProperty, value); }
-        }
-        public GridLength Pane2Length
-        {
-            get { return (GridLength)GetValue(Pane2LengthProperty); }
-            set { SetValue(Pane2LengthProperty, value); }
-        }
+		public GridLength Pane1Length
+		{
+			get { return (GridLength)GetValue(Pane1LengthProperty); }
+			set { SetValue(Pane1LengthProperty, value); }
+		}
+		public GridLength Pane2Length
+		{
+			get { return (GridLength)GetValue(Pane2LengthProperty); }
+			set { SetValue(Pane2LengthProperty, value); }
+		}
 
-        public TwoPaneViewMode Mode { get => (TwoPaneViewMode)GetValue(ModeProperty); }
+		public TwoPaneViewMode Mode { get => (TwoPaneViewMode)GetValue(ModeProperty); }
 
-        public TwoPaneViewTallModeConfiguration TallModeConfiguration
-        {
-            get { return (TwoPaneViewTallModeConfiguration)GetValue(TallModeConfigurationProperty); }
-            set { SetValue(TallModeConfigurationProperty, value); }
-        }
+		public TwoPaneViewTallModeConfiguration TallModeConfiguration
+		{
+			get { return (TwoPaneViewTallModeConfiguration)GetValue(TallModeConfigurationProperty); }
+			set { SetValue(TallModeConfigurationProperty, value); }
+		}
 
-        public TwoPaneViewWideModeConfiguration WideModeConfiguration
-        {
-            get { return (TwoPaneViewWideModeConfiguration)GetValue(WideModeConfigurationProperty); }
-            set { SetValue(WideModeConfigurationProperty, value); }
-        }
+		public TwoPaneViewWideModeConfiguration WideModeConfiguration
+		{
+			get { return (TwoPaneViewWideModeConfiguration)GetValue(WideModeConfigurationProperty); }
+			set { SetValue(WideModeConfigurationProperty, value); }
+		}
 
-        public View Pane1
-        {
-            get { return (View)GetValue(Pane1Property); }
-            set { SetValue(Pane1Property, value); }
-        }
+		public View Pane1
+		{
+			get { return (View)GetValue(Pane1Property); }
+			set { SetValue(Pane1Property, value); }
+		}
 
-        public View Pane2
-        {
-            get { return (View)GetValue(Pane2Property); }
-            set { SetValue(Pane2Property, value); }
-        }
+		public View Pane2
+		{
+			get { return (View)GetValue(Pane2Property); }
+			set { SetValue(Pane2Property, value); }
+		}
 
-        public TwoPaneViewPriority PanePriority
-        {
-            get { return (TwoPaneViewPriority)GetValue(PanePriorityProperty); }
-            set { SetValue(PanePriorityProperty, value); }
-        }
+		public TwoPaneViewPriority PanePriority
+		{
+			get { return (TwoPaneViewPriority)GetValue(PanePriorityProperty); }
+			set { SetValue(PanePriorityProperty, value); }
+		}
 
-        public TwoPaneView() : base()
-        {
-            _content1 = new ContentView();
-            _content2 = new ContentView();
+		public TwoPaneView() : this(null)
+		{
+		}
+
+		internal TwoPaneView(IDualScreenService dualScreenService)
+		{
+			_twoPaneViewLayoutGuide = new TwoPaneViewLayoutGuide(this, dualScreenService);
+			_content1 = new ContentView();
+			_content2 = new ContentView();
 
 			Children.Add(_content1);
 			Children.Add(_content2);
 
-            this.VerticalOptions = LayoutOptions.Fill;
-            this.HorizontalOptions = LayoutOptions.Fill;
-            ColumnSpacing = 0;
-            RowSpacing = 0;
+			this.VerticalOptions = LayoutOptions.Fill;
+			this.HorizontalOptions = LayoutOptions.Fill;
+			ColumnSpacing = 0;
+			RowSpacing = 0;
 
-            _modeStates = new VisualStateGroup()
-            {
-                Name = "ModeStates"
-            };
+			_modeStates = new VisualStateGroup()
+			{
+				Name = "ModeStates"
+			};
 
 			_modeStates.States.Add(new VisualState() { Name = "ViewMode_OneOnly" });
 			_modeStates.States.Add(new VisualState() { Name = "ViewMode_TwoOnly" });
@@ -216,9 +223,10 @@ namespace Xamarin.Forms.DualScreen
 
 			VisualStateManager.SetVisualStateGroups(this, new VisualStateGroupList() { _modeStates });
 
-            this.RowDefinitions = new RowDefinitionCollection() { new RowDefinition(), new RowDefinition(), new RowDefinition() };
-            this.ColumnDefinitions = new ColumnDefinitionCollection() { new ColumnDefinition(), new ColumnDefinition(), new ColumnDefinition() };
-        }
+			this.RowDefinitions = new RowDefinitionCollection() { new RowDefinition(), new RowDefinition(), new RowDefinition() };
+			this.ColumnDefinitions = new ColumnDefinitionCollection() { new ColumnDefinition(), new ColumnDefinition(), new ColumnDefinition() };
+
+		}
 
 		internal override void OnIsPlatformEnabledChanged()
 		{
@@ -235,237 +243,262 @@ namespace Xamarin.Forms.DualScreen
 			}
 		}
 
-        TwoPaneViewLayoutGuide TwoPaneViewLayoutGuide
-        {
-            get
-            {
-                if (_twoPaneViewLayoutGuide == null)
-                {
-                    _twoPaneViewLayoutGuide = new TwoPaneViewLayoutGuide(this);
-                }
+		TwoPaneViewLayoutGuide TwoPaneViewLayoutGuide => _twoPaneViewLayoutGuide;
 
-                return _twoPaneViewLayoutGuide;
-            }
-        }
 
-        void OnTwoPaneViewLayoutGuide(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-        {
-            UpdateMode();
-        }
+		void OnTwoPaneViewLayoutGuide(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			UpdateMode();
+		}
 
-        protected override void LayoutChildren(double x, double y, double width, double height)
-        {
-            if (_updatingMode)
-                return;
+		protected override void LayoutChildren(double x, double y, double width, double height)
+		{
+			if (_updatingMode)
+				return;
 
-            if (_hasMeasured)
-                base.LayoutChildren(x, y, width, height);
-            else
-                UpdateMode();
-        }
+			if (_hasMeasured)
+				base.LayoutChildren(x, y, width, height);
+			else
+				UpdateMode();
+		}
 
-        void UpdateMode()
-        {
-            _updatingMode = true;
-            try
-            {
-                double controlWidth = this.Width;
-                double controlHeight = this.Height;
+		void UpdateMode()
+		{
+			_updatingMode = true;
+			try
+			{
+				double controlWidth = this.Width;
+				double controlHeight = this.Height;
 
-                ViewMode newMode = (PanePriority == TwoPaneViewPriority.Pane1) ? ViewMode.Pane1Only : ViewMode.Pane2Only;
+				ViewMode newMode = (PanePriority == TwoPaneViewPriority.Pane1) ? ViewMode.Pane1Only : ViewMode.Pane2Only;
 
-                _hasMeasured = true;
+				_hasMeasured = true;
 
-                this.TwoPaneViewLayoutGuide.UpdateLayouts();
+				this.TwoPaneViewLayoutGuide.UpdateLayouts();
 
-                if (TwoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane)
-                {
-                    if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Wide)
-                    {
-                        // Regions are laid out horizontally
-                        if (WideModeConfiguration != TwoPaneViewWideModeConfiguration.SinglePane)
-                        {
-                            newMode = (WideModeConfiguration == TwoPaneViewWideModeConfiguration.LeftRight) ? ViewMode.LeftRight : ViewMode.RightLeft;
-                        }
-                    }
-                    else if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Tall)
-                    {
-                        // Regions are laid out vertically
-                        if (TallModeConfiguration != TwoPaneViewTallModeConfiguration.SinglePane)
-                        {
-                            newMode = (TallModeConfiguration == TwoPaneViewTallModeConfiguration.TopBottom) ? ViewMode.TopBottom : ViewMode.BottomTop;
-                        }
-                    }
-                }
-                else
-                {
-                    // One region
-                    if (controlWidth > MinWideModeWidth && WideModeConfiguration != TwoPaneViewWideModeConfiguration.SinglePane)
-                    {
-                        // Split horizontally
-                        newMode = (WideModeConfiguration == TwoPaneViewWideModeConfiguration.LeftRight) ? ViewMode.LeftRight : ViewMode.RightLeft;
-                    }
-                    else if (controlHeight > MinTallModeHeight && TallModeConfiguration != TwoPaneViewTallModeConfiguration.SinglePane)
-                    {
-                        // Split vertically
-                        newMode = (TallModeConfiguration == TwoPaneViewTallModeConfiguration.TopBottom) ? ViewMode.TopBottom : ViewMode.BottomTop;
-                    }
-                }
+				if (TwoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane)
+				{
+					if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Wide)
+					{
+						// Regions are laid out horizontally
+						if (WideModeConfiguration != TwoPaneViewWideModeConfiguration.SinglePane)
+						{
+							newMode = (WideModeConfiguration == TwoPaneViewWideModeConfiguration.LeftRight) ? ViewMode.LeftRight : ViewMode.RightLeft;
+						}
+					}
+					else if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Tall)
+					{
+						// Regions are laid out vertically
+						if (TallModeConfiguration != TwoPaneViewTallModeConfiguration.SinglePane)
+						{
+							newMode = (TallModeConfiguration == TwoPaneViewTallModeConfiguration.TopBottom) ? ViewMode.TopBottom : ViewMode.BottomTop;
+						}
+					}
+				}
+				else
+				{
+					// One region
+					if (controlWidth > MinWideModeWidth && WideModeConfiguration != TwoPaneViewWideModeConfiguration.SinglePane)
+					{
+						// Split horizontally
+						newMode = (WideModeConfiguration == TwoPaneViewWideModeConfiguration.LeftRight) ? ViewMode.LeftRight : ViewMode.RightLeft;
+					}
+					else if (controlHeight > MinTallModeHeight && TallModeConfiguration != TwoPaneViewTallModeConfiguration.SinglePane)
+					{
+						// Split vertically
+						newMode = (TallModeConfiguration == TwoPaneViewTallModeConfiguration.TopBottom) ? ViewMode.TopBottom : ViewMode.BottomTop;
+					}
+				}
 
-                // Update row/column sizes (this may need to happen even if the mode doesn't change)
-                UpdateRowsColumns(newMode);
+				// Update row/column sizes (this may need to happen even if the mode doesn't change)
+				UpdateRowsColumns(newMode);
 
-                // Update mode if necessary
-                if (newMode != _currentMode)
-                {
-                    _currentMode = newMode;
+				// Update mode if necessary
+				if (newMode != _currentMode)
+				{
+					_currentMode = newMode;
 
-                    TwoPaneViewMode newViewMode = TwoPaneViewMode.SinglePane;
+					TwoPaneViewMode newViewMode = TwoPaneViewMode.SinglePane;
 
-                    switch (_currentMode)
-                    {
-                        case ViewMode.Pane1Only:
-							VisualStateManager.GoToState(this, "ViewMode_OneOnly"); break;
-                        case ViewMode.Pane2Only:
-							VisualStateManager.GoToState(this, "ViewMode_TwoOnly"); break;
-                        case ViewMode.LeftRight:
-							VisualStateManager.GoToState(this, "ViewMode_LeftRight"); newViewMode = TwoPaneViewMode.Wide; break;
-                        case ViewMode.RightLeft:
-							VisualStateManager.GoToState(this, "ViewMode_RightLeft"); newViewMode = TwoPaneViewMode.Wide; break;
-                        case ViewMode.TopBottom:
-							VisualStateManager.GoToState(this, "ViewMode_TopBottom"); newViewMode = TwoPaneViewMode.Tall; break;
-                        case ViewMode.BottomTop:
-							VisualStateManager.GoToState(this, "ViewMode_BottomTop"); newViewMode = TwoPaneViewMode.Tall; break;
-                    }
+					switch (_currentMode)
+					{
+						case ViewMode.Pane1Only:
+							VisualStateManager.GoToState(this, "ViewMode_OneOnly");
+							break;
+						case ViewMode.Pane2Only:
+							VisualStateManager.GoToState(this, "ViewMode_TwoOnly");
+							break;
+						case ViewMode.LeftRight:
+							VisualStateManager.GoToState(this, "ViewMode_LeftRight");
+							newViewMode = TwoPaneViewMode.Wide;
+							break;
+						case ViewMode.RightLeft:
+							VisualStateManager.GoToState(this, "ViewMode_RightLeft");
+							newViewMode = TwoPaneViewMode.Wide;
+							break;
+						case ViewMode.TopBottom:
+							VisualStateManager.GoToState(this, "ViewMode_TopBottom");
+							newViewMode = TwoPaneViewMode.Tall;
+							break;
+						case ViewMode.BottomTop:
+							VisualStateManager.GoToState(this, "ViewMode_BottomTop");
+							newViewMode = TwoPaneViewMode.Tall;
+							break;
+					}
 
-                    if (newViewMode != Mode)
-                    {
-                        _updatingMode = false;
-                        SetValue(ModePropertyKey, newViewMode);
-                    }
-                }
+					if (newViewMode != Mode)
+					{
+						_updatingMode = false;
+						SetValue(ModePropertyKey, newViewMode);
+					}
+				}
 
-                _updatingMode = false;
+				_updatingMode = false;
 
-                if (_processPendingChange)
-                {
-                    _processPendingChange = false;
-                    UpdateMode();
-                }
-                else
-                {
-                    InvalidateLayout();
-                }
-            }
-            finally
-            {
-                _updatingMode = false;
-            }
-        }
+				if (_processPendingChange)
+				{
+					_processPendingChange = false;
+					UpdateMode();
+				}
+				else
+				{
+					InvalidateLayout();
+				}
+			}
+			finally
+			{
+				_updatingMode = false;
+			}
+		}
 
-        void UpdateRowsColumns(ViewMode newMode)
-        {
-            var _columnLeft = ColumnDefinitions[0];
-            var _columnMiddle = ColumnDefinitions[1];
-            var _columnRight = ColumnDefinitions[2];
+		void UpdateRowsColumns(ViewMode newMode)
+		{
+			var columnLeft = ColumnDefinitions[0];
+			var columnMiddle = ColumnDefinitions[1];
+			var columnRight = ColumnDefinitions[2];
 
-            var _rowTop = RowDefinitions[0];
-            var _rowMiddle = RowDefinitions[1];
-            var _rowBottom = RowDefinitions[2];
+			var rowTop = RowDefinitions[0];
+			var rowMiddle = RowDefinitions[1];
+			var rowBottom = RowDefinitions[2];
 
-            _columnMiddle.Width = new GridLength(0, GridUnitType.Absolute);
-            _rowMiddle.Height = new GridLength(0, GridUnitType.Absolute);
+			Rectangle pane1 = _twoPaneViewLayoutGuide.Pane1;
+			Rectangle pane2 = _twoPaneViewLayoutGuide.Pane2;
 
-            if (newMode == ViewMode.LeftRight || newMode == ViewMode.RightLeft)
-            {
-                _columnLeft.Width = ((newMode == ViewMode.LeftRight) ? Pane1Length : Pane2Length);
-                _columnRight.Width = ((newMode == ViewMode.LeftRight) ? Pane2Length : Pane1Length);
-            }
-            else
-            {
-                _columnLeft.Width = new GridLength(1, GridUnitType.Star);
-                _columnRight.Width = new GridLength(0, GridUnitType.Absolute);
-            }
+			columnMiddle.Width = new GridLength(0, GridUnitType.Absolute);
+			rowMiddle.Height = new GridLength(0, GridUnitType.Absolute);
 
-            if (newMode == ViewMode.TopBottom || newMode == ViewMode.BottomTop)
-            {
-                _rowTop.Height = ((newMode == ViewMode.TopBottom) ? Pane1Length : Pane2Length);
-                _rowBottom.Height = ((newMode == ViewMode.TopBottom) ? Pane2Length : Pane1Length);
-            }
-            else
-            {
-                _rowTop.Height = new GridLength(1, GridUnitType.Star);
-                _rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
-            }
+			if (newMode == ViewMode.LeftRight || newMode == ViewMode.RightLeft)
+			{
+				columnLeft.Width = ((newMode == ViewMode.LeftRight) ? Pane1Length : Pane2Length);
+				columnRight.Width = ((newMode == ViewMode.LeftRight) ? Pane2Length : Pane1Length);
+			}
+			else
+			{
+				columnLeft.Width = new GridLength(1, GridUnitType.Star);
+				columnRight.Width = new GridLength(0, GridUnitType.Absolute);
+			}
 
-            if (TwoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane && newMode != ViewMode.Pane1Only && newMode != ViewMode.Pane2Only)
-            {
-				Rectangle rc1 = _twoPaneViewLayoutGuide.Pane1;
-				Rectangle rc2 = _twoPaneViewLayoutGuide.Pane2;
+			if (newMode == ViewMode.TopBottom || newMode == ViewMode.BottomTop)
+			{
+				rowTop.Height = ((newMode == ViewMode.TopBottom) ? Pane1Length : Pane2Length);
+				rowBottom.Height = ((newMode == ViewMode.TopBottom) ? Pane2Length : Pane1Length);
+			}
+			else
+			{
+				rowTop.Height = new GridLength(1, GridUnitType.Star);
+				rowBottom.Height = new GridLength(0, GridUnitType.Absolute);
+			}
+
+			if (TwoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane && newMode != ViewMode.Pane1Only && newMode != ViewMode.Pane2Only)
+			{
 				Rectangle hinge = _twoPaneViewLayoutGuide.Hinge;
-                                
-                if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Wide)
-                {
-                    _columnMiddle.Width = new GridLength(hinge.Width, GridUnitType.Absolute);
-                    _columnLeft.Width = new GridLength(rc1.Width, GridUnitType.Absolute);
-                    _columnRight.Width = new GridLength(rc2.Width, GridUnitType.Absolute);
-                }
-                else
-                {
-                    _rowMiddle.Height = new GridLength(hinge.Height, GridUnitType.Absolute);
-                    _rowTop.Height = new GridLength(rc1.Height, GridUnitType.Absolute);
-                    _rowBottom.Height = new GridLength(rc2.Height, GridUnitType.Absolute);
-                }
-            }
 
-            switch (newMode)
-            {
-                case ViewMode.LeftRight:
-                    SetRowColumn(_content1, 0, 0);
-                    SetRowColumn(_content2, 0, 2);
-                    _content2.IsVisible = true;
-                    _content2.IsVisible = true;
-                    break;
-                case ViewMode.RightLeft:
-                    SetRowColumn(_content1, 0, 2);
-                    SetRowColumn(_content2, 0, 0);
-                    _content2.IsVisible = true;
-                    _content2.IsVisible = true;
-                    break;
-                case ViewMode.TopBottom:
-                    SetRowColumn(_content1, 0, 0);
-                    SetRowColumn(_content2, 2, 0);
-                    _content2.IsVisible = true;
-                    _content2.IsVisible = true;
-                    break;
-                case ViewMode.BottomTop:
-                    SetRowColumn(_content1, 2, 0);
-                    SetRowColumn(_content2, 0, 0);
-                    _content2.IsVisible = true;
-                    _content2.IsVisible = true;
-                    break;
-                case ViewMode.Pane1Only:
-                    SetRowColumn(_content1, 0, 0);
+				if (TwoPaneViewLayoutGuide.Mode == TwoPaneViewMode.Wide)
+				{
+					columnMiddle.Width = new GridLength(hinge.Width, GridUnitType.Absolute);
+					columnLeft.Width = new GridLength(pane1.Width, GridUnitType.Absolute);
+					columnRight.Width = new GridLength(pane2.Width, GridUnitType.Absolute);
+				}
+				else
+				{
+					rowMiddle.Height = new GridLength(hinge.Height, GridUnitType.Absolute);
+					rowTop.Height = new GridLength(pane1.Height, GridUnitType.Absolute);
+					rowBottom.Height = new GridLength(pane2.Height, GridUnitType.Absolute);
+				}
+			}
+
+			switch (newMode)
+			{
+				case ViewMode.LeftRight:
+					SetRowColumn(_content1, 0, 0);
+					SetRowColumn(_content2, 0, 2);
+					_content2.IsVisible = true;
+					_content2.IsVisible = true;
+
+					// add padding to content where the content is under the hinge
+					_content1.Padding = new Thickness(pane1.X, 0, 0, 0);
+					_content2.Padding = new Thickness(0, 0, Width - pane1.Width, 0);
+					break;
+				case ViewMode.RightLeft:
+					SetRowColumn(_content1, 0, 2);
+					SetRowColumn(_content2, 0, 0);
+					_content2.IsVisible = true;
+					_content2.IsVisible = true;
+
+					// add padding to content where the content is under the hinge
+					_content2.Padding = new Thickness(pane1.X, 0, 0, 0);
+					_content1.Padding = new Thickness(0, 0, Width - pane1.Width, 0);
+					break;
+				case ViewMode.TopBottom:
+					SetRowColumn(_content1, 0, 0);
+					SetRowColumn(_content2, 2, 0);
+					_content2.IsVisible = true;
+					_content2.IsVisible = true;
+
+					// add padding to content where the content is under the hinge
+					_content1.Padding = new Thickness(0, pane1.Y, 0, 0);
+					_content2.Padding = new Thickness(0, 0, 0, Height - pane1.Height);
+					break;
+				case ViewMode.BottomTop:
+					SetRowColumn(_content1, 2, 0);
+					SetRowColumn(_content2, 0, 0);
+					_content2.IsVisible = true;
+					_content2.IsVisible = true;
+
+					// add padding to content where the content is under the hinge
+					_content2.Padding = new Thickness(0, pane1.Y, 0, 0);
+					_content1.Padding = new Thickness(0, 0, 0, Height - pane1.Height);
+					break;
+				case ViewMode.Pane1Only:
+					SetRowColumn(_content1, 0, 0);
 					SetRowColumn(_content2, 0, 2);
 					_content1.IsVisible = true;
 					_content2.IsVisible = false;
-                    break;
-                case ViewMode.Pane2Only:
-                    SetRowColumn(_content1, 0, 2);
-                    SetRowColumn(_content2, 0, 0);
-                    _content1.IsVisible = false;
-					_content2.IsVisible = true;
-					break;
-            }
 
-            void SetRowColumn(BindableObject bo, int row, int column)
-            {
-                if (bo == null)
-                    return;
+					// add padding to content where the content is under the hinge
+					_content1.Padding = new Thickness(pane1.X, pane1.Y, Width - pane1.Width - pane1.X, Height - pane1.Height - pane1.Y);
+					_content2.Padding = new Thickness(0, 0, 0, 0);
+					break;
+				case ViewMode.Pane2Only:
+					SetRowColumn(_content1, 0, 2);
+					SetRowColumn(_content2, 0, 0);
+					_content1.IsVisible = false;
+					_content2.IsVisible = true;
+
+					_content1.Padding = new Thickness(0, 0, 0, 0);
+					// add padding to content where the content is under the hinge
+					_content2.Padding = new Thickness(pane1.X, pane1.Y, Width - pane1.Width - pane1.X, Height - pane1.Height - pane1.Y);
+					break;
+			}
+
+			void SetRowColumn(BindableObject bo, int row, int column)
+			{
+				if (bo == null)
+					return;
 
 				Grid.SetColumn(bo, column);
 				Grid.SetRow(bo, row);
-            }
-        }
-    }
+			}
+		}
+	}
 }

--- a/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
@@ -248,7 +248,7 @@ namespace Xamarin.Forms.DualScreen
 
 		void OnTwoPaneViewLayoutGuide(object sender, System.ComponentModel.PropertyChangedEventArgs e)
 		{
-			UpdateMode();
+			OnJustInvalidateLayout(this, null, null);
 		}
 
 		protected override void LayoutChildren(double x, double y, double width, double height)
@@ -264,6 +264,12 @@ namespace Xamarin.Forms.DualScreen
 
 		void UpdateMode()
 		{
+			if (_updatingMode)
+			{
+				_processPendingChange = true;
+				return;
+			}
+
 			_updatingMode = true;
 			try
 			{
@@ -383,6 +389,7 @@ namespace Xamarin.Forms.DualScreen
 
 			Rectangle pane1 = _twoPaneViewLayoutGuide.Pane1;
 			Rectangle pane2 = _twoPaneViewLayoutGuide.Pane2;
+			bool isLayoutSpanned = _twoPaneViewLayoutGuide.Mode != TwoPaneViewMode.SinglePane;
 
 			columnMiddle.Width = new GridLength(0, GridUnitType.Absolute);
 			rowMiddle.Height = new GridLength(0, GridUnitType.Absolute);
@@ -435,9 +442,17 @@ namespace Xamarin.Forms.DualScreen
 					_content2.IsVisible = true;
 					_content2.IsVisible = true;
 
-					// add padding to content where the content is under the hinge
-					_content1.Padding = new Thickness(pane1.X, 0, 0, 0);
-					_content2.Padding = new Thickness(0, 0, Width - pane1.Width, 0);
+					if (!isLayoutSpanned)
+					{
+						// add padding to content where the content is under the hinge
+						_content1.Padding = new Thickness(pane1.X, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, Width - pane1.Width, 0);
+					}
+					else
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
 					break;
 				case ViewMode.RightLeft:
 					SetRowColumn(_content1, 0, 2);
@@ -445,9 +460,17 @@ namespace Xamarin.Forms.DualScreen
 					_content2.IsVisible = true;
 					_content2.IsVisible = true;
 
-					// add padding to content where the content is under the hinge
-					_content2.Padding = new Thickness(pane1.X, 0, 0, 0);
-					_content1.Padding = new Thickness(0, 0, Width - pane1.Width, 0);
+					if (!isLayoutSpanned)
+					{
+						// add padding to content where the content is under the hinge
+						_content2.Padding = new Thickness(pane1.X, 0, 0, 0);
+						_content1.Padding = new Thickness(0, 0, Width - pane1.Width, 0);
+					}
+					else
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
 					break;
 				case ViewMode.TopBottom:
 					SetRowColumn(_content1, 0, 0);
@@ -455,9 +478,18 @@ namespace Xamarin.Forms.DualScreen
 					_content2.IsVisible = true;
 					_content2.IsVisible = true;
 
-					// add padding to content where the content is under the hinge
-					_content1.Padding = new Thickness(0, pane1.Y, 0, 0);
-					_content2.Padding = new Thickness(0, 0, 0, Height - pane1.Height);
+					if (!isLayoutSpanned)
+					{
+						// add padding to content where the content is under the hinge
+						_content1.Padding = new Thickness(0, pane1.Y, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, Height - pane1.Height);
+					}
+					else
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
+
 					break;
 				case ViewMode.BottomTop:
 					SetRowColumn(_content1, 2, 0);
@@ -465,29 +497,51 @@ namespace Xamarin.Forms.DualScreen
 					_content2.IsVisible = true;
 					_content2.IsVisible = true;
 
-					// add padding to content where the content is under the hinge
-					_content2.Padding = new Thickness(0, pane1.Y, 0, 0);
-					_content1.Padding = new Thickness(0, 0, 0, Height - pane1.Height);
+					if (!isLayoutSpanned)
+					{
+						// add padding to content where the content is under the hinge
+						_content2.Padding = new Thickness(0, pane1.Y, 0, 0);
+						_content1.Padding = new Thickness(0, 0, 0, Height - pane1.Height);
+					}
+					else
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
 					break;
 				case ViewMode.Pane1Only:
 					SetRowColumn(_content1, 0, 0);
 					SetRowColumn(_content2, 0, 2);
 					_content1.IsVisible = true;
 					_content2.IsVisible = false;
-
-					// add padding to content where the content is under the hinge
-					_content1.Padding = new Thickness(pane1.X, pane1.Y, Width - pane1.Width - pane1.X, Height - pane1.Height - pane1.Y);
-					_content2.Padding = new Thickness(0, 0, 0, 0);
+					if (!isLayoutSpanned)
+					{
+						// add padding to content where the content is under the hinge
+						_content1.Padding = new Thickness(pane1.X, pane1.Y, Width - pane1.Width - pane1.X, Height - pane1.Height - pane1.Y);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
+					else
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
 					break;
 				case ViewMode.Pane2Only:
 					SetRowColumn(_content1, 0, 2);
 					SetRowColumn(_content2, 0, 0);
 					_content1.IsVisible = false;
 					_content2.IsVisible = true;
-
-					_content1.Padding = new Thickness(0, 0, 0, 0);
-					// add padding to content where the content is under the hinge
-					_content2.Padding = new Thickness(pane1.X, pane1.Y, Width - pane1.Width - pane1.X, Height - pane1.Height - pane1.Y);
+					if (!isLayoutSpanned)
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						// add padding to content where the content is under the hinge
+						_content2.Padding = new Thickness(pane1.X, pane1.Y, Width - pane1.Width - pane1.X, Height - pane1.Height - pane1.Y);
+					}
+					else
+					{
+						_content1.Padding = new Thickness(0, 0, 0, 0);
+						_content2.Padding = new Thickness(0, 0, 0, 0);
+					}
 					break;
 			}
 

--- a/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs
@@ -257,7 +257,7 @@ namespace Xamarin.Forms.DualScreen
 						_newPane1 = new Rectangle(0, amountObscured, locationOnScreen.Width, locationOnScreen.Height - amountObscured);
 					}
 					else
-						_newPane1 = new Rectangle(0, 0, locationOnScreen.Height, locationOnScreen.Height);
+						_newPane1 = new Rectangle(0, 0, locationOnScreen.Width, locationOnScreen.Height);
 
 					_newPane2 = Rectangle.Zero;
 				}

--- a/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs
@@ -6,236 +6,333 @@ using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.DualScreen
 {
-    internal class TwoPaneViewLayoutGuide : INotifyPropertyChanged
-    {
-        public static TwoPaneViewLayoutGuide Instance => _twoPaneViewLayoutGuide.Value;
-        static Lazy<TwoPaneViewLayoutGuide> _twoPaneViewLayoutGuide = new Lazy<TwoPaneViewLayoutGuide>(() => new TwoPaneViewLayoutGuide());
+	internal class TwoPaneViewLayoutGuide : INotifyPropertyChanged
+	{
+		public static TwoPaneViewLayoutGuide Instance => _twoPaneViewLayoutGuide.Value;
+		static Lazy<TwoPaneViewLayoutGuide> _twoPaneViewLayoutGuide = new Lazy<TwoPaneViewLayoutGuide>(() => new TwoPaneViewLayoutGuide());
 
-        IDualScreenService DualScreenService =>
-            DependencyService.Get<IDualScreenService>() ?? NoDualScreenServiceImpl.Instance;
+		IDualScreenService DualScreenService =>
+			_dualScreenService ?? DependencyService.Get<IDualScreenService>() ?? NoDualScreenServiceImpl.Instance;
 
-        Rectangle _hinge;
-        Rectangle _leftPage;
-        Rectangle _rightPane;
-        TwoPaneViewMode _mode;
-        Layout _layout;
-        bool _isLandscape;
-        public event PropertyChangedEventHandler PropertyChanged;
-        List<string> _pendingPropertyChanges = new List<string>();
+		Rectangle _hinge;
+		Rectangle _leftPage;
+		Rectangle _rightPane;
+		TwoPaneViewMode _mode;
+		Layout _layout;
+		readonly IDualScreenService _dualScreenService;
+		bool _isLandscape;
+		public event PropertyChangedEventHandler PropertyChanged;
+		List<string> _pendingPropertyChanges = new List<string>();
 
-        TwoPaneViewLayoutGuide()
-        {
-        }
+		TwoPaneViewLayoutGuide()
+		{
+		}
 
-        public TwoPaneViewLayoutGuide(Layout layout)
-        {
-            _layout = layout;
-        }
+		public TwoPaneViewLayoutGuide(Layout layout)
+		{
+			_layout = layout;
+		}
 
-        public void WatchForChanges()
-        {
-            StopWatchingForChanges();
-            DualScreenService.OnScreenChanged += OnScreenChanged;
+		internal TwoPaneViewLayoutGuide(Layout layout, IDualScreenService dualScreenService)
+		{
+			_layout = layout;
+			_dualScreenService = dualScreenService;
+		}
 
-            if (_layout != null)
-            {
-                _layout.SizeChanged += OnLayoutChanged;
-            }
-            if (Device.Info is INotifyPropertyChanged npc)
-            {
-                npc.PropertyChanged += OnDeviceInfoChanged;
-            }
-        }
+		public void WatchForChanges()
+		{
+			StopWatchingForChanges();
+			DualScreenService.OnScreenChanged += OnScreenChanged;
 
-        public void StopWatchingForChanges()
-        {
-            DualScreenService.OnScreenChanged -= OnScreenChanged;
+			if (_layout != null)
+			{
+				_layout.SizeChanged += OnLayoutChanged;
+			}
 
-            if (_layout != null)
-            {
-                _layout.SizeChanged -= OnLayoutChanged;
-            }
-            if (Device.Info is INotifyPropertyChanged npc)
-            {
-                npc.PropertyChanged -= OnDeviceInfoChanged;
-            }
-        }
+			if (DualScreenService.DeviceInfo is INotifyPropertyChanged npc)
+			{
+				npc.PropertyChanged += OnDeviceInfoChanged;
+			}
+		}
 
-        void OnLayoutChanged(object sender, EventArgs e)
-        {
-            UpdateLayouts();
-        }
+		public void StopWatchingForChanges()
+		{
+			DualScreenService.OnScreenChanged -= OnScreenChanged;
 
-        void OnScreenChanged(object sender, EventArgs e)
-        {
-            UpdateLayouts();
-        }
+			if (_layout != null)
+			{
+				_layout.SizeChanged -= OnLayoutChanged;
+			}
 
-        void OnDeviceInfoChanged(object sender, PropertyChangedEventArgs args)
-        {
-            if (args.PropertyName == nameof(Device.Info.CurrentOrientation))
-            {
-                UpdateLayouts();
-            }
-        }
+			if (DualScreenService.DeviceInfo is INotifyPropertyChanged npc)
+			{
+				npc.PropertyChanged -= OnDeviceInfoChanged;
+			}
+		}
 
-        public bool IsLandscape
-        {
-            get => DualScreenService.IsLandscape;
-            set => SetProperty(ref _isLandscape, value);
-        }
+		void OnLayoutChanged(object sender, EventArgs e)
+		{
+			UpdateLayouts();
+		}
 
-        public TwoPaneViewMode Mode
-        {
-            get
-            {
-                return GetTwoPaneViewMode();
-            }
-            private set
-            {
-                SetProperty(ref _mode, value);
-            }
-        }
+		void OnScreenChanged(object sender, EventArgs e)
+		{
+			UpdateLayouts();
+		}
 
-        public Rectangle Pane1
-        {
-            get
-            {
-                return _leftPage;
-            }
-            private set
-            {
-                SetProperty(ref _leftPage, value);
-            }
-        }
+		void OnDeviceInfoChanged(object sender, PropertyChangedEventArgs args)
+		{
+			if (args.PropertyName == nameof(DualScreenService.DeviceInfo.CurrentOrientation))
+			{
+				UpdateLayouts();
+			}
+		}
 
-        public Rectangle Pane2
-        {
-            get
-            {
-                return _rightPane;
-            }
-            private set
-            {
-                SetProperty(ref _rightPane, value);
-            }
-        }
+		public bool IsLandscape
+		{
+			get => DualScreenService.IsLandscape;
+			set => SetProperty(ref _isLandscape, value);
+		}
 
-        public Rectangle Hinge
-        {
-            get
-            {
-                return DualScreenService.GetHinge();
-            }
-            private set
-            {
-                SetProperty(ref _hinge, value);
-            }
-        }
+		public TwoPaneViewMode Mode
+		{
+			get
+			{
+				return GetTwoPaneViewMode();
+			}
+			private set
+			{
+				SetProperty(ref _mode, value);
+			}
+		}
 
-        internal void UpdateLayouts()
-        {
-            Rectangle containerArea;
-            if (_layout == null)
-            {
-                containerArea = new Rectangle(Point.Zero, Device.info.ScaledScreenSize);
-            }
-            else
-            {
-                containerArea = _layout.Bounds;
-            }
+		public Rectangle Pane1
+		{
+			get
+			{
+				return _leftPage;
+			}
+			private set
+			{
+				SetProperty(ref _leftPage, value);
+			}
+		}
 
-            if (containerArea.Width <= 0)
-            {
-                return;
-            }
+		public Rectangle Pane2
+		{
+			get
+			{
+				return _rightPane;
+			}
+			private set
+			{
+				SetProperty(ref _rightPane, value);
+			}
+		}
 
-            Rectangle _newPane1 = Pane1;
-            Rectangle _newPane2 = Pane2;
+		public Rectangle Hinge
+		{
+			get
+			{
+				return DualScreenService.GetHinge();
+			}
+			private set
+			{
+				SetProperty(ref _hinge, value);
+			}
+		}
 
-            if (!DualScreenService.IsLandscape)
-            {
-                if (DualScreenService.IsSpanned)
-                {
-                    var paneWidth = (containerArea.Width - Hinge.Width) / 2;
-                    _newPane1 = new Rectangle(0, 0, paneWidth, containerArea.Height);
-                    _newPane2 = new Rectangle(paneWidth + Hinge.Width, 0, paneWidth, Pane1.Height);
-                }
-                else
-                {
-                    _newPane1 = new Rectangle(0, 0, containerArea.Width, containerArea.Height);
-                    _newPane2 = Rectangle.Zero;
-                }
-            }
-            else
-            {
-                if (DualScreenService.IsSpanned)
+		Rectangle GetContainerArea()
+		{
+			Rectangle containerArea;
+			if (_layout == null)
+			{
+				containerArea = new Rectangle(Point.Zero, DualScreenService.DeviceInfo.ScaledScreenSize);
+			}
+			else
+			{
+				containerArea = _layout.Bounds;
+			}
+
+			return containerArea;
+		}
+
+		Rectangle GetScreenRelativeBounds()
+		{
+			Rectangle containerArea;
+			if (_layout == null)
+			{
+				containerArea = new Rectangle(Point.Zero, DualScreenService.DeviceInfo.ScaledScreenSize);
+			}
+			else
+			{
+				var locationOnScreen = DualScreenService.GetLocationOnScreen(_layout);
+				if (!locationOnScreen.HasValue)
+					return Rectangle.Zero;
+
+				containerArea = new Rectangle(locationOnScreen.Value, _layout.Bounds.Size);
+			}
+
+			return containerArea;
+
+		}
+
+		internal void UpdateLayouts()
+		{
+			Rectangle containerArea = GetContainerArea();
+			if (containerArea.Width <= 0)
+			{
+				return;
+			}
+
+			// Pane dimensions are calculated relative to the layout container
+			Rectangle _newPane1 = Pane1;
+			Rectangle _newPane2 = Pane2;
+			var locationOnScreen = GetScreenRelativeBounds();
+			if (locationOnScreen == Rectangle.Zero && Hinge == Rectangle.Zero)
+				locationOnScreen = containerArea;
+
+			bool isSpanned = IsInMultipleRegions(locationOnScreen);
+
+			if (!DualScreenService.IsLandscape)
+			{
+				if (isSpanned)
 				{
-					Point displayedScreenAbsCoordinates = Point.Zero;
+					var pane2X = Hinge.X + Hinge.Width;
+					var containerRightX = locationOnScreen.X + locationOnScreen.Width;
+					var pane2Width = containerRightX - pane2X;
 
-					if (_layout != null)
-						displayedScreenAbsCoordinates = DualScreenService.GetLocationOnScreen(_layout) ?? Point.Zero;
+					_newPane1 = new Rectangle(0, 0, Hinge.X - locationOnScreen.X, locationOnScreen.Height);
+					_newPane2 = new Rectangle(_newPane1.Width + Hinge.Width, 0, pane2Width, locationOnScreen.Height);
+				}
+				else
+				{
+					// Check if part of the layout is underneath the hinge
+					var containerRightX = locationOnScreen.X + locationOnScreen.Width;
+					var hingeRightX = Hinge.X + Hinge.Width;
 
-					var screenSize = Device.info.ScaledScreenSize;
-                    var topStuffHeight = displayedScreenAbsCoordinates.Y;
-                    var bottomStuffHeight = screenSize.Height - topStuffHeight - containerArea.Height;
-                    var paneWidth = containerArea.Width;
-                    var leftPaneHeight = Hinge.Y - topStuffHeight;
-                    var rightPaneHeight = screenSize.Height - topStuffHeight - leftPaneHeight - bottomStuffHeight - Hinge.Height;
+					// Right side under hinge
+					if (containerRightX > Hinge.X && containerRightX < hingeRightX)
+					{
+						_newPane1 = new Rectangle(0, 0, Hinge.X - locationOnScreen.X, locationOnScreen.Height);
+					}
+					// left side under hinge
+					else if (Hinge.X < locationOnScreen.X && hingeRightX > locationOnScreen.X)
+					{
+						var amountObscured = hingeRightX - locationOnScreen.X;
+						_newPane1 = new Rectangle(amountObscured, 0, locationOnScreen.Width - amountObscured, locationOnScreen.Height);
+					}
+					else
+						_newPane1 = new Rectangle(0, 0, locationOnScreen.Width, locationOnScreen.Height);
 
-                    _newPane1 = new Rectangle(0, 0, paneWidth, leftPaneHeight);
-                    _newPane2 = new Rectangle(0, Hinge.Y + Hinge.Height - topStuffHeight, paneWidth, rightPaneHeight);
-                }
-                else
-                {
-                    _newPane1 = new Rectangle(0, 0, containerArea.Width, containerArea.Height);
-                    _newPane2 = Rectangle.Zero;
-                }
-            }
+					_newPane2 = Rectangle.Zero;
+				}
+			}
+			else
+			{
+				if (isSpanned)
+				{
+					var pane2Y = Hinge.Y + Hinge.Height;
+					var containerBottomY = locationOnScreen.Y + locationOnScreen.Height;
+					var pane2Height = containerBottomY - pane2Y;
 
-            if (_newPane2.Height < 0 || _newPane2.Width < 0)
-                _newPane2 = Rectangle.Zero;
+					_newPane1 = new Rectangle(0, 0, locationOnScreen.Width, Hinge.Y - locationOnScreen.Y);
+					_newPane2 = new Rectangle(0, _newPane1.Height + Hinge.Height, locationOnScreen.Width, pane2Height);
+				}
+				else
+				{
+					// Check if part of the layout is underneath the hinge
+					var containerBottomY = locationOnScreen.Y + locationOnScreen.Height;
+					var hingeBottomY = Hinge.Y + Hinge.Height;
 
-            if (_newPane1.Height < 0 || _newPane1.Width < 0)
-                _newPane1 = Rectangle.Zero;
+					// Right side under hinge
+					if (containerBottomY > Hinge.Y && containerBottomY < hingeBottomY)
+					{
+						_newPane1 = new Rectangle(0, 0, locationOnScreen.Width, Hinge.Y - locationOnScreen.Y);
+					}
+					// left side under hinge
+					else if (Hinge.Y < locationOnScreen.Y && hingeBottomY > locationOnScreen.Y)
+					{
+						var amountObscured = hingeBottomY - locationOnScreen.Y;
+						_newPane1 = new Rectangle(0, amountObscured, locationOnScreen.Width, locationOnScreen.Height - amountObscured);
+					}
+					else
+						_newPane1 = new Rectangle(0, 0, locationOnScreen.Height, locationOnScreen.Height);
 
-            Pane1 = _newPane1;
-            Pane2 = _newPane2;
-            Mode = GetTwoPaneViewMode();
-            Hinge = DualScreenService.GetHinge();
-            IsLandscape = DualScreenService.IsLandscape;
+					_newPane2 = Rectangle.Zero;
+				}
+			}
 
-            var properties = _pendingPropertyChanges.ToList();
-            _pendingPropertyChanges.Clear();
+			if (_newPane2.Height < 0 || _newPane2.Width < 0)
+				_newPane2 = Rectangle.Zero;
 
-            foreach(var property in properties)
-            {
-                PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
-            }
-        }
+			if (_newPane1.Height < 0 || _newPane1.Width < 0)
+				_newPane1 = Rectangle.Zero;
 
-        TwoPaneViewMode GetTwoPaneViewMode()
-        {
-            if (!DualScreenService.IsSpanned)
-                return TwoPaneViewMode.SinglePane;
+			Pane1 = _newPane1;
+			Pane2 = _newPane2;
+			Mode = GetTwoPaneViewMode();
+			Hinge = DualScreenService.GetHinge();
+			IsLandscape = DualScreenService.IsLandscape;
 
-            if (DualScreenService.IsLandscape)
-                return TwoPaneViewMode.Tall;
+			var properties = _pendingPropertyChanges.ToList();
+			_pendingPropertyChanges.Clear();
 
-            return TwoPaneViewMode.Wide;
-        }
+			foreach (var property in properties)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(property));
+			}
+		}
 
-        protected bool SetProperty<T>(ref T backingStore, T value,
-            [CallerMemberName]string propertyName = "",
-            Action onChanged = null)
-        {
-            if (EqualityComparer<T>.Default.Equals(backingStore, value))
-                return false;
 
-            backingStore = value;
-            onChanged?.Invoke();
-            _pendingPropertyChanges.Add(propertyName);
-            return true;
-        }
-    }
+		bool IsInMultipleRegions(Rectangle layoutBounds)
+		{
+			bool isInMultipleRegions = false;
+			var hinge = DualScreenService.GetHinge();
+
+			// Portrait
+			if (!DualScreenService.IsLandscape)
+			{
+				// Check that the control is over the split
+				if (layoutBounds.X < hinge.X && layoutBounds.X + layoutBounds.Width > (hinge.X + hinge.Width))
+				{
+					isInMultipleRegions = true;
+				}
+			}
+			else
+			{
+				// Check that the control is over the split
+				if (layoutBounds.Y < hinge.Y && layoutBounds.Y + layoutBounds.Height > (hinge.Y + hinge.Height))
+				{
+					isInMultipleRegions = true;
+				}
+			}
+
+			return isInMultipleRegions;
+		}
+
+		TwoPaneViewMode GetTwoPaneViewMode()
+		{
+			if (!IsInMultipleRegions(GetContainerArea()))
+				return TwoPaneViewMode.SinglePane;
+
+			if (DualScreenService.IsLandscape)
+				return TwoPaneViewMode.Tall;
+
+			return TwoPaneViewMode.Wide;
+		}
+
+		protected bool SetProperty<T>(ref T backingStore, T value,
+			[CallerMemberName]string propertyName = "",
+			Action onChanged = null)
+		{
+			if (EqualityComparer<T>.Default.Equals(backingStore, value))
+				return false;
+
+			backingStore = value;
+			onChanged?.Invoke();
+			_pendingPropertyChanges.Add(propertyName);
+			return true;
+		}
+	}
 }

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -34,6 +34,7 @@
   <ItemGroup>
     <Compile Include="**\*.shared.cs" />
     <Compile Include="**\*.shared.*.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('netstandard')) ">
     <Compile Include="**\*.netstandard.cs" />


### PR DESCRIPTION
### Description of Change ###

Fix TPV to always take into account the hinge regardless of size and position
- If any layout is spanned over the hinge it'll correctly size pane1/pane2
- If the hinge is only overlapping the tpv one one of the sides but the tpv doesn't span across the hinge then this will add padding to the tpv so content doesn't flow underneath the hinge
- Added constructor for DualScreenInfo to take a layout so users can supply whatever layout they want to to DualScreenInfo and it will return the calculations for that layout relative to the Hinge


### API Changes ###
Added:
 - public DualScreenInfo(Layout layout)

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
