### PR TITLE
Remove unreliable scroll from TestItemsPosition

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
@@ -236,17 +236,16 @@ namespace Xamarin.Forms.Core.UITests
 
 		void TestItemsPosition(string gallery)
 		{
+			var firstItem = "Item: 0";
+			var secondItem = "Item: 1";
+			var fourthItem = "Item: 3";
+
 			var isVertical = !gallery.Contains("Horizontal");
 			var isList = !gallery.Contains("Grid");
-			App.WaitForNoElement(t => t.Marked(gallery));
-
-			var element1 = App.Query(c => c.Marked("Item: 0"))[0];
-			if (App.Query(c => c.Marked("Item: 2")).Length == 0)
-			{
-				var collectionViewFrame = App.Query(q => q.Marked(_collectionViewId))[0].Rect;
-				App.ScrollForElement($"* marked:'Item: 2'", new Drag(collectionViewFrame, isVertical ? Drag.Direction.BottomToTop : Drag.Direction.RightToLeft, Drag.DragLength.Long), 50);
-			}
-			var element2 = App.Query(c => c.Marked("Item: 2"))[0];
+			App.WaitForNoElement(gallery);
+						
+			var element1 = App.Query(firstItem)[0];
+			var element2 = App.Query(secondItem)[0];
 
 			if (isVertical)
 			{
@@ -257,7 +256,7 @@ namespace Xamarin.Forms.Core.UITests
 				}
 				else
 				{
-					var element3 = App.Query(c => c.Marked("Item: 3"))[0];
+					var element3 = App.Query(fourthItem)[0];
 					Assert.AreEqual(element2.Rect.Y, element1.Rect.Y, message: $"{gallery} Elements are not align");
 					Assert.Greater(element3.Rect.Y, element1.Rect.Y, message: $"{gallery} Element3.Y is not greater that Element1.Y");
 					Assert.AreEqual(element3.Rect.X, element1.Rect.X, message: $"{gallery} Element3.X on second row is not below Element1X");
@@ -272,7 +271,7 @@ namespace Xamarin.Forms.Core.UITests
 				}
 				else
 				{
-					var element3 = App.Query(c => c.Marked("Item: 3"))[0];
+					var element3 = App.Query(fourthItem)[0];
 					Assert.AreEqual(element2.Rect.X, element1.Rect.X, message: $"{gallery} Elements are not align");
 					Assert.Greater(element3.Rect.X, element1.Rect.X, message: $"{gallery} Element2.X is not greater that Element1.X");
 					Assert.AreEqual(element3.Rect.Y, element1.Rect.Y, message: $"{gallery} Element3.Y is not in the same row as Element1.Y");

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CollectionViewUITests.cs
@@ -136,16 +136,16 @@ namespace Xamarin.Forms.Core.UITests
 		[TestCase("Observable Collection", new string[] { "Add/RemoveItemsList", "Add/RemoveItemsGrid" }, 1, 6)]
 		public void AddRemoveItems(string collectionTestName, string[] subGalleries, int firstItem, int lastItem)
 		{
-		VisitInitialGallery(collectionTestName);
+			VisitInitialGallery(collectionTestName);
 
-		foreach (var gallery in subGalleries)
-		{
-			if (gallery == "FilterItems")
-				continue;
+			foreach (var gallery in subGalleries)
+			{
+				if (gallery == "FilterItems")
+					continue;
 
-			VisitSubGallery(gallery, !gallery.Contains("Horizontal"), $"Item: {firstItem}", $"Item: {lastItem}", lastItem - 1, false, true);
-			App.NavigateBack();
-		}
+				VisitSubGallery(gallery, !gallery.Contains("Horizontal"), $"Item: {firstItem}", $"Item: {lastItem}", lastItem - 1, false, true);
+				App.NavigateBack();
+			}
 		}
 
 		[TestCase("Observable Collection", new string[] { "Add/RemoveItemsList", "Add/RemoveItemsGrid" }, 19, 6)]
@@ -161,7 +161,7 @@ namespace Xamarin.Forms.Core.UITests
 					continue;
 				App.WaitForElement(t => t.Marked(gallery));
 				App.Tap(t => t.Marked(gallery));
-				TesItemsPosition(gallery);
+				TestItemsPosition(gallery);
 				App.NavigateBack();
 			}
 		}
@@ -234,7 +234,7 @@ namespace Xamarin.Forms.Core.UITests
 			return collectionViewFrame;
 		}
 
-		void TesItemsPosition(string gallery)
+		void TestItemsPosition(string gallery)
 		{
 			var isVertical = !gallery.Contains("Horizontal");
 			var isList = !gallery.Contains("Grid");
@@ -252,56 +252,56 @@ namespace Xamarin.Forms.Core.UITests
 			{
 				if (isList)
 				{
-					Assert.AreEqual(element1.Rect.X, element2.Rect.X);
-					Assert.Greater(element2.Rect.Y, element1.Rect.Y);
+					Assert.AreEqual(element1.Rect.X, element2.Rect.X, message: $"{gallery} Elements are not align");
+					Assert.Greater(element2.Rect.Y, element1.Rect.Y, message: $"{gallery} Element2.Y is not greater that Element1.Y");
 				}
 				else
 				{
 					var element3 = App.Query(c => c.Marked("Item: 3"))[0];
-					Assert.AreEqual(element2.Rect.Y, element1.Rect.Y);
-					Assert.Greater(element3.Rect.Y, element1.Rect.Y);
-					Assert.AreEqual(element3.Rect.X, element1.Rect.X);
+					Assert.AreEqual(element2.Rect.Y, element1.Rect.Y, message: $"{gallery} Elements are not align");
+					Assert.Greater(element3.Rect.Y, element1.Rect.Y, message: $"{gallery} Element3.Y is not greater that Element1.Y");
+					Assert.AreEqual(element3.Rect.X, element1.Rect.X, message: $"{gallery} Element3.X on second row is not below Element1X");
 				}
 			}
 			else
 			{
 				if (isList)
 				{
-					Assert.AreEqual(element1.Rect.Y, element2.Rect.Y);
-					Assert.Greater(element2.Rect.X, element1.Rect.X);
+					Assert.AreEqual(element1.Rect.Y, element2.Rect.Y, message: $"{gallery} Elements are not align");
+					Assert.Greater(element2.Rect.X, element1.Rect.X, message: $"{gallery} Element2.X is not greater that Element1.X");
 				}
 				else
 				{
 					var element3 = App.Query(c => c.Marked("Item: 3"))[0];
-					Assert.AreEqual(element2.Rect.X, element1.Rect.X);
-					Assert.Greater(element3.Rect.X, element1.Rect.X);
-					Assert.AreEqual(element3.Rect.Y, element1.Rect.Y);
+					Assert.AreEqual(element2.Rect.X, element1.Rect.X, message: $"{gallery} Elements are not align");
+					Assert.Greater(element3.Rect.X, element1.Rect.X, message: $"{gallery} Element2.X is not greater that Element1.X");
+					Assert.AreEqual(element3.Rect.Y, element1.Rect.Y, message: $"{gallery} Element3.Y is not in the same row as Element1.Y");
 				}
 			}
 		}
 
 		[TestCase("EmptyView", "EmptyView (load simulation)", "photo")]
-        public void VisitAndCheckItem(string collectionTestName, string subgallery, string item)
-        {
-            VisitInitialGallery(collectionTestName);
+		public void VisitAndCheckItem(string collectionTestName, string subgallery, string item)
+		{
+			VisitInitialGallery(collectionTestName);
 
-            App.WaitForElement(t => t.Marked(subgallery));
-            App.Tap(t => t.Marked(subgallery));
+			App.WaitForElement(t => t.Marked(subgallery));
+			App.Tap(t => t.Marked(subgallery));
 
-            App.WaitForElement(t => t.Marked(item));
-        }
-		
-        [TestCase("DataTemplate Galleries", "DataTemplateSelector")]
-        void VisitAndCheckForItems(string collectionTestName, string subGallery)
-        {
-            VisitInitialGallery(collectionTestName);
-            
-            App.WaitForElement(t => t.Marked(subGallery));
-            App.Tap(t => t.Marked(subGallery));
+			App.WaitForElement(t => t.Marked(item));
+		}
 
-            App.WaitForElement("weekend");
-            App.WaitForElement("weekday");
-        }
-        
-    }
+		[TestCase("DataTemplate Galleries", "DataTemplateSelector")]
+		void VisitAndCheckForItems(string collectionTestName, string subGallery)
+		{
+			VisitInitialGallery(collectionTestName);
+
+			App.WaitForElement(t => t.Marked(subGallery));
+			App.Tap(t => t.Marked(subGallery));
+
+			App.WaitForElement("weekend");
+			App.WaitForElement("weekday");
+		}
+
+	}
 }


### PR DESCRIPTION
These changes add more information to the TestItemsPosition method when a test fails. They also remove the scrolling from the test to make it more reliable.