### PR TITLE
Fix Shell to use white as default if no color is specified

### DIFF
--- a/Xamarin.Forms.Platform.Android.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/ShellTests.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.OS;
+using Android.Runtime;
+using Android.Support.Design.Widget;
+using Android.Views;
+using Android.Widget;
+using NUnit.Framework;
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Platform.Android.UnitTests
+{
+	public class ShellTests : PlatformTestFixture
+	{
+		[Test, Category("Shell")]
+		[Description("Ensure Default Colors are White for BottomNavigationView")]
+		public async Task ShellTabColorsDefaultToWhite()
+		{
+			var shell = CreateShell();
+			var tracker = new ShellBottomNavViewAppearanceTracker(null, shell.Items[0]);
+			BottomNavigationView bottomView = new BottomNavigationView(this.Context);
+			bottomView.Menu.Add("test");
+			ColorChangeRevealDrawable ccr = 
+				await Device.InvokeOnMainThreadAsync(() =>
+				{
+					tracker.SetAppearance(bottomView, new ShellAppearanceTest());
+					return (ColorChangeRevealDrawable)bottomView.Background;
+				});
+
+			Assert.AreEqual(Color.White.ToAndroid(), ccr.EndColor);
+		}
+
+		public class ShellAppearanceTest : IShellAppearanceElement
+		{
+			public Color EffectiveTabBarBackgroundColor { get; set; }
+
+			public Color EffectiveTabBarDisabledColor { get; set; }
+
+			public Color EffectiveTabBarForegroundColor { get; set; }
+
+			public Color EffectiveTabBarTitleColor { get; set; }
+
+			public Color EffectiveTabBarUnselectedColor { get; set; }
+		}
+		Shell CreateShell()
+		{
+			return new Shell()
+			{
+				Items =
+				{
+					new FlyoutItem()
+					{
+						Items =
+						{
+							new Tab()
+							{
+								Items =
+								{
+									new ShellContent()
+									{
+										Content = new ContentPage()
+									}
+								}
+							}
+						}
+					}
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="RotationTests.cs" />
     <Compile Include="ScaleTests.cs" />
+    <Compile Include="ShellTests.cs" />
     <Compile Include="TestClasses\_5560Model.cs" />
     <Compile Include="TextTests.cs" />
     <Compile Include="TranslationTests.cs" />

--- a/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
@@ -15,7 +15,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		SrcIn,
 		Multiply,
-		SrcAtop
+		SrcAtop,
+		Clear
 	}
 
 	internal static class DrawableExtensions
@@ -32,6 +33,8 @@ namespace Xamarin.Forms.Platform.Android
 					return BlendMode.Multiply;
 				case FilterMode.SrcAtop:
 					return BlendMode.SrcAtop;
+				case FilterMode.Clear:
+					return BlendMode.Clear;
 			}
 
 			throw new Exception("Invalid Mode");
@@ -56,6 +59,8 @@ namespace Xamarin.Forms.Platform.Android
 					return PorterDuff.Mode.Multiply;
 				case FilterMode.SrcAtop:
 					return PorterDuff.Mode.SrcAtop;
+				case FilterMode.Clear:
+					return PorterDuff.Mode.Clear;
 			}
 
 			throw new Exception("Invalid Mode");

--- a/Xamarin.Forms.Platform.Android/Renderers/IShellBottomNavigationViewAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/IShellBottomNavigationViewAppearanceTracker.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public interface IShellBottomNavViewAppearanceTracker : IDisposable
 	{
-		void SetAppearance(BottomNavigationView bottomView, ShellAppearance appearance);
+		void SetAppearance(BottomNavigationView bottomView, IShellAppearanceElement appearance);
 		void ResetAppearance(BottomNavigationView bottomView);
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellBottomNavViewAppearanceTracker.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Android
 			SetBackgroundColor(bottomView, Color.White);
 		}
 
-		public virtual void SetAppearance(BottomNavigationView bottomView, ShellAppearance appearance)
+		public virtual void SetAppearance(BottomNavigationView bottomView, IShellAppearanceElement appearance)
 		{
 			IShellAppearanceElement controller = appearance;
 			var backgroundColor = controller.EffectiveTabBarBackgroundColor;
@@ -72,16 +72,21 @@ namespace Xamarin.Forms.Platform.Android
 			var colorDrawable = oldBackground as ColorDrawable;
 			var colorChangeRevealDrawable = oldBackground as ColorChangeRevealDrawable;
 			AColor lastColor = colorChangeRevealDrawable?.EndColor ?? colorDrawable?.Color ?? Color.Default.ToAndroid();
-			var newColor = color.ToAndroid();
+			AColor newColor;
+
+			if (color == Color.Default)
+				newColor = Color.White.ToAndroid();
+			else
+				newColor = color.ToAndroid();
 
 			if (menuView == null)
 			{
 				if (colorDrawable != null && lastColor == newColor)
 					return;
 
-				if (lastColor != color.ToAndroid() || colorDrawable == null)
+				if (lastColor != newColor || colorDrawable == null)
 				{
-					bottomView.SetBackground(new ColorDrawable(color.ToAndroid()));
+					bottomView.SetBackground(new ColorDrawable(newColor));
 				}
 			}
 			else
@@ -114,7 +119,7 @@ namespace Xamarin.Forms.Platform.Android
 				titleColor.ToAndroid().ToArgb();
 
 			var defaultColor = unselectedColor.IsDefault ?
-				_defaultList.GetColorForState(new int[0], AColor.Black) :
+				_defaultList.DefaultColor :
 				unselectedColor.ToAndroid().ToArgb();
 
 			return MakeColorStateList(checkedInt, disabledInt, defaultColor);


### PR DESCRIPTION
### Description of Change ###

If user hasn't specified a color then default the tab color to white. Otherwise the ColorChangeDrawable causes a really weird effect if you set any other colors of the TabBar 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
