### PR TITLE
[iOS] Fixed SwipeView regression issue 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9417.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9417.xaml
@@ -1,0 +1,71 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:androidSpecific="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+    xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9417"
+    x:Name="Issue9417Page">
+    <controls:TestContentPage.BindingContext>
+        <x:Reference Name="Issue9417Page"/>
+    </controls:TestContentPage.BindingContext>
+    <controls:TestContentPage.Resources>
+        <ResourceDictionary>
+
+            <x:String x:Key="TrashCanImage">calculator.png</x:String>
+            <x:String x:Key="EditImage">calculator.png</x:String>
+            <Color x:Key="DeleteButtonColor">Red</Color>
+            <Color x:Key="SaveButtonColor">Blue</Color>
+
+        </ResourceDictionary>
+    </controls:TestContentPage.Resources> 
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition/>
+        </Grid.RowDefinitions>
+        <CollectionView
+            Grid.Row="1"
+            ItemsSource="{Binding Items}"
+            androidSpecific:ListView.IsFastScrollEnabled="True"
+            VerticalOptions="FillAndExpand"
+            ItemSizingStrategy="MeasureAllItems">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="local:Issue9417Model">
+                    <SwipeView>
+                        <SwipeView.RightItems>
+                            <SwipeItems>
+                                <SwipeItem
+                                    Command="{Binding Source={x:Reference Issue9417Page}, Path=BindingContext.DeleteCommand}" 
+                                    CommandParameter="{Binding .}" 
+                                    Text="Delete" 
+                                    Icon="{StaticResource TrashCanImage}"
+                                    BackgroundColor="{StaticResource DeleteButtonColor}" />
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                        <SwipeView.LeftItems>
+                            <SwipeItems>
+                                <SwipeItem
+                                    Command="{Binding Source={x:Reference Issue9417Page}, Path=BindingContext.EditCommand}"
+                                    CommandParameter="{Binding .}"
+                                    Text="Edit"
+                                    Icon="{StaticResource EditImage}"
+                                    BackgroundColor="{StaticResource SaveButtonColor}" />
+                            </SwipeItems>
+                        </SwipeView.LeftItems>
+                            <Label
+                                HeightRequest="60"
+                                BackgroundColor="Beige"
+                                HorizontalTextAlignment="Center"
+                                VerticalTextAlignment="Center"
+                                Text="Swipe me"/>
+                        </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9417.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9417.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Linq;
+using System.Windows.Input;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+#if APP
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 9417, "[iOS] XF 4.5 pre2 crashes on Swipe GetSwipeItemSize", PlatformAffected.iOS)]
+    public partial class Issue9417 : TestContentPage
+    {
+        public Issue9417()
+        {
+#if APP
+            Title = "Issue 9417";
+            InitializeComponent();
+#endif
+        }
+
+        public ObservableCollection<Issue9417Model> Items { get; set; } = new ObservableCollection<Issue9417Model>(Enumerable.Range(0, 10).Select(i => new Issue9417Model()));
+        public Command DeleteCommand { get; set; }
+        public Command EditCommand { get; set; }
+
+        protected override void Init()
+        {
+
+        }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class Issue9417Model
+    {
+
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1291,6 +1291,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9767.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9054.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9306.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9417.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1465,6 +1466,9 @@
        <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9588.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9417.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Core/SwipeView.cs
+++ b/Xamarin.Forms.Core/SwipeView.cs
@@ -120,14 +120,8 @@ namespace Xamarin.Forms
 		{
 			swipeItems.Parent = this;
 
-			foreach (var item in swipeItems)
-			{
-				if (item is SwipeItem swipeItem)
-					swipeItem.Parent = swipeItems;
-
-				if (item is SwipeItemView swipeItemView)
-					swipeItemView.Parent = swipeItems;
-			}
+			foreach (var swipeItem in swipeItems)
+				((Element)swipeItem).Parent = swipeItems;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -992,16 +992,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		double ValidateSwipeThreshold(double swipeThreshold)
 		{
+			var swipeFrame = _contentView != null ? _contentView.Frame : Frame;
+
 			if (IsHorizontalSwipe())
 			{
-				if (swipeThreshold > _contentView.Frame.Width)
-					swipeThreshold = _contentView.Frame.Width;
+				if (swipeThreshold > swipeFrame.Width)
+					swipeThreshold = swipeFrame.Width;
 
 				return swipeThreshold;
 			}
 
-			if (swipeThreshold > _contentView.Frame.Height)
-				swipeThreshold = _contentView.Frame.Height;
+			if (swipeThreshold > swipeFrame.Height)
+				swipeThreshold = swipeFrame.Height;
 
 			return swipeThreshold;
 		}
@@ -1009,27 +1011,28 @@ namespace Xamarin.Forms.Platform.iOS
 		Size GetSwipeItemSize(ISwipeItem swipeItem)
 		{
 			var items = GetSwipeItemsByDirection();
+			var swipeFrame = _contentView != null ? _contentView.Frame : Frame;
 
 			if (IsHorizontalSwipe())
 			{
 				if (swipeItem is SwipeItem)
-					return new Size(items.Mode == SwipeMode.Execute ? _contentView.Frame.Width / items.Count : SwipeItemWidth, _contentView.Frame.Height);
+					return new Size(items.Mode == SwipeMode.Execute ? swipeFrame.Width / items.Count : SwipeItemWidth, swipeFrame.Height);
 
 				if (swipeItem is SwipeItemView horizontalSwipeItemView)
 				{
 					var swipeItemViewSizeRequest = horizontalSwipeItemView.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-					return new Size(swipeItemViewSizeRequest.Request.Width > 0 ? (float)swipeItemViewSizeRequest.Request.Width : SwipeItemWidth, _contentView.Frame.Height);
+					return new Size(swipeItemViewSizeRequest.Request.Width > 0 ? (float)swipeItemViewSizeRequest.Request.Width : SwipeItemWidth, swipeFrame.Height);
 				}
 			}
 			else
 			{
 				if (swipeItem is SwipeItem)
-					return new Size(_contentView.Frame.Width / items.Count, GetSwipeItemHeight()); 
+					return new Size(swipeFrame.Width / items.Count, GetSwipeItemHeight()); 
 
 				if (swipeItem is SwipeItemView horizontalSwipeItemView)
 				{
 					var swipeItemViewSizeRequest = horizontalSwipeItemView.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-					return new Size(_contentView.Frame.Width / items.Count, swipeItemViewSizeRequest.Request.Height > 0 ? (float)swipeItemViewSizeRequest.Request.Height : _contentView.Frame.Height);
+					return new Size(swipeFrame.Width / items.Count, swipeItemViewSizeRequest.Request.Height > 0 ? (float)swipeItemViewSizeRequest.Request.Height : swipeFrame.Height);
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

Fixed SwipeView regression issue adding some View as content without using a Layout on iOS.

### Issues Resolved ### 

- fixes #9417

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

After
![fix9417](https://user-images.githubusercontent.com/6755973/74032124-83f3fb80-49b3-11ea-9a27-7a748ec56c7e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue9417. Try to swipe some item from the collection. If you can swipe without problems, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
