### PR TITLE
Update ColorTypeConverter to support HSVA

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ColorUnitTests.cs
@@ -319,6 +319,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(Color.Blue, converter.ConvertFromInvariantString("hsl(240,110%, 50%)"));
 			Assert.AreEqual(Color.Blue.MultiplyAlpha(.8), converter.ConvertFromInvariantString("hsla(240,100%, 50%, .8)"));
 			Assert.AreEqual(Color.FromHsla(0.66916666666666669, 1, 0.5), converter.ConvertFromInvariantString("hsl(240.9,100%, 50%)"));
+			Assert.AreEqual(Color.FromHsva(0.89166666666666669, .71, 1, .8), converter.ConvertFromInvariantString("hsva(321,71%, 100%, .8)"));
+			Assert.AreEqual(Color.FromHsv(0.89166666666666669, .71, 1), converter.ConvertFromInvariantString("hsv(321,71%, 100%)"));
 			Assert.AreEqual(Color.Default, converter.ConvertFromInvariantString("Color.Default"));
 			Assert.AreEqual(Color.Accent, converter.ConvertFromInvariantString("Accent"));
 			var hotpink = Color.FromHex("#FF69B4");
@@ -328,6 +330,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString(""));
 			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("rgb(0,0,255"));
 			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("hsl(12, 100%)"));
+			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("hsv(12, 100%)"));
+			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("hsva(12, 100%)"));
 			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("rgba(0,0,255)"));
 		}
 

--- a/Xamarin.Forms.Core/ColorTypeConverter.cs
+++ b/Xamarin.Forms.Core/ColorTypeConverter.cs
@@ -15,6 +15,8 @@ namespace Xamarin.Forms
 		// RGBA		rgba(255, 0, 0, 0.8), rgba(100%, 0%, 0%, 0.8)	opacity is 0.0-1.0
 		// HSL		hsl(120, 100%, 50%)								h is 0-360, s and l are 0%-100%
 		// HSLA		hsla(120, 100%, 50%, .8)						opacity is 0.0-1.0
+		// HSV		hsv(120, 100%, 50%)								h is 0-360, s and v are 0%-100%
+		// HSVA		hsva(120, 100%, 50%, .8)						opacity is 0.0-1.0
 		// Predefined color											case insensitive
 		public override object ConvertFromInvariantString(string value)
 		{
@@ -80,6 +82,37 @@ namespace Xamarin.Forms
 					var s = ParseColorValue(triplet[1], 100, acceptPercent: true);
 					var l = ParseColorValue(triplet[2], 100, acceptPercent: true);
 					return Color.FromHsla(h, s, l);
+				}
+
+				if (value.StartsWith("hsva", StringComparison.OrdinalIgnoreCase))
+				{
+					var op = value.IndexOf('(');
+					var cp = value.LastIndexOf(')');
+					if (op < 0 || cp < 0 || cp < op)
+						throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Color)}");
+					var quad = value.Substring(op + 1, cp - op - 1).Split(',');
+					if (quad.Length != 4)
+						throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Color)}");
+					var h = ParseColorValue(quad[0], 360, acceptPercent: false);
+					var s = ParseColorValue(quad[1], 100, acceptPercent: true);
+					var v = ParseColorValue(quad[2], 100, acceptPercent: true);
+					var a = ParseOpacity(quad[3]);
+					return Color.FromHsva(h, s, v, a);
+				}
+
+				if (value.StartsWith("hsv", StringComparison.OrdinalIgnoreCase))
+				{
+					var op = value.IndexOf('(');
+					var cp = value.LastIndexOf(')');
+					if (op < 0 || cp < 0 || cp < op)
+						throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Color)}");
+					var triplet = value.Substring(op + 1, cp - op - 1).Split(',');
+					if (triplet.Length != 3)
+						throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Color)}");
+					var h = ParseColorValue(triplet[0], 360, acceptPercent: false);
+					var s = ParseColorValue(triplet[1], 100, acceptPercent: true);
+					var v = ParseColorValue(triplet[2], 100, acceptPercent: true);
+					return Color.FromHsv(h, s, v);
 				}
 
 				string[] parts = value.Split('.');


### PR DESCRIPTION
### Description of Change ###
Enhance existing `ColorTypeConverter` to support **HSVA** color format (newly introduced in #10054).

Supported inputs are as follows. (same as `HSLA`)
- **hsv(120, 100%, 50%)**  
  - _h is 0-360, s and l are 0%-100%_
- **hsva(120, 100%, 50%, .8)**
  - _opacity is 0.0-1.0_

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Testing Procedure ###
Go `ColorUnitTests.TestColorTypeConverter`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
