### PR TITLE
[UWP] Fix PeekAreaInsets usage on CarouselViewRenderer

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
@@ -48,9 +48,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
-				Position = 1,
 				Margin = new Thickness(0,10,0,10),
-				BackgroundColor = Color.LightGray,
+				BackgroundColor = Color.Red,
 				AutomationId = "TheCarouselView"
 			};
 
@@ -59,7 +58,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			else
 				carouselView.PeekAreaInsets = new Thickness(0, 30, 0, 30);
 
-			carouselView.Scrolled += CarouselView_Scrolled;
+			carouselView.Scrolled += CarouselViewScrolled;
 
 			StackLayout stacklayoutInfo = GetReadOnlyInfo(carouselView);
 
@@ -119,9 +118,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 
 			generator.GenerateItems();
+			positionControl.UpdatePosition(1);
 		}
 
-		private void CarouselView_Scrolled(object sender, ItemsViewScrolledEventArgs e)
+		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
 			_scrollInfoLabel.Text = $"First item: {e.FirstVisibleItemIndex}, Last item: {e.LastVisibleItemIndex}";
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
@@ -143,6 +143,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 				var frame = new Frame
 				{
 					Padding = new Thickness(5),
+					BackgroundColor = Color.Transparent,
 					Content = grid
 				};
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PositionControl.cs
@@ -69,14 +69,17 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			Grid.SetColumnSpan(stacklayout, 3);
 
 			Content = layout;
-			_slider.Value = 1;
 		}
 
 		public void UpdatePositionCount(int itemsCount)
 		{
 			if (itemsCount > 0)
 				_slider.Maximum = itemsCount - 1;
+		}
 
+		public void UpdatePosition(int position)
+		{
+			_slider.Value = position;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -191,6 +191,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdatePeekAreaInsets()
 		{
+			ListViewBase.Padding = new Windows.UI.Xaml.Thickness(Carousel.PeekAreaInsets.Left, Carousel.PeekAreaInsets.Top, Carousel.PeekAreaInsets.Right, Carousel.PeekAreaInsets.Bottom);
 			UpdateItemsSource();
 		}
 
@@ -392,6 +393,8 @@ namespace Xamarin.Forms.Platform.UWP
 					Style = (Windows.UI.Xaml.Style)UWPApp.Current.Resources["VerticalCarouselListStyle"]
 				};
 			}
+			
+			listView.Padding = new Windows.UI.Xaml.Thickness(Carousel.PeekAreaInsets.Left, Carousel.PeekAreaInsets.Top, Carousel.PeekAreaInsets.Right, Carousel.PeekAreaInsets.Bottom);
 
 			return listView;
 		}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -405,7 +405,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Horizontal)
 			{
-				itemWidth = (ActualWidth - Carousel.PeekAreaInsets.Left - Carousel.PeekAreaInsets.Right - CarouselItemsLayout.ItemSpacing);
+				itemWidth = (ActualWidth - Carousel.PeekAreaInsets.Left - Carousel.PeekAreaInsets.Right);
 			}
 
 			return Math.Max(itemWidth, 0);
@@ -417,7 +417,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (CarouselItemsLayout.Orientation == ItemsLayoutOrientation.Vertical)
 			{
-				itemHeight = (ActualHeight - Carousel.PeekAreaInsets.Top - Carousel.PeekAreaInsets.Bottom - CarouselItemsLayout.ItemSpacing);
+				itemHeight = (ActualHeight - Carousel.PeekAreaInsets.Top - Carousel.PeekAreaInsets.Bottom);
 			}
 
 			return Math.Max(itemHeight, 0);

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewStyles.xaml
@@ -190,6 +190,7 @@
                 <Style TargetType="ListViewItem">
                     <Setter Property="VerticalContentAlignment" Value="Stretch" />
                     <Setter Property="VerticalAlignment" Value="Stretch" />
+                    <Setter Property="Padding" Value="0,0,0,0" />
                 </Style>
             </Setter.Value>
         </Setter>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ScrollHelpers.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ScrollHelpers.cs
@@ -151,6 +151,9 @@ namespace Xamarin.Forms.Platform.UWP
 			// virtualization, but it'll be close enough to give us a direction to scroll toward
 			await JumpToItemAsync(list, targetItem, ScrollToPosition.Start);
 			var targetContainer = list.ContainerFromItem(targetItem) as UIElement;
+			if (targetContainer == null)
+				return new UWPPoint(0, 0);
+
 			var transform = targetContainer.TransformToVisual(scrollViewer.Content as UIElement);
 
 			// Return to the original position


### PR DESCRIPTION
### Description of Change ###

Set the padding do the FormsListView so the CarouselView items are always centered and have the same size, if they are first or last

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10019 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

Should be able to go to the first and last item when using PeekAreaInsets

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###

Try to go to first and last item on CarouselCodeGallery or IndicatorGallery

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
