### PR TITLE
[C] Avoid NRE in Flex.OnMeasure

### DIFF
--- a/Xamarin.Forms.Core/FlexLayout.cs
+++ b/Xamarin.Forms.Core/FlexLayout.cs
@@ -398,6 +398,9 @@ namespace Xamarin.Forms
 		bool _measuring;
 		protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 		{
+			if (_root == null)
+				return new SizeRequest(new Size(widthConstraint, heightConstraint));
+
 			//All of this is a HACK as X.Flex doesn't supports measuring
 			if (!double.IsPositiveInfinity(widthConstraint) && !double.IsPositiveInfinity(heightConstraint))
 				return new SizeRequest(new Size(widthConstraint, heightConstraint));
@@ -406,9 +409,10 @@ namespace Xamarin.Forms
 			//1. Set Shrink to 0, set align-self to start (to avoid stretching)
 			//   Set Image.Aspect to Fill to get the value we expect in measuring
 			foreach (var child in Children) {
-				var item = GetFlexItem(child);
-				item.Shrink = 0;
-				item.AlignSelf = Flex.AlignSelf.Start;
+				if (GetFlexItem(child) is Flex.Item item) {
+					item.Shrink = 0;
+					item.AlignSelf = Flex.AlignSelf.Start;
+				}
 			}
 			Layout(widthConstraint, heightConstraint);
 
@@ -426,9 +430,10 @@ namespace Xamarin.Forms
 
 			//3. reset Shrink, algin-self, and image.aspect
 			foreach (var child in Children) {
-				var item = GetFlexItem(child);
-				item.Shrink = (float)child.GetValue(ShrinkProperty);
-				item.AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)child.GetValue(AlignSelfProperty);
+				if (GetFlexItem(child) is Flex.Item item) {
+					item.Shrink = (float)child.GetValue(ShrinkProperty);
+					item.AlignSelf = (Flex.AlignSelf)(FlexAlignSelf)child.GetValue(AlignSelfProperty);
+				}
 			}
 			_measuring = false;
 			return new SizeRequest(new Size(widthConstraint, heightConstraint));


### PR DESCRIPTION
### Description of Change ###

Avoid NRE in OnMeasure, caused by race conditions


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9340

We don't have a repro project for that issue, but the fix has been tested by the OP, and it fixes the issue

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
