### PR TITLE
Fix6408 [WPF] box view not correctly restored

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/BoxViewRenderer.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Platform.WPF
 
 				UpdateBackground();
 				UpdateCornerRadius();
+				UpdateSize();
 			}
 
 			base.OnElementChanged(e);


### PR DESCRIPTION
### Description of Change ###

BoxView is not correctly restored after Navigation.PushAsync(); … Navigation.PopAsync();
This PR is instead of #9745  that was broken and contained incorrect changes.

### Issues Resolved ### 

- fixes #6408 

### Platforms Affected ### 

- WPF


### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->
![MainWindow](https://user-images.githubusercontent.com/17849938/75438560-d300d100-5960-11ea-8286-632e4003df07.gif)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)