### PR TITLE
Fix 9939 [iOS][UWP] Dispose method not called when adding control inside the NavigationPage.TitleView

### DIFF
--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -453,7 +453,10 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_currentPage != null)
 			{
 				if (isPopping)
+				{
 					_currentPage.Cleanup();
+					_container.TitleView?.Cleanup();
+				}
 
 				_container.Content = null;
 				_currentPage.PropertyChanged -= OnCurrentPagePropertyChanged;

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1079,6 +1079,12 @@ namespace Xamarin.Forms.Platform.iOS
 					_tracker.CollectionChanged -= TrackerOnCollectionChanged;
 					_tracker = null;
 
+					if (NavigationItem.TitleView != null)
+					{
+						NavigationItem.TitleView.Dispose();
+						NavigationItem.TitleView = null;
+					}
+
 					if (NavigationItem.RightBarButtonItems != null)
 					{
 						for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)


### PR DESCRIPTION
### Description of Change ###
Dispose() method is not called for a custom view added to  TitleView on iOS and UWP


### Issues Resolved ### 


- fixes #9939 

### Platforms Affected ### 

- iOS
- UWP


### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
