### PR TITLE
[Android] Properly unsubscribe ToolbarItem on removal

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9419.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9419.cs
@@ -1,0 +1,143 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ToolbarItem)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9419, "Crash when toolbar item removed then page changed", PlatformAffected.Android)]
+	public class Issue9419 : TestMasterDetailPage
+	{
+		const string OkResult = "Ok";
+
+		protected override async void Init()
+		{
+			Master = new ContentPage { Title = "Title" };
+			Detail = new NavigationPage(new Issue9419Page());
+
+			await Task.Delay(TimeSpan.FromSeconds(3));
+
+			Detail = new NavigationPage(new Issue9419Page());
+			
+			await Task.Delay(TimeSpan.FromSeconds(3));
+
+			GarbageCollectionHelper.Collect();
+
+			Detail = new NavigationPage(new ContentPage { Content = new Label { Text = OkResult } });
+		}
+
+		class ConditionalToolbarItem : ToolbarItem
+		{
+			public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(ConditionalToolbarItem), true, propertyChanged: IsVisiblePropertyChanged);
+			public static readonly BindableProperty IndexProperty = BindableProperty.Create(nameof(Index), typeof(int), typeof(ConditionalToolbarItem), 0);
+
+			public bool IsVisible
+			{
+				get { return (bool)GetValue(IsVisibleProperty); }
+				set { SetValue(IsVisibleProperty, value); }
+			}
+
+			public int Index
+			{
+				get { return (int)GetValue(IndexProperty); }
+				set { SetValue(IndexProperty, value); }
+			}
+
+			static void IsVisiblePropertyChanged(BindableObject bindable, object oldValue, object newValue)
+			{
+				var item = (ConditionalToolbarItem)bindable;
+
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					IList<ToolbarItem> items = ((Page)item.Parent)?.ToolbarItems;
+					
+					if (items == null) return;
+					
+					bool setValue = item.IsVisible;
+
+					if (setValue && !items.Contains(item))
+					{
+						int index = items.Count;
+						
+						for (int i = 0; i < items.Count; i++)
+						{
+							if (((ConditionalToolbarItem)items[i]).Index > item.Index)
+							{
+								index = i;
+								break;
+							}
+						}
+						
+						items.Insert(index, item);
+					}
+					else if (!setValue && items.Contains(item))
+					{
+						items.Remove(item);
+					}
+				});
+			}
+		}
+
+		class Issue9419Page : TestContentPage
+		{
+			ConditionalToolbarItem _conditionalToolbarItem;
+
+			bool _isVisible;
+
+			protected override void Init()
+			{
+				_conditionalToolbarItem = new ConditionalToolbarItem { Text = "Test" };
+
+				ToolbarItems.Add(_conditionalToolbarItem);
+			}
+
+			protected override async void OnAppearing()
+			{
+				base.OnAppearing();
+
+				_isVisible = true;
+
+				while (true)
+				{
+					_conditionalToolbarItem.IsVisible = !_conditionalToolbarItem.IsVisible;
+
+					await Task.Delay(TimeSpan.FromSeconds(1));
+
+					if (!_isVisible)
+					{
+						_conditionalToolbarItem.IsVisible = !_conditionalToolbarItem.IsVisible;
+
+						return;
+					}
+				}
+			}
+
+			protected override void OnDisappearing()
+			{
+				base.OnDisappearing();
+
+				_isVisible = false;
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void TestIssue9419()
+		{
+			RunningApp.WaitForElement(OkResult);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9419.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8262.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8902.xaml.cs">
       <DependentUpon>Issue8902.xaml</DependentUpon>

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -57,8 +57,8 @@ namespace Xamarin.Forms.Internals
 				List<ToolbarItem> returnValue = GetCurrentToolbarItems(Target);
 
 				if (AdditionalTargets != null)
-					foreach(var item in AdditionalTargets)
-						foreach(var toolbarItem in item.ToolbarItems)
+					foreach (var item in AdditionalTargets)
+						foreach (var toolbarItem in item.ToolbarItems)
 							returnValue.Add(toolbarItem);
 
 				returnValue.Sort(_toolBarItemComparer);
@@ -70,6 +70,11 @@ namespace Xamarin.Forms.Internals
 
 		void EmitCollectionChanged()
 			=> CollectionChanged?.Invoke(this, EventArgs.Empty);
+
+		public event EventHandler<NotifyCollectionChangedEventArgs> ToolbarItemsCollectionChanged;
+
+		void EmitToolbarItemsCollectionChanged(NotifyCollectionChangedEventArgs eventArgs) 
+			=> ToolbarItemsCollectionChanged?.Invoke(this, eventArgs);
 
 		List<ToolbarItem> GetCurrentToolbarItems(Page page)
 		{
@@ -131,6 +136,8 @@ namespace Xamarin.Forms.Internals
 		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
 			EmitCollectionChanged();
+
+			EmitToolbarItemsCollectionChanged(notifyCollectionChangedEventArgs);
 		}
 
 		void OnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)

--- a/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
+++ b/Xamarin.Forms.Core/Internals/ToolbarTracker.cs
@@ -71,11 +71,6 @@ namespace Xamarin.Forms.Internals
 		void EmitCollectionChanged()
 			=> CollectionChanged?.Invoke(this, EventArgs.Empty);
 
-		public event EventHandler<NotifyCollectionChangedEventArgs> ToolbarItemsCollectionChanged;
-
-		void EmitToolbarItemsCollectionChanged(NotifyCollectionChangedEventArgs eventArgs) 
-			=> ToolbarItemsCollectionChanged?.Invoke(this, eventArgs);
-
 		List<ToolbarItem> GetCurrentToolbarItems(Page page)
 		{
 			var result = new List<ToolbarItem>();
@@ -136,8 +131,6 @@ namespace Xamarin.Forms.Internals
 		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs notifyCollectionChangedEventArgs)
 		{
 			EmitCollectionChanged();
-
-			EmitToolbarItemsCollectionChanged(notifyCollectionChangedEventArgs);
 		}
 
 		void OnPropertyChanged(object sender, PropertyChangedEventArgs propertyChangedEventArgs)

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -9,7 +10,6 @@ using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
 using Android.Graphics.Drawables;
-using Android.OS;
 using Android.Runtime;
 using Android.Support.V4.Widget;
 using Android.Support.V7.Graphics.Drawable;
@@ -25,7 +25,6 @@ using FragmentTransaction = Android.Support.V4.App.FragmentTransaction;
 using Object = Java.Lang.Object;
 using static Xamarin.Forms.PlatformConfiguration.AndroidSpecific.AppCompat.NavigationPage;
 using static Android.Views.View;
-using System.IO;
 using Android.Widget;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
@@ -224,6 +223,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				if (_toolbarTracker != null)
 				{
 					_toolbarTracker.CollectionChanged -= ToolbarTrackerOnCollectionChanged;
+					_toolbarTracker.ToolbarItemsCollectionChanged -= ToolbarTrackerOnToolbarItemsCollectionChanged;
 
 					_toolbar.DisposeMenuItems(_toolbarTracker?.ToolbarItems, OnToolbarItemPropertyChanged);
 
@@ -340,6 +340,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					SetupToolbar();
 					_toolbarTracker = new ToolbarTracker();
 					_toolbarTracker.CollectionChanged += ToolbarTrackerOnCollectionChanged;
+					_toolbarTracker.ToolbarItemsCollectionChanged += ToolbarTrackerOnToolbarItemsCollectionChanged;
 				}
 
 				var parents = new List<Page>();
@@ -894,6 +895,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void ToolbarTrackerOnCollectionChanged(object sender, EventArgs eventArgs)
 		{
 			UpdateMenu();
+		}
+
+		void ToolbarTrackerOnToolbarItemsCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.OldItems == null)
+			{
+				return;
+			}
+
+			foreach (var toolbarItem in e.OldItems.OfType<ToolbarItem>())
+			{
+				toolbarItem.PropertyChanged -= OnToolbarItemPropertyChanged;
+			}
 		}
 
 		void UpdateMenu()

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -69,14 +69,13 @@ namespace Xamarin.Forms.Platform.Android
 			item.PropertyChanged -= toolbarItemChanged;
 			item.PropertyChanged += toolbarItemChanged;
 
-			toolbarItemsCreated?.Add(item);
-
 			IMenuItem menuitem;
 
 			if (menuItemIndex == null)
 			{
 				menuitem = menu.Add(new Java.Lang.String(item.Text));
 				menuItemsCreated?.Add(menuitem);
+				toolbarItemsCreated?.Add(item);
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -1,12 +1,11 @@
-﻿using System.ComponentModel;
+using System.ComponentModel;
 using Android.Views;
 using AToolbar = Android.Support.V7.Widget.Toolbar;
-using ATextView = global::Android.Widget.TextView;
+using ATextView = Android.Widget.TextView;
 using Android.Content;
 using Android.Graphics;
 using System.Collections.Generic;
 using System;
-using System.Linq;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -28,8 +27,10 @@ namespace Xamarin.Forms.Platform.Android
 			Color? tintColor,
 			PropertyChangedEventHandler toolbarItemChanged,
 			List<IMenuItem> menuItemsCreated,
-			Action<Context, IMenuItem, ToolbarItem> updateMenuItemIcon = null
-			)
+			List<ToolbarItem> toolbarItemsCreated,
+			Action<Context, 
+			IMenuItem, 
+			ToolbarItem> updateMenuItemIcon = null)
 		{
 			if (sortedToolbarItems == null || menuItemsCreated == null)
 				return;
@@ -40,37 +41,42 @@ namespace Xamarin.Forms.Platform.Android
 			foreach (var menuItem in menuItemsCreated)
 				menuItem.Dispose();
 
-			menuItemsCreated.Clear();
+			foreach (var toolbarItem in toolbarItemsCreated)
+				toolbarItem.PropertyChanged -= toolbarItemChanged;
 
-			int i = 0;
+			menuItemsCreated.Clear();
+			toolbarItemsCreated.Clear();
+
 			foreach (var item in sortedToolbarItems)
 			{
-				UpdateMenuItem(toolbar, context, menuItemsCreated, item, tintColor, toolbarItemChanged, null, updateMenuItemIcon);
-				i++;
+				UpdateMenuItem(toolbar, item, null, context, tintColor, toolbarItemChanged, menuItemsCreated, toolbarItemsCreated, updateMenuItemIcon);
 			}
 		}
 
-		internal static void UpdateMenuItem(
-			AToolbar toolbar,
-			Context context, 
-			List<IMenuItem> menuItemsCreated, 
-			ToolbarItem item, 
+		internal static void UpdateMenuItem(AToolbar toolbar,
+			ToolbarItem item,
+			int? menuItemIndex,
+			Context context,
 			Color? tintColor,
 			PropertyChangedEventHandler toolbarItemChanged,
-			int? menuItemIndex,
-			Action<Context, IMenuItem, ToolbarItem> updateMenuItemIcon = null)
+			List<IMenuItem> menuItemsCreated,
+			List<ToolbarItem> toolbarItemsCreated,
+			Action<Context,
+			IMenuItem, 
+			ToolbarItem> updateMenuItemIcon = null)
 		{
 			IMenu menu = toolbar.Menu;
 			item.PropertyChanged -= toolbarItemChanged;
 			item.PropertyChanged += toolbarItemChanged;
 
-			IMenuItem menuitem = null;
+			toolbarItemsCreated?.Add(item);
+
+			IMenuItem menuitem;
 
 			if (menuItemIndex == null)
 			{
 				menuitem = menu.Add(new Java.Lang.String(item.Text));
-				if (menuItemsCreated != null)
-					menuItemsCreated.Add(menuitem);
+				menuItemsCreated?.Add(menuitem);
 			}
 			else
 			{
@@ -91,7 +97,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (updateMenuItemIcon != null)
 				updateMenuItemIcon(context, menuitem, item);
 			else
-				UpdateMenuItemIcon(context, menu, menuItemsCreated, menuitem, item, tintColor);
+				UpdateMenuItemIcon(context, menuitem, item, tintColor);
 
 			if (item.Order != ToolbarItemOrder.Secondary)
 				menuitem.SetShowAsAction(ShowAsAction.Always);
@@ -111,9 +117,9 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		internal static void UpdateMenuItemIcon(Context context, IMenu menu, List<IMenuItem> menuItemsCreated, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
+		internal static void UpdateMenuItemIcon(Context context, IMenuItem menuItem, ToolbarItem toolBarItem, Color? tintColor)
 		{
-			_ = context.ApplyDrawableAsync(toolBarItem, ToolbarItem.IconImageSourceProperty, baseDrawable =>
+			_ = context.ApplyDrawableAsync(toolBarItem, MenuItem.IconImageSourceProperty, baseDrawable =>
 			{
 				if (menuItem == null || !menuItem.IsAlive())
 				{
@@ -144,37 +150,41 @@ namespace Xamarin.Forms.Platform.Android
 			this AToolbar toolbar,
 			PropertyChangedEventArgs e,
 			ToolbarItem toolbarItem,
-			IEnumerable<ToolbarItem> toolbarItems,
+			ICollection<ToolbarItem> toolbarItems,
 			Context context,
 			Color? tintColor,
 			PropertyChangedEventHandler toolbarItemChanged,
 			List<IMenuItem> currentMenuItems,
-			Action<Context, IMenuItem, ToolbarItem> updateMenuItemIcon = null)
+			List<ToolbarItem> currentToolbarItems,
+			Action<Context, 
+			IMenuItem,
+			ToolbarItem> updateMenuItemIcon = null)
 		{
 			if (toolbarItems == null)
 				return;
 
-			if (e.IsOneOf(MenuItem.TextProperty, MenuItem.IconImageSourceProperty, MenuItem.IsEnabledProperty))
-			{
-				int index = 0;
-				foreach (var item in toolbarItems)
-				{
-					if(item == toolbarItem)
-					{
-						break;
-					}
+			if (!e.IsOneOf(MenuItem.TextProperty, MenuItem.IconImageSourceProperty, MenuItem.IsEnabledProperty))
+				return;
 
-					index++;
+			int index = 0;
+
+			foreach (var item in toolbarItems)
+			{
+				if(item == toolbarItem)
+				{
+					break;
 				}
 
-				if (index >= currentMenuItems.Count)
-					return;
-
-				if (currentMenuItems[index].IsAlive())
-					UpdateMenuItem(toolbar, context, currentMenuItems, toolbarItem, tintColor, toolbarItemChanged, index, updateMenuItemIcon);
-				else
-					UpdateMenuItems(toolbar, toolbarItems, context, tintColor, toolbarItemChanged, currentMenuItems, updateMenuItemIcon);
+				index++;
 			}
+
+			if (index >= currentMenuItems.Count)
+				return;
+
+			if (currentMenuItems[index].IsAlive())
+				UpdateMenuItem(toolbar, toolbarItem, index, context, tintColor, toolbarItemChanged, currentMenuItems, currentToolbarItems, updateMenuItemIcon);
+			else
+				UpdateMenuItems(toolbar, toolbarItems, context, tintColor, toolbarItemChanged, currentMenuItems, currentToolbarItems, updateMenuItemIcon);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -1,4 +1,3 @@
-﻿using Android.App;
 using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
@@ -17,11 +16,9 @@ using LP = Android.Views.ViewGroup.LayoutParams;
 using R = Android.Resource;
 using Toolbar = Android.Support.V7.Widget.Toolbar;
 using ADrawableCompat = Android.Support.V4.Graphics.Drawable.DrawableCompat;
-using ATextView = global::Android.Widget.TextView;
 using Android.Support.Design.Widget;
-using AColor = Android.Graphics.Color;
-using Xamarin.Forms.Internals;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -58,6 +55,7 @@ namespace Xamarin.Forms.Platform.Android
 		float _appBarElevation;
 		GenericGlobalLayoutListener _globalLayoutListener;
 		List<IMenuItem> _currentMenuItems = new List<IMenuItem>();
+		List<ToolbarItem> _currentToolbarItems = new List<ToolbarItem>();
 
 		public ShellToolbarTracker(IShellContext shellContext, Toolbar toolbar, DrawerLayout drawerLayout)
 		{
@@ -158,10 +156,9 @@ namespace Xamarin.Forms.Platform.Android
 				if (_backButtonBehavior != null)
 					_backButtonBehavior.PropertyChanged -= OnBackButtonBehaviorChanged;
 
+				_toolbar.DisposeMenuItems(_currentToolbarItems, OnToolbarItemPropertyChanged);
 
-				_toolbar.DisposeMenuItems(Page?.ToolbarItems, OnToolbarItemPropertyChanged);
-
-				((IShellController)_shellContext?.Shell)?.RemoveFlyoutBehaviorObserver(this);
+				((IShellController)_shellContext.Shell)?.RemoveFlyoutBehaviorObserver(this);
 
 				UpdateTitleView(_shellContext.AndroidContext, _toolbar, null);
 
@@ -173,13 +170,14 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.Dispose();
 				}
 
-				if (_currentMenuItems != null)
-					_currentMenuItems.Clear();
+				_currentMenuItems?.Clear();
+				_currentToolbarItems?.Clear();
 
 				_drawerToggle?.Dispose();
 			}
 
 			_currentMenuItems = null;
+			_currentToolbarItems = null;
 			_globalLayoutListener = null;
 			_backButtonBehavior = null;
 			SearchHandler = null;
@@ -190,6 +188,7 @@ namespace Xamarin.Forms.Platform.Android
 			_toolbar = null;
 			_appBar = null;
 			_drawerLayout = null;
+
 			base.Dispose(disposing);
 		}
 
@@ -349,7 +348,7 @@ namespace Xamarin.Forms.Platform.Android
 					icon = new FlyoutIconDrawerDrawable(context, tintColor, customIcon, text);
 			}
 
-			if (!String.IsNullOrWhiteSpace(text) && icon == null)
+			if (!string.IsNullOrWhiteSpace(text) && icon == null)
 				icon = new FlyoutIconDrawerDrawable(context, tintColor, icon, text);
 
 			if(icon == null)
@@ -380,7 +379,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_drawerToggle.DrawerIndicatorEnabled = false;
 			}
-
 
 			_drawerToggle.SyncState();
 
@@ -497,9 +495,9 @@ namespace Xamarin.Forms.Platform.Android
 		protected virtual void UpdateToolbarItems(Toolbar toolbar, Page page)
 		{
 			var menu = toolbar.Menu;
-			var sortedItems = System.Linq.Enumerable.OrderBy(page.ToolbarItems, x => x.Order);
+			var sortedItems = page.ToolbarItems.OrderBy(x => x.Order);
 
-			toolbar.UpdateMenuItems(sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged, _currentMenuItems);
+			toolbar.UpdateMenuItems(sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged, _currentMenuItems, _currentToolbarItems);
 
 			SearchHandler = Shell.GetSearchHandler(page);
 			if (SearchHandler != null && SearchHandler.SearchBoxVisibility != SearchBoxVisibility.Hidden)
@@ -513,9 +511,7 @@ namespace Xamarin.Forms.Platform.Android
 					_searchView.LoadView();
 					_searchView.View.ViewAttachedToWindow += OnSearchViewAttachedToWindow;
 
-					var lp = new LP(LP.MatchParent, LP.MatchParent);
-					_searchView.View.LayoutParameters = lp;
-					lp.Dispose();
+					_searchView.View.LayoutParameters = new LP(LP.MatchParent, LP.MatchParent);
 					_searchView.SearchConfirmed += OnSearchConfirmed;
 				}
 
@@ -562,8 +558,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnToolbarItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			var sortedItems = System.Linq.Enumerable.OrderBy(Page.ToolbarItems, x => x.Order);
-			_toolbar.OnToolbarItemPropertyChanged(e, (ToolbarItem)sender, sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged, _currentMenuItems);
+			var sortedItems = Page.ToolbarItems.OrderBy(x => x.Order).ToList();
+			_toolbar.OnToolbarItemPropertyChanged(e, (ToolbarItem)sender, sortedItems, _shellContext.AndroidContext, TintColor, OnToolbarItemPropertyChanged, _currentMenuItems, _currentToolbarItems);
 		}
 
 		void OnSearchViewAttachedToWindow(object sender, AView.ViewAttachedToWindowEventArgs e)


### PR DESCRIPTION
### Description of Change ###
The NavigationPageRenderer doesn't track the removal of an ToolbarItem.
If the user decide to remove an item, the NavigationPageRenderer will rebuild the menu but not unsubscribe PropertyChange EventHandler subscribed in the ToolbarExtensions class.
When the renderer is disposed it try to dispose items by unsubscribe it, but in this case, they were deleted, so they aren't disposed correctly.
To fix that we have to track when item are removed, but we can't do that with the current event CollectionChange on the ToolbarTracker. So I introduced a new collection to store the current toolbar items.

### Issues Resolved ### 
- fixes #9419 

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Run UiTest included in this PR

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
