### PR TITLE
[UWP] SingleTapGesture called once on DoubleTap

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4714.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4714.cs
@@ -1,0 +1,72 @@
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(Core.UITests.UITestCategories.Gestures)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4714, "SingleTapGesture called once on DoubleTap", PlatformAffected.UWP)]
+	public class Issue4714 : TestContentPage
+	{
+		const string InitialText = "Click Me To Increment";
+
+		public Command TapCommand { get; set; }
+
+		protected override void Init()
+		{
+			int i = 0;
+
+			var tapGesture = new TapGestureRecognizer { NumberOfTapsRequired = 1 };
+			tapGesture.SetBinding(TapGestureRecognizer.CommandProperty, "TapCommand");
+			
+			var label = new Label()
+			{
+				AutomationId = InitialText,
+				HorizontalOptions = LayoutOptions.Center,
+				Text = InitialText,
+				GestureRecognizers =
+				{
+					tapGesture
+				}
+			};
+
+			TapCommand = new Command(() =>
+			{
+				i++;
+				label.Text = $"{InitialText}: {i}";
+			});
+
+			Content = new ContentView()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						label
+					}
+				}
+			};
+			BindingContext = this;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue4714Test() 
+		{
+			RunningApp.WaitForElement(InitialText);
+			RunningApp.DoubleTap(InitialText);
+			RunningApp.Tap(InitialText);
+			RunningApp.Tap(InitialText);
+			RunningApp.WaitForElement($"{InitialText}: 4");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -788,6 +788,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8145.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10222.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4714.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -324,7 +324,7 @@ namespace Xamarin.Forms.Platform.UWP
 			var children = (view as IGestureController)?.GetChildElements(new Point(tapPosition.X, tapPosition.Y));
 
 			if (children != null)
-				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2))
+				foreach (var recognizer in children.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2))
 				{
 					recognizer.SendTapped(view);
 					e.Handled = true;
@@ -333,7 +333,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (e.Handled)
 				return;
 
-			IEnumerable<TapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2);
+			IEnumerable<TapGestureRecognizer> doubleTapGestures = view.GestureRecognizers.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2);
 			foreach (TapGestureRecognizer recognizer in doubleTapGestures)
 			{
 				recognizer.SendTapped(view);
@@ -612,8 +612,8 @@ namespace Xamarin.Forms.Platform.UWP
 				}
 			}
 
-			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2).Any()
-				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 2).Any() == true)
+			if (gestures.GetGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any()
+				|| children?.GetChildGesturesFor<TapGestureRecognizer>(g => g.NumberOfTapsRequired == 1 || g.NumberOfTapsRequired == 2).Any() == true)
 			{
 				_container.DoubleTapped += OnDoubleTap;
 			}


### PR DESCRIPTION
### Description of Change ###
UWP don't fire second `Tapped` event on double tap as documented here: [UIElement.DoubleTapped](https://docs.microsoft.com/en-us/uwp/api/windows.ui.xaml.uielement.doubletapped#remarks)

> If a user interaction also fires DoubleTapped, Tapped will fire first to represent the first tap, but the second tap won't fire an additional Tapped. 

To fix this and have the same behavior on all platforms, the `TapGestureRecognizer` is also called during the `DoubleTap` event.

### Issues Resolved ### 
- fixes #4714

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###

<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Launch Control Gallery on UWP and navigate to the Issue4714. Double tap on label. If the label text ends with 2, the test has passed.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
