### PR TITLE
[UWP] Fixed crash setting the OnColor Switch property

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9694.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9694.cs
@@ -1,0 +1,94 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9694, "Switch control OnColor property breaks application",
+		PlatformAffected.UWP)]
+#if UITEST
+	[Category(UITestCategories.Switch)]
+#endif
+	public class Issue9694 : TestContentPage
+	{
+		readonly Color _customColor = Color.FromHex("#9999CCDD");
+		readonly Color _newCustomColor = Color.Purple;
+
+		public Issue9694()
+		{
+			Title = "Issue 9694";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If there is no exception, the test has passed."
+			};
+
+			var defaultSwitch = new Switch();
+
+			var onColorSwitch = new Switch
+			{
+				OnColor = Color.Orange
+			};
+
+			var switchLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var customSwitch = new Switch
+			{
+				OnColor = _customColor,
+				VerticalOptions = LayoutOptions.Center,
+				Margin = new Thickness(0, 0, 6, 0)
+			};
+
+			var updateButton = new Button
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Update Color"
+			};
+
+			var resetButton = new Button
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Reset Color"
+			};
+
+			switchLayout.Children.Add(customSwitch);
+			switchLayout.Children.Add(updateButton);
+			switchLayout.Children.Add(resetButton);
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(defaultSwitch);
+			layout.Children.Add(onColorSwitch);
+			layout.Children.Add(switchLayout);
+
+			Content = layout;
+
+			updateButton.Clicked += (sender, args) =>
+			{
+				customSwitch.OnColor = _newCustomColor;
+			};
+
+			resetButton.Clicked += (sender, args) =>
+			{
+				customSwitch.OnColor = _customColor;
+			};
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -182,6 +182,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9355.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8784.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9360.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9694.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwitchRenderer.cs
@@ -5,6 +5,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
 using Windows.UI.Xaml.Media.Animation;
 using Windows.UI.Xaml.Shapes;
+using WColor = Windows.UI.Color;
 using WGrid = Windows.UI.Xaml.Controls.Grid;
 using WRectangle = Windows.UI.Xaml.Shapes.Rectangle;
 using WVisualStateManager = Windows.UI.Xaml.VisualStateManager;
@@ -19,7 +20,7 @@ namespace Xamarin.Forms.Platform.UWP
 		const string ToggleSwitchKnobOn = "SwitchKnobOn";
 		const string ToggleSwitchFillMode = "Fill";
 
-		Brush _originalOnHoverColor;
+		object _originalOnHoverColor;
 		Brush _originalOnColorBrush;
 		Brush _originalThumbOnBrush;
 
@@ -114,10 +115,21 @@ namespace Xamarin.Forms.Platform.UWP
 							if (frame != null)
 							{
 								if (_originalOnHoverColor == null)
-									_originalOnHoverColor = frame.Value as Brush;
+								{
+									if (frame.Value is WColor color)
+										_originalOnHoverColor = color;
+
+									if (frame.Value is SolidColorBrush solidColorBrush)
+										_originalOnHoverColor = solidColorBrush;
+								}
 
 								if (!Element.OnColor.IsDefault)
-									frame.Value = new SolidColorBrush(Element.OnColor.ToWindowsColor()) { Opacity = _originalOnHoverColor.Opacity };
+								{
+									frame.Value = new SolidColorBrush(Element.OnColor.ToWindowsColor())
+									{
+										Opacity = _originalOnHoverColor is SolidColorBrush originalOnHoverBrush ? originalOnHoverBrush.Opacity : 1
+									};
+								}
 								else
 									frame.Value = _originalOnHoverColor;
 							}


### PR DESCRIPTION
### Description of Change ###

Fixed crash setting the OnColor Switch property on UWP. Recently we changed to reference 2.3.191211002 when targeting 16299 or later. This changes the OnColor type from Brush to Color and causes the issue.

### Issues Resolved ### 

- fixes #9694

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Screenshots ### 

<img width="1025" alt="Captura de pantalla 2020-03-03 a las 10 55 17" src="https://user-images.githubusercontent.com/6755973/75764022-88ef6500-5d3d-11ea-81c0-e26aa3746082.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 9694. If there is no exception, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
