### PR TITLE
[Tizen] Enable Page.ToolbarItem on Watch

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/FormsMoreOptionItem.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/FormsMoreOptionItem.cs
@@ -1,0 +1,9 @@
+﻿using ElmSharp.Wearable;
+
+namespace Xamarin.Forms.Platform.Tizen.Native.Watch
+{
+	public class FormsMoreOptionItem : MoreOptionItem
+	{
+		public ToolbarItem ToolbarItem { get; set; }
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/PageRenderer.cs
@@ -1,4 +1,7 @@
 using System;
+using System.Collections.Specialized;
+using ElmSharp.Wearable;
+using Xamarin.Forms.Platform.Tizen.Native.Watch;
 using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -12,6 +15,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		/// Native control which holds the contents.
 		/// </summary>
 		Native.Page _page;
+		Lazy<MoreOption> _moreOption;
 
 		/// <summary>
 		/// Default constructor.
@@ -32,6 +36,22 @@ namespace Xamarin.Forms.Platform.Tizen
 			base.OnElementChanged(e);
 		}
 
+		protected override void OnElementReady()
+		{
+			if (Device.Idiom == TargetIdiom.Watch)
+			{
+				_moreOption = new Lazy<MoreOption>(CreateMoreOption);
+				if (Element.ToolbarItems is INotifyCollectionChanged items)
+				{
+					items.CollectionChanged += OnToolbarCollectionChanged;
+				}
+				if (Element.ToolbarItems.Count > 0)
+				{
+					UpdateToolbarItems(true);
+				}
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)
@@ -39,6 +59,21 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (_page != null)
 				{
 					_page.LayoutUpdated -= OnLayoutUpdated;
+				}
+
+				if (Device.Idiom == TargetIdiom.Watch)
+				{
+					if (Element.ToolbarItems is INotifyCollectionChanged items)
+					{
+						items.CollectionChanged -= OnToolbarCollectionChanged;
+					}
+
+					if (_moreOption.IsValueCreated)
+					{
+						_moreOption.Value.Clicked -= OnMoreOptionItemClicked;
+						_moreOption.Value.Items.Clear();
+						_moreOption.Value.Unrealize();
+					}
 				}
 			}
 			base.Dispose(disposing);
@@ -61,9 +96,26 @@ namespace Xamarin.Forms.Platform.Tizen
 			// empty on purpose
 		}
 
-		void UpdateBackgroundImage(bool initiaize)
+		protected virtual FormsMoreOptionItem CreateMoreOptionItem(ToolbarItem item)
 		{
-			if (initiaize && Element.BackgroundImageSource.IsNullOrEmpty())
+			var moreOptionItem = new FormsMoreOptionItem
+			{
+				MainText = item.Text,
+				ToolbarItem = item
+			};
+			var icon = item.IconImageSource as FileImageSource;
+			if (icon != null)
+			{
+				var img = new ElmSharp.Image(_moreOption.Value);
+				img.Load(ResourcePath.GetPath(icon));
+				moreOptionItem.Icon = img;
+			}
+			return moreOptionItem;
+		}
+
+		void UpdateBackgroundImage(bool initialize)
+		{
+			if (initialize && Element.BackgroundImageSource.IsNullOrEmpty())
 				return;
 
 			// TODO: investigate if we can use the other image source types: stream, font, uri
@@ -78,6 +130,52 @@ namespace Xamarin.Forms.Platform.Tizen
 		void OnLayoutUpdated(object sender, Native.LayoutEventArgs e)
 		{
 			Element.Layout(e.Geometry.ToDP());
+
+			if (_moreOption != null && _moreOption.IsValueCreated)
+			{
+				_moreOption.Value.Geometry = _page.Geometry;
+			}
+		}
+
+		MoreOption CreateMoreOption()
+		{
+			var moreOption = new MoreOption(_page);
+			moreOption.Clicked += OnMoreOptionItemClicked;
+			_page.Children.Add(moreOption);
+			moreOption.Show();
+			return moreOption;
+		}
+
+		void OnToolbarCollectionChanged(object sender, EventArgs eventArgs)
+		{
+			if (Element.ToolbarItems.Count > 0 || _moreOption.IsValueCreated)
+			{
+				UpdateToolbarItems(false);
+			}
+		}
+
+		void UpdateToolbarItems(bool initialize)
+		{
+			//clear existing more option items and add toolbar item again on purpose.
+			if (!initialize && _moreOption.Value.Items.Count > 0)
+			{
+				_moreOption.Value.Items.Clear();
+			}
+
+			foreach (var item in Element.ToolbarItems)
+			{
+				_moreOption.Value.Items.Add(CreateMoreOptionItem(item));
+			}
+		}
+
+		void OnMoreOptionItemClicked(object sender, MoreOptionItemEventArgs e)
+		{
+			var formsMoreOptionItem = e.Item as FormsMoreOptionItem;
+			if (formsMoreOptionItem != null)
+			{
+				((IMenuItemController)formsMoreOptionItem.ToolbarItem)?.Activate();
+			}
+			_moreOption.Value.IsOpened = false;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
This PR is allow you to use `ToolbarItem` on Tizen wearable devices including Galaxy Watch series.
Previously, nothing happend even if you add a `ToolbarItem`to the `Page` on `TargetIdiom.Watch`.
Now with this PR you can use `ToolbarItem` as shown below.

If you add `ToolbarItem` to the page, it will look like this:
<img src="https://user-images.githubusercontent.com/1029134/78019707-177df300-738b-11ea-99e7-ecb2f9ed348d.png" width="240"/>

You can check the items by clicking the corresponding ("...") button :
<img src="https://user-images.githubusercontent.com/1029134/78019809-38dedf00-738b-11ea-87e5-6b53d91f7079.png" width="240"/>

> **Remark**
> This screenshot is from Tizen 5.5 version. According to the platform UX policy, in Tizen 5.0 and earlier, it is seen as a circular selector (called `Rotary Selector`) rather than a list.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
`ToolbarItem` is now works properly on TargetIdom.Watch.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)