### PR TITLE
Add Threshold BindableProperty to SwipeView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/HorizontalSwipeThresholdGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/HorizontalSwipeThresholdGallery.xaml
@@ -1,0 +1,195 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.HorizontalSwipeThresholdGallery"
+    Title="Horizontal SwipeThreshold Gallery">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Color x:Key="BackgroundColor">#2E249E</Color>
+            <Color x:Key="SwipeItemBackgroundColor">#FE744D</Color>
+            <Color x:Key="TitleColor">#55A1FA</Color>
+            <Color x:Key="SubTitleColor">#FFFFFF</Color>
+
+            <Style x:Key="TitleStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="10" />
+                <Setter Property="TextColor" Value="{StaticResource TitleColor}" />
+                <Setter Property="Margin" Value="12, 18, 6, 6" />
+            </Style>
+
+            <Style x:Key="SubTitleStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="{StaticResource SubTitleColor}" />
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="Margin" Value="12, 0, 6, 6" />
+            </Style>
+
+            <Style x:Key="SwipeItemTextStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="White" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="HorizontalOptions" Value="Center" />
+                <Setter Property="VerticalOptions" Value="Center" />
+            </Style>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <StackLayout
+            Padding="12">
+            <Label
+                Text="The Threshold property is only implemented for now on Android and iOS."
+                BackgroundColor="Black"
+                TextColor="White"/>
+            <Label
+                Text="Default Threshold (Reveal Mode)"/>
+            <SwipeView
+                HeightRequest="80">
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        Mode="Reveal">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Grid.Row="0"
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe to Left"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <Label
+                Text="Custom Threshold (only one SwipeItem using Reveal Mode)"/>
+            <Slider
+                x:Name="ThresholdRevealSlider"
+                Maximum="200"
+                Minimum="50"
+                Value="80"
+                MaximumTrackColor="Gray"
+                MinimumTrackColor="{StaticResource BackgroundColor}"
+                ThumbColor="{StaticResource BackgroundColor}"
+                ValueChanged="OnThresholdRevealSliderChanged"/>
+            <SwipeView
+                x:Name="RevealThresholdSwipeView"
+                Threshold="{Binding Source={x:Reference ThresholdRevealSlider}, Path=Value}"
+                HeightRequest="80">
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        Mode="Reveal">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Grid.Row="0"
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe to Left"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <Label
+                Text="Default Threshold (Execute Mode)"/>
+            <SwipeView
+                HeightRequest="80">
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        Mode="Execute">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Grid.Row="0"
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe to Left"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <Label
+                Text="Custom Threshold (only one SwipeItem using Execute Mode)"/>
+            <Slider
+                x:Name="ThresholdExecuteSlider"
+                Maximum="300"
+                Minimum="50"
+                Value="80"
+                MaximumTrackColor="Gray"
+                MinimumTrackColor="{StaticResource BackgroundColor}"
+                ThumbColor="{StaticResource BackgroundColor}"
+                ValueChanged="OnThresholdExecuteSliderChanged"/>
+            <SwipeView
+                x:Name="ExecuteThresholdSwipeView"
+                Threshold="{Binding Source={x:Reference ThresholdExecuteSlider}, Path=Value}"
+                HeightRequest="80">
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        Mode="Execute">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe to Left"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/HorizontalSwipeThresholdGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/HorizontalSwipeThresholdGallery.xaml.cs
@@ -1,0 +1,20 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class HorizontalSwipeThresholdGallery : ContentPage
+	{
+		public HorizontalSwipeThresholdGallery()
+		{
+			InitializeComponent();
+		}
+
+		void OnThresholdRevealSliderChanged(object sender, ValueChangedEventArgs args)
+		{
+			RevealThresholdSwipeView.Close();
+		}
+
+		void OnThresholdExecuteSliderChanged(object sender, ValueChangedEventArgs args)
+		{
+			ExecuteThresholdSwipeView.Close();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeThresholdCustomSwipeItemGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeThresholdCustomSwipeItemGallery.xaml
@@ -1,0 +1,133 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.SwipeThresholdCustomSwipeItemGallery"
+    Title="Threshold with custom SwipeItem Gallery">
+     <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Color x:Key="BackgroundColor">#2E249E</Color>
+            <Color x:Key="SwipeItemBackgroundColor">#FE744D</Color>
+            <Color x:Key="TitleColor">#55A1FA</Color>
+            <Color x:Key="SubTitleColor">#FFFFFF</Color>
+
+            <Style x:Key="TitleStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="10" />
+                <Setter Property="TextColor" Value="{StaticResource TitleColor}" />
+                <Setter Property="Margin" Value="6, 0, 6, 6" />
+            </Style>
+
+            <Style x:Key="SubTitleStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="{StaticResource SubTitleColor}" />
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="Margin" Value="6, 0, 6, 6" />
+            </Style>
+
+            <Style x:Key="SwipeItemTextStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="White" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="HorizontalOptions" Value="Center" />
+                <Setter Property="VerticalOptions" Value="Center" />
+            </Style>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <StackLayout
+            Padding="12">
+            <Label
+                Text="The Threshold property is only implemented for now on Android and iOS."
+                BackgroundColor="Black"
+                TextColor="White"/>
+            <SwipeView
+                HeightRequest="80">
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        Mode="Reveal">
+                        <SwipeItemView>
+                            <Grid
+                                WidthRequest="100">
+                                <BoxView
+                                    BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                                    CornerRadius="0, 6, 0, 6" />
+                                    <Label
+                                        Text="SwipeItem"
+                                        Style="{StaticResource SwipeItemTextStyle}"/>
+                            </Grid>
+                        </SwipeItemView>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Frame
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        CornerRadius="6"
+                        HasShadow="False"
+                        Padding="12">
+                        <Grid
+                            VerticalOptions="Center"
+                            RowSpacing="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Label
+                                Grid.Row="0"
+                                Text="Default Threshold"
+                                Style="{StaticResource TitleStyle}"/>
+                            <Label
+                                Grid.Row="1"
+                                Text="Swipe to the Left"
+                                Style="{StaticResource SubTitleStyle}"/>
+                        </Grid>
+                    </Frame>
+                </SwipeView.Content>
+            </SwipeView>
+             <SwipeView
+                 Threshold="90"
+                 HeightRequest="80">
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        Mode="Reveal">
+                        <SwipeItemView>
+                            <Grid
+                                WidthRequest="100">
+                                <BoxView
+                                    BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                                    CornerRadius="0, 6, 0, 6" />
+                                    <Label
+                                        Text="SwipeItem"
+                                        Style="{StaticResource SwipeItemTextStyle}"/>
+                            </Grid>
+                        </SwipeItemView>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Frame
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        CornerRadius="6"
+                        HasShadow="False"
+                        Padding="12">
+                        <Grid
+                            VerticalOptions="Center"
+                            RowSpacing="0">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                            </Grid.RowDefinitions>
+                            <Label
+                                Grid.Row="0"
+                                Text="Custom Threshold (90)"
+                                Style="{StaticResource TitleStyle}"/>
+                            <Label
+                                Grid.Row="1"
+                                Text="Swipe to the Left"
+                                Style="{StaticResource SubTitleStyle}"/>
+                        </Grid>
+                    </Frame>
+                </SwipeView.Content>
+            </SwipeView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeThresholdCustomSwipeItemGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeThresholdCustomSwipeItemGallery.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class SwipeThresholdCustomSwipeItemGallery : ContentPage
+	{
+		public SwipeThresholdCustomSwipeItemGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeThresholdGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeThresholdGallery.cs
@@ -1,0 +1,19 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public class SwipeThresholdGallery : ContentPage
+	{
+		public SwipeThresholdGallery()
+		{
+			Title = "SwipeThreshold Gallery";
+			Content = new StackLayout
+			{
+				Children =
+				{
+					GalleryBuilder.NavButton("Horizontal SwipeThreshold Gallery", () => new HorizontalSwipeThresholdGallery(), Navigation),
+					GalleryBuilder.NavButton("Vertical SwipeThreshold Gallery", () => new VerticalSwipeThresholdGallery(), Navigation),
+					GalleryBuilder.NavButton("SwipeThreshold with Custom SwipeItem Gallery", () => new SwipeThresholdCustomSwipeItemGallery(), Navigation),
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 					Children =
 					{
 	 					GalleryBuilder.NavButton("Basic SwipeView Gallery", () => new BasicSwipeGallery(), Navigation),
+						GalleryBuilder.NavButton("SwipeView Threshold Gallery", () => new SwipeThresholdGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeView Events Gallery", () => new SwipeViewEventsGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItems from Resource Gallery", () => new ResourceSwipeItemsGallery(), Navigation),
 						GalleryBuilder.NavButton("BindableLayout Gallery", () => new SwipeBindableLayoutGallery(), Navigation),

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/VerticalSwipeThresholdGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/VerticalSwipeThresholdGallery.xaml
@@ -1,0 +1,195 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.VerticalSwipeThresholdGallery"
+    Title="Vertical SwipeThreshold Gallery">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Color x:Key="BackgroundColor">#2E249E</Color>
+            <Color x:Key="SwipeItemBackgroundColor">#FE744D</Color>
+            <Color x:Key="TitleColor">#55A1FA</Color>
+            <Color x:Key="SubTitleColor">#FFFFFF</Color>
+
+            <Style x:Key="TitleStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="10" />
+                <Setter Property="TextColor" Value="{StaticResource TitleColor}" />
+                <Setter Property="Margin" Value="12, 18, 6, 6" />
+            </Style>
+
+            <Style x:Key="SubTitleStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="{StaticResource SubTitleColor}" />
+                <Setter Property="FontSize" Value="18" />
+                <Setter Property="Margin" Value="12, 0, 6, 6" />
+            </Style>
+
+            <Style x:Key="SwipeItemTextStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="White" />
+                <Setter Property="FontAttributes" Value="Bold" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="HorizontalOptions" Value="Center" />
+                <Setter Property="VerticalOptions" Value="Center" />
+            </Style>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <StackLayout
+            Padding="12">
+            <Label
+                Text="The Threshold property is only implemented for now on Android and iOS."
+                BackgroundColor="Black"
+                TextColor="White"/>
+            <Label
+                Text="Default Threshold (Reveal Mode)"/>
+            <SwipeView
+                HeightRequest="80">
+                <SwipeView.TopItems>
+                    <SwipeItems
+                        Mode="Reveal">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Grid.Row="0"
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe Down"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <Label
+                Text="Custom Threshold (only one SwipeItem using Reveal Mode)"/>
+            <Slider
+                x:Name="ThresholdRevealSlider"
+                Maximum="100"
+                Minimum="20"
+                Value="80"
+                MaximumTrackColor="Gray"
+                MinimumTrackColor="{StaticResource BackgroundColor}"
+                ThumbColor="{StaticResource BackgroundColor}"
+                ValueChanged="OnThresholdRevealSliderChanged"/>
+            <SwipeView
+                x:Name="RevealThresholdSwipeView"
+                Threshold="{Binding Source={x:Reference ThresholdRevealSlider}, Path=Value}"
+                HeightRequest="80">
+                <SwipeView.TopItems>
+                    <SwipeItems
+                        Mode="Reveal">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Grid.Row="0"
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe Down"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <Label
+                Text="Default Threshold (Execute Mode)"/>
+            <SwipeView
+                HeightRequest="80">
+                <SwipeView.TopItems>
+                    <SwipeItems
+                        Mode="Execute">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Grid.Row="0"
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe Down"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <Label
+                Text="Custom Threshold (only one SwipeItem using Execute Mode)"/>
+            <Slider
+                x:Name="ThresholdExecuteSlider"
+                Maximum="100"
+                Minimum="20"
+                Value="80"
+                MaximumTrackColor="Gray"
+                MinimumTrackColor="{StaticResource BackgroundColor}"
+                ThumbColor="{StaticResource BackgroundColor}"
+                ValueChanged="OnThresholdExecuteSliderChanged"/>
+            <SwipeView
+                x:Name="ExecuteThresholdSwipeView"
+                Threshold="{Binding Source={x:Reference ThresholdExecuteSlider}, Path=Value}"
+                HeightRequest="80">
+                <SwipeView.TopItems>
+                    <SwipeItems
+                        Mode="Execute">
+                        <SwipeItem
+                            BackgroundColor="{StaticResource SwipeItemBackgroundColor}"
+                            Icon="calculator.png"
+                            Text="SwipeItem"/>
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="{StaticResource BackgroundColor}"
+                        RowSpacing="0">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                        </Grid.RowDefinitions>
+                        <Label
+                            Text="Default Threshold Behavior"
+                            Style="{StaticResource TitleStyle}"/>
+                        <Label
+                            Grid.Row="1"
+                            Text="Swipe Down"
+                            Style="{StaticResource SubTitleStyle}"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/VerticalSwipeThresholdGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/VerticalSwipeThresholdGallery.xaml.cs
@@ -1,0 +1,20 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class VerticalSwipeThresholdGallery : ContentPage
+	{
+		public VerticalSwipeThresholdGallery()
+		{
+			InitializeComponent();
+		}
+
+		void OnThresholdRevealSliderChanged(object sender, ValueChangedEventArgs args)
+		{
+			RevealThresholdSwipeView.Close();
+		}
+
+		void OnThresholdExecuteSliderChanged(object sender, ValueChangedEventArgs args)
+		{
+			ExecuteThresholdSwipeView.Close();
+		}
+	}
+}

--- a/Xamarin.Forms.Core/SwipeView.cs
+++ b/Xamarin.Forms.Core/SwipeView.cs
@@ -16,6 +16,9 @@ namespace Xamarin.Forms
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<SwipeView>>(() => new PlatformConfigurationRegistry<SwipeView>(this));
 		}
 
+		public static readonly BindableProperty ThresholdProperty =
+			BindableProperty.Create(nameof(Threshold), typeof(double), typeof(SwipeView), default(double));
+
 		public static readonly BindableProperty LeftItemsProperty =
 			BindableProperty.Create(nameof(LeftItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
 				propertyChanged: OnSwipeItemsChanged);
@@ -31,6 +34,12 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty BottomItemsProperty =
 			BindableProperty.Create(nameof(BottomItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
 				propertyChanged: OnSwipeItemsChanged);
+
+		public double Threshold
+		{
+			get { return (double)GetValue(ThresholdProperty); }
+			set { SetValue(ThresholdProperty, value); }
+		}
 
 		public SwipeItems LeftItems
 		{
@@ -106,7 +115,7 @@ namespace Xamarin.Forms
 			if (BottomItems != null)
 				SetInheritedBindingContext(BottomItems, bc);
 		}
-  
+
 		SwipeItems SwipeItemsDefaultValueCreator() => new SwipeItems();
 
 		static object SwipeItemsDefaultValueCreator(BindableObject bindable)


### PR DESCRIPTION
### Description of Change ###

Add **Threshold** BindableProperty to SwipeView.

### Issues Resolved ### 

- fixes #8941
- fixes #8974

### API Changes ###

```
public class SwipeView 
{
     public double Threshold { get; set; }
}
```

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android


### Behavioral/Visual Changes ###

None

### Screenshots ### 
![horizontal-threshold](https://user-images.githubusercontent.com/6755973/74460840-da6aa980-4e8d-11ea-86d5-1204cc845788.gif)

<img width="385" alt="custom-threshold" src="https://user-images.githubusercontent.com/6755973/74461147-57961e80-4e8e-11ea-8dcd-4a70c1d2cb9c.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the SwipeView samples. Select the added Threshold samples to test with horizontal and vertical swipes.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
