### PR TITLE
[iOS] NullReferenceException at ScrollViewRenderer.cs

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_insetTracker?.OnLayoutSubviews();
 			base.LayoutSubviews();
 
-			if(Superview != null)
+			if(Superview != null && ScrollView != null)
 			{
 				if (_requestedScroll != null)
 				{


### PR DESCRIPTION
### Description of Change ###
Added extra null-check

### Issues Resolved ### 
- fixes #9435 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
No crash

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
- Open screen with a scroll view. Create a delayed task that must scroll to some element inside the scroll view after some time (e.g. 5 seconds). Run that task.
- Leave the page with the scroll view.
- After 5 seconds a NullRefException will occur.
