### PR TITLE
Fixed #9951 -  Setting ThumbColor on Switch causes a square block

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9951.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9951.cs
@@ -1,0 +1,54 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+using System.Threading.Tasks;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9951, "Android 10 Setting ThumbColor on Switch causes a square block", PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public class Issue9951 : TestContentPage
+	{
+		private const string switchId = "switch";
+
+		public Issue9951()
+		{
+		}
+
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout();
+
+			stackLayout.Children.Add(new Switch()
+			{
+				ThumbColor = Color.Red,
+				OnColor = Color.Yellow,
+				AutomationId = switchId
+			});
+
+			Content = stackLayout;
+		}
+
+#if UITEST && __ANDROID__
+		[Test]
+		public async Task SwitchColorTest()
+		{
+			RunningApp.WaitForElement(switchId);
+
+			RunningApp.Screenshot("Initial switch state");
+
+			RunningApp.Tap(switchId);
+
+			//Delay so that the switch toggling is finished
+			await Task.Delay(200);
+
+			RunningApp.Screenshot("Toggled switch state");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1333,6 +1333,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9417.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8272.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8964.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9951.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 				else
 				{
-					Control.TrackDrawable?.SetColorFilter(Element.OnColor, FilterMode.Multiply);
+					Control.TrackDrawable?.SetColorFilter(Element.OnColor, FilterMode.SrcAtop);
 				}
 			}
 			else
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (Element.ThumbColor != Color.Default)
 			{
-				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
+				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor, FilterMode.SrcAtop);
 				_changedThumbColor = true;
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -121,7 +121,7 @@ namespace Xamarin.Forms.Platform.Android
 					{
 						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
 						{
-							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), FilterMode.Multiply);
+							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), FilterMode.SrcAtop);
 						}
 					}
 				}
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (Element.ThumbColor != Color.Default)
 			{
-				Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
+				Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, FilterMode.SrcAtop);
 				_changedThumbColor = true;
 			}
 			else
@@ -150,7 +150,8 @@ namespace Xamarin.Forms.Platform.Android
 					_changedThumbColor = false;
 				}
 			}
-			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
+
+			Control.ThumbDrawable.SetColorFilter(Element.ThumbColor, FilterMode.SrcAtop);
 		}
 
 		void HandleToggled(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

### Issues Resolved ### 
- fixes #9951

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
It shows Switch without squares when OnColor and ThumbColor is set


### Before/After Screenshots ### 
Before:
![Screenshot_before](https://user-images.githubusercontent.com/6691971/78075467-deeb1300-73a4-11ea-94e9-20aab55e3f4d.png)

After:
![Screenshot_after](https://user-images.githubusercontent.com/6691971/78075397-c24edb00-73a4-11ea-9cb1-cfcbb212910f.png)

### Testing Procedure ###
Create a switch and set OnColor and ThumbColor.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
