### PR TITLE
Remove all uses of md5

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
@@ -12,6 +12,7 @@ using FileMode = System.IO.FileMode;
 using FileAccess = System.IO.FileAccess;
 using FileShare = System.IO.FileShare;
 using Stream = System.IO.Stream;
+using Xamarin.Forms.Internals;
 
 [assembly:Dependency (typeof(MockDeserializer))]
 [assembly:Dependency (typeof(MockResourcesProvider))]
@@ -44,6 +45,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			return Internals.Crc64.GetHash(input);
 		}
+
+		string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 		static int hex (int v)
 		{

--- a/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
@@ -40,18 +40,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			_isInvokeRequired = isInvokeRequired;
 		}
 
-		static MD5CryptoServiceProvider checksum = new MD5CryptoServiceProvider ();
-
-		public string GetMD5Hash (string input)
+		public string GetHash (string input)
 		{
-			var bytes = checksum.ComputeHash (Encoding.UTF8.GetBytes (input));
-			var ret = new char [32];
-			for (int i = 0; i < 16; i++){
-				ret [i*2] = (char)hex (bytes [i] >> 4);
-				ret [i*2+1] = (char)hex (bytes [i] & 0xf);
-			}
-			return new string (ret);
+			return Internals.Crc64.GetHash(input);
 		}
+
 		static int hex (int v)
 		{
 			if (v < 10)

--- a/Xamarin.Forms.Core.UnitTests/UriImageSourceTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/UriImageSourceTests.cs
@@ -128,16 +128,16 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void UrlHashKeyAreTheSame ()
 		{
-			var urlHash1 = Device.PlatformServices.GetMD5Hash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasdasdasdasd");
-			var urlHash2 = Device.PlatformServices.GetMD5Hash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasdasdasdasd");
+			var urlHash1 = Device.PlatformServices.GetHash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasdasdasdasd");
+			var urlHash2 = Device.PlatformServices.GetHash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasdasdasdasd");
 			Assert.IsTrue (urlHash1 == urlHash2);
 		}
 
 		[Test]
 		public void UrlHashKeyAreNotTheSame ()
 		{
-			var urlHash1 = Device.PlatformServices.GetMD5Hash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasdasdasdasd");
-			var urlHash2 = Device.PlatformServices.GetMD5Hash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasda");
+			var urlHash1 = Device.PlatformServices.GetHash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasdasdasdasd");
+			var urlHash2 = Device.PlatformServices.GetHash ("http://www.optipess.com/wp-content/uploads/2010/08/02_Bad-Comics6-10.png?a=bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbasdasdasdasdasasdasda");
 			Assert.IsTrue (urlHash1 != urlHash2);
 		}
 

--- a/Xamarin.Forms.Core/Crc64.cs
+++ b/Xamarin.Forms.Core/Crc64.cs
@@ -1,0 +1,224 @@
+﻿#if !NETSTANDARD1_0
+
+using System;
+using System.Runtime.InteropServices;
+using System.Security.Cryptography;
+using System.Text;
+
+/// <summary>
+/// https://github.com/xamarin/java.interop/blob/master/src/Java.Interop.Tools.JavaCallableWrappers/Java.Interop.Tools.JavaCallableWrappers/Crc64.cs
+/// </summary>
+namespace Xamarin.Forms.Internals
+{
+	/// <summary>
+	///  CRC64 variant: crc-64-jones 64-bit
+	///  * Poly: 0xad93d23594c935a9
+	///  Changes beyond initial implementation:
+	///  * Starting Value: ulong.MaxValue
+	///  * XOR length in HashFinal()
+	/// </summary>
+	internal class Crc64 : HashAlgorithm
+	{
+		static Crc64 _instance;
+		public static Crc64 Instance
+		{
+			get
+			{
+				if (_instance == null)
+					_instance = new Crc64();
+
+				return _instance;
+			}
+		}
+
+		Crc64() { }
+
+		static readonly ulong[] Table = {
+			0x0000000000000000, 0x7ad870c830358979,
+			0xf5b0e190606b12f2, 0x8f689158505e9b8b,
+			0xc038e5739841b68f, 0xbae095bba8743ff6,
+			0x358804e3f82aa47d, 0x4f50742bc81f2d04,
+			0xab28ecb46814fe75, 0xd1f09c7c5821770c,
+			0x5e980d24087fec87, 0x24407dec384a65fe,
+			0x6b1009c7f05548fa, 0x11c8790fc060c183,
+			0x9ea0e857903e5a08, 0xe478989fa00bd371,
+			0x7d08ff3b88be6f81, 0x07d08ff3b88be6f8,
+			0x88b81eabe8d57d73, 0xf2606e63d8e0f40a,
+			0xbd301a4810ffd90e, 0xc7e86a8020ca5077,
+			0x4880fbd87094cbfc, 0x32588b1040a14285,
+			0xd620138fe0aa91f4, 0xacf86347d09f188d,
+			0x2390f21f80c18306, 0x594882d7b0f40a7f,
+			0x1618f6fc78eb277b, 0x6cc0863448deae02,
+			0xe3a8176c18803589, 0x997067a428b5bcf0,
+			0xfa11fe77117cdf02, 0x80c98ebf2149567b,
+			0x0fa11fe77117cdf0, 0x75796f2f41224489,
+			0x3a291b04893d698d, 0x40f16bccb908e0f4,
+			0xcf99fa94e9567b7f, 0xb5418a5cd963f206,
+			0x513912c379682177, 0x2be1620b495da80e,
+			0xa489f35319033385, 0xde51839b2936bafc,
+			0x9101f7b0e12997f8, 0xebd98778d11c1e81,
+			0x64b116208142850a, 0x1e6966e8b1770c73,
+			0x8719014c99c2b083, 0xfdc17184a9f739fa,
+			0x72a9e0dcf9a9a271, 0x08719014c99c2b08,
+			0x4721e43f0183060c, 0x3df994f731b68f75,
+			0xb29105af61e814fe, 0xc849756751dd9d87,
+			0x2c31edf8f1d64ef6, 0x56e99d30c1e3c78f,
+			0xd9810c6891bd5c04, 0xa3597ca0a188d57d,
+			0xec09088b6997f879, 0x96d1784359a27100,
+			0x19b9e91b09fcea8b, 0x636199d339c963f2,
+			0xdf7adabd7a6e2d6f, 0xa5a2aa754a5ba416,
+			0x2aca3b2d1a053f9d, 0x50124be52a30b6e4,
+			0x1f423fcee22f9be0, 0x659a4f06d21a1299,
+			0xeaf2de5e82448912, 0x902aae96b271006b,
+			0x74523609127ad31a, 0x0e8a46c1224f5a63,
+			0x81e2d7997211c1e8, 0xfb3aa75142244891,
+			0xb46ad37a8a3b6595, 0xceb2a3b2ba0eecec,
+			0x41da32eaea507767, 0x3b024222da65fe1e,
+			0xa2722586f2d042ee, 0xd8aa554ec2e5cb97,
+			0x57c2c41692bb501c, 0x2d1ab4dea28ed965,
+			0x624ac0f56a91f461, 0x1892b03d5aa47d18,
+			0x97fa21650afae693, 0xed2251ad3acf6fea,
+			0x095ac9329ac4bc9b, 0x7382b9faaaf135e2,
+			0xfcea28a2faafae69, 0x8632586aca9a2710,
+			0xc9622c4102850a14, 0xb3ba5c8932b0836d,
+			0x3cd2cdd162ee18e6, 0x460abd1952db919f,
+			0x256b24ca6b12f26d, 0x5fb354025b277b14,
+			0xd0dbc55a0b79e09f, 0xaa03b5923b4c69e6,
+			0xe553c1b9f35344e2, 0x9f8bb171c366cd9b,
+			0x10e3202993385610, 0x6a3b50e1a30ddf69,
+			0x8e43c87e03060c18, 0xf49bb8b633338561,
+			0x7bf329ee636d1eea, 0x012b592653589793,
+			0x4e7b2d0d9b47ba97, 0x34a35dc5ab7233ee,
+			0xbbcbcc9dfb2ca865, 0xc113bc55cb19211c,
+			0x5863dbf1e3ac9dec, 0x22bbab39d3991495,
+			0xadd33a6183c78f1e, 0xd70b4aa9b3f20667,
+			0x985b3e827bed2b63, 0xe2834e4a4bd8a21a,
+			0x6debdf121b863991, 0x1733afda2bb3b0e8,
+			0xf34b37458bb86399, 0x8993478dbb8deae0,
+			0x06fbd6d5ebd3716b, 0x7c23a61ddbe6f812,
+			0x3373d23613f9d516, 0x49aba2fe23cc5c6f,
+			0xc6c333a67392c7e4, 0xbc1b436e43a74e9d,
+			0x95ac9329ac4bc9b5, 0xef74e3e19c7e40cc,
+			0x601c72b9cc20db47, 0x1ac40271fc15523e,
+			0x5594765a340a7f3a, 0x2f4c0692043ff643,
+			0xa02497ca54616dc8, 0xdafce7026454e4b1,
+			0x3e847f9dc45f37c0, 0x445c0f55f46abeb9,
+			0xcb349e0da4342532, 0xb1eceec59401ac4b,
+			0xfebc9aee5c1e814f, 0x8464ea266c2b0836,
+			0x0b0c7b7e3c7593bd, 0x71d40bb60c401ac4,
+			0xe8a46c1224f5a634, 0x927c1cda14c02f4d,
+			0x1d148d82449eb4c6, 0x67ccfd4a74ab3dbf,
+			0x289c8961bcb410bb, 0x5244f9a98c8199c2,
+			0xdd2c68f1dcdf0249, 0xa7f41839ecea8b30,
+			0x438c80a64ce15841, 0x3954f06e7cd4d138,
+			0xb63c61362c8a4ab3, 0xcce411fe1cbfc3ca,
+			0x83b465d5d4a0eece, 0xf96c151de49567b7,
+			0x76048445b4cbfc3c, 0x0cdcf48d84fe7545,
+			0x6fbd6d5ebd3716b7, 0x15651d968d029fce,
+			0x9a0d8ccedd5c0445, 0xe0d5fc06ed698d3c,
+			0xaf85882d2576a038, 0xd55df8e515432941,
+			0x5a3569bd451db2ca, 0x20ed197575283bb3,
+			0xc49581ead523e8c2, 0xbe4df122e51661bb,
+			0x3125607ab548fa30, 0x4bfd10b2857d7349,
+			0x04ad64994d625e4d, 0x7e7514517d57d734,
+			0xf11d85092d094cbf, 0x8bc5f5c11d3cc5c6,
+			0x12b5926535897936, 0x686de2ad05bcf04f,
+			0xe70573f555e26bc4, 0x9ddd033d65d7e2bd,
+			0xd28d7716adc8cfb9, 0xa85507de9dfd46c0,
+			0x273d9686cda3dd4b, 0x5de5e64efd965432,
+			0xb99d7ed15d9d8743, 0xc3450e196da80e3a,
+			0x4c2d9f413df695b1, 0x36f5ef890dc31cc8,
+			0x79a59ba2c5dc31cc, 0x037deb6af5e9b8b5,
+			0x8c157a32a5b7233e, 0xf6cd0afa9582aa47,
+			0x4ad64994d625e4da, 0x300e395ce6106da3,
+			0xbf66a804b64ef628, 0xc5bed8cc867b7f51,
+			0x8aeeace74e645255, 0xf036dc2f7e51db2c,
+			0x7f5e4d772e0f40a7, 0x05863dbf1e3ac9de,
+			0xe1fea520be311aaf, 0x9b26d5e88e0493d6,
+			0x144e44b0de5a085d, 0x6e963478ee6f8124,
+			0x21c640532670ac20, 0x5b1e309b16452559,
+			0xd476a1c3461bbed2, 0xaeaed10b762e37ab,
+			0x37deb6af5e9b8b5b, 0x4d06c6676eae0222,
+			0xc26e573f3ef099a9, 0xb8b627f70ec510d0,
+			0xf7e653dcc6da3dd4, 0x8d3e2314f6efb4ad,
+			0x0256b24ca6b12f26, 0x788ec2849684a65f,
+			0x9cf65a1b368f752e, 0xe62e2ad306bafc57,
+			0x6946bb8b56e467dc, 0x139ecb4366d1eea5,
+			0x5ccebf68aecec3a1, 0x2616cfa09efb4ad8,
+			0xa97e5ef8cea5d153, 0xd3a62e30fe90582a,
+			0xb0c7b7e3c7593bd8, 0xca1fc72bf76cb2a1,
+			0x45775673a732292a, 0x3faf26bb9707a053,
+			0x70ff52905f188d57, 0x0a2722586f2d042e,
+			0x854fb3003f739fa5, 0xff97c3c80f4616dc,
+			0x1bef5b57af4dc5ad, 0x61372b9f9f784cd4,
+			0xee5fbac7cf26d75f, 0x9487ca0fff135e26,
+			0xdbd7be24370c7322, 0xa10fceec0739fa5b,
+			0x2e675fb4576761d0, 0x54bf2f7c6752e8a9,
+			0xcdcf48d84fe75459, 0xb71738107fd2dd20,
+			0x387fa9482f8c46ab, 0x42a7d9801fb9cfd2,
+			0x0df7adabd7a6e2d6, 0x772fdd63e7936baf,
+			0xf8474c3bb7cdf024, 0x829f3cf387f8795d,
+			0x66e7a46c27f3aa2c, 0x1c3fd4a417c62355,
+			0x935745fc4798b8de, 0xe98f353477ad31a7,
+			0xa6df411fbfb21ca3, 0xdc0731d78f8795da,
+			0x536fa08fdfd90e51, 0x29b7d047efec8728,
+		};
+
+		ulong crc = ulong.MaxValue;
+		ulong length = 0;
+
+		public override void Initialize()
+		{
+			crc = ulong.MaxValue;
+			length = 0;
+		}
+
+		protected override void HashCore(byte[] array, int ibStart, int cbSize)
+		{
+			for (int i = ibStart; i < cbSize; i++)
+			{
+				crc = Table[(byte)(crc ^ array[i])] ^ (crc >> 8);
+			}
+			length += (ulong)cbSize;
+		}
+
+		protected override byte[] HashFinal() => BitConverter.GetBytes(crc ^ length);
+
+
+
+		// https://stackoverflow.com/questions/311165/how-do-you-convert-a-byte-array-to-a-hexadecimal-string-and-vice-versa/24343727#24343727
+		static readonly uint[] _lookup32 = CreateLookup32();
+
+		static uint[] CreateLookup32()
+		{
+			var result = new uint[256];
+			for (int i = 0; i < 256; i++)
+			{
+				string s = i.ToString("X2");
+				result[i] = ((uint)s[0]) + ((uint)s[1] << 16);
+			}
+			return result;
+		}
+
+		static string ByteArrayToHexViaLookup32(byte[] bytes)
+		{
+			var lookup32 = _lookup32;
+			var result = new char[bytes.Length * 2];
+			for (int i = 0; i < bytes.Length; i++)
+			{
+				var val = lookup32[bytes[i]];
+				result[2 * i] = (char)val;
+				result[2 * i + 1] = (char)(val >> 16);
+			}
+			return new string(result);
+		}
+
+		public static string GetHash(string input)
+		{
+			byte[] bytes = Instance.ComputeHash(Encoding.UTF8.GetBytes(input));
+			return ByteArrayToHexViaLookup32(bytes);
+		}
+
+	}
+}
+#endif

--- a/Xamarin.Forms.Core/IPlatformServices.cs
+++ b/Xamarin.Forms.Core/IPlatformServices.cs
@@ -19,6 +19,9 @@ namespace Xamarin.Forms.Internals
 
 		Assembly[] GetAssemblies();
 
+		string GetHash(string input);
+
+		[Obsolete("GetMD5Hash is obsolete as of version 4.7.0")]
 		string GetMD5Hash(string input);
 
 		double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes);

--- a/Xamarin.Forms.Core/UriImageSource.cs
+++ b/Xamarin.Forms.Core/UriImageSource.cs
@@ -101,7 +101,7 @@ namespace Xamarin.Forms
 
 		static string GetCacheKey(Uri uri)
 		{
-			return Device.PlatformServices.GetMD5Hash(uri.AbsoluteUri);
+			return Device.PlatformServices.GetHash(uri.AbsoluteUri);
 		}
 
 		async Task<bool> GetHasLocallyCachedCopyAsync(string key, bool checkValidity = true)

--- a/Xamarin.Forms.DualScreen.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/MockPlatformServices.cs
@@ -40,11 +40,9 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			_isInvokeRequired = isInvokeRequired;
 		}
 
-		static MD5CryptoServiceProvider checksum = new MD5CryptoServiceProvider();
-
-		public string GetMD5Hash(string input)
+		public string GetHash(string input)
 		{
-			var bytes = checksum.ComputeHash(Encoding.UTF8.GetBytes(input));
+			var bytes = Internals.Crc64.Instance.ComputeHash(Encoding.UTF8.GetBytes(input));
 			var ret = new char[32];
 			for (int i = 0; i < 16; i++)
 			{

--- a/Xamarin.Forms.DualScreen.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/MockPlatformServices.cs
@@ -12,6 +12,7 @@ using FileAccess = System.IO.FileAccess;
 using FileShare = System.IO.FileShare;
 using Stream = System.IO.Stream;
 using Xamarin.Forms.DualScreen.UnitTests;
+using Xamarin.Forms.Internals;
 
 [assembly: Dependency(typeof(MockDeserializer))]
 [assembly: Dependency(typeof(MockResourcesProvider))]
@@ -40,17 +41,9 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			_isInvokeRequired = isInvokeRequired;
 		}
 
-		public string GetHash(string input)
-		{
-			var bytes = Internals.Crc64.Instance.ComputeHash(Encoding.UTF8.GetBytes(input));
-			var ret = new char[32];
-			for (int i = 0; i < 16; i++)
-			{
-				ret[i * 2] = (char)hex(bytes[i] >> 4);
-				ret[i * 2 + 1] = (char)hex(bytes[i] & 0xf);
-			}
-			return new string(ret);
-		}
+		public string GetHash(string input) => Internals.Crc64.GetHash(input);
+		string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
+
 		static int hex(int v)
 		{
 			if (v < 10)

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -610,7 +610,6 @@ namespace Xamarin.Forms
 
 		class AndroidPlatformServices : IPlatformServices
 		{
-			static readonly MD5CryptoServiceProvider Checksum = new MD5CryptoServiceProvider();
 			double _buttonDefaultSize;
 			double _editTextDefaultSize;
 			double _labelDefaultSize;
@@ -655,17 +654,9 @@ namespace Xamarin.Forms
 				return AppDomain.CurrentDomain.GetAssemblies();
 			}
 
-			public string GetMD5Hash(string input)
-			{
-				byte[] bytes = Checksum.ComputeHash(Encoding.UTF8.GetBytes(input));
-				var ret = new char[32];
-				for (var i = 0; i < 16; i++)
-				{
-					ret[i * 2] = (char)Hex(bytes[i] >> 4);
-					ret[i * 2 + 1] = (char)Hex(bytes[i] & 0xf);
-				}
-				return new string(ret);
-			}
+			public string GetHash(string input) => Crc64.GetHash(input);
+
+			string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 			public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 			{

--- a/Xamarin.Forms.Platform.Android/ResourceManager.cs
+++ b/Xamarin.Forms.Platform.Android/ResourceManager.cs
@@ -219,7 +219,7 @@ namespace Xamarin.Forms.Platform.Android
 					// volley the requests better up front so that if the same request comes in it isn't requeued
 					if (initialSource is UriImageSource uri && uri.CachingEnabled)
 					{
-						cacheKey = Device.PlatformServices.GetMD5Hash(uri.Uri.ToString());
+						cacheKey = Device.PlatformServices.GetHash(uri.Uri.ToString());
 						var cacheObject = await GetCache().GetAsync(cacheKey, uri.CacheValidity, async () =>
 						{
 							var drawable = await context.GetFormsDrawableAsync(initialSource, cancellationToken);

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -42,6 +42,7 @@
     <AndroidResource Link="Resources\Layout\ShellContent.axml" Include="Resources\Layout\Android\ShellContent.axml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs" Link="Crc64.cs" />
     <Compile Include="..\Xamarin.Forms.Core\StreamWrapper.cs" Link="StreamWrapper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
@@ -12,8 +12,6 @@ namespace Xamarin.Forms.Platform.GTK
 {
 	internal class GtkPlatformServices : IPlatformServices
 	{
-		private static readonly MD5CryptoServiceProvider Checksum = new MD5CryptoServiceProvider();
-
 		public bool IsInvokeRequired => Thread.CurrentThread.IsBackground;
 
 		public string RuntimePlatform => Device.GTK;
@@ -33,17 +31,9 @@ namespace Xamarin.Forms.Platform.GTK
 			return AppDomain.CurrentDomain.GetAssemblies();
 		}
 
-		public string GetMD5Hash(string input)
-		{
-			var bytes = Checksum.ComputeHash(Encoding.UTF8.GetBytes(input));
-			var ret = new char[32];
-			for (var i = 0; i < 16; i++)
-			{
-				ret[i * 2] = (char)Hex(bytes[i] >> 4);
-				ret[i * 2 + 1] = (char)Hex(bytes[i] & 0xf);
-			}
-			return new string(ret);
-		}
+		public string GetHash(string input) => Crc64.GetHash(input);
+
+		string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -93,6 +93,9 @@
     <PackageReference Include="OpenTK" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs">
+      <Link>Crc64.cs</Link>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Core\StreamWrapper.cs">
       <Link>StreamWrapper.cs</Link>
     </Compile>

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -78,6 +78,9 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs">
+      <Link>Crc64.cs</Link>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Core\StreamWrapper.cs">
       <Link>StreamWrapper.cs</Link>
     </Compile>

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -15,8 +15,6 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	internal class TizenPlatformServices : IPlatformServices
 	{
-		static Lazy<MD5> checksum = new Lazy<MD5>(CreateChecksum);
-
 		static SynchronizationContext s_context;
 
 		public TizenPlatformServices()
@@ -158,18 +156,9 @@ namespace Xamarin.Forms.Platform.Tizen
 			return new TizenIsolatedStorageFile();
 		}
 
-		static readonly char[] HexDigits = { '0', '1', '2', '3', '4', '5', '6', '7', '8', '9', 'a', 'b', 'c', 'd', 'e', 'f' };
-		public string GetMD5Hash(string input)
-		{
-			byte[] bin = checksum.Value.ComputeHash(System.Text.Encoding.UTF8.GetBytes(input));
-			char[] hex = new char[32];
-			for (var i = 0; i < 16; ++i)
-			{
-				hex[2 * i] = HexDigits[bin[i] >> 4];
-				hex[2 * i + 1] = HexDigits[bin[i] & 0xf];
-			}
-			return new string(hex);
-		}
+		public string GetHash(string input) => Crc64.GetHash(input);
+
+		string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 		public void QuitApplication()
 		{
@@ -257,11 +246,6 @@ namespace Xamarin.Forms.Platform.Tizen
 		public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{
 			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
-		}
-
-		static MD5 CreateChecksum()
-		{
-			return MD5.Create();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
+++ b/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
@@ -15,6 +15,9 @@
     <None Remove="Resource\menu.png" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs" Link="Crc64.cs" />
+  </ItemGroup>
+  <ItemGroup>
     <EmbeddedResource Include="Resource\arrow_left.png" />
     <EmbeddedResource Include="Resource\dots_horizontal.png" />
     <EmbeddedResource Include="Resource\img_button_pause.png" />

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -91,12 +91,9 @@ namespace Xamarin.Forms.Platform.UWP
 			return assemblies.ToArray();
 		}
 
-		public string GetMD5Hash(string input)
-		{
-			HashAlgorithmProvider algorithm = HashAlgorithmProvider.OpenAlgorithm(HashAlgorithmNames.Md5);
-			IBuffer buffer = algorithm.HashData(Encoding.Unicode.GetBytes(input).AsBuffer());
-			return CryptographicBuffer.EncodeToHexString(buffer);
-		}
+		public string GetHash(string input) => Crc64.GetHash(input);
+
+		string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -105,6 +105,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs" Link="Crc64.cs" />
     <Compile Include="..\Xamarin.Forms.Core\StreamWrapper.cs" Link="StreamWrapper.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.WPF/Microsoft.Windows.Shell/Standard/Utilities.cs
+++ b/Xamarin.Forms.Platform.WPF/Microsoft.Windows.Shell/Standard/Utilities.cs
@@ -114,19 +114,6 @@ namespace Standard
             }
         }
 
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        public static string GetHashString(string value)
-        {
-            using (MD5 md5 = MD5.Create())
-            {
-                byte[] signatureHash = md5.ComputeHash(Encoding.UTF8.GetBytes(value));
-                string signature = signatureHash.Aggregate(
-                    new StringBuilder(),
-                    (sb, b) => sb.Append(b.ToString("x2", CultureInfo.InvariantCulture))).ToString();
-                return signature;
-            }
-        }
-
         // See: http://stackoverflow.com/questions/7913325/win-api-in-c-get-hi-and-low-word-from-intptr/7913393#7913393
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
         public static System.Windows.Point GetPoint(IntPtr ptr)
@@ -461,22 +448,6 @@ namespace Standard
 
             // Reset the Seek pointer before returning.
             destination.Position = 0;
-        }
-
-        [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]
-        public static string HashStreamMD5(Stream stm)
-        {
-            stm.Position = 0;
-            var hashBuilder = new StringBuilder();
-            using (MD5 md5 = MD5.Create())
-            {
-                foreach (byte b in md5.ComputeHash(stm))
-                {
-                    hashBuilder.Append(b.ToString("x2", CultureInfo.InvariantCulture));
-                }
-            }
-
-            return hashBuilder.ToString();
         }
 
         [SuppressMessage("Microsoft.Performance", "CA1811:AvoidUncalledPrivateCode")]

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -43,29 +43,9 @@ namespace Xamarin.Forms.Platform.WPF
 			return AppDomain.CurrentDomain.GetAssemblies();
 		}
 
-		public string GetMD5Hash(string input)
-		{
-			// MSDN - Documentation -https://msdn.microsoft.com/en-us/library/system.security.cryptography.md5(v=vs.110).aspx
-			using (MD5 md5Hash = MD5.Create()) 
-			{
-				// Convert the input string to a byte array and compute the hash.
-				byte[] data = md5Hash.ComputeHash(Encoding.UTF8.GetBytes(input));
+		public string GetHash(string input) => Crc64.GetHash(input);
 
-				// Create a new Stringbuilder to collect the bytes
-				// and create a string.
-				StringBuilder sBuilder = new StringBuilder();
-
-				// Loop through each byte of the hashed data 
-				// and format each one as a hexadecimal string.
-				for (int i = 0; i < data.Length; i++)
-				{
-					sBuilder.Append(data[i].ToString("x2"));
-				}
-
-				// Return the hexadecimal string.
-				return sBuilder.ToString();
-			}
-		}
+		string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 		public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 		{

--- a/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
+++ b/Xamarin.Forms.Platform.WPF/Xamarin.Forms.Platform.WPF.csproj
@@ -55,6 +55,9 @@
     <PackageReference Include="OpenTK.GLControl" Version="3.0.1" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs">
+      <Link>Crc64.cs</Link>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Platform.UAP\TextBlockExtensions.cs">
       <Link>Extensions\TextBlockExtensions.cs</Link>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -200,8 +200,6 @@ namespace Xamarin.Forms
 #endif
 			}
 
-			static readonly MD5CryptoServiceProvider s_checksum = new MD5CryptoServiceProvider();
-
 			public void BeginInvokeOnMainThread(Action action)
 			{
 				NSRunLoop.Main.BeginInvokeOnMainThread(action.Invoke);
@@ -217,17 +215,9 @@ namespace Xamarin.Forms
 				return AppDomain.CurrentDomain.GetAssemblies();
 			}
 
-			public string GetMD5Hash(string input)
-			{
-				var bytes = s_checksum.ComputeHash(Encoding.UTF8.GetBytes(input));
-				var ret = new char[32];
-				for (var i = 0; i < 16; i++)
-				{
-					ret[i * 2] = (char)Hex(bytes[i] >> 4);
-					ret[i * 2 + 1] = (char)Hex(bytes[i] & 0xf);
-				}
-				return new string(ret);
-			}
+			public string GetHash(string input) => Crc64.GetHash(input);
+
+			string IPlatformServices.GetMD5Hash(string input) => GetHash(input);
 
 			public double GetNamedSize(NamedSize size, Type targetElementType, bool useOldSizes)
 			{

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -113,6 +113,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Renderers\WebViewRenderer.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Properties\AssemblyInfo.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Extensions\CellExtensions.cs" />
+    <Compile Include="..\Xamarin.Forms.Core\Crc64.cs">
+      <Link>Crc64.cs</Link>
+    </Compile>
     <Compile Include="..\Xamarin.Forms.Core\StreamWrapper.cs">
       <Link>StreamWrapper.cs</Link>
     </Compile>


### PR DESCRIPTION
### Description of Change ###

Replace all uses of md5 for creating a hash. The only place we really use this is for hashing a uri so we have a consistent length to use for a hashkey


### API Changes ###

Added:
 - string IPlatformServices.GetHash

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Testing Procedure ###
- UI tests pass
- Images load and are cached

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
