### PR TITLE
[Enhancement] Add WebView UserAgent

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,3 +75,5 @@ Visual Studio 2019/**
 TestResult.xml
 build/packages
 WriteDevopsVariables.csproj
+# MFractors (Xamarin productivity tool) working folder 
+.mfractor/

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -181,7 +181,7 @@
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\Icon.png" />
     <AndroidResource Include="Resources\drawable\cover1.jpg" />
-  </ItemGroup>
+  </ItemGroup> 
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">
       <Project>{cb9c96ce-125c-4a68-b6a1-c3ff1fbf93e1}</Project>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -52,7 +52,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -181,8 +181,8 @@
   <ItemGroup>
     <AndroidResource Include="Resources\drawable\Icon.png" />
     <AndroidResource Include="Resources\drawable\cover1.jpg" />
-  </ItemGroup> 
-  <ItemGroup>
+  </ItemGroup>
+  <ItemGroup>  
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">
       <Project>{cb9c96ce-125c-4a68-b6a1-c3ff1fbf93e1}</Project>
       <Name>Xamarin.Forms.Controls</Name>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -52,10 +52,14 @@
     <WarningLevel>4</WarningLevel>
     <AndroidLinkMode>None</AndroidLinkMode>
     <EmbedAssembliesIntoApk>true</EmbedAssembliesIntoApk>
-    <AndroidSupportedAbis>armeabi-v7a;x86</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi-v7a;x86;x86_64</AndroidSupportedAbis>
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AotAssemblies>false</AotAssemblies>
+    <EnableLLVM>false</EnableLLVM>
+    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
+    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -56,10 +56,6 @@
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AotAssemblies>false</AotAssemblies>
-    <EnableLLVM>false</EnableLLVM>
-    <AndroidEnableProfiledAot>false</AndroidEnableProfiledAot>
-    <BundleAssemblies>false</BundleAssemblies>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			string UserAgentString = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko";
+			string UserAgentString = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko XAMARIN Rocks";
 
 			Label header = new Label
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
@@ -19,11 +19,11 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
-			string UserAgentString = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko XAMARIN Rocks";
+			string UAString = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko XAMARIN Rocks";
 
 			Label header = new Label
 			{
-				Text = $"A Webview of www.WhatIsMyBrowser.com and the UserAgent - {UserAgentString} ",
+				Text = $"A Webview of www.WhatIsMyBrowser.com and the UserAgent - {UAString} ",
 				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
 				HorizontalOptions = LayoutOptions.Center
 			};
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Source = "https://www.whatismybrowser.com/detect/what-http-headers-is-my-browser-sending",
 				HorizontalOptions = LayoutOptions.FillAndExpand,
 				VerticalOptions = LayoutOptions.FillAndExpand,
-				setUserAgentString = UserAgentString
+				UserAgentString = UAString
 			};
 
 			Content = new StackLayout

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8432, "WebView - possibility to set custom user agent", PlatformAffected.All)]
+	public class Issue8432 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Label header = new Label
+			{
+				Text = "A Webview should open below and display www.WhatIsMyBrowser.com and the UserAgent that is set here.",
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			WebView webView = new WebView
+			{
+				Source = "https://www.whatismybrowser.com/detect/what-http-headers-is-my-browser-sending",
+				HorizontalOptions = LayoutOptions.FillAndExpand,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				setUserAgentString = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705 CLIFF"
+			};
+
+			Content = new StackLayout
+			{
+				Padding = new Thickness(20),
+				Children =
+				{
+					header,
+					webView
+				}
+			};
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8432.cs
@@ -19,9 +19,11 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			string UserAgentString = "Mozilla/5.0 (Windows NT 6.3; Trident/7.0; rv:11.0) like Gecko";
+
 			Label header = new Label
 			{
-				Text = "A Webview should open below and display www.WhatIsMyBrowser.com and the UserAgent that is set here.",
+				Text = $"A Webview of www.WhatIsMyBrowser.com and the UserAgent - {UserAgentString} ",
 				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
 				HorizontalOptions = LayoutOptions.Center
 			};
@@ -31,7 +33,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Source = "https://www.whatismybrowser.com/detect/what-http-headers-is-my-browser-sending",
 				HorizontalOptions = LayoutOptions.FillAndExpand,
 				VerticalOptions = LayoutOptions.FillAndExpand,
-				setUserAgentString = "Mozilla/4.0 (compatible; MSIE 6.0; Windows NT 5.2; .NET CLR 1.0.3705 CLIFF"
+				setUserAgentString = UserAgentString
 			};
 
 			Content = new StackLayout
@@ -44,6 +46,5 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 		}
-
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -143,6 +143,7 @@
       <DependentUpon>Issue6184.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8432.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8715.xaml.cs">
       <DependentUpon>Issue8715.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/WebViewUnitTests.cs
@@ -162,5 +162,16 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.IsNotNull(defaultWebView.Cookies);
 		}
+
+		[Test]
+		public void TestSettingUserAgentString()
+		{
+			var defaultWebView = new WebView
+			{
+				UserAgentString = "Test UAS"
+			};
+
+			Assert.AreEqual(defaultWebView.UserAgentString, "Test UAS");
+		}
 	}
 }

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty CookiesProperty = BindableProperty.Create(nameof(Cookies), typeof(CookieContainer), typeof(WebView), null);
 
-		public static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(setUserAgentString), typeof(string), typeof(WebView), default(string));
+		public static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(UserAgentString), typeof(string), typeof(WebView), default(string));
 
 		readonly Lazy<PlatformConfigurationRegistry<WebView>> _platformConfigurationRegistry;
 
@@ -79,7 +79,7 @@ namespace Xamarin.Forms
 			set { SetValue(CookiesProperty, value); }
 		}
 
-		public string setUserAgentString
+		public string UserAgentString
 		{
 			get { return (string)GetValue(UserAgentProperty); }
 			set { SetValue(UserAgentProperty, value); }

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -40,6 +40,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty CookiesProperty = BindableProperty.Create(nameof(Cookies), typeof(CookieContainer), typeof(WebView), null);
 
+		public static readonly BindableProperty UserAgentProperty = BindableProperty.Create(nameof(setUserAgentString), typeof(string), typeof(WebView), default(string));
+
 		readonly Lazy<PlatformConfigurationRegistry<WebView>> _platformConfigurationRegistry;
 
 		public WebView()
@@ -75,6 +77,12 @@ namespace Xamarin.Forms
 		{
 			get { return (CookieContainer)GetValue(CookiesProperty); }
 			set { SetValue(CookiesProperty, value); }
+		}
+
+		public string setUserAgentString
+		{
+			get { return (string)GetValue(UserAgentProperty); }
+			set { SetValue(UserAgentProperty, value); }
 		}
 
 		[TypeConverter(typeof(WebViewSourceTypeConverter))]

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -143,6 +143,7 @@ namespace Xamarin.Forms.Platform.Android
 				_webChromeClient = GetFormsWebChromeClient();
 				_webChromeClient.SetContext(Context);
 				webView.SetWebChromeClient(_webChromeClient);
+				webView.Settings.UserAgentString = Element.setUserAgentString;
 
 				if (Context.IsDesignerContext())
 				{

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -143,7 +143,7 @@ namespace Xamarin.Forms.Platform.Android
 				_webChromeClient = GetFormsWebChromeClient();
 				_webChromeClient.SetContext(Context);
 				webView.SetWebChromeClient(_webChromeClient);
-				webView.Settings.UserAgentString = Element.setUserAgentString;
+				webView.Settings.UserAgentString = Element.UserAgentString;
 
 				if (Context.IsDesignerContext())
 				{

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -73,7 +73,7 @@ if(bases.length == 0){
 				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
-			if (Element.Cookies?.Count > 0 || Element.setUserAgentString != null)
+			if (Element.Cookies?.Count > 0 || Element.UserAgentString != null)
 			{
 				try
 				{
@@ -91,9 +91,9 @@ if(bases.length == 0){
 						}
 					}
 
-					if (Element.setUserAgentString != null)
+					if (Element.UserAgentString != null)
 					{
-						httpRequestMessage.Headers.Add("User-Agent", Element.setUserAgentString);
+						httpRequestMessage.Headers.Add("User-Agent", Element.UserAgentString);
 					}
 
 					Control.NavigateWithHttpRequestMessage(httpRequestMessage);

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -73,14 +73,29 @@ if(bases.length == 0){
 				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
-			var cookies = Element.Cookies?.GetCookies(uri);
-			if (cookies != null)
+			if (Element.Cookies?.Count > 0 || Element.setUserAgentString != null)
 			{
-				SyncNativeCookies(url);
-
 				try
 				{
 					var httpRequestMessage = new Windows.Web.Http.HttpRequestMessage(Windows.Web.Http.HttpMethod.Get, uri);
+
+					if (Element.Cookies?.Count > 0)
+					{
+						//Set the Cookies...
+						var filter = new Windows.Web.Http.Filters.HttpBaseProtocolFilter();
+						foreach (Cookie cookie in Element.Cookies?.GetCookies(uri))
+						{
+							HttpCookie httpCookie = new HttpCookie(cookie.Name, cookie.Domain, cookie.Path);
+							httpCookie.Value = cookie.Value;
+							filter.CookieManager.SetCookie(httpCookie, false);
+						}
+					}
+
+					if (Element.setUserAgentString != null)
+					{
+						httpRequestMessage.Headers.Add("User-Agent", Element.setUserAgentString);
+					}
+
 					Control.NavigateWithHttpRequestMessage(httpRequestMessage);
 				}
 				catch (System.Exception exc)

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -240,6 +240,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (uri == null)
 				return false;
+				
+			CustomUserAgent = WebView.UserAgentString;
 
 			var myCookieJar = WebView.Cookies;
 			if (myCookieJar == null)


### PR DESCRIPTION
### Description of Change ###

Added the ability for the UserAgent used by the Webview to be set/changed for IOS/Android and UWP.

There is now a new Bindable property called setUserAgentString that when set will change the user agent of the HTTPRequest when using the WebView.

### Issues Resolved ### 

- fixes #8432 

### API Changes ###

Added:
 - string setUserAgentString { get; set; } //Bindable Property

### Platforms Affected ### 

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
In the ControlGallery opening the Issue 8432 will show a WebView on the device that will point to the website whatismybrowser.com and in here you will see the UserAgent that has been set.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
