### PR TITLE
Shell hotreload fixes when changing Shell class

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -929,5 +929,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(2, item1.Items.Count);
 			Assert.AreEqual(section1, shell.CurrentItem.CurrentItem);
 		}
+
+		[Test]
+		public async Task ShellLocationRestoredWhenItemsAreReAdded()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem(shellContentRoute: "root1"));
+			shell.Items.Add(CreateShellItem(shellContentRoute: "root2"));
+
+			await shell.GoToAsync("//root2");
+			Assert.AreEqual("//root2", shell.CurrentState.Location.ToString());
+
+			shell.Items.Add(CreateShellItem(shellContentRoute: "root1"));
+			shell.Items.Add(CreateShellItem(shellContentRoute: "root2"));
+
+			shell.Items.Clear();
+			Assert.AreEqual("//root2", shell.CurrentState.Location.ToString());
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -9,7 +9,8 @@ namespace Xamarin.Forms
 		static int s_routeCount = 0;
 		static Dictionary<string, RouteFactory> s_routes = new Dictionary<string, RouteFactory>();
 
-		internal const string ImplicitPrefix = "IMPL_";
+		const string ImplicitPrefix = "IMPL_";
+		const string DefaultPrefix = "D_FAULT_";
 		const string _pathSeparator = "/";
 
 		internal static string GenerateImplicitRoute(string source)
@@ -26,7 +27,11 @@ namespace Xamarin.Forms
 		{
 			return IsImplicit(GetRoute(source));
 		}
-		
+		internal static bool IsDefault(string source)
+		{
+			return source.StartsWith(DefaultPrefix, StringComparison.Ordinal);
+		}
+
 		internal static void Clear()
 		{
 			s_routes.Clear();
@@ -38,7 +43,7 @@ namespace Xamarin.Forms
 
 		static object CreateDefaultRoute(BindableObject bindable)
 		{
-			return bindable.GetType().Name + ++s_routeCount;
+			return $"{DefaultPrefix}{bindable.GetType().Name}{++s_routeCount}";
 		}
 
 		internal static string[] GetRouteKeys()
@@ -83,18 +88,33 @@ namespace Xamarin.Forms
 			return $"{source}/";
 		}
 
-		internal static Uri RemoveImplicit(Uri uri)
+		internal static Uri Remove(Uri uri, bool implicitRoutes, bool defaultRoutes)
 		{
 			uri = ShellUriHandler.FormatUri(uri);
 
 			string[] parts = uri.OriginalString.TrimEnd(_pathSeparator[0]).Split(_pathSeparator[0]);
 
+			bool userDefinedRouteAdded = false;
 			List<string> toKeep = new List<string>();
 			for (int i = 0; i < parts.Length; i++)
-				if (!IsImplicit(parts[i]))
+				if (!(IsDefault(parts[i]) && defaultRoutes) && !(IsImplicit(parts[i]) && implicitRoutes))
+				{
+					if (!String.IsNullOrWhiteSpace(parts[i]))
+						userDefinedRouteAdded = true;
 					toKeep.Add(parts[i]);
+				}
+
+			if(!userDefinedRouteAdded && parts.Length > 0)
+			{
+				toKeep.Add(parts[parts.Length - 1]);
+			}
 
 			return new Uri(string.Join(_pathSeparator, toKeep), UriKind.Relative);
+		}
+
+		internal static Uri RemoveImplicit(Uri uri)
+		{
+			return Remove(uri, true, false);
 		}
 
 		public static string FormatRoute(List<string> segments)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -448,7 +448,7 @@ namespace Xamarin.Forms
 			var shellSection = navigationRequest.Request.Section;
 			var currentShellSection = CurrentItem?.CurrentItem;
 			var nextActiveSection = shellSection ?? shellItem?.CurrentItem;
-			
+
 			ShellContent shellContent = navigationRequest.Request.Content;
 			bool modalStackPreBuilt = false;
 
@@ -458,7 +458,7 @@ namespace Xamarin.Forms
 				modalStackPreBuilt = true;
 				await nextActiveSection.GoToAsync(navigationRequest, queryData, false);
 			}
-			
+
 			if (shellItem != null)
 			{
 				ApplyQueryAttributes(shellItem, queryData, navigationRequest.Request.Section == null);
@@ -527,7 +527,7 @@ namespace Xamarin.Forms
 			if (!isLastItem)
 			{
 				var route = Routing.GetRoute(element);
-				if (string.IsNullOrEmpty(route) || route.StartsWith(Routing.ImplicitPrefix, StringComparison.Ordinal))
+				if (string.IsNullOrEmpty(route) || Routing.IsImplicit(route))
 					return;
 				prefix = route + ".";
 			}
@@ -610,7 +610,7 @@ namespace Xamarin.Forms
 						{
 							var topPage = modalStack[i];
 
-							if(i > 0)
+							if (i > 0)
 								stateBuilder.Append("/");
 
 							stateBuilder.Append(Routing.GetRoute(topPage));
@@ -688,7 +688,7 @@ namespace Xamarin.Forms
 				SendStructureChanged();
 			};
 
-			void SetCurrentItem()
+			async void SetCurrentItem()
 			{
 				var shellItems = ShellController.GetItems();
 
@@ -697,12 +697,33 @@ namespace Xamarin.Forms
 
 				ShellItem shellItem = null;
 
-				foreach (var item in shellItems)
+				// If shell item has been removed try to renavigate to current location
+				// Just in case the item was replaced. This is mainly relevant for hot reload
+				if (CurrentItem != null)
 				{
-					if (item is ShellItem && ValidDefaultShellItem(item))
+					try
 					{
-						shellItem = item;
-						break;
+						var location = CurrentState.Location;
+						if (ShellUriHandler.GetNavigationRequest(this, ((ShellNavigationState)location).FullLocation, false) != null)
+							await GoToAsync(location, false);
+
+						return;
+					}
+					catch (Exception exc)
+					{
+						Log.Warning(nameof(Shell), $"If you're using hot reload add a route to everything in your shell file:  {exc}");
+					}
+				}
+
+				if (shellItem == null)
+				{
+					foreach (var item in shellItems)
+					{
+						if (item is ShellItem && ValidDefaultShellItem(item))
+						{
+							shellItem = item;
+							break;
+						}
 					}
 				}
 
@@ -1273,7 +1294,7 @@ namespace Xamarin.Forms
 				if (ModalStack.Count == 0)
 					_shell.CurrentItem.SendDisappearing();
 
-				if(!_shell.CurrentItem.CurrentItem.IsPushingModalStack)
+				if (!_shell.CurrentItem.CurrentItem.IsPushingModalStack)
 					modal.SendAppearing();
 
 				return base.OnPushModal(modal, animated);

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms
 			set
 			{
 				_fullLocation = value;
-				Location = Routing.RemoveImplicit(value);
+				Location = Routing.Remove(value, true, true);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

When you make changes to the AppShell file hot reload adds all the items and then removes them. If the current item has been removed this PR will cause shell to look too see if the item has been re-added and then navigate to it

- Added a D_FAULT prefix to routes that are created without a route name so they can be filtered out of the Location representing users current location. This was needed for hotreload because when trying to renavigate I need to strip off the routes that are just generated from a counter

### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- Navigate to a different flyout item and make a change to AppShell. The same item should stay active

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
