### PR TITLE
[Android] Fix SwipeView icon size using FontImageSource

### DIFF
--- a/Xamarin.Forms.Core/SwipeView.cs
+++ b/Xamarin.Forms.Core/SwipeView.cs
@@ -29,13 +29,16 @@ namespace Xamarin.Forms
 				propertyChanged: OnSwipeItemsChanged);
 
 		public static readonly BindableProperty RightItemsProperty =
-			BindableProperty.Create(nameof(RightItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator);
+			BindableProperty.Create(nameof(RightItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
+				propertyChanged: OnSwipeItemsChanged);
 
 		public static readonly BindableProperty TopItemsProperty =
-			BindableProperty.Create(nameof(TopItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator);
+			BindableProperty.Create(nameof(TopItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
+				propertyChanged: OnSwipeItemsChanged);
 
 		public static readonly BindableProperty BottomItemsProperty =
-			BindableProperty.Create(nameof(BottomItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator);
+			BindableProperty.Create(nameof(BottomItems), typeof(SwipeItems), typeof(SwipeView), null, BindingMode.OneWay, null, defaultValueCreator: SwipeItemsDefaultValueCreator,
+				propertyChanged: OnSwipeItemsChanged);
 
 		public SwipeItems LeftItems
 		{
@@ -117,8 +120,14 @@ namespace Xamarin.Forms
 		{
 			swipeItems.Parent = this;
 
-			foreach (var swipeItem in swipeItems)
-				((VisualElement)swipeItem).Parent = swipeItems;
+			foreach (var item in swipeItems)
+			{
+				if (item is SwipeItem swipeItem)
+					swipeItem.Parent = swipeItems;
+
+				if (item is SwipeItemView swipeItemView)
+					swipeItemView.Parent = swipeItems;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -3,17 +3,15 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using Android.Content;
-using Android.Graphics;
 using Android.Graphics.Drawables;
 #if __ANDROID_29__
 using AndroidX.Core.Widget;
-using AButton = AndroidX.AppCompat.Widget.AppCompatButton;
 using AndroidX.RecyclerView.Widget;
 using AndroidX.AppCompat.Widget;
+using AButton = AndroidX.AppCompat.Widget.AppCompatButton;
 #else
-using Android.Support.V4.Widget;
-using AButton = Android.Support.V7.Widget.AppCompatButton;
 using Android.Support.V7.Widget;
+using AButton = Android.Support.V7.Widget.AppCompatButton;
 #endif
 using Android.Views;
 using Xamarin.Forms.Internals;
@@ -673,7 +671,22 @@ namespace Xamarin.Forms.Platform.Android
 
 			_ = this.ApplyDrawableAsync(formsSwipeItem, MenuItem.IconImageSourceProperty, Context, drawable =>
 			{
-				drawable.SetBounds(0, 0, iconSize, iconSize);
+				int drawableWidth = drawable.IntrinsicWidth;
+				int drawableHeight = drawable.IntrinsicHeight;
+
+				if(drawableWidth > drawableHeight)
+				{
+					var iconWidth = iconSize;
+					var iconHeight = drawableHeight * iconWidth / drawableWidth;
+					drawable.SetBounds(0, 0, iconWidth, iconHeight);
+				}
+				else
+				{
+					var iconHeight = iconSize;
+					var iconWidth = drawableWidth * iconHeight / drawableHeight;
+					drawable.SetBounds(0, 0, iconWidth, iconHeight);
+				}
+
 				drawable.SetColorFilter(textColor.ToAndroid(), FilterMode.SrcAtop);
 				swipeButton.SetCompoundDrawables(null, drawable, null, null);
 			});


### PR DESCRIPTION
### Description of Change ###
Fixed SwipeView icon size using FontImageSource on Android.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="429" alt="fonticon-before" src="https://user-images.githubusercontent.com/6755973/76606888-5ac70d80-6513-11ea-99b8-11b162af1bee.png">

#### After
<img width="430" alt="fonticon-after" src="https://user-images.githubusercontent.com/6755973/76606874-5864b380-6513-11ea-877b-4576676c7228.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the SwipeView samples. Open the SwipeView Icons sample and verify the icon using FontImageSource.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
