### PR TITLE
Fix packageVersion parameter on build.cake

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -36,6 +36,7 @@ PowerShell:
 
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
+var packageVersion = Argument("packageVersion", "");
 
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
@@ -171,9 +172,17 @@ Task("_NuGetPack")
     .Description("Create Nugets without building anything")
     .Does(() =>
     {
-        var nugetVersionFile = 
-            GetFiles(".XamarinFormsVersionFile.txt");
-        var nugetversion = FileReadText(nugetVersionFile.First());
+        var nugetversion = String.Empty;
+
+        if(!String.IsNullOrWhiteSpace(packageVersion))
+        {
+            nugetversion = packageVersion;
+        }
+        else
+        {
+            var nugetVersionFile = GetFiles(".XamarinFormsVersionFile.txt");
+            nugetversion = FileReadText(nugetVersionFile.First());
+        }
 
         Information("Nuget Version: {0}", nugetversion);
 


### PR DESCRIPTION
### Description of Change ###

Fix build.cake so that it works with the packageVersion parameter

### Issues Resolved ### 
- fixes #9523 


### Testing Procedure ###
- ensure this works
`./build.ps1 -Target NugetPack -ScriptArgs '-packageVersion="9.9.9-custom"'`
- ensure this still works
`./build.ps1 -Target NugetPack`


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
