### PR TITLE
Set text color for disabled states on material buttons

### DIFF
--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -6,13 +6,10 @@ using Android.Content.Res;
 using Android.Graphics;
 #if __ANDROID_29__
 using AndroidX.Core.View;
-#else
-using Android.Support.V4.View;
-#endif
-#if __ANDROID_29__
 using AndroidX.AppCompat.Widget;
 using MButton = Google.Android.Material.Button.MaterialButton;
 #else
+using Android.Support.V4.View;
 using Android.Support.V7.Widget;
 using MButton = Android.Support.Design.Button.MaterialButton;
 #endif
@@ -321,13 +318,20 @@ namespace Xamarin.Forms.Material.Android
 			// text
 			Color textColor = Element.TextColor;
 			AColor text;
+			AColor disabledText;
+
 			if (textColor.IsDefault)
+			{
 				text = MaterialColors.Light.OnPrimaryColor;
+				disabledText = MaterialColors.Light.DisabledColor;
+			}
 			else
-				text = textColor.ToAndroid();
+			{
+				text = disabledText = textColor.ToAndroid();
+			}
 
 			// apply
-			SetTextColor(MaterialColors.CreateButtonTextColors(background, text));
+			SetTextColor(MaterialColors.CreateButtonTextColors(background, text, disabledText));
 			ViewCompat.SetBackgroundTintList(this, MaterialColors.CreateButtonBackgroundColors(background));
 		}
 

--- a/Xamarin.Forms.Material.Android/MaterialColors.cs
+++ b/Xamarin.Forms.Material.Android/MaterialColors.cs
@@ -132,6 +132,13 @@ namespace Xamarin.Forms.Material.Tizen
 			new int[] { }
 		};
 
+		public static readonly int[][] ButtonTextStates =
+		{
+			new int[] { global::Android.Resource.Attribute.StateEnabled },
+			new int[] { ~global::Android.Resource.Attribute.StateEnabled },
+			new int[] { }
+		};
+
 		public static readonly int[][] EntryHintTextStates =
 		{
 			new []{ global::Android.Resource.Attribute.StateEnabled, global::Android.Resource.Attribute.StatePressed  },
@@ -154,10 +161,10 @@ namespace Xamarin.Forms.Material.Tizen
 
 		// State list from material-components-android
 		// https://github.com/material-components/material-components-android/blob/3637c23078afc909e42833fd1c5fd47bb3271b5f/lib/java/com/google/android/material/button/res/color/mtrl_btn_text_color_selector.xml
-		public static ColorStateList CreateButtonTextColors(PlatformColor primary, PlatformColor text)
+		public static ColorStateList CreateButtonTextColors(PlatformColor primary, PlatformColor text, PlatformColor disabledText)
 		{
-			var colors = new int[] { text, primary.WithAlpha(0.38) };
-			return new ColorStateList(ButtonStates, colors);
+			var colors = new int[] { text, disabledText, primary.WithAlpha(0.38) };
+			return new ColorStateList(ButtonTextStates, colors);
 		}
 
 		public static ColorStateList CreateEntryFilledPlaceholderColors(PlatformColor inlineColor, PlatformColor floatingColor)
@@ -268,6 +275,7 @@ namespace Xamarin.Forms.Material.Tizen
 			public static readonly PlatformColor OnPrimaryColor = PlatformColor.White;
 			public static readonly PlatformColor SecondaryColor = FromRgb(33, 33, 33);
 			public static readonly PlatformColor OnSecondaryColor = PlatformColor.White;
+			public static readonly PlatformColor DisabledColor = WithAlpha(PlatformColor.Black, 0.38f);
 
 			// the Colors for "UI"
 			public static readonly PlatformColor BackgroundColor = PlatformColor.White;

--- a/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
@@ -96,6 +96,13 @@ namespace Xamarin.Forms.Material.iOS
 
 			// Colors have to be re-applied to Character spacing
 			_buttonLayoutManager?.UpdateText();
+
+			Color textColor = Element.TextColor;
+
+			if (textColor.IsDefault)
+				Control.SetTitleColor(MaterialColors.Light.DisabledColor, UIControlState.Disabled);
+			else
+				Control.SetTitleColor(textColor.ToUIColor(), UIControlState.Disabled);
 		}
 
 		protected override MButton CreateNativeControl() => new MButton();
@@ -246,7 +253,7 @@ namespace Xamarin.Forms.Material.iOS
 				else
 					colorScheme.OnPrimaryColor = textColor.ToUIColor();
 			}
-			
+
 		}
 
 		// IImageVisualElementRenderer


### PR DESCRIPTION
### Description of Change ###

Apply Text Color to disabled states on Buttons

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9261


### Platforms Affected ### 
- iOS
- Android

### Behavioral/Visual Changes ###
Disabled buttons will now apply whatever you have set the TextColor to. This is a breaking change but prior to this fix it was impossible to change the color when the button is in a disabled state. 

### Before/After Screenshots ### 

Below is the visual gallery.
On the left is before and on the right is after

![image](https://user-images.githubusercontent.com/5375137/74973901-8ad23380-53e1-11ea-9a32-598d8837cbf7.png)


### Testing Procedure ###
- run the visual gallery and compare ios and android

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
