### PR TITLE
[Core,iOS] Invalidate size when IndicatorView collection/count changes

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -1,6 +1,8 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries
@@ -150,18 +152,23 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 		public CarouselItemsGalleryViewModel()
 		{
-			Items = new ObservableCollection<CarouselData>();
-
-			var random = new Random();
-
-			for (int n = 0; n < 5; n++)
+			Task.Run(async () =>
 			{
-				_items.Add(new CarouselData
+				await Task.Delay(200);
+				var random = new Random();
+
+				var source = new List<CarouselData>();
+				for (int n = 0; n < 5; n++)
 				{
-					Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
-					Name = $"{n + 1}"
-				});
-			}
+					source.Add(new CarouselData
+					{
+						Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
+						Name = $"{n + 1}"
+					});
+				}
+				Items = new ObservableCollection<CarouselData>(source);
+			});
+
 		}
 
 		public ObservableCollection<CarouselData> Items

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -143,6 +143,8 @@ namespace Xamarin.Forms
 				collection.CollectionChanged += OnCollectionChanged;
 
 			OnCollectionChanged(ItemsSource, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+
+			InvalidateMeasureInternal(Internals.InvalidationTrigger.MeasureChanged);
 		}
 
 		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

The size of the IndicatorView is based on the number of indicators and the size and padding. When the Collection and respective count changes we need to invalidate so a new size is calculated

### Issues Resolved ### 

- fixes #9666 

### API Changes ###
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###
Indicators should appeared if setting the ItemSource of a CarousselView in a delayed fashion. 

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Visit the IndicatorGallery, make sure you see the Indicators

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
