### PR TITLE
#6698 do not throw exeption when target of WeakReference was collected

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6698.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6698.cs
@@ -1,0 +1,124 @@
+﻿#if !UITEST
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6698, "crash on TypedBinding.Apply", PlatformAffected.All)]
+	public class Issue6698 : TestContentPage
+	{
+		protected override void Init()
+		{
+			_container = new AbsoluteLayout();
+			var button1 = new Button { Text = "Test 1 (AbsoluteLayout)" };
+			button1.Clicked += Button1OnClicked;
+			Grid.SetRow(button1, 1);
+			var content = new Grid
+			{
+				RowDefinitions =
+				{
+					new RowDefinition { Height = GridLength.Star },
+					new RowDefinition { Height = GridLength.Auto }
+				},
+				Children = { _container, button1 }
+			};
+			Content = content;
+		}
+
+		async void Button1OnClicked(object sender, EventArgs e)
+		{
+			// Simulation of page transition
+			for (var i = 0; i < 1000; i++)
+			{
+				// Exception triggered by this update
+				GetLongLifecycleModel().Next();
+
+				ReplaceView(new Issue6698View2 { BindingContext = CreateContainerViewModel() });
+
+				await Task.Delay(10);
+			}
+
+			Cleanup();
+		}
+
+		void ReplaceView(View view)
+		{
+			Cleanup();
+
+			AbsoluteLayout.SetLayoutFlags(view,
+				AbsoluteLayoutFlags.WidthProportional | AbsoluteLayoutFlags.HeightProportional);
+			AbsoluteLayout.SetLayoutBounds(view, new Rectangle(0, 0, 1, 1));
+
+			_container.Children.Add(view);
+		}
+
+		void Cleanup()
+		{
+			// If you clear the BindingContext of the old View, no problem occurs?
+			//foreach (var view in Container.Children)
+			//{
+			//    view.BindingContext = null;
+			//}
+
+			_container.Children.Clear();
+		}
+
+		static Issue6698LongLifecycleModel _longLifecycleModel;
+		AbsoluteLayout _container;
+		ListView _listView;
+
+		static Issue6698LongLifecycleModel GetLongLifecycleModel() =>
+			_longLifecycleModel ?? (_longLifecycleModel = new Issue6698LongLifecycleModel());
+
+		static Issue6698ContainerViewModel CreateContainerViewModel() =>
+			new Issue6698ContainerViewModel(GetLongLifecycleModel());
+	}
+
+	public class Issue6698LongLifecycleModel : INotifyPropertyChanged
+	{
+		private int nextId;
+
+		public Issue6698Entity Entity { get; private set; }
+
+		public void Next()
+		{
+			nextId++;
+			Entity = new Issue6698Entity { Id = nextId, Name = $"Entity-{nextId}", Buffer = new byte[1024] };
+
+			for (var i = 0; i < 80; i++)
+				OnPropertyChanged(nameof(Entity));
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+
+	public class Issue6698ContainerViewModel
+	{
+		public Issue6698LongLifecycleModel LongLifecycleModel { get; }
+
+		public Issue6698ContainerViewModel(Issue6698LongLifecycleModel longLifecycle)
+		{
+			LongLifecycleModel = longLifecycle;
+		}
+	}
+
+	public class Issue6698Entity
+	{
+		public int Id { get; set; }
+
+		public string Name { get; set; }
+
+		public byte[] Buffer { get; set; }
+	}
+}
+#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6698View2.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6698View2.xaml
@@ -1,0 +1,17 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues;assembly=Xamarin.Forms.Controls"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue6698View2"
+             x:DataType="{x:Type issues:Issue6698ContainerViewModel}">
+  <ContentView.Content>
+      <StackLayout>
+          <Label BackgroundColor="IndianRed"
+                 Text="{Binding LongLifecycleModel.Entity.Name}"
+                 FontSize="28" />
+      </StackLayout>
+  </ContentView.Content>
+</ContentView>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6698View2.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6698View2.xaml.cs
@@ -1,0 +1,15 @@
+﻿#if !UITEST
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class Issue6698View2
+    {
+        public Issue6698View2()
+        {
+            InitializeComponent();
+        }
+    }
+}
+#endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -18,6 +18,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9006.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8207.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6362.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6698.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewItemsSourceTypes.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue1455.xaml.cs">
@@ -682,6 +683,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)MultipleClipToBounds.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6994.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7371.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6698View2.xaml.cs">
+      <DependentUpon>Issue6698View2.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8145.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
@@ -1698,6 +1703,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8902.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6698View2.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -739,7 +739,7 @@ namespace Xamarin.Forms
 				}
 
 				Action action = () => _expression.Apply();
-				if (_expression._weakTarget.TryGetTarget(out BindableObject obj) && obj.Dispatcher != null && obj.Dispatcher.IsInvokeRequired)
+				if (_expression._weakTarget != null && _expression._weakTarget.TryGetTarget(out BindableObject obj) && obj.Dispatcher != null && obj.Dispatcher.IsInvokeRequired)
 				{
 					obj.Dispatcher.BeginInvokeOnMainThread(action);
 				}

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -96,7 +96,7 @@ namespace Xamarin.Forms.Internals
 			BindableObject target;
 #if DO_NOT_CHECK_FOR_BINDING_REUSE
 			if (!_weakTarget.TryGetTarget(out target))
-				throw new InvalidOperationException();
+				return;
 #else
 			if (!_weakTarget.TryGetTarget(out target) || target == null) {
 				Unapply();


### PR DESCRIPTION
### Description of Change ###

- in TypedBinding.Apply return instead of throwing an InvalidOperationException
- add a null-check in BindingExpression
- add a ControlGallery page to reproduce the issue

### Issues Resolved ### 

- fixes #6698

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

App will not crash when the target of a binding is collected by the GC

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Open Control Pages, search for "6698"
- Click the button
- the counter should get to 1000 without the app crashing

![typedbindingfix](https://user-images.githubusercontent.com/10390959/74265116-31dc0e80-4d02-11ea-8369-bed6e4545eca.gif)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
