### PR TITLE
Disable swipe in SwipeView with IsEnabled property

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9329.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9329.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+using CategoryAttribute = NUnit.Framework.CategoryAttribute;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9329, "Xamarin.Forms SwipeView IsEnabled not working", PlatformAffected.All)]
+	public class Issue9329 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 9329";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Check/uncheck the CheckBox to enable or disable the SwipeView."
+			};
+
+			var swipeItem = new SwipeItem { BackgroundColor = Color.Red, Text = "Test", IconImageSource = "coffee.png" };
+
+			var swipeView = new SwipeView
+			{
+				HeightRequest = 60,
+				BackgroundColor = Color.LightGray,
+				LeftItems = new SwipeItems(new List<SwipeItem> { swipeItem })
+				{
+					Mode = SwipeMode.Execute
+				},
+				RightItems = new SwipeItems(new List<SwipeItem> { swipeItem })
+			};
+
+			var content = new Grid
+			{
+				BackgroundColor = Color.LightGoldenrodYellow
+			};
+
+			var info = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe"
+			};
+
+			content.Children.Add(info);
+
+			swipeView.Content = content;
+
+			var checkLayout = new StackLayout();
+			checkLayout.Orientation = StackOrientation.Horizontal;
+
+			var checkBox = new CheckBox
+			{
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var checkInfoLabel = new Label
+			{
+				Text = "SwipeView Enabled",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			checkBox.CheckedChanged += (sender, args) =>
+			{
+				swipeView.IsEnabled = !swipeView.IsEnabled;
+				checkInfoLabel.Text = swipeView.IsEnabled ? "SwipeView Enabled" : "SwipeView Disabled";
+			};
+
+			checkLayout.Children.Add(checkBox);
+			checkLayout.Children.Add(checkInfoLabel);
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(swipeView);
+			layout.Children.Add(checkLayout);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1252,6 +1252,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7924.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8777.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9329.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -50,16 +50,18 @@ namespace Xamarin.Forms.Platform.Android
 		float _swipeThreshold;
 		double _previousScrollX;
 		double _previousScrollY;
+		bool _isSwipeEnabled;
 		bool _isDisposed;
 
 		public SwipeViewRenderer(Context context) : base(context)
 		{
 			SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
+
 			_context = context;
 
-			AutoPackage = false;
+			this.SetClipToOutline(true);
 
-			this.SetClipToOutline(true, Element);
+			AutoPackage = false;
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<SwipeView> e)
@@ -77,6 +79,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				UpdateContent();
+				UpdateIsSwipeEnabled();
 				UpdateSwipeTransitionMode();
 				UpdateBackgroundColor();
 			}
@@ -100,6 +103,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateContent();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+				UpdateIsSwipeEnabled();
 			else if (e.PropertyName == Specifics.SwipeTransitionModeProperty.PropertyName)
 				UpdateSwipeTransitionMode();
 		}
@@ -142,7 +147,7 @@ namespace Xamarin.Forms.Platform.Android
 			else
 				Control.SetWindowBackground();
 
-			if (_contentView.Background == null)
+			if (_contentView != null && _contentView.Background == null)
 				_contentView?.SetWindowBackground();
 		}
 
@@ -420,6 +425,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool HandleTouchInteractions(GestureStatus status, APointF point)
 		{
+			if (!_isSwipeEnabled)
+				return false;
+
 			switch (status)
 			{
 				case GestureStatus.Started:
@@ -696,6 +704,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			swipeItemView.Layout(new Rectangle(0, 0, swipeItemWidth, swipeItemHeight));
 			swipeItemView.Content?.Layout(new Rectangle(0, 0, swipeItemWidth, swipeItemHeight));
+		}
+
+		void UpdateIsSwipeEnabled()
+		{
+			_isSwipeEnabled = Element.IsEnabled;
 		}
 
 		void UpdateSwipeTransitionMode()

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms.Platform.iOS
 		List<CGRect> _swipeItemsRect;
 		double _previousScrollX;
 		double _previousScrollY;
+		bool _isSwipeEnabled;
 		bool _isDisposed;
 
 		public SwipeViewRenderer()
@@ -59,6 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				UpdateContent();
+				UpdateIsSwipeEnabled();
 				UpdateSwipeTransitionMode();
 				SetBackgroundColor(Element.BackgroundColor);
 			}
@@ -124,6 +126,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateContent();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				SetBackgroundColor(Element.BackgroundColor);
+			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
+				UpdateIsSwipeEnabled();
 			else if (e.PropertyName == Specifics.SwipeTransitionModeProperty.PropertyName)
 				UpdateSwipeTransitionMode();
 		}
@@ -299,6 +303,11 @@ namespace Xamarin.Forms.Platform.iOS
 				if (content != null)
 					_contentView = content;
 			}
+		}
+
+		void UpdateIsSwipeEnabled()
+		{
+			_isSwipeEnabled = Element.IsEnabled;
 		}
 
 		UIView CreateEmptyContent()
@@ -498,6 +507,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HandleTouchInteractions(NSSet touches, GestureStatus gestureStatus)
 		{
+			if (!_isSwipeEnabled)
+				return;
+
 			var anyObject = touches.AnyObject as UITouch;
 			nfloat x = anyObject.LocationInView(this).X;
 			nfloat y = anyObject.LocationInView(this).Y;


### PR DESCRIPTION
### Description of Change ###

Disable swipe in SwipeView using the VisualElement IsEnabled property.

### Issues Resolved ### 

- fixes #9329

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

After
![fix9329](https://user-images.githubusercontent.com/6755973/74140956-5945b500-4bf6-11ea-8287-5258ffa5f5bc.gif)

### Testing Procedure ###

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
