### PR TITLE
[iOS] Hardcoded to Semantic colors (dark mode support)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/CellRenderer.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (!UIDevice.CurrentDevice.CheckSystemVersion(7, 0))
 						return;
 
-					uiBgColor = new UIColor(247f / 255f, 247f / 255f, 247f / 255f, 1);
+					uiBgColor = ColorExtensions.GroupedBackground;
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/EntryCellRenderer.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class EntryCellRenderer : CellRenderer
 	{
-		static readonly Color DefaultTextColor = Color.Black;
+		static readonly Color DefaultTextColor = ColorExtensions.LabelColor.ToColor();
 
 		[Preserve(Conditional = true)]
 		public EntryCellRenderer()

--- a/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/TextCellRenderer.cs
@@ -6,8 +6,8 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class TextCellRenderer : CellRenderer
 	{
-		static readonly Color DefaultDetailColor = new Color(.32, .4, .57);
-		static readonly Color DefaultTextColor = Color.Black;
+		readonly Color DefaultDetailColor = ColorExtensions.SecondaryLabelColor.ToColor();
+		readonly Color DefaultTextColor = ColorExtensions.LabelColor.ToColor();
 
 		[Preserve(Conditional = true)]
 		public TextCellRenderer()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/DefaultCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/DefaultCell.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			Label = new UILabel(frame)
 			{
-				TextColor = UIColor.Black,
+				TextColor = ColorExtensions.LabelColor,
 				Lines = 1,
 				Font = UIFont.PreferredBody,
 				TranslatesAutoresizingMaskIntoConstraints = false

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewCell.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var selectedBackgroundView = new UIView
 			{
-				BackgroundColor = UIColor.Gray
+				BackgroundColor = ColorExtensions.Gray
 			};
 
 			SelectedBackgroundView = selectedBackgroundView;

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -33,19 +33,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UIGraphics.BeginImageContext(size);
 			var context = UIGraphics.GetCurrentContext();
-#if __XCODE11__
-			context.SetFillColor(UIColor.SystemRedColor.ToColor().ToCGColor());
-#else
-			context.SetFillColor(1, 0, 0, 1);
-#endif
+			context.SetFillColor(ColorExtensions.Red.CGColor);
 			context.FillRect(rect);
 			DestructiveBackground = UIGraphics.GetImageFromCurrentImageContext();
 
-#if __XCODE11__
-			context.SetFillColor(UIColor.SystemGrayColor.ToColor().ToCGColor());
-#else
-			context.SetFillColor(UIColor.LightGray.ToColor().ToCGColor());
-#endif
+			context.SetFillColor(ColorExtensions.LightGray.CGColor);
 			context.FillRect(rect);
 
 			NormalBackground = UIGraphics.GetImageFromCurrentImageContext();

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -33,11 +33,19 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UIGraphics.BeginImageContext(size);
 			var context = UIGraphics.GetCurrentContext();
+#if __XCODE11__
+			context.SetFillColor(UIColor.SystemRedColor.ToColor().ToCGColor());
+#else
 			context.SetFillColor(1, 0, 0, 1);
+#endif
 			context.FillRect(rect);
 			DestructiveBackground = UIGraphics.GetImageFromCurrentImageContext();
 
+#if __XCODE11__
+			context.SetFillColor(UIColor.SystemGrayColor.ToColor().ToCGColor());
+#else
 			context.SetFillColor(UIColor.LightGray.ToColor().ToCGColor());
+#endif
 			context.FillRect(rect);
 
 			NormalBackground = UIGraphics.GetImageFromCurrentImageContext();

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -115,6 +115,42 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
+		internal static UIColor Red
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SystemRedColor;
+#endif
+				return UIColor.FromRGBA(1, 0, 0, 1);
+			}
+		}
+
+		internal static UIColor Gray
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SystemGrayColor;
+#endif
+				return UIColor.Gray;
+			}
+		}
+
+		internal static UIColor LightGray
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SystemGray2Color;
+#endif
+				return UIColor.LightGray;
+			}
+		}
+
 #else
 		internal static readonly NSColor Black = NSColor.Black;
 		internal static readonly NSColor SeventyPercentGrey = NSColor.FromRgba(0.7f, 0.7f, 0.7f, 1);

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -18,9 +18,108 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 		internal static readonly UIColor Black = UIColor.Black;
 		internal static readonly UIColor SeventyPercentGrey = new UIColor(0.7f, 0.7f, 0.7f, 1);
+
+		internal static UIColor LabelColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.LabelColor;
+#endif
+				return UIColor.Black;
+			}
+		}
+
+		internal static UIColor PlaceholderColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.PlaceholderTextColor;
+#endif
+				return SeventyPercentGrey;
+			}
+		}
+
+		internal static UIColor SecondaryLabelColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SecondaryLabelColor;
+#endif
+				return new Color(.32, .4, .57).ToUIColor();
+			}
+		}
+
+		internal static UIColor BackgroundColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SystemBackgroundColor;
+#endif
+				return UIColor.White;
+			}
+		}
+
+		internal static UIColor SeparatorColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SeparatorColor;
+#endif
+				return UIColor.Gray;
+			}
+		}
+
+		internal static UIColor OpaqueSeparatorColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.OpaqueSeparatorColor;
+#endif
+				return UIColor.Black;
+			}
+		}
+
+		internal static UIColor GroupedBackground
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SystemGroupedBackgroundColor;
+#endif
+				return new UIColor(247f / 255f, 247f / 255f, 247f / 255f, 1);
+			}
+		}
+
+		internal static UIColor AccentColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsiOS13OrNewer)
+					return UIColor.SystemBlueColor;
+#endif
+				return Color.FromRgba(50, 79, 133, 255).ToUIColor();
+			}
+		}
+
 #else
 		internal static readonly NSColor Black = NSColor.Black;
 		internal static readonly NSColor SeventyPercentGrey = NSColor.FromRgba(0.7f, 0.7f, 0.7f, 1);
+		internal static readonly NSColor LabelColor = NSColor.Black;
+		internal static readonly NSColor AccentColor = Color.FromRgba(50, 79, 133, 255).ToNSColor();
 #endif
 
 		public static CGColor ToCGColor(this Color color)

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -122,7 +122,8 @@ namespace Xamarin.Forms
 			if (IsInitialized)
 				return;
 			IsInitialized = true;
-			Color.SetAccent(Color.FromRgba(50, 79, 133, 255));
+
+			Color.SetAccent(ColorExtensions.AccentColor.ToColor());
 
 			Log.Listeners.Add(new DelegateLogListener((c, m) => Trace.WriteLine(m, c)));
 

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -168,7 +168,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (ModalPresentationStyle == UIKit.UIModalPresentationStyle.FullScreen)
 			{
 				Color modalBkgndColor = ((Page)_modal.Element).BackgroundColor;
-				View.BackgroundColor = modalBkgndColor.IsDefault ? UIColor.White : modalBkgndColor.ToUIColor();
+				View.BackgroundColor = modalBkgndColor.IsDefault ? ColorExtensions.BackgroundColor : modalBkgndColor.ToUIColor();
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -313,7 +313,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_appeared)
 				return;
 
-			_renderer.View.BackgroundColor = UIColor.White;
+			_renderer.View.BackgroundColor = ColorExtensions.BackgroundColor;
 			_renderer.View.ContentMode = UIViewContentMode.Redraw;
 
 #pragma warning disable CS0618 // Type or member is obsolete

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// while it's being replaced on the Window.RootViewController with a new MainPage
 			if (!_disposed)
 			{
-				View.BackgroundColor = UIColor.White;
+				View.BackgroundColor = ColorExtensions.BackgroundColor;
 				Platform.WillAppear();
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
@@ -367,7 +367,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (bgImage != null)
 					View.BackgroundColor = UIColor.FromPatternImage(bgImage);
 				else if (Element.BackgroundColor.IsDefault)
-					View.BackgroundColor = UIColor.White;
+					View.BackgroundColor = ColorExtensions.BackgroundColor;
 				else
 					View.BackgroundColor = Element.BackgroundColor.ToUIColor();
 			});

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public class EditorRenderer : EditorRendererBase<UITextView>
 	{
 		// Using same placeholder color as for the Entry
-		readonly UIColor _defaultPlaceholderColor = ColorExtensions.SeventyPercentGrey;
+		readonly UIColor _defaultPlaceholderColor = ColorExtensions.PlaceholderColor;
 
 		UILabel _placeholderLabel;
 
@@ -346,7 +346,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var textColor = Element.TextColor;
 
 			if (textColor.IsDefault)
-				TextView.TextColor = UIColor.Black;
+				TextView.TextColor = ColorExtensions.LabelColor;
 			else
 				TextView.TextColor = textColor.ToUIColor();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (fgcolor.IsDefault)
 				fgcolor = defaultForegroundColor;
 			if (fgcolor.IsDefault)
-				fgcolor = Color.Black; // as defined by apple docs		
+				fgcolor = ColorExtensions.LabelColor.ToColor();
 
 #if __MOBILE__
 			return new NSAttributedString(span.Text, font == Font.Default ? null : font.ToUIFont(), fgcolor.ToUIColor(), 
@@ -106,7 +106,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (fgcolor.IsDefault)
 				fgcolor = defaultForegroundColor;
 			if (fgcolor.IsDefault)
-				fgcolor = Color.Black; // as defined by apple docs
+				fgcolor = ColorExtensions.LabelColor.ToColor();
 
 #if __MOBILE__
 			UIColor spanFgColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -38,6 +38,16 @@ namespace Xamarin.Forms.Platform.iOS
 				SetupLayer();
 		}
 
+#if __XCODE11__
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
+
+			// Make sure the control adheres to changes UI theme
+			SetupLayer();
+		}
+#endif
+
 		public virtual void SetupLayer()
 		{
 			float cornerRadius = Element.CornerRadius;
@@ -49,7 +59,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Layer.MasksToBounds = Layer.CornerRadius > 0;
 
 			if (Element.BackgroundColor == Color.Default)
-				Layer.BackgroundColor = UIColor.White.CGColor;
+				Layer.BackgroundColor = ColorExtensions.BackgroundColor.CGColor;
 			else
 				Layer.BackgroundColor = Element.BackgroundColor.ToCGColor();
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
-			// Make sure the control adheres to changes UI theme
+			// Make sure the control adheres to changes in UI theme
 			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				SetupLayer();
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -38,15 +38,15 @@ namespace Xamarin.Forms.Platform.iOS
 				SetupLayer();
 		}
 
-#if __XCODE11__
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
-
+#if __XCODE11__
 			// Make sure the control adheres to changes UI theme
-			SetupLayer();
-		}
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				SetupLayer();
 #endif
+		}
 
 		public virtual void SetupLayer()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the control adheres to changes in UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				SetupLayer();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -246,7 +246,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public sealed class FontImageSourceHandler : IImageSourceHandler
 	{
 		//should this be the default color on the BP for iOS? 
-		readonly Color _defaultColor = Color.White;
+		readonly Color _defaultColor = ColorExtensions.LabelColor.ToColor();
 
 		[Preserve(Conditional = true)]
 		public FontImageSourceHandler()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -245,7 +245,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 	public sealed class FontImageSourceHandler : IImageSourceHandler
 	{
-		//should this be the default color on the BP for iOS? 
 		readonly Color _defaultColor = ColorExtensions.LabelColor.ToColor();
 
 		[Preserve(Conditional = true)]

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -517,7 +517,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			// default value of color documented to be black in iOS docs
 #if __MOBILE__
-			Control.TextColor = textColor.ToUIColor(ColorExtensions.Black);
+			Control.TextColor = textColor.ToUIColor(ColorExtensions.LabelColor);
 #else
 			var alignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
 			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(ColorExtensions.Black), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -301,7 +301,15 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
 				UpdateHorizontalScrollBarVisibility();
 		}
+#if __XCODE11__
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
 
+			// Make sure the cells adhere to changes UI theme
+			ReloadData();
+		}
+#endif
 		NSIndexPath[] GetPaths(int section, int index, int count)
 		{
 			var paths = new NSIndexPath[count];
@@ -685,7 +693,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// ...and Steve said to the unbelievers the separator shall be gray, and gray it was. The unbelievers looked on, and saw that it was good, and
 			// they went forth and documented the default color. The holy scripture still reflects this default.
 			// Defined here: https://developer.apple.com/library/ios/documentation/UIKit/Reference/UITableView_Class/#//apple_ref/occ/instp/UITableView/separatorColor
-			Control.SeparatorColor = color.ToUIColor(UIColor.Gray);
+			Control.SeparatorColor = color.ToUIColor(ColorExtensions.SeparatorColor);
 		}
 
 		void UpdateSeparatorVisibility()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -301,15 +301,17 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (e.PropertyName == ScrollView.HorizontalScrollBarVisibilityProperty.PropertyName)
 				UpdateHorizontalScrollBarVisibility();
 		}
-#if __XCODE11__
+
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
-
+#if __XCODE11__
 			// Make sure the cells adhere to changes UI theme
-			ReloadData();
-		}
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				ReloadData();
 #endif
+		}
+
 		NSIndexPath[] GetPaths(int section, int index, int count)
 		{
 			var paths = new NSIndexPath[count];

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -307,7 +307,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the cells adhere to changes UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				ReloadData();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -363,7 +363,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the control adheres to changes in UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				UpdateBackgroundColor();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -358,6 +358,16 @@ namespace Xamarin.Forms.Platform.iOS
 			return shown;
 		}
 
+#if __XCODE11__
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
+
+			// Make sure the control adheres to changes UI theme
+			UpdateBackgroundColor();
+		}
+#endif
+
 		ParentingViewController CreateViewControllerForPage(Page page)
 		{
 			if (Platform.GetRenderer(page) == null)
@@ -640,7 +650,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateBackgroundColor()
 		{
-			var color = Element.BackgroundColor == Color.Default ? Color.White : Element.BackgroundColor;
+			var color = Element.BackgroundColor == Color.Default ? ColorExtensions.BackgroundColor.ToColor() : Element.BackgroundColor;
 			View.BackgroundColor = color.ToUIColor();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -362,7 +362,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
-			// Make sure the control adheres to changes UI theme
+			// Make sure the control adheres to changes in UI theme
 			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				UpdateBackgroundColor();
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -358,15 +358,16 @@ namespace Xamarin.Forms.Platform.iOS
 			return shown;
 		}
 
-#if __XCODE11__
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
-
+#if __XCODE11__
 			// Make sure the control adheres to changes UI theme
-			UpdateBackgroundColor();
-		}
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				UpdateBackgroundColor();
 #endif
+		}
+
 
 		ParentingViewController CreateViewControllerForPage(Page page)
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -507,7 +507,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (bgImage != null)
 					NativeView.BackgroundColor = UIColor.FromPatternImage(bgImage);
 				else if (Element.BackgroundColor.IsDefault)
-					NativeView.BackgroundColor = UIColor.White;
+					NativeView.BackgroundColor = ColorExtensions.BackgroundColor;
 				else
 					NativeView.BackgroundColor = Element.BackgroundColor.ToUIColor();
 			});

--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -195,7 +195,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Control.Font = Element.ToUIFont();
 		}
 
-		readonly Color _defaultPlaceholderColor = ColorExtensions.SeventyPercentGrey.ToColor();
+		readonly Color _defaultPlaceholderColor = ColorExtensions.PlaceholderColor.ToColor();
 		protected internal virtual void UpdatePlaceholder()
 		{
 			var formatted = (FormattedString)Element.Title;

--- a/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonCALayer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonCALayer.cs
@@ -56,7 +56,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_radioButton.IsChecked)
 				{
 					_containerLayer.StrokeColor = _checkBorderStrokeColor?.CGColor ?? _nativeControl.CurrentTitleColor.CGColor;
-					_containerLayer.FillColor = _checkMarkFillColor?.CGColor ?? UIColor.White.CGColor;
+					_containerLayer.FillColor = _checkMarkFillColor?.CGColor ?? ColorExtensions.BackgroundColor.CGColor;
 					_checkLayer.FillColor = _checkBorderFillColor?.CGColor ?? _nativeControl.CurrentTitleColor.CGColor;
 					_checkLayer.StrokeColor = _checkMarkStrokeColor?.CGColor ?? _nativeControl.CurrentTitleColor.CGColor;
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
@@ -138,15 +138,17 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			return new RadioButtonCALayer(Element, Control);
 		}
-#if __XCODE11__
+
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
-
+#if __XCODE11__
 			// Make sure the control adheres to changes UI theme
-			_radioButtonLayer.SetNeedsDisplay();
-		}
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				_radioButtonLayer.SetNeedsDisplay();
 #endif
+		}
+
 		void SetRadioBoxLayer(CALayer layer)
 		{
 			_radioButtonLayer = layer;

--- a/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the control adheres to changes in UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				_radioButtonLayer.SetNeedsDisplay();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
-			// Make sure the control adheres to changes UI theme
+			// Make sure the control adheres to changes in UI theme
 			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				_radioButtonLayer.SetNeedsDisplay();
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
@@ -138,7 +138,15 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			return new RadioButtonCALayer(Element, Control);
 		}
+#if __XCODE11__
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
 
+			// Make sure the control adheres to changes UI theme
+			_radioButtonLayer.SetNeedsDisplay();
+		}
+#endif
 		void SetRadioBoxLayer(CALayer layer)
 		{
 			_radioButtonLayer = layer;

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -176,15 +176,17 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return sizeThatFits;
 		}
-#if __XCODE11__
+
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
-
+#if __XCODE11__
 			// Make sure the control adheres to changes UI theme
-			UpdateTextColor();
-		}
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				UpdateTextColor();
 #endif
+		}
+
 		void OnCancelClicked(object sender, EventArgs args)
 		{
 			ElementController.SetValueFromRenderer(SearchBar.TextProperty, null);

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -181,7 +181,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
-			// Make sure the control adheres to changes UI theme
+			// Make sure the control adheres to changes in UI theme
 			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				UpdateTextColor();
 #endif

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -176,7 +176,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return sizeThatFits;
 		}
+#if __XCODE11__
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
 
+			// Make sure the control adheres to changes UI theme
+			UpdateTextColor();
+		}
+#endif
 		void OnCancelClicked(object sender, EventArgs args)
 		{
 			ElementController.SetValueFromRenderer(SearchBar.TextProperty, null);
@@ -300,7 +308,7 @@ namespace Xamarin.Forms.Platform.iOS
 				// https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextField_Class/index.html#//apple_ref/occ/instp/UITextField/placeholder
 
 				var color = Element.IsEnabled && !targetColor.IsDefault 
-					? targetColor : ColorExtensions.SeventyPercentGrey.ToColor();
+					? targetColor : ColorExtensions.PlaceholderColor.ToColor();
 
 				_textField.AttributedPlaceholder = formatted.ToAttributed(Element, color);
 				_textField.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
@@ -309,7 +317,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				_textField.AttributedPlaceholder = formatted.ToAttributed(Element, targetColor.IsDefault 
-					? ColorExtensions.SeventyPercentGrey.ToColor() : targetColor);
+					? ColorExtensions.PlaceholderColor.ToColor() : targetColor);
 				_textField.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -182,7 +182,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the control adheres to changes in UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				UpdateTextColor();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchHandlerAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchHandlerAppearanceTracker.cs
@@ -172,7 +172,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var formatted = (FormattedString)_searchHandler.Placeholder ?? string.Empty;
 			var targetColor = _searchHandler.PlaceholderColor;
-			var placeHolderColor = targetColor.IsDefault ? ColorExtensions.SeventyPercentGrey.ToColor() : targetColor;
+			var placeHolderColor = targetColor.IsDefault ? ColorExtensions.PlaceholderColor.ToColor() : targetColor;
 			textField.AttributedPlaceholder = formatted.ToAttributed(_searchHandler, placeHolderColor, _searchHandler.HorizontalTextAlignment);
 
 			//Center placeholder

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -49,7 +49,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void UpdateBackground()
 		{
 			var color = _shellContext.Shell.FlyoutBackgroundColor;
-			View.BackgroundColor = color.ToUIColor(Color.White);
+			View.BackgroundColor = color.ToUIColor(ColorExtensions.BackgroundColor);
 
 			if (View.BackgroundColor.CGColor.Alpha < 1)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -252,7 +252,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var color = Shell.BackgroundColor;
 			if (color.IsDefault)
-				color = Color.Black;
+				color = ColorExtensions.BackgroundColor.ToColor();
 
 			FlyoutRenderer.View.BackgroundColor = color.ToUIColor();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -210,7 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_line = new UIView
 				{
-					BackgroundColor = UIColor.Black,
+					BackgroundColor = ColorExtensions.OpaqueSeparatorColor,
 					TranslatesAutoresizingMaskIntoConstraints = true,
 					Alpha = 0.2f
 				};

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -156,14 +156,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void SetBackgroundColor(Color color)
 		{
-			UIColor backgroundColor;
-
-#if __XCODE11__
-			if (Forms.IsiOS13OrNewer)
-				backgroundColor = UIColor.SystemBackgroundColor;
-			else
-#endif
-				backgroundColor = UIColor.White;
+			UIColor backgroundColor = ColorExtensions.BackgroundColor;
 
 			if (Element.BackgroundColor != Color.Default)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -127,15 +127,15 @@ namespace Xamarin.Forms.Platform.iOS
 			base.UpdateNativeWidget();
 		}
 
-#if __XCODE11__
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
-
+#if __XCODE11__
 			// Make sure the cells adhere to changes UI theme
-			Control.ReloadData();
-		}
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				Control.ReloadData();
 #endif
+		}
 
 		void SetSource()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -127,6 +127,16 @@ namespace Xamarin.Forms.Platform.iOS
 			base.UpdateNativeWidget();
 		}
 
+#if __XCODE11__
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
+
+			// Make sure the cells adhere to changes UI theme
+			Control.ReloadData();
+		}
+#endif
+
 		void SetSource()
 		{
 			var modeledView = Element;

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the cells adhere to changes UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				Control.ReloadData();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -372,7 +372,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewWillLayoutSubviews()
 		{
 			base.ViewWillLayoutSubviews();
-			_masterController.View.BackgroundColor = UIColor.White;
+			_masterController.View.BackgroundColor = ColorExtensions.BackgroundColor;
 		}
 
 		public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)
@@ -511,7 +511,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (bgImage != null)
 					View.BackgroundColor = UIColor.FromPatternImage(bgImage);
 				else if (Element.BackgroundColor == Color.Default)
-					View.BackgroundColor = UIColor.White;
+					View.BackgroundColor = ColorExtensions.BackgroundColor;
 				else
 					View.BackgroundColor = Element.BackgroundColor.ToUIColor();
 			});

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
+using UIKit;
 
 #if __MOBILE__
 using NativeColor = UIKit.UIColor;
@@ -230,6 +231,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			AddSubview(uiview);
 
 			_controlChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
+		{
+			base.TraitCollectionDidChange(previousTraitCollection);
+#if __XCODE11__
+			// Make sure the cells adhere to changes UI theme
+			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+				Control.SetNeedsDisplay();
+#endif
 		}
 
 #if __MOBILE__

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -238,7 +238,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
-			// Make sure the cells adhere to changes UI theme
+			// Make sure the control adheres to changes in UI theme
 			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				Control.SetNeedsDisplay();
 #endif

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -239,7 +239,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.TraitCollectionDidChange(previousTraitCollection);
 #if __XCODE11__
 			// Make sure the control adheres to changes in UI theme
-			if (previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
 				Control.SetNeedsDisplay();
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -3,9 +3,9 @@ using System.ComponentModel;
 
 using RectangleF = CoreGraphics.CGRect;
 using SizeF = CoreGraphics.CGSize;
-using UIKit;
 
 #if __MOBILE__
+using UIKit;
 using NativeColor = UIKit.UIColor;
 using NativeControl = UIKit.UIControl;
 using NativeView = UIKit.UIView;
@@ -233,6 +233,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			_controlChanged?.Invoke(this, EventArgs.Empty);
 		}
 
+#if __MOBILE__
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
@@ -243,7 +244,6 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 		}
 
-#if __MOBILE__
 		internal override void SendVisualElementInitialized(VisualElement element, NativeView nativeView)
 		{
 			base.SendVisualElementInitialized(element, Control);


### PR DESCRIPTION
### Description of Change ###

Remove all hardcoded colors from the iOS project to make them play nice with Dark Mode.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- related to #9804
- fixes #7683
- fixes #8495

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###

There will be some (small) color changes when running on iOS 13. Specifically these controls might show a slightly different color than before:

- Accent color (was `Rgba(50, 79, 133, 255)`, now `UIColor.SystemBlue`) 
- Group header for `ListView` and `TableView` (was `UIColor(247f / 255f, 247f / 255f, 247f / 255f, 1)`, now `UIColor.SystemGroupedBackgroundColor`)
- Background colors for `ContextAction`s (was `RGBA(1, 0, 0, 1)`, now `UIColor.SystemRed` for descructive and was `LightGray`, now `UIColor.SystemGray2` for normal)
- `TextCell.Detail` (was `Color(.32, .4, .57)`, now `UIColor.SecondaryLabelColor`)
- Placeholder colors (was `UIColor(0.7f, 0.7f, 0.7f, 1)`, now `UIColor.PlaceholderTextColor`)

For the actual color values from Apple, please refer to: https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/color/

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

#### Before (Dark Mode)

![Simulator Screen Shot - iPhone 11 - 2020-03-04 at 14 10 38](https://user-images.githubusercontent.com/939291/75882824-418ed480-5e22-11ea-9140-5257ec1585c3.png)

![Screenshot 2020-03-04 at 14 11 37](https://user-images.githubusercontent.com/939291/75882833-43f12e80-5e22-11ea-81d2-381f798a8732.png)

![Screenshot 2020-03-04 at 14 11 17](https://user-images.githubusercontent.com/939291/75882837-45baf200-5e22-11ea-853f-1dd99cbb7d47.png)

#### Before (Light Mode)

![Simulator Screen Shot - iPhone 11 - 2020-03-04 at 14 13 26](https://user-images.githubusercontent.com/939291/75882891-5ec3a300-5e22-11ea-9457-c032b609e6f2.png)

![Screenshot 2020-03-04 at 14 13 18](https://user-images.githubusercontent.com/939291/75882894-5ff4d000-5e22-11ea-832d-75de2aa60694.png)

![Screenshot 2020-03-04 at 14 13 44](https://user-images.githubusercontent.com/939291/75882901-62572a00-5e22-11ea-8e0d-15f3db9f40a5.png)

#### After (Dark Mode)

![Simulator Screen Shot - iPhone 11 - 2020-03-04 at 13 37 14](https://user-images.githubusercontent.com/939291/75881797-15725400-5e20-11ea-9964-c8df4ed28295.png)

![Screenshot 2020-03-04 at 13 39 32](https://user-images.githubusercontent.com/939291/75881808-1905db00-5e20-11ea-966e-957884a20b35.png)

![Screenshot 2020-03-04 at 13 40 49](https://user-images.githubusercontent.com/939291/75881815-1b683500-5e20-11ea-9615-ab54984a49c0.png)

#### After (Light Mode)

![Simulator Screen Shot - iPhone 11 - 2020-03-04 at 14 00 15](https://user-images.githubusercontent.com/939291/75882019-96c9e680-5e20-11ea-8fe8-291da137e293.png)

![Screenshot 2020-03-04 at 14 01 21](https://user-images.githubusercontent.com/939291/75882052-a5180280-5e20-11ea-9cb5-d7d7ce0debd1.png)

![Screenshot 2020-03-04 at 14 00 52](https://user-images.githubusercontent.com/939291/75882057-a77a5c80-5e20-11ea-9c8b-ecb26b66d602.png)

### Testing Procedure ###
Run the gallery app and go through all of your favorite controls and pages. Everything should look as intended depending on light/dark mode. That means; no unreadable texts (unless a test case still has a hardcoded color), no white/black blobs while you are running dark/light mode, etc. You'll recognize something that looks off.

Also, try to switch from time to time while the app is running. Switch to the Settings app, then Developer and toggle the Dark Appearance. Then go back to the gallery app and see if everything updated as you would expect.

If you really want to go the extra mile pull down the NuGets and install them on any (sample) app that you might have laying around. Or maybe start a new Forms app from File > New, install these NuGets and try some things.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
