### PR TITLE
Change StateTriggerBase OnAttached and OnDetached methods to be public

### DIFF
--- a/Xamarin.Forms.Core/AdaptiveTrigger.cs
+++ b/Xamarin.Forms.Core/AdaptiveTrigger.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms
 			((AdaptiveTrigger)bindable).UpdateState();
 		}
 
-		internal override void OnAttached()
+		protected override void OnAttached()
 		{
 			base.OnAttached();
 
@@ -50,7 +50,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal override void OnDetached()
+		protected override void OnDetached()
 		{
 			base.OnDetached();
 

--- a/Xamarin.Forms.Core/CompareStateTrigger.cs
+++ b/Xamarin.Forms.Core/CompareStateTrigger.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms
 			((CompareStateTrigger)bindable).UpdateState();
 		}
 
-		internal override void OnAttached()
+		protected override void OnAttached()
 		{
 			base.OnAttached();
 			UpdateState();

--- a/Xamarin.Forms.Core/OrientationStateTrigger.cs
+++ b/Xamarin.Forms.Core/OrientationStateTrigger.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms
 			((OrientationStateTrigger)bindable).UpdateState();
 		}
 
-		internal override void OnAttached()
+		protected override void OnAttached()
 		{
 			base.OnAttached();
 
@@ -37,7 +37,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal override void OnDetached()
+		protected override void OnDetached()
 		{
 			base.OnDetached();
 

--- a/Xamarin.Forms.Core/StateTrigger.cs
+++ b/Xamarin.Forms.Core/StateTrigger.cs
@@ -20,7 +20,7 @@
 			}
 		}
 
-		internal override void OnAttached()
+		protected override void OnAttached()
 		{
 			base.OnAttached();
 			UpdateState();

--- a/Xamarin.Forms.Core/StateTriggerBase.cs
+++ b/Xamarin.Forms.Core/StateTriggerBase.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms
 
 		}
 
-		internal virtual void SendAttached()
+		internal void SendAttached()
 		{
 			if (IsAttached)
 				return;
@@ -54,7 +54,7 @@ namespace Xamarin.Forms
 			IsAttached = true;
 		}
 
-		internal virtual void SendDetached()
+		internal void SendDetached()
 		{
 			if (!IsAttached)
 				return;

--- a/Xamarin.Forms.Core/StateTriggerBase.cs
+++ b/Xamarin.Forms.Core/StateTriggerBase.cs
@@ -34,12 +34,12 @@ namespace Xamarin.Forms
 			VisualState?.VisualStateGroup?.UpdateStateTriggers();
 		}
 
-		internal virtual void OnAttached()
+		public virtual void OnAttached()
 		{
 
 		}
 
-		internal virtual void OnDetached()
+		public virtual void OnDetached()
 		{
 
 		}

--- a/Xamarin.Forms.Core/StateTriggerBase.cs
+++ b/Xamarin.Forms.Core/StateTriggerBase.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Forms
 
 		internal VisualState VisualState { get; set; }
 
+		public bool IsAttached { get; private set; }
+
 		protected void SetActive(bool active)
 		{
 			IsActive = active;
@@ -34,14 +36,30 @@ namespace Xamarin.Forms
 			VisualState?.VisualStateGroup?.UpdateStateTriggers();
 		}
 
-		public virtual void OnAttached()
+		protected virtual void OnAttached()
 		{
 
 		}
 
-		public virtual void OnDetached()
+		protected virtual void OnDetached()
 		{
 
+		}
+
+		internal virtual void SendAttached()
+		{
+			if (IsAttached)
+				return;
+			OnAttached();
+			IsAttached = true;
+		}
+
+		internal virtual void SendDetached()
+		{
+			if (!IsAttached)
+				return;
+			OnDetached();
+			IsAttached = false;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -841,9 +841,9 @@ namespace Xamarin.Forms
 					foreach (var stateTrigger in state.StateTriggers)
 					{
 						if(attach)
-							stateTrigger.OnAttached();
+							stateTrigger.SendAttached();
 						else
-							stateTrigger.OnDetached();
+							stateTrigger.SendDetached();
 					}
 		}
 

--- a/Xamarin.Forms.DualScreen/SpanModeStateTrigger.shared.cs
+++ b/Xamarin.Forms.DualScreen/SpanModeStateTrigger.shared.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.DualScreen
 			_info = new DualScreenInfo(_visualElement);
 		}
 
-		internal override void OnAttached()
+		protected override void OnAttached()
 		{
 			base.OnAttached();
 
@@ -55,7 +55,7 @@ namespace Xamarin.Forms.DualScreen
 			}
 		}
 
-		internal override void OnDetached()
+		protected override void OnDetached()
 		{
 			base.OnDetached();
 

--- a/Xamarin.Forms.DualScreen/WindowSpanModeStateTrigger.shared.cs
+++ b/Xamarin.Forms.DualScreen/WindowSpanModeStateTrigger.shared.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.DualScreen
 			((WindowSpanModeStateTrigger)bindable).UpdateState();
 		}
 
-		internal override void OnAttached()
+		protected override void OnAttached()
 		{
 			base.OnAttached();
 
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.DualScreen
 			}
 		}
 
-		internal override void OnDetached()
+		protected override void OnDetached()
 		{
 			base.OnDetached();
 


### PR DESCRIPTION
### Description of Change ###

When creating a custom State Trigger (Example https://github.com/jsuarezruiz/XamarinFormsStateTriggers) we may need to register or subscribe events. In this PR we change the  StateTriggerBase OnAttached and OnDetached methods to be public. This will help to create more complex StateTriggers in an easy way.

### API Changes ###
 
 None

### Platforms Affected ### 

- Core

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
