### PR TITLE
[UWP] Fix TextBox styling to adopt Dark Theme

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/App.xaml
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/App.xaml
@@ -2,8 +2,7 @@
     x:Class="Xamarin.Forms.ControlGallery.WindowsUniversal.App"
     xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
-    xmlns:local="using:Xamarin.Forms.ControlGallery.WindowsUniversal"
-	RequestedTheme="Light">
+    xmlns:local="using:Xamarin.Forms.ControlGallery.WindowsUniversal">
 
 	<Application.Resources>
 		<ResourceDictionary>

--- a/Xamarin.Forms.Platform.UAP/FormsAutoSuggestBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsAutoSuggestBoxStyle.xaml
@@ -61,11 +61,11 @@
 		<Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
 		<Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
 		<Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-		<Setter Property="ForegroundFocusBrush" Value="{ThemeResource SystemControlForegroundChromeBlackHighBrush}" />
+        <Setter Property="ForegroundFocusBrush" Value="{ThemeResource SystemColorWindowTextColor}" />
 		<Setter Property="PlaceholderForegroundBrush" Value="{ThemeResource SystemControlPageTextBaseMediumBrush}" />
 		<Setter Property="PlaceholderForegroundFocusBrush" Value="{ThemeResource SystemControlPageTextChromeBlackMediumLowBrush}" />
 		<Setter Property="Background" Value="{ThemeResource SystemControlBackgroundAltHighBrush}" />
-		<Setter Property="BackgroundFocusBrush" Value="{ThemeResource SystemControlBackgroundChromeWhiteBrush}" />
+        <Setter Property="BackgroundFocusBrush" Value="{ThemeResource TextControlBackground}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}" />
 		<Setter Property="SelectionHighlightColor" Value="{ThemeResource SystemControlHighlightAccentBrush}" />
 		<Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -8,11 +8,11 @@
 		<Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
 		<Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
 		<Setter Property="Foreground" Value="{ThemeResource SystemControlForegroundBaseHighBrush}" />
-		<Setter Property="ForegroundFocusBrush" Value="{ThemeResource SystemControlForegroundChromeBlackHighBrush}" />
+        <Setter Property="ForegroundFocusBrush" Value="{ThemeResource SystemColorWindowTextColor}" />
 		<Setter Property="PlaceholderForegroundBrush" Value="{ThemeResource SystemControlPageTextBaseMediumBrush}" />
 		<Setter Property="PlaceholderForegroundFocusBrush" Value="{ThemeResource SystemControlPageTextChromeBlackMediumLowBrush}" />
 		<Setter Property="Background" Value="{ThemeResource SystemControlBackgroundAltHighBrush}" />
-		<Setter Property="BackgroundFocusBrush" Value="{ThemeResource SystemControlBackgroundChromeWhiteBrush}" />
+        <Setter Property="BackgroundFocusBrush" Value="{ThemeResource TextControlBackground}" />
 		<Setter Property="BorderBrush" Value="{ThemeResource SystemControlForegroundChromeDisabledLowBrush}" />
 		<Setter Property="SelectionHighlightColor" Value="{ThemeResource SystemControlHighlightAccentBrush}" />
 		<Setter Property="BorderThickness" Value="{ThemeResource TextControlBorderThemeThickness}" />


### PR DESCRIPTION
### Description of Change ###

Fix minor styling in the UWP `TextBox` to support the adoption of Dark Theme. The only control that stood out was the `TextBox` which would get a white background and black text when focused. 

This fix uses the background determined by the system as well as the font.

From what I can tell the `TextBox` also doesn't play nicely on pure native UWP. Maybe it's intended if I read this; https://github.com/microsoft/microsoft-ui-xaml/issues/2068 but I disagree 😬 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- related to #9804

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

In itself; none. When combined with the template fix that is coming _or_ when users remove the fixed `RequestedTheme="Light"` from the App.xaml (in UWP project, like in the changes of this PR) the Dark theme will be applied and now also to the `Entry`

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

For light theme no change

#### Before
![image](https://user-images.githubusercontent.com/939291/78038365-0de59280-736d-11ea-8cfb-f9e205188a63.png)

#### After

![image](https://user-images.githubusercontent.com/939291/78037056-51d79800-736b-11ea-8616-1c251e1a3e91.png)

### Testing Procedure ###
Open gallery app and find every `Entry` control you can, see if it looks funny

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
