### PR TITLE
[Android] Fix getting the position on SingleSnapHelper 

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -39,7 +39,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				ItemsSource = viewModel.Items,
 				IsScrollAnimated = true,
 				IsBounceEnabled = true,
-				EmptyView = "This is the empty view"
+				EmptyView = "This is the empty view",
+				PeekAreaInsets = new Thickness(50)
 			};
 
 			var absolute = new AbsoluteLayout();

--- a/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Forms.Platform.Android
 				return CurrentTargetPosition;
 			}
 
+			var itemCount = layoutManager.ItemCount;
 			var increment = 1;
 
 			if (layoutManager.CanScrollHorizontally())
@@ -85,6 +86,11 @@ namespace Xamarin.Forms.Platform.Android
 			if (IsLayoutReversed(layoutManager))
 			{
 				increment = increment * -1;
+			}
+
+			if (CurrentTargetPosition == itemCount - 1 && increment == 1)
+			{
+				return CurrentTargetPosition;
 			}
 
 			CurrentTargetPosition = CurrentTargetPosition + increment;


### PR DESCRIPTION

### Description of Change ###

The SingleSnapHelper was providing the wrong postion, because it was incrementing by one even when getting to the end of the Collection. We should not increment if we are already on the last item.

### Issues Resolved ### 

- fixes #9020 

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

When getting to the last item and slide left , swiping back to the right should go to the previous item.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Go to CarouselItemsGallery, go to the last time, swipe left again, then swipe right it should go to the previous item, if you need to swipe 2 times the test failed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
