### PR TITLE
[MediaElement] Removed line that pauses player before setting it to null.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9525.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9525.cs
@@ -1,0 +1,76 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9525, "MediaElement Disposing exception when MainPage is changed on iOS", PlatformAffected.iOS)]
+	public class Issue9525 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "MediaElement_Experimental" });
+
+			PushAsync(CreateRoot());
+#endif
+		}
+		private ContentPage CreateRoot()
+		{ 
+			var button = new Button
+			{
+				AutomationId = "Issue9525Button",
+				Text = "Go to new page",
+			};
+			button.Clicked += Button_Clicked;
+			return new ContentPage
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new MediaElement
+						{
+							AutomationId = "Issue9525MediaElement",
+							Source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+							HeightRequest=200,
+						},
+						button
+					}
+				}
+			};
+			
+		}
+		private void Button_Clicked(object sender, System.EventArgs e)
+		{
+			Navigation.InsertPageBefore(CreateRoot(), CurrentPage);
+			PopAsync().Wait();
+		}
+
+
+#if UITEST
+		[Test]
+		public void Issue9525Test()
+		{
+			//Will be exeption if fail.
+			RunningApp.Screenshot("I am at Issue9525");
+			for (var i = 0; i < 10; i++)
+			{
+				RunningApp.WaitForElement(q => q.Marked("Issue9525Button"));
+				RunningApp.Screenshot("I see the Button");
+				RunningApp.Tap("Issue9525Button");
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9525.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9525.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Reflection;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
@@ -19,11 +20,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-#if APP
 			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "MediaElement_Experimental" });
 
 			PushAsync(CreateRoot());
-#endif
 		}
 		private ContentPage CreateRoot()
 		{ 
@@ -42,7 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 						new MediaElement
 						{
 							AutomationId = "Issue9525MediaElement",
-							Source="https://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4",
+							Source = "https://sec.ch9.ms/ch9/80a3/6563611f-6a39-44fa-a768-1a58bdd080a3/HotRestart.mp4",
 							HeightRequest=200,
 						},
 						button
@@ -54,7 +53,7 @@ namespace Xamarin.Forms.Controls.Issues
 		private void Button_Clicked(object sender, System.EventArgs e)
 		{
 			Navigation.InsertPageBefore(CreateRoot(), CurrentPage);
-			PopAsync().Wait();
+			Navigation.RemovePage(CurrentPage);
 		}
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -267,6 +267,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9833.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9929.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9525.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
@@ -129,7 +129,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			RemoveStatusObserver();
 
-			_avPlayerViewController?.Player?.Pause();
 			_avPlayerViewController?.Player?.ReplaceCurrentItemWithPlayerItem(null);
 
 			base.Dispose(disposing);

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -160,6 +160,7 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.UAP.UnitTests", "Xamarin.Forms.Platform.UAP.UnitTests\Xamarin.Forms.Platform.UAP.UnitTests.csproj", "{8F245976-F555-4814-B935-9AD58F4D2871}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.iOS.UnitTests", "Xamarin.Forms.Platform.iOS.UnitTests\Xamarin.Forms.Platform.iOS.UnitTests.csproj", "{52C50E88-7F15-45FE-A63C-8E7C76CA2BAE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.DualScreen.UnitTests", "Xamarin.Forms.DualScreen.UnitTests\Xamarin.Forms.DualScreen.UnitTests.csproj", "{00D50743-7821-4293-92F2-7C614C256BD6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -160,7 +160,6 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.UAP.UnitTests", "Xamarin.Forms.Platform.UAP.UnitTests\Xamarin.Forms.Platform.UAP.UnitTests.csproj", "{8F245976-F555-4814-B935-9AD58F4D2871}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.iOS.UnitTests", "Xamarin.Forms.Platform.iOS.UnitTests\Xamarin.Forms.Platform.iOS.UnitTests.csproj", "{52C50E88-7F15-45FE-A63C-8E7C76CA2BAE}"
-Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.DualScreen.UnitTests", "Xamarin.Forms.DualScreen.UnitTests\Xamarin.Forms.DualScreen.UnitTests.csproj", "{00D50743-7821-4293-92F2-7C614C256BD6}"
 EndProject
 Global
 	GlobalSection(SharedMSBuildProjectFiles) = preSolution


### PR DESCRIPTION
### Description of Change ###
Removed line that pauses player before setting it to null.
I think the pause is there to stop background playback of the media element, but since the next line also seems to stop it, I removed the line.
I appreciate there is probably a lot more going on here though @peterfoot .
I'm not sure how to handle the video source, there has to be one for the exception to occur. It's currently taking a hard-coded URL source.

### Issues Resolved ### 
- fixes #9525 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###

Will now not give an exception on Dispose.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Have a page in iOS with a media element. Change page so that the media element is disposed.
### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
