### PR TITLE
[UWP] Fixed a crash hidden a DatePicker (Xamarin.Forms 4.5-pre4)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9783.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9783.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9783"
+    Title="Issue 9783">
+    <ContentPage.Content>
+        <StackLayout>	
+            <Label
+                Text="Below we have a hidden DatePicker and another one visible. If there is no exception, the test has passed."
+                TextColor="White"
+                BackgroundColor="Black"/>  
+            <DatePicker 
+                IsVisible="True"/>
+            <DatePicker 
+                IsVisible="False"/>
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9783.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9783.xaml.cs
@@ -8,7 +8,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue9783()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9783.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9783.xaml.cs
@@ -1,0 +1,19 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9783, "DatePicker begin to cause Exception in version 4.5.0-282-pre4 and above in some situations",
+		PlatformAffected.UWP)]
+	public partial class Issue9783 : TestContentPage
+	{
+		public Issue9783()
+		{
+			InitializeComponent();
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -182,6 +182,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9355.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8784.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9360.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9783.xaml.cs">
+      <DependentUpon>Issue9783.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1826,6 +1830,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9196.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9783.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/DatePickerRenderer.cs
@@ -89,7 +89,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 			// We also have to intercept the VSM changes on the DatePicker's button
 			var button = Control.GetDescendantsByName<Windows.UI.Xaml.Controls.Button>("FlyoutButton").FirstOrDefault();
-			InterceptVisualStateManager.Hook(button.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>(), button, Element);
+
+			if (button != null)
+				InterceptVisualStateManager.Hook(button.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>(), button, Element);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
@@ -75,7 +75,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 			// We also have to intercept the VSM changes on the TimePicker's button
 			var button = Control.GetDescendantsByName<Windows.UI.Xaml.Controls.Button>("FlyoutButton").FirstOrDefault();
-			InterceptVisualStateManager.Hook(button.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>(), button, Element);
+
+			if (button != null)
+				InterceptVisualStateManager.Hook(button.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>(), button, Element);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Fixed a crash hidden a DatePicker on UWP. Recently we changed to reference 2.3.191211002 when targeting 16299 or later. This has changed the template of the control. Only have one child element called _"FlyoutButton"_ if the control is visible.

### Issues Resolved ### 

- fixes #9783

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Screenshots ### 

<img width="1123" alt="Captura de pantalla 2020-03-03 a las 11 38 59" src="https://user-images.githubusercontent.com/6755973/75767784-a3c4d800-5d43-11ea-881a-5920042474a2.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 9783. If there is no exception, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
