### PR TITLE
[Bug] macOS: 4.4->4.5 regression, labels are invisible (same TextColor as background)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -520,7 +520,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			Control.TextColor = textColor.ToUIColor(ColorExtensions.Black);
 #else
 			var alignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
-			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });
+			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(ColorExtensions.Black), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });
 			textWithColor = textWithColor.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
 			Control.AttributedStringValue = textWithColor;
 #endif


### PR DESCRIPTION
### Description of Change ###

Fixed regression bug on Mac OS. Default color is not converted to Black for macOs.

### Issues Resolved ### 

- fixes #9526

### API Changes ###
None

### Platforms Affected ### 
- macOS
### Behavioral/Visual Changes ###
Default text color of Labels on Mac became BLACK instead of transparent.

### Testing Procedure ###
Create a content page with a label inside. Run the sample on MacOs. See that label is invisible.

