### PR TITLE
[iOS,Android] Fix CurrentItem position when adding a item

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
@@ -61,12 +61,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 		void CarouselViewUnderTest_PositionChanged(object sender, PositionChangedEventArgs e)
 		{
-			_lbl.Text = $"Item CurrentItemChanged {e.CurrentPosition}";
+			System.Diagnostics.Debug.WriteLine($"PositionChanged {CarouselViewUnderTest.Position}");
+			_lbl.Text = $"Item Position - {e.CurrentPosition}";
 		}
 
 		void CarouselViewUnderTestCurrentItemChanged(object sender, CurrentItemChangedEventArgs e)
 		{
-			System.Diagnostics.Debug.WriteLine("Item CurrentItemChanged");
+			System.Diagnostics.Debug.WriteLine($"CurrentItemChanged {CarouselViewUnderTest.Position}");
 			_counter++;
 			ItemSourceUnderTest.Insert(0, new ModelIssue8964 { Name = $"Counter {_counter}", Color = Color.Red, Index = _counter });
 		}
@@ -126,12 +127,22 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue8964Test() 
+		public void Issue8964Test()
 		{
-			RunningApp.WaitForElement(q => q.Marked($"Item CurrentItemChanged 4"));
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
 			var rect = RunningApp.Query("carouseView")[0].Rect;
-			RunningApp.DragCoordinates(rect.X + rect.Width - 10, rect.Y, rect.X, rect.Y);
-			RunningApp.WaitForElement(q => q.Marked($"Item CurrentItemChanged 4"));
+			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
+			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
+			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
+			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
+			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
+			RunningApp.WaitForElement(q => q.Marked($"Counter 6"));
+
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
@@ -28,9 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 			ItemSourceUnderTest = new ObservableCollection<ModelIssue8964>(GetCarouselItems());
 			var lbl = new Label
 			{
-				Text = @"Scroll to the previous item until see the Item with counter 6,
-						 since we are inserting items on the start of the collection
-						 the position should be  the same"
+				Text = "Scroll to the previous item until see the Item with counter 6, since we are inserting items on the start of the collection the position should be  the same"
 			};
 			CarouselViewUnderTest = new CarouselView
 			{
@@ -129,6 +127,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue8964Test()
 		{
+			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
 			var rect = RunningApp.Query("carouseView")[0].Rect;
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
 			SwipePreviousItem(rect);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
@@ -130,16 +130,15 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue8964Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			var rect = RunningApp.Query("carouseView")[0].Rect;
-			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.SwipeLeftToRight("carouseView");
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.SwipeLeftToRight("carouseView");
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.SwipeLeftToRight("carouseView");
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.SwipeLeftToRight("carouseView");
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+			RunningApp.SwipeLeftToRight("carouseView");
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
 			RunningApp.WaitForElement(q => q.Marked($"Counter 6"));
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
@@ -129,19 +129,29 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue8964Test()
 		{
+			var rect = RunningApp.Query("carouseView")[0].Rect;
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.SwipeLeftToRight("carouseView");
+			SwipePreviousItem(rect);
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.SwipeLeftToRight("carouseView");
+			SwipePreviousItem(rect);
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.SwipeLeftToRight("carouseView");
+			SwipePreviousItem(rect);
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.SwipeLeftToRight("carouseView");
+			SwipePreviousItem(rect);
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
-			RunningApp.SwipeLeftToRight("carouseView");
+			SwipePreviousItem(rect);
 			RunningApp.WaitForElement(q => q.Marked($"Item Position - 4"));
 			RunningApp.WaitForElement(q => q.Marked($"Counter 6"));
 
+		}
+
+		void SwipePreviousItem(UITest.Queries.AppRect rect)
+		{
+#if __ANDROID__
+			RunningApp.DragCoordinates(rect.X + 10, rect.Y, rect.X + rect.Width - 10, rect.Y);
+#else
+			RunningApp.SwipeLeftToRight("carouseView");
+#endif
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
@@ -1,0 +1,160 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.Collections.Generic;
+using System;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8964, "Adding an item to the beginning of the bound ItemSource causes the carousel to skip sometimes", PlatformAffected.Android)]
+	public class Issue8964 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		object _currentItem;
+		int _counter;
+		Label _lbl;
+
+		protected override void Init()
+		{
+			ItemSourceUnderTest = new ObservableCollection<ModelIssue8964>(GetCarouselItems());
+			var lbl = new Label
+			{
+				Text = @"Scroll to the previous item until see the Item with counter 6,
+						 since we are inserting items on the start of the collection
+						 the position should be  the same"
+			};
+			CarouselViewUnderTest = new CarouselView
+			{
+				HeightRequest = 250,
+				IsSwipeEnabled = true,
+				ItemsSource = ItemSourceUnderTest,
+				ItemTemplate = GetCarouselTemplate(),
+				CurrentItem = _currentItem,
+				AutomationId = "carouseView"
+			};
+			CarouselViewUnderTest.CurrentItemChanged += CarouselViewUnderTestCurrentItemChanged;
+			CarouselViewUnderTest.PositionChanged += CarouselViewUnderTest_PositionChanged;
+
+			_lbl = new Label
+			{
+				Text = $"Item Position - {CarouselViewUnderTest.Position}"
+			};
+
+			Content = new StackLayout
+			{
+				VerticalOptions = LayoutOptions.Center,
+				Children = { lbl, CarouselViewUnderTest, _lbl, }
+			};
+		}
+
+		public ObservableCollection<ModelIssue8964> ItemSourceUnderTest { get; set; }
+		public CarouselView CarouselViewUnderTest { get; set; }
+
+		void CarouselViewUnderTest_PositionChanged(object sender, PositionChangedEventArgs e)
+		{
+			_lbl.Text = $"Item CurrentItemChanged {e.CurrentPosition}";
+		}
+
+		void CarouselViewUnderTestCurrentItemChanged(object sender, CurrentItemChangedEventArgs e)
+		{
+			System.Diagnostics.Debug.WriteLine("Item CurrentItemChanged");
+			_counter++;
+			ItemSourceUnderTest.Insert(0, new ModelIssue8964 { Name = $"Counter {_counter}", Color = Color.Red, Index = _counter });
+		}
+
+		DataTemplate GetCarouselTemplate()
+		{
+			return new DataTemplate(() =>
+			{
+				var grid = new Grid();
+
+				var info = new Label
+				{
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center,
+					Margin = new Thickness(6)
+				};
+
+				info.SetBinding(Label.TextProperty, new Binding("Name"));
+
+				grid.Children.Add(info);
+
+				var frame = new Frame
+				{
+					CornerRadius = 12,
+					Content = grid,
+					HasShadow = false,
+					Margin = new Thickness(12)
+				};
+
+				frame.SetBinding(BackgroundColorProperty, new Binding("Color"));
+
+				return frame;
+			});
+		}
+
+		List<ModelIssue8964> GetCarouselItems()
+		{
+			var random = new Random();
+
+			var items = new List<ModelIssue8964>();
+
+			for (int n = 0; n < 5; n++)
+			{
+				items.Add(new ModelIssue8964
+				{
+					Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
+					Name = DateTime.Now.AddDays(n).ToString("D"),
+					Index = _counter
+				});
+				_counter++;
+			}
+
+			_currentItem = items[4];
+
+			return items;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue8964Test() 
+		{
+			RunningApp.WaitForElement(q => q.Marked($"Item CurrentItemChanged 4"));
+			var rect = RunningApp.Query("carouseView")[0].Rect;
+			RunningApp.DragCoordinates(rect.X + rect.Width - 10, rect.Y, rect.X, rect.Y);
+			RunningApp.WaitForElement(q => q.Marked($"Item CurrentItemChanged 4"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue8964
+	{
+		public ViewModelIssue8964()
+		{
+
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ModelIssue8964
+	{
+		public Color Color { get; set; }
+		public string Name { get; set; }
+		public int Index { get; set; }
+
+		public override string ToString()
+		{
+			return Name;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1293,6 +1293,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9306.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9417.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8272.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8964.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -240,6 +240,13 @@ namespace Xamarin.Forms.Platform.Android
 				carouselPosition = 0;
 			}
 
+			//If we are adding a new item make sure to mantain the CurrentItemPosition
+			if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
+				&& currentItemPosition != -1)
+			{
+				carouselPosition = currentItemPosition;
+			}
+
 			_gotoPosition = -1;
 
 			SetCurrentItem(carouselPosition);

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -367,14 +367,13 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdatePosition(int position)
 		{
 			var carouselPosition = Carousel.Position;
+
 			//we arrived center
 			if (position == _gotoPosition)
 				_gotoPosition = -1;
 
 			if (_gotoPosition == -1 && carouselPosition != position)
-			{
 				Carousel.SetValueFromRenderer(FormsCarouselView.PositionProperty, position);
-			}
 		}
 
 		void SetCurrentItem(int carouselPosition)
@@ -388,7 +387,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateFromCurrentItem()
 		{
-			var currentItemPosition = (ItemsViewAdapter.ItemsSource as IItemsViewSource).GetPosition(Carousel.CurrentItem);
+			var currentItemPosition = ItemsViewAdapter.ItemsSource.GetPosition(Carousel.CurrentItem);
 			var carouselPosition = Carousel.Position;
 
 			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -1,14 +1,14 @@
 ﻿using System;
+using System.Collections;
 using System.ComponentModel;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Data;
 using UWPApp = Windows.UI.Xaml.Application;
 using UWPDataTemplate = Windows.UI.Xaml.DataTemplate;
 using WScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility;
-using WSnapPointsType = Windows.UI.Xaml.Controls.SnapPointsType;
-using WSnapPointsAlignment = Windows.UI.Xaml.Controls.Primitives.SnapPointsAlignment;
 using WScrollMode = Windows.UI.Xaml.Controls.ScrollMode;
-using System.Collections;
+using WSnapPointsAlignment = Windows.UI.Xaml.Controls.Primitives.SnapPointsAlignment;
+using WSnapPointsType = Windows.UI.Xaml.Controls.SnapPointsType;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		ScrollViewer _scrollViewer;
 		int _gotoPosition = -1;
+		bool _noNeedForScroll;
 
 		public CarouselViewRenderer()
 		{
@@ -103,8 +104,6 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 
 			base.UpdateItemsSource();
-
-			UpdateInitialPosition();
 		}
 
 		protected override CollectionViewSource CreateCollectionViewSource()
@@ -158,6 +157,7 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (removingFirstElement && !removingCurrentElement)
 			{
 				carouselPosition = currentItemPosition;
+				_noNeedForScroll = true;
 			}
 
 			//If we are adding a new item make sure to mantain the CurrentItemPosition
@@ -167,11 +167,10 @@ namespace Xamarin.Forms.Platform.UWP
 				carouselPosition = currentItemPosition;
 			}
 
-			if (removingCurrentElement)
-			{
-				SetCurrentItem(carouselPosition);
-				UpdatePosition(carouselPosition);
-			}
+			_gotoPosition = -1;
+
+			SetCurrentItem(carouselPosition);
+			UpdatePosition(carouselPosition);
 		}
 
 		void OnListSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
@@ -179,6 +178,7 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateItemsSource();
 			UpdateSnapPointsType();
 			UpdateSnapPointsAlignment();
+			UpdateInitialPosition();
 		}
 
 		void OnScrollViewChanging(object sender, ScrollViewerViewChangingEventArgs e)
@@ -316,7 +316,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)
 			{
 				_gotoPosition = currentItemPosition;
-				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
+				Carousel.ScrollTo(currentItemPosition, position: ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
 			}
 		}
 
@@ -331,10 +331,16 @@ namespace Xamarin.Forms.Platform.UWP
 			if (carouselPosition == _gotoPosition)
 				_gotoPosition = -1;
 
+			if (_noNeedForScroll)
+			{
+				_noNeedForScroll = false;
+				return;
+			}
+
 			if (_gotoPosition == -1 && !Carousel.IsDragging && !Carousel.IsScrolling)
 			{
 				_gotoPosition = carouselPosition;
-				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
+				Carousel.ScrollTo(carouselPosition, position: ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
 			}
 			SetCurrentItem(carouselPosition);
 		}
@@ -399,7 +405,7 @@ namespace Xamarin.Forms.Platform.UWP
 					Style = (Windows.UI.Xaml.Style)UWPApp.Current.Resources["VerticalCarouselListStyle"]
 				};
 			}
-			
+
 			listView.Padding = new Windows.UI.Xaml.Thickness(Carousel.PeekAreaInsets.Left, Carousel.PeekAreaInsets.Top, Carousel.PeekAreaInsets.Right, Carousel.PeekAreaInsets.Bottom);
 
 			return listView;

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -160,12 +160,18 @@ namespace Xamarin.Forms.Platform.UWP
 				carouselPosition = currentItemPosition;
 			}
 
+			//If we are adding a new item make sure to mantain the CurrentItemPosition
+			if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
+				&& currentItemPosition != -1)
+			{
+				carouselPosition = currentItemPosition;
+			}
+
 			if (removingCurrentElement)
 			{
 				SetCurrentItem(carouselPosition);
 				UpdatePosition(carouselPosition);
 			}
-
 		}
 
 		void OnListSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -278,8 +278,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			SetCurrentItem(position);
 			UpdatePosition(position);
-			if (position > 0)
-				UpdateFromPosition();
+			//if (position > 0)
+			//	UpdateFromPosition();
 		}
 
 		void UpdatePositionFromScroll()
@@ -303,7 +303,9 @@ namespace Xamarin.Forms.Platform.UWP
 										_scrollViewer.VerticalOffset > _previousVerticalOffset;
 
 			var position = ListViewBase.GetVisibleIndexes(CarouselItemsLayout.Orientation, goingNext).centerItemIndex;
-
+			if (position == -1)
+				return;
+			System.Diagnostics.Debug.WriteLine(position);
 			UpdatePosition(position);
 		}
 

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -159,9 +159,8 @@ namespace Xamarin.Forms.Platform.UWP
 				carouselPosition = currentItemPosition;
 				_noNeedForScroll = true;
 			}
-
 			//If we are adding a new item make sure to maintain the CurrentItemPosition
-			if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
+			else if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
 				&& currentItemPosition != -1)
 			{
 				carouselPosition = currentItemPosition;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -38,9 +38,8 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewWillLayoutSubviews();
 			if (!_viewInitialized)
 			{
-				UpdateInitialPosition();
-
 				_viewInitialized = true;
+				UpdateInitialPosition();
 			}
 
 			UpdateVisualStates();
@@ -96,7 +95,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override void BoundsSizeChanged()
 		{
 			base.BoundsSizeChanged();
-			Carousel.ScrollTo(Carousel.Position, position: ScrollToPosition.Center, animate: false);
+			Carousel.ScrollTo(Carousel.Position, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 		}
 
 		internal void TearDown()
@@ -136,7 +135,7 @@ namespace Xamarin.Forms.Platform.iOS
 				carouselPosition = currentItemPosition;
 			}
 
-			if(e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
+			if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Reset)
 			{
 				carouselPosition = 0;
 			}
@@ -147,6 +146,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				carouselPosition = currentItemPosition;
 			}
+
+			_gotoPosition = -1;
 
 			SetCurrentItem(carouselPosition);
 			SetPosition(carouselPosition);
@@ -198,14 +199,19 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateFromCurrentItem()
 		{
 			var currentItemPosition = GetIndexForItem(Carousel.CurrentItem).Row;
-			var carouselPosition = Carousel.Position;
+			
+			ScrollToPosition(currentItemPosition, Carousel.Position);
 
-			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)
-			{
-				_gotoPosition = currentItemPosition;
-				Carousel.ScrollTo(currentItemPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
-			}
 			UpdateVisualStates();
+		}
+
+		void ScrollToPosition(int goToPosition, int carouselPosition)
+		{
+			if (_gotoPosition == -1 && goToPosition != carouselPosition)
+			{
+				_gotoPosition = goToPosition;
+				Carousel.ScrollTo(goToPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimateCurrentItemChanges);
+			}
 		}
 
 		void UpdateFromPosition()
@@ -215,11 +221,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (carouselPosition == _gotoPosition)
 				_gotoPosition = -1;
 
-			if (_gotoPosition == -1 && !Carousel.IsDragging && currentItemPosition != carouselPosition)
-			{
-				_gotoPosition = carouselPosition;
-				Carousel.ScrollTo(carouselPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
-			}
+			if(!Carousel.IsDragging)
+				ScrollToPosition(carouselPosition, currentItemPosition);
 
 			SetCurrentItem(carouselPosition);
 		}
@@ -241,11 +244,13 @@ namespace Xamarin.Forms.Platform.iOS
 					}
 				}
 
-				var initialPosition = position;
-				Carousel.Position = initialPosition;
+				//we need to do this becausee if the CurrentItem was set
+				ScrollToPosition(position, Carousel.Position);
 			}
-
-			SetCurrentItem(Carousel.Position);
+			else
+			{
+				SetCurrentItem(Carousel.Position);
+			}
 		}
 
 		void UpdateVisualStates()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -141,6 +141,13 @@ namespace Xamarin.Forms.Platform.iOS
 				carouselPosition = 0;
 			}
 
+			//If we are adding a new item make sure to mantain the CurrentItemPosition
+			if (e.Action == System.Collections.Specialized.NotifyCollectionChangedAction.Add
+				&& currentItemPosition != -1)
+			{
+				carouselPosition = currentItemPosition;
+			}
+
 			SetCurrentItem(carouselPosition);
 			SetPosition(carouselPosition);
 		}


### PR DESCRIPTION
### Description of Change ###

If we are adding a new item we need to keep the position on the CurrentItem. 
Fixes a regression on the new code introduced.

### Issues Resolved ### 

- fixes #8964

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

None

### Testing Procedure ###


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
