### PR TITLE
Ios 2017 compatible Xamarin.Forms.Platform.iOS

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -298,10 +298,9 @@
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\Xamarin.Mac" />
+    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.Mac" />
     <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.macOS.dll" target="build\XCODE11" />
-    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="build\XCODE11" />
     <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.macOS.dll" target="build\XCODE10" />
-    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.dll" target="build\XCODE10" />
 
     <!-- iOS Localized String Resource Assemblies -->
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\ar\Xamarin.Forms.Platform.iOS.resources.dll" target="lib\Xamarin.iOS10\ar" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -207,9 +207,14 @@
     <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid10.0" />
 
     <!--iPhone Unified-->
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="lib\Xamarin.iOS10" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*pdb" target="lib\Xamarin.iOS10" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*mdb" target="lib\Xamarin.iOS10" />
+    <file src="_._" target="lib\lib\Xamarin.iOS10\_._" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="build\XCODE10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*pdb" target="build\XCODE10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*mdb" target="build\XCODE10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.dll" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.*pdb" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.*mdb" target="build\XCODE11" />
+
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*mdb" target="lib\Xamarin.iOS10" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -87,7 +87,6 @@
       </group>
       <group targetFramework="Xamarin.Mac">
         <reference file="Xamarin.Forms.Core.dll" />
-        <reference file="Xamarin.Forms.Platform.macOS.dll" />
         <reference file="Xamarin.Forms.Platform.dll" />
         <reference file="Xamarin.Forms.Xaml.dll" />
       </group>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -58,7 +58,6 @@
         <reference file="Xamarin.Forms.Core.dll" />
         <reference file="Xamarin.Forms.Platform.dll" />
         <reference file="Xamarin.Forms.Xaml.dll" />
-        <reference file="Xamarin.Forms.Platform.iOS.dll" />
       </group>
       <group targetFramework="MonoAndroid10.0">
         <reference file="Xamarin.Forms.Core.dll" />
@@ -207,13 +206,12 @@
     <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid10.0" />
 
     <!--iPhone Unified-->
-    <file src="_._" target="lib\lib\Xamarin.iOS10\_._" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="build\XCODE10" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*pdb" target="build\XCODE10" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*mdb" target="build\XCODE10" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.dll" target="build\XCODE11" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.*pdb" target="build\XCODE11" />
-    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.*mdb" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*pdb" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.*mdb" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.dll" target="build\XCODE10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.*pdb" target="build\XCODE10" />
+    <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.iOS.*mdb" target="build\XCODE10" />
 
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\Xamarin.iOS10" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -298,8 +298,10 @@
     <!--Mac-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\Xamarin.Mac" />
     <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\Xamarin.Mac" />
-    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.macOS.dll" target="lib\Xamarin.Mac" />
-    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="lib\Xamarin.Mac" />
+    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.macOS.dll" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\Xamarin.Forms.Platform.dll" target="build\XCODE11" />
+    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.macOS.dll" target="build\XCODE10" />
+    <file src="..\Xamarin.Forms.Platform.MacOS\bin\$Configuration$\2017\Xamarin.Forms.Platform.dll" target="build\XCODE10" />
 
     <!-- iOS Localized String Resource Assemblies -->
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\ar\Xamarin.Forms.Platform.iOS.resources.dll" target="lib\Xamarin.iOS10\ar" />

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -186,7 +186,7 @@
 
 
   <!-- Xamarin iOS targets -->
-  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' OR '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
     <CoreCompileDependsOn>
       IncludeCorrectXIOSReference;
       $(CoreCompileDependsOn);
@@ -198,20 +198,22 @@
   </PropertyGroup>
 
   
-  <Target Name="IncludeCorrectXIOSReference" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
+  <Target Name="IncludeCorrectXIOSReference" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS' OR '$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">
 	<PropertyGroup>
 		<Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildRuntimeType)' == 'Mono'">$(FrameworkSDKRoot.Contains('/Versions/5'))</Use2017>
 		<Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildAssemblyVersion)' &lt; '16.0'">true</Use2017>
 		<Use2017 Condition="'$(Use2017)' == ''">false</Use2017>
+		<FrameworkDll Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">Xamarin.Forms.Platform.iOS.dll</FrameworkDll>
+		<FrameworkDll Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.Mac'">Xamarin.Forms.Platform.macOS.dll</FrameworkDll>
 	</PropertyGroup>
     <ItemGroup Condition="'$(Use2017)' != 'true'">
 		<Reference Include="Xamarin.Forms.Platform.iOS">
-			<HintPath>$(MSBuildThisFileDirectory)\XCODE11\Xamarin.Forms.Platform.iOS.dll</HintPath>
+			<HintPath>$(MSBuildThisFileDirectory)\XCODE11\$(FrameworkDll)</HintPath>
 		</Reference>
     </ItemGroup>
     <ItemGroup Condition="'$(Use2017)' == 'true'">
 		<Reference Include="Xamarin.Forms.Platform.iOS">
-			<HintPath>$(MSBuildThisFileDirectory)\XCODE10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+			<HintPath>$(MSBuildThisFileDirectory)\XCODE10\$(FrameworkDll)</HintPath>
 		</Reference>
     </ItemGroup>
   </Target>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -183,7 +183,39 @@
     <Error Code="XF005"  Condition="$(TargetFrameworkVersionWithoutV) &lt; $(MinTargetFrameworkVersionForForms)"
            Text="The %24(TargetFrameworkVersion) for $(ProjectName) ($(TargetFrameworkVersion)) is less than the minimum required %24(TargetFrameworkVersion) for Xamarin.Forms ($(MinTargetFrameworkVersionForForms)). You need to increase the %24(TargetFrameworkVersion) for $(ProjectName)."   />
   </Target>
+
+
+  <!-- Xamarin iOS targets -->
+  <PropertyGroup Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
+    <CoreCompileDependsOn>
+      IncludeCorrectXIOSReference;
+      $(CoreCompileDependsOn);
+    </CoreCompileDependsOn>
+    <PrepareForBuildDependsOn>
+      IncludeCorrectXIOSReference;
+      $(PrepareForBuildDependsOn);
+    </PrepareForBuildDependsOn>
+  </PropertyGroup>
+
   
+  <Target Name="IncludeCorrectXIOSReference" Condition="'$(TargetFrameworkIdentifier)' == 'Xamarin.iOS'">
+	<PropertyGroup>
+		<Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildRuntimeType)' == 'Mono'">$(FrameworkSDKRoot.Contains('/Versions/5'))</Use2017>
+		<Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildAssemblyVersion)' &lt; '16.0'">true</Use2017>
+		<Use2017 Condition="'$(Use2017)' == ''">false</Use2017>
+	</PropertyGroup>
+    <ItemGroup Condition="'$(Use2017)' != 'true'">
+		<Reference Include="Xamarin.Forms.Platform.iOS">
+			<HintPath>$(MSBuildThisFileDirectory)\XCODE11\Xamarin.Forms.Platform.iOS.dll</HintPath>
+		</Reference>
+    </ItemGroup>
+    <ItemGroup Condition="'$(Use2017)' == 'true'">
+		<Reference Include="Xamarin.Forms.Platform.iOS">
+			<HintPath>$(MSBuildThisFileDirectory)\XCODE10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+		</Reference>
+    </ItemGroup>
+  </Target>
+
   <!-- UWP Targets-->
   <Target Name="WinUICheckTargetPlatformVersion" BeforeTargets="PrepareForBuild"
       Condition="'$(TargetPlatformVersion)' != '' and '$(TargetPlatformMinVersion)' != ''">

--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -57,6 +57,9 @@
     <Reference Include="Xamarin.iOS" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup Condition="'$(Use2017)' == 'true'">
+    <Reference Include="netstandard" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -65,6 +65,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup Condition="'$(Use2017)' == 'true'">
+    <Reference Include="netstandard" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -94,6 +94,9 @@
     </ProjectReference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <ItemGroup Condition="'$(Use2017)' == 'true'">
+    <Reference Include="netstandard" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
@@ -473,10 +473,13 @@ namespace Xamarin.Forms.Platform.MacOS
 					(Source as ListViewDataSource)?.OnRowClicked();
 			}
 
+#if __XCODE11__
 			public override bool ValidateProposedFirstResponder(NSResponder responder, NSEvent forEvent)
 			{
 				return true;
 			}
+#endif
+
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\Environment.Build.props" />
   <PropertyGroup>
     <Description>macOS Backend for Xamarin.Forms</Description>
     <AssemblyName>Xamarin.Forms.Platform.macOS</AssemblyName>
@@ -59,6 +60,13 @@
     </LinkMode>
     <XamMacArch>
     </XamMacArch>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Use2017)' == 'true' ">
+    <DefineConstants>__XCODE10__;$(DefineConstants);</DefineConstants>
+    <OutputPath>$(OutputPath)\2017</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Use2017)' != 'true' ">
+    <DefineConstants>__XCODE11__;$(DefineConstants);</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -278,4 +278,7 @@
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Mac\Xamarin.Mac.CSharp.targets" />
   <Target Name="_VerifyBuildSignature" />
+  <ItemGroup>
+    <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
+  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -18,9 +18,11 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
+#if __XCODE11__
 					if(Forms.IsiOS13OrNewer)
 						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium });
 					else
+#endif
 						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
 				}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -628,6 +628,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
+#if __XCODE11__
 				var navigationBarAppearance = new UINavigationBarAppearance();
 
 				if (barBackgroundColor == Color.Default)
@@ -641,6 +642,7 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.CompactAppearance = navigationBarAppearance;
 				NavigationBar.StandardAppearance = navigationBarAppearance;
 				NavigationBar.ScrollEdgeAppearance = navigationBarAppearance;
+#endif
 			}
 		}
 
@@ -669,6 +671,7 @@ namespace Xamarin.Forms.Platform.iOS
 				};
 			}
 
+#if __XCODE11__
 			if (Forms.IsiOS13OrNewer)
 			{
 				NavigationBar.CompactAppearance.TitleTextAttributes = titleTextAttributes;
@@ -681,6 +684,7 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.ScrollEdgeAppearance.LargeTitleTextAttributes = largeTitleTextAttributes;
 			}
 			else
+#endif
 			{
 				NavigationBar.TitleTextAttributes = titleTextAttributes;
 
@@ -701,14 +705,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (statusBarColorMode == StatusBarTextColorMode.DoNotAdjust || barTextColor.Luminosity <= 0.5)
 			{
+#if __XCODE11__
 				// Use dark text color for status bar
 				if (Forms.IsiOS13OrNewer)
 				{
 					UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.DarkContent;
 				}
 				else
+#endif
 				{
-					UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.Default;
+						UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.Default;
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -619,16 +619,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var barBackgroundColor = NavPage.BarBackgroundColor;
 
-			if (!Forms.IsiOS13OrNewer)
-			{
-				// Set navigation bar background color
-				NavigationBar.BarTintColor = barBackgroundColor == Color.Default
-				? UINavigationBar.Appearance.BarTintColor
-				: barBackgroundColor.ToUIColor();
-			}
-			else
-			{
 #if __XCODE11__
+			if (Forms.IsiOS13OrNewer)
+			{
 				var navigationBarAppearance = new UINavigationBarAppearance();
 
 				if (barBackgroundColor == Color.Default)
@@ -642,7 +635,14 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.CompactAppearance = navigationBarAppearance;
 				NavigationBar.StandardAppearance = navigationBarAppearance;
 				NavigationBar.ScrollEdgeAppearance = navigationBarAppearance;
+			}
+			else
 #endif
+			{
+				// Set navigation bar background color
+				NavigationBar.BarTintColor = barBackgroundColor == Color.Default
+				? UINavigationBar.Appearance.BarTintColor
+				: barBackgroundColor.ToUIColor();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -137,9 +137,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			UIColor backgroundColor;
 
+#if __XCODE11__
 			if (Forms.IsiOS13OrNewer)
 				backgroundColor = UIColor.SystemBackgroundColor;
 			else
+#endif
 				backgroundColor = UIColor.White;
 
 			if (Element.BackgroundColor != Color.Default)

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -307,6 +307,9 @@
       <Name>Xamarin.Forms.Core</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup Condition="'$(Use2017)' == 'true'">
+    <Reference Include="netstandard" />
+  </ItemGroup>
   <ItemGroup>
     <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -18,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
+    <DefineConstants>$(DefineConstants);DEBUG;</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\Environment.Build.props" />
   <PropertyGroup>
     <Description>iOS Backend for Xamarin.Forms</Description>
     <AssemblyName>Xamarin.Forms.Platform.iOS</AssemblyName>
@@ -17,7 +18,7 @@
     <DebugSymbols>true</DebugSymbols>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>$(DefineConstants);UWP_14393</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -32,6 +33,13 @@
     <ConsolePause>false</ConsolePause>
     <NoWarn>
     </NoWarn>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Use2017)' == 'true' ">
+    <DefineConstants>$(DefineConstants);__XCODE10__</DefineConstants>
+    <OutputPath>$(OutputPath)\2017</OutputPath>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Use2017)' != 'true' ">
+    <DefineConstants>$(DefineConstants);__XCODE11__</DefineConstants>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -108,6 +108,12 @@ jobs:
       - sh
       - msbuild
       - Xamarin.iOS
+  strategy:
+    matrix:
+      BuildForVS2017:
+        buildForVS2017:  'true'
+      BuildForVS2019:
+        buildForVS2017:  'false'
   variables:
     provisionator.osxPath : 'build/provisioning/provisioning.csx'
     provisionator.signPath : 'build/provisioning/provisioning_sign.csx'
@@ -115,6 +121,7 @@ jobs:
     slnPath: $(SolutionFile)
     iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
     iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
+    buildForVS2017: $(buildForVS2017)
   steps:
      - template: build/steps/build-osx.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -65,9 +65,6 @@ jobs:
     name: win
     displayName: Build Windows Phase
     vmImage: $(win2019VmImage)
-    msbuildExtraArguments: '/nowarn:VSX1000'
-    buildConfiguration: $(DefaultBuildConfiguration)
-    buildPlatform: $(DefaultBuildPlatform)
     provisionatorPath : 'build/provisioning/provisioning.csx'
 
 - template: build/steps/build-android.yml

--- a/build.cake
+++ b/build.cake
@@ -263,6 +263,12 @@ Task("BuildForNuget")
                     msbuildSettings
                         .WithTarget("rebuild")
                         .WithProperty("USE2017", "true"));
+
+        binaryLogger.FileName = $"{artifactStagingDirectory}/macos-{configuration}-csproj.binlog";
+        MSBuild("./Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.MacOS.csproj",
+                    msbuildSettings
+                        .WithTarget("rebuild")
+                        .WithProperty("USE2017", "true"));
     }
     catch(Exception)
     {

--- a/build.cake
+++ b/build.cake
@@ -37,7 +37,7 @@ PowerShell:
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
 var packageVersion = Argument("packageVersion", "");
-string artifactStagingDirectory = (string)Argument("Build_ArtifactStagingDirectory", null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
+string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 

--- a/build.cake
+++ b/build.cake
@@ -167,7 +167,6 @@ Task("provision")
 
 Task("NuGetPack")
     .Description("Build and Create Nugets")
-    .IsDependentOn("Build")
     .IsDependentOn("BuildForNuget")
     .IsDependentOn("_NuGetPack");
 
@@ -234,17 +233,17 @@ Task("BuildForNuget")
 
         msbuildSettings.BinaryLogger = binaryLogger;
         msbuildSettings.ArgumentCustomization = args => args.Append("/nowarn:VSX1000");
-        binaryLogger.FileName = $"{artifactStagingDirectory}\win-${configuration}.binlog";
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}.binlog";
 
         MSBuild("./Xamarin.Forms.sln", msbuildSettings.WithRestore());
 
-        binaryLogger.FileName = $"{artifactStagingDirectory}\win-${configuration}-csproj.binlog";
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
                     msbuildSettings
                         .WithTarget("rebuild")
                         .WithProperty("DisableEmbeddedXbf", "false"));
 
-        binaryLogger.FileName = $"{artifactStagingDirectory}\ios-${configuration}-csproj.binlog";
+        binaryLogger.FileName = $"{artifactStagingDirectory}/ios-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj",
                     msbuildSettings
                         .WithTarget("rebuild")

--- a/build.cake
+++ b/build.cake
@@ -48,14 +48,9 @@ var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
 
 string[] androidSdkManagerInstalls = new string[0];//new [] { "platforms;android-24", "platforms;android-28"};
 
-string androidSDK_macos = "";
-string monoSDK_macos = "";
-string iOSSDK_macos = "";
-string macSDK_macos = "";
 
 Information ("Team Project: {0}", teamProject);
 Information ("buildForVS2017: {0}", buildForVS2017);
-
 
 var releaseChannel = ReleaseChannel.Stable;
 if(releaseChannelArg == "Preview")
@@ -69,6 +64,9 @@ string androidSDK_macos = "";
 string monoSDK_macos = "";
 string iOSSDK_macos = "";
 string macSDK_macos = "";
+string monoPatchVersion = "";
+string monoMajorVersion = "";
+string monoVersion = "";
 
 if(buildForVS2017)
 {

--- a/build.cake
+++ b/build.cake
@@ -235,7 +235,7 @@ Task("BuildForNuget")
         msbuildSettings.ArgumentCustomization = args => args.Append("/nowarn:VSX1000");
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}.binlog";
 
-        MSBuild("./Xamarin.Forms.sln", msbuildSettings.WithRestore());
+        MSBuild("./Xamarin.Forms.sln", msbuildSettings);
 
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",

--- a/build.cake
+++ b/build.cake
@@ -22,7 +22,7 @@ PowerShell:
 #addin "nuget:?package=Cake.Android.Adb&version=3.0.0"
 #addin "nuget:?package=Cake.Git&version=0.19.0"
 #addin "nuget:?package=Cake.Android.SdkManager&version=3.0.2"
-#addin "nuget:?package=Cake.Boots&version=1.0.0.291"
+#addin "nuget:?package=Cake.Boots&version=1.0.2.421"
 
 #addin "nuget:?package=Cake.FileHelpers&version=3.2.0"
 //////////////////////////////////////////////////////////////////////
@@ -37,37 +37,65 @@ PowerShell:
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
 var packageVersion = Argument("packageVersion", "");
+var releaseChannelArg = Argument("releaseChannel", "Stable");
+releaseChannelArg = EnvironmentVariable("releaseChannel") ?? releaseChannelArg;
+var teamProject = Argument("TeamProject", "");
+bool buildForVS2017 = Convert.ToBoolean(Argument("buildForVS2017", "false"));
+
 string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
-string monoMajorVersion = "5.18.1";
-string monoPatchVersion = "28";
-string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
+string[] androidSdkManagerInstalls = new string[0];//new [] { "platforms;android-24", "platforms;android-28"};
 
-string monoSDK_windows = "";//$"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "";//"https://aka.ms/xamarin-android-commercial-d15-9-windows";
-string iOSSDK_windows = "";//"https://download.visualstudio.microsoft.com/download/pr/71f33151-5db4-49cc-ac70-ba835a9f81e2/d256c6c50cd80ec0207783c5c7a4bc2f/xamarin.visualstudio.apple.sdk.4.12.3.83.vsix";
-string macSDK_windows = "";
+string androidSDK_macos = "";
+string monoSDK_macos = "";
+string iOSSDK_macos = "";
+string macSDK_macos = "";
 
-monoMajorVersion = "6.6.0";
-monoPatchVersion = "";
+Information ("Team Project: {0}", teamProject);
+Information ("buildForVS2017: {0}", buildForVS2017);
+
+
+var releaseChannel = ReleaseChannel.Stable;
+if(releaseChannelArg == "Preview")
+{
+    releaseChannel = ReleaseChannel.Preview;
+}
+
+Information ("Release Channel: {0}", releaseChannel);
+
+string androidSDK_macos = "";
+string monoSDK_macos = "";
+string iOSSDK_macos = "";
+string macSDK_macos = "";
+
+if(buildForVS2017)
+{
+    // VS2017
+    monoMajorVersion = "5.18.1";
+    monoPatchVersion = "";
+    androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d15-9-macos";
+    iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.ios-12.4.0.64.pkg";
+    macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";
+
+}
+
 if(String.IsNullOrWhiteSpace(monoPatchVersion))
     monoVersion = $"{monoMajorVersion}";
 else
     monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
+
+if(!String.IsNullOrWhiteSpace(monoVersion))
+{
+    monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+}
     
-string androidSDK_macos = "https://aka.ms/xamarin-android-commercial-d16-4-macos";
-string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11.3/5f802ef535488d12886f264b598b9c59ca2f2404/36/package/notarized/xamarin.ios-13.10.0.17.pkg";
-string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode11.3/5f802ef535488d12886f264b598b9c59ca2f2404/36/package/notarized/xamarin.mac-6.10.0.17.pkg";
 
-string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
-string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;
-string iosSDK = IsRunningOnWindows() ? iOSSDK_windows : iOSSDK_macos;
+string androidSDK = IsRunningOnWindows() ? "" : androidSDK_macos;
+string monoSDK = IsRunningOnWindows() ? "" : monoSDK_macos;
+string iosSDK = IsRunningOnWindows() ? "" : iOSSDK_macos;
 string macSDK  = IsRunningOnWindows() ? "" : macSDK_macos;
-
-string[] androidSdkManagerInstalls = new string[0];//new [] { "platforms;android-24", "platforms;android-28"};
 
 //////////////////////////////////////////////////////////////////////
 // TASKS
@@ -85,9 +113,12 @@ Task("provision-macsdk")
     .Description("Install Xamarin.Mac SDK")
     .Does(async () =>
     {
-        if(!IsRunningOnWindows() && !String.IsNullOrWhiteSpace(macSDK))
+        if(!IsRunningOnWindows())
         {
-            await Boots(macSDK);
+            if(!String.IsNullOrWhiteSpace(macSDK))
+                await Boots(macSDK);
+            else
+                await Boots (Product.XamarinMac, releaseChannel);
         }
     });
 
@@ -95,8 +126,12 @@ Task("provision-iossdk")
     .Description("Install Xamarin.iOS SDK")
     .Does(async () =>
     {
-        if(!String.IsNullOrWhiteSpace(iosSDK))
-            await Boots(iosSDK);
+        if (!IsRunningOnWindows ()) {
+            if(!String.IsNullOrWhiteSpace(iosSDK))
+                await Boots(iosSDK);
+            else
+                await Boots (Product.XamariniOS, releaseChannel);
+        }
     });
 
 Task("provision-androidsdk")
@@ -112,49 +147,30 @@ Task("provision-androidsdk")
                 SkipVersionCheck = true
             };
 
-
             AcceptLicenses (androidSdkSettings);
-
             AndroidSdkManagerUpdateAll (androidSdkSettings);
-
             AcceptLicenses (androidSdkSettings);
-
             AndroidSdkManagerInstall (androidSdkManagerInstalls, androidSdkSettings);
         }
-        if(!String.IsNullOrWhiteSpace(androidSDK))
-            await Boots (androidSDK);
+
+        if (!IsRunningOnWindows ()) {
+            if(!String.IsNullOrWhiteSpace(androidSDK))
+                await Boots (androidSDK);
+            else
+                await Boots (Product.XamarinAndroid, releaseChannel);
+        }
     });
 
 Task("provision-monosdk")
     .Description("Install Mono SDK")
     .Does(async () =>
     {
-        if(IsRunningOnWindows())
-        {
-            if(!String.IsNullOrWhiteSpace(monoSDK))
-            {
-                string monoPath = $"{System.IO.Path.GetTempPath()}mono.msi";
-
-                if(!String.IsNullOrWhiteSpace(EnvironmentVariable("Build.Repository.LocalPath")))
-                    monoPath = EnvironmentVariable("Build.Repository.LocalPath") + "\\" + "mono.msi";
-
-                Information("Mono Path: {0}", monoPath);
-                Information("Mono Version: {0}", monoSDK);
-                DownloadFile(monoSDK, monoPath);
-
-                StartProcess("msiexec", new ProcessSettings {
-                    Arguments = new ProcessArgumentBuilder()
-                        .Append(@"/i")
-                        .Append(monoPath)
-                        .Append("/qn")
-                    }
-                );
-            }
-        }
-        else
+        if(!IsRunningOnWindows())
         {
             if(!String.IsNullOrWhiteSpace(monoSDK))
                 await Boots(monoSDK);
+            else
+                await Boots (Product.Mono, releaseChannel);
         }
     });
 

--- a/build.cake
+++ b/build.cake
@@ -181,6 +181,7 @@ Task("provision")
 
 Task("NuGetPack")
     .Description("Build and Create Nugets")
+    .IsDependentOn("Restore")
     .IsDependentOn("BuildForNuget")
     .IsDependentOn("_NuGetPack");
 

--- a/build.cake
+++ b/build.cake
@@ -37,7 +37,7 @@ PowerShell:
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
 var packageVersion = Argument("packageVersion", "");
-var artifactStagingDirectory = EnvironmentVariable("Build.ArtifactStagingDirectory") ?? ".";
+var artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 

--- a/build.cake
+++ b/build.cake
@@ -37,7 +37,7 @@ PowerShell:
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
 var packageVersion = Argument("packageVersion", "");
-var artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
+string artifactStagingDirectory = (string)Argument("Build_ArtifactStagingDirectory", null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -42,7 +42,6 @@ steps:
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'
-    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       certSecureFile: 'Xamarin Forms iOS Certificate.p12'
       certPwd: $(P12password)

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -42,12 +42,14 @@ steps:
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'
+    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       certSecureFile: 'Xamarin Forms iOS Certificate.p12'
       certPwd: $(P12password)
 
   - task: InstallAppleProvisioningProfile@1
     displayName: 'Install an Apple provisioning profile'
+    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
 

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -15,7 +15,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target provision
+      arguments: --target provision --buildForVS2017=$(buildForVS2017)
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -56,11 +56,12 @@ steps:
     inputs:
       solutionFile: $(slnPath)
       configuration: $(buildConfiguration)
-      args: /bl:$(Build.ArtifactStagingDirectory)/ios.binlog
+      args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
 
 
   - task: CopyFiles@2
     displayName: 'Copy test-cloud.exe'
+    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       Contents: '**/Xamarin.UITest.*/tools/test-cloud.exe'
       TargetFolder: '$(build.artifactstagingdirectory)/testcloud'
@@ -71,6 +72,7 @@ steps:
 
   - task: CopyFiles@2
     displayName: 'Copy iOS Files for UITest'
+    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       Contents: |
        **/$(IpaName)
@@ -87,6 +89,7 @@ steps:
 
   - task: CopyFiles@2
     displayName: 'Copy Android Files for UITest'
+    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       Contents: |
        Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -49,7 +49,6 @@ steps:
 
   - task: InstallAppleProvisioningProfile@1
     displayName: 'Install an Apple provisioning profile'
-    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
 

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -9,9 +9,6 @@ parameters:
   postBuildSteps: []  # any additional steps to run after the build
   slnPath : 'Xamarin.Forms.sln'
   csprojPath : 'Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj'
-  buildConfiguration : 'Debug'
-  releaseBuildConfiguration : 'Release'
-  buildPlatform : 'any cpu'
   msbuildExtraArguments : ''
   artifactsTargetFolder: '$(build.artifactstagingdirectory)'
   artifactsName: 'win_build'
@@ -33,11 +30,9 @@ jobs:
     strategy:
       matrix:
         debug:
-          BuildConfiguration:  ${{ parameters.buildConfiguration }}
-          BuildPlatform: ${{ parameters.buildPlatform }}
+          BuildConfiguration:  'Debug'
         release:
-          BuildConfiguration:  ${{ parameters.releaseBuildConfiguration }}
-          BuildPlatform: ${{ parameters.buildPlatform }}
+          BuildConfiguration:  'Release'
     steps:
     - checkout: self
       clean: true

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -65,7 +65,7 @@ jobs:
       inputs:
         restoreSolution: ${{ parameters.slnPath }}
 
-    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)" -Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
+    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
       name: winbuild
       displayName: 'Build Projects For Nuget'
 

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -66,6 +66,7 @@ jobs:
         restoreSolution: ${{ parameters.slnPath }}
 
     - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration) -Build_ArtifactStagingDirectory=$(Build.ArtifactStagingDirectory)"'
+      name: winbuild
       displayName: 'Build Projects For Nuget'
 
     - task: VSTest@2

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -65,23 +65,8 @@ jobs:
       inputs:
         restoreSolution: ${{ parameters.slnPath }}
 
-    - task: MSBuild@1
-      displayName: 'Build solution ${{ parameters.slnPath }}'
-      name: winbuild
-      inputs:
-        solution: ${{ parameters.slnPath }}
-        platform: '$(BuildPlatform)'
-        configuration: '$(BuildConfiguration)'
-        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration).binlog
-
-    - task: MSBuild@1
-      displayName: 'Embed XBF into PRI'
-      condition: eq(${{ parameters.includeUwp }}, 'true')
-      name: winbuild_pri_embed
-      inputs:
-        solution: ${{ parameters.csprojPath }}
-        configuration: '$(BuildConfiguration)'
-        msbuildArguments: ${{ parameters.msbuildExtraArguments }} /t:rebuild /p:DisableEmbeddedXbf=false /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration)-csproj.binlog
+    - script: build.cmd -Target BuildForNuget --verbosity=diagnostic -ScriptArgs '-configuration="$(BuildConfiguration)"'
+      displayName: 'Build Projects For Nuget'
 
     - task: VSTest@2
       displayName: 'Unit Tests'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -36,7 +36,7 @@ jobs:
     steps:
     - checkout: self
       clean: true
-    - script: build.cmd -Target provision --verbosity=diagnostic
+    - script: build.cmd -Target provision
       displayName: 'Cake Provision'
       condition: eq(variables['provisioningCake'], 'true')
 
@@ -65,7 +65,7 @@ jobs:
       inputs:
         restoreSolution: ${{ parameters.slnPath }}
 
-    - script: build.cmd -Target BuildForNuget --verbosity=diagnostic -ScriptArgs '-configuration="$(BuildConfiguration)"'
+    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)"'
       displayName: 'Build Projects For Nuget'
 
     - task: VSTest@2

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -65,7 +65,7 @@ jobs:
       inputs:
         restoreSolution: ${{ parameters.slnPath }}
 
-    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)"'
+    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration) -Build_ArtifactStagingDirectory=$(Build.ArtifactStagingDirectory)"'
       displayName: 'Build Projects For Nuget'
 
     - task: VSTest@2

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -65,7 +65,7 @@ jobs:
       inputs:
         restoreSolution: ${{ parameters.slnPath }}
 
-    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration) -Build_ArtifactStagingDirectory=$(Build.ArtifactStagingDirectory)"'
+    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)" -Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
       name: winbuild
       displayName: 'Build Projects For Nuget'
 


### PR DESCRIPTION
### Description of Change ###
Build different ios platform dlls for xcode10 and xcode11 compatibility

The problem with our previous approach for Xcode10 compatibility is that at runtime or link time VS 2017 will encounter types that it doesn't understand. 

So given the scenario of a Xamarin.Forms.iOS application built on VS2017 running on iOS13 you will hit exceptions if you encounter types that VS2017 doesn't understand

This PR doesn't build our DLL on VS 2017 it only if defs out any apis that are iOS13 specific which should produce a dll that will compile on VS2017 and then run/link successfully

I've also included an extra iOS build lane that installs all the VS 2017 sdks and compiles our control gallery to ensure we aren't exposing any APIS that VS 2017 doesn't understand

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- use this nuget with full linking on vs2017 and vs2019. Make sure everything runs

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
