### PR TITLE
[iOS] Remove unused FormsButton to fix Aspect

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9054.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9054.cs
@@ -21,24 +21,24 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 			StackLayout stackLayout = new StackLayout();
-
+			string imageSource = "coffee.png";
 			ImageButton imageButton1 = new ImageButton()
 			{
-				Source = "coffee.png",
+				Source = imageSource,
 				Aspect = Aspect.AspectFill,
 				AutomationId = "TestImage"
 			};
 
 			ImageButton imageButton2 = new ImageButton()
 			{
-				Source = "coffee.png",
+				Source = imageSource,
 				Aspect = Aspect.AspectFit,
 				AutomationId = "TestImage"
 			};
 
 			ImageButton imageButton3 = new ImageButton()
 			{
-				Source = "coffee.png",
+				Source = imageSource,
 				Aspect = Aspect.Fill,
 				AutomationId = "TestImage"
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9054.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9054.cs
@@ -1,0 +1,57 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9054, "[Bug] ImageButton.Aspect Property is always Fill",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ImageButton)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public class Issue9054 : TestContentPage
+	{
+		protected override void Init()
+		{
+			StackLayout stackLayout = new StackLayout();
+
+			ImageButton imageButton1 = new ImageButton()
+			{
+				Source = "coffee.png",
+				Aspect = Aspect.AspectFill,
+				AutomationId = "TestImage"
+			};
+
+			ImageButton imageButton2 = new ImageButton()
+			{
+				Source = "coffee.png",
+				Aspect = Aspect.AspectFit,
+				AutomationId = "TestImage"
+			};
+
+			ImageButton imageButton3 = new ImageButton()
+			{
+				Source = "coffee.png",
+				Aspect = Aspect.Fill,
+				AutomationId = "TestImage"
+			};
+
+			stackLayout.Children.Add(new Label() { Text = $"Verify Image Button Aspects Are Working" });
+			stackLayout.Children.Add(new Label() { Text = $"{imageButton1.Aspect}" });
+			stackLayout.Children.Add(imageButton1);
+			stackLayout.Children.Add(new Label() { Text = $"{imageButton2.Aspect}" });
+			stackLayout.Children.Add(imageButton2);
+			stackLayout.Children.Add(new Label() { Text = $"{imageButton3.Aspect}" });
+			stackLayout.Children.Add(imageButton3);
+
+			Content = stackLayout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1201,6 +1201,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7875.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7924.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8461.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9054.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
@@ -114,50 +114,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override UIButton CreateNativeControl()
 		{			
-			return new FormsButton();
-		}
-
-		class FormsButton : UIButton
-		{
-			UIImageView _imageView;
-			public FormsButton() : base()
-			{
-			}
-
-			public override void LayoutSubviews()
-			{
-				base.LayoutSubviews();
-			}
-
-			public override void AddSubview(UIView view)
-			{
-				base.AddSubview(view);
-			}
-
-
-			public override void InsertSubview(UIView view, nint atIndex)
-			{
-				base.InsertSubview(view, atIndex);
-			}
-			public override UIImageView ImageView
-			{
-				get
-				{
-					if (_imageView == null)
-					{
-						_imageView = new FormsUIImageView();
-					}
-
-					return _imageView;
-				}
-			}
-
-
-			//[Export("imageViewClass")]
-			//public static ObjCRuntime.Class imageViewClass()
-			//{
-			//	return new ObjCRuntime.Class(typeof(FormsUIImageView));
-			//}
+			return new UIButton();
 		}
 
 		protected override void SetAccessibilityLabel()


### PR DESCRIPTION
### Description of Change ###
Delete the FormsButton because it's not being used. This was code left over when I was trying to get GIF Animations work on Buttons but was unsuccessful. 

![image](https://user-images.githubusercontent.com/5375137/75003020-a2321080-5423-11ea-813e-c7a24a313be1.png)

### Issues Resolved ### 
- fixes #9054


### Platforms Affected ### 
- iOS

### Testing Procedure ###
- Added a manual test. Not really sure if this can be automated. The UIImageView is always the same size regardless of the aspect setting.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
