### PR TITLE
[XamlC] use XmlReader for detecting XAML and x:Class

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/CecilExtensionsTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/CecilExtensionsTests.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using Mono.Cecil;
+using NUnit.Framework;
+using Xamarin.Forms.Build.Tasks;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[TestFixture]
+	public class CecilExtensionsTests : IAssemblyResolver
+	{
+		const string testNamespace = "Xamarin.Forms.Xaml.UnitTests";
+		AssemblyDefinition assembly;
+		readonly List<AssemblyDefinition> assemblies = new List<AssemblyDefinition>();
+		readonly ReaderParameters readerParameters;
+
+		public CecilExtensionsTests()
+		{
+			readerParameters = new ReaderParameters
+			{
+				AssemblyResolver = this,
+			};
+		}
+
+		[SetUp]
+		public void SetUp ()
+		{
+			assembly = AssemblyDefinition.ReadAssembly(GetType().Assembly.Location, readerParameters);
+			assemblies.Add(assembly);
+		}
+
+		public AssemblyDefinition Resolve(AssemblyNameReference name)
+		{
+			var path = Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location), name.Name + ".dll");
+			var assembly = AssemblyDefinition.ReadAssembly(path, readerParameters);
+			assemblies.Add(assembly);
+			return assembly;
+		}
+
+		public AssemblyDefinition Resolve(AssemblyNameReference name, ReaderParameters parameters)
+		{
+			var path = Path.Combine(Path.GetDirectoryName(GetType().Assembly.Location), name.Name + ".dll");
+			var assembly = AssemblyDefinition.ReadAssembly(path, parameters);
+			assemblies.Add(assembly);
+			return assembly;
+		}
+
+		[TearDown]
+		public void Dispose()
+		{
+			foreach (var assembly in assemblies)
+			{
+				assembly.Dispose();
+			}
+			assemblies.Clear();
+		}
+
+		EmbeddedResource GetResource (string name)
+		{
+			var resourceName = $"{testNamespace}.{name}.xaml";
+			foreach (EmbeddedResource res in assembly.MainModule.Resources)
+			{
+				if (res.Name == resourceName)
+					return res;
+			}
+			throw new InvalidOperationException($"Resource '{resourceName}' not found in assembly '{assembly.Name.Name}'.");
+		}
+
+		static string[] IsXamlTrueSource = new[]
+		{
+			"IsCompiledDefault",
+			"X2006Namespace",
+			"X2009Primitives",
+		};
+
+		[Test, TestCaseSource (nameof (IsXamlTrueSource))]
+		public void IsXamlTrue (string name)
+		{
+			var resource = GetResource(name);
+			Assert.IsTrue(resource.IsXaml(assembly.MainModule, out string className), $"IsXaml should return true for '{name}'.");
+			Assert.AreEqual(className, $"{testNamespace}.{name}"); // Test cases x:Class matches the file name
+		}
+
+		static string[] IsXamlFalseSource = new[]
+		{
+			"Validation.MissingXClass",
+			"Validation.NotXaml",
+		};
+
+		[Test, TestCaseSource(nameof(IsXamlFalseSource))]
+		public void IsXamlFalse(string name)
+		{
+			var resource = GetResource(name);
+			Assert.IsFalse(resource.IsXaml(assembly.MainModule, out _), $"IsXaml should return false for '{name}'.");
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Validation/MissingXClass.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Validation/MissingXClass.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Validation/NotXaml.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Validation/NotXaml.xaml
@@ -1,0 +1,3 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<foo>
+</foo>

--- a/Xamarin.Forms.Xaml.UnitTests/X2006Namespace.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/X2006Namespace.xaml
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             x:Class="Xamarin.Forms.Xaml.UnitTests.X2006Namespace">
+</ContentPage>


### PR DESCRIPTION
### Description of Change ###

Context: https://www.jetbrains.com/profiler/

I was profiling Xamarin.Android project builds with `dotTrace`, and
noticed an `IsXaml` method from XamlC taking time:

    0.07%   IsXaml  •  40/0 ms  •  Xamarin.Forms.Build.Tasks.CecilExtensions.IsXaml(EmbeddedResource, ModuleDefinition, out String)
      0.07%   Execute  •  Xamarin.Forms.Build.Tasks.XamlCTask.Execute(out IList)
        0.07%   Execute  •  Xamarin.Forms.Build.Tasks.XamlTask.Execute

In this build, I had changed only XAML and the netstandard project was
using `<ProduceReferenceAssembly>True</ProduceReferenceAssembly>`.

The project is here:

https://github.com/xamarin/xamarin-android/tree/master/tests/Xamarin.Forms-Performance-Integration

Reviewing `IsXaml`, it uses `XmlDocument` to parse every
`EmbeddedResource` with a `.xaml` extension. The problem with this, is
that `XmlDocument` loads the entire XML file into memory and parses
it. This is a step before the actual work of XamlC, so it is currently
parsing every file twice.

If we switch this code to use `XmlReader` instead, we can read to the
first XML element and stop there to get the information needed. We
don't need to parse the entire file at this step.

The results of building the Xamarin.Forms.Controls project on
Windows:

    Before:
    1973 ms  XamlCTask                                  1 calls
    After:
    1917 ms  XamlCTask                                  1 calls

The same project running on Mono / macOS:

    Before:
    6785 ms  XamlCTask                                  1 calls
    After:
    6224 ms  XamlCTask                                  1 calls

My Mac is a slightly slower machine than my PC, but the big difference
is Mono vs .NET Framework.

### Issues Resolved ### 

n/a

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I added some unit tests here. I think the existing CI will be sufficient.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
