### PR TITLE
[BUG][iOS] IsVisible=false isn't working with Frame

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -32,7 +32,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName ||
 			    e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||
 				e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
-				e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName)
+				e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName ||
+				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName)
 				SetupLayer();
 		}
 
@@ -68,6 +69,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_shadowView.UpdateBackgroundColor();
 				_shadowView.Layer.CornerRadius = Layer.CornerRadius;
 				_shadowView.Layer.BorderColor = Layer.BorderColor;
+				_shadowView.Hidden = !Element.IsVisible;
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###
Looks like IsVisible=false doesn't hide Frame's shadow.
Seems bug was introduced in e2101e4ea4471ff682525f52d2e393830a03db10

### Issues Resolved ### 
- fixes #9782

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
IsVisible=False|True shows/hides the frame

### Testing Procedure ###
Use this very simple sample:

```csharp
var frame = new Frame() { VerticalOptions = LayoutOptions.CenterAndExpand, Content = new Label { Text = "Text" } };
var btn = new Button
{
	Text = "click",
	VerticalOptions = LayoutOptions.EndAndExpand,
	Command = new Command(() =>
	{
		frame.IsVisible = !frame.IsVisible;
	})
};

MainPage = new ContentPage
{
	Content = new StackLayout
	{
		Children =
		{
			frame,
			btn
		}
	}
};
```
