### PR TITLE
[iOS] Update ItemsViewController constrains when bounds change

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8902.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8902.xaml
@@ -7,28 +7,30 @@
              xmlns:controls="clr-namespace:Xamarin.Forms.Controls"  
              x:Class="Xamarin.Forms.Controls.Issues.Issue8902">
     <controls:TestContentPage.Content>
-        <CarouselView ItemsSource="{Binding Persons}">
-            <CarouselView.ItemsLayout>
-                <LinearItemsLayout Orientation="Horizontal"
+        <StackLayout>
+            <CarouselView ItemsSource="{Binding Persons}">
+                <CarouselView.ItemsLayout>
+                    <LinearItemsLayout Orientation="Horizontal"
                          SnapPointsType="MandatorySingle" />
-            </CarouselView.ItemsLayout>
-            <CarouselView.ItemTemplate>
-                <DataTemplate>
-                    <Frame>
-                        <StackLayout>
-                            <ContentView Margin="30"
+                </CarouselView.ItemsLayout>
+                <CarouselView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame>
+                            <StackLayout>
+                                <ContentView Margin="30"
                          BackgroundColor="Gray"
                          HorizontalOptions="Fill">
-                                <Label FontSize="Large"
+                                    <Label FontSize="Large"
                      Text="{Binding Name}" />
-                            </ContentView>
-                            <Label HorizontalOptions="Center"
+                                </ContentView>
+                                <Label HorizontalOptions="Center"
                    Text="{Binding Age}"
                    VerticalOptions="Center" />
-                        </StackLayout>
-                    </Frame>
-                </DataTemplate>
-            </CarouselView.ItemTemplate>
-        </CarouselView>
+                            </StackLayout>
+                        </Frame>
+                    </DataTemplate>
+                </CarouselView.ItemTemplate>
+            </CarouselView>
+        </StackLayout>
     </controls:TestContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
@@ -47,7 +47,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
 				Position = 2,
-				//NumberOfSideItems = 1,
 				Margin = new Thickness(0,10,0,10),
 				BackgroundColor = Color.LightGray,
 				AutomationId = "TheCarouselView"

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			var layout = new Grid
 			{
 				RowDefinitions = new RowDefinitionCollection {
-								new RowDefinition { Height = GridLength.Auto },
+								new RowDefinition { Height = 30 },
 								new RowDefinition { Height = GridLength.Auto },
 								new RowDefinition { Height = GridLength.Auto },
 					},

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -74,6 +74,12 @@ namespace Xamarin.Forms.Platform.iOS
 			base.RegisterViewTypes();
 		}
 
+		public override void BoundsSizeChanged()
+		{
+			base.BoundsSizeChanged();
+			_carouselView.ScrollTo(_carouselView.Position, animate: false);
+		}
+
 		internal void TearDown()
 		{
 			_carouselView.PropertyChanged -= CarouselViewPropertyChanged;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.RegisterViewTypes();
 		}
 
-		public override void BoundsSizeChanged()
+		protected override void BoundsSizeChanged()
 		{
 			base.BoundsSizeChanged();
 			_carouselView.ScrollTo(_carouselView.Position, animate: false);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void BoundsSizeChanged()
 		{
 			base.BoundsSizeChanged();
-			_carouselView.ScrollTo(_carouselView.Position, animate: false);
+			_carouselView.ScrollTo(_carouselView.Position, position: ScrollToPosition.Center, animate: false);
 		}
 
 		internal void TearDown()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -17,7 +17,9 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _isEmpty;
 		bool _emptyViewDisplayed;
 		bool _disposed;
-  
+
+		CGSize _size;
+
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
 
@@ -148,7 +150,8 @@ namespace Xamarin.Forms.Platform.iOS
 			// are set up the first time this method is called.
 			if (!_initialConstraintsSet)
 			{
-				ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
+				_size = CollectionView.Bounds.Size;
+				ItemsViewLayout.ConstrainTo(_size);
 				UpdateEmptyView();
 				_initialConstraintsSet = true;
 			}
@@ -158,15 +161,24 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		public override void WillAnimateRotation(UIInterfaceOrientation toInterfaceOrientation, double duration)
+		
+		public override void ViewDidLayoutSubviews()
+		{
+			base.ViewDidLayoutSubviews();
+			if (CollectionView.Bounds.Size != _size)
+			{
+				_size = CollectionView.Bounds.Size;
+				BoundsSizeChanged();
+			}
+		}
+
+		protected virtual void BoundsSizeChanged()
 		{
 			//We are changing orientation and we need to tell our layout
 			//to update based on new size constrains
 			ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
 			//We call ReloadData so our VisibleCells also update their size
 			CollectionView.ReloadData();
-
-			base.WillAnimateRotation(toInterfaceOrientation, duration);
 		}
 
 		protected virtual UICollectionViewDelegateFlowLayout CreateDelegator()


### PR DESCRIPTION
### Description of Change ###

Better fix for orientation changes on CollectionView and CarouselView. Monitor the bound changes, for example when we change the orientation.
Also fixes when the visibility changes. Initially the bounds are something like 1,1 when visibility changes we set a new frame to the CollectionView.

### Issues Resolved ### 

- fixes #9583 
- fixes #9609
- fixes #8521

### API Changes ###

`ItemsViewController<TItemsView> `
Added:
 - `protected virtual void BoundsSizeChanged();`


### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

CarouselView should update the item size when rotating the device.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Use issue 8902

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
