### PR TITLE
Unhook Header/Footer measure handlers on Dispose

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Tests/NavigationTests.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/Tests/NavigationTests.cs
@@ -14,12 +14,15 @@ namespace Xamarin.Forms.ControlGallery.iOS.Tests
 				Title = "root",
 				Content = new Label { Text = "Hello" }
 			};
-			var navPage = new NavigationPage(root);
-			var renderer = GetRenderer(navPage);
 
-			// Calling Dispose more than once should be fine
-			renderer.Dispose();
-			renderer.Dispose();
+			Device.InvokeOnMainThreadAsync(() => { 
+				var navPage = new NavigationPage(root);
+				var renderer = GetRenderer(navPage);
+
+				// Calling Dispose more than once should be fine
+				renderer.Dispose();
+				renderer.Dispose();
+			});
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8308.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8308.xaml
@@ -1,0 +1,46 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestShell xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+             Title="Test 8308" xmlns:local="using:Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue8308">
+
+    <FlyoutItem Title="Page 1" AutomationId="Page1">
+        <Tab Title="Page 1">
+            <ShellContent>
+                <ContentPage Title="Control">
+                    <StackLayout>
+                        <Label Text="Open the flyout and navigate to the other page." AutomationId="Instructions"/>
+                        <CollectionView>
+                            <CollectionView.Header>
+                                <Label Text="CollectionView"/>
+                            </CollectionView.Header>
+                            <CollectionView.ItemTemplate>
+                                <DataTemplate>
+                                    <Label Text="Item"/>
+                                </DataTemplate>
+                            </CollectionView.ItemTemplate>
+                        </CollectionView>
+                    </StackLayout>
+                </ContentPage>
+            </ShellContent>
+        </Tab>
+    </FlyoutItem>
+
+    <FlyoutItem Title="Page 2" AutomationId="Page2">
+        <ShellContent>
+            <ContentPage Title="Control">
+                <ScrollView>
+                    <StackLayout>
+                        <Label AutomationId="Instructions2" 
+                            Text="Open the flyout and return to the first page. If the app crashes, this test has failed.">
+                        </Label>
+                    </StackLayout>
+                </ScrollView>
+            </ContentPage>
+        </ShellContent>
+    </FlyoutItem>
+
+</local:TestShell>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8308.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8308.xaml.cs
@@ -30,14 +30,14 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		[Category(UITestCategories.Shell)]
 		[Category(UITestCategories.CollectionView)]
-		public void NavigatingBackAndForthDoesNotCrash()
+		public void NavigatingBackToCollectionViewShouldNotCrash()
 		{
 			RunningApp.WaitForElement("Instructions");
 
-			TapInFlyout("Page2");
+			TapInFlyout("Page 2");
 			RunningApp.WaitForElement("Instructions2");
 
-			TapInFlyout("Page1");
+			TapInFlyout("Page 1");
 			RunningApp.WaitForElement("Instructions");
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8308.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8308.xaml.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 8308, 
+		"[Bug] [iOS] Cannot access a disposed object. Object name: 'GroupableItemsViewController`1",
+		PlatformAffected.iOS)]
+	public partial class Issue8308 : TestShell
+	{
+		public Issue8308()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.Shell)]
+		[Category(UITestCategories.CollectionView)]
+		public void NavigatingBackAndForthDoesNotCrash()
+		{
+			RunningApp.WaitForElement("Instructions");
+
+			TapInFlyout("Page2");
+			RunningApp.WaitForElement("Instructions2");
+
+			TapInFlyout("Page1");
+			RunningApp.WaitForElement("Instructions");
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -16,6 +16,10 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue3262.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8308.xaml.cs">
+      <DependentUpon>Issue8308.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8715.xaml.cs">
       <DependentUpon>Issue8715.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -1446,8 +1450,8 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8449.xaml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7924.xaml" />
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9305.xaml">
-       <SubType>Designer</SubType>
-       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9588.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
@@ -1873,6 +1877,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8715.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8308.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -34,11 +34,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
+				if (_headerViewFormsElement != null)
+				{
+					_headerViewFormsElement.MeasureInvalidated -= OnFormsElementMeasureInvalidated;
+				}
+
+				if (_footerViewFormsElement != null)
+				{
+					_footerViewFormsElement.MeasureInvalidated -= OnFormsElementMeasureInvalidated;
+				}
+
 				_headerUIView = null;
 				_headerViewFormsElement = null;
 				_footerUIView = null;
 				_footerViewFormsElement = null;
-				
 			}
 
 			base.Dispose(disposing);


### PR DESCRIPTION
### Description of Change ###

The handlers set up to remeasure the Header/Footer when their Forms element sizes changed were not being unhooked on Dispose; this led to the events firing and calling the handlers with a reference to an already disposed UICollectionView.

These changes unhook the handlers on Dispose.

### Issues Resolved ### 

- fixes #8308 

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
