### PR TITLE
Handle "groups but no actual cells" cases for reloading UICollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9580.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		const string Success = "Success";
 		const string Test9580 = "9580";
-		const string Test9686 = "9686";
 
 		protected override void Init()
 		{
@@ -28,15 +27,16 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var groups = new ObservableCollection<_9580Group>()
 			{
-				new _9580Group() { Name = "One" }, new _9580Group(){ Name = "Two" }
+				new _9580Group() { Name = "One" }, new _9580Group(){ Name = "Two" }, new _9580Group(){ Name = "Three" },
+				new _9580Group() { Name = "Four" }, new _9580Group(){ Name = "Five" }, new _9580Group(){ Name = "Six" }
 			};
 
 			cv.ItemTemplate = new DataTemplate(() => {
-				var label = new Label();
+				var label = new Label() { Margin = new Thickness(5, 0, 0, 0) };
 				label.SetBinding(Label.TextProperty, new Binding("Text"));
 				return label;
 			});
-
+			
 			cv.GroupHeaderTemplate = new DataTemplate(() => {
 				var label = new Label();
 				label.SetBinding(Label.TextProperty, new Binding("Name"));
@@ -45,29 +45,20 @@ namespace Xamarin.Forms.Controls.Issues
 
 			cv.ItemsSource = groups;
 
-			var instructions = new Label { Text = $"Tap the button for the issue to test. The application doesn't crash, this test has passed."};
+			var instructions = new Label { Text = $"Tap the '{Test9580}' button. The application doesn't crash, this test has passed." };
 
 			var result = new Label { };
 
 			var button = new Button { Text = Test9580 };
-			button.Clicked += (sender, args) => {
+			button.Clicked += (sender, args) =>
+			{
 				groups[0].Add(new _9580Item { Text = "An Item" });
-				result.Text = Success;
-			};
-
-			var button2 = new Button { Text = Test9686 };
-			button2.Clicked += (sender, args) => {
-				var group = groups[0];
-				groups.Remove(group);
-				group.Add(new _9580Item { Text = "An Item" });
-				groups.Insert(0, group);
 				result.Text = Success;
 			};
 
 			layout.Children.Add(instructions);
 			layout.Children.Add(result);
 			layout.Children.Add(button);
-			layout.Children.Add(button2);
 			layout.Children.Add(cv);
 
 			Content = layout;
@@ -92,17 +83,6 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(Test9580);
 			RunningApp.WaitForElement(Success);
 		}
-
-		[Category(UITestCategories.CollectionView)]
-		[Test]
-		public void AddRemoveEmptyGroupsShouldNotCrashOnInsert()
-		{
-			RunningApp.WaitForElement(Test9686);
-			RunningApp.Tap(Test9686);
-			RunningApp.WaitForElement(Success);
-		}
 #endif
 	}
-
-
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9580.cs
@@ -1,0 +1,87 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9580, "[Bug] CollectionView - iOS - Crash when adding first item to empty item group", PlatformAffected.iOS)]
+	public class Issue9580 : TestContentPage
+	{
+		const string Success = "Success";
+		const string Start = "Go";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var cv = new CollectionView
+			{
+				IsGrouped = true
+			};
+
+			var groups = new ObservableCollection<_9580Group>()
+			{
+				new _9580Group() { Name = "One" }, new _9580Group(){ Name = "Two" }
+			};
+
+			cv.ItemTemplate = new DataTemplate(() => {
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("Text"));
+				return label;
+			});
+
+			cv.GroupHeaderTemplate = new DataTemplate(() => {
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("Name"));
+				return label;
+			});
+
+			cv.ItemsSource = groups;
+
+			var instructions = new Label { Text = $"Tap the {Start} button. The application doesn't crash, this test has passed."};
+
+			var result = new Label { };
+
+			var button = new Button { Text = "Go" };
+			button.Clicked += (sender, args) => {
+				groups[0].Add(new _9580Item { Text = "An Item" });
+				result.Text = Success;
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(result);
+			layout.Children.Add(button);
+			layout.Children.Add(cv);
+
+			Content = layout;
+		}
+
+		class _9580Item
+		{ 
+			public string Text { get; set; }
+		}
+
+		class _9580Group : ObservableCollection<_9580Item> 
+		{
+			public string Name { get; set; }
+		}
+
+#if UITEST
+		[Category(UITestCategories.CollectionView)]
+		[Test]
+		public void AllEmptyGroupsShouldNotCrashOnItemInsert()
+		{
+			RunningApp.WaitForElement(Start);
+			RunningApp.Tap(Start);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9580.cs
@@ -9,11 +9,13 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	[Issue(IssueTracker.Github, 9580, "[Bug] CollectionView - iOS - Crash when adding first item to empty item group", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Github, 9580, "[Bug] CollectionView - iOS - Crash when adding first item to empty item group", 
+		PlatformAffected.iOS)]
 	public class Issue9580 : TestContentPage
 	{
 		const string Success = "Success";
-		const string Start = "Go";
+		const string Test9580 = "9580";
+		const string Test9686 = "9686";
 
 		protected override void Init()
 		{
@@ -43,19 +45,29 @@ namespace Xamarin.Forms.Controls.Issues
 
 			cv.ItemsSource = groups;
 
-			var instructions = new Label { Text = $"Tap the {Start} button. The application doesn't crash, this test has passed."};
+			var instructions = new Label { Text = $"Tap the button for the issue to test. The application doesn't crash, this test has passed."};
 
 			var result = new Label { };
 
-			var button = new Button { Text = "Go" };
+			var button = new Button { Text = Test9580 };
 			button.Clicked += (sender, args) => {
 				groups[0].Add(new _9580Item { Text = "An Item" });
+				result.Text = Success;
+			};
+
+			var button2 = new Button { Text = Test9686 };
+			button2.Clicked += (sender, args) => {
+				var group = groups[0];
+				groups.Remove(group);
+				group.Add(new _9580Item { Text = "An Item" });
+				groups.Insert(0, group);
 				result.Text = Success;
 			};
 
 			layout.Children.Add(instructions);
 			layout.Children.Add(result);
 			layout.Children.Add(button);
+			layout.Children.Add(button2);
 			layout.Children.Add(cv);
 
 			Content = layout;
@@ -76,8 +88,17 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void AllEmptyGroupsShouldNotCrashOnItemInsert()
 		{
-			RunningApp.WaitForElement(Start);
-			RunningApp.Tap(Start);
+			RunningApp.WaitForElement(Test9580);
+			RunningApp.Tap(Test9580);
+			RunningApp.WaitForElement(Success);
+		}
+
+		[Category(UITestCategories.CollectionView)]
+		[Test]
+		public void AddRemoveEmptyGroupsShouldNotCrashOnInsert()
+		{
+			RunningApp.WaitForElement(Test9686);
+			RunningApp.Tap(Test9686);
 			RunningApp.WaitForElement(Success);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
@@ -168,6 +168,10 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				var index = Groups.IndexOf(group);
 				Groups.Remove(group);
+				if (group.Count == 0)
+				{
+					group.GroupName = Success;
+				}
 				Groups.Insert(index, group);
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
@@ -183,6 +183,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement(Test9686);
 			RunningApp.Tap(Test9686);
+			RunningApp.WaitForElement("Item 1");
 			RunningApp.Tap(Test9686);
 			RunningApp.WaitForElement(Success);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			cv.SetBinding(ItemsView.ItemsSourceProperty, new Binding(nameof(_9686ViewModel.Groups)));
 
-			var instructions = new Label { Text = $"Tap the '{Test9686}' header once, then again. The application doesn't crash, this test has passed." };
+			var instructions = new Label { Text = $"Tap the first group header once, then again. The application doesn't crash, this test has passed." };
 
 			var result = new Label { };
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Controls.Issues
 	public class Issue9686 : TestContentPage
 	{
 		const string Success = "Success";
-		const string Test9686 = "9686";
+		const string Run = "Run";
 
 		protected override void Init()
 		{
@@ -39,23 +39,21 @@ namespace Xamarin.Forms.Controls.Issues
 			cv.GroupHeaderTemplate = new DataTemplate(() => {
 				var label = new Label();
 				label.SetBinding(Label.TextProperty, new Binding("GroupName"));
-
-				var tgr = new TapGestureRecognizer();
-				tgr.Command = ((_9686ViewModel)BindingContext).ShowOrHideCommand;
-				tgr.SetBinding(TapGestureRecognizer.CommandParameterProperty, new Binding("."));
-
-				label.GestureRecognizers.Add(tgr);
-
 				return label;
 			});
 
 			cv.SetBinding(ItemsView.ItemsSourceProperty, new Binding(nameof(_9686ViewModel.Groups)));
 
-			var instructions = new Label { Text = $"Tap the first group header once, then again. The application doesn't crash, this test has passed." };
+			var instructions = new Label { Text = $"Tap the button once, then again. The application doesn't crash, this test has passed." };
 
 			var result = new Label { };
 
+			var button = new Button { Text  = Run, AutomationId = Run };
+			button.Command = ((_9686ViewModel)BindingContext).ShowOrHideCommand;
+			button.CommandParameter = ((_9686ViewModel)BindingContext).Groups[0];
+
 			layout.Children.Add(instructions);
+			layout.Children.Add(button);
 			layout.Children.Add(result);
 			layout.Children.Add(cv);
 
@@ -88,14 +86,15 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				ShowOrHideCommand = new Command<_9686Group>((group) => ShowOrHideItems(group));
 
-				Groups = new ObservableCollection<_9686Group>();
-
-				Groups.Add(new _9686Group($"{Test9686}", new ObservableCollection<_9686Item>()));
-				Groups.Add(new _9686Group("Group 2", new ObservableCollection<_9686Item>()));
-				Groups.Add(new _9686Group("Group 3", new ObservableCollection<_9686Item>()));
-				Groups.Add(new _9686Group("Group 4", new ObservableCollection<_9686Item>()));
-				Groups.Add(new _9686Group("Group 5", new ObservableCollection<_9686Item>()));
-				Groups.Add(new _9686Group("Group 6", new ObservableCollection<_9686Item>()));
+				Groups = new ObservableCollection<_9686Group>
+				{
+					new _9686Group("Group 1", new ObservableCollection<_9686Item>()),
+					new _9686Group("Group 2", new ObservableCollection<_9686Item>()),
+					new _9686Group("Group 3", new ObservableCollection<_9686Item>()),
+					new _9686Group("Group 4", new ObservableCollection<_9686Item>()),
+					new _9686Group("Group 5", new ObservableCollection<_9686Item>()),
+					new _9686Group("Group 6", new ObservableCollection<_9686Item>())
+				};
 			}
 
 			void ShowOrHideItems(_9686Group group)
@@ -181,10 +180,10 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void AddRemoveEmptyGroupsShouldNotCrashOnInsert()
 		{
-			RunningApp.WaitForElement(Test9686);
-			RunningApp.Tap(Test9686);
+			RunningApp.WaitForElement(Run);
+			RunningApp.Tap(Run);
 			RunningApp.WaitForElement("Item 1");
-			RunningApp.Tap(Test9686);
+			RunningApp.Tap(Run);
 			RunningApp.WaitForElement(Success);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9686.cs
@@ -1,0 +1,187 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9686, "[Bug, CollectionView,iOS] Foundation.Monotouch Exception in Grouped CollectionView",
+			PlatformAffected.iOS)]
+	public class Issue9686 : TestContentPage
+	{
+		const string Success = "Success";
+		const string Test9686 = "9686";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var cv = new CollectionView
+			{
+				IsGrouped = true
+			};
+
+			BindingContext = new _9686ViewModel();
+
+			cv.ItemTemplate = new DataTemplate(() => {
+				var label = new Label() { Margin = new Thickness(5, 0, 0, 0) };
+				label.SetBinding(Label.TextProperty, new Binding("Name"));
+				return label;
+			});
+
+			cv.GroupHeaderTemplate = new DataTemplate(() => {
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("GroupName"));
+
+				var tgr = new TapGestureRecognizer();
+				tgr.Command = ((_9686ViewModel)BindingContext).ShowOrHideCommand;
+				tgr.SetBinding(TapGestureRecognizer.CommandParameterProperty, new Binding("."));
+
+				label.GestureRecognizers.Add(tgr);
+
+				return label;
+			});
+
+			cv.SetBinding(ItemsView.ItemsSourceProperty, new Binding(nameof(_9686ViewModel.Groups)));
+
+			var instructions = new Label { Text = $"Tap the '{Test9686}' header once, then again. The application doesn't crash, this test has passed." };
+
+			var result = new Label { };
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(result);
+			layout.Children.Add(cv);
+
+			Content = layout;
+		}
+
+		public class _9686Item
+		{
+			public string Name { get; set; }
+		}
+
+		public class _9686Group : List<_9686Item>
+		{
+			public string GroupName { get; set; }
+
+			public _9686Group(string groupName, ObservableCollection<_9686Item> items) : base(items)
+			{
+				GroupName = groupName;
+			}
+		}
+
+		public class _9686ViewModel
+		{
+			public ICommand ShowOrHideCommand { get; set; }
+			public ObservableCollection<_9686Group> Groups { get; set; }
+
+			public _9686Group PreviousGroup { get; set; }
+
+			public _9686ViewModel()
+			{
+				ShowOrHideCommand = new Command<_9686Group>((group) => ShowOrHideItems(group));
+
+				Groups = new ObservableCollection<_9686Group>();
+
+				Groups.Add(new _9686Group($"{Test9686}", new ObservableCollection<_9686Item>()));
+				Groups.Add(new _9686Group("Group 2", new ObservableCollection<_9686Item>()));
+				Groups.Add(new _9686Group("Group 3", new ObservableCollection<_9686Item>()));
+				Groups.Add(new _9686Group("Group 4", new ObservableCollection<_9686Item>()));
+				Groups.Add(new _9686Group("Group 5", new ObservableCollection<_9686Item>()));
+				Groups.Add(new _9686Group("Group 6", new ObservableCollection<_9686Item>()));
+			}
+
+			void ShowOrHideItems(_9686Group group)
+			{
+				if (PreviousGroup == group)
+				{
+					if (PreviousGroup.Any())
+					{
+						PreviousGroup.Clear();
+					}
+					else
+					{
+						PreviousGroup.AddRange(new List<_9686Item>
+						{
+							new _9686Item
+							{
+								Name = "Item 1"
+							},
+							new _9686Item
+							{
+								Name = "Item 2"
+							},
+							new _9686Item
+							{
+								Name = "Item 3"
+							},
+							new _9686Item
+							{
+								Name = "Item 4"
+							},
+						});
+					}
+
+					UpdateCollection(PreviousGroup);
+				}
+				else
+				{
+					if (PreviousGroup != null)
+					{
+						PreviousGroup.Clear();
+						UpdateCollection(PreviousGroup);
+					}
+
+					group.AddRange(new List<_9686Item>
+					{
+						new _9686Item
+						{
+							Name = "Item 1"
+						},
+						new _9686Item
+						{
+							Name = "Item 2"
+						},
+						new _9686Item
+						{
+							Name = "Item 3"
+						},
+						new _9686Item
+						{
+							Name = "Item 4"
+						},
+					});
+
+					UpdateCollection(group);
+					PreviousGroup = group;
+				}
+			}
+
+			void UpdateCollection(_9686Group group)
+			{
+				var index = Groups.IndexOf(group);
+				Groups.Remove(group);
+				Groups.Insert(index, group);
+			}
+		}
+
+#if UITEST
+		[Category(UITestCategories.CollectionView)]
+		[Test]
+		public void AddRemoveEmptyGroupsShouldNotCrashOnInsert()
+		{
+			RunningApp.WaitForElement(Test9686);
+			RunningApp.Tap(Test9686);
+			RunningApp.Tap(Test9686);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -217,6 +217,7 @@
       <DependentUpon>Issue9783.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9686.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9694.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9771.xaml.cs">
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -37,6 +37,7 @@
       <DependentUpon>Issue8902.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9580.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9682.xaml.cs">
       <DependentUpon>Issue9682.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Forms.Platform.iOS
 			},
 					(_) =>
 					{
-						if (_batchUpdating.CurrentCount > 0)
+						if (_batchUpdating.CurrentCount == 0)
 						{
 							_batchUpdating.Release();
 						}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -227,7 +227,6 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-			// TODO Should we just move this queueing into Reload?
 			if (ReloadRequired())
 			{
 				await Reload();


### PR DESCRIPTION
### Description of Change ###

On iOS, a CollectionView with all empty groups is crashing when adding the first item; UICollectionView internal accounting gets confused.

These changes check for that circumstance and tell the UICollectionView to do a data reload instead, which allows it to get the internal accounting correct (and prevent the crash).

This also adds a check to prevent UICollectionView full reloads while the UICollectionView is in the process of animating other changes (which results in a garbled cell arrangement).

### Issues Resolved ### 

- Fixes #9580
- Fixes #9686

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test (Issue 9580)
Automated test (Issue 9686)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
