### PR TITLE
Added more StateTriggers samples to Core Gallery

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerEventsGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerEventsGallery.xaml
@@ -1,0 +1,47 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:viewmodels="clr-namespace:Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries.StateTriggerEventsGallery"
+    Title="StateTriggerEvents Gallery">
+    <ContentPage.BindingContext>
+       <viewmodels:StateTriggerEventsGalleryViewModel />
+    </ContentPage.BindingContext>
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <VisualStateManager.VisualStateGroups>
+            <VisualStateGroup>
+                <VisualState x:Name="Greem">
+                    <VisualState.StateTriggers>
+                        <CompareStateTrigger Property="{Binding ToggleState}" Value="True" IsActiveChanged="OnGreenStateTriggerIsActiveChanged" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Property="BackgroundColor" Value="Green" />
+                    </VisualState.Setters>
+                </VisualState>
+                <VisualState x:Name="Red">
+                    <VisualState.StateTriggers>
+                        <CompareStateTrigger Property="{Binding ToggleState}" Value="False" IsActiveChanged="OnRedStateTriggerIsActiveChanged" />
+                    </VisualState.StateTriggers>
+                    <VisualState.Setters>
+                        <Setter Property="BackgroundColor" Value="Red" />
+                    </VisualState.Setters>
+                </VisualState>
+            </VisualStateGroup>
+        </VisualStateManager.VisualStateGroups>
+        <Button
+            Text="Click to toggle BackgroundColor"
+            Command="{Binding ToggleCommand}"
+            HorizontalOptions="Center"
+            VerticalOptions="Center" />
+        <ScrollView
+            Grid.Row="1">
+            <Label
+                x:Name="InfoLabel"/>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerEventsGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerEventsGallery.xaml.cs
@@ -1,0 +1,51 @@
+﻿using System;
+using System.Windows.Input;
+
+namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
+{
+	public partial class StateTriggerEventsGallery : ContentPage
+	{
+		public StateTriggerEventsGallery()
+		{
+			InitializeComponent();
+		}
+
+		void OnRedStateTriggerIsActiveChanged(object sender, EventArgs e)
+		{
+			var stateTrigger = (StateTriggerBase)sender;
+
+			if (InfoLabel != null)
+				InfoLabel.Text += $"OnRedStateTriggerIsActiveChanged: {stateTrigger.IsActive} {Environment.NewLine}";
+		}
+
+		void OnGreenStateTriggerIsActiveChanged(object sender, EventArgs e)
+		{
+			var stateTrigger = (StateTriggerBase)sender;
+
+			if (InfoLabel != null)
+				InfoLabel.Text += $"OnGreenStateTriggerIsActiveChanged: {stateTrigger.IsActive} {Environment.NewLine}";
+		}
+	}
+
+	public class StateTriggerEventsGalleryViewModel : BindableObject
+	{
+		bool _toggleState;
+
+		public bool ToggleState
+		{
+			get => _toggleState;
+			set
+			{
+				_toggleState = value;
+				OnPropertyChanged(nameof(ToggleState));
+			}
+		}
+
+		public ICommand ToggleCommand => new Command(OnToggle);
+
+		void OnToggle()
+		{
+			ToggleState = !ToggleState;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerGallery.cs
@@ -26,6 +26,7 @@
 					GalleryBuilder.NavButton("StateTriggers directly on Elements", () => new StateTriggersDirectlyOnElements(), Navigation),
 					GalleryBuilder.NavButton("DualScreenStateTrigger Gallery", () => new DualScreenStateTriggerGallery(), Navigation),
 					GalleryBuilder.NavButton("State Trigger IsActive Toggling", () => new StateTriggerToggleGallery(), Navigation),
+					GalleryBuilder.NavButton("State Trigger Events Gallery", () => new StateTriggerEventsGallery(), Navigation)
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerToggleGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerToggleGallery.xaml
@@ -4,7 +4,8 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
              mc:Ignorable="d"
-             x:Class="Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries.StateTriggerToggleGallery">
+             x:Class="Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries.StateTriggerToggleGallery"
+             Title="StateTriggerToggle Gallery">
     <ContentPage.Resources>
         <ResourceDictionary>
 

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerToggleGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerToggleGallery.xaml.cs
@@ -1,11 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using System.Windows.Input;
-using Xamarin.Forms;
-using Xamarin.Forms.Xaml;
+﻿using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
 {
@@ -15,7 +8,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
 		public StateTriggerToggleGallery()
 		{
 			InitializeComponent();
-			this.BindingContext = new StateTriggerToggleGalleryViewModel();
+			BindingContext = new StateTriggerToggleGalleryViewModel();
 		}
 
 		public class StateTriggerToggleGalleryViewModel : BindableObject

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggersDirectlyOnElements.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggersDirectlyOnElements.xaml
@@ -10,6 +10,10 @@
     </ContentPage.BindingContext>
     <ContentPage.Content>
         <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup>
                     <VisualState x:Name="Wide">
@@ -18,6 +22,8 @@
                         </VisualState.StateTriggers>
                         <VisualState.Setters>
                             <Setter Property="BackgroundColor" Value="Green" />
+                            <Setter TargetName="InfoLabel" Property="Label.Text" Value="Wide (CompareStateTrigger)"/>
+                            <Setter TargetName="InfoLabel" Property="Label.FontSize" Value="24"/>
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Narrow">
@@ -26,6 +32,8 @@
                         </VisualState.StateTriggers>
                         <VisualState.Setters>
                             <Setter Property="BackgroundColor" Value="Red" />
+                            <Setter TargetName="InfoLabel" Property="Label.Text" Value="Narrow (CompareStateTrigger)"/>
+                            <Setter TargetName="InfoLabel" Property="Label.FontSize" Value="12"/>
                         </VisualState.Setters>
                     </VisualState>
                     <VisualState x:Name="Medium">
@@ -34,6 +42,8 @@
                         </VisualState.StateTriggers>
                         <VisualState.Setters>
                             <Setter Property="BackgroundColor" Value="Blue" />
+                            <Setter TargetName="InfoLabel" Property="Label.Text" Value="Medium (AdaptiveTrigger)"/>
+                            <Setter TargetName="InfoLabel" Property="Label.FontSize" Value="18"/>
                         </VisualState.Setters>
                     </VisualState>
                 </VisualStateGroup>
@@ -43,6 +53,9 @@
                 Command="{Binding ToggleCommand}"
                 HorizontalOptions="Center"
                 VerticalOptions="Center" />
+            <Label
+                Grid.Row="1"
+                x:Name="InfoLabel"/>
         </Grid>
     </ContentPage.Content>
 </ContentPage>


### PR DESCRIPTION
### Description of Change ###

I have done some StateTriggers (AdaptiveTriggers) tests and this PR just adds more samples to Core Gallery testing cases not added before (use of events, use of TargetName, etc).

<img width="384" alt="statetriggers-sample" src="https://user-images.githubusercontent.com/6755973/74151494-97e66a00-4c0c-11ea-8935-cf8678c8c8d3.png">

### API Changes ###
 
 None

### Platforms Affected ### 

- Core

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the StateTriggers samples. Now, you can find new samples test the events, etc.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
