### PR TITLE
Fix-9952 On<iOS>().SetHideNavigationBarSeparator(true) does not work on Xamarin.Forms latest stable version (4.5.0.356)

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -55,7 +55,6 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -55,6 +55,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -30,8 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 		nfloat _navigationBottom = 0;
 		bool _hasNavigationBar;
 		UIImage _defaultNavBarShadowImage;
-		UIImage _defaultNavBarBackImage;
-		UIColor _defaultSeparatorColor;
+		UIImage _defaultNavBarBackImage;		
 
 		[Preserve(Conditional = true)]
 		public NavigationRenderer() : base(typeof(FormsNavigationBar), null)
@@ -479,11 +478,6 @@ namespace Xamarin.Forms.Platform.iOS
 #if __XCODE11__
 			if (Forms.IsiOS13OrNewer)
 			{
-				if (_defaultSeparatorColor == null)
-				{
-					_defaultSeparatorColor = NavigationBar.StandardAppearance.ShadowColor;
-				}
-
 				if (shouldHide)
 				{
 					NavigationBar.CompactAppearance.ShadowColor = UIColor.Clear;
@@ -492,9 +486,9 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 				else
 				{
-					NavigationBar.CompactAppearance.ShadowColor = _defaultSeparatorColor;
-					NavigationBar.StandardAppearance.ShadowColor = _defaultSeparatorColor;
-					NavigationBar.ScrollEdgeAppearance.ShadowColor = _defaultSeparatorColor;
+					NavigationBar.CompactAppearance.ShadowColor = UIColor.FromRGBA(0, 0, 0, 76); //default ios13 shadow color
+					NavigationBar.StandardAppearance.ShadowColor = UIColor.FromRGBA(0, 0, 0, 76);					
+					NavigationBar.ScrollEdgeAppearance.ShadowColor = UIColor.FromRGBA(0, 0, 0, 76);					
 				}
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -475,10 +475,24 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_defaultNavBarShadowImage == null)
 				_defaultNavBarShadowImage = NavigationBar.ShadowImage;
 
-			if (shouldHide)
-				NavigationBar.ShadowImage = new UIImage();
+#if __XCODE11__
+			if (Forms.IsiOS13OrNewer)
+			{
+				if (shouldHide)
+				{
+					NavigationBar.CompactAppearance.ShadowColor = UIColor.Clear;
+					NavigationBar.StandardAppearance.ShadowColor = UIColor.Clear;
+					NavigationBar.ScrollEdgeAppearance.ShadowColor = UIColor.Clear;
+				}					
+			}
 			else
-				NavigationBar.ShadowImage = _defaultNavBarShadowImage;
+#endif
+			{
+				if (shouldHide)
+					NavigationBar.ShadowImage = new UIImage();
+				else
+					NavigationBar.ShadowImage = _defaultNavBarShadowImage;
+			}
 
 			if (!Forms.IsiOS11OrNewer)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -31,6 +31,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _hasNavigationBar;
 		UIImage _defaultNavBarShadowImage;
 		UIImage _defaultNavBarBackImage;
+		UIColor _defaultSeparatorColor;
 
 		[Preserve(Conditional = true)]
 		public NavigationRenderer() : base(typeof(FormsNavigationBar), null)
@@ -478,12 +479,23 @@ namespace Xamarin.Forms.Platform.iOS
 #if __XCODE11__
 			if (Forms.IsiOS13OrNewer)
 			{
+				if (_defaultSeparatorColor == null)
+				{
+					_defaultSeparatorColor = NavigationBar.StandardAppearance.ShadowColor;
+				}
+
 				if (shouldHide)
 				{
 					NavigationBar.CompactAppearance.ShadowColor = UIColor.Clear;
 					NavigationBar.StandardAppearance.ShadowColor = UIColor.Clear;
 					NavigationBar.ScrollEdgeAppearance.ShadowColor = UIColor.Clear;
-				}					
+				}
+				else
+				{
+					NavigationBar.CompactAppearance.ShadowColor = _defaultSeparatorColor;
+					NavigationBar.StandardAppearance.ShadowColor = _defaultSeparatorColor;
+					NavigationBar.ScrollEdgeAppearance.ShadowColor = _defaultSeparatorColor;
+				}
 			}
 			else
 #endif


### PR DESCRIPTION
### Description of Change ###

[Bug] On().SetHideNavigationBarSeparator(true) does not work on Xamarin.Forms latest stable version (4.5.0.356) and latest preview version (4.6.379-pre1), it works well on 4.4.0.991757. 

### Issues Resolved ### 


- fixes #9952 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->


- iOS



### Behavioral/Visual Changes ###


Separator is not visible

### Before/After Screenshots ### 
![separator](https://user-images.githubusercontent.com/17849938/76772537-b90d1e00-67a9-11ea-9314-3f1bc2832695.gif)




### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
