### PR TITLE
Set frame for EmptyView when adding it to UICollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9196.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9196.xaml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue9196">
+    <ContentPage.Content>
+        <StackLayout>
+
+            <Label Text="Success"/>
+
+            <CollectionView x:Name="ReceiptsCollection" SelectionMode="Single" ItemSizingStrategy="MeasureAllItems" 
+					    ItemsSource="{Binding ReceiptsList}">
+
+                <CollectionView.EmptyView>
+                    <StackLayout Padding="30">
+                        <Label Text="No Receipt Available" HorizontalTextAlignment="Center" 
+					       VerticalTextAlignment="Center" LineBreakMode="WordWrap" Margin="0,10"></Label>
+                    </StackLayout>
+                </CollectionView.EmptyView>
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <StackLayout>
+                            <Grid Padding="10">
+                                <Grid.RowDefinitions>
+                                    <RowDefinition Height="Auto"/>
+                                    <RowDefinition Height="Auto"/>
+                                </Grid.RowDefinitions>
+                                <Grid.ColumnDefinitions>
+                                    <ColumnDefinition Width="2*"/>
+                                    <ColumnDefinition Width="1*"/>
+                                </Grid.ColumnDefinitions>
+                                <Label VerticalOptions="CenterAndExpand"
+                                        Text="DateTime"/>
+                                <Label VerticalOptions="CenterAndExpand" FontAttributes="Bold" Grid.Column="1" 
+							        HorizontalTextAlignment="End">
+                                    <Label.FormattedText>
+                                        <FormattedString>
+                                            <Span Text="$" />
+                                            <Span Text="100" />
+                                        </FormattedString>
+                                    </Label.FormattedText>
+                                </Label>
+                                <Label VerticalOptions="CenterAndExpand" Grid.Row="1"  Grid.ColumnSpan="2"
+                                        Text="Item"/>
+                            </Grid>
+                        </StackLayout>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9196.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9196.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9196, "[Bug] [iOS] CollectionView EmptyView causes the application to crash",
+		PlatformAffected.iOS)]
+	public partial class Issue9196 : TestContentPage
+	{
+		public Issue9196()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			BindingContext = new _9196ViewModel();
+		}
+
+#if UITEST
+		[Test, Category(UITestCategories.CollectionView)]
+		public void EmptyViewShouldNotCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+
+	public class _9196ViewModel
+	{
+		public _9196ViewModel()
+		{
+			ReceiptsList = new List<string>();
+		}
+
+		public List<string> ReceiptsList { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -168,6 +168,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8743.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9092.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9087.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9196.xaml.cs">
+      <DependentUpon>Issue9196.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9355.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8784.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9360.cs" />
@@ -1801,6 +1805,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8902.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9196.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -7,8 +8,6 @@ namespace Xamarin.Forms.Platform.iOS
 	public abstract class ItemsViewController<TItemsView> : UICollectionViewController
 	where TItemsView : ItemsView
 	{
-		public const int HeaderTag = 111;
-		public const int FooterTag = 222;
 		public const int EmptyTag = 333;
 
 		public IItemsViewSource ItemsSource { get; protected set; }
@@ -155,7 +154,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				ResizeEmptyView();
+				LayoutEmptyView();
 			}
 		}
 
@@ -292,27 +291,21 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
 		}
 
-		void ResizeEmptyView()
+		protected virtual CGRect DetermineEmptyViewFrame() 
 		{
-			nfloat headerHeight = 0;
-			var headerView = CollectionView.ViewWithTag(HeaderTag);
+			return new CGRect(CollectionView.Frame.X, CollectionView.Frame.Y,
+					CollectionView.Frame.Width, CollectionView.Frame.Height);
+		}
 
-			if (headerView != null)
-				headerHeight = headerView.Frame.Height;
-
-			nfloat footerHeight = 0;
-			var footerView = CollectionView.ViewWithTag(FooterTag);
-
-			if (footerView != null)
-				footerHeight = footerView.Frame.Height;
-
-			var emptyViewFrame = new CoreGraphics.CGRect(CollectionView.Frame.X, CollectionView.Frame.Y, CollectionView.Frame.Width, Math.Abs(CollectionView.Frame.Height - (headerHeight + footerHeight)));
+		void LayoutEmptyView()
+		{
+			var frame = DetermineEmptyViewFrame();	
 
 			if (_emptyUIView != null)
-				_emptyUIView.Frame = emptyViewFrame;
+				_emptyUIView.Frame = frame;
 
-			if (_emptyViewFormsElement != null)
-				_emptyViewFormsElement.Layout(emptyViewFrame.ToRectangle());
+			if (_emptyViewFormsElement != null && ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
+				_emptyViewFormsElement.Layout(frame.ToRectangle());
 		}
 
 		protected void RemeasureLayout(VisualElement formsElement)
@@ -377,7 +370,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_emptyUIView.Tag = EmptyTag;
 				CollectionView.AddSubview(_emptyUIView);
-				ResizeEmptyView();
+				LayoutEmptyView();
 
 				if (_emptyViewFormsElement != null)
 				{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
 		bool _initialConstraintsSet;
 		bool _isEmpty;
-		bool _currentBackgroundIsEmptyView;
+		bool _emptyViewDisplayed;
 		bool _disposed;
   
 		UIView _emptyUIView;
@@ -377,6 +377,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_emptyUIView.Tag = EmptyTag;
 				CollectionView.AddSubview(_emptyUIView);
+				ResizeEmptyView();
 
 				if (_emptyViewFormsElement != null)
 				{
@@ -390,18 +391,18 @@ namespace Xamarin.Forms.Platform.iOS
 					_emptyViewFormsElement.Layout(_emptyUIView.Frame.ToRectangle());
 				}
 
-				_currentBackgroundIsEmptyView = true;
+				_emptyViewDisplayed = true;
 			}
 			else
 			{
 				// Is the empty view currently in the background? Swap back to the default.
-				if (_currentBackgroundIsEmptyView)
+				if (_emptyViewDisplayed)
 				{
 					_emptyUIView.RemoveFromSuperview();
 					ItemsView.RemoveLogicalChild(_emptyViewFormsElement);
 				}
 
-				_currentBackgroundIsEmptyView = false;
+				_emptyViewDisplayed = false;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using CoreGraphics;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -6,6 +7,9 @@ namespace Xamarin.Forms.Platform.iOS
 	public class StructuredItemsViewController<TItemsView> : ItemsViewController<TItemsView>
 		where TItemsView : StructuredItemsView
 	{
+		public const int HeaderTag = 111;
+		public const int FooterTag = 222;
+
 		bool _disposed;
 
 		UIView _headerUIView;
@@ -41,6 +45,24 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		protected override bool IsHorizontal => (ItemsView?.ItemsLayout as ItemsLayout)?.Orientation == ItemsLayoutOrientation.Horizontal;
+
+		protected override CGRect DetermineEmptyViewFrame()
+		{
+			nfloat headerHeight = 0;
+			var headerView = CollectionView.ViewWithTag(HeaderTag);
+
+			if (headerView != null)
+				headerHeight = headerView.Frame.Height;
+
+			nfloat footerHeight = 0;
+			var footerView = CollectionView.ViewWithTag(FooterTag);
+
+			if (footerView != null)
+				footerHeight = footerView.Frame.Height;
+
+			return new CGRect(CollectionView.Frame.X, CollectionView.Frame.Y, CollectionView.Frame.Width, 
+				Math.Abs(CollectionView.Frame.Height - (headerHeight + footerHeight)));
+		}
 
 		public override void ViewWillLayoutSubviews()
 		{


### PR DESCRIPTION
### Description of Change ###

The EmptyView's UIView frame was not being set immediately upon being added to the UICollectionView, which resulted in layout exceptions if the EmptyView contained a StackLayout with Padding set. 

These changes update the frame immediately after adding the UIView, preventing the issues (and saving an extra layout cycle). These changes also clean up the sizing implementation so that the ItemsViewController doesn't need to know about header/footer tags.

### Issues Resolved ### 

- fixes #9196 

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
