### PR TITLE
Add default fontsize back to size BP on FontImageSource

### DIFF
--- a/Xamarin.Forms.Core/FontImageSource.cs
+++ b/Xamarin.Forms.Core/FontImageSource.cs
@@ -28,7 +28,7 @@
 			set => SetValue(GlyphProperty, value);
 		}
 
-		public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(double), typeof(FontImageSource), default(double),
+		public static readonly BindableProperty SizeProperty = BindableProperty.Create(nameof(Size), typeof(double), typeof(FontImageSource), 30d,
 			propertyChanged: (b, o, n) => ((FontImageSource)b).OnSourceChanged());
 
 		[TypeConverter(typeof(FontSizeConverter))]

--- a/Xamarin.Forms.Xaml.UnitTests/FontImageExtension.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/FontImageExtension.xaml
@@ -8,5 +8,6 @@
     <Tab Title="Hello" Icon="{FontImage Size={x:Static local:FontImageExtension.Size}, Color={x:Static local:FontImageExtension.Color}, FontFamily={x:Static local:FontImageExtension.FontFamily}, Glyph={x:Static local:FontImageExtension.Glyph}}" />
     <Tab Title="World" Icon="{FontImage Size={x:Static local:FontImageExtension.Size}, Color={x:Static local:FontImageExtension.Color}, FontFamily={x:Static local:FontImageExtension.FontFamily}, Glyph={x:Static local:FontImageExtension.Glyph}}" />
     <Tab Title="ContentProperty" Icon="{FontImage MyGlyph, Size={x:Static local:FontImageExtension.Size}, Color={x:Static local:FontImageExtension.Color}, FontFamily={x:Static local:FontImageExtension.FontFamily}}" />
+    <Tab Title="DefaultSize" Icon="{FontImage MyGlyph, Color={x:Static local:FontImageExtension.Color}, FontFamily={x:Static local:FontImageExtension.FontFamily}}" />
 
 </TabBar>

--- a/Xamarin.Forms.Xaml.UnitTests/FontImageExtension.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/FontImageExtension.xaml.cs
@@ -29,7 +29,8 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new FontImageExtension(useCompiledXaml);
 				var tabs = layout.AllChildren;
 
-				foreach (var tab in tabs)
+				int i = 0;
+				foreach(var tab in tabs)
 				{
 					Tab myTab = (Tab)tab;
 					if (myTab == null)
@@ -40,8 +41,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					var fontImage = (FontImageSource)myTab.Icon;
 					Assert.AreEqual(FontFamily, fontImage.FontFamily);
 					Assert.AreEqual(Glyph, fontImage.Glyph);
-					Assert.AreEqual(Size, fontImage.Size);
+
+					if(i == 3)
+						Assert.AreEqual(30d, fontImage.Size);
+					else
+						Assert.AreEqual(Size, fontImage.Size);
+
 					Assert.AreEqual(Color, fontImage.Color);
+					i++;
 				}
 			}
 


### PR DESCRIPTION
### Description of Change ###

The default size for font was originally set to 30 and removing it causes a regression. Especially on android because it tries to render the font at a size of zero which causes an exception.

If setting default Fontsize isn't an option then we will need to set it to something on Android when it's rendering the image so that it doesn't regress and actually renderers like other platforms

### Issues Resolved ### 
- fixes #9371

### Regression Introduced ###
https://github.com/xamarin/Xamarin.Forms/pull/8063/files#diff-286d535dfc3a7d8dda9c1f9a78e8130aL28

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
