### PR TITLE
[iOS] Fix NRE if the detail renderer wasn't created

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -247,7 +247,10 @@ namespace Xamarin.Forms.Platform.iOS
 			var masterFrame = frame;
 			nfloat opacity = 1;
 			masterFrame.Width = (int)(Math.Min(masterFrame.Width, masterFrame.Height) * 0.8);
-			var detailView = Platform.GetRenderer(MasterDetailPage.Detail).ViewController.View;
+			var detailRenderer = Platform.GetRenderer(MasterDetailPage.Detail);
+			if (detailRenderer == null)
+				return;
+			var detailView = detailRenderer.ViewController.View;
 
 			var isRTL = (Element as IVisualElementController)?.EffectiveFlowDirection.IsRightToLeft() == true;
 			if (isRTL)


### PR DESCRIPTION
### Description of Change ###

Fix NRE caused by calling Layout Children method without having the Renderer created yet for the the detail page. 

### Issues Resolved ### 

- fixes failing test 2964 on iOS

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

iOS test for issue 2964 should pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
