### PR TITLE
[iOS] Fix MediaElement crash opening URL without connection

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
@@ -183,7 +183,13 @@ namespace Xamarin.Forms.Platform.iOS
 					break;
 
 				case AVPlayerStatus.ReadyToPlay:
-					Controller.Duration = TimeSpan.FromSeconds(_avPlayerViewController.Player.CurrentItem.Duration.Seconds);
+					var duration = _avPlayerViewController.Player.CurrentItem.Duration;
+
+					if (duration.IsIndefinite)
+						Controller.Duration = TimeSpan.Zero;
+					else
+						Controller.Duration = TimeSpan.FromSeconds(duration.Seconds);
+
 					Controller.VideoHeight = (int)_avPlayerViewController.Player.CurrentItem.Asset.NaturalSize.Height;
 					Controller.VideoWidth = (int)_avPlayerViewController.Player.CurrentItem.Asset.NaturalSize.Width;
 					Controller.OnMediaOpened();


### PR DESCRIPTION
### Description of Change ###

Fixed a MediaElement crash trying to reproduce a video from a URL without internet connection.

### Issues Resolved ### 

- fixes #9742

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery. Make sure you don't have internet connection on the device or simulator. Then, select the MediaElement sample and press the Play Button. If the video does not play but no error occurs (exception), the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
