### PR TITLE
Fix-9838 [WPF] Picker does not respect BackgroundColor

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/PickerRenderer.cs
@@ -82,13 +82,13 @@ namespace Xamarin.Forms.Platform.WPF
 			Control.SelectedIndex = Element.SelectedIndex;
 		}
 
-		private void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
+		void OnControlSelectionChanged(object sender, WSelectionChangedEventArgs e)
 		{
 			if (Element != null)
 				Element.SelectedIndex = Control.SelectedIndex;
 		}
 
-		private void OnControlLoaded(object sender, System.Windows.RoutedEventArgs e)
+		void OnControlLoaded(object sender, System.Windows.RoutedEventArgs e)
 		{
 			UpdateBackgroundColor();
 		}

--- a/Xamarin.Forms.Platform.WPF/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/PickerRenderer.cs
@@ -11,7 +11,8 @@ using WSelectionChangedEventArgs = System.Windows.Controls.SelectionChangedEvent
 namespace Xamarin.Forms.Platform.WPF
 {
 	public class PickerRenderer : ViewRenderer<Picker, ComboBox>
-	{
+	{		
+		const string TextBoxTemplate = "PART_EditableTextBox";
 		protected override void OnElementChanged(ElementChangedEventArgs<Picker> e)
 		{
 			if (e.NewElement != null)
@@ -19,8 +20,10 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Control == null) // construct and SetNativeControl and suscribe control event
 				{
 					SetNativeControl(new ComboBox());
+					Control.IsEditable = true;
 					Control.SelectionChanged += OnControlSelectionChanged;
-				}
+					Control.Loaded += OnControlLoaded;
+				}								
 
 				// Update control property 
 				UpdateTitle();
@@ -31,7 +34,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 			base.OnElementChanged(e);
 		}
-		
+
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
@@ -48,6 +51,10 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				UpdateTextColor();
 			}
+			else if (e.PropertyName == Picker.BackgroundColorProperty.PropertyName)
+			{
+				UpdateBackgroundColor();
+			}
 		}
 
 		void UpdateTitle()
@@ -60,6 +67,16 @@ namespace Xamarin.Forms.Platform.WPF
 			Control.UpdateDependencyColor(ComboBox.ForegroundProperty, Element.TextColor);
 		}
 
+		void UpdateBackgroundColor()
+		{			
+			var textbox = (TextBox)Control.Template.FindName(TextBoxTemplate, Control);
+			if (textbox != null)
+			{
+				var parent = (Border)textbox.Parent;
+				parent.Background = Element.BackgroundColor.ToBrush();
+			}			
+		}
+
 		void UpdateSelectedIndex()
 		{
 			Control.SelectedIndex = Element.SelectedIndex;
@@ -69,6 +86,11 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			if (Element != null)
 				Element.SelectedIndex = Control.SelectedIndex;
+		}
+
+		private void OnControlLoaded(object sender, System.Windows.RoutedEventArgs e)
+		{
+			UpdateBackgroundColor();
 		}
 
 		bool _isDisposed;
@@ -83,6 +105,7 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Control != null)
 				{
 					Control.SelectionChanged -= OnControlSelectionChanged;
+					Control.Loaded -= OnControlLoaded;
 					Control.ItemsSource = null;
 				}
 


### PR DESCRIPTION
### Description of Change ###
Picker  background color is not implemented on WPF 

### Issues Resolved ### 
- fixes #9838  


### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###
BackgroundColor is updated


### Before/After Screenshots ### 
![WPFPicker](https://user-images.githubusercontent.com/17849938/75905812-35b90780-5e4e-11ea-8cd2-c79b047d439e.gif)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
