### PR TITLE
Remove duplicate NS 2.0 on vsmac

### DIFF
--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -3,7 +3,8 @@
     <RootNamespace>Xamarin.Forms.DualScreen</RootNamespace>
     <AssemblyName>Xamarin.Forms.DualScreen</AssemblyName>
     <PackageId>Xamarin.Forms.DualScreen</PackageId>
-    <TargetFrameworks>$(TargetFrameworks);$(AndroidTargetFrameworks);netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">$(TargetFrameworks);$(AndroidTargetFrameworks);netstandard1.0;netstandard2.0</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">$(AndroidTargetFrameworks);netstandard1.0;netstandard2.0</TargetFrameworks>
     <SkipMicrosoftUIXamlCheckTargetPlatformVersion>true</SkipMicrosoftUIXamlCheckTargetPlatformVersion>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>


### PR DESCRIPTION
### Description of Change ###
Duplicate NS 2.0 imports on DualScreen breaking intellisense on VS MAC

### Testing Procedure ###
- verify intellisense still works and DualScreen project is still deploying ok

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
