### PR TITLE
[iOS|Android] Fix screen reader order

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/A11yTabIndex.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/A11yTabIndex.xaml
@@ -42,14 +42,14 @@
 
         <Button Text="Skip" AutomationProperties.IsInAccessibleTree="False" TabIndex="3" Grid.Row="3"/>
 
-        <Frame BackgroundColor="Cornsilk" Margin="20" CornerRadius="2" BorderColor="Gray" Grid.Row="4">
+        <Frame BackgroundColor="Cornsilk" Margin="20" CornerRadius="2" BorderColor="Gray" Grid.Row="4"  AutomationProperties.IsInAccessibleTree="False">
             <StackLayout>
                 <Button Text="Twelve" TabIndex="3"/>
                 <Button Text="Ten" TabIndex="2"/>
             </StackLayout>
         </Frame>
 
-        <Frame BackgroundColor="Cornsilk" Margin="20" CornerRadius="2" BorderColor="Gray" Grid.Row="5">
+        <Frame BackgroundColor="Cornsilk" Margin="20" CornerRadius="2" BorderColor="Gray" Grid.Row="5"  AutomationProperties.IsInAccessibleTree="False">
             <StackLayout>
                 <StackLayout>
                     <Button Text="Six" />

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -286,6 +286,7 @@ namespace Xamarin.Forms.Controls
 		}
 
 		List<GalleryPageFactory> _pages = new List<GalleryPageFactory> {
+				new GalleryPageFactory(() => new TabIndexTest.TabIndex(), "Accessibility TabIndex (2)"),
 				new GalleryPageFactory(() => new PlatformTestsConsole(), "Platform Automated Tests"),
 				new GalleryPageFactory(() => new MemoryLeakGallery(), "Memory Leak"),
 				new GalleryPageFactory(() => new Issues.A11yTabIndex(), "Accessibility TabIndex"),

--- a/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml
@@ -60,37 +60,37 @@
                 <Frame.Triggers>
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Sunday}">
                         <Setter Property="AutomationProperties.Name" Value="Sunday"/>
-                        <Setter Property="TabIndex" Value="1"/>
+                        <!--<Setter Property="TabIndex" Value="1"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Monday}">
                         <Setter Property="AutomationProperties.Name" Value="Monday"/>
-                        <Setter Property="TabIndex" Value="2"/>
+                        <!--<Setter Property="TabIndex" Value="2"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Tuesday}">
                         <Setter Property="AutomationProperties.Name" Value="Tuesday"/>
-                        <Setter Property="TabIndex" Value="3"/>
+                        <!--<Setter Property="TabIndex" Value="3"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Wednesday}">
                         <Setter Property="AutomationProperties.Name" Value="Wednesday"/>
-                        <Setter Property="TabIndex" Value="4"/>
+                        <!--<Setter Property="TabIndex" Value="4"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Thursday}">
                         <Setter Property="AutomationProperties.Name" Value="Thursday"/>
-                        <Setter Property="TabIndex" Value="5"/>
+                        <!--<Setter Property="TabIndex" Value="5"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Friday}">
                         <Setter Property="AutomationProperties.Name" Value="Friday"/>
-                        <Setter Property="TabIndex" Value="6"/>
+                        <!--<Setter Property="TabIndex" Value="6"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Saturday}">
                         <Setter Property="AutomationProperties.Name" Value="Saturday"/>
-                        <Setter Property="TabIndex" Value="7"/>
+                        <!--<Setter Property="TabIndex" Value="7"/>-->
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding IsSelected}" Value="True">

--- a/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml
@@ -10,7 +10,7 @@
   <ContentView.Content>
         <StackLayout BindingContext="{x:Reference this}"
                      HorizontalOptions="FillAndExpand"
-                     AutomationProperties.IsInAccessibleTree="False" IsTabStop="False">
+                     AutomationProperties.IsInAccessibleTree="False">
             <Frame Margin="0"
                    Padding="0"
                    HasShadow="False"
@@ -25,7 +25,7 @@
                        HorizontalOptions="FillAndExpand"
                        VerticalOptions="FillAndExpand"
                        VerticalTextAlignment="Center"
-                       HorizontalTextAlignment="Center" IsTabStop="False">
+                       HorizontalTextAlignment="Center">
                     <Label.Triggers>
                         <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Sunday}">
                             <Setter Property="Text" Value="S"/>
@@ -60,30 +60,37 @@
                 <Frame.Triggers>
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Sunday}">
                         <Setter Property="AutomationProperties.Name" Value="Sunday"/>
+                        <Setter Property="TabIndex" Value="1"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Monday}">
                         <Setter Property="AutomationProperties.Name" Value="Monday"/>
+                        <Setter Property="TabIndex" Value="2"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Tuesday}">
                         <Setter Property="AutomationProperties.Name" Value="Tuesday"/>
+                        <Setter Property="TabIndex" Value="3"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Wednesday}">
                         <Setter Property="AutomationProperties.Name" Value="Wednesday"/>
+                        <Setter Property="TabIndex" Value="4"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Thursday}">
                         <Setter Property="AutomationProperties.Name" Value="Thursday"/>
+                        <Setter Property="TabIndex" Value="5"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Friday}">
                         <Setter Property="AutomationProperties.Name" Value="Friday"/>
+                        <Setter Property="TabIndex" Value="6"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Saturday}">
                         <Setter Property="AutomationProperties.Name" Value="Saturday"/>
+                        <Setter Property="TabIndex" Value="7"/>
                     </DataTrigger>
 
                     <DataTrigger TargetType="Frame" Binding="{Binding IsSelected}" Value="True">

--- a/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentView xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             xmlns:enums="clr-namespace:Xamarin.Forms.Controls.TabIndexTest"
+             x:Name="this"
+             x:Class="Xamarin.Forms.Controls.TabIndexTest.DayView">
+  <ContentView.Content>
+        <StackLayout BindingContext="{x:Reference this}"
+                     HorizontalOptions="FillAndExpand"
+                     AutomationProperties.IsInAccessibleTree="False" IsTabStop="False">
+            <Frame Margin="0"
+                   Padding="0"
+                   HasShadow="False"
+                   WidthRequest="32" 
+                   HeightRequest="32" 
+                   CornerRadius="16"
+                   HorizontalOptions="Center"
+                   BackgroundColor="{Binding ButtonBackgroundColor}"
+                   AutomationProperties.IsInAccessibleTree="True">
+                <Label TextColor="{Binding TextColor}"
+                       AutomationProperties.IsInAccessibleTree="False"
+                       HorizontalOptions="FillAndExpand"
+                       VerticalOptions="FillAndExpand"
+                       VerticalTextAlignment="Center"
+                       HorizontalTextAlignment="Center" IsTabStop="False">
+                    <Label.Triggers>
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Sunday}">
+                            <Setter Property="Text" Value="S"/>
+                        </DataTrigger>
+
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Monday}">
+                            <Setter Property="Text" Value="M"/>
+                        </DataTrigger>
+
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Tuesday}">
+                            <Setter Property="Text" Value="T"/>
+                        </DataTrigger>
+
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Wednesday}">
+                            <Setter Property="Text" Value="W"/>
+                        </DataTrigger>
+
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Thursday}">
+                            <Setter Property="Text" Value="T"/>
+                        </DataTrigger>
+
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Friday}">
+                            <Setter Property="Text" Value="F"/>
+                        </DataTrigger>
+
+                        <DataTrigger TargetType="Label" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Saturday}">
+                            <Setter Property="Text" Value="S"/>
+                        </DataTrigger>
+                    </Label.Triggers>
+                </Label>
+                <!-- The view's accessibility label triggers -->
+                <Frame.Triggers>
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Sunday}">
+                        <Setter Property="AutomationProperties.Name" Value="Sunday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Monday}">
+                        <Setter Property="AutomationProperties.Name" Value="Monday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Tuesday}">
+                        <Setter Property="AutomationProperties.Name" Value="Tuesday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Wednesday}">
+                        <Setter Property="AutomationProperties.Name" Value="Wednesday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Thursday}">
+                        <Setter Property="AutomationProperties.Name" Value="Thursday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Friday}">
+                        <Setter Property="AutomationProperties.Name" Value="Friday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding Day}" Value="{x:Static enums:DaysOfWeek.Saturday}">
+                        <Setter Property="AutomationProperties.Name" Value="Saturday"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding IsSelected}" Value="True">
+                        <Setter Property="AutomationProperties.HelpText" Value="On"/>
+                    </DataTrigger>
+
+                    <DataTrigger TargetType="Frame" Binding="{Binding IsSelected}" Value="False">
+                        <Setter Property="AutomationProperties.HelpText" Value="Off"/>
+                    </DataTrigger>
+                </Frame.Triggers>
+                <Frame.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding TouchCommand}"/>
+                </Frame.GestureRecognizers>
+            </Frame>
+        </StackLayout>
+    </ContentView.Content>
+</ContentView>

--- a/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml.cs
+++ b/Xamarin.Forms.Controls/TabIndexTest/DayView.xaml.cs
@@ -1,0 +1,114 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.TabIndexTest
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class DayView : ContentView
+	{
+		Color _buttonBackgroundColor;
+		public Color ButtonBackgroundColor
+		{
+			get => _buttonBackgroundColor;
+			set
+			{
+				_buttonBackgroundColor = value;
+				OnPropertyChanged(nameof(ButtonBackgroundColor));
+			}
+		}
+
+		Color _textColor;
+		public Color TextColor
+		{
+			get => _textColor;
+			set
+			{
+				_textColor = value;
+				OnPropertyChanged(nameof(TextColor));
+			}
+		}
+
+		public static readonly BindableProperty DayProperty = BindableProperty.Create(
+			nameof(Day),
+			typeof(DaysOfWeek),
+			typeof(DayView),
+			DaysOfWeek.None);
+
+		public DaysOfWeek Day
+		{
+			get => (DaysOfWeek)GetValue(DayProperty);
+			set => SetValue(DayProperty, value);
+		}
+
+		public static readonly BindableProperty DayTouchedProperty = BindableProperty.Create(
+			nameof(DayTouched),
+			typeof(Command<DaysOfWeek>),
+			typeof(DayView),
+			default(Command<DaysOfWeek>));
+
+		public Command<DaysOfWeek> DayTouched
+		{
+			get => (Command<DaysOfWeek>)GetValue(DayTouchedProperty);
+			set => SetValue(DayTouchedProperty, value);
+		}
+
+		public static readonly BindableProperty IsSelectedProperty = BindableProperty.Create(
+			nameof(IsSelected),
+			typeof(bool),
+			typeof(DayView),
+			default(bool),
+			propertyChanged: (bindable, value, newValue) =>
+			{
+				if (bindable is DayView view)
+				{
+					view.RenderSelection((bool)newValue);
+				}
+			});
+		public bool IsSelected
+		{
+			get => (bool)GetValue(IsSelectedProperty);
+			set => SetValue(IsSelectedProperty, value);
+		}
+
+		public ICommand TouchCommand { get; }
+
+		public DayView()
+		{
+			TouchCommand = new Command(DoDayTouched);
+			RenderSelection(false);
+			InitializeComponent();
+		}
+
+		public void RenderSelection(bool selected)
+		{
+			if (selected)
+			{
+				ButtonBackgroundColor = Colors.Cerulean;
+				TextColor = Colors.White;
+			}
+			else
+			{
+				ButtonBackgroundColor = Colors.Gray;
+				TextColor = Colors.Black;
+			}
+		}
+
+		public void Toggle()
+		{
+			IsSelected = !IsSelected;
+			RenderSelection(IsSelected);
+		}
+
+		void DoDayTouched()
+		{
+			Toggle();
+			DayTouched?.Execute(Day);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/TabIndexTest/DaysOfWeekView.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/DaysOfWeekView.xaml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<Grid xmlns="http://xamarin.com/schemas/2014/forms" 
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:enums="clr-namespace:Xamarin.Forms.Controls.TabIndexTest"
+             xmlns:views="clr-namespace:Xamarin.Forms.Controls.TabIndexTest"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.TabIndexTest.DaysOfWeekView" IsTabStop="False">
+
+    <views:DayView x:Name="Sunday" Grid.Column="0" 
+                   Day="{x:Static enums:DaysOfWeek.Sunday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="1"/>
+
+        <views:DayView x:Name="Monday" Grid.Column="1" 
+                   Day="{x:Static enums:DaysOfWeek.Monday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="2"/>
+
+        <views:DayView x:Name="Tuesday" Grid.Column="2" 
+                   Day="{x:Static enums:DaysOfWeek.Tuesday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="3"/>
+
+        <views:DayView x:Name="Wednesday" Grid.Column="3" 
+                   Day="{x:Static enums:DaysOfWeek.Wednesday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="4"/>
+
+        <views:DayView x:Name="Thursday" Grid.Column="4" 
+                   Day="{x:Static enums:DaysOfWeek.Thursday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="5"/>
+
+        <views:DayView x:Name="Friday" Grid.Column="5" 
+                   Day="{x:Static enums:DaysOfWeek.Friday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="6"/>
+
+        <views:DayView x:Name="Saturday" Grid.Column="6" 
+                   Day="{x:Static enums:DaysOfWeek.Saturday}" 
+                   DayTouched="{Binding DayTouched}"
+                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="7"/>
+</Grid>

--- a/Xamarin.Forms.Controls/TabIndexTest/DaysOfWeekView.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/DaysOfWeekView.xaml
@@ -6,40 +6,40 @@
              xmlns:enums="clr-namespace:Xamarin.Forms.Controls.TabIndexTest"
              xmlns:views="clr-namespace:Xamarin.Forms.Controls.TabIndexTest"
              mc:Ignorable="d"
-             x:Class="Xamarin.Forms.Controls.TabIndexTest.DaysOfWeekView" IsTabStop="False">
+             x:Class="Xamarin.Forms.Controls.TabIndexTest.DaysOfWeekView">
 
     <views:DayView x:Name="Sunday" Grid.Column="0" 
                    Day="{x:Static enums:DaysOfWeek.Sunday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="1"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 
-        <views:DayView x:Name="Monday" Grid.Column="1" 
+    <views:DayView x:Name="Monday" Grid.Column="1" 
                    Day="{x:Static enums:DaysOfWeek.Monday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="2"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 
-        <views:DayView x:Name="Tuesday" Grid.Column="2" 
+    <views:DayView x:Name="Tuesday" Grid.Column="2" 
                    Day="{x:Static enums:DaysOfWeek.Tuesday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="3"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 
-        <views:DayView x:Name="Wednesday" Grid.Column="3" 
+    <views:DayView x:Name="Wednesday" Grid.Column="3" 
                    Day="{x:Static enums:DaysOfWeek.Wednesday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="4"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 
-        <views:DayView x:Name="Thursday" Grid.Column="4" 
+    <views:DayView x:Name="Thursday" Grid.Column="4" 
                    Day="{x:Static enums:DaysOfWeek.Thursday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="5"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 
-        <views:DayView x:Name="Friday" Grid.Column="5" 
+    <views:DayView x:Name="Friday" Grid.Column="5" 
                    Day="{x:Static enums:DaysOfWeek.Friday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="6"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 
-        <views:DayView x:Name="Saturday" Grid.Column="6" 
+    <views:DayView x:Name="Saturday" Grid.Column="6" 
                    Day="{x:Static enums:DaysOfWeek.Saturday}" 
                    DayTouched="{Binding DayTouched}"
-                   AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="7"/>
+                   AutomationProperties.IsInAccessibleTree="false" IsTabStop="false"/>
 </Grid>

--- a/Xamarin.Forms.Controls/TabIndexTest/DaysOfWeekView.xaml.cs
+++ b/Xamarin.Forms.Controls/TabIndexTest/DaysOfWeekView.xaml.cs
@@ -1,0 +1,20 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.TabIndexTest
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class DaysOfWeekView : Grid
+	{
+		public DaysOfWeekView()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
@@ -15,15 +15,15 @@
                 <views:DaysOfWeekView x:Name="composite"/>
 
                 <Label Text="Start Time" HorizontalOptions="FillAndExpand"
-                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="10" x:Name="label2"/>
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True"  x:Name="label2"/>
                 <TimePicker
-                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="11" x:Name="timePicker"/>
+                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True"  x:Name="timePicker"/>
 
                 <Label Text="Stop Time" HorizontalOptions="FillAndExpand"
-                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="12" x:Name="label3"/>
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True"  x:Name="label3"/>
 
                 <TimePicker
-                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="13" x:Name="timePicker2"/>
+                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" x:Name="timePicker2"/>
             </StackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
@@ -10,7 +10,7 @@
         <ScrollView x:Name="scroll">
             <StackLayout x:Name="stack">
                 <Label Text="Select Days" HorizontalOptions="CenterAndExpand"
-                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="1" x:Name="label"/>
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" x:Name="label"/>
 
                 <views:DaysOfWeekView x:Name="composite"/>
 

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
@@ -7,23 +7,23 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.TabIndexTest.TabIndex">
     <ContentPage.Content>
-        <ScrollView IsTabStop="False">
-            <StackLayout IsTabStop="False">
+        <ScrollView x:Name="scroll">
+            <StackLayout x:Name="stack">
                 <Label Text="Select Days" HorizontalOptions="CenterAndExpand"
-                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="1"/>
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="1" x:Name="label"/>
 
-                <views:DaysOfWeekView/>
+                <views:DaysOfWeekView x:Name="composite"/>
 
                 <Label Text="Start Time" HorizontalOptions="FillAndExpand"
-                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="10"/>
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="10" x:Name="label2"/>
                 <TimePicker
-                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="11"/>
+                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="11" x:Name="timePicker"/>
 
                 <Label Text="Stop Time" HorizontalOptions="FillAndExpand"
-                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="12"/>
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="12" x:Name="label3"/>
 
                 <TimePicker
-                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="13"/>
+                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="13" x:Name="timePicker2"/>
             </StackLayout>
         </ScrollView>
     </ContentPage.Content>

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:views="clr-namespace:Xamarin.Forms.Controls.TabIndexTest"
+             mc:Ignorable="d"
+             x:Class="Xamarin.Forms.Controls.TabIndexTest.TabIndex">
+    <ContentPage.Content>
+        <ScrollView IsTabStop="False">
+            <StackLayout IsTabStop="False">
+                <Label Text="Select Days" HorizontalOptions="CenterAndExpand"
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="1"/>
+
+                <views:DaysOfWeekView/>
+
+                <Label Text="Start Time" HorizontalOptions="FillAndExpand"
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="10"/>
+                <TimePicker
+                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="11"/>
+
+                <Label Text="Stop Time" HorizontalOptions="FillAndExpand"
+                       AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="12"/>
+
+                <TimePicker
+                    AutomationProperties.IsInAccessibleTree="True" IsTabStop="True" TabIndex="13"/>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml.cs
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml.cs
@@ -3,13 +3,13 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
-
+using NUnit.Framework;
 using Xamarin.Forms;
+//using Xamarin.Forms.Core.UnitTests;
 using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.TabIndexTest
 {
-	[XamlCompilation(XamlCompilationOptions.Compile)]
 	public partial class TabIndex : ContentPage
 	{
 		public TabIndex()
@@ -17,6 +17,93 @@ namespace Xamarin.Forms.Controls.TabIndexTest
 			InitializeComponent();
 		}
 
+		public TabIndex(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
 
+		//[TestFixture]
+		//public class Tests
+		//{
+		//	[SetUp]
+		//	public void Setup()
+		//	{
+		//		//Device.PlatformServices = new MockPlatformServices();
+		//	}
+
+		//	[TearDown]
+		//	public void TearDown()
+		//	{
+		//		Device.PlatformServices = null;
+		//	}
+
+		//	[TestCase(false)]
+		//	[TestCase(true)]
+		//	public void TabIndexIsProperlySet(bool useCompiledXaml)
+		//	{
+		//		var layout = new TabIndex(useCompiledXaml);
+
+		//		SortedDictionary<int, List<ITabStopElement>> tabIndexes = null;
+		//		foreach (var child in layout.LogicalChildren)
+		//		{
+		//			if (!(child is VisualElement ve))
+		//				continue;
+
+		//			tabIndexes = ve.GetSortedTabIndexesOnParentPage();
+		//			break;
+		//		}
+
+		//		if (tabIndexes == null)
+		//			return;
+
+		//		Assert.That(tabIndexes.Any());
+
+		//		Assert.AreEqual(3, tabIndexes[0].Count, "Too many items in group 0");
+		//		Assert.AreEqual(tabIndexes[0][0], layout.scroll);
+		//		Assert.AreEqual(tabIndexes[0][1], layout.stack);
+		//		Assert.AreEqual(tabIndexes[0][2], layout.composite);
+
+		//		Assert.AreEqual(2, tabIndexes[1].Count, "Too many items in group 1");
+		//		Assert.AreEqual(tabIndexes[1][0], layout.label);
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[1][1]);
+		//		Assert.AreEqual("Sunday", AutomationProperties.GetName(((Frame)tabIndexes[1][1])));
+
+		//		Assert.AreEqual(1, tabIndexes[2].Count, "Too many items in group 2");
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[2][0]);
+		//		Assert.AreEqual("Monday", AutomationProperties.GetName(((Frame)tabIndexes[2][0])));
+
+		//		Assert.AreEqual(1, tabIndexes[3].Count, "Too many items in group 3");
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[3][0]);
+		//		Assert.AreEqual("Tuesday", AutomationProperties.GetName(((Frame)tabIndexes[3][0])));
+
+		//		Assert.AreEqual(1, tabIndexes[4].Count, "Too many items in group 4");
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[4][0]);
+		//		Assert.AreEqual("Wednesday", AutomationProperties.GetName(((Frame)tabIndexes[4][0])));
+
+		//		Assert.AreEqual(1, tabIndexes[5].Count, "Too many items in group 5");
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[5][0]);
+		//		Assert.AreEqual("Thursday", AutomationProperties.GetName(((Frame)tabIndexes[5][0])));
+
+		//		Assert.AreEqual(1, tabIndexes[6].Count, "Too many items in group 6");
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[6][0]);
+		//		Assert.AreEqual("Friday", AutomationProperties.GetName(((Frame)tabIndexes[6][0])));
+
+		//		Assert.AreEqual(1, tabIndexes[7].Count, "Too many items in group 7");
+		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[7][0]);
+		//		Assert.AreEqual("Saturday", AutomationProperties.GetName(((Frame)tabIndexes[7][0])));
+
+		//		Assert.IsFalse(tabIndexes.ContainsKey(8), "Something unexpected in group 8");
+		//		Assert.IsFalse(tabIndexes.ContainsKey(9), "Something unexpected in group 9");
+
+		//		Assert.AreEqual(1, tabIndexes[10].Count, "Too many items in group 10");
+		//		Assert.AreEqual(tabIndexes[10][0], layout.label2);
+		//		Assert.AreEqual(1, tabIndexes[11].Count, "Too many items in group 11");
+		//		Assert.AreEqual(tabIndexes[11][0], layout.timePicker);
+		//		Assert.AreEqual(1, tabIndexes[12].Count, "Too many items in group 12");
+		//		Assert.AreEqual(tabIndexes[12][0], layout.label3);
+		//		Assert.AreEqual(1, tabIndexes[13].Count, "Too many items in group 13");
+		//		Assert.AreEqual(tabIndexes[13][0], layout.timePicker2);
+		//	}
+		//}
 	}
 }

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml.cs
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.TabIndexTest
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TabIndex : ContentPage
+	{
+		public TabIndex()
+		{
+			InitializeComponent();
+		}
+
+
+	}
+}

--- a/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml.cs
+++ b/Xamarin.Forms.Controls/TabIndexTest/TabIndex.xaml.cs
@@ -1,12 +1,5 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-using NUnit.Framework;
-using Xamarin.Forms;
-//using Xamarin.Forms.Core.UnitTests;
-using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.TabIndexTest
 {
@@ -16,94 +9,5 @@ namespace Xamarin.Forms.Controls.TabIndexTest
 		{
 			InitializeComponent();
 		}
-
-		public TabIndex(bool useCompiledXaml)
-		{
-			//this stub will be replaced at compile time
-		}
-
-		//[TestFixture]
-		//public class Tests
-		//{
-		//	[SetUp]
-		//	public void Setup()
-		//	{
-		//		//Device.PlatformServices = new MockPlatformServices();
-		//	}
-
-		//	[TearDown]
-		//	public void TearDown()
-		//	{
-		//		Device.PlatformServices = null;
-		//	}
-
-		//	[TestCase(false)]
-		//	[TestCase(true)]
-		//	public void TabIndexIsProperlySet(bool useCompiledXaml)
-		//	{
-		//		var layout = new TabIndex(useCompiledXaml);
-
-		//		SortedDictionary<int, List<ITabStopElement>> tabIndexes = null;
-		//		foreach (var child in layout.LogicalChildren)
-		//		{
-		//			if (!(child is VisualElement ve))
-		//				continue;
-
-		//			tabIndexes = ve.GetSortedTabIndexesOnParentPage();
-		//			break;
-		//		}
-
-		//		if (tabIndexes == null)
-		//			return;
-
-		//		Assert.That(tabIndexes.Any());
-
-		//		Assert.AreEqual(3, tabIndexes[0].Count, "Too many items in group 0");
-		//		Assert.AreEqual(tabIndexes[0][0], layout.scroll);
-		//		Assert.AreEqual(tabIndexes[0][1], layout.stack);
-		//		Assert.AreEqual(tabIndexes[0][2], layout.composite);
-
-		//		Assert.AreEqual(2, tabIndexes[1].Count, "Too many items in group 1");
-		//		Assert.AreEqual(tabIndexes[1][0], layout.label);
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[1][1]);
-		//		Assert.AreEqual("Sunday", AutomationProperties.GetName(((Frame)tabIndexes[1][1])));
-
-		//		Assert.AreEqual(1, tabIndexes[2].Count, "Too many items in group 2");
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[2][0]);
-		//		Assert.AreEqual("Monday", AutomationProperties.GetName(((Frame)tabIndexes[2][0])));
-
-		//		Assert.AreEqual(1, tabIndexes[3].Count, "Too many items in group 3");
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[3][0]);
-		//		Assert.AreEqual("Tuesday", AutomationProperties.GetName(((Frame)tabIndexes[3][0])));
-
-		//		Assert.AreEqual(1, tabIndexes[4].Count, "Too many items in group 4");
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[4][0]);
-		//		Assert.AreEqual("Wednesday", AutomationProperties.GetName(((Frame)tabIndexes[4][0])));
-
-		//		Assert.AreEqual(1, tabIndexes[5].Count, "Too many items in group 5");
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[5][0]);
-		//		Assert.AreEqual("Thursday", AutomationProperties.GetName(((Frame)tabIndexes[5][0])));
-
-		//		Assert.AreEqual(1, tabIndexes[6].Count, "Too many items in group 6");
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[6][0]);
-		//		Assert.AreEqual("Friday", AutomationProperties.GetName(((Frame)tabIndexes[6][0])));
-
-		//		Assert.AreEqual(1, tabIndexes[7].Count, "Too many items in group 7");
-		//		Assert.IsAssignableFrom(typeof(Frame), tabIndexes[7][0]);
-		//		Assert.AreEqual("Saturday", AutomationProperties.GetName(((Frame)tabIndexes[7][0])));
-
-		//		Assert.IsFalse(tabIndexes.ContainsKey(8), "Something unexpected in group 8");
-		//		Assert.IsFalse(tabIndexes.ContainsKey(9), "Something unexpected in group 9");
-
-		//		Assert.AreEqual(1, tabIndexes[10].Count, "Too many items in group 10");
-		//		Assert.AreEqual(tabIndexes[10][0], layout.label2);
-		//		Assert.AreEqual(1, tabIndexes[11].Count, "Too many items in group 11");
-		//		Assert.AreEqual(tabIndexes[11][0], layout.timePicker);
-		//		Assert.AreEqual(1, tabIndexes[12].Count, "Too many items in group 12");
-		//		Assert.AreEqual(tabIndexes[12][0], layout.label3);
-		//		Assert.AreEqual(1, tabIndexes[13].Count, "Too many items in group 13");
-		//		Assert.AreEqual(tabIndexes[13][0], layout.timePicker2);
-		//	}
-		//}
 	}
 }

--- a/Xamarin.Forms.Controls/TabIndexTest/ViewModels.cs
+++ b/Xamarin.Forms.Controls/TabIndexTest/ViewModels.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Xamarin.Forms.Controls.TabIndexTest
+{
+	public static class Colors
+	{
+		public static Color Cerulean = Color.FromRgb(0, 115, 209);
+		public static Color Gray = Color.FromRgb(216, 221, 230);
+		public static Color White = Color.White;
+		public static Color Black = Color.Black;
+	}
+	[Flags]
+	public enum DaysOfWeek
+	{
+		None = 0,
+		Sunday = 1 << 0,
+		Monday = 1 << 1,
+		Tuesday = 1 << 2,
+		Wednesday = 1 << 3,
+		Thursday = 1 << 4,
+		Friday = 1 << 5,
+		Saturday = 1 << 6,
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -39,6 +39,22 @@
     <PackageReference Include="Newtonsoft.Json" Version="11.0.2" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
   </ItemGroup>
+  <ItemGroup>
+    <Compile Update="TabIndexTest\DaysOfWeekView.xaml.cs">
+      <DependentUpon>DaysOfWeekView.xaml</DependentUpon>
+    </Compile>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Update="TabIndexTest\DayView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="TabIndexTest\TabIndex.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="TabIndexTest\DaysOfWeekView.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
 
   <Target Name="CreateControllGalleryConfig" BeforeTargets="Build">
     <CreateItem Include="blank.config">

--- a/Xamarin.Forms.Core.UnitTests/TabIndexTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TabIndexTests.cs
@@ -1,4 +1,5 @@
 using NUnit.Framework;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Xamarin.Forms.Core.UnitTests
@@ -6,7 +7,6 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class TabIndexTests : BaseTestFixture
 	{
-
 		[Test]
 		public void GetTabIndexesOnParentPage_ImplicitZero()
 		{
@@ -26,6 +26,243 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			//StackLayout is technically the first element with TabIndex 0.
 			Assert.AreEqual(target, tabIndexes[0][0]);
+		}
+
+		class CustomGrid : Grid
+		{
+			public CustomGrid()
+			{
+				foreach (var i in Enumerable.Range(1, 7))
+				{
+					Children.Add(new CustomContent(i), i, 0);
+				}
+			}
+		}
+
+		class CustomContent : ContentView
+		{
+			public Frame Frame { get; set; } = new Frame();
+			public CustomContent(int idx)
+			{
+				AutomationProperties.SetIsInAccessibleTree(this, false);
+
+				IsTabStop = false;
+
+				Frame.IsTabStop = true;
+				Frame.TabIndex = idx;
+
+				var stack = new StackLayout();
+				var label = new Label() { Text = idx.ToString() };
+
+				Frame.Content = label;
+				stack.Children.Add(Frame);
+
+				AutomationProperties.SetHelpText(Frame, idx.ToString());
+
+				AutomationProperties.SetIsInAccessibleTree(label, false);
+				AutomationProperties.SetIsInAccessibleTree(Frame, true);
+				AutomationProperties.SetIsInAccessibleTree(stack, false);
+
+				Content = stack;
+			}
+		}
+
+		[Test]
+		public void GetTabIndexesOnParentPage_CompositeControls()
+		{
+			var label = new Label() { TabIndex = 1 };
+
+			var composite = new CustomGrid();
+
+			var label2 = new Label() { TabIndex = 10 };
+
+			var timePicker = new TimePicker() { TabIndex = 11 };
+
+			var label3 = new Label() { TabIndex = 12 };
+
+			var timePicker2 = new TimePicker() { TabIndex = 13 };
+
+			var stack = new StackLayout
+			{
+				Children = {
+					label,
+					composite,
+					label2,
+					timePicker,
+					label3,
+					timePicker2
+				}
+			};
+
+			var scroll = new ScrollView() { Content = stack };
+
+			var page = new ContentPage { Content = scroll };
+
+			SortedDictionary<int, List<ITabStopElement>> tabIndexes = null;
+			foreach (var child in page.LogicalChildren)
+			{
+				if (!(child is VisualElement ve))
+					continue;
+
+				tabIndexes = ve.GetSortedTabIndexesOnParentPage();
+				break;
+			}
+
+			Assert.That(tabIndexes.Any());
+
+			Assert.AreEqual(3, tabIndexes[0].Count, "Too many items in group 0");
+			Assert.AreEqual(tabIndexes[0][0], scroll);
+			Assert.AreEqual(tabIndexes[0][1], stack);
+			Assert.AreEqual(tabIndexes[0][2], composite);
+
+			Assert.AreEqual(2, tabIndexes[1].Count, "Too many items in group 1");
+			Assert.AreEqual(tabIndexes[1][0], label);
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[1][1]);
+			Assert.AreEqual("1", AutomationProperties.GetHelpText(((Frame)tabIndexes[1][1])));
+
+			Assert.AreEqual(1, tabIndexes[2].Count, "Too many items in group 2");
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[2][0]);
+			Assert.AreEqual("2", AutomationProperties.GetHelpText(((Frame)tabIndexes[2][0])));
+
+			Assert.AreEqual(1, tabIndexes[3].Count, "Too many items in group 3");
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[3][0]);
+			Assert.AreEqual("3", AutomationProperties.GetHelpText(((Frame)tabIndexes[3][0])));
+
+			Assert.AreEqual(1, tabIndexes[4].Count, "Too many items in group 4");
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[4][0]);
+			Assert.AreEqual("4", AutomationProperties.GetHelpText(((Frame)tabIndexes[4][0])));
+
+			Assert.AreEqual(1, tabIndexes[5].Count, "Too many items in group 5");
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[5][0]);
+			Assert.AreEqual("5", AutomationProperties.GetHelpText(((Frame)tabIndexes[5][0])));
+
+			Assert.AreEqual(1, tabIndexes[6].Count, "Too many items in group 6");
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[6][0]);
+			Assert.AreEqual("6", AutomationProperties.GetHelpText(((Frame)tabIndexes[6][0])));
+
+			Assert.AreEqual(1, tabIndexes[7].Count, "Too many items in group 7");
+			Assert.IsAssignableFrom(typeof(Frame), tabIndexes[7][0]);
+			Assert.AreEqual("7", AutomationProperties.GetHelpText(((Frame)tabIndexes[7][0])));
+
+			Assert.IsFalse(tabIndexes.ContainsKey(8), "Something unexpected in group 8");
+			Assert.IsFalse(tabIndexes.ContainsKey(9), "Something unexpected in group 9");
+
+			Assert.AreEqual(1, tabIndexes[10].Count, "Too many items in group 10");
+			Assert.AreEqual(tabIndexes[10][0], label2);
+			Assert.AreEqual(1, tabIndexes[11].Count, "Too many items in group 11");
+			Assert.AreEqual(tabIndexes[11][0], timePicker);
+			Assert.AreEqual(1, tabIndexes[12].Count, "Too many items in group 12");
+			Assert.AreEqual(tabIndexes[12][0], label3);
+			Assert.AreEqual(1, tabIndexes[13].Count, "Too many items in group 13");
+			Assert.AreEqual(tabIndexes[13][0], timePicker2);
+		}
+
+		[Test]
+		public void GetTabIndexesOnParentPage_GetTabIndexForLayoutChildren()
+		{
+			var target = new Label { TabIndex = 0 };
+			var stack = new StackLayout
+			{
+				IsTabStop = false,
+				Children = {
+					new Label { TabIndex = 1 },
+					target,
+					new Label { TabIndex = 3 },
+					new Label { TabIndex = 2 },
+				}
+			};
+
+			var page = new ContentPage { Content = stack };
+
+			var tabIndexes = stack.GetTabIndexesOnParentPage(out int _);
+
+			Assert.That(tabIndexes.Any());
+			Assert.AreEqual(target, tabIndexes[0][0]);
+		}
+
+		[Test]
+		public void GetTabIndexesOnParentPage_MasterPage()
+		{
+			var target = new Label { TabIndex = 0 };
+			var stack = new StackLayout
+			{
+				IsTabStop = false,
+				Children = {
+					new Label { TabIndex = 1 },
+					target,
+					new Label { TabIndex = 3 },
+					new Label { TabIndex = 2 },
+				}
+			};
+
+			var stack2 = new StackLayout
+			{
+				IsTabStop = false,
+				Children = {
+					new Label { TabIndex = 1 },
+					new Label { TabIndex = 3 },
+					new Label { TabIndex = 2 },
+				}
+			};
+
+			var masterPage = new ContentPage { Content = stack, Title = "master" };
+
+			var detailPage = new ContentPage { Content = stack2 };
+
+			var mdp = new MasterDetailPage { Master = masterPage, Detail = detailPage };
+
+			var tabIndexes = stack.GetTabIndexesOnParentPage(out int _);
+
+			Assert.That(tabIndexes.Any());
+			Assert.AreEqual(target, tabIndexes[0][0]);
+		}
+
+		[Test]
+		public void GetTabIndexesOnParentPage_DetailPage()
+		{
+			var target = new Label { TabIndex = 0 };
+			var stack = new StackLayout
+			{
+				IsTabStop = false,
+				Children = {
+					new Label { TabIndex = 1 },
+					target,
+					new Label { TabIndex = 3 },
+					new Label { TabIndex = 2 },
+				}
+			};
+
+			var stack2 = new StackLayout
+			{
+				IsTabStop = false,
+				Children = {
+					new Label { TabIndex = 1 },
+					new Label { TabIndex = 3 },
+					new Label { TabIndex = 2 },
+				}
+			};
+
+			var masterPage = new ContentPage { Content = stack2, Title = "master" };
+
+			var detailPage = new ContentPage { Content = stack };
+
+			var mdp = new MasterDetailPage { Master = masterPage, Detail = detailPage };
+
+			var tabIndexes = stack.GetTabIndexesOnParentPage(out int _);
+
+			Assert.That(tabIndexes.Any());
+			Assert.AreEqual(target, tabIndexes[0][0]);
+		}
+
+		[Test]
+		public void GetTabIndexesOnParentPage_NoPageZeroCount()
+		{
+			var element = new Label { TabIndex = 0 };
+
+			var _ = element.GetTabIndexesOnParentPage(out int target);
+
+			Assert.AreEqual(0, target);
+			Assert.AreEqual(new Dictionary<int, List<ITabStopElement>>(), _);
 		}
 
 		[Test]
@@ -191,7 +428,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var page = new ContentPage { Content = stackLayout };
 
-			var tabIndexes = stackLayout.GetTabIndexesOnParentPage(out int maxAttempts);
+			var tabIndexes = stackLayout.GetTabIndexesOnParentPage(out int _);
 
 			int _ = target.TabIndex;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -177,6 +177,10 @@ namespace Xamarin.Forms.Platform.Android
 			if (tabIndexes == null)
 				return;
 
+			// Let the page handle tab order itself
+			if (tabIndexes.Count <= 1)
+				return;
+
 			AView prevControl = null;
 			foreach (var idx in tabIndexes?.Keys)
 			{
@@ -186,7 +190,7 @@ namespace Xamarin.Forms.Platform.Android
 					if (!(child is VisualElement ve && ve.GetRenderer()?.View is AView view))
 						continue;
 
-					AView thisControl = view;
+					AView thisControl = null;
 
 					if (view is ITabStop tabStop)
 						thisControl = tabStop.TabStop;
@@ -204,10 +208,6 @@ namespace Xamarin.Forms.Platform.Android
 						if (thisControl != prevControl)
 							thisControl.AccessibilityTraversalAfter = prevControl.Id;
 					}
-
-					if (thisControl is global::Android.Widget.TextView tv)
-						if (prevControl is global::Android.Widget.TextView pv)
-							System.Diagnostics.Debug.WriteLine($"{tv.Text} after {pv.Text}");
 
 					prevControl = thisControl;
 				}

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -170,7 +170,7 @@ namespace Xamarin.Forms.Platform.Android
 				if (!(child is VisualElement ve))
 					continue;
 
-				tabIndexes = ve.GetSortedTabIndexesOnParentPage(out _);
+				tabIndexes = ve.GetSortedTabIndexesOnParentPage();
 				break;
 			}
 
@@ -183,15 +183,13 @@ namespace Xamarin.Forms.Platform.Android
 				var tabGroup = tabIndexes[idx];
 				foreach (var child in tabGroup)
 				{
-					if (child is Layout || 
-						!(
-							child is VisualElement ve && ve.IsTabStop
-							&& AutomationProperties.GetIsInAccessibleTree(ve) != false // accessible == true
-							&& ve.GetRenderer()?.View is ITabStop tabStop)
-						 )
+					if (!(child is VisualElement ve && ve.GetRenderer()?.View is AView view))
 						continue;
 
-					var thisControl = tabStop.TabStop;
+					AView thisControl = view;
+
+					if (view is ITabStop tabStop)
+						thisControl = tabStop.TabStop;
 
 					if (thisControl == null)
 						continue;
@@ -206,6 +204,10 @@ namespace Xamarin.Forms.Platform.Android
 						if (thisControl != prevControl)
 							thisControl.AccessibilityTraversalAfter = prevControl.Id;
 					}
+
+					if (thisControl is global::Android.Widget.TextView tv)
+						if (prevControl is global::Android.Widget.TextView pv)
+							System.Diagnostics.Debug.WriteLine($"{tv.Text} after {pv.Text}");
 
 					prevControl = thisControl;
 				}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -127,7 +127,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				// use OS default--there's no need for us to keep going if there's one or fewer tab indexes!
 				if (tabIndexes.Count <= 1)
-					return null;
+					return base.FocusSearch(direction);
 
 				int tabIndex = element.TabIndex;
 				AView control = null;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -125,6 +125,10 @@ namespace Xamarin.Forms.Platform.Android
 				if (tabIndexes == null)
 					return base.FocusSearch(direction);
 
+				// use OS default--there's no need for us to keep going if there's one or fewer tab indexes!
+				if (tabIndexes.Count <= 1)
+					return null;
+
 				int tabIndex = element.TabIndex;
 				AView control = null;
 				int attempt = 0;

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -173,6 +173,10 @@ namespace Xamarin.Forms.Platform.Android
 			if (tabIndexes == null)
 				return base.FocusSearch(focused, direction);
 
+			// use OS default--there's no need for us to keep going if there's one or fewer tab indexes!
+			if (tabIndexes.Count <= 1)
+				return base.FocusSearch(focused, direction);
+
 			int tabIndex = element.TabIndex;
 			AView control = null;
 			int attempt = 0;

--- a/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
@@ -22,6 +22,20 @@ namespace Xamarin.Forms.Platform.MacOS
 			return self.Subviews.Concat(self.Subviews.SelectMany(s => s.Descendants()));
 		}
 
+		internal static IEnumerable<UIView> DescendantsTree(this UIView self)
+		{
+			var children = self.Subviews;
+			for (var i = 0; i < children.Length; i++)
+			{
+				UIView child = children[i];
+				yield return child;
+				foreach (var grandChild in child.DescendantsTree())
+				{
+					yield return grandChild;
+				}
+			}
+		}
+
 		public static SizeRequest GetSizeRequest(this UIView self, double widthConstraint, double heightConstraint,
 			double minimumWidth = -1, double minimumHeight = -1)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -4,8 +4,10 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class FrameRenderer : VisualElementRenderer<Frame>
+	public class FrameRenderer : VisualElementRenderer<Frame>, ITabStop
 	{
+		UIView ITabStop.TabStop => this;
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
 		{
 			base.OnElementChanged(e);

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
@@ -1,7 +1,6 @@
 using Foundation;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
@@ -23,16 +22,14 @@ namespace Xamarin.Forms.Platform.iOS
 			IsAccessibilityElement = false;
 		}
 
-		List<NSObject> DefaultOrder => this.Descendants().Select(i => i as NSObject).ToList();
-
 		List<NSObject> AccessibilityElements
 		{
 			get
 			{
 				// lazy-loading this list so that the expensive call to GetAccessibilityElements only happens when VoiceOver is on.
-				if (_accessibilityElements == null)
+				if (AccessibilityElements == null || AccessibilityElements.Count == 0)
 				{
-					_accessibilityElements = _parent.GetAccessibilityElements() ?? DefaultOrder;
+					_accessibilityElements = _parent.GetAccessibilityElements();
 				}
 				return _accessibilityElements;
 			}
@@ -56,7 +53,7 @@ namespace Xamarin.Forms.Platform.iOS
 		[Export("accessibilityElementCount")]
 		nint AccessibilityElementCount()
 		{
-			if (AccessibilityElements == null)
+			if (AccessibilityElements == null || AccessibilityElements.Count == 0)
 				return 0;
 
 			// Note: this will only be called when VoiceOver is enabled
@@ -66,7 +63,7 @@ namespace Xamarin.Forms.Platform.iOS
 		[Export("accessibilityElementAtIndex:")]
 		NSObject GetAccessibilityElementAt(nint index)
 		{
-			if (AccessibilityElements == null)
+			if (AccessibilityElements == null || AccessibilityElements.Count == 0)
 				return NSNull.Null;
 
 			// Note: this will only be called when VoiceOver is enabled
@@ -76,7 +73,7 @@ namespace Xamarin.Forms.Platform.iOS
 		[Export("indexOfAccessibilityElement:")]
 		int GetIndexOfAccessibilityElement(NSObject element)
 		{
-			if (AccessibilityElements == null)
+			if (AccessibilityElements == null || AccessibilityElements.Count == 0)
 				return int.MaxValue;
 
 			// Note: this will only be called when VoiceOver is enabled

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageContainer.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.iOS
 			get
 			{
 				// lazy-loading this list so that the expensive call to GetAccessibilityElements only happens when VoiceOver is on.
-				if (AccessibilityElements == null || AccessibilityElements.Count == 0)
+				if (_accessibilityElements == null || _accessibilityElements.Count == 0)
 				{
 					_accessibilityElements = _parent.GetAccessibilityElements();
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -43,12 +43,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 
+		List<NSObject> DefaultOrder()
+		{
+			var views = new List<NSObject>();
+			views.AddRange(Container.DescendantsTree());
+			return views;
+		}
+
 		public List<NSObject> GetAccessibilityElements()
 		{
 			if (Container == null || Element == null)
-				return null;
+				return new List<NSObject>();
 
-			List<NSObject> views = new List<NSObject>();
 			SortedDictionary<int, List<ITabStopElement>> tabIndexes = null;
 			foreach (var child in Element.LogicalChildren)
 			{
@@ -60,12 +66,13 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			if (tabIndexes == null)
-				return null;
+				return DefaultOrder();
 
 			// Just return all elements on the page in order.
 			if (tabIndexes.Count <= 1)
-				return null;
+				return DefaultOrder();
 
+			var views = new List<NSObject>();
 			foreach (var idx in tabIndexes?.Keys)
 			{
 				var tabGroup = tabIndexes[idx];

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -62,6 +62,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (tabIndexes == null)
 				return null;
 
+			// Just return all elements on the page in order.
+			if (tabIndexes.Count <= 1)
+				return null;
+
 			foreach (var idx in tabIndexes?.Keys)
 			{
 				var tabGroup = tabIndexes[idx];
@@ -70,7 +74,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (!(child is VisualElement ve && ve.GetRenderer()?.NativeView is UIView view))
 						continue;
 
-					var thisControl = view;
+					UIView thisControl = null;
 
 					if (view is ITabStop tabStop)
 						thisControl = tabStop.TabStop;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -46,7 +46,8 @@ namespace Xamarin.Forms.Platform.iOS
 		List<NSObject> DefaultOrder()
 		{
 			var views = new List<NSObject>();
-			views.AddRange(Container.DescendantsTree());
+			if (Container != null)
+				views.AddRange(Container.DescendantsTree());
 			return views;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -48,15 +48,14 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Container == null || Element == null)
 				return null;
 
-			var children = Element.Descendants();
-			SortedDictionary<int, List<ITabStopElement>> tabIndexes = null;
 			List<NSObject> views = new List<NSObject>();
-			foreach (var child in children)
+			SortedDictionary<int, List<ITabStopElement>> tabIndexes = null;
+			foreach (var child in Element.LogicalChildren)
 			{
 				if (!(child is VisualElement ve))
 					continue;
 
-				tabIndexes = ve.GetSortedTabIndexesOnParentPage(out _);
+				tabIndexes = ve.GetSortedTabIndexesOnParentPage();
 				break;
 			}
 
@@ -68,18 +67,13 @@ namespace Xamarin.Forms.Platform.iOS
 				var tabGroup = tabIndexes[idx];
 				foreach (var child in tabGroup)
 				{
-					if (
-						!(
-							child is VisualElement ve && ve.IsTabStop
-							&& AutomationProperties.GetIsInAccessibleTree(ve) != false // accessible == true
-							&& ve.GetRenderer()?.NativeView is UIView view)
-						 )
+					if (!(child is VisualElement ve && ve.GetRenderer()?.NativeView is UIView view))
 						continue;
 
 					var thisControl = view;
 
-					if (view is ITabStop tabstop)
-						thisControl = tabstop.TabStop;
+					if (view is ITabStop tabStop)
+						thisControl = tabStop.TabStop;
 
 					if (thisControl == null)
 						continue;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -43,10 +43,13 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 				_presented = value;
 				LayoutChildren(true);
+
 				if (value)
 					AddClickOffView();
 				else
 					RemoveClickOffView();
+
+				ToggleAccessibilityElementsHidden();
 
 				((IElementController)Element).SetValueFromRenderer(Xamarin.Forms.MasterDetailPage.IsPresentedProperty, value);
 			}
@@ -341,6 +344,8 @@ namespace Xamarin.Forms.Platform.iOS
 			SetNeedsStatusBarAppearanceUpdate();
 			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
+
+			ToggleAccessibilityElementsHidden();
 		}
 
 		void UpdateLeftBarButton()
@@ -375,6 +380,17 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		void ToggleAccessibilityElementsHidden()
+		{
+			var masterView = _masterController?.View;
+			if (masterView != null)
+				masterView.AccessibilityElementsHidden = !Presented;
+
+			var detailView = _detailController?.View;
+			if (detailView != null)
+				detailView.AccessibilityElementsHidden = Presented;
+		}
+
 		void UpdatePanGesture()
 		{
 			var model = (MasterDetailPage)Element;
@@ -391,11 +407,11 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-   			bool shouldReceive(UIGestureRecognizer g, UITouch t)
+			bool shouldReceive(UIGestureRecognizer g, UITouch t)
 			{
 				return !(t.View is UISlider) && !(IsSwipeView(t.View));
 			}
-   
+
 			var center = new PointF();
 			_panGesture = new UIPanGestureRecognizer(g =>
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -161,7 +161,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public void FocusSearch(bool forwardDirection)
 		{
 			var element = Shell.CurrentItem as ITabStopElement;
-			var tabIndexes = element?.GetTabIndexesOnParentPage(out _, checkContainsElement: false);
+			var tabIndexes = element?.GetTabIndexesOnParentPage(out _);
 			if (tabIndexes == null)
 				return;
 


### PR DESCRIPTION
### Description of Change ###

* iOS MasterDetailPage will no longer read MasterPage contents when the master page is hidden and will no longer read DetailPage contents when the master page is visible.
* iOS can now tab stop on a Frame and can read its contents properly.
* iOS/Android screen readers should no longer skip over layouts and should read all children in declaration order and/or TabIndex order.
* TabIndex should no longer return elements that are `Enabled = false` or `IsAccessibilityElement = false`.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9653
- fixes #4220 
- fixes #9191 
- fixes #8613
- fixes #9137
- fixes #8691 
- fixes #7606
- fixes #4270
- fixes #5879

### API Changes ###
 
These are breaking API changes, but they drive me crazy. I will revert if someone has an issue with this.

`TabIndexExtensions`:
```diff
-public static SortedDictionary<int, List<ITabStopElement>> GetSortedTabIndexesOnParentPage(this VisualElement element, out int countChildrensWithTabStopWithoutThis)
+public static SortedDictionary<int, List<ITabStopElement>> GetSortedTabIndexesOnParentPage(this VisualElement element)


-public static IDictionary<int, List<ITabStopElement>> GetTabIndexesOnParentPage(this ITabStopElement element, out int countChildrensWithTabStopWithoutThis, bool checkContainsElement = true)
+public static IDictionary<int, List<ITabStopElement>> GetTabIndexesOnParentPage(this ITabStopElement element, out int countChildrenWithTabStopWithoutThis)
```

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Use TalkBack/VoiceOver to test the Control Gallery and make sure everything is read in an expected order.
2. Use keyboard to test that TabIndex is still functioning as expected.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
