### PR TITLE
Adds Color.FromHsva

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -242,6 +242,48 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void TestFromHsv()
+		{
+			var color = Color.FromRgb(1, .29, .752);
+			var colorHsv = Color.FromHsv(321, 71, 100);
+			Assert.That(color.R, Is.EqualTo(colorHsv.R).Within(0.001));
+			Assert.That(color.G, Is.EqualTo(colorHsv.G).Within(0.001));
+			Assert.That(color.B, Is.EqualTo(colorHsv.B).Within(0.001));
+		}
+
+		[Test]
+		public void TestFromHsva()
+		{
+			var color = Color.FromRgba(1, .29, .752, .5);
+			var colorHsv = Color.FromHsva(321, 71, 100, 50);
+			Assert.That(color.R, Is.EqualTo(colorHsv.R).Within(0.001));
+			Assert.That(color.G, Is.EqualTo(colorHsv.G).Within(0.001));
+			Assert.That(color.B, Is.EqualTo(colorHsv.B).Within(0.001));
+			Assert.That(color.A, Is.EqualTo(colorHsv.A).Within(0.001));
+		}
+
+		[Test]
+		public void TestFromHsvDouble()
+		{
+			var color = Color.FromRgb(1, .29, .758);
+			var colorHsv = Color.FromHsv(.89, .71, 1);
+			Assert.That(color.R, Is.EqualTo(colorHsv.R).Within(0.001));
+			Assert.That(color.G, Is.EqualTo(colorHsv.G).Within(0.001));
+			Assert.That(color.B, Is.EqualTo(colorHsv.B).Within(0.001));
+		}
+
+		[Test]
+		public void TestFromHsvaDouble()
+		{
+			var color = Color.FromRgba(1, .29, .758, .5);
+			var colorHsv = Color.FromHsva(.89, .71, 1, .5);
+			Assert.That(color.R, Is.EqualTo(colorHsv.R).Within(0.001));
+			Assert.That(color.G, Is.EqualTo(colorHsv.G).Within(0.001));
+			Assert.That(color.B, Is.EqualTo(colorHsv.B).Within(0.001));
+			Assert.That(color.A, Is.EqualTo(colorHsv.A).Within(0.001));
+		}
+
+		[Test]
 		public void FromRGBDouble ()
 		{
 			var color = Color.FromRgb (0.2, 0.3, 0.4);

--- a/Xamarin.Forms.Core/Color.cs
+++ b/Xamarin.Forms.Core/Color.cs
@@ -420,6 +420,49 @@ namespace Xamarin.Forms
 		{
 			return new Color(h, s, l, a, Mode.Hsl);
 		}
+
+		public static Color FromHsva(double h, double s, double v, double a)
+		{
+			h = h.Clamp(0, 1);
+			s = s.Clamp(0, 1);
+			v = v.Clamp(0, 1);
+			var range = (int)(Math.Floor(h * 6)) % 6;
+			var f = h * 6 - Math.Floor(h * 6);
+			var p = v * (1 - s);
+			var q = v * (1 - f * s);
+			var t = v * (1 - (1 - f) * s);
+
+			switch (range)
+			{
+				case 0:
+					return FromRgba(v, t, p, a);
+				case 1:
+					return FromRgba(q, v, p, a);
+				case 2:
+					return FromRgba(p, v, t, a);
+				case 3:
+					return FromRgba(p, q, v, a);
+				case 4:
+					return FromRgba(t, p, v, a);
+			}
+			return FromRgba(v, p, q, a);
+		}
+
+		public static Color FromHsv(double h, double s, double v)
+		{
+			return FromHsva(h, s, v, 1d);
+		}
+
+		public static Color FromHsva(int h, int s, int v, int a)
+		{
+			return FromHsva(h / 360d, s / 100d, v / 100d, a / 100d);
+		}
+
+		public static Color FromHsv(int h, int s, int v)
+		{
+			return FromHsva(h / 360d, s / 100d, v / 100d, 1d);
+		}
+
 #if !NETSTANDARD1_0
 		public static implicit operator System.Drawing.Color(Color color)
 		{


### PR DESCRIPTION
### Description of Change ###

This PR adds `Color.FromHsva()` to support **[HSV](https://en.wikipedia.org/wiki/HSL_and_HSV)** (Hue, Saturation, Value- also known as **HSB** - Hue, Saturation, Brightness) color space. Previously, `Xamarin.Forms.Color` could be created from RGB, HSL, HEX, and Uint values, but there was no way to generate them from HSV(HSB) values. 

HSV(HSB) is similar to HSL. They're both based on cylindrical geometries, but HSV is based on a "Hexacone" model while HSL is based on a "Bi-Hexacone" model. Read more about the differences on [wikipedia](https://en.wikipedia.org/wiki/HSL_and_HSV).

I don't want to extend `Color.Mode`, or make it heavier. I'd like to add only `Color.FromHsva()` method that can easily generate a `Color` from HSV values just like `Color.FromHex()` or `Color.FromUint()`.

### Issues Resolved ### 
None

### API Changes ###

Added:
 - Color Color.FromHsva(double h, double s, double v, double a); 
 - Color Color.FromHsv(double h, double s, double v);
 - Color Color.FromHsva(int h, int s, int v, int a); 
 - Color Color.FromHsv(int h, int s, int v);

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Run `ColorUnitTests`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [] Targets the correct branch
- [] Tests are passing (or failures are unrelated)
