### PR TITLE
[Bug] [macOS] Slider doesn't update its value

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
@@ -3,6 +3,7 @@ using AppKit;
 using System.ComponentModel;
 using CoreGraphics;
 using Xamarin.Forms.Platform.macOS.Controls;
+using Foundation;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
@@ -79,8 +80,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (Control == null)
 				{
 					SetNativeControl(new FormsNSSlider());
-					Control.Activated += OnControlActivated;
 					Control.Cell = new FormsSliderCell();
+					Control.Action = new ObjCRuntime.Selector(nameof(ValueChanged));
+					Control.Target = this;
 				}
 
 				UpdateMaximum();
@@ -147,13 +149,18 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				_disposed = true;
 				if (Control != null)
-					Control.Activated -= OnControlActivated;
+				{
+					Control.Target = null;
+					Control.Action = null;
+				}
 			}
 
 			base.Dispose(disposing);
 		}
 
-		void OnControlActivated(object sender, EventArgs eventArgs)
+
+		[Export(nameof(ValueChanged))]
+		void ValueChanged()
 		{
 			ElementController?.SetValueFromRenderer(Slider.ValueProperty, Control.DoubleValue);
 


### PR DESCRIPTION
### Description of Change ###
Replaced broken event handler by working Selector.
I believe regression was introduced in ae72c0adf7

### Issues Resolved ### 
- fixes #9748

### API Changes ###
None

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
Slider provides consistent value.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
1. Put Slider in XAML, name it (slider), set min/max values (from 0 to 100),
2. Bind slider.Value with property in ViewModel (for ex. SliderValue)
3. Bind Label.Text with slider.Value (Label.Text="{Binding Value, Source={x:Reference slider}}")