### PR TITLE
Set CALayer and UIView on main thread

### DIFF
--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -309,7 +309,7 @@ namespace Xamarin.Forms.Platform.MacOS
 							caLayer.AnchorPoint = _originalAnchor;
 
 						caLayer.Transform = transform;
-						uiview.Frame = newTarget;
+						uiview.Frame = newTarget.Value;
 
 						if (shouldRelayoutSublayers)
 							caLayer.LayoutSublayers();


### PR DESCRIPTION
### Description of Change ###

This fixes cases where CALayer and UIView are sometimes modified by background threads. The previous code was inconsistent, in one place ensuring that CALayer.Transform was called on the main thread and in another place not. Now, modification is always on the main thread.

I made the change solely based on examining the existing code. I have not tested or even compiled the change.

### Issues Resolved ### 

- fixes #9469

### Platforms Affected ### 

- iOS

### PR Checklist ###

- [ ] Targets the correct branch [It probably doesn't. I didn't see the note about targeting latest stable until I had already made the commit from master in GitHub. It would be great if someone could move the change to the proper branch.]
- [ ] Tests are passing (or failures are unrelated)
