### PR TITLE
Disable EnableTypeInfoReflection for nugets when building for debug

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -256,7 +256,8 @@ Task("BuildForNuget")
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
                     msbuildSettings
                         .WithTarget("rebuild")
-                        .WithProperty("DisableEmbeddedXbf", "false"));
+                        .WithProperty("DisableEmbeddedXbf", "false")
+                        .WithProperty("EnableTypeInfoReflection", "false"));
 
         binaryLogger.FileName = $"{artifactStagingDirectory}/ios-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj",


### PR DESCRIPTION
### Description of Change ###
When building nugets in debug UWP includes a reference to an extra dll that won't be present with the nugets

Disabling EnableTypeInfoReflection removes the dll from being referenced

The targets file for this property looks like this
```
    <EnableTypeInfoReflection Condition="'$(EnableTypeInfoReflection)' == '' AND '$(Configuration)' == 'Debug' AND '$(UseDotNetNativeToolChain)' != 'true'">true</EnableTypeInfoReflection>
    <EnableTypeInfoReflection Condition="'$(EnableTypeInfoReflection)' == ''">false</EnableTypeInfoReflection>
```

So basically I just force it to false when building for nugets. 

### Testing Procedure ###
Pull down debug nugets and test them on vs2017/vs2019

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
