### PR TITLE
NotchMode on xamarin forms

### DIFF
--- a/Xamarin.Forms.Core/NotchMode.cs
+++ b/Xamarin.Forms.Core/NotchMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.Forms
+{
+	public enum NotchMode
+	{
+		PlatformDefault = 0,
+		UseFullScreen = 1,
+		SaveNotchArea = 2
+	}
+}

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -8,6 +8,9 @@ using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 namespace Xamarin.Forms
 {
@@ -41,6 +44,9 @@ namespace Xamarin.Forms
 		[Obsolete("IconProperty is obsolete as of 4.0.0. Please use IconImageSourceProperty instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static readonly BindableProperty IconProperty = IconImageSourceProperty;
+
+		public static readonly BindableProperty NotchModeProperty = BindableProperty.Create(nameof(NotchMode), typeof(NotchMode), typeof(Page), NotchMode.PlatformDefault, propertyChanged:(bo, o, n)=>((Page)bo).OnNotchModeChanged((NotchMode)n));
+
 
 		readonly Lazy<PlatformConfigurationRegistry<Page>> _platformConfigurationRegistry;
 
@@ -103,6 +109,12 @@ namespace Xamarin.Forms
 		{
 			get { return (bool)GetValue(IsBusyProperty); }
 			set { SetValue(IsBusyProperty, value); }
+		}
+
+		public NotchMode NotchMode
+		{
+			get => (NotchMode)GetValue(NotchModeProperty);
+			set => SetValue(NotchModeProperty, value);
 		}
 
 		public Thickness Padding
@@ -489,6 +501,12 @@ namespace Xamarin.Forms
 				return;
 			foreach (IElement item in args.NewItems)
 				item.Parent = this;
+		}
+
+		void OnNotchModeChanged(NotchMode newValue)
+		{
+			On<iOS>().SetUseSafeArea(newValue == NotchMode.SaveNotchArea);
+			On<Android>().SetCutoutMode((CutoutMode)(int)newValue);
 		}
 
 		bool ShouldLayoutChildren()

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/CutoutMode.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/CutoutMode.cs
@@ -1,0 +1,9 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	public enum CutoutMode
+	{
+		Default = 0,
+		ShortEdges = 1,
+		Never = 2
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Page.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/Page.cs
@@ -1,0 +1,32 @@
+﻿
+namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using Xamarin.Forms.PlatformConfiguration;
+	using FormsElement = Forms.Page;
+
+	public static class Page
+	{
+		public static bool AnyCutoutModeSet { get; private set; }
+
+		public static readonly BindableProperty CutoutModeProperty =
+			BindableProperty.Create("CutoutMode", typeof(CutoutMode), typeof(Page), CutoutMode.Default);
+
+		public static bool IsDefaultCutoutMode(this IPlatformElementConfiguration<Android, FormsElement> config) =>
+			GetCutoutMode(config.Element) == CutoutMode.Default;
+
+		public static CutoutMode GetCutoutMode(BindableObject element) =>
+			(CutoutMode)element.GetValue(CutoutModeProperty);
+
+		public static void SetCutoutMode(BindableObject element, CutoutMode value)
+		{
+			AnyCutoutModeSet = true;
+			element.SetValue(CutoutModeProperty, value);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetCutoutMode(this IPlatformElementConfiguration<Android, FormsElement> config, CutoutMode value)
+		{
+			SetCutoutMode(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -7,9 +7,11 @@ using Android.Support.V4.Content;
 using Android.Support.V7.Widget;
 using Android.Views;
 using Android.Views.Accessibility;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AColor = Android.Graphics.Color;
 using AColorRes = Android.Resource.Color;
 using AView = Android.Views.View;
+using ASpecificPage = Xamarin.Forms.PlatformConfiguration.AndroidSpecific.Page;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -59,6 +61,8 @@ namespace Xamarin.Forms.Platform.Android
 			var pageContainer = Parent as PageContainer;
 			if (pageContainer != null && (pageContainer.IsInFragment || pageContainer.Visibility == ViewStates.Gone))
 				return;
+
+			UpdateCutoutMode();
 			PageController.SendAppearing();
 		}
 
@@ -95,6 +99,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateBackground(false);
 			else if (e.PropertyName == VisualElement.HeightProperty.PropertyName)
 				UpdateHeight();
+			else if (e.PropertyName == ASpecificPage.CutoutModeProperty.PropertyName)
+				UpdateCutoutMode();
 		}
 
 		void UpdateHeight()
@@ -150,6 +156,22 @@ namespace Xamarin.Forms.Platform.Android
 					}
 				}
 			});
+		}
+
+		void UpdateCutoutMode()
+		{
+			if (Build.VERSION.SdkInt < BuildVersionCodes.P)
+				return;
+
+			var isDefaultCutoutMode = !Element.On<PlatformConfiguration.Android>().IsDefaultCutoutMode();
+			var anyCutoutModeSet = ASpecificPage.AnyCutoutModeSet;
+
+			if (isDefaultCutoutMode && !anyCutoutModeSet)
+				return;
+
+			var currentCutoutMode = ASpecificPage.GetCutoutMode(Element);
+			var activity = Context.GetActivity();
+			activity.Window.Attributes.LayoutInDisplayCutoutMode = (LayoutInDisplayCutoutMode)(int)currentCutoutMode;
 		}
 
 		void IOrderedTraversalController.UpdateTraversalOrder()


### PR DESCRIPTION
### Description of Change ###
I'm creating this Pr to suggest a way to manipulate Notch mode from xamarin forms, since android and IOS has an implementation of this feature.

**If this feature considered valid for Xamarin forms, I will include the Tests and images**

### Issues Resolved ### 
fixes #10090 

### API Changes ###

Added:
 - NochMode Page.NotchMode { get; set; } //Bindable Property
 - CutoutMode AndroidSpecific.Page.CutoutMode { get; set; }

 
### Platforms Affected ### 
- Core/XAML (all platforms)
- Android

### Behavioral/Visual Changes ###
When Page.NotchMode is set, the notch safe area will be manipulated.

- **NotchMode.PlatformDefault** will keep default platform behaviour ex: Ios UseSafeArea= false and Android LAYOUT_IN_DISPLAY_CUTOUT_MODE_DEFAULT

- **NotchMode.UseFullScreen** will use notch area ex: Ios UseSafeArea= false and Android LAYOUT_IN_DISPLAY_CUTOUT_MODE_SHORT_EDGES

- **NotchMode.SaveNotchArea** will use notch area ex: Ios UseSafeArea= true and Android LAYOUT_IN_DISPLAY_CUTOUT_MODE_NEVER

### Before/After Screenshots ### 
> I Will create it if this feature considered valid

### Testing Procedure ###
- Set Page.NotchMode = NotchMode.UseFullScreen and your page will use the notch area
- Set Page.NotchMode = NotchMode.SaveNotchArea and your page will save the notch area
- Set Page.NotchMode = NotchMode.DefaultPlatform and your page will keep the defaut platform behavior for the notch area

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
