### PR TITLE
Don't Init DualScreenService on non duo device

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/TwoPaneViewGalleries/TwoPanePropertiesGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/TwoPaneViewGalleries/TwoPanePropertiesGallery.xaml
@@ -16,10 +16,13 @@
                            WideModeConfiguration="{Binding Source={x:Reference WideModeConfiguration}, Path=SelectedItem}">
             <local:TwoPaneView.Pane1>
                 <StackLayout Padding="20">
+                    <Label x:Name="lblScreenDim"  Text=""></Label>
                     <Label Text="MinTallModeHeight"></Label>
-                    <Slider x:Name="MinTallModeHeight" ></Slider>
+                    <Slider x:Name="MinTallModeHeight" Maximum="2000" ></Slider>
+                    <Label Text="{Binding Source={x:Reference MinTallModeHeight}, Path=Value}"></Label>
                     <Label Text="MinWideModeWidth"></Label>
-                    <Slider x:Name="MinWideModeWidth"></Slider>
+                    <Slider x:Name="MinWideModeWidth" Maximum="2000"></Slider>
+                    <Label Text="{Binding Source={x:Reference MinWideModeWidth}, Path=Value}"></Label>
                     <Label Text="Pane1Length"></Label>
                     <Slider x:Name="Pane1Length" Maximum="1" Value="1"></Slider>
                     <Label Text="Pane2Length"></Label>

--- a/Xamarin.Forms.Controls/GalleryPages/TwoPaneViewGalleries/TwoPanePropertiesGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/TwoPaneViewGalleries/TwoPanePropertiesGallery.xaml.cs
@@ -34,7 +34,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.TwoPaneViewGalleries
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			Setup(Width, Height);
 
 			PanePriority.SelectedIndex = 0;
 			TallModeConfiguration.SelectedIndex = 1;
@@ -46,9 +45,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.TwoPaneViewGalleries
 			if (width <= 0 || height <= 0)
 				return;
 
-
-			MinTallModeHeight.Maximum = height;
-			MinWideModeWidth.Maximum = width;
+			lblScreenDim.Text = $"Screen Dimensions: {width}x{height}";
 		}
 
 		protected override void OnSizeAllocated(double width, double height)

--- a/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewNotSpannedTests.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/TwoPaneViewNotSpannedTests.cs
@@ -308,5 +308,69 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
 			Assert.IsFalse(twoPaneView.Children[1].IsVisible);
 		}
+
+		[Test]
+		public void Pane1BecomesVisibleAfterOnlyPane2IsVisibleWideMode()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView();
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+			twoPaneView.MinWideModeWidth = 4000;
+			twoPaneView.PanePriority = TwoPaneViewPriority.Pane2;
+
+			Assert.IsFalse(twoPaneView.Children[0].IsVisible);
+			Assert.IsTrue(twoPaneView.Children[1].IsVisible);
+			twoPaneView.MinWideModeWidth = 0;
+			Assert.AreEqual(twoPaneView.Mode, TwoPaneViewMode.Wide);
+			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
+			Assert.IsTrue(twoPaneView.Children[1].IsVisible);
+		}
+
+		[Test]
+		public void Pane2BecomesVisibleAfterOnlyPane1IsVisibleWideMode()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView();
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+			twoPaneView.MinWideModeWidth = 4000;
+			twoPaneView.PanePriority = TwoPaneViewPriority.Pane1;
+
+			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
+			Assert.IsFalse(twoPaneView.Children[1].IsVisible);
+			twoPaneView.MinWideModeWidth = 0;
+			Assert.AreEqual(twoPaneView.Mode, TwoPaneViewMode.Wide);
+			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
+			Assert.IsTrue(twoPaneView.Children[1].IsVisible);
+		}
+
+		[Test]
+		public void Pane1BecomesVisibleAfterOnlyPane2IsVisibleTallMode()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView();
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+			twoPaneView.MinTallModeHeight = 4000;
+			twoPaneView.PanePriority = TwoPaneViewPriority.Pane2;
+			
+			Assert.IsFalse(twoPaneView.Children[0].IsVisible);
+			Assert.IsTrue(twoPaneView.Children[1].IsVisible);
+			twoPaneView.MinTallModeHeight = 0;
+			Assert.AreEqual(twoPaneView.Mode, TwoPaneViewMode.Tall);
+			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
+			Assert.IsTrue(twoPaneView.Children[1].IsVisible);
+		}
+
+		[Test]
+		public void Pane2BecomesVisibleAfterOnlyPane1IsVisibleTallMode()
+		{
+			TwoPaneView twoPaneView = CreateTwoPaneView();
+			twoPaneView.Layout(new Rectangle(0, 0, 300, 500));
+			twoPaneView.MinTallModeHeight = 4000;
+			twoPaneView.PanePriority = TwoPaneViewPriority.Pane1;
+
+			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
+			Assert.IsFalse(twoPaneView.Children[1].IsVisible);
+			twoPaneView.MinTallModeHeight = 0;
+			Assert.AreEqual(twoPaneView.Mode, TwoPaneViewMode.Tall);
+			Assert.IsTrue(twoPaneView.Children[0].IsVisible);
+			Assert.IsTrue(twoPaneView.Children[1].IsVisible);
+		}
 	}
 }

--- a/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using System.Threading.Tasks;
+using Windows.Foundation.Metadata;
 using Windows.Graphics.Display;
 using Windows.UI.ViewManagement;
 
@@ -39,6 +40,9 @@ namespace Xamarin.Forms.DualScreen
         {
             get
             {
+				if (!ApiInformation.IsMethodPresent("Windows.UI.ViewManagement.ApplicationView", "GetSpanningRects"))
+					return false;
+
                 var visibleBounds = Window.Current.Bounds;
 
                 if (visibleBounds.Height > 1200 || visibleBounds.Width > 1200)

--- a/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
@@ -36,11 +36,13 @@ namespace Xamarin.Forms.DualScreen
 			OnScreenChanged?.Invoke(this, EventArgs.Empty);
 		}
 
+		bool IsDualScreenDevice => ApiInformation.IsMethodPresent("Windows.UI.ViewManagement.ApplicationView", "GetSpanningRects");
+
 		public bool IsSpanned
         {
             get
             {
-				if (!ApiInformation.IsMethodPresent("Windows.UI.ViewManagement.ApplicationView", "GetSpanningRects"))
+				if (!IsDualScreenDevice)
 					return false;
 
                 var visibleBounds = Window.Current.Bounds;
@@ -51,6 +53,7 @@ namespace Xamarin.Forms.DualScreen
                 return false;
             }
 		}
+
 		public DeviceInfo DeviceInfo => Device.info;
 
 		public bool IsLandscape
@@ -73,12 +76,11 @@ namespace Xamarin.Forms.DualScreen
 			}
 		}
 
-		public void Dispose()
-        {
-        }
-
         public Rectangle GetHinge()
         {
+			if (!IsDualScreenDevice)
+				return Rectangle.Zero;
+
             var screen = DisplayInformation.GetForCurrentView();
 
             if (IsLandscape)

--- a/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneView.shared.cs
@@ -484,7 +484,7 @@ namespace Xamarin.Forms.DualScreen
 				case ViewMode.LeftRight:
 					SetRowColumn(_content1, 0, 0);
 					SetRowColumn(_content2, 0, 2);
-					_content2.IsVisible = true;
+					_content1.IsVisible = true;
 					_content2.IsVisible = true;
 
 					if (!isLayoutSpanned)
@@ -502,7 +502,7 @@ namespace Xamarin.Forms.DualScreen
 				case ViewMode.RightLeft:
 					SetRowColumn(_content1, 0, 2);
 					SetRowColumn(_content2, 0, 0);
-					_content2.IsVisible = true;
+					_content1.IsVisible = true;
 					_content2.IsVisible = true;
 
 					if (!isLayoutSpanned)
@@ -520,7 +520,7 @@ namespace Xamarin.Forms.DualScreen
 				case ViewMode.TopBottom:
 					SetRowColumn(_content1, 0, 0);
 					SetRowColumn(_content2, 2, 0);
-					_content2.IsVisible = true;
+					_content1.IsVisible = true;
 					_content2.IsVisible = true;
 
 					if (!isLayoutSpanned)
@@ -539,7 +539,7 @@ namespace Xamarin.Forms.DualScreen
 				case ViewMode.BottomTop:
 					SetRowColumn(_content1, 2, 0);
 					SetRowColumn(_content2, 0, 0);
-					_content2.IsVisible = true;
+					_content1.IsVisible = true;
 					_content2.IsVisible = true;
 
 					if (!isLayoutSpanned)


### PR DESCRIPTION
### Description of Change ###

If a device isn't a Duo then don't initialize any of the duo services.
Fixed an issue where Pane1 was staying non visible after Pane2 was set as priority

### Platforms Affected ### 
- Android


### Testing Procedure ###
- Use the CG App on an API 29 device (non duo) and make sure you can change the orientation on the device without crashing
- On a duo device set Pane2 as the priority, tweak the minwide/tall mode settings so only pane2 shows up, span the app, unspan the app, and verify both panes are displaying

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
