### PR TITLE
Fix route removal to keep one default route if it's needed

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -314,6 +314,33 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task RoutePathDefaultRemovalWithGlobalRoutesKeepsOneDefaultRoute()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			Routing.RegisterRoute(nameof(RoutePathDefaultRemovalWithGlobalRoutesKeepsOneDefaultRoute), typeof(ContentPage));
+			await shell.GoToAsync(nameof(RoutePathDefaultRemovalWithGlobalRoutesKeepsOneDefaultRoute));
+
+			// If all routes on the shell are default we still need to make sure it appends something that represents where you are in the
+			// shell structure
+			Assert.AreNotEqual($"//{nameof(RoutePathDefaultRemovalWithGlobalRoutesKeepsOneDefaultRoute)}", shell.CurrentState.Location.ToString());
+		}
+
+
+		[Test]
+		public async Task RoutePathDefaultRemovalWithGlobalRoutesKeepsOneNamedRoute()
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem(shellContentRoute: "content"));
+
+			Routing.RegisterRoute(nameof(RoutePathDefaultRemovalWithGlobalRoutesKeepsOneNamedRoute), typeof(ContentPage));
+			await shell.GoToAsync(nameof(RoutePathDefaultRemovalWithGlobalRoutesKeepsOneNamedRoute));
+
+			Assert.AreEqual($"//content/{nameof(RoutePathDefaultRemovalWithGlobalRoutesKeepsOneNamedRoute)}", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
 		public async Task NavigationWithQueryStringWhenPageMatchesBindingContext()
 		{
 			var shell = new Shell();

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -97,12 +97,22 @@ namespace Xamarin.Forms
 			bool userDefinedRouteAdded = false;
 			List<string> toKeep = new List<string>();
 			for (int i = 0; i < parts.Length; i++)
+			{
+				// This means there are no routes defined on the shell but the user has navigated to a global route
+				// so we need to attach the final route where the user left the shell
+				if (s_routes.ContainsKey(parts[i]) && !userDefinedRouteAdded && i > 0)
+				{
+					toKeep.Add(parts[i - 1]);
+				}
+
 				if (!(IsDefault(parts[i]) && defaultRoutes) && !(IsImplicit(parts[i]) && implicitRoutes))
 				{
 					if (!String.IsNullOrWhiteSpace(parts[i]))
 						userDefinedRouteAdded = true;
+
 					toKeep.Add(parts[i]);
 				}
+			}
 
 			if(!userDefinedRouteAdded && parts.Length > 0)
 			{
@@ -110,11 +120,6 @@ namespace Xamarin.Forms
 			}
 
 			return new Uri(string.Join(_pathSeparator, toKeep), UriKind.Relative);
-		}
-
-		internal static Uri RemoveImplicit(Uri uri)
-		{
-			return Remove(uri, true, false);
 		}
 
 		public static string FormatRoute(List<string> segments)


### PR DESCRIPTION
### Description of Change ###
As part of this https://github.com/xamarin/Xamarin.Forms/pull/10064 I removed all the default routes so that hot reload would be able to reroute to where the user was working.

This introduced a bug where if you've pushed a global route then it'll strip off all routes that are part of shell if everything is default. 

If the user has navigated to a global route than we have to retain the last default route to give an accurate indication of where the user is 

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
