### PR TITLE
[Tizen] Provides global Circle Surface for wearable

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
+{
+	using FormsElement = Forms.Application;
+
+	public static class Application
+	{
+		public static readonly BindableProperty UseBezelInteractionProperty = BindableProperty.Create("UseBezelInteraction", typeof(bool), typeof(FormsElement), true);
+
+		public static bool GetUseBezelInteraction(BindableObject element)
+		{
+			return (bool)element.GetValue(UseBezelInteractionProperty);
+		}
+
+		public static void SetUseBezelInteraction(BindableObject element, bool value)
+		{
+			element.SetValue(UseBezelInteractionProperty, value);
+		}
+
+		public static bool GetUseBezelInteraction(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetUseBezelInteraction(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetUseBezelInteraction(this IPlatformElementConfiguration<Tizen, FormsElement> config, bool value)
+		{
+			SetUseBezelInteraction(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -11,6 +11,7 @@ using Tizen.Applications;
 using TSystemInfo = Tizen.System.Information;
 using ELayout = ElmSharp.Layout;
 using DeviceOrientation = Xamarin.Forms.Internals.DeviceOrientation;
+using ElmSharp.Wearable;
 
 namespace Xamarin.Forms
 {
@@ -184,6 +185,11 @@ namespace Xamarin.Forms
 		}
 
 		public static ELayout BaseLayout => NativeParent as ELayout;
+
+		public static CircleSurface CircleSurface
+		{
+			get; internal set;
+		}
 
 		public static bool IsInitialized
 		{
@@ -471,6 +477,10 @@ namespace Xamarin.Forms
 			}
 			Color.SetAccent(GetAccentColor(profile));
 			ExpressionSearch.Default = new TizenExpressionSearch();
+
+			if (application is WatchApplication)
+				s_platformType = PlatformType.Lightweight;
+
 			IsInitialized = true;
 		}
 


### PR DESCRIPTION
### Description of Change ###
This PR is about global circle surface and circle objects for tizen wearable devices.
On Tizen, you can use `CircleSurafce` to rendner various circle objects including circle progress bar and circle slider and so on. Plus, this PR also includes a Tizen Specific API that determines whether app use bezel (or crown) interactions on wearable device like Galaxy Watch. For example, you can decide whether to control the scrolling behavior of the ListView, ScrollView by rotating the bezel. 

#### Developer Guide ####

This Tizen platform-specific is used to decide whether to use bezel interaction for scrolling or not in your app, The default is `true`, so when you rotate the bezel, it will scroll to list view or scroll view. It's consumed in XAML by setting the `Application.UseBezelInteraction` to `true` or `false` :

```xml
<Application ...
             xmlns:tizen="clr-namespace:Xamarin.Forms.PlatformConfiguration.TizenSpecific;assembly=Xamarin.Forms.Core"
             tizen:Application.UseBezelInteraction= "False">
  ...
</Application>
```

Alternatively, it can be consumed from C# using the fluent API:

```cs
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.TizenSpecific;

Application.Current.On<Tizen>().SetUseBezelInteraction(false);
```

### Issues Resolved ### 
None

### API Changes ###
`namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific`

Added:
- bool Application.UseBezelInteraction //BindableProperty

`namespace Xamarin.Forms`

Added:
- CircleSurface Forms.CircleSurface {get}

`namespace Xamarin.Forms.Platform.Tizen`

Added:
- FormsApplication.BaseCircleSurface {get}
- FormsApplication.UseBezelInteraction {get}

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
New Tizen specific APIs

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
