### PR TITLE
Add support for animation rate parameter

### DIFF
--- a/Xamarin.Forms.Core/AnimationExtensions.cs
+++ b/Xamarin.Forms.Core/AnimationExtensions.cs
@@ -176,7 +176,7 @@ namespace Xamarin.Forms
 
 			var info = new Info { Rate = rate, Length = length, Easing = easing ?? Easing.Linear };
 
-			var tweener = new Tweener(info.Length);
+			var tweener = new Tweener(info.Length, info.Rate);
 			tweener.Handle = key;
 			tweener.ValueUpdated += HandleTweenerUpdated;
 			tweener.Finished += HandleTweenerFinished;

--- a/Xamarin.Forms.Core/Tweener.cs
+++ b/Xamarin.Forms.Core/Tweener.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms
 					_lastMilliseconds = ms;
 				}
 
-				long wantedFrames = _lastMilliseconds / Rate;
+				long wantedFrames = (_lastMilliseconds / Rate) + 1;
 				if(wantedFrames > _frames || Value >= 1.0f)
 				{
 					ValueUpdated?.Invoke(this, EventArgs.Empty);

--- a/Xamarin.Forms.Core/Tweener.cs
+++ b/Xamarin.Forms.Core/Tweener.cs
@@ -36,6 +36,14 @@ namespace Xamarin.Forms
 		int _timer;
 		long _frames;
 
+		public Tweener(uint length)
+		{
+			Value = 0.0f;
+			Length = length;
+			Rate = 1;
+			Loop = false;
+		}
+
 		public Tweener(uint length, uint rate)
 		{
 			Value = 0.0f;

--- a/Xamarin.Forms.Core/Tweener.cs
+++ b/Xamarin.Forms.Core/Tweener.cs
@@ -34,17 +34,21 @@ namespace Xamarin.Forms
 		long _lastMilliseconds;
 
 		int _timer;
+		long _frames;
 
-		public Tweener(uint length)
+		public Tweener(uint length, uint rate)
 		{
 			Value = 0.0f;
 			Length = length;
+			Rate = rate;
 			Loop = false;
 		}
 
 		public AnimatableKey Handle { get; set; }
 
 		public uint Length { get; }
+
+		public uint Rate { get; }
 
 		public bool Loop { get; set; }
 
@@ -66,6 +70,7 @@ namespace Xamarin.Forms
 			Pause();
 
 			_lastMilliseconds = 0;
+			_frames = 0;
 
 			if (!Ticker.Default.SystemEnabled)
 			{
@@ -89,7 +94,12 @@ namespace Xamarin.Forms
 					_lastMilliseconds = ms;
 				}
 
-				ValueUpdated?.Invoke(this, EventArgs.Empty);
+				long wantedFrames = _lastMilliseconds / Rate;
+				if(wantedFrames > _frames || Value >= 1.0f)
+				{
+					ValueUpdated?.Invoke(this, EventArgs.Empty);
+				}
+				_frames = wantedFrames;
 
 				if (Value >= 1.0f)
 				{


### PR DESCRIPTION
### Description of Change ###

Adds support for the `rate` parameter for `Animation`. This parameter existed but was unused.

### Issues Resolved ### 
fixes #5322

### API Changes ###

Added:
- `public Tweener(uint length, uint rate)`
 - `uint Tweener.Rate { get; }`

The existing constructor of `Tweener` is also kept and defaults `rate` to `1`. This way existing code which uses the `Tweener` does not have to be updated.

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Below are three GIFs for an example animation with 50ms, 200ms and 500ms rate. 

#### Rate=50 -> 20 frames per second
![50ms](https://media.giphy.com/media/XD3XYpPGjOpCpziWHQ/giphy.gif)
#### Rate=200 -> 5 frames per second
![200ms](https://media.giphy.com/media/JTOLxIJhZFR1trV2fT/giphy.gif)
#### Rate=500 -> 2 frames per second
![500ms](https://media.giphy.com/media/TFBpoeCMsNAJJaAqhg/giphy.gif)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
