### PR TITLE
Fix9906 [Bug] Setting CharacterSpacing on Button leads to crash on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/Extensions.cs
@@ -140,6 +140,11 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				mutableAttributedString = new NSMutableAttributedString(attributedString);
+
+				if (!mutableAttributedString.MutableString.ToString().Equals(text))
+				{
+					mutableAttributedString.MutableString.SetString(new NSString(text));
+				}
 			}
 
 			AddKerningAdjustment(mutableAttributedString, text, characterSpacing);


### PR DESCRIPTION
### Description of Change ###

Text update for controls with modified CharacterSpacing property leads to a crash on iOS.
This issue also relates to Label, Entry, Editor, Picker.

### Issues Resolved ### 

- fixes #9906 

### API Changes ###

 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS



### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
