### PR TITLE
[iOS] Fix NRE when not using template on CarouselView

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -140,7 +140,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			foreach (var cell in cells)
 			{
-				var itemView = (cell as CarouselTemplatedCell)?.VisualElementRenderer?.Element as View;
+				if (!((cell as CarouselTemplatedCell)?.VisualElementRenderer?.Element is View itemView))
+					return;
+
 				var item = itemView.BindingContext;
 				var pos = GetPosition(item);
 


### PR DESCRIPTION
### Description of Change ###

If the user doesn't provide a template we might not have a View to apply a VisualState

### Issues Resolved ### 

None

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
