### PR TITLE
Add non androidx classes back into Proguard File

### DIFF
--- a/.nuspec/proguard.cfg
+++ b/.nuspec/proguard.cfg
@@ -8,3 +8,6 @@
 -keep class androidx.appcompat.widget.AlertDialogLayout { *; }
 -keep class androidx.appcompat.widget.DialogTitle { *; }
 -keep class androidx.appcompat.widget.ButtonBarLayout { *; }
+-keep class android.support.v7.widget.AlertDialogLayout { *; }
+-keep class android.support.v7.widget.DialogTitle { *; }
+-keep class android.support.v7.widget.ButtonBarLayout { *; }


### PR DESCRIPTION
### Description of Change ###
When 4.4.0 got merged up to 4.5.0 it replaced the support library versions with androidx when it should have just appended them 

### Issues Resolved ### 
- fixes #9696

### Testing Procedure ###
- test nugets with #9696

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
