### PR TITLE
Remove controller from UINavigationController stack  when page is removed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6484.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6484.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 6484, "[iOS] Shell - Go back two pages crashes the app with a NullReferenceException",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue6484 : TestShell
+	{
+		StackLayout layout = null;
+		ContentPage page = null;
+		protected override void Init()
+		{
+			layout = new StackLayout();
+			page = new ContentPage()
+			{
+				Content = layout
+			};
+
+			page.Appearing += OnPageAppearing;
+
+			AddContentPage(page);
+
+		}
+
+		async void OnPageAppearing(object sender, EventArgs e)
+		{
+			page.Appearing -= OnPageAppearing;
+
+			var removeMe = new ContentPage();
+			await Navigation.PushAsync(removeMe);
+			await Navigation.PushAsync(new ContentPage());
+
+			await Task.Delay(1);
+
+			Navigation.RemovePage(removeMe);
+			await Navigation.PopAsync();
+
+
+			await Task.Delay(1);
+			layout.Children.Add(
+				new Label()
+				{
+					Text = "If app hasn't crashed test has succeeded",
+					AutomationId = "Success"
+				});
+
+		}
+
+#if UITEST
+		[Test]
+		public void RemovingIntermediatePagesBreaksShell()
+		{
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6484.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6484.cs
@@ -67,6 +67,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void RemovingIntermediatePagesBreaksShell()
 		{
+			RunningApp.WaitForElement("Success");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6187.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3228.xaml.cs">
       <DependentUpon>Issue3228.xaml</DependentUpon>
@@ -1459,12 +1460,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9735.xaml">
-       <SubType>Designer</SubType>
-       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9305.xaml">
-       <SubType>Designer</SubType>
-       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9588.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -724,20 +724,22 @@ namespace Xamarin.Forms
 			bool currentPage = (((IShellSectionController)this).PresentedPage) == page;
 			var stack = _navStack.ToList();
 			stack.Remove(page);
-			var allow = ((IShellController)Shell).ProposeNavigation(
-				ShellNavigationSource.Remove,
-				ShellItem,
-				this,
-				CurrentItem,
-				stack,
-				true
-			);
+			var allow = (!currentPage) ? true : 
+				((IShellController)Shell).ProposeNavigation(
+					ShellNavigationSource.Remove,
+					ShellItem,
+					this,
+					CurrentItem,
+					stack,
+					true
+				);
 
 			if (!allow)
 				return;
 
 			if(currentPage)
 				PresentedPageDisappearing();
+
 			_navStack.Remove(page);
 
 			if(currentPage)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -105,12 +105,6 @@ namespace Xamarin.Forms.Platform.iOS
 			return false;
 		}
 
-
-		public override void AddChildViewController(UIViewController childController)
-		{
-			base.AddChildViewController(childController);
-		}
-
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();


### PR DESCRIPTION
### Description of Change ###
The renderer on the page was being being removed before the event was propagated down to shell. Shell was using the renderer on the page to access the viewcontroller in order to remove it from the stack. This code makes the platform code less dependent on the ordering of the xplat code. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #6484 


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- automated tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
