### PR TITLE
#8783 - uwp - images - when the uwp app suspends and resumes again the image source should be reupdated as uwp replaces images with transparent images onResume

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Platform.UWP
 		public ImageRenderer() : base()
 		{
 			ImageElementManager.Init(this);
+			Windows.UI.Xaml.Application.Current.Resuming += OnResumingAsync;
 		}
 
 		bool IImageVisualElementRenderer.IsDisposed => _disposed;
@@ -44,6 +45,7 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					Control.ImageOpened -= OnImageOpened;
 					Control.ImageFailed -= OnImageFailed;
+					Windows.UI.Xaml.Application.Current.Resuming -= OnResumingAsync;
 				}
 			}
 
@@ -117,6 +119,20 @@ namespace Xamarin.Forms.Platform.UWP
 		protected async Task UpdateSource()
 		{
 			await ImageElementManager.UpdateSource(this).ConfigureAwait(false);
+		}
+
+		async void OnResumingAsync(object sender, object e)
+		{
+			try
+			{
+				await ImageElementManager.UpdateSource(this);
+			}
+			catch (Exception exception)
+			{
+				Log.Warning("Update image source after app resume", 
+					$"ImageSource failed to update after app resume: {exception.Message}");
+				
+			}
 		}
 
 		void IImageVisualElementRenderer.SetImage(Windows.UI.Xaml.Media.ImageSource image)

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -103,6 +103,21 @@ namespace Xamarin.Forms.Platform.UWP
 			InitializeStatusBar();
 
 			SystemNavigationManager.GetForCurrentView().BackRequested += OnBackRequested;
+			Windows.UI.Xaml.Application.Current.Resuming += OnResumingAsync;
+		}
+
+		async void OnResumingAsync(object sender, object e)
+		{
+			try
+			{
+				await UpdateToolbarItems();
+			}
+			catch (Exception exception)
+			{
+				Log.Warning("Update toolbar items after app resume", 
+					$"UpdateToolbarItems failed after app resume: {exception.Message}");
+
+			}
 		}
 
 		internal void SetPage(Page newRoot)


### PR DESCRIPTION
### Description of Change ###
Uwp seems to replace images with transparent images when resuming the app after suspending it.
This only happens when we wait more then 15 seconds before we resume the app.

To fix this issue we set the `ImageSource` again when the app is resuming.
Refreshing the `ImageSource` is not enough.

To accomplish this the `ImageRenderer` has to subscribe to the `Resuming` eventhandler.

ToolbarItems can also use images. It is not enough to reset the `ImgaeSource` for the toolbaritems.
When the app resumes we have to update the toolbaritems as well.

### Issues Resolved ### 
- fixes #8783
- fixes #9249
- fixes #10168

### API Changes ###
Added:
- `async void OnResumingAsync(object sender, object e)` in the `Xamarin.Forms.Platform.UWP.ImageRenderer` which subscribed to `Windows.UI.Xaml.Application.Current.Resuming `

- `async void OnResumingAsync(object sender, object e)` in the `Xamarin.Forms.Platform.UWP.Platform` class which subscribes to `Windows.UI.Xaml.Application.Current.Resuming` in order to update the toolbar onResume

Changed:
- none
 
 Removed:
- none

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
- Images are not transparent after suspending and then resuming the app again
- The images on toolbarItems are not transparent as well when reusing the app

### Before/After Screenshots ### 
- Fixed:
![uwp-imagesource-onresume-fixed](https://user-images.githubusercontent.com/35541212/78126088-3d9aa600-7412-11ea-882c-f48fed8f7c0d.gif)

- Not fixed:
![uwp-imagesource-onresume-not-fixed](https://user-images.githubusercontent.com/35541212/78126719-3b851700-7413-11ea-96b4-5073d6391bcf.gif)


### Testing Procedure ###
1.) Set the uwp control galery as startup porject and run it
2.) Open the `Font ImageSource` page
3.) Suspend the app
4.) Wait 15 seconds
5.) Resume the app
6a) Images should be visible and should not be transparent
6b) the images of the toolbar should be visible as well

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)

