### PR TITLE
[iOS] Fix SwipeView programmatically Open issue

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -1159,6 +1159,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void ProgrammaticallyOpenSwipeItem(OpenSwipeItem openSwipeItem)
 		{
+			if (_isOpen)
+				return;
+
 			switch (openSwipeItem)
 			{
 				case OpenSwipeItem.BottomItems:

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -566,7 +566,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			var items = GetSwipeItemsByDirection();
 
-			if (items == null)
+			if (items == null || items.Count == 0)
 				return;
 
 			_actionView = new LinearLayoutCompat(_context);

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -1200,6 +1200,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ProgrammaticallyOpenSwipeItem(OpenSwipeItem openSwipeItem)
 		{
+			if (_isOpen)
+				return;
+
 			switch (openSwipeItem)
 			{
 				case OpenSwipeItem.BottomItems:

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -133,11 +133,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (Element.Content != null)
 				Element.Content.Layout(Bounds.ToRectangle());
-
-			if (_contentView != null)
-			{
-				_contentView.Frame = Bounds;
-			}
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -398,7 +393,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				swipeItemsWidth = _contentView.Frame.Width;
 
-			if (items == null)
+			if (items == null || items.Count == 0)
 				return;
 
 			_actionView = new UIStackView
@@ -1230,11 +1225,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_swipeOffset = swipeThreshold;
 
 			UpdateSwipeItems();
-
-			Animate(SwipeAnimationDuration, 0.0, UIViewAnimationOptions.CurveEaseOut, () =>
-			{
-				Swipe();
-			}, null);
+			Swipe();
 		}
 
 		void OnCloseRequested(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

Fix SwipeView Open issue in iOS.

![fix-10096](https://user-images.githubusercontent.com/6755973/77650959-63d0c980-6f6c-11ea-98f1-808ea9a89122.gif)

Validate that there are swipe items and do not reassign the Bounds to the control to fix the programmatically open logic. These are validations that I think we have lost in some rebase. For example: https://github.com/xamarin/Xamarin.Forms/pull/9635/commits/a85ef9f7ef749dffde4dda993151d651143c340b#diff-cdef6ff7f48a8d49afb93057ab79f8c7R1159

### Issues Resolved ### 

- fixes #10095
- fixes #10096 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the "Open/Close SwipeView" sample. Try open and close the SwipeView several times with both buttons and gestures. Verify that everything always works as expected.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
