### PR TITLE
[Android] Fix for Talkback reporting incorrect number of list items (#4090)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4090.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4090.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4090, "Talkback reports incorrect number of list items", PlatformAffected.Android)]
+	public class Issue4090 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+
+			List<string> menuItems = new List<string>
+			{
+				"Browse","About"
+			};
+
+			StackLayout stack = new StackLayout();
+
+			ListView ListViewMenu = new ListView();
+			ListViewMenu.ItemsSource = menuItems;
+
+			ListViewMenu.SelectedItem = menuItems[0];
+
+			Label label = new Label();
+			label.Text = "When clicking 'Browse' or 'About', Talkback should report that the element is in list of 2 items";
+			stack.Children.Add(label);
+			stack.Children.Add(ListViewMenu);
+			Content = stack;
+
+
+			BindingContext = new ViewModelIssue4090();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue4090
+	{
+		public ViewModelIssue4090()
+		{
+
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ModelIssue4090
+	{
+		public ModelIssue4090()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -2277,10 +2277,4 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
-  <ItemGroup>
-    <EmbeddedResource Include="$(MSBuildThisFileDirectory)ShellFlyoutItemIsVisible.xaml">
-      <SubType>Designer</SubType>
-      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>
-  </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -50,6 +50,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11311.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4090.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6187.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue3228.xaml.cs">
@@ -2272,6 +2273,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11853.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)ShellFlyoutItemIsVisible.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -359,7 +359,15 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			if (footer == null)
+			{
+				if (_footerView.ChildCount == 0)
+				{
+					AListView nativeListView = Control;
+					nativeListView.RemoveFooterView(_adapter.FooterView);
+				}
 				return;
+			}
+
 
 			if (_footerRenderer != null)
 				_footerRenderer.SetElement(footer);
@@ -391,7 +399,15 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			if (header == null)
+			{
+				if (_headerView.ChildCount == 0)
+				{
+					AListView nativeListView = Control;
+					nativeListView.RemoveHeaderView(_adapter.HeaderView);
+				}
 				return;
+			}
+
 
 			if (_headerRenderer != null)
 				_headerRenderer.SetElement(header);


### PR DESCRIPTION
### Description of Change ###

The native ListView control in Android had two phantom items (header and footer). Even if they were invisible, they still counted toward the children count. Therefore, a list with 2 items would get narrated as "a list of 4 items".

### Issues Resolved ### 

- fixes #4090

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run Issue4090 in Control Gallery.
When clicking 'Browse' or 'About', Talkback should report that the element is in a list of 2 items.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
