### PR TITLE
[Bug][iOS] MediaElement ArgumentException when attempting to play video from library

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
@@ -183,7 +183,9 @@ namespace Xamarin.Forms.Platform.iOS
 					break;
 
 				case AVPlayerStatus.ReadyToPlay:
-					Controller.Duration = TimeSpan.FromSeconds(_avPlayerViewController.Player.CurrentItem.Duration.Seconds);
+					Controller.Duration = _avPlayerViewController.Player.CurrentItem.Duration.IsInvalid
+						? default(TimeSpan?)
+						: TimeSpan.FromSeconds(_avPlayerViewController.Player.CurrentItem.Duration.Seconds);
 					Controller.VideoHeight = (int)_avPlayerViewController.Player.CurrentItem.Asset.NaturalSize.Height;
 					Controller.VideoWidth = (int)_avPlayerViewController.Player.CurrentItem.Asset.NaturalSize.Width;
 					Controller.OnMediaOpened();


### PR DESCRIPTION
### Description of Change ###
Prevent ArgumentException by checking if the duration is valid TimeSpan

### Issues Resolved ### 
- fixes #9568 

### API Changes ###
None


### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
No crash

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Described in the bug's ticket (sample attached)

