### PR TITLE
[iOS] Fixed issues related with NavigationBar colors

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9767.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9767.cs
@@ -1,0 +1,105 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System.Reflection;
+using System;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Navigation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9767, "[Bug] [iOS] NavigationBar resetting TextColor to black at every change of BarBackgroundColor", PlatformAffected.iOS)]
+	public class Issue9767 : TestNavigationPage
+	{
+		public Issue9767()
+		{
+			var page = new ContentPage
+			{
+				Title = "Issue 9767"
+			};
+
+			var layout = new StackLayout();
+
+			var updateBarBackgroundButton = new Button
+			{
+				Text = "Update BarBackgroundColor"
+			};
+
+			updateBarBackgroundButton.Clicked += (sender, args) =>
+			{
+				BarBackgroundColor = GetRandomColor();
+			};
+
+			var updateBarTextButton = new Button
+			{
+				Text = "Update BarTextColor"
+			};
+
+			updateBarTextButton.Clicked += (sender, args) =>
+			{
+				BarTextColor = GetRandomColor();
+			};
+
+			var resetBarBackgroundButton = new Button
+			{
+				Text = "Reset BarBackgroundColor"
+			};
+
+			resetBarBackgroundButton.Clicked += (sender, args) =>
+			{
+				BarBackgroundColor = Color.Default;
+			};
+
+			var resetBarTextButton = new Button
+			{
+				Text = "Reset BarTextColor"
+			};
+
+			resetBarTextButton.Clicked += (sender, args) =>
+			{
+				BarTextColor = Color.Default;
+			};
+
+			layout.Children.Add(updateBarBackgroundButton);
+			layout.Children.Add(updateBarTextButton);
+			layout.Children.Add(resetBarBackgroundButton);
+			layout.Children.Add(resetBarTextButton);
+
+			page.Content = layout;
+
+			PushAsync(page);
+		}
+
+		protected override void Init()
+		{
+		
+		}
+
+		Color GetRandomColor()
+		{
+			var colors = new List<string>();
+
+			foreach (var field in typeof(Color).GetFields(BindingFlags.Static | BindingFlags.Public))
+			{
+				if (field != null && !string.IsNullOrEmpty(field.Name))
+					colors.Add(field.Name);
+			}
+
+			Random random = new Random();
+			var randomColorName = colors[random.Next(colors.Count)];
+
+			var colorConverter = new ColorTypeConverter();
+			var result = colorConverter.ConvertFromInvariantString(randomColorName);
+
+			return (Color)result;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1266,6 +1266,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8461.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8777.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9329.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9767.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -622,7 +622,7 @@ namespace Xamarin.Forms.Platform.iOS
 #if __XCODE11__
 			if (Forms.IsiOS13OrNewer)
 			{
-				var navigationBarAppearance = new UINavigationBarAppearance();
+				var navigationBarAppearance = NavigationBar.StandardAppearance;
 
 				if (barBackgroundColor == Color.Default)
 					navigationBarAppearance.ConfigureWithDefaultBackground();


### PR DESCRIPTION
### Description of Change ###

Fixed issues related with NavigationBar colors (`BarBackgroundColor` and `BarTextColor`).

### Issues Resolved ### 

- fixes #9767 
- fixes #9790 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue9767-before](https://user-images.githubusercontent.com/6755973/75877600-65e5b380-5e18-11ea-8551-085f6ec4cbe1.gif)

#### After
![issue9767-after](https://user-images.githubusercontent.com/6755973/75877596-641bf000-5e18-11ea-8050-c180bcfd2365.gif)

### Testing Procedure ###
To test 9767 launch Core Gallery and navigate to the Issue9767. Press the available button and verify that everything works as expected.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
