### PR TITLE
[iOS] Fix SwipeItem issue with big icons

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemIconGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemIconGallery.cs
@@ -112,7 +112,7 @@
 					FontFamily = fontFamily,
 					Size = 16
 				},
-				Text = "Url"
+				Text = "Font"
 			};
 
 			fontSwipeItem.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Font Invoked", "Ok"); };

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemSizeGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemSizeGallery.xaml
@@ -1,0 +1,153 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.SwipeItemSizeGallery"
+    Title="SwipeItem Size Gallery">
+    <ContentPage.Content>
+        <ScrollView>
+            <StackLayout
+                Padding="12">
+                <Label
+                    FontAttributes="Bold"
+                    Text="Different icon sizes"/>
+                <Label
+                    Text="128x128 Icon"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/128/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <Grid
+                        HeightRequest="60"
+                        BackgroundColor="LightGray">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Swipe to Left"/>
+                    </Grid>
+                </SwipeView>
+                <Label
+                    Text="256x256 Icon"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/256/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <Grid
+                        HeightRequest="60"
+                        BackgroundColor="LightGray">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Swipe to Left"/>
+                    </Grid>
+                </SwipeView>
+                <Label
+                    Text="512x512 Icon"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/512/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <Grid
+                        HeightRequest="60"
+                        BackgroundColor="LightGray">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Swipe to Left"/>
+                    </Grid>
+                </SwipeView>
+                <Label
+                    FontAttributes="Bold"
+                    Text="Different SwipeView sizes"/>
+                <Label
+                    Text="SwipeView 128 Height"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/512/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <Grid
+                        HeightRequest="128"
+                        BackgroundColor="LightGray">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Swipe to Left"/>
+                    </Grid>
+                </SwipeView>
+                <Label
+                    Text="SwipeView 256 Height"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/512/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <Grid
+                        HeightRequest="256"
+                        BackgroundColor="LightGray">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Swipe to Left"/>
+                    </Grid>
+                </SwipeView>
+                <Label
+                    Text="SwipeView 512 Height"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/512/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <Grid
+                        HeightRequest="512"
+                        BackgroundColor="LightGray">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Swipe to Left"/>
+                    </Grid>
+                </SwipeView>
+                <Label
+                    Text="SwipeView No Size"/>
+                <SwipeView>
+                    <SwipeView.LeftItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            IconImageSource="https://image.flaticon.com/icons/png/512/61/61848.png"
+                            Text="Delete"
+                            Invoked="OnSwipeItemInvoked"/> 
+                    </SwipeView.LeftItems>
+                    <StackLayout
+                        BackgroundColor="LightGray">
+                        <Label
+                            Text="Swipe to Left"/>
+                        <Label
+                            FontAttributes="Bold"
+                            Text="SwipeView without Size"/>
+                    </StackLayout>
+                </SwipeView>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemSizeGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemSizeGallery.xaml.cs
@@ -1,0 +1,17 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class SwipeItemSizeGallery : ContentPage
+	{
+		public SwipeItemSizeGallery()
+		{
+			InitializeComponent();
+		}
+
+		void OnSwipeItemInvoked(object sender, EventArgs e)
+		{
+			DisplayAlert("SwipeItemSizeGallery", "Delete SwipeItem Invoked", "Ok");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 						GalleryBuilder.NavButton("Custom SwipeItem Galleries", () => new CustomSwipeItemGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeView BindingContext Gallery", () => new SwipeViewBindingContextGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItem Icon Gallery", () => new SwipeItemIconGallery(), Navigation),
+						GalleryBuilder.NavButton("SwipeItem Size Gallery", () => new SwipeItemSizeGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeTransitionMode Gallery", () => new SwipeTransitionModeGallery(), Navigation),
 						GalleryBuilder.NavButton("Add/Remove SwipeItems Gallery", () => new AddRemoveSwipeItemsGallery(), Navigation),
 						GalleryBuilder.NavButton("Open/Close SwipeView Gallery", () => new CloseSwipeGallery(), Navigation),

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -430,6 +430,12 @@ namespace Xamarin.Forms.Platform.iOS
 						break;
 				}
 
+				if (swipeItem is UIButton button)
+				{
+					UpdateSwipeItemIconImage(button, (SwipeItem)item);
+					UpdateSwipeItemInsets(button);
+				}
+
 				_actionView.AddSubview(swipeItem);
 				_swipeItemsRect.Add(swipeItem.Frame);
 				previousWidth += swipeItemWidth;
@@ -450,12 +456,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			swipeItem.SetTitle(formsSwipeItem.Text, UIControlState.Normal);
 
-			UpdateSwipeItemIconImage(swipeItem, formsSwipeItem);
-
 			var textColor = GetSwipeItemColor(formsSwipeItem.BackgroundColor);
 			swipeItem.SetTitleColor(textColor.ToUIColor(), UIControlState.Normal);
 			swipeItem.UserInteractionEnabled = false;
-			UpdateSwipeItemInsets(swipeItem);
 
 			return swipeItem;
 		}
@@ -488,6 +491,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (button.ImageView?.Image == null)
 				return;
 
+			button.ContentMode = UIViewContentMode.Center;
+			button.ImageView.ContentMode = UIViewContentMode.ScaleAspectFit;
+
 			var imageSize = button.ImageView.Image.Size;
 
 			var titleEdgeInsets = new UIEdgeInsets(spacing, -imageSize.Width, -imageSize.Height, 0.0f);
@@ -519,9 +525,14 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var image = await swipeItem.IconImageSource.GetNativeImageAsync();
 
+				var maxWidth = swipeButton.Frame.Width * 0.5f;
+				var maxHeight = swipeButton.Frame.Height * 0.5f;
+
+				var resizedImage = MaxResizeSwipeItemIconImage(image, maxWidth, maxHeight);
+
 				try
 				{
-					swipeButton.SetImage(image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate), UIControlState.Normal);
+					swipeButton.SetImage(resizedImage.ImageWithRenderingMode(UIImageRenderingMode.AlwaysTemplate), UIControlState.Normal);
 					var tintColor = GetSwipeItemColor(swipeItem.BackgroundColor);
 					swipeButton.TintColor = tintColor.ToUIColor();
 				}
@@ -531,6 +542,27 @@ namespace Xamarin.Forms.Platform.iOS
 					Log.Warning("SwipeView", "Can not load SwipeItem Icon.");
 				}
 			}
+		}
+
+		UIImage MaxResizeSwipeItemIconImage(UIImage sourceImage, nfloat maxWidth, nfloat maxHeight)
+		{
+			if (sourceImage == null)
+				return null;
+
+			var sourceSize = sourceImage.Size;
+			var maxResizeFactor = Math.Min(maxWidth / sourceSize.Width, maxHeight / sourceSize.Height);
+
+			if (maxResizeFactor > 1)
+				return sourceImage;
+
+			var width = maxResizeFactor * sourceSize.Width;
+			var height = maxResizeFactor * sourceSize.Height;
+			UIGraphics.BeginImageContextWithOptions(new CGSize((nfloat)width, (nfloat)height), false, 0);
+			sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
+			var resultImage = UIGraphics.GetImageFromCurrentImageContext();
+			UIGraphics.EndImageContext();
+
+			return resultImage;
 		}
 
 		void HandleTouchInteractions(GestureStatus status, CGPoint point)


### PR DESCRIPTION
### Description of Change ###

In iOS, using large icons, the icon does not fit correctly. This PR fix the SwipeItem issue with big icons.

<img width="408" alt="Captura de pantalla 2020-03-30 a las 11 38 53" src="https://user-images.githubusercontent.com/6755973/77898278-2f665180-727b-11ea-84e2-496ff08e2b25.png">
<img width="410" alt="Captura de pantalla 2020-03-30 a las 11 39 23" src="https://user-images.githubusercontent.com/6755973/77898283-31301500-727b-11ea-9992-42f86d759d61.png">

### Issues Resolved ### 

- fixes #10113 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the SwipeView samples. Select "SwipeItem Size Gallery". There are several SwipeView's using different icon sizes, etc. Open all the SwipeView's and verify that the icon have the correct size in all the cases.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
