### PR TITLE
Fix 9265 [iOS] Frame BackgroundColor overflows CornerRadius

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -46,6 +46,7 @@ namespace Xamarin.Forms.Platform.iOS
 				cornerRadius = 5f; // default corner radius
 
 			Layer.CornerRadius = cornerRadius;
+			Layer.MasksToBounds = Layer.CornerRadius > 0;
 
 			if (Element.BackgroundColor == Color.Default)
 				Layer.BackgroundColor = UIColor.White.CGColor;


### PR DESCRIPTION
### Description of Change ###

Setting a BackgroundColor for a Frame on iOS causes the background color to draw outside of the Frame's rounded corners.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9265, #9774


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS


### Behavioral/Visual Changes ###
Background color does not overflow Frame's rounded corners



### Before/After Screenshots ### 

![Simulator Screen Shot - iPhone 8 - 2020-03-19 at 12 47 04](https://user-images.githubusercontent.com/17849938/77059635-e80cd500-69df-11ea-91de-71bac7e134f4.png)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
