### PR TITLE
[Android] Fix NRE when setting the VisualState on the default cell

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -255,7 +255,8 @@ namespace Xamarin.Forms.Platform.Android
 			for (int i = first; i <= last; i++)
 			{
 				var cell = layoutManager.FindViewByPosition(i);
-				var itemView = (cell as ItemContentView)?.VisualElementRenderer?.Element as View;
+				if (!((cell as ItemContentView)?.VisualElementRenderer?.Element is View itemView))
+					return;
 
 				if (i == carouselPosition)
 				{


### PR DESCRIPTION
### Description of Change ###

If we aren't using a template we might not have a View to set a state

### Issues Resolved ### 

none

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
