### PR TITLE
[iOS] Fix Label TextDecorations issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8272.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8272.cs
@@ -1,0 +1,94 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8272, "[Bug] TextDecorations don't work", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Label)]
+#endif
+	public class Issue8272 : TestContentPage
+	{
+		public Issue8272()
+		{
+#if APP
+			Title = "Issue 8272";
+#endif
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				Padding = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Toggle the Switch. If the text below is underline, the test has passed."
+			};
+
+			Grid grid = new Grid { Margin = new Thickness(20) };
+			grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+			grid.ColumnDefinitions.Add(new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) });
+			grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+			grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+			grid.RowDefinitions.Add(new RowDefinition { Height = new GridLength(1, GridUnitType.Auto) });
+
+			ScrollView scrollView = new ScrollView();
+			Label label = new Label
+			{
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
+				CharacterSpacing = 2,
+				Text = "The Switch should toggle underline on this Label."
+			};
+			scrollView.Content = label;
+
+			Label underlineLabel = new Label { Text = "Underline:", VerticalOptions = LayoutOptions.Center };
+			Switch underlineSwitch = new Switch { VerticalOptions = LayoutOptions.Center };
+
+			Label characterSpacingLabel = new Label { Text = "CharacterSpacing:", VerticalOptions = LayoutOptions.Center };
+			Slider characterSpacingSlider = new Slider
+			{
+				Maximum = 24,
+				Minimum = 0,
+				Value = 2,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			grid.Children.Add(underlineLabel, 0, 0);
+			grid.Children.Add(underlineSwitch, 1, 0);
+			grid.Children.Add(characterSpacingLabel, 0, 1);
+			grid.Children.Add(characterSpacingSlider, 1, 1);
+			grid.Children.Add(scrollView, 0, 2);
+			Grid.SetColumnSpan(scrollView, 4);
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(grid);
+
+			underlineSwitch.Toggled += (sender, args) =>
+			{
+				if (underlineSwitch.IsToggled)
+					label.TextDecorations = TextDecorations.Underline;
+				else
+					label.TextDecorations = TextDecorations.None;
+			};
+
+			characterSpacingSlider.ValueChanged += (sender, args) =>
+			{
+				label.CharacterSpacing = characterSpacingSlider.Value;
+			};
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1292,6 +1292,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9054.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9306.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9417.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8272.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -250,9 +250,6 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Element?.TextType != TextType.Text)
 				return;
 
-			if (!Element.IsSet(Label.TextDecorationsProperty))
-				return;
-
 #if __MOBILE__
 			if (!(Control.AttributedText?.Length > 0))
 				return;
@@ -284,7 +281,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
 
-#if !__MOBILE__
+#if __MOBILE__
+			Control.AttributedText = newAttributedText;
+#else
 			Control.AttributedStringValue = newAttributedText;
 #endif
 			UpdateCharacterSpacing();


### PR DESCRIPTION
### Description of Change ###

 Fix Label **TextDecorations** (Example: Underline) issue on iOS from Xamarin.Forms 4.3.

![fix8272](https://user-images.githubusercontent.com/6755973/77409447-8d95bf00-6db9-11ea-81fa-45492a9f1780.gif)

### Issues Resolved ### 

- fixes #8272

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue8272. Toggle the Switch. If the text below is underline, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
