### PR TITLE
Call UpdateToolBarItems after page is changed

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationItem.Title = Page.Title;
 		}
 
-		protected virtual void OnPageSet(Page oldPage, Page newPage)
+		protected virtual async void OnPageSet(Page oldPage, Page newPage)
 		{
 			if (oldPage != null)
 			{
@@ -149,6 +149,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (oldPage == null)
 				((IShellController)_context.Shell).AddFlyoutBehaviorObserver(this);
+
+			if (newPage != null)
+			{
+				try
+				{
+					await UpdateToolbarItems();
+				}
+				catch(Exception exc)
+				{
+					Internals.Log.Warning(nameof(ShellPageRendererTracker), $"Failed to update toolbar items: {exc}");
+				}
+			}
 		}
 
 		protected virtual void OnRendererSet()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				try
 				{
-					await UpdateToolbarItems();
+					await UpdateToolbarItems().ConfigureAwait(false);
 				}
 				catch(Exception exc)
 				{


### PR DESCRIPTION
### Description of Change ###
On iOS call UpdateToolBarItems after the page is set on ShellPageRendererTracker. The page is set after an animation effect occurs so the state of the active page on ShellPageRendererTracker is out of sync when appearancechanged notifications are fired

### Issues Resolved ### 
- fixes #9483

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
