### PR TITLE
[UWP] Make sure to call UpdateInitialPosition on CarouselView

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -272,7 +272,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			SetCurrentItem(position);
 			UpdatePosition(position);
-			UpdateFromPosition();
+			if (position > 0)
+				UpdateFromPosition();
 		}
 
 		void UpdatePositionFromScroll()

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -103,6 +103,8 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 
 			base.UpdateItemsSource();
+
+			UpdateInitialPosition();
 		}
 
 		protected override CollectionViewSource CreateCollectionViewSource()
@@ -270,6 +272,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			SetCurrentItem(position);
 			UpdatePosition(position);
+			UpdateFromPosition();
 		}
 
 		void UpdatePositionFromScroll()


### PR DESCRIPTION
### Description of Change ###

We need to call the correct position when CarouselView loads.

### Issues Resolved ### 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Shows go to the correct position on load.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Open CarouselView (Code, Horizontal) and make sure it goes to Position 1.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
