### PR TITLE
[Housekeeping] NuGet Icon switch to PackageIcon

### DIFF
--- a/.nuspec/Xamarin.Forms.AppLinks.nuspec
+++ b/.nuspec/Xamarin.Forms.AppLinks.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms applinks xamarinforms xamarin.forms</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -36,6 +36,8 @@
     </references>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Platform.Android.AppLinks\bin\$Configuration$\MonoAndroid90\Xamarin.Forms.Platform.Android.AppLinks.dll" target="lib\MonoAndroid90" />
     <file src="..\Xamarin.Forms.Platform.Android.AppLinks\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.Android.AppLinks.dll" target="lib\MonoAndroid10.0" />
   </files>

--- a/.nuspec/Xamarin.Forms.DualScreen.nuspec
+++ b/.nuspec/Xamarin.Forms.DualScreen.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms twopaneview DualScreen xamarinforms xamarinformsdualscreen xamarin.forms.dualscreen</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -26,7 +26,8 @@
     </dependencies>
   </metadata>
   <files>
-
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <!--netstandard 1.0-->
     <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\netstandard1.0\Xamarin.Forms.DualScreen.dll" target="lib\netstandard1.0" />
     <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\netstandard1.0\Xamarin.Forms.DualScreen.*pdb" target="lib\netstandard1.0" />

--- a/.nuspec/Xamarin.Forms.Maps.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.GTK.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms maps xamarinforms xamarinformsmaps xamarin.forms.maps gtk gtk-sharp linux</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -21,6 +21,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Platform.GTK\Libs\GMaps\GMap.NET.Core.dll" target="lib\net45" />
     <file src="..\Xamarin.Forms.Platform.GTK\Libs\GMaps\GMap.NET.GTK.dll" target="lib\net45" />
     <file src="..\Xamarin.Forms.Maps.GTK\bin\$Configuration$\Xamarin.Forms.Maps.GTK.dll" target="lib\net45"/>

--- a/.nuspec/Xamarin.Forms.Maps.WPF.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.WPF.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms maps xamarinforms xamarinformsmaps xamarin.forms.maps wpf</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -24,6 +24,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Maps.WPF\bin\$Configuration$\Xamarin.Forms.Maps.WPF.dll" target="lib\net45" />
     <file src="..\Xamarin.Forms.Maps.WPF\bin\$Configuration$\Xamarin.Forms.Maps.WPF.*pdb" target="lib\net45" />
   </files>

--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms maps xamarinforms xamarinformsmaps xamarin.forms.maps</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -38,6 +38,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Maps.dll" target="lib\netstandard1.0" />
     <file src="..\docs\Xamarin.Forms.Maps.xml" target="lib\netstandard1.0" />
 

--- a/.nuspec/Xamarin.Forms.Pages.Azure.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.Azure.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft xamarin</owners>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -21,6 +21,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Pages.Azure\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.Azure.dll" target="lib\netstandard1.4" />
     <file src="..\Xamarin.Forms.Pages.Azure\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.Azure.dll" target="lib\netstandard2.0" />
   </files>

--- a/.nuspec/Xamarin.Forms.Pages.nuspec
+++ b/.nuspec/Xamarin.Forms.Pages.nuspec
@@ -6,7 +6,7 @@
     <authors>Microsoft</authors>
     <owners>microsoft xamarin</owners>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -20,6 +20,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard1.4\Xamarin.Forms.Pages.dll" target="lib\netstandard1.4" />
     <file src="..\Xamarin.Forms.Pages\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Pages.dll" target="lib\netstandard2.0" />
   </files>

--- a/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
+++ b/.nuspec/Xamarin.Forms.Platform.GTK.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms xamarinforms xamarin.forms gtk gtk-sharp linux</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -21,6 +21,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Platform.GTK\Libs\webkit-sharp\webkit-sharp.dll" target="lib\net45"/>
     <file src="..\Xamarin.Forms.Platform.GTK\Libs\webkit-sharp\webkit-sharp.dll.config" target="content"/>
     <file src="..\Xamarin.Forms.Platform.GTK\bin\$Configuration$\Xamarin.Forms.Platform.GTK.dll" target="lib\net45"/>

--- a/.nuspec/Xamarin.Forms.Platform.WPF.nuspec
+++ b/.nuspec/Xamarin.Forms.Platform.WPF.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms xamarinforms xamarin.forms wpf</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -22,6 +22,8 @@
     </dependencies>
   </metadata>
   <files>
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <file src="..\Xamarin.Forms.Platform.WPF\bin\$Configuration$\Xamarin.Forms.Platform.WPF.dll" target="lib\net45" />
     <file src="..\Xamarin.Forms.Platform.WPF\bin\$Configuration$\Xamarin.Forms.Platform.WPF.*pdb" target="lib\net45" />
   </files>

--- a/.nuspec/Xamarin.Forms.Visual.Material.nuspec
+++ b/.nuspec/Xamarin.Forms.Visual.Material.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms visual material xamarinforms xamarinformsvisualmaterial xamarin.forms.visual.material</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -38,7 +38,8 @@
     </dependencies>
   </metadata>
   <files>
-    
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <!--netstandard-->
     <file src="_._" target="lib\netstandard1.0\_._" />
 

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -7,7 +7,7 @@
     <owners>microsoft xamarin</owners>
     <tags>xamarin forms xamarinforms xamarin.forms</tags>
     <license type="expression">MIT</license>
-    <iconUrl>https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Assets/xamarin_128x128.png</iconUrl>
+    <icon>Assets\xamarin_128x128.png</icon>
     <projectUrl>http://xamarin.com/forms</projectUrl>
     <repository type="git" url="https://github.com/xamarin/xamarin.forms"/>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
@@ -100,7 +100,8 @@
   </metadata>
 
   <files>
-
+    <!--Icon-->
+    <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
     <!--netstandard 1.0-->
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Core.dll" target="lib\netstandard1.0" />
     <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard1.0\Xamarin.Forms.Core.*pdb" target="lib\netstandard1.0" />


### PR DESCRIPTION
### Description of Change ###
Updated nuspec files to use the package icon instead of URL icon.
More info here: https://docs.microsoft.com/en-us/nuget/reference/msbuild-targets#packageiconurl

### Issues Resolved ### 
- fixes #8619

### API Changes ###
None

### Platforms Affected ### 
None

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Try to build nuget package
