### PR TITLE
Fix disposal pattern for NavigationRenderer and ParentingViewController

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Tests/NavigationTests.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/Tests/NavigationTests.cs
@@ -1,0 +1,25 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.Forms.ControlGallery.iOS.Tests
+{
+	[TestFixture]
+	public class NavigationTests : PlatformTestFixture
+	{
+		[Test, Category("Navigation"), Category("Dispose")]
+		[Description("Multiple calls to NavigationRenderer.Dispose shouldn't crash")]
+		public void NavigationRendererDoubleDisposal()
+		{
+			var root = new ContentPage()
+			{
+				Title = "root",
+				Content = new Label { Text = "Hello" }
+			};
+			var navPage = new NavigationPage(root);
+			var renderer = GetRenderer(navPage);
+
+			// Calling Dispose more than once should be fine
+			renderer.Dispose();
+			renderer.Dispose();
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -128,6 +128,7 @@
     <Compile Include="Tests\CornerRadiusTests.cs" />
     <Compile Include="Tests\IsEnabledTests.cs" />
     <Compile Include="Tests\IsVisibleTests.cs" />
+    <Compile Include="Tests\NavigationTests.cs" />
     <Compile Include="Tests\OpacityTests.cs" />
     <Compile Include="Tests\PlatformTestSettings.cs" />
     <Compile Include="Tests\PlatformTestFixture.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1069,10 +1069,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (disposing)
 				{
-					Child.SendDisappearing();
-
 					if (Child != null)
 					{
+						Child.SendDisappearing();
 						Child.PropertyChanged -= HandleChildPropertyChanged;
 						Child = null;
 					}

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _hasNavigationBar;
 		UIImage _defaultNavBarShadowImage;
 		UIImage _defaultNavBarBackImage;
+		bool _disposed;
 
 		[Preserve(Conditional = true)]
 		public NavigationRenderer() : base(typeof(FormsNavigationBar), null)
@@ -247,6 +248,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+			{
+				return;
+			}
+
+			_disposed = true;
+
 			if (disposing)
 			{
 				MessagingCenter.Unsubscribe<IVisualElementRenderer>(this, UpdateToolbarButtons);
@@ -275,7 +283,8 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			base.Dispose(disposing);
-			if (_appeared)
+			
+			if (disposing && _appeared)
 			{
 				PageController.SendDisappearing();
 
@@ -939,6 +948,7 @@ namespace Xamarin.Forms.Platform.iOS
 			readonly WeakReference<NavigationRenderer> _navigation;
 
 			Page _child;
+			bool _disposed;
 			ToolbarTracker _tracker = new ToolbarTracker();
 
 			public ParentingViewController(NavigationRenderer navigation)
@@ -1050,6 +1060,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 			protected override void Dispose(bool disposing)
 			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+
 				if (disposing)
 				{
 					Child.SendDisappearing();
@@ -1076,6 +1093,7 @@ namespace Xamarin.Forms.Platform.iOS
 							ToolbarItems[i].Dispose();
 					}
 				}
+
 				base.Dispose(disposing);
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1456,6 +1456,7 @@ namespace Xamarin.Forms.Platform.iOS
 			FormsNavigationBar _bar;
 			IVisualElementRenderer _child;
 			UIImageView _icon;
+			bool _disposed;
 
 			public Container(View view, UINavigationBar bar) : base(bar.Bounds)
 			{
@@ -1571,6 +1572,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 			protected override void Dispose(bool disposing)
 			{
+				if (_disposed)
+				{
+					return;
+				}
+
+				_disposed = true;
+
 				if (disposing)
 				{
 
@@ -1587,6 +1595,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_icon?.Dispose();
 					_icon = null;
 				}
+
 				base.Dispose(disposing);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

The iOS NavigationRenderer, Container, and ParentingViewController classes were not set up to handle multiple calls to `Dispose`. Double disposal of a ParentingViewController (which is triggered by double disposal of Container and/or NavigationRenderer) causes a NullReferenceException on the second call when attempting to call `Child.SendDisappearing()`.

These changes place the call to `Child.SendDisappearing()` inside a null check, and also implement the normal disposal pattern for these classes.

### Issues Resolved ### 

- Fixes #9841

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated platform test (NavigationRendererDoubleDisposal).

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
