### PR TITLE
[Bug][iOS] Impossible to move a slider that binds to MediaElement.Volume

### DIFF
--- a/Xamarin.Forms.Core/MediaElement.cs
+++ b/Xamarin.Forms.Core/MediaElement.cs
@@ -148,15 +148,8 @@ namespace Xamarin.Forms
 
 		public double Volume
 		{
-			get
-			{
-				VolumeRequested?.Invoke(this, EventArgs.Empty);
-				return (double)GetValue(VolumeProperty);
-			}
-			set
-			{
-				SetValue(VolumeProperty, value);
-			}
+			get => (double)GetValue(VolumeProperty);
+			set => SetValue(VolumeProperty, value);
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -167,10 +160,6 @@ namespace Xamarin.Forms
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public event EventHandler PositionRequested;
-
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public event EventHandler VolumeRequested;
-
 
 		public void Play()
 		{


### PR DESCRIPTION
### Description of Change ###
- Removed useless VolumeRequested event (Added volume observer instead)
- fixed more null-ref exceptions (for example if you try to change the volume with Source == null, you get an exception)

### Issues Resolved ### 
- fixes #9571 

### API Changes ###
Removed:
- VolumeRequested event (It was marked as EditorBrowsable.Never, so I am not sure it's a part of API indeed)


### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
You can bind Slider.Value to MediaElement.Volume

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Sample attached in original issue ticket
