### PR TITLE
[iOS] Fix NRE when Entry Completed fires

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -246,7 +246,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Control.ResignFirstResponder();
 			((IEntryController)Element).SendCompleted();
 
-			if (Element.ReturnType == ReturnType.Next)
+			if (Element != null && Element.ReturnType == ReturnType.Next)
 			{
 				FocusSearch(true);
 			}


### PR DESCRIPTION
### Description of Change ###

When we fire the completed event on the entry on iOS we could also be disposed , so the Element will be set to null.  Since in that event we were checking the ReturnType it could throw a NRE

### Issues Resolved ### 
- fixes #9460 

### API Changes ###
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
on App.cs use this code :

```
	var page = new ContentPage();
        var entry = new Entry();
	entry.Completed += (s,e) => SetMainPage(CreateDefaultMainPage());
        page.Content = entry;
	MainPage = page;
```

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
