### PR TITLE
Fixed not applied BarTintColor in iOS NavBar using iOS 13

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -645,7 +645,10 @@ namespace Xamarin.Forms.Platform.iOS
 				var navigationBarAppearance = NavigationBar.StandardAppearance;
 
 				if (barBackgroundColor == Color.Default)
+				{
 					navigationBarAppearance.ConfigureWithDefaultBackground();
+					navigationBarAppearance.BackgroundColor = UINavigationBar.Appearance.BarTintColor;
+				}
 				else
 				{
 					navigationBarAppearance.ConfigureWithOpaqueBackground();
@@ -734,7 +737,7 @@ namespace Xamarin.Forms.Platform.iOS
 				else
 #endif
 				{
-						UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.Default;
+					UIApplication.SharedApplication.StatusBarStyle = UIStatusBarStyle.Default;
 				}
 			}
 			else


### PR DESCRIPTION
### Description of Change ###

This PR fixes an issue that caused the `UINavigationBar.Appearance.BarTintColor` not to be applied in the NavigationBar in iOS 13.

NOTE: Changing other options like `TintColor` or `TitleTextAttributes` works. Changing `BarTintColor` works on iOS <= 12.

### Issues Resolved ### 

- fixes #9765

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Open Core Gallery and include the following lines in the `AppDelegate`:
```
UINavigationBar.Appearance.BarTintColor = UIColor.FromPatternImage(UIImage.FromFile("coffee.png"));
UINavigationBar.Appearance.TintColor = UIColor.Orange;
UINavigationBar.Appearance.SetTitleTextAttributes(new UITextAttributes() { TextColor = UIColor.Green });
```

The result must be:
![Simulator Screen Shot - iPhone 11 - 2020-03-31 at 09 36 49](https://user-images.githubusercontent.com/6755973/78000684-effc3b80-7334-11ea-8b30-3c9a05f619b7.png)

```
UINavigationBar.Appearance.BarTintColor = UIColor.FromPatternImage(UIImage.FromFile("coffee.png"));
UINavigationBar.Appearance.TintColor = UIColor.Orange;
UINavigationBar.Appearance.LargeTitleTextAttributes = new UIStringAttributes() { ForegroundColor = UIColor.Yellow };
```

The result must be:
![Simulator Screen Shot - iPhone 11 - 2020-03-31 at 09 35 15](https://user-images.githubusercontent.com/6755973/78000685-f12d6880-7334-11ea-9e00-794d3c7025c6.png)

Navigate to the Issue9767. Verify that setting the BarBackgroundColor and BarTextColor works and when resetting the colors, we must continue seeing the initial configuration established in AppDelegate.

![update-ios-barcolors](https://user-images.githubusercontent.com/6755973/78001458-fb9c3200-7335-11ea-9a6f-0d89f6215656.gif)

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
