### PR TITLE
Adding null check for picker items

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2674.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2674.cs
@@ -1,0 +1,46 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Picker)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2674, "Exception occurs when giving null values in picker itemsource collection", PlatformAffected.All)]
+	public class Issue2674 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var _picker = new Picker()
+			{
+				ItemsSource = new List<string> { "cat", null, "rabbit" },
+				AutomationId = "picker",
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					_picker
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Issue2674Test()
+		{
+			RunningApp.Screenshot("I am at Issue2674");
+			RunningApp.WaitForElement("picker");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3228.xaml.cs">
       <DependentUpon>Issue3228.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Forms
 		string GetDisplayMember(object item)
 		{
 			if (ItemDisplayBinding == null)
-				return item.ToString();
+				return item == null ? string.Empty : item.ToString();
 
 			ItemDisplayBinding.Apply(item, this, s_displayProperty);
 			ItemDisplayBinding.Unapply();


### PR DESCRIPTION
### Description of Change ###

Adding a null check for items in Picker source and add Empty string for any null item

### Issues Resolved ### 

- fixes #2674 

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
If there are null items in Picker source list, UI will display empty entries instread of crashing

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Tested in Android simulator by running test before and after fix

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
