### PR TITLE
[iOS] Fix square shape and indicator size on IndicatorView 

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star },
 					new RowDefinition { Height = GridLength.Auto }
 				}
@@ -148,11 +149,34 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			layout.Children.Add(stckTemplate);
 
+			var stckSize = new StackLayout { Orientation = StackOrientation.Horizontal };
+			stckSize.Children.Add(new Label { VerticalOptions = LayoutOptions.Center, Text = "Indicator Size" });
+
+			//indicatorView.IndicatorSize = 25;
+
+			var sizeSlider = new Slider
+			{
+				WidthRequest = 150,
+				Value = indicatorView.IndicatorSize,
+				Maximum = 50,
+			};
+
+			sizeSlider.ValueChanged += (s, e) =>
+			{
+				var indicatorSize = sizeSlider.Value;
+				indicatorView.IndicatorSize = indicatorSize;
+			};
+
+			stckSize.Children.Add(sizeSlider);
+
+			layout.Children.Add(stckSize);
+
 			Grid.SetRow(generator, 0);
 			Grid.SetRow(stckColors, 1);
 			Grid.SetRow(stckTemplate, 2);
-			Grid.SetRow(carouselView, 3);
-			Grid.SetRow(indicatorView, 4);
+			Grid.SetRow(stckSize, 3);
+			Grid.SetRow(carouselView, 4);
+			Grid.SetRow(indicatorView, 5);
 
 			Content = layout;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -141,9 +141,10 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateIndicatorTemplate();
 			}
-			else if (changedProperty.Is(IndicatorView.IndicatorsShapeProperty) ||
-					 changedProperty.Is(IndicatorView.IndicatorColorProperty) ||
-					 changedProperty.Is(IndicatorView.SelectedIndicatorColorProperty))
+			else if (changedProperty.IsOneOf(IndicatorView.IndicatorsShapeProperty,
+											IndicatorView.IndicatorColorProperty,
+											IndicatorView.IndicatorSizeProperty,
+											IndicatorView.SelectedIndicatorColorProperty))
 			{
 				ResetIndicators();
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using CoreGraphics;
 using UIKit;
 using static Xamarin.Forms.IndicatorView;
 
@@ -8,7 +9,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		UIColor _defaultPagesIndicatorTintColor;
 		UIColor _defaultCurrentPagesIndicatorTintColor;
-		UIPageControl UIPager => Control as UIPageControl;
+		FormsPageControl UIPager => Control as FormsPageControl;
 		bool _disposed;
 		bool _updatingPosition;
 
@@ -89,14 +90,14 @@ namespace Xamarin.Forms.Platform.iOS
 				UIPager.ValueChanged -= UIPagerValueChanged;
 			}
 
-			var uiPager = new UIPageControl();
+			var uiPager = new FormsPageControl { IsSquare = Element.IndicatorsShape == IndicatorShape.Square };
 			_defaultPagesIndicatorTintColor = uiPager.PageIndicatorTintColor;
 			_defaultCurrentPagesIndicatorTintColor = uiPager.CurrentPageIndicatorTintColor;
 			uiPager.ValueChanged += UIPagerValueChanged;
 
 			return uiPager;
 		}
-	
+
 		void UpdateControl()
 		{
 			ClearIndicators();
@@ -116,7 +117,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateIndicator()
 		{
-			if (Element.IndicatorsShape == IndicatorShape.Circle && Element.IndicatorTemplate == null)
+			if (Element.IndicatorTemplate == null)
 				UpdateIndicatorShape();
 			else
 				UpdateIndicatorTemplate();
@@ -125,7 +126,9 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateIndicatorShape()
 		{
 			ClearIndicators();
+			UIPager.IsSquare = Element.IndicatorsShape == IndicatorShape.Square;
 			AddSubview(UIPager);
+			UIPager.LayoutSubviews();
 		}
 
 		void UpdateIndicatorTemplate()
@@ -191,6 +194,24 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var color = Element.SelectedIndicatorColor;
 			UIPager.CurrentPageIndicatorTintColor = color.IsDefault ? _defaultCurrentPagesIndicatorTintColor : color.ToUIColor();
+		}
+	}
+
+	class FormsPageControl : UIPageControl
+	{
+		public bool IsSquare { get; set; }
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			if (Subviews.Length == 0 || !IsSquare)
+				return;
+
+			foreach (var view in Subviews)
+			{
+				view.Layer.CornerRadius = 0;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
@@ -211,6 +211,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 	class FormsPageControl : UIPageControl
 	{
+		const int DefaultIndicatorSize = 7;
+
 		public bool IsSquare { get; set; }
 
 		public double IndicatorSize { get; set; }
@@ -219,21 +221,19 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.LayoutSubviews();
 
+			float scale = (float)IndicatorSize / DefaultIndicatorSize;
+			var newTransform = CGAffineTransform.MakeScale(scale, scale);
+
+			Transform = newTransform;
 			if (Subviews.Length == 0)
 				return;
 
 			foreach (var view in Subviews)
 			{
-				if(IsSquare)
+				if (IsSquare)
 				{
 					view.Layer.CornerRadius = 0;
 				}
-
-				float scale = (float)IndicatorSize / 7;
-				System.Diagnostics.Debug.WriteLine($"{IndicatorSize} scale {scale}");
-				CGAffineTransform newTransform = CGAffineTransform.MakeScale(scale, scale);
-
-				view.Transform = newTransform;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
@@ -66,6 +66,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.OnElementPropertyChanged(sender, e);
 
+			if (e.PropertyName == IndicatorSizeProperty.PropertyName)
+				UpdateIndicatorSize();
 			if (e.PropertyName == IndicatorsShapeProperty.PropertyName ||
 				e.PropertyName == ItemsSourceProperty.PropertyName)
 				UpdateIndicator();
@@ -90,7 +92,11 @@ namespace Xamarin.Forms.Platform.iOS
 				UIPager.ValueChanged -= UIPagerValueChanged;
 			}
 
-			var uiPager = new FormsPageControl { IsSquare = Element.IndicatorsShape == IndicatorShape.Square };
+			var uiPager = new FormsPageControl
+			{
+				IsSquare = Element.IndicatorsShape == IndicatorShape.Square,
+				IndicatorSize = Element.IndicatorSize
+			};
 			_defaultPagesIndicatorTintColor = uiPager.PageIndicatorTintColor;
 			_defaultCurrentPagesIndicatorTintColor = uiPager.CurrentPageIndicatorTintColor;
 			uiPager.ValueChanged += UIPagerValueChanged;
@@ -128,6 +134,12 @@ namespace Xamarin.Forms.Platform.iOS
 			ClearIndicators();
 			UIPager.IsSquare = Element.IndicatorsShape == IndicatorShape.Square;
 			AddSubview(UIPager);
+			UIPager.LayoutSubviews();
+		}
+
+		void UpdateIndicatorSize()
+		{
+			UIPager.IndicatorSize = Element.IndicatorSize;
 			UIPager.LayoutSubviews();
 		}
 
@@ -201,16 +213,27 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public bool IsSquare { get; set; }
 
+		public double IndicatorSize { get; set; }
+
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
 
-			if (Subviews.Length == 0 || !IsSquare)
+			if (Subviews.Length == 0)
 				return;
 
 			foreach (var view in Subviews)
 			{
-				view.Layer.CornerRadius = 0;
+				if(IsSquare)
+				{
+					view.Layer.CornerRadius = 0;
+				}
+
+				float scale = (float)IndicatorSize / 7;
+				System.Diagnostics.Debug.WriteLine($"{IndicatorSize} scale {scale}");
+				CGAffineTransform newTransform = CGAffineTransform.MakeScale(scale, scale);
+
+				view.Transform = newTransform;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Make a UIPagerControl that can renderer squares instead of circles 

### Issues Resolved ### 

- fixes #8913
- fixes #8933

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

When specifying IndicatorShape as Square it should show squares on tie UIPagerControl

### Before/After Screenshots ### 

Before:
![Simulator Screen Shot - iPhone 11 - 2020-02-14 at 19 21 56](https://user-images.githubusercontent.com/1235097/74560990-a2cc3200-4f5f-11ea-85f8-0719422f8cdd.png)

After:
![Simulator Screen Shot - iPhone 11 - 2020-02-14 at 19 19 57](https://user-images.githubusercontent.com/1235097/74560981-9d6ee780-4f5f-11ea-969c-78e52818a51b.png)



### Testing Procedure ###

Visit CarouselView Gallery, Enable IndicatorVIew, click  IndicatorView sample , then change the IndicatorTemplate to Square

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
