### PR TITLE
revert [Android] Fix BottomNavigationItemView issue with MasterDetailPage

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Platform.Android
 				var item = items[i];
 				using (var title = new Java.Lang.String(item.title))
 				{
-					var menuItem = menu.Add(0, Platform.GenerateViewId(), 0, title);
+					var menuItem = menu.Add(0, i, 0, title);
 					menuItems.Add(menuItem);
 					loadTasks.Add(SetMenuItemIcon(menuItem, item.icon, context));
 					UpdateEnabled(item.tabEnabled, menuItem);


### PR DESCRIPTION
### Description of Change ###

#9187 broke the following UI tests on master

TabBottomIconsAndTitlesChange_google_pixel_2
AddAndRemovePages_google_pixel_2-8_1_0
BottomTabbedPageWithModalIssueTestsPopFromSecondTab_google_pixel_2-8_1_0


### Testing Procedure ###
- All Green on Master

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
