### PR TITLE
[iOS,Android, UWP] Set Position and CurrentItem when ItemsSource items change

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue9771">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition/>
+            <RowDefinition Height="40"/>
+        </Grid.RowDefinitions>
+        <local:ExtendedCarousel ItemsSource="{Binding Items}" Position="{Binding Position, Mode=TwoWay}" >
+            <local:ExtendedCarousel.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout>
+                        <Label Text="{Binding .}"/>
+                        <Entry BackgroundColor="Blue" ClearButtonVisibility="Never"/>
+                    </StackLayout>
+
+                </DataTemplate>
+            </local:ExtendedCarousel.ItemTemplate>
+        </local:ExtendedCarousel>
+
+        <StackLayout Orientation="Horizontal" Grid.Row="1">
+            <Button Text="Left" Command="{Binding LeftButtonCommand}"/>
+            <Label Text="{Binding Position}" />
+            <Button Text="Right" Command="{Binding RightButtonCommand}"/>
+        </StackLayout>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml
@@ -12,7 +12,7 @@
             <RowDefinition/>
             <RowDefinition Height="40"/>
         </Grid.RowDefinitions>
-        <local:ExtendedCarousel ItemsSource="{Binding Items}" Position="{Binding Position, Mode=TwoWay}" >
+        <local:ExtendedCarousel x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position, Mode=TwoWay}" >
             <local:ExtendedCarousel.ItemTemplate>
                 <DataTemplate>
                     <StackLayout>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
@@ -1,0 +1,185 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Threading.Tasks;
+using System.Windows.Input;
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.CustomAttributes;
+
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9771, "Changing CarouselView Position does not change view ", PlatformAffected.UWP)]
+	public partial class Issue9771 : TestContentPage
+	{
+		public Issue9771()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			BindingContext = new MainViewModel();
+		}
+	}
+
+
+	public class MainViewModel : ViewModelBase
+	{
+		bool _isLoading;
+		public bool IsLoading
+		{
+			get { return _isLoading; }
+			set
+			{
+				_isLoading = value;
+				OnPropertyChanged();
+			}
+		}
+
+
+		public MainViewModel()
+		{
+			Task.Run(async () =>
+			{
+				IsLoading = true;
+
+				await Task.Delay(1000);
+
+				Items = new List<string>();
+				for (int i = 0; i < 100; i++)
+				{
+					Items.Add(i.ToString());
+				}
+
+				Position = 100 / 2;
+
+				IsLoading = false;
+			});
+
+
+		}
+
+		List<string> _items;
+		public List<string> Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		int _position;
+		public int Position
+		{
+			get { return _position; }
+			set
+			{
+				_position = value;
+				OnPropertyChanged();
+			}
+		}
+
+		ICommand _LeftButtonCommand;
+		public ICommand LeftButtonCommand
+		{
+			get
+			{
+				return _LeftButtonCommand
+					?? (_LeftButtonCommand = new Command(
+					() =>
+					{
+						Position--;
+					}));
+			}
+		}
+
+		private ICommand _rightButtonCommand;
+		public ICommand RightButtonCommand
+		{
+			get
+			{
+				return _rightButtonCommand
+					?? (_rightButtonCommand = new Command(
+					() =>
+					{
+						Position++;
+					}));
+			}
+		}
+	}
+
+	public class ExtendedCarousel : CarouselView, INotifyPropertyChanged, IDisposable
+	{
+		public ExtendedCarousel()
+		{
+			HorizontalScrollBarVisibility = ScrollBarVisibility.Never;
+			VerticalScrollBarVisibility = ScrollBarVisibility.Never;
+
+			IsScrollAnimated = true;
+
+			ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
+			{
+				SnapPointsAlignment = SnapPointsAlignment.Center,
+				SnapPointsType = SnapPointsType.MandatorySingle
+			};
+		}
+
+		public void Dispose()
+		{
+		}
+
+		protected override void OnPositionChanged(PositionChangedEventArgs args)
+		{
+			var d = this.CurrentItem;
+
+			IsLoading = false;
+			base.OnPositionChanged(args);
+		}
+
+		protected override void OnPropertyChanging([CallerMemberName] string propertyName = null)
+		{
+			if (propertyName == nameof(Position))
+			{
+				IsLoading = true;
+			}
+			base.OnPropertyChanging(propertyName);
+		}
+
+		public static readonly BindableProperty IsLoadingProperty = BindableProperty.Create(nameof(IsLoading), typeof(bool), typeof(ExtendedCarousel), false, defaultBindingMode: BindingMode.TwoWay);
+		public bool IsLoading
+		{
+			get { return (bool)this.GetValue(IsLoadingProperty); }
+			set
+			{
+				this.SetValue(IsLoadingProperty, value);
+				RaisePropertyChanged();
+			}
+		}
+
+		public new event PropertyChangedEventHandler PropertyChanged;
+
+		void RaisePropertyChanged([CallerMemberName] String propertyName = "")
+		{
+			if (PropertyChanged != null)
+			{
+				PropertyChanged(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+	}
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
@@ -59,12 +59,12 @@ namespace Xamarin.Forms.Controls.Issues
 				await Task.Delay(1000);
 
 				Items = new List<string>();
-				for (int i = 0; i < 10; i++)
+				for (int i = 0; i < 100; i++)
 				{
 					Items.Add(i.ToString());
 				}
 
-				//Position = 100 / 2;
+				Position = 100 / 2;
 
 				IsLoading = false;
 			});

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
@@ -59,12 +59,12 @@ namespace Xamarin.Forms.Controls.Issues
 				await Task.Delay(1000);
 
 				Items = new List<string>();
-				for (int i = 0; i < 100; i++)
+				for (int i = 0; i < 10; i++)
 				{
 					Items.Add(i.ToString());
 				}
 
-				Position = 100 / 2;
+				//Position = 100 / 2;
 
 				IsLoading = false;
 			});

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
@@ -143,6 +143,8 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 		}
 
+		public override bool AnimatePositionChanges => false;
+
 		public void Dispose()
 		{
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9771.xaml.cs
@@ -26,6 +26,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 #if APP
 			InitializeComponent();
+			carousel.Scrolled += (s, e) =>
+			{
+				System.Diagnostics.Debug.WriteLine($" Center Item:{e.CenterItemIndex} Scroll:{e.HorizontalOffset} Delta:{e.HorizontalDelta}");
+			};
 #endif
 		}
 
@@ -64,7 +68,7 @@ namespace Xamarin.Forms.Controls.Issues
 					Items.Add(i.ToString());
 				}
 
-				Position = 100 / 2;
+				Position = Items.Count / 2;
 
 				IsLoading = false;
 			});

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -189,6 +189,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9694.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9771.xaml.cs">
+      <SubType>Code</SubType>
+      <DependentUpon>Issue9771.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
@@ -1398,6 +1402,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4040.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9771.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)VisualControlsPage.xaml">

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 
-			SetMainPage(CreateDefaultMainPage());
+			SetMainPage(new NavigationPage(new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselViewGallery()));
 
 			//TestMainPageSwitches();
 

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 
-			SetMainPage(new NavigationPage(new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselViewGallery()));
+			SetMainPage(CreateDefaultMainPage());
 
 			//TestMainPageSwitches();
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
-				Position = 2,
+				Position = 1,
 				Margin = new Thickness(0,10,0,10),
 				BackgroundColor = Color.LightGray,
 				AutomationId = "TheCarouselView"

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
@@ -26,9 +26,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			{
 				RowDefinitions = new RowDefinitionCollection
 				{
-					new RowDefinition { Height = GridLength.Auto },
-					new RowDefinition { Height = GridLength.Auto },
-					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = 40 },
+					new RowDefinition { Height = 80 },
+					new RowDefinition { Height = 30},
+					new RowDefinition { Height = 20},
+					new RowDefinition { Height = 20},
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star }
 				}
@@ -63,16 +65,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var generator = new ItemsSourceGenerator(carouselView, initialItems: nItems, itemsSourceType: ItemsSourceType.ObservableCollection);
 
-			layout.Children.Add(generator);
-
 			var positionControl = new PositionControl(carouselView, nItems);
-			layout.Children.Add(positionControl);
-
+			
 			var spacingModifier = new SpacingModifier(carouselView.ItemsLayout, "Update Spacing");
-
-			layout.Children.Add(spacingModifier);
-
-			layout.Children.Add(stacklayoutInfo);
 
 			var stckPeek = new StackLayout { Orientation = StackOrientation.Horizontal };
 			stckPeek.Children.Add(new Label { Text = "Peek" });
@@ -95,9 +90,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 
 			stckPeek.Children.Add(padi);
-			stacklayoutInfo.Children.Add(stckPeek);
-			stacklayoutInfo.Children.Add(_scrollInfoLabel);
-
+		
 			var content = new Grid();
 			content.Children.Add(carouselView);
 
@@ -105,13 +98,20 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			// Uncomment this line to add a helper to visualize the center of each element.
 			//content.Children.Add(CreateDebuggerLines());
 #endif
-
+			layout.Children.Add(generator);
+			layout.Children.Add(positionControl);
+			layout.Children.Add(stacklayoutInfo);
+			layout.Children.Add(stckPeek);
+			layout.Children.Add(spacingModifier);
+			layout.Children.Add(_scrollInfoLabel);
 			layout.Children.Add(content);
 
 			Grid.SetRow(positionControl, 1);
 			Grid.SetRow(stacklayoutInfo, 2);
-			Grid.SetRow(spacingModifier, 3);
-			Grid.SetRow(content, 4);
+			Grid.SetRow(stckPeek, 3);
+			Grid.SetRow(spacingModifier, 4);
+			Grid.SetRow(_scrollInfoLabel, 5);
+			Grid.SetRow(content, 6);
 
 			Content = layout;
 			generator.CollectionChanged += (sender, e) => {

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -29,7 +29,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			new LinearItemsLayout(ItemsLayoutOrientation.Horizontal)
 			{
 				SnapPointsType = SnapPointsType.MandatorySingle,
-				SnapPointsAlignment = SnapPointsAlignment.Center
+				SnapPointsAlignment = SnapPointsAlignment.Center,
+				ItemSpacing = 8
 			};
 
 			var itemTemplate = GetCarouselTemplate();

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -124,9 +124,14 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				viewModel.Items.Clear();
 			};
 
+			var lbl = new Label();
+			lbl.SetBinding(Label.TextProperty, nameof(CarouselView.Position));
+			lbl.BindingContext = carouselView;
+
 			stacklayoutButtons.Children.Add(addItemButton);
 			stacklayoutButtons.Children.Add(removeItemButton);
 			stacklayoutButtons.Children.Add(clearItemsButton);
+			stacklayoutButtons.Children.Add(lbl);
 
 			grid.Children.Add(stacklayoutButtons, 0, 1);
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselSnapGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselSnapGallery.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		{
 			On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Never);
 
-			var viewModel = new CarouselItemsGalleryViewModel();
+			var viewModel = new CarouselItemsGalleryViewModel(false, false);
 
 			Title = $"CarouselView Snap Options";
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -34,16 +34,18 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 						GalleryBuilder.NavButton("CarouselView (XAML, Horizontal)", () =>
 							new CarouselXamlGallery(), Navigation),
 						GalleryBuilder.NavButton("CarouselView (Indicators Forms)", () =>
-							new CarouselItemsGallery(), Navigation),
+							new CarouselItemsGallery(false,false,false), Navigation),
 						GalleryBuilder.NavButton("CarouselView (Indicators Default (Native))", () =>
-							new CarouselItemsGallery(), Navigation),
+							new CarouselItemsGallery(false,false,true), Navigation),
+						GalleryBuilder.NavButton("CarouselView Async", () =>
+							new CarouselItemsGallery(false,true,true), Navigation),
 	  					GalleryBuilder.NavButton("CarouselView Snap", () =>
  							new CarouselSnapGallery(), Navigation),
 						GalleryBuilder.NavButton("ObservableCollection and CarouselView", () =>
  							new CollectionCarouselViewGallery(), Navigation),
 						GalleryBuilder.NavButton("CarouselView EmptyView", () =>
-  							new EmptyCarouselGallery(), Navigation),    
-	  					GalleryBuilder.NavButton("IndicatorView", () =>
+  							new EmptyCarouselGallery(), Navigation),
+						GalleryBuilder.NavButton("IndicatorView", () =>
   							new IndicatorCodeGallery(), Navigation)
 					}
 				}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -23,8 +23,12 @@
         <Label Text="{Binding Path=CurrentItem.Index , Source={x:Reference Name=carousel}}" AutomationId="lblCurrentItem" Grid.Row="2" Grid.Column="1" />
         <Label Text="Selected: " Grid.Row="3" Grid.Column="0" />
         <Label Text="{Binding Selected.Index}" AutomationId="lblSelected" Grid.Row="3" Grid.Column="1" />
-        <Button Command="{Binding RemoveCommand}" Grid.Row="4" Grid.ColumnSpan="2" AutomationId="btnRemove"
-                Text="{Binding Selected.Index}" BackgroundColor="LightGray" TextColor="Black" />
+
+        <StackLayout Grid.Row="4" Grid.ColumnSpan="2" Orientation="Horizontal" HorizontalOptions="Center">
+            <Button Command="{Binding PreviousCommand}" AutomationId="btnPrev" Text="&lt;" FontAttributes="Bold" BackgroundColor="LightGray" TextColor="Black" />
+            <Button Command="{Binding RemoveCommand}"  AutomationId="btnRemove" Text="{Binding Path=Selected.Index, StringFormat='Remove {0}'}" BackgroundColor="LightGray" TextColor="Black" />
+            <Button Command="{Binding NextCommand}"  AutomationId="btnNext" Text="&gt;" FontAttributes="Bold" BackgroundColor="LightGray" TextColor="Black" />
+        </StackLayout>
         <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="5" Grid.ColumnSpan="2"
                       CurrentItem="{Binding Selected}" >
             <CarouselView.ItemTemplate>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -21,7 +21,7 @@
                       StringFormat='The current Position is {0}'}"
                       VerticalTextAlignment="Center"
                       VerticalOptions="Center"
-                      Grid.Column="0" Grid.Row="1" 
+                      Grid.Column="0" Grid.Row="1"
                       Padding="7"/>
         <Entry Text="{Binding Position}"
                       VerticalTextAlignment="Center"
@@ -35,26 +35,19 @@
                       Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2"
                       AutomationId="lblVisibleViews"
                       Padding="7"/>
-        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="3" HeightRequest="400" Grid.ColumnSpan="2"
-                      PeekAreaInsets="50,0">
+        <StackLayout Orientation="Vertical"  Grid.Row="3">
+            <Label Text="{Binding Path=Position , Source={x:Reference Name=carousel}}"></Label>
+            <Label Text="{Binding Path=CurrentItem.Index , Source={x:Reference Name=carousel}}"></Label>
+            <Label Text="{Binding Selected.Index}"></Label>
+            <Button Command="{Binding RemoveCommand}" Text="{Binding Selected.Index}"></Button>
+        </StackLayout>
+
+        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="4" CurrentItem="{Binding Selected}" HeightRequest="400">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <gallery:ExampleTemplateCarousel />
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
-
-        <Frame Margin="15" x:Name="layoutNormal" Grid.Row="4" Grid.ColumnSpan="2" HeightRequest="150" OutlineColor="#00000088" Padding="5">
-            <Grid>
-                <CarouselView x:Name="carouselNormal" ItemsSource="{Binding Items}" Position="{Binding Position}">
-                    <CarouselView.ItemTemplate>
-                        <DataTemplate>
-                            <Image Source="{Binding Image}" Aspect="AspectFill" />
-                        </DataTemplate>
-                    </CarouselView.ItemTemplate>
-                </CarouselView>
-            </Grid>
-        </Frame>
-        <IndicatorView x:Name="indicator" IndicatorColor="Gray" SelectedIndicatorColor="Black" Grid.Row="4"></IndicatorView>
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -3,7 +3,7 @@
     xmlns:gallery="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries" xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselXamlGallery"
     Title="CarouselView Xaml">
-    <Grid Margin="10,50,10,0">
+    <Grid Margin="0,0,0,10">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
@@ -11,43 +11,21 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
-            <RowDefinition Height="150" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
             <ColumnDefinition />
         </Grid.ColumnDefinitions>
-        <Slider x:Name="slider" Margin="5" Value="{Binding Position, Mode=TwoWay}" Maximum="{Binding Count}" Grid.ColumnSpan="2" />
-        <Label Text="{Binding Source={x:Reference slider},
-                      Path=Value,
-                      StringFormat='The current Position is {0}'}"
-                      VerticalTextAlignment="Center"
-                      VerticalOptions="Center"
-                      Grid.Column="0" Grid.Row="1"
-                      Padding="7"/>
-        <Entry Text="{Binding Position}"
-                      VerticalTextAlignment="Center"
-                      VerticalOptions="Center"
-                      Grid.Column="1" Grid.Row="1"/>
-        <Label Text="{Binding Source={x:Reference carousel},
-                      Path=VisibleViews.Count,
-                      StringFormat='Number of VisibleViews {0}'}"
-                      VerticalTextAlignment="Center"
-                      VerticalOptions="Center"
-                      Grid.Column="0" Grid.Row="2" Grid.ColumnSpan="2"
-                      AutomationId="lblVisibleViews"
-                      Padding="7"/>
-        <StackLayout Orientation="Vertical"  Grid.Row="3">
-            <Label Text="Position:" />
-            <Label Text="{Binding Path=Position , Source={x:Reference Name=carousel}}"  AutomationId="lblPosition"/>
-            <Label Text="CurrentItem :" />
-            <Label Text="{Binding Path=CurrentItem.Index , Source={x:Reference Name=carousel}}" AutomationId="lblCurrentItem"/>
-            <Label Text="Selected: " />
-            <Label Text="{Binding Selected.Index}" AutomationId="lblSelected"/>
-        </StackLayout>
-        <Button Command="{Binding RemoveCommand}" Grid.Row="4" AutomationId="btnRemove"
+        <Slider x:Name="slider" Margin="5" Value="{Binding Position, Mode=TwoWay}" Maximum="{Binding Count}" Grid.ColumnSpan="2"/>
+        <Label Text="Position:" Grid.Row="1" Grid.Column="0" />
+        <Label Text="{Binding Path=Position , Source={x:Reference Name=carousel}}"  AutomationId="lblPosition" Grid.Row="1" Grid.Column="1" />
+        <Label Text="CurrentItem :"  Grid.Row="2" Grid.Column="0" />
+        <Label Text="{Binding Path=CurrentItem.Index , Source={x:Reference Name=carousel}}" AutomationId="lblCurrentItem" Grid.Row="2" Grid.Column="1" />
+        <Label Text="Selected: " Grid.Row="3" Grid.Column="0" />
+        <Label Text="{Binding Selected.Index}" AutomationId="lblSelected" Grid.Row="3" Grid.Column="1" />
+        <Button Command="{Binding RemoveCommand}" Grid.Row="4" Grid.ColumnSpan="2" AutomationId="btnRemove"
                 Text="{Binding Selected.Index}" BackgroundColor="LightGray" TextColor="Black" />
-        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="5"
+        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="5" Grid.ColumnSpan="2"
                       CurrentItem="{Binding Selected}" >
             <CarouselView.ItemTemplate>
                 <DataTemplate>
@@ -55,16 +33,5 @@
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
-        <Frame Margin="15" x:Name="layoutNormal" Grid.Row="6" OutlineColor="#00000088" Padding="5">
-            <Grid>
-                <CarouselView x:Name="carouselNormal" ItemsSource="{Binding Items}" Position="{Binding Position}">
-                    <CarouselView.ItemTemplate>
-                        <DataTemplate>
-                            <Image Source="{Binding Image}" Aspect="AspectFill" />
-                        </DataTemplate>
-                    </CarouselView.ItemTemplate>
-                </CarouselView>
-            </Grid>
-        </Frame>
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -38,13 +38,14 @@
                       AutomationId="lblVisibleViews"
                       Padding="7"/>
         <StackLayout Orientation="Vertical"  Grid.Row="3">
-            <Label Text="{Binding Path=Position , Source={x:Reference Name=carousel}}"></Label>
-            <Label Text="{Binding Path=CurrentItem.Index , Source={x:Reference Name=carousel}}"></Label>
-            <Label Text="{Binding Selected.Index}"></Label>
-            <Button Command="{Binding RemoveCommand}" Text="{Binding Selected.Index}"></Button>
+            <Label Text="Position:" />
+            <Label Text="{Binding Path=Position , Source={x:Reference Name=carousel}}"  AutomationId="lblPosition"/>
+            <Label Text="CurrentItem :" />
+            <Label Text="{Binding Path=CurrentItem.Index , Source={x:Reference Name=carousel}}" AutomationId="lblCurrentItem"/>
+            <Label Text="Selected: " />
+            <Label Text="{Binding Selected.Index}" AutomationId="lblSelected"/>
         </StackLayout>
-
-        <Button Command="{Binding RemoveCommand}" Grid.Row="4"
+        <Button Command="{Binding RemoveCommand}" Grid.Row="4" AutomationId="btnRemove"
                 Text="{Binding Selected.Index}" BackgroundColor="LightGray" TextColor="Black" />
         <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="5"
                       CurrentItem="{Binding Selected}" >

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -2,14 +2,16 @@
 <ContentPage
     xmlns:gallery="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries" xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselXamlGallery"
-    Title="CarouselView Xaml" >
-    <Grid Margin="0,20,00,0">
+    Title="CarouselView Xaml">
+    <Grid Margin="10,50,10,0">
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="150" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
@@ -42,12 +44,26 @@
             <Button Command="{Binding RemoveCommand}" Text="{Binding Selected.Index}"></Button>
         </StackLayout>
 
-        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="4" CurrentItem="{Binding Selected}" HeightRequest="400">
+        <Button Command="{Binding RemoveCommand}" Grid.Row="4"
+                Text="{Binding Selected.Index}" BackgroundColor="LightGray" TextColor="Black" />
+        <CarouselView AutomationId="TheCarouselView" x:Name="carousel" ItemsSource="{Binding Items}" Position="{Binding Position}" Grid.Row="5"
+                      CurrentItem="{Binding Selected}" >
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <gallery:ExampleTemplateCarousel />
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
+        <Frame Margin="15" x:Name="layoutNormal" Grid.Row="6" OutlineColor="#00000088" Padding="5">
+            <Grid>
+                <CarouselView x:Name="carouselNormal" ItemsSource="{Binding Items}" Position="{Binding Position}">
+                    <CarouselView.ItemTemplate>
+                        <DataTemplate>
+                            <Image Source="{Binding Image}" Aspect="AspectFill" />
+                        </DataTemplate>
+                    </CarouselView.ItemTemplate>
+                </CarouselView>
+            </Grid>
+        </Frame>
     </Grid>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -56,13 +56,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			MessagingCenter.Subscribe<ExampleTemplateCarousel>(this, "remove", (obj) => Items.Remove(obj.BindingContext as CarouselItem));
 
 			Items = new ObservableCollection<CarouselItem>(items);
-			Items.CollectionChanged += ItemsCollectionChanged;
-			Count = Items.Count - 1;
-
-		}
-
-		void ItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
-		{
 			Count = Items.Count - 1;
 		}
 
@@ -94,6 +87,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		public ICommand RemoveCommand => new Command(() =>
 		{
 			Items.Remove(Selected);
+			Count = Items.Count - 1;
 		});
 
 		public ICommand PreviousCommand => new Command(() =>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Windows.Input;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries
@@ -11,7 +12,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		{
 			InitializeComponent();
 			BindingContext = new CarouselViewModel(CarouselXamlSampleType.Peek);
-			carouselNormal.BindingContext = new CarouselViewModel(CarouselXamlSampleType.Normal);
+			//carouselNormal.BindingContext = new CarouselViewModel(CarouselXamlSampleType.Normal);
 		}
 
 		protected override void OnAppearing()
@@ -83,6 +84,18 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			get { return _items; }
 			set { SetProperty(ref _items, value); }
 		}
+
+		CarouselItem _selected;
+		public CarouselItem Selected
+		{
+			get { return _selected; }
+			set { SetProperty(ref _selected, value); }
+		}
+
+		public ICommand RemoveCommand => new Command(() => {
+			Items.Remove(Selected);
+		
+		});
 	}
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -12,13 +12,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		{
 			InitializeComponent();
 			BindingContext = new CarouselViewModel(CarouselXamlSampleType.Peek);
-			carouselNormal.BindingContext = new CarouselViewModel(CarouselXamlSampleType.Normal);
 		}
 
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-			(BindingContext as CarouselViewModel).Position = 2;
+		//	(BindingContext as CarouselViewModel).Position = 2;
 		}
 	}
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		{
 			InitializeComponent();
 			BindingContext = new CarouselViewModel(CarouselXamlSampleType.Peek);
-			//carouselNormal.BindingContext = new CarouselViewModel(CarouselXamlSampleType.Normal);
+			carouselNormal.BindingContext = new CarouselViewModel(CarouselXamlSampleType.Normal);
 		}
 
 		protected override void OnAppearing()

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		protected override void OnAppearing()
 		{
 			base.OnAppearing();
-		//	(BindingContext as CarouselViewModel).Position = 2;
+			//	(BindingContext as CarouselViewModel).Position = 2;
 		}
 	}
 
@@ -91,9 +91,29 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			set { SetProperty(ref _selected, value); }
 		}
 
-		public ICommand RemoveCommand => new Command(() => {
+		public ICommand RemoveCommand => new Command(() =>
+		{
 			Items.Remove(Selected);
-		
+		});
+
+		public ICommand PreviousCommand => new Command(() =>
+		{
+			var indexCurrent = Items.IndexOf(Selected);
+			if (indexCurrent > 0)
+			{
+				var newItem = Items[indexCurrent - 1];
+				Selected = newItem;
+			}
+		});
+
+		public ICommand NextCommand => new Command(() =>
+		{
+			var indexCurrent = Items.IndexOf(Selected);
+			if (indexCurrent < Items.Count - 1)
+			{
+				var newItem = Items[indexCurrent + 1];
+				Selected = newItem;
+			}
 		});
 	}
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
@@ -60,13 +60,5 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 			//GestureRecognizers.Add(gesture);
 		}
-
-		void ExampleTemplateCarouselPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
-		{
-			if (e.PropertyName == VisualElement.ScaleProperty.PropertyName)
-			{
-				System.Diagnostics.Debug.WriteLine($"{Scale}");
-			}
-		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ExampleTemplateCarousel.xaml.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var gesture = new PanGestureRecognizer();
 
-			PropertyChanged += ExampleTemplateCarouselPropertyChanged;
-
 			gesture.PanUpdated += (sender, e) =>
 			{
 				if (e.StatusType == GestureStatus.Started)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			Grid.SetRow(stckTemplate, 2);
 			Grid.SetRow(stckSize, 3);
 			Grid.SetRow(_carouselView, 4);
-			Grid.SetRow(indicatorView, 5);
+			Grid.SetRow(indicatorView, 6);
 
 			var btn = new Button
 			{

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
@@ -8,6 +9,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 	[Preserve(AllMembers = true)]
 	public class IndicatorCodeGallery : ContentPage
 	{
+		CarouselView _carouselView;
 		public IndicatorCodeGallery()
 		{
 			Title = "IndicatorView Gallery";
@@ -25,6 +27,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Star },
+					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = GridLength.Auto }
 				}
 			};
@@ -37,7 +40,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var itemTemplate = ExampleTemplates.CarouselTemplate();
 
-			var carouselView = new CarouselView
+			_carouselView = new CarouselView
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
@@ -45,9 +48,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				AutomationId = "TheCarouselView"
 			};
 
-			layout.Children.Add(carouselView);
-
-			var generator = new ItemsSourceGenerator(carouselView, nItems, ItemsSourceType.ObservableCollection);
+			layout.Children.Add(_carouselView);
+			var generator = new ItemsSourceGenerator(_carouselView, nItems, ItemsSourceType.ObservableCollection);
 
 			layout.Children.Add(generator);
 
@@ -60,10 +62,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				IndicatorColor = Color.Gray,
 				SelectedIndicatorColor = Color.Black,
 				IndicatorsShape = IndicatorShape.Square,
-				AutomationId = "TheIndicatorView"
+				AutomationId = "TheIndicatorView",
+				Count = 5,
+				Position = 2
 			};
 
-			carouselView.IndicatorView = indicatorView;
+			_carouselView.IndicatorView = indicatorView;
 
 			layout.Children.Add(indicatorView);
 
@@ -175,10 +179,28 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			Grid.SetRow(stckColors, 1);
 			Grid.SetRow(stckTemplate, 2);
 			Grid.SetRow(stckSize, 3);
-			Grid.SetRow(carouselView, 4);
+			Grid.SetRow(_carouselView, 4);
 			Grid.SetRow(indicatorView, 5);
 
+			var btn = new Button
+			{
+				Text = "Remove",
+				Command = new Command(() =>
+				{
+					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
+					items.Remove(items[0]);
+				})
+			};
+			_carouselView.PropertyChanged += CarouselView_PropertyChanged;
+			layout.Children.Add(btn);
+			Grid.SetRow(btn, 5);
 			Content = layout;
+		}
+
+		void CarouselView_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if(e.PropertyName ==  nameof(CarouselView.Position))
+				System.Diagnostics.Debug.WriteLine($"Position {_carouselView.Position}");
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 	public class IndicatorCodeGallery : ContentPage
 	{
 		CarouselView _carouselView;
+		Button _btnPrev;
+		Button _btnNext;
 		public IndicatorCodeGallery()
 		{
 			Title = "IndicatorView Gallery";
@@ -50,11 +52,13 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			layout.Children.Add(_carouselView);
 			var generator = new ItemsSourceGenerator(_carouselView, nItems, ItemsSourceType.ObservableCollection);
-
 			layout.Children.Add(generator);
 
 			generator.GenerateItems();
 
+			_carouselView.PropertyChanged += CarouselViewPropertyChanged;
+			(_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>).CollectionChanged += IndicatorCodeGalleryCollectionChanged;
+ 
 			var indicatorView = new IndicatorView
 			{
 				HorizontalOptions = LayoutOptions.Center,
@@ -182,25 +186,94 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			Grid.SetRow(_carouselView, 4);
 			Grid.SetRow(indicatorView, 6);
 
-			var btn = new Button
+			var layoutBtn = new StackLayout
 			{
-				Text = "Remove",
+				Orientation = StackOrientation.Horizontal,
+				HorizontalOptions = LayoutOptions.Center,
+			};
+
+			var btnRemove = new Button
+			{
+				Text = "Remove First",
+				AutomationId = "btnRemoveFirst",
+				BackgroundColor = Color.LightGray,
+				Padding = new Thickness(10),
 				Command = new Command(() =>
 				{
 					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
 					items.Remove(items[0]);
 				})
 			};
-			_carouselView.PropertyChanged += CarouselView_PropertyChanged;
-			layout.Children.Add(btn);
-			Grid.SetRow(btn, 5);
+
+			_btnPrev = new Button
+			{
+				Text = "Prev",
+				AutomationId = "btnPrev",
+				BackgroundColor = Color.LightGray,
+				Padding = new Thickness(10),
+				Command = new Command(() =>
+				{
+					_carouselView.Position--;
+				}, () =>
+				{
+					return _carouselView.Position > 0;
+				})
+			};
+
+			_btnNext = new Button
+			{
+				Text = "Next",
+				AutomationId = "btnNext",
+				BackgroundColor = Color.LightGray,
+				Padding = new Thickness(10),
+				Command = new Command(() =>
+				{
+					_carouselView.Position++;
+				}, () =>
+				{
+					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
+					return _carouselView.Position < items.Count - 1;
+				})
+			};
+
+			var btnRemoveLast = new Button
+			{
+				Text = "Remove Last",
+				AutomationId = "btnRemoveLast",
+				BackgroundColor = Color.LightGray,
+				Padding = new Thickness(10),
+				Command = new Command(() =>
+				{
+					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
+					var indexToRemove = items.Count - 1;
+					items.Remove(items[indexToRemove]);
+				})
+			};
+
+			layoutBtn.Children.Add(btnRemove);
+			layoutBtn.Children.Add(_btnPrev);
+			layoutBtn.Children.Add(_btnNext);
+			layoutBtn.Children.Add(btnRemoveLast);
+
+			layout.Children.Add(layoutBtn);
+			Grid.SetRow(layoutBtn, 5);
 			Content = layout;
 		}
 
-		void CarouselView_PropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		void IndicatorCodeGalleryCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
-			if(e.PropertyName ==  nameof(CarouselView.Position))
-				System.Diagnostics.Debug.WriteLine($"Position {_carouselView.Position}");
+			UpdateButtons();
+		}
+
+		void CarouselViewPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			UpdateButtons();
+		}
+
+		void UpdateButtons()
+		{
+			(_btnPrev?.Command as Command)?.ChangeCanExecute();
+			(_btnNext?.Command as Command)?.ChangeCanExecute();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -194,10 +194,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var btnRemove = new Button
 			{
-				Text = "Remove First",
+				Text = "DEL First",
+				FontSize = 8,
 				AutomationId = "btnRemoveFirst",
 				BackgroundColor = Color.LightGray,
-				Padding = new Thickness(10),
+				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
 					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);
@@ -208,9 +209,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			_btnPrev = new Button
 			{
 				Text = "Prev",
+				FontSize = 8,
 				AutomationId = "btnPrev",
 				BackgroundColor = Color.LightGray,
-				Padding = new Thickness(10),
+				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
 					_carouselView.Position--;
@@ -223,9 +225,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			_btnNext = new Button
 			{
 				Text = "Next",
+				FontSize = 8,
 				AutomationId = "btnNext",
 				BackgroundColor = Color.LightGray,
-				Padding = new Thickness(10),
+				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
 					_carouselView.Position++;
@@ -238,10 +241,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var btnRemoveLast = new Button
 			{
-				Text = "Remove Last",
+				Text = "DEL Last",
+				FontSize = 8,
 				AutomationId = "btnRemoveLast",
 				BackgroundColor = Color.LightGray,
-				Padding = new Thickness(10),
+				Padding = new Thickness(5),
 				Command = new Command(() =>
 				{
 					var items = (_carouselView.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>);

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
@@ -69,6 +69,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			Grid.SetColumnSpan(stacklayout, 3);
 
 			Content = layout;
+			_slider.Value = 1;
 		}
 
 		public void UpdatePositionCount(int itemsCount)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
@@ -38,9 +38,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			var layout = new Grid
 			{
 				RowDefinitions = new RowDefinitionCollection {
-								new RowDefinition { Height = 30 },
-								new RowDefinition { Height = GridLength.Auto },
-								new RowDefinition { Height = GridLength.Auto },
+								new RowDefinition { Height = 20 },
+								new RowDefinition { Height = 20 },
+								new RowDefinition { Height = 20 },
 					},
 				ColumnDefinitions = new ColumnDefinitionCollection
 					{

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Controls
 		{
 			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
 			InitializeComponent();
-			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel();
+			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel(false, false);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls
 		{
 			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
 			InitializeComponent();
-			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel();
+			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel(false, false);
 		}
 
 		public void MaximumVisibleClicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -16,6 +16,37 @@ namespace Xamarin.Forms.Core.UITests
 			App.Tap(_carouselViewGalleries);
 		}
 
+		[TestCase("CarouselView (XAML, Horizontal)")]
+		public void CarouselViewRemoveAndUpdateCurrentItem(string subgallery)
+		{
+			VisitSubGallery(subgallery);
+			var position = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(position == "0");
+			var currentItem = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItem == "0");
+			var selected = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selected == "0");
+			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
+			var centerX = rect.CenterX;
+			var rightX = rect.X + 1;
+			App.DragCoordinates(centerX, rect.CenterY, rightX, rect.CenterY);
+			var positionAfter = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(positionAfter == "1");
+			var currentItemAfter = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItemAfter == "1");
+			var selectedAfter = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selectedAfter == "1");
+			App.Tap(x => x.Marked("btnRemove"));
+			var positionAfterRemove = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(positionAfterRemove == "1");
+			var currentItemAfterRemove = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItemAfterRemove == "2");
+			var selectedAfterRemove = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selectedAfterRemove == "2");
+
+
+		}
+
 		[TestCase("CarouselView (Code, Horizontal)")]
 		//[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewHorizontal(string subgallery)

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Core.UITests
 			var selectedAfterRemove = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
 			Assert.IsTrue(selectedAfterRemove == "2");
 
-
+			App.Back();
 		}
 
 		[TestCase("CarouselView (Code, Horizontal)")]
@@ -113,6 +113,7 @@ namespace Xamarin.Forms.Core.UITests
 
 			App.WaitForNoElement("pos:0", "Swiped while swipe is disabled");
 #endif
+			App.Back();
 		}
 
 		void VisitSubGallery(string galleryName)

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -28,8 +28,8 @@ namespace Xamarin.Forms.Core.UITests
 			Assert.IsTrue(selected == "0");
 			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
 			var centerX = rect.CenterX;
-			var rightX = rect.X + 1;
-			App.DragCoordinates(centerX, rect.CenterY, rightX, rect.CenterY);
+			var rightX = rect.X - 5;
+			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
 			var positionAfter = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
 			Assert.IsTrue(positionAfter == "1");
 			var currentItemAfter = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -47,6 +47,89 @@ namespace Xamarin.Forms.Core.UITests
 			App.Back();
 		}
 
+
+		[TestCase("CarouselView (XAML, Horizontal)")]
+		public void CarouselViewRemoveFirstCurrentItem(string subgallery)
+		{
+			VisitSubGallery(subgallery);
+			var position = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(position == "0");
+			var currentItem = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItem == "0");
+			App.Tap(x => x.Marked("btnRemove"));
+			var positionAfterRemove = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(positionAfterRemove == "0");
+			var currentItemAfterRemove = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItemAfterRemove == "1");
+			var selectedAfterRemove = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selectedAfterRemove == "1");
+
+			App.Back();
+		}
+
+
+		[TestCase("CarouselView (XAML, Horizontal)")]
+		public void CarouselViewRemoveLastCurrentItem(string subgallery)
+		{
+			VisitSubGallery(subgallery);
+			var position = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(position == "0");
+			var currentItem = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItem == "0");
+			var selected = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selected == "0");
+			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
+			var centerX = rect.CenterX;
+			var rightX = rect.X - 5;
+			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			var positionAfter = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(positionAfter == "4");
+			var currentItemAfter = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItemAfter == "4");
+			var selectedAfter = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selectedAfter == "4");
+			App.Tap(x => x.Marked("btnRemove"));
+			var positionAfterRemove = App.WaitForElement(x => x.Marked("lblPosition")).First().Text;
+			Assert.IsTrue(positionAfterRemove == "3");
+			var currentItemAfterRemove = App.WaitForElement(x => x.Marked("lblCurrentItem")).First().Text;
+			Assert.IsTrue(currentItemAfterRemove == "3");
+			var selectedAfterRemove = App.WaitForElement(x => x.Marked("lblSelected")).First().Text;
+			Assert.IsTrue(selectedAfterRemove == "3");
+
+			App.Back();
+		}
+
+
+		[TestCase("IndicatorView")]
+		public void CarouselViewFirstLastPosition(string subgallery)
+		{
+			VisitSubGallery(subgallery, true);
+			App.WaitForElement("Item: 0");
+			App.Tap(x => x.Marked("btnRemoveFirst"));
+			App.WaitForElement("Item: 1");
+			App.Tap(x => x.Marked("btnNext"));
+			App.WaitForElement("Item: 2");
+			App.Tap(x => x.Marked("btnRemoveFirst"));
+			App.WaitForElement("Item: 2");
+			App.Tap(x => x.Marked("btnNext"));
+			App.Tap(x => x.Marked("btnNext"));
+			App.Tap(x => x.Marked("btnNext"));
+			App.Tap(x => x.Marked("btnNext"));
+			App.Tap(x => x.Marked("btnNext"));
+			App.Tap(x => x.Marked("btnNext"));
+			App.Tap(x => x.Marked("btnNext"));
+			App.WaitForElement("Item: 9");
+			App.Tap(x => x.Marked("btnRemoveLast"));
+			App.WaitForElement("Item: 8");
+			App.Tap(x => x.Marked("btnPrev"));
+			App.WaitForElement("Item: 7");
+
+			App.Back();
+		}
+
 		[TestCase("CarouselView (Code, Horizontal)")]
 		//[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewHorizontal(string subgallery)
@@ -116,9 +199,11 @@ namespace Xamarin.Forms.Core.UITests
 			App.Back();
 		}
 
-		void VisitSubGallery(string galleryName)
+		void VisitSubGallery(string galleryName, bool enableIndicator = false)
 		{
 			App.WaitForElement(t => t.Marked(galleryName));
+			if (enableIndicator)
+				App.Tap(t => t.Marked("EnableIndicatorView"));
 			App.Tap(t => t.Marked(galleryName));
 		}
 	}

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -1,5 +1,6 @@
 ﻿using System.Linq;
 using NUnit.Framework;
+using Xamarin.UITest;
 
 namespace Xamarin.Forms.Core.UITests
 {
@@ -201,9 +202,16 @@ namespace Xamarin.Forms.Core.UITests
 
 		void VisitSubGallery(string galleryName, bool enableIndicator = false)
 		{
-			App.WaitForElement(t => t.Marked(galleryName));
+		
 			if (enableIndicator)
 				App.Tap(t => t.Marked("EnableIndicatorView"));
+
+			App.QueryUntilPresent(() =>
+			{
+				App.ScrollDown();
+				return App.Query(t => t.Marked(galleryName));
+			});
+
 			App.Tap(t => t.Marked(galleryName));
 		}
 	}

--- a/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
@@ -73,25 +73,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsTrue(countFired == 1);
 		}
 
-		[Test]
-		public void TestCurrentItemChangesPosition()
-		{
-			var gotoPosition = 1;
-			var source = new List<string> { "1", "2", "3" };
-			var carouselView = new CarouselView
-			{
-				ItemsSource = source
-			};
+		//[Test]
+		//public void TestCurrentItemChangesPosition()
+		//{
+		//	var gotoPosition = 1;
+		//	var source = new List<string> { "1", "2", "3" };
+		//	var carouselView = new CarouselView
+		//	{
+		//		ItemsSource = source
+		//	};
 
-			int countFired = 0;
-			carouselView.PositionChangedCommand = new Command(() =>
-			{
-				countFired += 1;
-			});
-			Assert.AreSame(source, carouselView.ItemsSource);
-			carouselView.CurrentItem = source[gotoPosition];
-			Assert.AreEqual(gotoPosition, carouselView.Position);
-		}
+		//	int countFired = 0;
+		//	carouselView.PositionChangedCommand = new Command(() =>
+		//	{
+		//		countFired += 1;
+		//	});
+		//	Assert.AreSame(source, carouselView.ItemsSource);
+		//	carouselView.CurrentItem = source[gotoPosition];
+		//	Assert.AreEqual(gotoPosition, carouselView.Position);
+		//}
 
 		[Test]
 		public void TestCurrentItemChangedCommand()

--- a/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/CarouselViewTests.cs
@@ -54,6 +54,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsTrue(countFired == 1);
 		}
 
+		[Test]
 		public void TestPositionChangedEvent()
 		{
 			var gotoPosition = 1;
@@ -72,26 +73,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			carouselView.Position = gotoPosition;
 			Assert.IsTrue(countFired == 1);
 		}
-
-		//[Test]
-		//public void TestCurrentItemChangesPosition()
-		//{
-		//	var gotoPosition = 1;
-		//	var source = new List<string> { "1", "2", "3" };
-		//	var carouselView = new CarouselView
-		//	{
-		//		ItemsSource = source
-		//	};
-
-		//	int countFired = 0;
-		//	carouselView.PositionChangedCommand = new Command(() =>
-		//	{
-		//		countFired += 1;
-		//	});
-		//	Assert.AreSame(source, carouselView.ItemsSource);
-		//	carouselView.CurrentItem = source[gotoPosition];
-		//	Assert.AreEqual(gotoPosition, carouselView.Position);
-		//}
 
 		[Test]
 		public void TestCurrentItemChangedCommand()
@@ -132,28 +113,5 @@ namespace Xamarin.Forms.Core.UnitTests
 			carouselView.CurrentItem = source[gotoPosition];
 			Assert.IsTrue(countFired == 1);
 		}
-
-		// TODO when Scrolled is implemented
-		//[Test]
-		//public void TestScrolled()
-		//{
-		//	var scrollPosition = 100;
-		//	var scrollDirection = ScrollDirection.Down;
-		//	var scrolledDirection = ScrollDirection.Up;
-		//	var source = new List<string> { "1", "2", "3" };
-		//	var carouselView = new CarouselView
-		//	{
-		//		ItemsSource = source
-		//	};
-		//	int countFired = 0;
-		//	carouselView.Scrolled += (s, e) =>
-		//	{
-		//		countFired += 1;
-		//		scrolledDirection = e.Direction;
-		//	};
-		//	carouselView.SendScrolled(scrollPosition, scrollDirection);
-		//	Assert.IsTrue(countFired == 1);
-		//	Assert.IsTrue(scrollDirection == scrolledDirection);
-		//}
 	}
 }

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -115,6 +115,7 @@ namespace Xamarin.Forms
 			}
 
 			var positionItem = GetPositionForItem(carouselView, newValue);
+
 			var gotoPosition = carouselView._gotoPosition;
 
 			if (positionItem == gotoPosition || gotoPosition == -1)
@@ -244,7 +245,6 @@ namespace Xamarin.Forms
 
 		static void PositionPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-
 			var carousel = (CarouselView)bindable;
 
 			var args = new PositionChangedEventArgs((int)oldValue, (int)newValue);
@@ -266,11 +266,14 @@ namespace Xamarin.Forms
 			if (args.CurrentPosition == carousel._gotoPosition)
 				carousel._gotoPosition = -1;
 
-			// User is interacting with the carousel we don't need to scroll to item 
-			if (!carousel.IsDragging && !carousel.IsScrolling)
+			var currentItemPosition = GetPositionForItem(carousel, carousel.CurrentItem);
+
+			// User is interacting with the carousel we don't need to scroll to item
+			// If the currentItemPosition is the same as the new Position we don't need to scroll
+			if ((!carousel.IsDragging && !carousel.IsScrolling) && currentItemPosition != args.CurrentPosition)
 			{
 				carousel._gotoPosition = args.CurrentPosition;
-
+				
 				Action actionSCroll = () =>
 				{
 					carousel.ScrollTo(args.CurrentPosition, position: ScrollToPosition.Center, animate: carousel.IsScrollAnimated);

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -183,9 +183,6 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public bool IsScrolling { get; set; }
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
-		public Queue<Action> ScrollToActions = new Queue<Action>();
-
 		public event EventHandler<CurrentItemChangedEventArgs> CurrentItemChanged;
 		public event EventHandler<PositionChangedEventArgs> PositionChanged;
 

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -314,10 +314,13 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SetCurrentItem(object item, int position = -1)
 		{
-			if(item == null && position != -1)
+			if (item == null && position != -1)
 				item = GetItemForPosition(this, position);
 
-			SetValueFromRenderer(CurrentItemProperty, item);
+			if (item == CurrentItem && position != -1 && position != Position)
+				SetValueFromRenderer(PositionProperty, position);
+			else
+				SetValueFromRenderer(CurrentItemProperty, item);
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -312,8 +312,11 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public void SetCurrentItem(object item)
+		public void SetCurrentItem(object item, int position = -1)
 		{
+			if(item == null && position != -1)
+				item = GetItemForPosition(this, position);
+
 			SetValueFromRenderer(CurrentItemProperty, item);
 		}
 

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -248,5 +248,12 @@ namespace Xamarin.Forms
 		{
 			SetValue(IsDraggingPropertyKey, value);
 		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public virtual bool AnimatePositionChanges => IsScrollAnimated;
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public virtual bool AnimateCurrentItemChanges => IsScrollAnimated;
+
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -222,7 +222,12 @@ namespace Xamarin.Forms.Platform.Android
 		void CollectionItemsSourceChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
 			if (ItemsViewAdapter?.ItemsSource is IItemsViewSource observableItemsSource)
-				Carousel.SetCurrentItem(observableItemsSource.GetItem(Carousel.Position));
+			{
+				var positon = Carousel.Position;
+				var count = observableItemsSource.Count;
+				if (count > 0 && positon < count)
+					Carousel.SetCurrentItem(observableItemsSource.GetItem(Carousel.Position));
+			}
 		}
 
 		void UpdateInitialPosition()

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -153,22 +153,6 @@ namespace Xamarin.Forms.Platform.Android
 			return Carousel.ItemsLayout;
 		}
 
-		protected override void UpdateAdapter()
-		{
-			// By default the CollectionViewAdapter creates the items at whatever size the template calls for
-			// But for the Carousel, we want it to create the items to fit the width/height of the viewport
-			// So we give it an alternate delegate for creating the views
-
-			var oldItemViewAdapter = ItemsViewAdapter;
-
-			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView,
-				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
-
-			SwapAdapter(ItemsViewAdapter, false);
-
-			oldItemViewAdapter?.Dispose();
-		}
-
 		int GetItemWidth()
 		{
 			var itemWidth = Width;

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -221,15 +221,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void CollectionItemsSourceChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
-			var centerItemIndex = -1;
-
-			if (GetLayoutManager() is LinearLayoutManager linearLayoutManager)
-			{
-				var firstVisibleItemIndex = linearLayoutManager.FindFirstVisibleItemPosition();
-				centerItemIndex = RecyclerExtensions.CalculateCenterItemIndex(firstVisibleItemIndex, this, linearLayoutManager);
-			}
-
-			Carousel.SetCurrentItem(null, centerItemIndex);
+			if (ItemsViewAdapter?.ItemsSource is IItemsViewSource observableItemsSource)
+				Carousel.SetCurrentItem(observableItemsSource.GetItem(Carousel.Position));
 		}
 
 		void UpdateInitialPosition()

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -129,13 +129,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			if (_itemDecoration != null)
-			{
-				RemoveItemDecoration(_itemDecoration);
-			}
-
-			_itemDecoration = CreateSpacingDecoration(ItemsLayout);
-			AddItemDecoration(_itemDecoration);
+			UpdateItemDecoration();
 
 			var adapter = GetAdapter();
 
@@ -226,8 +220,25 @@ namespace Xamarin.Forms.Platform.Android
 				var positon = Carousel.Position;
 				var count = observableItemsSource.Count;
 				if (count > 0 && positon < count)
+				{
 					Carousel.SetCurrentItem(observableItemsSource.GetItem(Carousel.Position));
-			}
+				}
+
+				//If we are adding or removing the last item we need to update
+				//the inset that we give to items so they are centered
+				if (e.NewStartingIndex == count - 1 || e.OldStartingIndex == count)
+				{
+					UpdateItemDecoration();
+				}
+			}	
+		}
+
+		void UpdateItemDecoration()
+		{
+			if (_itemDecoration != null)
+				RemoveItemDecoration(_itemDecoration);
+			_itemDecoration = CreateSpacingDecoration(ItemsLayout);
+			AddItemDecoration(_itemDecoration);
 		}
 
 		void UpdateInitialPosition()

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -255,7 +255,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (Carousel.CurrentItem != null)
 			{
-			
 				var items = Carousel.ItemsSource as IList;
 
 				for (int n = 0; n < items?.Count; n++)
@@ -362,7 +361,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SetCurrentItem(int carouselPosition)
 		{
-			var item = (ItemsViewAdapter.ItemsSource as IItemsViewSource).GetItem(carouselPosition);
+			if (ItemsViewAdapter?.ItemsSource?.Count == 0)
+				return;
+
+			var item = ItemsViewAdapter.ItemsSource.GetItem(carouselPosition);
 			Carousel.SetValueFromRenderer(FormsCarouselView.CurrentItemProperty, item);
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		int _oldPosition;
 		int _gotoPosition = -1;
 		bool _noNeedForScroll;
+		bool _initialized;
 
 		List<View> _oldViews;
 		CarouselViewwOnGlobalLayoutListener _carouselViewLayoutListener;
@@ -418,13 +419,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		void LayoutReady(object sender, EventArgs e)
 		{
-			Carousel.Scrolled += CarouselViewScrolled;
+			if(!_initialized)
+			{
+				Carousel.Scrolled += CarouselViewScrolled;
 
-			if (Carousel.Position > 0)
-				Carousel.ScrollTo(Carousel.Position, -1, Xamarin.Forms.ScrollToPosition.Center, Carousel.IsScrollAnimated);
+				UpdateInitialPosition();
+				_initialized = true;
+			}
 
 			UpdateVisualStates();
-			ClearLayoutListener();
 		}
 
 		void ClearLayoutListener()
@@ -457,13 +460,6 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				carouselViewRenderer.Carousel.IsScrolling = state != ScrollStateIdle;
-			}
-
-			public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
-			{
-				base.OnScrolled(recyclerView, dx, dy);
-				CarouselViewRenderer carouselViewRenderer = (CarouselViewRenderer)recyclerView;
-				carouselViewRenderer.UpdateVisualStates();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -229,6 +229,12 @@ namespace Xamarin.Forms.Platform.Android
 					carouselPosition = currentItemPosition;
 					_noNeedForScroll = true;
 				}
+
+				if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+				{
+					carouselPosition = 0;
+				}
+
 				SetCurrentItem(carouselPosition);
 				UpdatePosition(carouselPosition);
 				//If we are adding or removing the last item we need to update

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -233,6 +233,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
 				{
+					_gotoPosition = -1;
 					carouselPosition = 0;
 				}
 
@@ -388,7 +389,15 @@ namespace Xamarin.Forms.Platform.Android
 		}
 		void UpdateFromPosition()
 		{
+			var itemCount = ItemsViewAdapter?.ItemsSource.Count;
 			var carouselPosition = Carousel.Position;
+
+			if (itemCount == 0)
+				return;
+
+			if (carouselPosition >= itemCount || carouselPosition < 0)
+				throw new IndexOutOfRangeException($"Can't set CarouselView to position {carouselPosition}. ItemsSource has {itemCount} items.");
+
 			if (carouselPosition == _gotoPosition)
 				_gotoPosition = -1;
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (!(ItemsViewAdapter?.ItemsSource is IItemsViewSource observableItemsSource))
 				return;
-			
+
 			var carouselPosition = Carousel.Position;
 			var currentItemPosition = observableItemsSource.GetPosition(Carousel.CurrentItem);
 			var count = observableItemsSource.Count;
@@ -387,7 +387,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)
 			{
 				_gotoPosition = currentItemPosition;
-				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
 			}
 		}
 		void UpdateFromPosition()
@@ -413,7 +413,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling)
 			{
 				_gotoPosition = carouselPosition;
-				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
 			}
 			SetCurrentItem(carouselPosition);
 		}
@@ -431,7 +431,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void LayoutReady(object sender, EventArgs e)
 		{
-			if(!_initialized)
+			if (!_initialized)
 			{
 				Carousel.Scrolled += CarouselViewScrolled;
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -582,6 +582,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void ScrollToRequested(object sender, ScrollToRequestEventArgs args)
 		{
+			(GetSnapManager()?.GetCurrentSnapHelper() as SingleSnapHelper)?.ResetCurrentTargetPosition();
 			ScrollTo(args);
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 
-		public event EventHandler<NotifyCollectionChangedEventArgs> CollectionItemsSourceChanged;
+		public event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
 
 		public int Count => ItemsCount() + (HasHeader ? 1 : 0) + (HasFooter ? 1 : 0);
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
@@ -18,6 +18,9 @@ namespace Xamarin.Forms.Platform.Android
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 
+
+		public event EventHandler<NotifyCollectionChangedEventArgs> CollectionItemsSourceChanged;
+
 		public int Count => ItemsCount() + (HasHeader ? 1 : 0) + (HasFooter ? 1 : 0);
 
 		public bool HasHeader { get; set; }
@@ -91,6 +94,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				CollectionChanged(args);
 			}
+			
 		}
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
@@ -115,6 +119,7 @@ namespace Xamarin.Forms.Platform.Android
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
+			CollectionItemsSourceChanged?.Invoke(this, args);
 		}
 
 		void Move(NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ObservableItemsSource.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 
-		public event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
+		internal event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
 
 		public int Count => ItemsCount() + (HasHeader ? 1 : 0) + (HasFooter ? 1 : 0);
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
@@ -8,7 +8,7 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.CollectionView
 {
-	public class RecyclerViewScrollListener<TItemsView, TItemsViewSource> : RecyclerView.OnScrollListener 
+	public class RecyclerViewScrollListener<TItemsView, TItemsViewSource> : RecyclerView.OnScrollListener
 		where TItemsView : ItemsView
 		where TItemsViewSource : IItemsViewSource
 	{
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 			{
 				firstVisibleItemIndex = linearLayoutManager.FindFirstVisibleItemPosition();
 				lastVisibleItemIndex = linearLayoutManager.FindLastVisibleItemPosition();
-				centerItemIndex = CalculateCenterItemIndex(firstVisibleItemIndex, recyclerView, linearLayoutManager);
+				centerItemIndex = RecyclerExtensions.CalculateCenterItemIndex(firstVisibleItemIndex, recyclerView, linearLayoutManager);
 			}
 
 			var context = recyclerView.Context;
@@ -77,31 +77,6 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 						_itemsView.SendRemainingItemsThresholdReached();
 					break;
 			}
-		}
-
-		static int CalculateCenterItemIndex(int firstVisibleItemIndex, RecyclerView recyclerView, LinearLayoutManager linearLayoutManager)
-		{
-			// This can happen if a layout pass has not happened yet
-			if (firstVisibleItemIndex == -1)
-				return firstVisibleItemIndex;
-
-			AView centerView;
-
-			if (linearLayoutManager.Orientation == LinearLayoutManager.Horizontal)
-			{
-				float centerX = recyclerView.Width / 2;
-				centerView = recyclerView.FindChildViewUnder(centerX, recyclerView.Top);
-			}
-			else
-			{
-				float centerY = recyclerView.Height / 2;
-				centerView = recyclerView.FindChildViewUnder(recyclerView.Left, centerY);
-			}
-
-			if (centerView != null)
-				return recyclerView.GetChildAdapterPosition(centerView);
-
-			return firstVisibleItemIndex;
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 			{
 				firstVisibleItemIndex = linearLayoutManager.FindFirstVisibleItemPosition();
 				lastVisibleItemIndex = linearLayoutManager.FindLastVisibleItemPosition();
-				centerItemIndex = RecyclerExtensions.CalculateCenterItemIndex(firstVisibleItemIndex, recyclerView, linearLayoutManager);
+				centerItemIndex = recyclerView.CalculateCenterItemIndex(firstVisibleItemIndex, linearLayoutManager);
 			}
 
 			var context = recyclerView.Context;

--- a/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		// CurrentTargetPosition will have this value until the user scrolls around
 		protected int CurrentTargetPosition = -1;
+		int _previousCount = 0;
 
 		protected static OrientationHelper CreateOrientationHelper(RecyclerView.LayoutManager layoutManager)
 		{
@@ -59,13 +60,21 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override int FindTargetSnapPosition(RecyclerView.LayoutManager layoutManager, int velocityX, int velocityY)
 		{
+			var itemCount = layoutManager.ItemCount;
+			//reset CurrentTargetPosition if  our count changes
+			if (_previousCount != itemCount)
+			{
+				CurrentTargetPosition = -1;
+				_previousCount = itemCount;
+			}
+
 			if (CurrentTargetPosition == -1)
 			{
 				CurrentTargetPosition = base.FindTargetSnapPosition(layoutManager, velocityX, velocityY);
 				return CurrentTargetPosition;
 			}
 
-			var itemCount = layoutManager.ItemCount;
+		
 			var increment = 1;
 
 			if (layoutManager.CanScrollHorizontally())

--- a/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SingleSnapHelper.cs
@@ -16,8 +16,6 @@ namespace Xamarin.Forms.Platform.Android
 		// Or if the number of items on the ItemsSource changes
 		protected int CurrentTargetPosition = -1;
 		int _previousCount = 0;
-		bool _disposed;
-		CarouselView _carouselView;
 
 		protected static OrientationHelper CreateOrientationHelper(RecyclerView.LayoutManager layoutManager)
 		{
@@ -37,23 +35,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			return false;
-		}
-
-		protected override void Dispose(bool disposing)
-		{
-			if (_disposed)
-			{
-				return;
-			}
-
-			_disposed = true;
-
-			if (disposing && _carouselView != null)
-			{
-				_carouselView.ScrollToRequested -= CarouselViewScrollToRequested;
-			}
-
-			base.Dispose(disposing);
 		}
 
 		public override AView FindSnapView(RecyclerView.LayoutManager layoutManager)
@@ -77,17 +58,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			return null;
-		}
-
-		public override void AttachToRecyclerView(RecyclerView recyclerView)
-		{
-			if ((recyclerView as CarouselViewRenderer)?.Element is CarouselView carouselView)
-			{
-				_carouselView = carouselView;
-				_carouselView.ScrollToRequested += CarouselViewScrollToRequested;
-			}
-
-			base.AttachToRecyclerView(recyclerView);
 		}
 
 		public override int FindTargetSnapPosition(RecyclerView.LayoutManager layoutManager, int velocityX, int velocityY)
@@ -140,7 +110,7 @@ namespace Xamarin.Forms.Platform.Android
 			return CurrentTargetPosition;
 		}
 
-		void CarouselViewScrollToRequested(object sender, ScrollToRequestEventArgs e)
+		internal void ResetCurrentTargetPosition()
 		{
 			//reset CurrentTargetPosition if ScrollTo is requested
 			CurrentTargetPosition = -1;

--- a/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Android.Support.V7.Widget;
+using AView = Android.Views.View;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	internal class RecyclerExtensions
+	{
+		public static int CalculateCenterItemIndex(int firstVisibleItemIndex, RecyclerView recyclerView, LinearLayoutManager linearLayoutManager)
+		{
+			// This can happen if a layout pass has not happened yet
+			if (firstVisibleItemIndex == -1)
+				return firstVisibleItemIndex;
+
+			AView centerView;
+
+			if (linearLayoutManager.Orientation == LinearLayoutManager.Horizontal)
+			{
+				float centerX = recyclerView.Width / 2;
+				centerView = recyclerView.FindChildViewUnder(centerX, recyclerView.Top);
+			}
+			else
+			{
+				float centerY = recyclerView.Height / 2;
+				centerView = recyclerView.FindChildViewUnder(recyclerView.Left, centerY);
+			}
+
+			if (centerView != null)
+				return recyclerView.GetChildAdapterPosition(centerView);
+
+			return firstVisibleItemIndex;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
@@ -1,4 +1,9 @@
-﻿using Android.Support.V7.Widget;
+﻿#if __ANDROID_29__
+using AndroidX.AppCompat.Widget;
+using AndroidX.RecyclerView.Widget;
+#else
+using Android.Support.V7.Widget;
+#endif
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android

--- a/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
@@ -8,9 +8,9 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	internal class RecyclerExtensions
+	internal static class RecyclerExtensions
 	{
-		public static int CalculateCenterItemIndex(int firstVisibleItemIndex, RecyclerView recyclerView, LinearLayoutManager linearLayoutManager)
+		public static int CalculateCenterItemIndex(this RecyclerView recyclerView, int firstVisibleItemIndex, LinearLayoutManager linearLayoutManager)
 		{
 			// This can happen if a layout pass has not happened yet
 			if (firstVisibleItemIndex == -1)

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -69,5 +69,5 @@
   <ItemGroup>
     <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
-  
+
 </Project>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (!(ListViewBase.Items[position - 1] is ItemTemplateContext itemTemplateContext))
 				throw new InvalidOperationException("Visible item not found");
 
-			CarouselView.SetCurrentItem(itemTemplateContext.Item);
+		//	CarouselView.SetCurrentItem(itemTemplateContext.Item);
 		}
 
 		ListViewBase CreateCarouselListLayout(ItemsLayoutOrientation layoutOrientation)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.ComponentModel;
-using System.Threading.Tasks;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using UWPApp = Windows.UI.Xaml.Application;
@@ -9,7 +8,6 @@ using WScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility;
 using WSnapPointsType = Windows.UI.Xaml.Controls.SnapPointsType;
 using WSnapPointsAlignment = Windows.UI.Xaml.Controls.Primitives.SnapPointsAlignment;
 using WScrollMode = Windows.UI.Xaml.Controls.ScrollMode;
-using System.Linq;
 using System.Collections;
 
 namespace Xamarin.Forms.Platform.UWP
@@ -68,7 +66,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				ListViewBase.SizeChanged += OnListSizeChanged;
 			}
-
 		}
 
 		protected override void TearDownOldElement(ItemsView oldElement)
@@ -174,20 +171,6 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateItemsSource();
 			UpdateSnapPointsType();
 			UpdateSnapPointsAlignment();
-
-			HackFixInitialPadding();
-			UpdateInitialPosition();
-		}
-
-		void HackFixInitialPadding()
-		{
-			//There's a 12 pixel on the left that i couldn't figure yet how to remove
-			//We set the offset to 12 pixels to make align correctly
-			Device.StartTimer(TimeSpan.FromMilliseconds(10), () =>
-			{
-				_scrollViewer.ChangeView(12, null, null);
-				return false;
-			});
 		}
 
 		void OnScrollViewChanging(object sender, ScrollViewerViewChangingEventArgs e)
@@ -286,6 +269,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			SetCurrentItem(position);
+			UpdatePosition(position);
 		}
 
 		void UpdatePositionFromScroll()
@@ -339,7 +323,7 @@ namespace Xamarin.Forms.Platform.UWP
 			var carouselPosition = Carousel.Position;
 			var newPosition = FixPosition(position);
 
-			if (newPosition < 0 || newPosition > ListViewBase.Items.Count)
+			if (newPosition < 0 || newPosition >= ListViewBase.Items.Count)
 				return;
 
 			//we arrived center

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -110,9 +110,9 @@ namespace Xamarin.Forms.Platform.UWP
 			var collectionViewSource = TemplatedItemSourceFactory.Create(Element.ItemsSource, Element.ItemTemplate, Element,
 					GetItemHeight(), GetItemWidth(), GetItemSpacing());
 
-			if(collectionViewSource is ObservableItemTemplateCollection observableItemsSource)
+			if (collectionViewSource is ObservableItemTemplateCollection observableItemsSource)
 				observableItemsSource.CollectionChanged += CollectionItemsSourceChanged;
-		
+
 			return new CollectionViewSource
 			{
 				Source = collectionViewSource,
@@ -151,19 +151,19 @@ namespace Xamarin.Forms.Platform.UWP
 			if (removingCurrentElementButNotFirst)
 			{
 				carouselPosition = Carousel.Position - 1;
-			
+
 			}
 			else if (removingFirstElement && !removingCurrentElement)
 			{
 				carouselPosition = currentItemPosition;
 			}
 
-			if(removingCurrentElement)
+			if (removingCurrentElement)
 			{
 				SetCurrentItem(carouselPosition);
 				UpdatePosition(carouselPosition);
 			}
-			
+
 		}
 
 		void OnListSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
@@ -282,6 +282,8 @@ namespace Xamarin.Forms.Platform.UWP
 			if (itemCount == 0)
 				return;
 
+			itemCount--;
+
 			int position;
 
 			if (_scrollViewer.HorizontalOffset > _scrollViewer.VerticalOffset)
@@ -320,23 +322,25 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdatePosition(int position)
 		{
-			var carouselPosition = Carousel.Position;
-			var newPosition = FixPosition(position);
-
-			if (newPosition < 0 || newPosition >= ListViewBase.Items.Count)
+			if (!ValidatePosition(position))
 				return;
 
+			var carouselPosition = Carousel.Position;
+
 			//we arrived center
-			if (newPosition == _gotoPosition)
+			if (position == _gotoPosition)
 				_gotoPosition = -1;
 
-			if (_gotoPosition == -1 && carouselPosition != newPosition)
-				Carousel.SetValueFromRenderer(CarouselView.PositionProperty, newPosition);
+			if (_gotoPosition == -1 && carouselPosition != position)
+				Carousel.SetValueFromRenderer(CarouselView.PositionProperty, position);
 		}
 
 		void SetCurrentItem(int carouselPosition)
 		{
-			if (carouselPosition < 0 && carouselPosition > ListViewBase.Items.Count)
+			if (ListViewBase.Items.Count == 0)
+				return;
+
+			if (!ValidatePosition(carouselPosition))
 				return;
 
 			if (!(ListViewBase.Items[carouselPosition] is ItemTemplateContext itemTemplateContext))
@@ -344,6 +348,17 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var item = itemTemplateContext.Item;
 			Carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, item);
+		}
+
+		bool ValidatePosition(int position)
+		{
+			if (ListViewBase.Items.Count == 0)
+				return false;
+
+			if (position < 0 || position >= ListViewBase.Items.Count)
+				return false;
+
+			return true;
 		}
 
 		ListViewBase CreateCarouselListLayout(ItemsLayoutOrientation layoutOrientation)
@@ -473,7 +488,5 @@ namespace Xamarin.Forms.Platform.UWP
 
 			listView.Loaded += ListViewLoaded;
 		}
-
-		static int FixPosition(int position) => position - 1;
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -305,7 +305,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)
 			{
 				_gotoPosition = currentItemPosition;
-				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
 			}
 		}
 
@@ -323,7 +323,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling)
 			{
 				_gotoPosition = carouselPosition;
-				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
 			}
 			SetCurrentItem(carouselPosition);
 		}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
@@ -174,6 +174,7 @@
                 <Style TargetType="ListViewItem">
                     <Setter Property="HorizontalAlignment" Value="Stretch" />
                     <Setter Property="HorizontalContentAlignment" Value="Stretch" />
+                    <Setter Property="Padding" Value="0,0,0,0" />
                 </Style>
             </Setter.Value>
         </Setter>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
@@ -4,7 +4,7 @@
     xmlns:local="using:Xamarin.Forms.Platform.UWP">
     
     <ItemsPanelTemplate x:Key="HorizontalListItemsPanel">
-        <ItemsStackPanel Orientation="Horizontal"  />
+        <ItemsStackPanel Orientation="Horizontal" />
     </ItemsPanelTemplate>
 
     <ItemsPanelTemplate x:Key="HorizontalGridItemsPanel">

--- a/Xamarin.Forms.Platform.UAP/Extensions/CollectionViewExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions/CollectionViewExtensions.cs
@@ -34,33 +34,42 @@ namespace Xamarin.Forms.Platform.UWP
 			};
 		}
 
-		public static (int firstVisibleItemIndex, int lastVisibleItemIndex, int centerItemIndex) GetVisibleIndexes(ListViewBase listViewBase, ItemsLayoutOrientation itemsLayoutOrientation)
+		public static (int firstVisibleItemIndex, int lastVisibleItemIndex, int centerItemIndex) GetVisibleIndexes(this ListViewBase listViewBase, ItemsLayoutOrientation itemsLayoutOrientation , bool goingNext)
 		{
 			int firstVisibleItemIndex = -1;
 			int lastVisibleItemIndex = -1;
-			int centerItemIndex = -1;
-
-			var scrollViewer = listViewBase.GetFirstDescendant<ScrollViewer>();
-			var presenters = listViewBase.GetChildren<ListViewItemPresenter>();
-
-			if (presenters != null || scrollViewer == null)
+			
+			var itemsPanel = (listViewBase.ItemsPanelRoot as ItemsStackPanel);
+			if (itemsPanel != null)
 			{
-				int count = 0;
-				foreach (ListViewItemPresenter presenter in presenters)
-				{
-					if (CollectionViewExtensions.IsListViewItemVisible(presenter, scrollViewer, itemsLayoutOrientation))
-					{
-						if (firstVisibleItemIndex == -1)
-							firstVisibleItemIndex = count;
-
-						lastVisibleItemIndex = count;
-					}
-
-					count++;
-				}
-
-				centerItemIndex = (lastVisibleItemIndex + firstVisibleItemIndex) / 2;
+				firstVisibleItemIndex = itemsPanel.FirstVisibleIndex;
+				lastVisibleItemIndex = itemsPanel.LastVisibleIndex;
 			}
+			else
+			{
+				var scrollViewer = listViewBase.GetFirstDescendant<ScrollViewer>();
+				var presenters = listViewBase.GetChildren<ListViewItemPresenter>();
+
+				if (presenters != null || scrollViewer == null)
+				{
+					int count = 0;
+					foreach (ListViewItemPresenter presenter in presenters)
+					{
+						if (IsListViewItemVisible(presenter, scrollViewer, itemsLayoutOrientation))
+						{
+							if (firstVisibleItemIndex == -1)
+								firstVisibleItemIndex = count;
+
+							lastVisibleItemIndex = count;
+						}
+
+						count++;
+					}
+				}
+			}
+
+			double center = (lastVisibleItemIndex + firstVisibleItemIndex) / 2.0;
+			int centerItemIndex = goingNext ? (int)Math.Ceiling(center) : (int)Math.Floor(center);
 
 			return (firstVisibleItemIndex, lastVisibleItemIndex, centerItemIndex);
 		}

--- a/Xamarin.Forms.Platform.UAP/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/IndicatorViewRenderer.cs
@@ -36,13 +36,12 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					UpdateControl();
 				}
+				_fillColor = new SolidColorBrush(Element.IndicatorColor.ToWindowsColor());
+
+				_selectedColor = new SolidColorBrush(Element.SelectedIndicatorColor.ToWindowsColor());
+
+				CreateIndicators();
 			}
-
-			_fillColor = new SolidColorBrush(Element.IndicatorColor.ToWindowsColor());
-
-			_selectedColor = new SolidColorBrush(Element.SelectedIndicatorColor.ToWindowsColor());
-
-			CreateIndicators();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -22,6 +22,8 @@ namespace Xamarin.Forms.Platform.iOS
 			Carousel.PropertyChanged += CarouselViewPropertyChanged;
 			Carousel.Scrolled += CarouselViewScrolled;
 			_oldViews = new List<View>();
+
+			
 		}
 
 		protected override UICollectionViewDelegateFlowLayout CreateDelegator()
@@ -145,29 +147,10 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (removingFirstElement && !removingCurrentElement)
 			{
 				carouselPosition = currentItemPosition;
-				//when removing an item before the current item
-				//the UICollectionView always scrolls to the next item
-				//but we want to keept it on the same item
-				HackForPositionScroll();
 			}
 
 			SetCurrentItem(carouselPosition);
 			SetPosition(carouselPosition);
-		}
-
-		void HackForPositionScroll()
-		{
-			Device.StartTimer(new System.TimeSpan(1), () =>
-			{
-				var offset = CollectionView.ContentOffset;
-				var newOffset = new CGPoint(offset);
-				if (IsHorizontal)
-					newOffset = new CGPoint(offset.X - ItemsViewLayout.ItemSize.Width, offset.Y);
-				else
-					newOffset = new CGPoint(offset.X, offset.Y - ItemsViewLayout.ItemSize.Height);
-				CollectionView.SetContentOffset(newOffset, false);
-				return false;
-			});
 		}
 
 		void SubscribeCollectionItemsSourceChanged(IItemsViewSource itemsSource)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -1,5 +1,7 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
+using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -79,10 +81,61 @@ namespace Xamarin.Forms.Platform.iOS
 			base.BoundsSizeChanged();
 			_carouselView.ScrollTo(_carouselView.Position, position: ScrollToPosition.Center, animate: false);
 		}
+		
+		protected override IItemsViewSource CreateItemsViewSource()
+		{
+			var itemsSource = base.CreateItemsViewSource();
+			SubscribeCollectionItemsSourceChanged(itemsSource);
+			return itemsSource;
+		}
+
+		public override void UpdateItemsSource()
+		{
+			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
+			base.UpdateItemsSource();
+			SubscribeCollectionItemsSourceChanged(ItemsSource);
+		}
+
+		void CollectionItemsSourceChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			var centerItemIndex = -1;
+
+			var indexPathsForVisibleItems = CollectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
+
+			if (indexPathsForVisibleItems.Count == 0)
+				return;
+
+			var collectionView = CollectionView;
+
+			var contentInset = collectionView.ContentInset;
+			var contentOffsetX = collectionView.ContentOffset.X + contentInset.Left;
+			var contentOffsetY = collectionView.ContentOffset.Y + contentInset.Top;
+
+			var firstVisibleItemIndex = (int)indexPathsForVisibleItems.First().Item;
+
+			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
+			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
+			centerItemIndex = centerIndexPath?.Row ?? firstVisibleItemIndex;
+
+			_carouselView.SetCurrentItem(null, centerItemIndex);
+		}
+
+		void SubscribeCollectionItemsSourceChanged(IItemsViewSource itemsSource)
+		{
+			if (itemsSource is ObservableItemsSource newItemsSource)
+				newItemsSource.CollectionItemsSourceChanged += CollectionItemsSourceChanged;
+		}
+
+		void UnsubscribeCollectionItemsSourceChanged(IItemsViewSource oldItemsSource)
+		{
+			if (oldItemsSource is ObservableItemsSource oldObservableItemsSource)
+				oldObservableItemsSource.CollectionItemsSourceChanged -= CollectionItemsSourceChanged;
+		}
 
 		internal void TearDown()
 		{
 			_carouselView.PropertyChanged -= CarouselViewPropertyChanged;
+			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
 		}
 
 		public override void DraggingStarted(UIScrollView scrollView)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -1,7 +1,5 @@
 ﻿using System.Collections;
 using System.Collections.Generic;
-using System.Linq;
-using CoreGraphics;
 using Foundation;
 using UIKit;
 
@@ -10,6 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public class CarouselViewController : ItemsViewController<CarouselView>
 	{
 		protected readonly CarouselView Carousel;
+
 		bool _viewInitialized;
 		List<View> _oldViews;
 		int _gotoPosition = -1;
@@ -22,13 +21,6 @@ namespace Xamarin.Forms.Platform.iOS
 			Carousel.PropertyChanged += CarouselViewPropertyChanged;
 			Carousel.Scrolled += CarouselViewScrolled;
 			_oldViews = new List<View>();
-
-			
-		}
-
-		protected override UICollectionViewDelegateFlowLayout CreateDelegator()
-		{
-			return new CarouselViewDelegator(ItemsViewLayout, this);
 		}
 
 		public override UICollectionViewCell GetCell(UICollectionView collectionView, NSIndexPath indexPath)
@@ -78,12 +70,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override bool IsHorizontal => (Carousel?.ItemsLayout as ItemsLayout)?.Orientation == ItemsLayoutOrientation.Horizontal;
 
+		protected override UICollectionViewDelegateFlowLayout CreateDelegator() => new CarouselViewDelegator(ItemsViewLayout, this);
+
 		protected override string DetermineCellReuseId()
 		{
 			if (Carousel.ItemTemplate != null)
-			{
 				return CarouselTemplatedCell.ReuseId;
-			}
+
 			return base.DetermineCellReuseId();
 		}
 
@@ -164,37 +157,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (oldItemsSource is ObservableItemsSource oldObservableItemsSource)
 				oldObservableItemsSource.CollectionItemsSourceChanged -= CollectionItemsSourceChanged;
 		}
-		
+
 		void CarouselViewPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs changedProperty)
 		{
 			if (changedProperty.Is(CarouselView.PositionProperty))
 				UpdateFromPosition();
 			else if (changedProperty.Is(CarouselView.CurrentItemProperty))
 				UpdateFromCurrentItem();
-		}
-
-		void UpdateInitialPosition()
-		{
-			if (Carousel.CurrentItem != null)
-			{
-				int position = 0;
-
-				var items = Carousel.ItemsSource as IList;
-
-				for (int n = 0; n < items?.Count; n++)
-				{
-					if (items[n] == Carousel.CurrentItem)
-					{
-						position = n;
-						break;
-					}
-				}
-
-				var initialPosition = position;
-				Carousel.Position = initialPosition;
-			}
-
-			SetCurrentItem(Carousel.Position);
 		}
 
 		void SetPosition(int position)
@@ -236,13 +205,38 @@ namespace Xamarin.Forms.Platform.iOS
 			var carouselPosition = Carousel.Position;
 			if (carouselPosition == _gotoPosition)
 				_gotoPosition = -1;
-			
-			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling && currentItemPosition != carouselPosition)
+
+			if (_gotoPosition == -1 && !Carousel.IsDragging && currentItemPosition != carouselPosition)
 			{
 				_gotoPosition = carouselPosition;
 				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center);
 			}
+
 			SetCurrentItem(carouselPosition);
+		}
+
+		void UpdateInitialPosition()
+		{
+			if (Carousel.CurrentItem != null)
+			{
+				int position = 0;
+
+				var items = Carousel.ItemsSource as IList;
+
+				for (int n = 0; n < items?.Count; n++)
+				{
+					if (items[n] == Carousel.CurrentItem)
+					{
+						position = n;
+						break;
+					}
+				}
+
+				var initialPosition = position;
+				Carousel.Position = initialPosition;
+			}
+
+			SetCurrentItem(Carousel.Position);
 		}
 
 		void UpdateVisualStates()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -12,6 +12,7 @@ namespace Xamarin.Forms.Platform.iOS
 		readonly CarouselView _carouselView;
 		bool _viewInitialized;
 		List<View> _oldViews;
+		int _initialPosition = -1;
 
 		public CarouselViewController(CarouselView itemsView, ItemsViewLayout layout) : base(itemsView, layout)
 		{
@@ -54,6 +55,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_carouselView.PlatformInitialized();
 				_viewInitialized = true;
 			}
+
 			UpdateVisualStates();
 		}
 
@@ -110,7 +112,10 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var centerItemIndex = CollectionView.GetCenteredIndex();
 
-			if (centerItemIndex != -1)
+			//check if we scrolled to the initial positions
+			_initialPosition = _initialPosition == centerItemIndex ? -1 : _initialPosition;
+
+			if (centerItemIndex != -1 && _initialPosition < 1)
 				_carouselView.SetCurrentItem(null, centerItemIndex);
 		}
 
@@ -172,6 +177,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			while (_carouselView.ScrollToActions.Count > 0)
 			{
+				_initialPosition = _carouselView.Position;
 				var action = _carouselView.ScrollToActions.Dequeue();
 				action();
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -43,9 +43,10 @@ namespace Xamarin.Forms.Platform.iOS
 			return cell;
 		}
 
-		public override void ViewDidLayoutSubviews()
+
+		public override void ViewWillLayoutSubviews()
 		{
-			base.ViewDidLayoutSubviews();
+			base.ViewWillLayoutSubviews();
 			if (!_viewInitialized)
 			{
 				UpdateInitialPosition();
@@ -54,6 +55,13 @@ namespace Xamarin.Forms.Platform.iOS
 				_viewInitialized = true;
 			}
 			UpdateVisualStates();
+		}
+
+		public override void ViewDidLayoutSubviews()
+		{
+			base.ViewDidLayoutSubviews();
+
+			UpdateCarouselViewPosition();
 		}
 
 		protected override bool IsHorizontal => (_carouselView?.ItemsLayout as ItemsLayout)?.Orientation == ItemsLayoutOrientation.Horizontal;
@@ -159,10 +167,8 @@ namespace Xamarin.Forms.Platform.iOS
 				var initialPosition = position;
 				_carouselView.Position = initialPosition;
 			}
-			else
-			{
-				UpdateCarouselViewPosition();
-			}
+
+			UpdateCarouselViewPosition();
 
 			while (_carouselView.ScrollToActions.Count > 0)
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -86,12 +86,6 @@ namespace Xamarin.Forms.Platform.iOS
 			base.RegisterViewTypes();
 		}
 
-		protected override void BoundsSizeChanged()
-		{
-			base.BoundsSizeChanged();
-			_carouselView.ScrollTo(_carouselView.Position, position: ScrollToPosition.Center, animate: false);
-		}
-		
 		protected override IItemsViewSource CreateItemsViewSource()
 		{
 			var itemsSource = base.CreateItemsViewSource();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -43,12 +43,9 @@ namespace Xamarin.Forms.Platform.iOS
 			return cell;
 		}
 
-		// Here because ViewDidAppear (and associates) are not fired consistently for this class
-		// See a more extensive explanation in the ItemsViewController.ViewWillLayoutSubviews method
-		public override void ViewWillLayoutSubviews()
+		public override void ViewDidLayoutSubviews()
 		{
-			base.ViewWillLayoutSubviews();
-
+			base.ViewDidLayoutSubviews();
 			if (!_viewInitialized)
 			{
 				UpdateInitialPosition();
@@ -98,26 +95,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionItemsSourceChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
 		{
-			var centerItemIndex = -1;
+			UpdateCarouselViewPosition();
+		}
 
-			var indexPathsForVisibleItems = CollectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
+		void UpdateCarouselViewPosition()
+		{
+			var centerItemIndex = CollectionView.GetCenteredIndex();
 
-			if (indexPathsForVisibleItems.Count == 0)
-				return;
-
-			var collectionView = CollectionView;
-
-			var contentInset = collectionView.ContentInset;
-			var contentOffsetX = collectionView.ContentOffset.X + contentInset.Left;
-			var contentOffsetY = collectionView.ContentOffset.Y + contentInset.Top;
-
-			var firstVisibleItemIndex = (int)indexPathsForVisibleItems.First().Item;
-
-			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
-			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
-			centerItemIndex = centerIndexPath?.Row ?? firstVisibleItemIndex;
-
-			_carouselView.SetCurrentItem(null, centerItemIndex);
+			if (centerItemIndex != -1)
+				_carouselView.SetCurrentItem(null, centerItemIndex);
 		}
 
 		void SubscribeCollectionItemsSourceChanged(IItemsViewSource itemsSource)
@@ -172,6 +158,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 				var initialPosition = position;
 				_carouselView.Position = initialPosition;
+			}
+			else
+			{
+				UpdateCarouselViewPosition();
 			}
 
 			while (_carouselView.ScrollToActions.Count > 0)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -136,6 +136,11 @@ namespace Xamarin.Forms.Platform.iOS
 				carouselPosition = currentItemPosition;
 			}
 
+			if(e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+			{
+				carouselPosition = 0;
+			}
+
 			SetCurrentItem(carouselPosition);
 			SetPosition(carouselPosition);
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -175,6 +175,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void SetCurrentItem(int carouselPosition)
 		{
+			if (ItemsSource.ItemCount == 0)
+				return;
+
 			var item = GetItemAtIndex(NSIndexPath.FromItemSection(carouselPosition, 0));
 			Carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, item);
 			UpdateVisualStates();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -196,7 +196,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)
 			{
 				_gotoPosition = currentItemPosition;
-				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
 			}
 			UpdateVisualStates();
 		}
@@ -211,7 +211,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_gotoPosition == -1 && !Carousel.IsDragging && currentItemPosition != carouselPosition)
 			{
 				_gotoPosition = carouselPosition;
-				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center);
+				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
 			}
 
 			SetCurrentItem(carouselPosition);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		readonly CarouselView _carouselView;
 		readonly ItemsLayout _itemsLayout;
+		CGPoint? _pendingOffset;
 
 		public CarouselViewLayout(ItemsLayout itemsLayout, CarouselView carouselView) : base(itemsLayout)
 		{
@@ -59,6 +60,43 @@ namespace Xamarin.Forms.Platform.iOS
 			var bottom = insets.Bottom + (float)_carouselView.PeekAreaInsets.Bottom;
 
 			return new UIEdgeInsets(top, left, bottom, right);
+		}
+
+		public override void PrepareForCollectionViewUpdates(UICollectionViewUpdateItem[] updateItems)
+		{
+			base.PrepareForCollectionViewUpdates(updateItems);
+
+			// Determine whether the change is a removal 
+			if (updateItems.Length == 0 || updateItems[0].UpdateAction != UICollectionUpdateAction.Delete)
+			{
+				return;
+			}
+
+			// Determine whether the removed item is before the current position
+			if (updateItems[0].IndexPathBeforeUpdate.Item >= _carouselView.Position)
+			{
+				return;
+			}
+
+			// If an earlier item is being removed, we'll need to adjust the content offset to account for 
+			// the now mising item. Calculate what the new offset will be and store that.
+			var currentOffset = CollectionView.ContentOffset;
+			if (ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+				_pendingOffset = new CGPoint(currentOffset.X - ItemSize.Width, currentOffset.Y);
+			else
+				_pendingOffset = new CGPoint(currentOffset.X, currentOffset.Y - ItemSize.Height);
+		}
+
+		public override void FinalizeCollectionViewUpdates()
+		{
+			base.FinalizeCollectionViewUpdates();
+
+			// Adjust the offset if necessary (e.g., if we've removed items from earlier in the carousel)
+			if (_pendingOffset.HasValue)
+			{
+				CollectionView.SetContentOffset(_pendingOffset.Value, false);
+				_pendingOffset = null;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class CarouselViewRenderer : ItemsViewRenderer<CarouselView, CarouselViewController>
 	{
-		CarouselView CarouselView => Element;
+		CarouselView Carousel => Element;
 
 		[Preserve(Conditional = true)]
 		public CarouselViewRenderer()
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override ItemsViewLayout SelectLayout()
 		{
-			return new CarouselViewLayout(CarouselView.ItemsLayout, CarouselView);
+			return new CarouselViewLayout(Carousel.ItemsLayout, Carousel);
 		}
 
 		protected override void SetUpNewElement(CarouselView newElement)
@@ -53,18 +53,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateIsSwipeEnabled()
 		{
-			if (CarouselView == null)
+			if (Carousel == null)
 				return;
 
-			Controller.CollectionView.ScrollEnabled = CarouselView.IsSwipeEnabled;
+			Controller.CollectionView.ScrollEnabled = Carousel.IsSwipeEnabled;
 		}
 
 		void UpdateIsBounceEnabled()
 		{
-			if (CarouselView == null)
+			if (Carousel == null)
 				return;
 
-			Controller.CollectionView.Bounces = CarouselView.IsBounceEnabled;
+			Controller.CollectionView.Bounces = Carousel.IsBounceEnabled;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
@@ -27,17 +27,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (indexPathsForVisibleItems.Count == 0)
 				return;
-
+	
 			var contentInset = scrollView.ContentInset;
 			var contentOffsetX = scrollView.ContentOffset.X + contentInset.Left;
 			var contentOffsetY = scrollView.ContentOffset.Y + contentInset.Top;
 
 			var firstVisibleItemIndex = (int)indexPathsForVisibleItems.First().Item;
-
-			var collectionView = ViewController.CollectionView;
-			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
-			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
-			var centerItemIndex = centerIndexPath?.Row ?? firstVisibleItemIndex;
+			var centerItemIndex = ViewController.CollectionView.GetCenteredIndex();
 			var lastVisibleItemIndex = (int)indexPathsForVisibleItems.Last().Item;
 			var itemsViewScrolledEventArgs = new ItemsViewScrolledEventArgs
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 
-		public event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
+		internal event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
 
 		public int Count { get; private set; }
 
@@ -206,7 +206,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
 			var count = args.OldItems.Count;
-
+			
 			_collectionView.PerformBatchUpdates(() =>
 			{
 				_collectionView.DeleteItems(CreateIndexesFrom(startIndex, count));

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 
-		public event EventHandler<NotifyCollectionChangedEventArgs> CollectionItemsSourceChanged;
+		public event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
 
 		public int Count { get; private set; }
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Forms.Platform.iOS
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 
+		public event EventHandler<NotifyCollectionChangedEventArgs> CollectionItemsSourceChanged;
+
 		public int Count { get; private set; }
 
 		public object this[int index] => ElementAt(index);
@@ -126,6 +128,8 @@ namespace Xamarin.Forms.Platform.iOS
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
+
+			CollectionItemsSourceChanged?.Invoke(this, args);
 		}
 
 		void Reload()

--- a/Xamarin.Forms.Platform.iOS/Extensions/UICollectionViewExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/UICollectionViewExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Linq;
+using CoreGraphics;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal static class CollectionViewExtensions
+	{
+		public static int GetCenteredIndex(this UICollectionView collectionView)
+		{
+			var centerItemIndex = -1;
+
+			var indexPathsForVisibleItems = collectionView.IndexPathsForVisibleItems.OrderBy(x => x.Row).ToList();
+
+			if (indexPathsForVisibleItems.Count == 0)
+				return -1;
+
+			var firstVisibleItemIndex = (int)indexPathsForVisibleItems.First().Item;
+
+			var centerPoint = new CGPoint(collectionView.Center.X + collectionView.ContentOffset.X, collectionView.Center.Y + collectionView.ContentOffset.Y);
+			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
+			centerItemIndex = centerIndexPath?.Row ?? firstVisibleItemIndex;
+			return centerItemIndex;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -257,7 +257,6 @@
     <Compile Include="Renderers\IndicatorViewRenderer.cs" />
     <Compile Include="Renderers\SwipeViewRenderer.cs" />
     <Compile Include="Extensions\UIApplicationExtensions.cs" />
-    <Compile Include="Extensions\CollectionViewExtensions.cs" />
     <Compile Include="Extensions\UICollectionViewExtensions.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -257,6 +257,7 @@
     <Compile Include="Renderers\IndicatorViewRenderer.cs" />
     <Compile Include="Renderers\SwipeViewRenderer.cs" />
     <Compile Include="Extensions\UIApplicationExtensions.cs" />
+    <Compile Include="Extensions\CollectionViewExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -258,6 +258,7 @@
     <Compile Include="Renderers\SwipeViewRenderer.cs" />
     <Compile Include="Extensions\UIApplicationExtensions.cs" />
     <Compile Include="Extensions\CollectionViewExtensions.cs" />
+    <Compile Include="Extensions\UICollectionViewExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />


### PR DESCRIPTION
### Description of Change ###

When we add or remove items from the ItemsSource, we need to tell the new Position/CurrentItem on the Carousel. This change will listen to changes on Observable Collections and get the new position, when we set the Position we update the CurrrentItem.

Also resets the ItemDecoration on android when adding or removing items in the last position, since we add an extra spacing to those items so they can be centered. (#9401)

Fixes a small issue with IndicatorView on UWP when it's disposing.

Adds 2 new properties to have more fine grain control over the `Position` and `CurrentItem` updates. If a user want's to just jump to a position when setting the CarouselView Position property  without animation, he can override AnimatePositionChanges and set it to false, while animate CurrentItems changes or vice versa. By default this properties are hooked tot IsScrollAnimated

### Issues Resolved ### 

- fixes #9322
- fixes #9401 
- fixes #9432 
- fixes #9771

### API Changes ###

Removed from CarouseView.cs

- `public void SetCurrentItem(object item)`
- `public void PlatformInitialized()`
- `public void PlatformInitialized()`
- `public Queue<Action> ScrollToActions = new Queue<Action>();`

Added to CarouseView.cs
```
	[EditorBrowsable(EditorBrowsableState.Never)]
	public virtual bool AnimatePositionChanges => IsScrollAnimated;

	[EditorBrowsable(EditorBrowsableState.Never)]
	public virtual bool AnimateCurrentItemChanges => IsScrollAnimated;
```
### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Should update CurrentItem

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

Enable the Indicator Flag.

Go to CarouselXamlGallery, swipe to the second item , click on the button to Remove make sure the Position and the CurrentItem change.

To test 9432 go to IndicatorCodeGallery , swipe to the last item, click remove, check that the Indicators update and the last one is still selected.

To test 9401 , visit the CarouselView / CarouselView (Indicators Forms), go to the last item, click add item,  make sure the added item doesn't show a extra spacing on the left of the last item on Android.

Test 9771 issue page, make sure you go to 50 and can go to previous and next on UWP

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
