### PR TITLE
[SwipeView] Added IsEnabled and IsVisible properties to SwipeItem

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemIsEnabledGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemIsEnabledGallery.cs
@@ -1,0 +1,167 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public class SwipeItemIsEnabledGallery : ContentPage
+	{
+		public SwipeItemIsEnabledGallery()
+		{
+			Title = "SwipeItem IsEnabled Gallery";
+
+			var swipeLayout = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "RemainOpen is used as SwipeBehaviorOnInvoked, tapping on a SwipeItem will not close it."
+			};
+
+			swipeLayout.Children.Add(instructions);
+
+			var closeButton = new Button
+			{
+				Text = "Close SwipeView"
+			};
+
+			swipeLayout.Children.Add(closeButton);
+
+			var swipeItem1 = new SwipeItem
+			{
+				BackgroundColor = Color.Red,
+				IconImageSource = "calculator.png",
+				Text = "Test 1"
+			};
+
+			swipeItem1.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Test 1 Invoked", "Ok"); };
+
+			var swipeItem2 = new SwipeItem
+			{
+				BackgroundColor = Color.Orange,
+				IconImageSource = "coffee.png",
+				Text = "Test 2"
+			};
+
+			swipeItem2.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Test 2 Invoked", "Ok"); };
+
+			var swipeItems = new SwipeItems { swipeItem1, swipeItem2 };
+
+			swipeItems.SwipeBehaviorOnInvoked = SwipeBehaviorOnInvoked.RemainOpen;
+			swipeItems.Mode = SwipeMode.Reveal;
+
+			var swipeContent = new Grid
+			{
+				BackgroundColor = Color.Gray
+			};
+
+			var fileSwipeLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Right"
+			};
+
+			swipeContent.Children.Add(fileSwipeLabel);
+
+			var swipeView = new SwipeView
+			{
+				HeightRequest = 60,
+				WidthRequest = 300,
+				LeftItems = swipeItems,
+				Content = swipeContent
+			};
+
+			swipeLayout.Children.Add(swipeView);
+
+
+			var swipeItem1Layout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var swipeItem1Button = new Button
+			{
+				Text = "Disable SwipeItem 1",
+				WidthRequest = 250,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var swipeItem1Label = new Label
+			{
+				Text = "SwipeItem 1 is enabled",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			swipeItem1Layout.Children.Add(swipeItem1Button);
+			swipeItem1Layout.Children.Add(swipeItem1Label);
+
+			swipeLayout.Children.Add(swipeItem1Layout);
+
+			var swipeItem2Layout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var swipeItem2Button = new Button
+			{
+				Text = "Disable SwipeItem 2",
+				WidthRequest = 250,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var swipeItem2Label = new Label
+			{
+				Text = "SwipeItem 2 is enabled",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			swipeItem2Layout.Children.Add(swipeItem2Button);
+			swipeItem2Layout.Children.Add(swipeItem2Label);
+
+			swipeLayout.Children.Add(swipeItem2Layout);
+
+			Content = swipeLayout;
+
+			closeButton.Clicked += (sender, e) =>
+			{
+				swipeView.Close();
+			};
+
+			swipeItem1Button.Clicked += (sender, args) =>
+			{
+				swipeItem1.IsEnabled = !swipeItem1.IsEnabled;
+
+				if (swipeItem1.IsEnabled)
+				{
+					swipeItem1Button.Text = "Disable SwipeItem 1";
+					swipeItem1Label.Text = "SwipeItem 1 is enabled";
+				}
+				else
+				{
+					swipeItem1Button.Text = "Enable SwipeItem 1";
+					swipeItem1Label.Text = "SwipeItem 1 is disabled";
+				}
+			};
+
+			swipeItem2Button.Clicked += (sender, args) =>
+			{
+				swipeItem2.IsEnabled = !swipeItem2.IsEnabled;
+
+				if (swipeItem2.IsEnabled)
+				{
+					swipeItem2Button.Text = "Disable SwipeItem 2";
+					swipeItem2Label.Text = "SwipeItem 2 is enabled";
+				}
+				else
+				{
+					swipeItem2Button.Text = "Enable SwipeItem 2";
+					swipeItem2Label.Text = "SwipeItem 2 is disabled";
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemIsVisibleGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemIsVisibleGallery.cs
@@ -1,0 +1,168 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public class SwipeItemIsVisibleGallery : ContentPage
+	{
+		public SwipeItemIsVisibleGallery()
+		{
+			Title = "SwipeItem IsVisible Gallery";
+
+			var swipeLayout = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "RemainOpen is used as SwipeBehaviorOnInvoked, tapping on a SwipeItem will not close it."
+			};
+
+			swipeLayout.Children.Add(instructions);
+
+			var closeButton = new Button
+			{
+				Text = "Close SwipeView"
+			};
+
+			swipeLayout.Children.Add(closeButton);
+
+			var swipeItem1 = new SwipeItem
+			{
+				BackgroundColor = Color.Red,
+				IconImageSource = "calculator.png",
+				Text = "Test 1",
+				IsVisible = false
+			};
+
+			swipeItem1.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Test 1 Invoked", "Ok"); };
+
+			var swipeItem2 = new SwipeItem
+			{
+				BackgroundColor = Color.Orange,
+				IconImageSource = "coffee.png",
+				Text = "Test 2"
+			};
+
+			swipeItem2.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Test 2 Invoked", "Ok"); };
+
+			var swipeItems = new SwipeItems { swipeItem1, swipeItem2 };
+
+			swipeItems.SwipeBehaviorOnInvoked = SwipeBehaviorOnInvoked.RemainOpen;
+			swipeItems.Mode = SwipeMode.Reveal;
+
+			var swipeContent = new Grid
+			{
+				BackgroundColor = Color.Gray
+			};
+
+			var fileSwipeLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Right"
+			};
+
+			swipeContent.Children.Add(fileSwipeLabel);
+
+			var swipeView = new SwipeView
+			{
+				HeightRequest = 60,
+				WidthRequest = 300,
+				LeftItems = swipeItems,
+				Content = swipeContent
+			};
+
+			swipeLayout.Children.Add(swipeView);
+
+
+			var swipeItem1Layout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var swipeItem1Button = new Button
+			{
+				Text = "Show SwipeItem 1",
+				WidthRequest = 250,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var swipeItem1Label = new Label
+			{
+				Text = "SwipeItem 1 is hidden",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			swipeItem1Layout.Children.Add(swipeItem1Button);
+			swipeItem1Layout.Children.Add(swipeItem1Label);
+
+			swipeLayout.Children.Add(swipeItem1Layout);
+
+			var swipeItem2Layout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var swipeItem2Button = new Button
+			{
+				Text = "Hide SwipeItem 2",
+				WidthRequest = 250,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var swipeItem2Label = new Label
+			{
+				Text = "SwipeItem 2 is visible",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			swipeItem2Layout.Children.Add(swipeItem2Button);
+			swipeItem2Layout.Children.Add(swipeItem2Label);
+
+			swipeLayout.Children.Add(swipeItem2Layout);
+
+			Content = swipeLayout;
+
+			closeButton.Clicked += (sender, e) =>
+			{
+				swipeView.Close();
+			};
+
+			swipeItem1Button.Clicked += (sender, args) =>
+			{
+				swipeItem1.IsVisible = !swipeItem1.IsVisible;
+
+				if (swipeItem1.IsVisible)
+				{
+					swipeItem1Button.Text = "Hide SwipeItem 1";
+					swipeItem1Label.Text = "SwipeItem 1 is visible";
+				}
+				else
+				{
+					swipeItem1Button.Text = "Show SwipeItem 1";
+					swipeItem1Label.Text = "SwipeItem 1 is hidden";
+				}
+			};
+
+			swipeItem2Button.Clicked += (sender, args) =>
+			{
+				swipeItem2.IsVisible = !swipeItem2.IsVisible;
+
+				if (swipeItem2.IsVisible)
+				{
+					swipeItem2Button.Text = "Hide SwipeItem 2";
+					swipeItem2Label.Text = "SwipeItem 2 is visible";
+				}
+				else
+				{
+					swipeItem2Button.Text = "Show SwipeItem 2";
+					swipeItem2Label.Text = "SwipeItem 2 is hidden";
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
@@ -33,6 +33,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 						GalleryBuilder.NavButton("SwipeView BindingContext Gallery", () => new SwipeViewBindingContextGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItem Icon Gallery", () => new SwipeItemIconGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItem Size Gallery", () => new SwipeItemSizeGallery(), Navigation),
+						GalleryBuilder.NavButton("SwipeItem IsEnabled Gallery", () => new SwipeItemIsEnabledGallery(), Navigation),
+ 						GalleryBuilder.NavButton("SwipeItem IsVisible Gallery", () => new SwipeItemIsVisibleGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeTransitionMode Gallery", () => new SwipeTransitionModeGallery(), Navigation),
 						GalleryBuilder.NavButton("Add/Remove SwipeItems Gallery", () => new AddRemoveSwipeItemsGallery(), Navigation),
 						GalleryBuilder.NavButton("Open/Close SwipeView Gallery", () => new CloseSwipeGallery(), Navigation),

--- a/Xamarin.Forms.Core/ISwipeItem.cs
+++ b/Xamarin.Forms.Core/ISwipeItem.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Forms
 {
 	public interface ISwipeItem
 	{
+		bool IsVisible { get; set; }
 		ICommand Command { get; set; }
 		object CommandParameter { get; set; }
 

--- a/Xamarin.Forms.Core/SwipeItem.cs
+++ b/Xamarin.Forms.Core/SwipeItem.cs
@@ -7,10 +7,18 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty BackgroundColorProperty = BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(SwipeItem), Color.Default);
 
+		public static readonly BindableProperty IsVisibleProperty = BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(SwipeItem), true);
+
 		public Color BackgroundColor
 		{
 			get { return (Color)GetValue(BackgroundColorProperty); }
 			set { SetValue(BackgroundColorProperty, value); }
+		}
+
+		public bool IsVisible
+		{
+			get { return (bool)GetValue(IsVisibleProperty); }
+			set { SetValue(IsVisibleProperty, value); }
 		}
 
 		public event EventHandler<EventArgs> Invoked;

--- a/Xamarin.Forms.Core/SwipeItemView.cs
+++ b/Xamarin.Forms.Core/SwipeItemView.cs
@@ -6,9 +6,12 @@ namespace Xamarin.Forms
 {
 	public class SwipeItemView : ContentView, ISwipeItem
 	{
-		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SwipeItemView));
+		public static readonly BindableProperty CommandProperty = BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(SwipeItemView), null,
+			propertyChanging: (bo, o, n) => ((SwipeItemView)bo).OnCommandChanging(),
+			propertyChanged: (bo, o, n) => ((SwipeItemView)bo).OnCommandChanged());
 
-		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SwipeItemView));
+		public static readonly BindableProperty CommandParameterProperty = BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(SwipeItemView), null,
+			propertyChanged: (bo, o, n) => ((SwipeItemView)bo).OnCommandParameterChanged());
 
 		public ICommand Command
 		{
@@ -31,6 +34,37 @@ namespace Xamarin.Forms
 				Command.Execute(CommandParameter);
 
 			Invoked?.Invoke(this, EventArgs.Empty);
+		}
+
+		void OnCommandChanged()
+		{
+			IsEnabled = Command?.CanExecute(CommandParameter) ?? true;
+
+			if (Command == null)
+				return;
+
+			Command.CanExecuteChanged += OnCommandCanExecuteChanged;
+		}
+
+		void OnCommandChanging()
+		{
+			if (Command == null)
+				return;
+
+			Command.CanExecuteChanged -= OnCommandCanExecuteChanged;
+		}
+
+		void OnCommandParameterChanged()
+		{
+			if (Command == null)
+				return;
+
+			IsEnabled = Command.CanExecute(CommandParameter);
+		}
+
+		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)
+		{
+			IsEnabled = Command.CanExecute(CommandParameter);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -901,7 +901,7 @@ namespace Xamarin.Forms.Platform.Android
 
 					_swipeDirection = null;
 
-					_contentView.Animate().TranslationX(0).SetDuration(SwipeAnimationDuration).WithEndAction(new Java.Lang.Runnable(() =>
+					_contentView.Animate().TranslationX(0).SetDuration(resetAnimationDuration).WithEndAction(new Java.Lang.Runnable(() =>
 					{
 						if (_swipeDirection == null)
 							DisposeSwipeItems();

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		const double SwipeAnimationDuration = 0.2;
 		const double SwipeMinimumDelta = 10;
 
+		readonly Dictionary<ISwipeItem, object> _swipeItems;
 		UITapGestureRecognizer _tapGestureRecognizer;
 		UIPanGestureRecognizer _panGestureRecognizer;
 		View _scrollParent;
@@ -43,6 +44,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public SwipeViewRenderer()
 		{
 			SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
+
+			_swipeItems = new Dictionary<ISwipeItem, object>();
 
 			_tapGestureRecognizer = new UITapGestureRecognizer(HandleTap)
 			{
@@ -378,7 +381,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_swipeItemsRect = new List<CGRect>();
 
+			SwipeItems visibleItems = GetVisibleSwipeItemsByDirection();
+
+			if (visibleItems == null || visibleItems.Count == 0)
+				return;
+
 			SwipeItems items = GetSwipeItemsByDirection();
+
 			double swipeItemsWidth;
 
 			if (_swipeDirection == SwipeDirection.Left || _swipeDirection == SwipeDirection.Right)
@@ -386,53 +395,126 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				swipeItemsWidth = _contentView.Frame.Width;
 
-			if (items == null || items.Count == 0)
-				return;
-
 			_actionView = new UIStackView
 			{
 				Axis = UILayoutConstraintAxis.Horizontal,
 				Frame = new CGRect(0, 0, swipeItemsWidth, _contentView.Frame.Height)
 			};
 
-			int i = 0;
-			float previousWidth = 0;
-
 			foreach (var item in items)
 			{
-				var swipeItem = (item is SwipeItem) ? CreateSwipeItem((SwipeItem)item) : CreateSwipeItemView((SwipeItemView)item);
+				UIView swipeItem = null;
 
-				var swipeItemSize = GetSwipeItemSize(item);
-				float swipeItemHeight = (float)swipeItemSize.Height;
-				float swipeItemWidth = (float)swipeItemSize.Width;
-
-				switch (_swipeDirection)
+				if (item is SwipeItem formsSwipeItem)
 				{
-					case SwipeDirection.Left:
-						swipeItem.Frame = new CGRect(_contentView.Frame.Width - (swipeItemWidth + previousWidth), 0, i + 1 * swipeItemWidth, swipeItemHeight);
-						break;
-					case SwipeDirection.Right:
-					case SwipeDirection.Up:
-					case SwipeDirection.Down:
-						swipeItem.Frame = new CGRect(previousWidth, 0, i + 1 * swipeItemWidth, swipeItemHeight);
-						break;
+					formsSwipeItem.PropertyChanged += OnSwipeItemPropertyChanged;
+					swipeItem = CreateSwipeItem(formsSwipeItem);
+					_actionView.AddSubview(swipeItem);
+					_swipeItems.Add(formsSwipeItem, swipeItem);
 				}
 
-				if (swipeItem is UIButton button)
+				if (item is SwipeItemView formsSwipeItemView)
 				{
-					UpdateSwipeItemIconImage(button, (SwipeItem)item);
-					UpdateSwipeItemInsets(button);
+					formsSwipeItemView.PropertyChanged += OnSwipeItemPropertyChanged;
+					swipeItem = CreateSwipeItemView(formsSwipeItemView);
+					_actionView.AddSubview(swipeItem);
+					_swipeItems.Add(formsSwipeItemView, swipeItem);
 				}
-
-				_actionView.AddSubview(swipeItem);
-				_swipeItemsRect.Add(swipeItem.Frame);
-				previousWidth += swipeItemWidth;
-
-				i++;
 			}
 
 			AddSubview(_actionView);
 			BringSubviewToFront(_contentView);
+
+			LayoutSwipeItems(GetNativeSwipeItems());
+		}
+
+		void LayoutSwipeItems(List<UIView> childs)
+		{
+			if (_actionView == null || childs == null)
+				return;
+
+			_swipeItemsRect.Clear();
+
+			var items = GetSwipeItemsByDirection();
+			int i = 0;
+			float previousWidth = 0;
+
+			foreach (var child in childs)
+			{
+				if (!child.Hidden)
+				{
+					var item = items[i];
+					var swipeItemSize = GetSwipeItemSize(item);
+					float swipeItemHeight = (float)swipeItemSize.Height;
+					float swipeItemWidth = (float)swipeItemSize.Width;
+
+					switch (_swipeDirection)
+					{
+						case SwipeDirection.Left:
+							child.Frame = new CGRect(_contentView.Frame.Width - (swipeItemWidth + previousWidth), 0, i + 1 * swipeItemWidth, swipeItemHeight);
+							break;
+						case SwipeDirection.Right:
+						case SwipeDirection.Up:
+						case SwipeDirection.Down:
+							child.Frame = new CGRect(previousWidth, 0, i + 1 * swipeItemWidth, swipeItemHeight);
+							break;
+					}
+
+					if (child is UIButton button)
+					{
+						UpdateSwipeItemIconImage(button, (SwipeItem)item);
+						UpdateSwipeItemInsets(button);
+					}
+
+					i++;
+					previousWidth += swipeItemWidth;
+					_swipeItemsRect.Add(child.Frame);
+				}
+			}
+		}
+
+		List<UIView> GetNativeSwipeItems()
+		{
+			var swipeItems = new List<UIView>();
+
+			foreach (var view in _actionView.Subviews)
+				swipeItems.Add(view);
+
+			return swipeItems;
+		}
+
+		void OnSwipeItemPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			var swipeItem = (ISwipeItem)sender;
+
+			if (e.PropertyName == SwipeItem.IsVisibleProperty.PropertyName)
+			{
+				UpdateIsVisibleSwipeItem(swipeItem);
+			}
+		}
+
+		void UpdateIsVisibleSwipeItem(ISwipeItem item)
+		{
+			if (!_isOpen)
+				return;
+
+			_swipeItems.TryGetValue(item, out object view);
+
+			if (view != null && view is UIView nativeView)
+			{
+				bool hidden = false;
+
+				if (item is SwipeItem swipeItem)
+					hidden = !swipeItem.IsVisible;
+
+				if (item is SwipeItemView swipeItemView)
+					hidden = !swipeItemView.IsVisible;
+
+				_swipeThreshold = 0;
+				nativeView.Hidden = hidden;
+				LayoutSwipeItems(GetNativeSwipeItems());
+				SwipeToThreshold(false);
+			}
 		}
 
 		UIButton CreateSwipeItem(SwipeItem formsSwipeItem)
@@ -442,11 +524,18 @@ namespace Xamarin.Forms.Platform.iOS
 				BackgroundColor = formsSwipeItem.BackgroundColor.ToUIColor()
 			};
 
+			if (!string.IsNullOrEmpty(formsSwipeItem.Text))
+				swipeItem.RestorationIdentifier = formsSwipeItem.Text;
+
+			if (!string.IsNullOrEmpty(formsSwipeItem.AutomationId))
+				swipeItem.AccessibilityIdentifier = formsSwipeItem.AutomationId;
+
 			swipeItem.SetTitle(formsSwipeItem.Text, UIControlState.Normal);
 
 			var textColor = GetSwipeItemColor(formsSwipeItem.BackgroundColor);
 			swipeItem.SetTitleColor(textColor.ToUIColor(), UIControlState.Normal);
 			swipeItem.UserInteractionEnabled = false;
+			swipeItem.Hidden = !formsSwipeItem.IsVisible;
 
 			return swipeItem;
 		}
@@ -456,7 +545,13 @@ namespace Xamarin.Forms.Platform.iOS
 			var renderer = Platform.CreateRenderer(formsSwipeItemView);
 			Platform.SetRenderer(formsSwipeItemView, renderer);
 			UpdateSwipeItemViewLayout(formsSwipeItemView);
-			return renderer?.NativeView;
+
+			var swipeItemView = renderer?.NativeView;
+
+			if (swipeItemView != null)
+				swipeItemView.Hidden = !formsSwipeItemView.IsVisible;
+
+			return swipeItemView;
 		}
 
 		void UpdateSwipeItemViewLayout(SwipeItemView swipeItemView)
@@ -589,22 +684,15 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_contentView == null || !TouchInsideContent(point))
 				return;
 
-			var swipeDirection = _swipeDirection;
-
-			if (!_isOpen && !_isResettingSwipe)
-				swipeDirection = SwipeDirectionHelper.GetSwipeDirection(new Point(_initialPoint.X, _initialPoint.Y), new Point(point.X, point.Y));
-
-			if (_swipeDirection != swipeDirection)
+			if (!_isOpen)
 			{
-				_swipeDirection = swipeDirection;
+				ResetSwipeToInitialPosition();
 
-				if (!_isOpen)
-				{
-					ResetSwipe(false);
-					UpdateSwipeItems();
-				}
+				_swipeDirection = SwipeDirectionHelper.GetSwipeDirection(new Point(_initialPoint.X, _initialPoint.Y), new Point(point.X, point.Y));
+
+				UpdateSwipeItems();
 			}
-
+			
 			if (!_isSwiping)
 			{
 				RaiseSwipeStarted();
@@ -694,6 +782,20 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return swipeItems;
+		}
+
+		SwipeItems GetVisibleSwipeItemsByDirection()
+		{
+			SwipeItems swipeItems = GetSwipeItemsByDirection();
+
+			if (swipeItems == null || swipeItems.Count == 0)
+				return swipeItems;
+
+			return new SwipeItems(swipeItems.Where(s => s.IsVisible))
+			{
+				Mode = swipeItems.Mode,
+				SwipeBehaviorOnInvoked = swipeItems.SwipeBehaviorOnInvoked
+			};
 		}
 
 		void Swipe()
@@ -806,10 +908,28 @@ namespace Xamarin.Forms.Platform.iOS
 			return offset;
 		}
 
+		void UnsubscribeSwipeItemEvents()
+		{
+			var items = GetSwipeItemsByDirection();
+
+			if (items == null)
+				return;
+
+			foreach (var item in items)
+			{
+				if (item is SwipeItem formsSwipeItem)
+					formsSwipeItem.PropertyChanged -= OnSwipeItemPropertyChanged;
+
+				if (item is SwipeItemView formsSwipeItemView)
+					formsSwipeItemView.PropertyChanged -= OnSwipeItemPropertyChanged;
+			}
+		}
+
 		void DisposeSwipeItems()
 		{
 			_isOpen = false;
-			_swipeThreshold = 0;
+			UnsubscribeSwipeItemEvents();
+			_swipeItems.Clear();
 
 			if (_actionView != null)
 			{
@@ -823,6 +943,15 @@ namespace Xamarin.Forms.Platform.iOS
 				_swipeItemsRect.Clear();
 				_swipeItemsRect = null;
 			}
+		}
+
+		void ResetSwipeToInitialPosition()
+		{
+			_isResettingSwipe = false;
+			_isSwiping = false;
+			_swipeThreshold = 0;
+			_swipeDirection = null;
+			DisposeSwipeItems();
 		}
 
 		void ResetSwipe(bool animated = true)
@@ -839,7 +968,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			Animate(resetAnimationDuration, 0.0, UIViewAnimationOptions.CurveEaseOut, () =>
 			{
-				_contentView.Frame = new CGRect(_originalBounds.X, _originalBounds.Y, _originalBounds.Width, _originalBounds.Height);
+				if (_originalBounds != CGRect.Empty)
+					_contentView.Frame = new CGRect(_originalBounds.X, _originalBounds.Y, _originalBounds.Width, _originalBounds.Height);
 			},
 			() =>
 			{
@@ -857,7 +987,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (Math.Abs(_swipeOffset) >= swipeThresholdPercent)
 			{
-				var swipeItems = GetSwipeItemsByDirection();
+				var swipeItems = GetVisibleSwipeItemsByDirection();
 
 				if (swipeItems == null)
 					return;
@@ -873,13 +1003,13 @@ namespace Xamarin.Forms.Platform.iOS
 						ResetSwipe();
 				}
 				else
-					CompleteSwipe();
+					SwipeToThreshold();
 			}
 			else
 				ResetSwipe();
 		}
 
-		void CompleteSwipe(bool animated = true)
+		void SwipeToThreshold(bool animated = true)
 		{
 			var completeAnimationDuration = animated ? SwipeAnimationDuration : 0;
 
@@ -960,7 +1090,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Math.Abs(_swipeThreshold) > double.Epsilon)
 				return _swipeThreshold;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = GetVisibleSwipeItemsByDirection();
 
 			if (swipeItems == null)
 				return 0;
@@ -1089,7 +1219,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool ValidateSwipeDirection()
 		{
-			var swipeItems = GetSwipeItemsByDirection();
+			if (_swipeDirection == null)
+				return false;
+
+			var swipeItems = GetVisibleSwipeItemsByDirection();
 			return IsValidSwipeItems(swipeItems);
 		}
 
@@ -1117,7 +1250,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_isResettingSwipe)
 				return;
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = GetVisibleSwipeItemsByDirection();
 
 			if (swipeItems == null || _swipeItemsRect == null)
 				return;
@@ -1184,12 +1317,21 @@ namespace Xamarin.Forms.Platform.iOS
 			return null;
 		}
 
-		void ExecuteSwipeItem(ISwipeItem swipeItem)
+		void ExecuteSwipeItem(ISwipeItem item)
 		{
-			if (swipeItem == null)
+			if (item == null)
 				return;
 
-			swipeItem.OnInvoked();
+			bool isEnabled = true;
+
+			if (item is SwipeItem swipeItem)
+				isEnabled = swipeItem.IsEnabled;
+
+			if (item is SwipeItemView swipeItemView)
+				isEnabled = swipeItemView.IsEnabled;
+
+			if (isEnabled)
+				item.OnInvoked();
 		}
 
 		void OnParentScrolled(object sender, ScrolledEventArgs e)
@@ -1244,7 +1386,7 @@ namespace Xamarin.Forms.Platform.iOS
 					break;
 			}
 
-			var swipeItems = GetSwipeItemsByDirection();
+			var swipeItems = GetVisibleSwipeItemsByDirection();
 
 			if (swipeItems.Count == 0)
 				return;


### PR DESCRIPTION
### Description of Change ###

Added IsEnabled and IsVisible properties to SwipeItem.

### Issues Resolved ### 

- fixes #9881 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Screenshots ### 
![disable-swipeitem](https://user-images.githubusercontent.com/6755973/76535681-8696b480-647b-11ea-9baa-66563e76a735.gif)

![swipeitem-isvisible](https://user-images.githubusercontent.com/6755973/76535674-84ccf100-647b-11ea-8e10-84b598881b81.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the SwipeView demos. Now, you can find two new demos to test the SwipeItem `IsEnabled` and `IsVisible` properties.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
