### PR TITLE
[UWP] Fix FontIcon issue using a empty font name

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
@@ -6,6 +6,7 @@ using Microsoft.Graphics.Canvas.Text;
 using Microsoft.Graphics.Canvas.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
+using WFontIconSource = Microsoft.UI.Xaml.Controls.FontIconSource;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -57,13 +58,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (imagesource is FontImageSource fontImageSource)
 			{
-				image = new Microsoft.UI.Xaml.Controls.FontIconSource
+				image = new WFontIconSource
 				{
 					Glyph = fontImageSource.Glyph,
-					FontFamily = new FontFamily(fontImageSource.FontFamily),
 					FontSize = fontImageSource.Size,
 					Foreground = fontImageSource.Color.ToBrush()
 				};
+
+				if (!string.IsNullOrEmpty(fontImageSource.FontFamily))
+					((WFontIconSource)image).FontFamily = new FontFamily(fontImageSource.FontFamily);
 			}
 
 			return Task.FromResult(image);
@@ -78,10 +81,12 @@ namespace Xamarin.Forms.Platform.UWP
 				image = new FontIcon
 				{
 					Glyph = fontImageSource.Glyph,
-					FontFamily = new FontFamily(fontImageSource.FontFamily),
 					FontSize = fontImageSource.Size,
 					Foreground = fontImageSource.Color.ToBrush()
 				};
+
+				if (!string.IsNullOrEmpty(fontImageSource.FontFamily))
+					((FontIcon)image).FontFamily = new FontFamily(fontImageSource.FontFamily);
 			}
 
 			return Task.FromResult(image);


### PR DESCRIPTION
### Description of Change ###

Testing this PR https://github.com/xamarin/Xamarin.Forms/pull/9915 I have found an exception creating FontIcons.
Fixed exception creating a FontFamily with an empty font name using a **FontIcon** in **UWP**.

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and go to the Shell Store sample. Open the Flyout menu. If no exception is thrown by opening the Flyout the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
