### PR TITLE
[Bug] DisplayPromptAsync overload hurts usability

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6713.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var button = new Button { Text = "Default keyboard" };
 			button.Clicked += async (sender, e) =>
 			{
-				var result = await DisplayPromptAsync("What’s the most useless product around today?", "The USB pet rock is definitely up there. What items do you have a hard time believing they actually exist?", initialValue: "");
+				var result = await DisplayPromptAsync("What’s the most useless product around today?", "The USB pet rock is definitely up there. What items do you have a hard time believing they actually exist?");
 
 				if (result != null)
 					(sender as Button).Text = result;
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls.Issues
             var button2 = new Button { Text = "Numeric keyboard" };
             button2.Clicked += async (sender, e) =>
             {
-	            var result = await DisplayPromptAsync("What’s the meaning of life?", "You know that number.", maxLength:2, keyboard:Keyboard.Numeric, initialValue: "");
+	            var result = await DisplayPromptAsync("What’s the meaning of life?", "You know that number.", maxLength:2, keyboard:Keyboard.Numeric);
 
 	            if (result != null)
 					(sender as Button).Text = result;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8526.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8526.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override async void Init()
 		{
-			await DisplayPromptAsync(Success, "This prompt should display when the page loads.", initialValue: "");
+			await DisplayPromptAsync(Success, "This prompt should display when the page loads.");
 		}
 
 #if UITEST

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -211,7 +211,7 @@ namespace Xamarin.Forms
 
 		[Obsolete("DisplayPromptAsync overload is obsolete as of version 4.5.0 and is no longer supported.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+		public Task<string> DisplayPromptAsync(string title, string message, string accept, string cancel, string placeholder, int maxLength, Keyboard keyboard)
 		{
 			return DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, "");
 		}

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -209,13 +209,6 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		[Obsolete("DisplayPromptAsync overload is obsolete as of version 4.5.0 and is no longer supported.")]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
-		{
-			return DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, "");
-		}
-
 		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -209,6 +209,13 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
+		[Obsolete("DisplayPromptAsync overload is obsolete as of version 4.5.0 and is no longer supported.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+		{
+			return DisplayPromptAsync(title, message, accept, cancel, placeholder, maxLength, keyboard, "");
+		}
+
 		public Task<string> DisplayPromptAsync(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			var args = new PromptArguments(title, message, accept, cancel, placeholder, maxLength, keyboard, initialValue);

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Internals
 	{
 		[Obsolete("PromptArguments overload is obsolete as of version 4.5.0 and is no longer supported.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+		public PromptArguments(string title, string message, string accept, string cancel, string placeholder, int maxLength, Keyboard keyboard)
 			: this (title, message, accept, cancel, placeholder, maxLength, keyboard, "")
 		{ }
 

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
@@ -6,6 +7,12 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{
+		[Obsolete("PromptArguments overload is obsolete as of version 4.5.0 and is no longer supported.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
+			: this (title, message, accept, cancel, placeholder, maxLength, keyboard, "")
+		{ }
+
 		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			Title = title;

--- a/Xamarin.Forms.Core/PromptArguments.cs
+++ b/Xamarin.Forms.Core/PromptArguments.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.ComponentModel;
+﻿using System.ComponentModel;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
@@ -7,12 +6,6 @@ namespace Xamarin.Forms.Internals
 	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PromptArguments
 	{
-		[Obsolete("PromptArguments overload is obsolete as of version 4.5.0 and is no longer supported.")]
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard))
-			: this (title, message, accept, cancel, placeholder, maxLength, keyboard, "")
-		{ }
-
 		public PromptArguments(string title, string message, string accept = "OK", string cancel = "Cancel", string placeholder = null, int maxLength = -1, Keyboard keyboard = default(Keyboard), string initialValue = "")
 		{
 			Title = title;


### PR DESCRIPTION
### Description of Change ###

Removes the optional parameters from the obsoleted methods to avoid the CS0121 error when using prompts.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9171

### API Changes ###

Essentially none. Optional parameters are still compiled into non-optional ones, so this does not break ABI. As for API, the new signature still has all the optional parameters, so people still on the obsolete signature should not notice any difference. That is because they technically automatically migrate to the new signature.

Hope this makes sense...

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Users upgrading should not notice anything. All parameters have the optional thing going all, transition should happen invisible.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
