### PR TITLE
[Enhancement] Added Resumed and Asleep events to Application

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -167,6 +167,10 @@ namespace Xamarin.Forms
 
 		public event EventHandler<Page> PageDisappearing;
 
+		public event EventHandler Asleep;
+
+		public event EventHandler Resumed;
+
 		async void SaveProperties()
 		{
 			try
@@ -272,12 +276,14 @@ namespace Xamarin.Forms
 		{
 			Current = this;
 			OnResume();
+			Resumed?.Invoke(this, EventArgs.Empty);
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendSleep()
 		{
 			OnSleep();
+			Asleep?.Invoke(this, EventArgs.Empty);
 			SavePropertiesAsFireAndForget();
 		}
 
@@ -285,6 +291,7 @@ namespace Xamarin.Forms
 		public Task SendSleepAsync()
 		{
 			OnSleep();
+			Asleep?.Invoke(this, EventArgs.Empty);
 			return SavePropertiesAsync();
 		}
 


### PR DESCRIPTION
### Description of Change ###
Added **Resumed** and **Asleep** events to Application class.
These properties would help developers of 3rd party libraries to determine the app state. Sometimes it is important to know, that the app is going to background, but currently, it's not possible to get the state in cross-platform code, since there are only methods **OnResume** and **OnSleep** and there are no events/signals there.

### API Changes ###
Added:
 - **event** Resumed; // in Application
 - **event** Asleep; // in Application

### Platforms Affected ### 
- Core

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable
