### PR TITLE
[Android] Remove dead code, fix the indicator position on load

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -198,18 +198,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateItemsSource();
 
 			ElevationHelper.SetElevation(this, newElement);
-		}
 
-		void IndicatorsViewItemSourcePropertyChanged(object sender, PropertyChangedEventArgs changedProperty)
-		{
-			if (changedProperty.Is(ItemsView.ItemsSourceProperty))
-			{
-				UpdateItemsSource();
-			}
-			else if (changedProperty.Is(SelectableItemsView.SelectedItemProperty))
-			{
-				UpdateSelectedIndicator();
-			}
+			UpdateSelectedIndicator();
 		}
 
 		void UpdateSelectedIndicator()


### PR DESCRIPTION
### Description of Change ###

Fixes issue qhen changing Shell tabs with indicators.

### Issues Resolved ### 

- fixes #9473 9473
- fixes comment https://github.com/xamarin/Xamarin.Forms/pull/8709#issuecomment-581092711

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

When changing tabs on a Shell with indicators the position should be kept.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Paste code, and check if changing tabs the indicator stays in the correct position

```
var shell = new Shell();
var tabBar = new TabBar();
var tab = new Tab { Title = "Page 1" };
var tab1 = new Tab { Title = "Page 2" };
tab.Items.Add(new Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.IndicatorCodeGallery());
tab1.Items.Add(new Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.IndicatorCodeGallery());
tabBar.Items.Add(tab);
tabBar.Items.Add(tab1);
shell.Items.Add(tabBar);
MainPage = shell;
```

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
