### PR TITLE
[X] consume trailing spaces in markup

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh9212.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh9212.xaml
@@ -4,5 +4,5 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         xmlns:local="using:Xamarin.Forms.Xaml.UnitTests"
         x:Class="Xamarin.Forms.Xaml.UnitTests.Gh9212">
-    <Label x:Name="label" Text="{local:Gh9212Markup 'Foo, Bar'}" />
+    <Label x:Name="label" Text="{local:Gh9212Markup 'Foo, Bar' }" />
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh9212.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh9212.xaml.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[TearDown] public void TearDown() => Device.PlatformServices = null;
 
 			[Test]
-			public void SingleQuoteInMarkupValue([Values(false, true)]bool useCompiledXaml)
+			public void SingleQuoteAndTrailingSpaceInMarkupValue([Values(false, true)]bool useCompiledXaml)
 			{
 				var layout = new Gh9212(useCompiledXaml);
 				Assert.That(layout.label.Text, Is.EqualTo("Foo, Bar"));

--- a/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExpressionParser.cs
@@ -122,7 +122,6 @@ namespace Xamarin.Forms.Xaml
 
 		protected Property ParseProperty(IServiceProvider serviceProvider, ref string remaining)
 		{
-			char next;
 			object value = null;
 			string str_value;
 			string name;
@@ -131,7 +130,7 @@ namespace Xamarin.Forms.Xaml
 			if (remaining[0] == '{')
 				return ParsePropertyExpression(null, serviceProvider, ref remaining);
 
-			str_value = GetNextPiece(serviceProvider, ref remaining, out next);
+			str_value = GetNextPiece(serviceProvider, ref remaining, out var next);
 			if (next == '=') {
 				remaining = remaining.TrimStart();
 				if (remaining[0] == '{')
@@ -147,7 +146,7 @@ namespace Xamarin.Forms.Xaml
 			return new Property { last = next == '}', name = name, strValue = str_value, value = value };
 		}
 
-		private Property ParsePropertyExpression(string prop, IServiceProvider serviceProvider, ref string remaining)
+		Property ParsePropertyExpression(string prop, IServiceProvider serviceProvider, ref string remaining)
 		{
 			bool last;
 			var value = ParseExpression(ref remaining, serviceProvider);
@@ -165,7 +164,7 @@ namespace Xamarin.Forms.Xaml
 			return new Property { last = last, name = prop, strValue = value as string, value = value };
 		}
 
-		private string GetNextPiece(IServiceProvider serviceProvider, ref string remaining, out char next)
+		string GetNextPiece(IServiceProvider serviceProvider, ref string remaining, out char next)
 		{
 			bool inString = false;
 			int end = 0;
@@ -182,6 +181,8 @@ namespace Xamarin.Forms.Xaml
 					{
 						inString = false;
 						end ++;
+						while (remaining[end] == ' ')
+							end++;
 						break;
 					}
 				}


### PR DESCRIPTION
### Description of Change ###

consume trailing spaces after quoted string in markup. this was regressed by #8980

### Issues Resolved ### 

- fixes #9212

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
