### PR TITLE
CompositeStateTrigger

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/CompositeStateTriggerGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/CompositeStateTriggerGallery.xaml
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries.CompositeStateTriggerGallery"
+    Title="CompositeStateTrigger Gallery">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Style TargetType="CheckBox">
+                <Setter Property="VerticalOptions" Value="Center" />
+            </Style>
+
+            <Style TargetType="Label">
+                <Setter Property="VerticalOptions" Value="Center" />
+            </Style>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <Grid>
+            <VisualStateManager.VisualStateGroups>
+			    <VisualStateGroup>
+				    <VisualState x:Name="AndFalse">
+					    <VisualState.StateTriggers>
+						    <CompositeStateTrigger Operator="And">
+							    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox1}}" Value="False" />
+							    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox2}}" Value="False" />
+                            </CompositeStateTrigger>
+					    </VisualState.StateTriggers>
+					    <VisualState.Setters>
+                            <Setter TargetName="InfoLabel" Property="Label.Text" Value="No CheckBox checked (And)"/>
+					    </VisualState.Setters>
+				    </VisualState>
+                    <VisualState x:Name="AndTrue">
+					    <VisualState.StateTriggers>
+						    <CompositeStateTrigger Operator="And">
+							    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox1}}" Value="True" />
+							    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox2}}" Value="True" />
+                            </CompositeStateTrigger>
+					    </VisualState.StateTriggers>
+					    <VisualState.Setters>
+                            <Setter TargetName="InfoLabel" Property="Label.Text" Value="All CheckBoxes are checked (And)"/>
+					    </VisualState.Setters>
+				    </VisualState>
+				    <VisualState x:Name="Or">
+					    <VisualState.StateTriggers>
+						    <CompositeStateTrigger Operator="Or">
+							    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox1}}" Value="True" />
+							    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox2}}" Value="True" />
+						    </CompositeStateTrigger>
+					    </VisualState.StateTriggers>
+					    <VisualState.Setters>
+                            <Setter TargetName="InfoLabel" Property="Label.Text" Value="At least 1 CheckBox is checked (Or)"/>
+					    </VisualState.Setters>
+				    </VisualState>
+			    </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+		    <StackLayout
+                Padding="12">
+                <StackLayout
+                    Orientation="Horizontal">
+			        <CheckBox
+                        x:Name="CheckBox1" />
+                    <Label
+                        Text="CheckBox1"/>
+                </StackLayout>
+                <StackLayout
+                    Orientation="Horizontal">
+			        <CheckBox
+                        x:Name="CheckBox2" />
+                    <Label
+                        Text="CheckBox2"/>
+                </StackLayout>
+			    <Label
+                    x:Name="InfoLabel"
+                    Text="No CheckBox checked (And)" />
+		    </StackLayout>
+	    </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/CompositeStateTriggerGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/CompositeStateTriggerGallery.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.VisualStateManagerGalleries
+{
+	public partial class CompositeStateTriggerGallery : ContentPage
+	{
+		public CompositeStateTriggerGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/StateTriggerGallery.cs
@@ -13,6 +13,7 @@
 					GalleryBuilder.NavButton("MinWindowWidth AdaptiveTrigger Gallery", () => new MinWindowWidthAdaptiveTriggerGallery(), Navigation),
 					GalleryBuilder.NavButton("MinWindowHeight AdaptiveTrigger Gallery", () => new MinWindowHeightAdaptiveTriggerGallery(), Navigation),
 					GalleryBuilder.NavButton("CompareStateTrigger Gallery", () => new CompareStateTriggerGallery(), Navigation),
+					GalleryBuilder.NavButton("CompositeStateTrigger Gallery", () => new CompositeStateTriggerGallery(), Navigation),
 					GalleryBuilder.NavButton("DeviceStateTrigger Gallery", () => new DeviceStateTriggerGallery(), Navigation),
 					GalleryBuilder.NavButton("OrientationStateTrigger Gallery", () => new OrientationStateTriggerGallery(), Navigation),
 					GalleryBuilder.NavButton("StateTriggers directly on Elements", () => new StateTriggersDirectlyOnElements(), Navigation),

--- a/Xamarin.Forms.Core/CompositeStateTrigger.cs
+++ b/Xamarin.Forms.Core/CompositeStateTrigger.cs
@@ -1,0 +1,128 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+
+namespace Xamarin.Forms
+{
+	[ContentProperty("StateTriggers")]
+	public class CompositeStateTrigger : StateTriggerBase
+	{
+		public CompositeStateTrigger()
+		{
+			StateTriggers = new ObservableCollection<StateTriggerBase>();
+
+			UpdateState();
+		}
+
+		public ObservableCollection<StateTriggerBase> StateTriggers
+		{
+			get { return (ObservableCollection<StateTriggerBase>)GetValue(StateTriggersProperty); }
+			set { SetValue(StateTriggersProperty, value); }
+		}
+
+		public static readonly BindableProperty StateTriggersProperty =
+			BindableProperty.Create(nameof(StateTriggers), typeof(ObservableCollection<StateTriggerBase>), typeof(CompositeStateTrigger), null,
+				propertyChanged: OnStateTriggersPropertyChanged);
+		
+		public CompositeOperator Operator
+		{
+			get { return (CompositeOperator)GetValue(OperatorProperty); }
+			set { SetValue(OperatorProperty, value); }
+		}
+
+		public static readonly BindableProperty OperatorProperty =
+			BindableProperty.Create(nameof(Operator), typeof(CompositeOperator), typeof(CompositeStateTrigger), CompositeOperator.And,
+				propertyChanged: OnOperatorPropertyChanged);
+		
+		static void OnStateTriggersPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+		{
+			CompositeStateTrigger trigger = (CompositeStateTrigger)bindable;
+
+			if (oldvalue is INotifyCollectionChanged)
+				(oldvalue as INotifyCollectionChanged).CollectionChanged -= trigger.OnCompositeTriggerCollectionChanged;
+	
+			if (newvalue is INotifyCollectionChanged)
+				(newvalue as INotifyCollectionChanged).CollectionChanged += trigger.OnCompositeTriggerCollectionChanged;
+		
+			if (newvalue is IEnumerable<StateTriggerBase>)
+			{
+				foreach (var item in newvalue as IEnumerable<StateTriggerBase>)
+				{
+					if (!(item is StateTrigger))
+						trigger.SetValue(StateTriggersProperty, oldvalue); 
+				}
+
+				trigger.OnCompositeTriggerCollectionChanged(newvalue,
+					new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, (newvalue as IEnumerable<StateTriggerBase>).ToList()));
+			}
+
+			trigger.UpdateState();
+		}
+
+		static void OnOperatorPropertyChanged(BindableObject bindable, object oldvalue, object newvalue)
+		{
+			CompositeStateTrigger trigger = (CompositeStateTrigger)bindable;
+			trigger.UpdateState();
+		}
+
+		void OnCompositeTriggerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.NewItems != null)
+			{
+				foreach (var item in e.NewItems)
+				{
+					if (item is StateTriggerBase stateTrigger)
+						stateTrigger.IsActiveChanged += OnStateTriggerIsActiveChanged;
+				}
+			}
+			if (e.OldItems != null)
+			{
+				foreach (var item in e.OldItems)
+				{
+					if (item is StateTriggerBase stateTrigger)
+						stateTrigger.IsActiveChanged -= OnStateTriggerIsActiveChanged;
+				}
+			}
+
+			UpdateState();
+		}
+
+		void OnStateTriggerIsActiveChanged(object sender, System.EventArgs e)
+		{
+			UpdateState();
+		}
+
+		void UpdateState()
+		{
+			if (!StateTriggers.Any())
+			{
+				SetActive(false);
+			}
+			else if (Operator == CompositeOperator.Or)
+			{
+				bool isActive = GetIsActiveFromStateTriggers().Where(t => t).Any();
+				SetActive(isActive);
+			}
+			else if (Operator == CompositeOperator.And)
+			{
+				bool isActive = !GetIsActiveFromStateTriggers().Where(t => !t).Any();
+				SetActive(isActive);
+			}
+		}
+
+		IEnumerable<bool> GetIsActiveFromStateTriggers()
+		{
+			foreach (var trigger in StateTriggers)
+			{
+				yield return trigger.IsActive;
+			}
+		}
+	}
+
+	public enum CompositeOperator
+	{
+		And,
+		Or
+	}
+}

--- a/Xamarin.Forms.Core/CompositeStateTrigger.cs
+++ b/Xamarin.Forms.Core/CompositeStateTrigger.cs
@@ -66,6 +66,16 @@ namespace Xamarin.Forms
 			trigger.UpdateState();
 		}
 
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			object bc = BindingContext;
+
+			foreach (var stateTrigger in StateTriggers)
+				SetInheritedBindingContext(stateTrigger, bc);
+		}
+
 		void OnCompositeTriggerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			if (e.NewItems != null)

--- a/Xamarin.Forms.Core/CompositeStateTrigger.cs
+++ b/Xamarin.Forms.Core/CompositeStateTrigger.cs
@@ -101,12 +101,12 @@ namespace Xamarin.Forms
 			}
 			else if (Operator == CompositeOperator.Or)
 			{
-				bool isActive = GetIsActiveFromStateTriggers().Where(t => t).Any();
+				bool isActive = GetIsActiveFromStateTriggers().Any();
 				SetActive(isActive);
 			}
 			else if (Operator == CompositeOperator.And)
 			{
-				bool isActive = !GetIsActiveFromStateTriggers().Where(t => !t).Any();
+				bool isActive = GetIsActiveFromStateTriggers().All();
 				SetActive(isActive);
 			}
 		}

--- a/Xamarin.Forms.Core/CompositeStateTrigger.cs
+++ b/Xamarin.Forms.Core/CompositeStateTrigger.cs
@@ -101,12 +101,12 @@ namespace Xamarin.Forms
 			}
 			else if (Operator == CompositeOperator.Or)
 			{
-				bool isActive = GetIsActiveFromStateTriggers().Any();
+				bool isActive = GetIsActiveFromStateTriggers().Where(t => t).Any();
 				SetActive(isActive);
 			}
 			else if (Operator == CompositeOperator.And)
 			{
-				bool isActive = GetIsActiveFromStateTriggers().All();
+				bool isActive = !GetIsActiveFromStateTriggers().Where(t => !t).Any();
 				SetActive(isActive);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

After adding the `IsStateChanged` event we open several new possibilities when creating StateTriggers. One of the most interesting is the creation of **CompositionStateTrigger**. This trigger combines other triggers using, And, Or boolean operators to create more complex and powerful triggers.

Example:
```
<VisualStateManager.VisualStateGroups>
    <VisualStateGroup>
        <VisualState x:Name="AndFalse">
            <VisualState.StateTriggers>
                <CompositeStateTrigger Operator="And">
                    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox1}}" Value="False" />
                    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox2}}" Value="False" />
                </CompositeStateTrigger>
            </VisualState.StateTriggers>
            <VisualState.Setters>
                <Setter TargetName="InfoLabel" Property="Label.Text" Value="No CheckBox checked (And)"/>
            </VisualState.Setters>
        </VisualState>
        <VisualState x:Name="AndTrue">
            <VisualState.StateTriggers>
                <CompositeStateTrigger Operator="And">
                    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox1}}" Value="True" />
                    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox2}}" Value="True" />
                </CompositeStateTrigger>
            </VisualState.StateTriggers>
            <VisualState.Setters>
                <Setter TargetName="InfoLabel" Property="Label.Text" Value="All CheckBoxes are checked (And)"/>
            </VisualState.Setters>
        </VisualState>
        <VisualState x:Name="Or">
            <VisualState.StateTriggers>
                <CompositeStateTrigger Operator="Or">
                    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox1}}" Value="True" />
                    <CompareStateTrigger Property="{Binding IsChecked, Source={x:Reference CheckBox2}}" Value="True" />
                </CompositeStateTrigger>
            </VisualState.StateTriggers>
            <VisualState.Setters>
                <Setter TargetName="InfoLabel" Property="Label.Text" Value="At least 1 CheckBox is checked (Or)"/>
            </VisualState.Setters>
        </VisualState>
    </VisualStateGroup>
</VisualStateManager.VisualStateGroups>
```

The result:
![compositestatetriggers](https://user-images.githubusercontent.com/6755973/74228099-15b77d80-4cc0-11ea-8488-fb1681991f17.gif)

Ideal for cases like manage the Mode and 0rientation in Duo for example.

### API Changes ###

```
class CompositionStateTrigger : StateTrigerBase
{
     public ObservableCollection<StateTriggerBase> StateTriggers { get; set; }
     public CompositeOperator Operator { get; set; }
}
```

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the VisualStateManager samples. Within this section you will find samples related to State Triggers and there is a new sample to test CompositeStateTrigger.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
