### PR TITLE
Add equivalent androidx proguard rules

### DIFF
--- a/.nuspec/proguard.cfg
+++ b/.nuspec/proguard.cfg
@@ -1,9 +1,14 @@
 -keep class android.support.v7.widget.FitWindowsFrameLayout { *; }
 -dontwarn android.support.v7.widget.FitWindowsFrameLayout
+-keep class androidx.appcompat.widget.FitWindowsFrameLayout { *; }
+-dontwarn androidx.appcompat.widget.FitWindowsFrameLayout
 -keep class android.support.design.** { *; }
 -keep class android.support.multidex.MultiDexApplication { *; }
+-keep class androidx.multidex.MultiDexApplication { *; }
 -keep class android.support.design.internal.BaselineLayout { *; }
 -dontwarn android.support.design.internal.BaselineLayout
+-keep class com.google.android.material.internal.BaselineLayout { *; }
+-dontwarn com.google.android.material.internal.BaselineLayout
 -keep class com.google.firebase.provider.FirebaseInitProvider { *; }
 -keep class androidx.appcompat.widget.AlertDialogLayout { *; }
 -keep class androidx.appcompat.widget.DialogTitle { *; }


### PR DESCRIPTION
### Description of Change ###

When a project isn't running androidx migration (so not referencing any support libraries) than the migration doesn't migrate the proguard rules. So we need to have the equivalent androidx proguard rules in place


### Platforms Affected ### 
- Android

### Testing Procedure ###
- download nugets
- create new forms projects
- update essentials/forms to latest androidx dependent packages
- ensure you're targeting API 29
- enable r8/d8 and linker
- make sure project runs

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
