### PR TITLE
[WPF] Dont set Slider.Value if it already matches control

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/SliderRenderer.cs
@@ -60,7 +60,8 @@ namespace Xamarin.Forms.Platform.WPF
 
 		void HandleValueChanged(object sender, RoutedPropertyChangedEventArgs<double> routedPropertyChangedEventArgs)
 		{
-			((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Control.Value);
+			if (Control.Value != Element.Value)
+				((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Control.Value);
 		}
 
 		bool _isDisposed;


### PR DESCRIPTION
### Description of Change ###

If you get into a scenario where a set bindable property is queue'd up internally it will cause the Slider to hit an infinite loop. The BP will set the value which then causes the Control to get set, which was then causing a value to get set from the renderer to the element, which would then get queue'd up, etc...

### Platforms Affected ### 

- WPF

### Testing Procedure ###
- make sure sliders all still work on WPF
- The place I Was seeing this issue was on the TwoPaneView gallery. On the properties gallery if you set both of the MinTall and MinWide values to max then resized the window

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
