### PR TITLE
[UWP] [CollectionView] RemainingItemsThresholdReachedCommand support

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9013.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9013.xaml
@@ -1,0 +1,72 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9013"
+    x:DataType="issues:ViewModelIssue9013">
+
+    <Grid>
+        
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+
+        <StackLayout
+            Grid.Row="0"
+            Orientation="Horizontal"
+            Padding="10">
+            
+            <Button
+                Text="{Binding RunTestButtonText}" />
+
+            <Label 
+                Text="{Binding TestResult}"
+                VerticalOptions="CenterAndExpand"/>
+
+        </StackLayout>
+
+        <CollectionView
+            Grid.Row="1"
+            ItemsSource="{Binding Groups}"
+            IsGrouped="True"
+            RemainingItemsThreshold="10"
+            RemainingItemsThresholdReachedCommand="{Binding ThresholdReachedCommand}">
+
+            <CollectionView.GroupHeaderTemplate>
+                <DataTemplate x:DataType="issues:GroupIssue9013">
+
+                    <ContentView
+                        Padding="10"
+                        BackgroundColor="DarkSeaGreen">
+
+                        <Label
+                            HeightRequest="30"
+                            Text="{Binding Title}" />
+
+                    </ContentView>
+
+                </DataTemplate>
+            </CollectionView.GroupHeaderTemplate>
+
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="issues:ItemIssue9013">
+
+                    <ContentView
+                        Padding="10"
+                        BackgroundColor="BurlyWood">
+
+                        <Label Text="{Binding Text}" />
+
+                    </ContentView>
+
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+
+        </CollectionView>
+
+    </Grid>
+
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9013.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9013.xaml.cs
@@ -1,0 +1,165 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9013, "[Bug] [UWP] RemainingItemsThresholdReachedCommand in CollectionView is not working", PlatformAffected.UWP)]
+	public partial class Issue9013 : TestContentPage
+	{
+		internal const string RunTestButtonText = "Run test";
+		internal const string Success = "Success";
+
+		ViewModelIssue9013 _viewModel;
+
+		public Issue9013()
+        {
+#if APP
+	        InitializeComponent();
+
+			SetRunButtonClickHandler();
+#endif
+		}
+
+		protected override void Init()
+        {
+			_viewModel = new ViewModelIssue9013();
+			BindingContext = _viewModel;
+
+#if UITEST
+	        SetRunButtonClickHandler();
+#endif
+        }
+
+        void SetRunButtonClickHandler()
+        {
+	        var grid = (Grid)Content;
+	        var stackLayout = (StackLayout)grid.Children.First();
+	        var button = (Button)stackLayout.Children.First();
+
+	        button.Clicked += OnRunButtonClicked;
+		}
+
+        void OnRunButtonClicked(object sender, EventArgs e)
+        {
+	        var grid = (Grid)Content;
+	        var collectionView = (CollectionView)grid.Children.Single(v => v is CollectionView);
+
+	        collectionView.ScrollTo(_viewModel.ItemsCount - _viewModel.RemainingItemsThreshold - 1);
+        }
+
+#if UITEST
+        [Test]
+		[NUnit.Framework.Category(UITestCategories.CollectionView)]
+        public void RemainingItemsThresholdReachedCommandIsWorking()
+        {
+			RunningApp.WaitForElement(RunTestButtonText);
+			RunningApp.Tap(RunTestButtonText);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue9013 : INotifyPropertyChanged
+	{
+		int _countOfGroupsInBatch = 5;
+		int _countOfItemsInGroup = 10;
+		int _itemCounter = -1;
+
+		string _testResult;
+
+		public string TestResult
+		{
+			get
+			{
+				return _testResult;
+			}
+			set
+			{
+				if (_testResult == value)
+				{
+					return;
+				}
+
+				_testResult = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public string RunTestButtonText => Issue9013.RunTestButtonText;
+
+		public ObservableCollection<GroupIssue9013> Groups { get; set; }
+
+		public int RemainingItemsThreshold { get; set; }
+
+		public int ItemsCount => _itemCounter + 1;
+
+		public Command ThresholdReachedCommand { get; set; }
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public ViewModelIssue9013()
+		{
+			TestResult = string.Empty;
+			Groups = new ObservableCollection<GroupIssue9013>();
+			ThresholdReachedCommand = new Command(ExecuteThresholdReachedCommand);
+			RemainingItemsThreshold = 10;
+			GenerateItems();
+		}
+
+		protected virtual void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		void ExecuteThresholdReachedCommand()
+		{
+			GenerateItems();
+			TestResult = Issue9013.Success;
+		}
+
+		void GenerateItems()
+		{
+			for (int i = 0; i < _countOfGroupsInBatch; i++)
+			{
+				var group = new GroupIssue9013();
+
+				for (int j = 0; j < _countOfItemsInGroup; j++)
+				{
+					_itemCounter++;
+					group.Add(new ItemIssue9013 { Text = $"Item index: {_itemCounter}" });
+				}
+
+				Groups.Add(group);
+			}
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ItemIssue9013
+	{
+		public string Text { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class GroupIssue9013 : ObservableCollection<ItemIssue9013>
+	{
+		public string Title => "Group title";
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -173,6 +173,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7963.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8743.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9013.xaml.cs">
+      <DependentUpon>Issue9013.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9092.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9087.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9355.cs" />
@@ -1829,6 +1833,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8902.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9013.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/Items/ItemsView.cs
+++ b/Xamarin.Forms.Core/Items/ItemsView.cs
@@ -181,6 +181,23 @@ namespace Xamarin.Forms
 			OnRemainingItemsThresholdReached();
 		}
 
+		public void ResolveRemainingItemsThreshold(int itemsCount, int lastVisibleItemIndex)
+		{
+			switch (RemainingItemsThreshold)
+			{
+				case -1:
+					return;
+				case 0:
+					if (lastVisibleItemIndex == itemsCount - 1)
+						SendRemainingItemsThresholdReached();
+					break;
+				default:
+					if (itemsCount - 1 - lastVisibleItemIndex <= RemainingItemsThreshold)
+						SendRemainingItemsThresholdReached();
+					break;
+			}
+		}
+
 		public void SendScrolled(ItemsViewScrolledEventArgs e)
 		{
 			Scrolled?.Invoke(this, e);

--- a/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
@@ -64,19 +64,7 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 			if (lastVisibleItemIndex == -1)
 				return;
 
-			switch (_itemsView.RemainingItemsThreshold)
-			{
-				case -1:
-					return;
-				case 0:
-					if (lastVisibleItemIndex == _itemsViewAdapter.ItemCount - 1)
-						_itemsView.SendRemainingItemsThresholdReached();
-					break;
-				default:
-					if (_itemsViewAdapter.ItemCount - 1 - lastVisibleItemIndex <= _itemsView.RemainingItemsThreshold)
-						_itemsView.SendRemainingItemsThresholdReached();
-					break;
-			}
+			_itemsView.ResolveRemainingItemsThreshold(_itemsViewAdapter.ItemCount, lastVisibleItemIndex);
 		}
 
 		static int CalculateCenterItemIndex(int firstVisibleItemIndex, RecyclerView recyclerView, LinearLayoutManager linearLayoutManager)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
@@ -57,19 +57,7 @@ namespace Xamarin.Forms.Platform.iOS
 			PreviousHorizontalOffset = (float)contentOffsetX;
 			PreviousVerticalOffset = (float)contentOffsetY;
 
-			switch (itemsView.RemainingItemsThreshold)
-			{
-				case -1:
-					return;
-				case 0:
-					if (lastVisibleItemIndex == source.ItemCount - 1)
-						itemsView.SendRemainingItemsThresholdReached();
-					break;
-				default:
-					if (source.ItemCount - 1 - lastVisibleItemIndex <= itemsView.RemainingItemsThreshold)
-						itemsView.SendRemainingItemsThresholdReached();
-					break;
-			}
+			itemsView.ResolveRemainingItemsThreshold(source.ItemCount, lastVisibleItemIndex);
 		}
 
 		public override UIEdgeInsets GetInsetForSection(UICollectionView collectionView, UICollectionViewLayout layout,


### PR DESCRIPTION
### Description of Change ###

Added support for CollectionView's RemainingItemsThresholdReachedCommand on UWP platform.

### Issues Resolved ### 

- fixes #9013

### API Changes ###

Added:
 - void ItemsView.ResolveRemainingItemsThreshold ();

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
