### PR TITLE
[iOS] Check if Current Item on Shell Section is set before proceeding 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -9,6 +9,7 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using System.Threading;
 using System.ComponentModel;
+using System.Threading.Tasks;
 
 
 #if UITEST
@@ -33,6 +34,12 @@ namespace Xamarin.Forms.Controls.Issues
 			var vm = new ShellViewModel();
 			this.BindingContext = vm;
 
+			SetupShell();
+		}
+
+		void SetupShell()
+		{
+			var vm = BindingContext as ShellViewModel;
 			Func<string, ContentPage> createPage = (title) => new ContentPage()
 			{
 				Title = title,
@@ -84,6 +91,20 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								GoToAsync("//Item2");
 							})
+						},
+						new Button()
+						{
+							Text = "Clear and Recreate",
+							AutomationId = "ClearAndRecreate",
+							Command = new Command(async () =>
+							{
+								this.Items[0].Items[0].Items.Clear();
+								await Task.Delay(10);
+								this.Items[0].Items.Clear();
+								await Task.Delay(10);
+								this.Items.Clear();
+								SetupShell();
+							})
 						}
 					}
 				}
@@ -110,7 +131,6 @@ namespace Xamarin.Forms.Controls.Issues
 					this.FlyoutIsPresented = false;
 				})
 			}));
-
 		}
 
 		[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -179,6 +179,15 @@ namespace Xamarin.Forms.Controls.Issues
 			ShowFlyout();
 			RunningApp.WaitForNoElement("Item1 Flyout");
 		}
+
+		[Test]
+		public void ClearAndRecreateShellElements()
+		{
+			RunningApp.WaitForElement("ClearAndRecreate");
+			RunningApp.Tap("ClearAndRecreate");
+			RunningApp.WaitForElement("ClearAndRecreate");
+			RunningApp.Tap("ClearAndRecreate");
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -165,13 +165,18 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (e.PropertyName == ShellSection.CurrentItemProperty.PropertyName)
 			{
-				var items = ShellSectionController.GetItems();
 				var currentItem = ShellSection.CurrentItem;
+				if (currentItem == null)
+					return;
+
+				var items = ShellSectionController.GetItems();
+				if (items.Count == 0)
+					return;
 
 				var oldIndex = _currentIndex;
 				var oldItem = items[oldIndex];
 
-				_currentIndex = ShellSectionController.GetItems().IndexOf(currentItem);
+				_currentIndex = items.IndexOf(currentItem);
 
 				var oldRenderer = _renderers[oldItem];
 				var currentRenderer = _renderers[currentItem];


### PR DESCRIPTION
### Description of Change ###

Add check inside ShellSectionRenderer on iOS to see if Current Item is set. If it's not set then don't process any renderer changes

### Issues Resolved ### 
- fixes #9801

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
