### PR TITLE
Fix SwipeView rendering in Xamarin.Forms Previewer

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			App.IOSVersion = int.Parse(versionPart[0]);
 
 			Xamarin.Calabash.Start();
-			Forms.SetFlags("SwipeView_Experimental", "MediaElement_Experimental");
+			Forms.SetFlags("MediaElement_Experimental");
 			Forms.Init();
 			FormsMaps.Init();
 #if __XCODE11__

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public SwipeViewRenderer(Context context) : base(context)
 		{
-			if (ShouldVerifySwipeViewFlagEnabled())
+			if (ShouldVerifySwipeViewFlagEnabled(context))
 				SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
 
 			_context = context;
@@ -1149,9 +1149,9 @@ namespace Xamarin.Forms.Platform.Android
 			swipeItem.OnInvoked();
 		}
 
-		bool ShouldVerifySwipeViewFlagEnabled()
+		static bool ShouldVerifySwipeViewFlagEnabled(Context context)
 		{
-			if (_context.IsDesignerContext())
+			if (context.IsDesignerContext())
 				return false;
 
 			return true;

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -53,7 +53,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public SwipeViewRenderer(Context context) : base(context)
 		{
-			SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
+			if (ShouldVerifySwipeViewFlagEnabled())
+				SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
 
 			_context = context;
 
@@ -1146,6 +1147,14 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			swipeItem.OnInvoked();
+		}
+
+		bool ShouldVerifySwipeViewFlagEnabled()
+		{
+			if (_context.IsDesignerContext())
+				return false;
+
+			return true;
 		}
 
 		void OnOpenRequested(object sender, OpenSwipeEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Extensions/UIApplicationExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/UIApplicationExtensions.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using UIKit;
+﻿using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -21,7 +20,15 @@ namespace Xamarin.Forms.Platform.iOS
 #else
 			return application.KeyWindow;
 #endif
+		}
 
+		public static bool UsePreviewerDelegate(this UIApplication application)
+		{
+#if __MOBILE__
+			return application?.Delegate?.GetType()?.FullName == "XamarinFormsPreviewer.iOS.AppDelegate";
+#else
+			return false;
+#endif
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -125,8 +125,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual IShellFlyoutRenderer CreateFlyoutRenderer()
 		{
-			// HACK
-			if(UIApplication.SharedApplication?.Delegate?.GetType()?.FullName == "XamarinFormsPreviewer.iOS.AppDelegate")
+			if (UIApplication.SharedApplication.UsePreviewerDelegate())
 			{
 				return new DesignerFlyoutRenderer(this);
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -1195,7 +1195,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool ShouldVerifySwipeViewFlagEnabled()
 		{
-			if (UIApplication.SharedApplication?.Delegate?.GetType()?.FullName == "XamarinFormsPreviewer.iOS.AppDelegate")
+			if (UIApplication.SharedApplication.UsePreviewerDelegate())
 				return false;
 
 			return true;

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -42,7 +42,8 @@ namespace Xamarin.Forms.Platform.iOS
 		[Preserve(Conditional = true)]
 		public SwipeViewRenderer()
 		{
-			SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
+			if (ShouldVerifySwipeViewFlagEnabled())
+				SwipeView.VerifySwipeViewFlagEnabled(nameof(SwipeViewRenderer));
 
 			_tapGestureRecognizer = new UITapGestureRecognizer(HandleTap)
 			{
@@ -1170,6 +1171,14 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			swipeItem.OnInvoked();
+		}
+
+		bool ShouldVerifySwipeViewFlagEnabled()
+		{
+			if (UIApplication.SharedApplication?.Delegate?.GetType()?.FullName == "XamarinFormsPreviewer.iOS.AppDelegate")
+				return false;
+
+			return true;
 		}
 
 		void OnParentScrolled(object sender, ScrolledEventArgs e)


### PR DESCRIPTION
### Description of Change ###

Avoid verify the SwipeView Experimental flag using Xamarin.Forms **Previewer**.

### Issues Resolved ### 

- fixes #10111 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before

```
[2020-03-30 08:19:02.3] Renderer >> 4 [monodroid] SWITCHING CONTEXT
[2020-03-30 08:19:02.3] Renderer >> 4 [monodroid] SWITCHING CONTEXT
[2020-03-30 08:19:02.3] Renderer >> INFO: Trying to load class xamarindesigner.AndroidFormsPreviewerRenderer
[2020-03-30 08:19:02.3] Renderer >> 
[2020-03-30 08:19:02.3] Renderer >> INFO: InstantiateObject(): ResourceProvider2: Enabled - CreateFromXamlWithDesignPropsDelegate: Enabled.
[2020-03-30 08:19:02.3] Renderer >> INFO: InstantiateObject() => ShouldRender() => true (SwipeViewTest.App is not a VisualElement)
[2020-03-30 08:19:02.3] Renderer >> INFO: ResourceProvider2: SwipeViewTest: App.xaml (isMainFile: True)
[2020-03-30 08:19:02.3] Renderer >> INFO: ResourceProvider2: SwipeViewTest: MainPage.xaml (isMainFile: False)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.Label is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.Label is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.Grid is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.SwipeView is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.StackLayout is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: XamarinFormsLoaderAndroid >>> InitializeApplication -> Found a RegisterHandlers method.
[2020-03-30 08:19:02.3] Renderer >> INFO: InstantiateObject(): ResourceProvider2: Enabled - CreateFromXamlWithDesignPropsDelegate: Enabled.
[2020-03-30 08:19:02.3] Renderer >> INFO: InstantiateObject() => ShouldRender() => false (SwipeViewTest.MainPage is not DesignTimeVisible, nor does it implement IComponent)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.ContentPage is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.Label is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.Label is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.Grid is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.SwipeView is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> INFO: FallbackTypeResolverHandler() => ShouldRender() => true (Xamarin.Forms.StackLayout is a Forms type)
[2020-03-30 08:19:02.3] Renderer >> 4 [monodroid] SWITCHING CONTEXT
[2020-03-30 08:19:02.3] ERROR: : The renderer encountered an error while rendering this file: System.InvalidOperationException: The class, property, or method you are attempting to use ('.ctor') is part of SwipeView; to use it, you must opt-in by calling Forms.SetFlags("SwipeView_Experimental") before calling Forms.Init().
Xamarin.Forms.ExperimentalFlags.VerifyFlagEnabled (System.String coreComponentName, System.String flagName, System.String constructorHint, System.String memberName) in D:\a\1\s\Xamarin.Forms.Core\ExperimentalFlags.cs:38
Xamarin.Forms.SwipeView.VerifySwipeViewFlagEnabled (System.String constructorHint, System.String memberName) in D:\a\1\s\Xamarin.Forms.Core\SwipeView.cs:25
Xamarin.Forms.Platform.Android.SwipeViewRenderer..ctor (Android.Content.Context context) in D:\a\1\s\Xamarin.Forms.Platform.Android\Renderers\SwipeViewRenderer.cs:48
<unknown method>
System.Reflection.RuntimeConstructorInfo.InternalInvoke (System.Object obj, System.Object[] parameters, System.Boolean wrapExceptions) in /Users/builder/jenkins/workspace/archive-mono/2019-10/android/release/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:936

[2020-03-30 08:19:02.3] ERROR: : AndroidXamlRenderer had a rendering error: System.InvalidOperationException: The class, property, or method you are attempting to use ('.ctor') is part of SwipeView; to use it, you must opt-in by calling Forms.SetFlags("SwipeView_Experimental") before calling Forms.Init().
Xamarin.Forms.ExperimentalFlags.VerifyFlagEnabled (System.String coreComponentName, System.String flagName, System.String constructorHint, System.String memberName) in D:\a\1\s\Xamarin.Forms.Core\ExperimentalFlags.cs:38
Xamarin.Forms.SwipeView.VerifySwipeViewFlagEnabled (System.String constructorHint, System.String memberName) in D:\a\1\s\Xamarin.Forms.Core\SwipeView.cs:25
Xamarin.Forms.Platform.Android.SwipeViewRenderer..ctor (Android.Content.Context context) in D:\a\1\s\Xamarin.Forms.Platform.Android\Renderers\SwipeViewRenderer.cs:48
<unknown method>
System.Reflection.RuntimeConstructorInfo.InternalInvoke (System.Object obj, System.Object[] parameters, System.Boolean wrapExceptions) in /Users/builder/jenkins/workspace/archive-mono/2019-10/android/release/mcs/class/corlib/System.Reflection/RuntimeMethodInfo.cs:936
```

####After
<img width="1683" alt="Captura de pantalla 2020-03-30 a las 8 33 02" src="https://user-images.githubusercontent.com/6755973/77896199-30e24a80-7278-11ea-930c-22235d46b7d2.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the SwipeView samples. Open the "Basic SwipeView Gallery" XAML page (for example) and load the Previewer. The Previewer must work.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)

> VS bug [#1091165](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1091165)