### PR TITLE
Fix 9842 [Bug][iOS] MasterDetailPage shadow platform-specific not applied when first set

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -142,6 +142,8 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateBackground();
 
 			UpdatePanGesture();
+			UpdateApplyShadow(((MasterDetailPage)Element).OnThisPlatform().GetApplyShadow());
+
 		}
 
 		public override void WillRotate(UIInterfaceOrientation toInterfaceOrientation, double duration)


### PR DESCRIPTION
### Description of Change ###

MasterDetailPage shadow platform-specific not applied when first set

### Issues Resolved ### 
- fixes #9842 

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###
Detail page drags with shadow.


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
