### PR TITLE
[iOS] Fix Editor excessive horizontal scroll and placeholder line break

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/EditorCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/EditorCoreGalleryPage.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Controls
 			var textFontSizeContainer = new ViewContainer<Editor>(Test.Editor.FontSize, new Editor { Text = "I have default size text" });
 			var textFontSizeDefaultContainer = new ViewContainer<Editor>(Test.Editor.FontSize, new Editor { Text = "I also have default size text" });
 			textFontSizeDefaultContainer.View.FontSize = Device.GetNamedSize(NamedSize.Default, textFontSizeDefaultContainer.View);
-			var textFontSizeLargeContainer = new ViewContainer<Editor>(Test.Editor.FontSize, new Editor { Text = "I have size 48 (huge) text", FontSize = 48 });
+			var textFontSizeLargeContainer = new ViewContainer<Editor>(Test.Editor.FontSize, new Editor { Text = "I have size 48 (huge) text", FontSize = 48, Placeholder = "This is a placeholder" });
 
 			var textColorContainer = new ViewContainer<Editor>(Test.Editor.TextColor,
 				new Editor { Text = "I should have red text", TextColor = Color.Red });

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -42,7 +42,9 @@ namespace Xamarin.Forms.Platform.iOS
 				// create label so it can get updated during the initial setup loop
 				_placeholderLabel = new UILabel
 				{
-					BackgroundColor = UIColor.Clear
+					BackgroundColor = UIColor.Clear,
+					Frame = new RectangleF(0, 0, Frame.Width, Frame.Height),
+					Lines = 0
 				};
 			}
 
@@ -63,6 +65,8 @@ namespace Xamarin.Forms.Platform.iOS
 		protected internal override void UpdatePlaceholderText()
 		{
 			_placeholderLabel.Text = Element.Placeholder;
+
+			_placeholderLabel.SizeToFit();
 		}
 
 		protected internal override void UpdateCharacterSpacing()
@@ -72,7 +76,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if(textAttr != null)
 				TextView.AttributedText = textAttr;
 
-			var placeHolder = TextView.AttributedText.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
+			var placeHolder = _placeholderLabel.AttributedText.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 
 			if(placeHolder != null)
 				_placeholderLabel.AttributedText = placeHolder;
@@ -112,7 +116,7 @@ namespace Xamarin.Forms.Platform.iOS
 					new NSObject[] { _placeholderLabel }, new NSObject[] { new NSString("_placeholderLabel") })
 			);
 
-			_placeholderLabel.TranslatesAutoresizingMaskIntoConstraints = false;
+			_placeholderLabel.TranslatesAutoresizingMaskIntoConstraints = true;
 			_placeholderLabel.AttributedText = _placeholderLabel.AttributedText.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 
 			Control.AddConstraints(hConstraints);


### PR DESCRIPTION
### Description of Change ###

Makes the `UILabel` that fakes the placeholder functionality resize properly to prevent unexplained horizontal scrolling and also implemented the placeholder line break. The latter was actually the root cause for the scrolling.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8569
- fixes #4291

### API Changes ###
<!-- List all API changes here (or just put None), example:
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

No more excessive horizontal scrolling for the Editor on iOS and the placeholder does proper line breaks.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before

![image](https://user-images.githubusercontent.com/939291/75280793-6a094400-580e-11ea-8e86-b639a410df86.png)

![image](https://user-images.githubusercontent.com/939291/75280818-7392ac00-580e-11ea-811b-1612d9ec9520.png)

After

![image](https://user-images.githubusercontent.com/939291/75280489-d59ee180-580d-11ea-83bf-3f95da83c816.png)

### Testing Procedure ###
Go to Gallery app > Editor Gallery and find the 3rd FontSize option which has the 48pt font. Notice how it does not scroll horizontally when you land on the page. It does without this fix. Then remove the text and notice how the placeholder text goes multiline as well.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
