### PR TITLE
[iOS] Fix initial wrong RefreshColor in RefreshView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshScrollViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshScrollViewGallery.xaml.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
 		public RefreshScrollViewGallery()
 		{
 			InitializeComponent();
-			BindingContext = new RefreshViewModel();
+			BindingContext = new RefreshViewModel(true);
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
@@ -62,11 +62,15 @@ namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
 		bool _isRefresing;
 		ObservableCollection<RefreshItem> _items;
 		
-		public RefreshViewModel()
+		public RefreshViewModel(bool initialRefresh = false)
 		{
 			_random = new Random();
 			Items = new ObservableCollection<RefreshItem>();
-			LoadItems();
+
+			if (initialRefresh)
+				ExecuteRefresh();
+			else
+				LoadItems();
 		}
 
 		public bool IsRefreshing

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -25,15 +25,14 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Element != null && Element.IsRefreshing != _isRefreshing)
 					Element.SetValueFromRenderer(RefreshView.IsRefreshingProperty, _isRefreshing);
 
-
 				if (_isRefreshing != _refreshControl.Refreshing)
 				{
+					TryOffsetRefresh(this, IsRefreshing);
+
 					if (_isRefreshing)
 						_refreshControl.BeginRefreshing();
 					else
 						_refreshControl.EndRefreshing();
-
-					TryOffsetRefresh(this, IsRefreshing);
 				}
 			}
 		}
@@ -68,8 +67,8 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			UpdateColors();
-			UpdateIsRefreshing();
 			UpdateIsEnabled();
+			UpdateIsRefreshing();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -27,12 +27,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_isRefreshing != _refreshControl.Refreshing)
 				{
-					TryOffsetRefresh(this, IsRefreshing);
-
 					if (_isRefreshing)
+					{
+						TryOffsetRefresh(this, IsRefreshing);
 						_refreshControl.BeginRefreshing();
+					}
 					else
+					{
 						_refreshControl.EndRefreshing();
+						TryOffsetRefresh(this, IsRefreshing);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Fix initial wrong RefreshColor in RefreshView.

### Issues Resolved ### 

- fixes #8940

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue8940-before](https://user-images.githubusercontent.com/6755973/76967789-2777ea80-6928-11ea-85ef-7d2b9c14fe32.gif)

#### After
![issue8940-after](https://user-images.githubusercontent.com/6755973/76967793-28a91780-6928-11ea-895d-b18815e62c20.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the RefreshView samples. Select the sample using a ScrollView and verify that the initial RefreshColor is not the default one (black).

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
