### PR TITLE
Fix 9997 [Bug] iOS Frame Shadow memory leak

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -98,6 +98,21 @@ namespace Xamarin.Forms.Platform.iOS
 			base.LayoutSubviews();
 		}
 
+		protected override void Dispose(bool disposing)
+		{
+			base.Dispose(disposing);
+			if (disposing)
+			{
+				if (_shadowView != null)
+				{
+					_shadowView.RemoveFromSuperview();
+					_shadowView.Dispose();
+					_shadowView = null;
+				}
+			}
+		}
+
+
 		[Preserve(Conditional = true)]
 		class ShadowView : UIView
 		{


### PR DESCRIPTION
### Description of Change ###

When using a FlexLayout with a TemplateSelector, rendering of the items in the collection becomes corrupted when switching between different collections.
 Actually the problem is not with Flexlayout but with disposing of shadow view for a Frame control.

### Issues Resolved ### 

- fixes #9997 

### API Changes ###

 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->


- iOS


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 

![swap](https://user-images.githubusercontent.com/17849938/76981237-f9ec6a80-6942-11ea-8c03-ab3d64e4d427.gif)


### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
