### PR TITLE
Add null check to OnActionItemClickedImpl

### DIFF
--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -265,6 +265,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnActionItemClickedImpl(IMenuItem item)
 		{
+			if (ActionModeContext == null)
+			{
+				return;
+			}
+
 			int index = item.ItemId;
 			IMenuItemController action = ActionModeContext.ContextActions[index];
 


### PR DESCRIPTION
### Description of Change ###

Add a null check in OnActionItemClickedImpl. If items are in the process of being added/removed from the list, it's possible to have the context menu tap race against the actual existence of the underlying Cell.

### Issues Resolved ### 

- fixes #9786

### API Changes ###

None

### Platforms Affected ### 

- Android


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

This one is painful to test; it's difficult to get the timing right in the original repro, and it requires tapping around in a way that's too fast for a UI test to replicate. Tooks a stab writing a platform test, but the tight coupling between the Android ListView implementation and the OS stuff for context menus makes it a very involved task.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
