### PR TITLE
[AND] Default style to DayNight (Dark Theme support)

### DIFF
--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -7,4 +7,28 @@
   <style name="NestedScrollBarStyle" android:id="@+id/nestedScrollViewStyle">
     <item name="android:scrollbars">vertical|horizontal</item>
   </style>
+    <style name="MainTheme" parent="MainTheme.Base">
+    </style>
+    <!-- Base theme applied no matter what API -->
+    <style name="MainTheme.Base" parent="Theme.AppCompat.DayNight.DarkActionBar">
+        <!--If you are using revision 22.1 please use just windowNoTitle. Without android:-->
+        <item name="windowNoTitle">true</item>
+        <!--We will be using the toolbar so no need to show ActionBar-->
+        <item name="windowActionBar">false</item>
+        <!-- Set theme colors from https://aka.ms/material-colors -->
+        <!-- colorPrimary is used for the default action bar background -->
+        <item name="colorPrimary">#2196F3</item>
+        <!-- colorPrimaryDark is used for the status bar -->
+        <item name="colorPrimaryDark">#1976D2</item>
+        <!-- colorAccent is used as the default value for colorControlActivated
+         which is used to tint widgets -->
+        <item name="colorAccent">#FF4081</item>
+        <!-- You can also set colorControlNormal, colorControlActivated
+         colorControlHighlight and colorSwitchThumbNormal. -->
+        <item name="windowActionModeOverlay">true</item>
+        <item name="android:datePickerDialogTheme">@style/AppCompatDialogStyle</item>
+    </style>
+    <style name="AppCompatDialogStyle" parent="Theme.AppCompat.DayNight.Dialog">
+        <item name="colorAccent">#FF4081</item>
+    </style>
 </resources>


### PR DESCRIPTION
### Description of Change ###

Pull the default style into the Android platform project and update it to use DayNight to support Dark Theme.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- related #9804

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

From what I can think of these would be the scenarios:
- When the user has created customizations in the theme we supply in the templates by default, this should still override whatever we do here.

- If the user has created their own theme altogether, they are not hit by this change

- If the user is still using the default theme from the templates, nothing changes. It will act as an override to the theme we specify here

Basically the only way the user will see this change is if they throw out the current theme in their project and whenever we decide to remove the theme from the template and use this as the default. Whenever that happens, the user will see that the app responds to changes in light/dark theme as expected

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Go through the scenarios under "Behavioral/Visual Changes" as much as possible. If you have any (sample) apps laying around, pull down the NuGets, install them on that project and see if it behaves as you would expect.

There is not much to see from the gallery app as it has its own custom theme. You can fiddle around with that to see what happens as well.

All of this across different API levels to ensure backwards compatibility.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
