### PR TITLE
[Bug][iOS] SwipeView MonoTouchException in iOS 12 in Forms 4.5-pre3

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			UIColor backgroundColor;
 
-			if (Forms.IsiOS11OrNewer)
+			if (Forms.IsiOS13OrNewer)
 				backgroundColor = UIColor.SystemBackgroundColor;
 			else
 				backgroundColor = UIColor.White;


### PR DESCRIPTION
### Description of Change ###

Amended iOS version check (should be check for 13 or newer instead of 11 or newer because systemBackground color was introduced in iOS 13 SDK.)

### Issues Resolved ### 
- fixes #9499 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
No crash on iOS 12 during SwipeView using

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Please find the steps attached to the bug ticket.

