### PR TITLE
[iOS] Fixed scroll issue disabling a RefreshView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/IsEnabledRefreshViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/IsEnabledRefreshViewGallery.xaml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries.IsEnabledRefreshViewGallery"
+    Title="Is enabled">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <RefreshView
+                Grid.Row="0"
+                x:Name="RefreshContainer"
+                IsRefreshing="{Binding IsRefreshing}"
+                RefreshColor="Pink"
+                Command="{Binding RefreshCommand}"
+                HorizontalOptions="FillAndExpand"
+                VerticalOptions="FillAndExpand">
+                <CollectionView
+                    ItemsSource="{Binding Items}">
+                    <CollectionView.ItemTemplate>
+                         <DataTemplate>
+                             <ScrollView>
+                                 <Grid>
+                                     <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="48" />
+                                        <ColumnDefinition Width="*" />
+                                     </Grid.ColumnDefinitions>
+                                     <BoxView
+                                        Grid.Column="0"
+                                        Color="{Binding Color}"
+                                        HeightRequest="48"/>
+                                     <Label
+                                        Grid.Column="1"
+                                        Text="{Binding Name}"/>
+                                 </Grid>
+                            </ScrollView>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </RefreshView>
+            <Grid
+                Grid.Row="1">
+                <Button
+                    x:Name="IsEnabledBtn"
+                    Text="Disable RefreshView"
+                    Clicked="IsEnabledBtnClicked"/>
+            </Grid>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/IsEnabledRefreshViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/IsEnabledRefreshViewGallery.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
+{
+	public partial class IsEnabledRefreshViewGallery : ContentPage
+	{
+		public IsEnabledRefreshViewGallery()
+		{
+			InitializeComponent();
+			BindingContext = new RefreshViewModel();
+		}
+
+		void IsEnabledBtnClicked(object sender, EventArgs e)
+		{
+			var button = (Button)sender;
+
+			if (RefreshContainer.IsEnabled)
+			{
+				button.Text = "Enable RefreshView";
+				RefreshContainer.IsEnabled = false;
+				Title = "Is disabled";
+			}
+			else
+			{
+				button.Text = "Disable RefreshView";
+				RefreshContainer.IsEnabled = true;
+				Title = "Is enabled";
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCollectionViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshCollectionViewGallery.xaml
@@ -5,7 +5,7 @@
     x:Class="Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries.RefreshCollectionViewGallery"
     Title="CollectionView (Pull To Refresh)">
     <ContentPage.Content>
-        <RefreshView
+        <RefreshView 
             IsRefreshing="{Binding IsRefreshing}"
             RefreshColor="Pink"
             Command="{Binding RefreshCommand}"

--- a/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RefreshViewGalleries/RefreshViewGallery.cs
@@ -29,7 +29,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.RefreshViewGalleries
 					GalleryBuilder.NavButton("Refresh ListView Gallery", () => new RefreshListViewGallery(), Navigation),
 					GalleryBuilder.NavButton("Refresh CollectionView Gallery", () => new RefreshCollectionViewGallery(), Navigation),
 					GalleryBuilder.NavButton("Refresh CarouselView Gallery", () => new RefreshCarouselViewGallery(), Navigation),
-					GalleryBuilder.NavButton("Refresh WebView Gallery", () => new RefreshWebViewGallery(), Navigation)
+					GalleryBuilder.NavButton("Refresh WebView Gallery", () => new RefreshWebViewGallery(), Navigation),
+					GalleryBuilder.NavButton("IsEnabled RefreshView Gallery", () => new IsEnabledRefreshViewGallery(), Navigation)
 				}
 			};
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -205,6 +205,8 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_refreshControl.Superview != null)
 					_refreshControl.RemoveFromSuperview();
 			}
+
+			UserInteractionEnabled = true;
 		}
 
 		bool CanUseRefreshControlProperty()


### PR DESCRIPTION
### Description of Change ###

If you have a RefreshView with a ScrollView (or other scrollable content) inside and `IsEnabled` on the RefreshView is set to False you can't scroll anymore on iOS. This PR fix the scroll issues disabling a RefreshView.

### Issues Resolved ### 

- fixes #9232 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 
![fix9232-small](https://user-images.githubusercontent.com/6755973/76976487-4ed4b480-6934-11ea-8f4f-97e3f2204df3.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to RefreshView samples. Select the "RefreshView IsEnabled Gallery". Enable/disable the RefreshView and verify that the interaction with the list continues working.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
