### PR TITLE
Add preview channel args and fixup provisionator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -98,33 +98,19 @@ jobs:
     buildConfiguration: $(AndroidBuildConfiguration)
     provisionatorPath : 'build/provisioning/provisioning.csx'
 
-- job: osx
-  workspace:
-    clean: all
-  displayName: OSX Phase
-  strategy:
-    matrix:
-      BuildForVS2017:
-        buildForVS2017:  'true'
-        imageName : 'macOS-10.14'
-      BuildForVS2019:
-        buildForVS2017:  'false'
-        imageName : 'macOS-10.14'
-  pool:
-    vmImage: $(imageName)
-    demands:
-      - sh
-      - msbuild
-      - Xamarin.iOS
-  variables:
-    provisionator.osxPath : 'build/provisioning/provisioning.csx'
-    buildConfiguration: $(DefaultBuildConfiguration)
-    slnPath: $(SolutionFile)
-    iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
-    iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
-    buildForVS2017: $(buildForVS2017)
-  steps:
-     - template: build/steps/build-osx.yml
+- template: build/steps/build-osx.yml
+  parameters:
+    vmImage: $(macOSXVmImage)
+    name: osx
+    buildForVS2017: 'false'
+    displayName: 'OSX Phase'
+
+- template: build/steps/build-osx.yml
+  parameters:
+    vmImage: 'macOS-10.14'
+    name: osx_2017
+    buildForVS2017: 'true'
+    displayName: 'OSX Phase 2017'
 
 - job: nuget_pack
   workspace:

--- a/build.cake
+++ b/build.cake
@@ -78,15 +78,29 @@ if(buildForVS2017)
     macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";
 
 }
-
-if(String.IsNullOrWhiteSpace(monoPatchVersion))
-    monoVersion = $"{monoMajorVersion}";
 else
-    monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
-
-if(!String.IsNullOrWhiteSpace(monoVersion))
 {
-    monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+    // Xcode 11.3
+    monoMajorVersion = "";
+    monoPatchVersion = "";
+    androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+    iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/21e09d8084eb7c15eaa07c970e0eccdc/xamarin.ios-13.14.1.39.pkg";
+    macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/979144aead55378df75482d35957cdc9/xamarin.mac-6.14.1.39.pkg";
+    monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+
+}
+
+if(String.IsNullOrWhiteSpace(monoSDK_macos))
+{
+    if(String.IsNullOrWhiteSpace(monoPatchVersion))
+        monoVersion = $"{monoMajorVersion}";
+    else
+        monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
+
+    if(!String.IsNullOrWhiteSpace(monoVersion))
+    {
+        monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+    }
 }
     
 

--- a/build.cake
+++ b/build.cake
@@ -83,7 +83,7 @@ else
     // Xcode 11.3
     monoMajorVersion = "";
     monoPatchVersion = "";
-    androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+    androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
     iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/21e09d8084eb7c15eaa07c970e0eccdc/xamarin.ios-13.14.1.39.pkg";
     macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/979144aead55378df75482d35957cdc9/xamarin.mac-6.14.1.39.pkg";
     monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -1,36 +1,36 @@
-
-string monoMajorVersion = "6.4.0";
-string monoPatchVersion = "198";
+string monoMajorVersion = "6.8.0";
+string monoPatchVersion = "123";
 string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
 
-string monoSDK_windows = $"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "https://download.visualstudio.microsoft.com/download/pr/1131a8f5-99f5-4326-93b1-f5827b54ecd5/e7bd0f680004131157a22982c389b05f2d3698cc04fab3901ce2d7ded47ad8e0/Xamarin.Android.Sdk-10.0.0.43.vsix";
+string monoSDK_windows = "";//$"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
+string androidSDK_windows = "";//"https://download.visualstudio.microsoft.com/download/pr/1131a8f5-99f5-4326-93b1-f5827b54ecd5/e7bd0f680004131157a22982c389b05f2d3698cc04fab3901ce2d7ded47ad8e0/Xamarin.Android.Sdk-10.0.0.43.vsix";
 string iOSSDK_windows = "";
 string macSDK_windows = "";
 
-string androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/d5a432e4-09f3-4da6-9bdd-1d4fdd87f34c/c4ce0854064ffc16b957f22ccc08f9df/xamarin.android-10.0.0.43.pkg";
-string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.ios-13.2.0.42.pkg";
-string macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-3/5e8a208b5f44c4885060d95e3c3ad68d6a5e95e8/40/package/xamarin.mac-6.2.0.42.pkg";
+string androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
+string monoSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+string iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/cf7090bee19401076987a57cd12f11e5/xamarin.ios-13.16.0.11.pkg";
+string macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
+
 
 if (IsMac)
 {
-	Item (XreItem.Xcode_11_1_0_rc).XcodeSelect ();
+	Item (XreItem.Xcode_11_4_0).XcodeSelect ();
 
-  if(!String.IsNullOrEmpty(monoSDK_macos))
-    Item ("Mono", monoVersion)
-      .Source (_ => monoSDK_macos);
+  	if(!String.IsNullOrEmpty(monoSDK_macos))
+    	Item ("Mono", monoVersion)
+      	.Source (_ => monoSDK_macos);
 
 	if(!String.IsNullOrEmpty(androidSDK_macos))
-		Item ("Xamarin.Android", "10.0.0.43")
+		Item ("Xamarin.Android", "10.2.0.100")
       .Source (_ => androidSDK_macos);
 
 	if(!String.IsNullOrEmpty(iOSSDK_macos))
-		Item ("Xamarin.iOS", "13.2.0.42")
+		Item ("Xamarin.iOS", "13.16.0.11")
       .Source (_ => iOSSDK_macos);
 
 	if(!String.IsNullOrEmpty(macSDK_macos))
-		Item ("Xamarin.Mac", "6.2.0.42")
+		Item ("Xamarin.Mac", "6.16.0.11")
       .Source (_ => macSDK_macos);
     
 	ForceJavaCleanup();
@@ -66,7 +66,7 @@ else
 
 }
 
-Item(XreItem.Java_OpenJDK_1_8_0_25);
+// Item(XreItem.Java_OpenJDK_1_8_0_25);
 AndroidSdk ().ApiLevel((AndroidApiLevel)24);
 AndroidSdk ().ApiLevel((AndroidApiLevel)28);
 AndroidSdk ().ApiLevel((AndroidApiLevel)29);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -8,14 +8,14 @@ string iOSSDK_windows = "";
 string macSDK_windows = "";
 
 string androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-string monoSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
 string iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/cf7090bee19401076987a57cd12f11e5/xamarin.ios-13.16.0.11.pkg";
 string macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 
 
 if (IsMac)
 {
-	Item (XreItem.Xcode_11_4_0).XcodeSelect ();
+	// Item (XreItem.Xcode_11_4_0).XcodeSelect ();
 
   	if(!String.IsNullOrEmpty(monoSDK_macos))
     	Item ("Mono", monoVersion)

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -8,7 +8,7 @@ string iOSSDK_windows = "";
 string macSDK_windows = "";
 
 string androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-string monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
+string monoSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
 string iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/cf7090bee19401076987a57cd12f11e5/xamarin.ios-13.16.0.11.pkg";
 string macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -45,7 +45,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target provision
+          arguments: --target provision --releaseChannel=$(releaseChannel)
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -1,111 +1,135 @@
-steps:
-  - checkout: self
-    clean: true
+parameters:
+  name: ''            # in the form type_platform_host
+  displayName: ''            
+  vmImage: ''         # the VM image
+  buildForVS2017: 'false'
 
-  - task: xamops.azdevex.provisionator-task.provisionator@1
-    displayName: 'Provisionator'
-    condition: eq(variables['provisioning'], 'true')
-    inputs:
-      provisioning_script: $(provisionator.osxPath)
-      provisioning_extra_args: $(provisionator.extraArguments)
+jobs:
+  - job: ${{ parameters.name }}
+    workspace:
+      clean: all
+    displayName: ${{ parameters.displayName }}
+    pool:
+      vmImage: ${{ parameters.vmImage }}
+      demands:
+        - sh
+        - msbuild
+        - Xamarin.iOS
+    variables:
+      provisionator.osxPath : 'build/provisioning/provisioning.csx'
+      buildConfiguration: $(DefaultBuildConfiguration)
+      slnPath: $(SolutionFile)
+      iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
+      iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
+      buildForVS2017: ${{ parameters.buildForVS2017 }}
+    steps:
+    - checkout: self
+      clean: true
 
-  - task: Bash@3
-    displayName: 'Cake Provision'
-    condition: eq(variables['provisioningCake'], 'true')
-    inputs:
-      targetType: 'filePath'
-      filePath: 'build.sh'
-      arguments: --target provision --buildForVS2017=$(buildForVS2017)
+    - task: xamops.azdevex.provisionator-task.provisionator@1
+      displayName: 'Provisionator'
+      condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
+      inputs:
+        provisioning_script: $(provisionator.osxPath)
+        provisioning_extra_args: $(provisionator.extraArguments)
 
-  - task: UseDotNet@2
-    displayName: 'Install .net core $(DOTNET_VERSION)'
-    condition: ne(variables['DOTNET_VERSION'], '')
-    inputs:
-      version: $(DOTNET_VERSION)
-      packageType: 'sdk'
+    - task: Bash@3
+      displayName: 'Cake Provision'
+      condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
+      inputs:
+        targetType: 'filePath'
+        filePath: 'build.sh'
+        arguments: --target provision --buildForVS2017=$(buildForVS2017) --releaseChannel=$(releaseChannel)
 
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet'
-    condition: ne(variables['NUGET_VERSION'], '')
-    inputs:
-      versionSpec: $(NUGET_VERSION)
+    - task: UseDotNet@2
+      displayName: 'Install .net core $(DOTNET_VERSION)'
+      condition: ne(variables['DOTNET_VERSION'], '')
+      inputs:
+        version: $(DOTNET_VERSION)
+        packageType: 'sdk'
 
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore'
-    inputs:
-      restoreSolution: $(slnPath)
+    - task: NuGetToolInstaller@1
+      displayName: 'Use NuGet'
+      condition: ne(variables['NUGET_VERSION'], '')
+      inputs:
+        versionSpec: $(NUGET_VERSION)
 
-  - task: MSBuild@1
-    displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
-    inputs:
-      solution: Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+    - task: NuGetCommand@2
+      displayName: 'NuGet restore'
+      inputs:
+        restoreSolution: $(slnPath)
 
-  - task: InstallAppleCertificate@2
-    displayName: 'Install an Apple certificate'
-    inputs:
-      certSecureFile: 'Xamarin Forms iOS Certificate.p12'
-      certPwd: $(P12password)
+    - task: MSBuild@1
+      displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
+      inputs:
+        solution: Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
 
-  - task: InstallAppleProvisioningProfile@1
-    displayName: 'Install an Apple provisioning profile'
-    inputs:
-      provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
+    - task: InstallAppleCertificate@2
+      displayName: 'Install an Apple certificate'
+      inputs:
+        certSecureFile: 'Xamarin Forms iOS Certificate.p12'
+        certPwd: $(P12password)
 
-  - task: XamariniOS@2
-    displayName: 'Build Xamarin.iOS solution $(slnPath)'
-    inputs:
-      solutionFile: $(slnPath)
-      configuration: $(buildConfiguration)
-      args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
+    - task: InstallAppleProvisioningProfile@1
+      displayName: 'Install an Apple provisioning profile'
+      inputs:
+        provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
 
-
-  - task: CopyFiles@2
-    displayName: 'Copy test-cloud.exe'
-    condition: eq(variables['buildForVS2017'], 'false')
-    inputs:
-      Contents: '**/Xamarin.UITest.*/tools/test-cloud.exe'
-      TargetFolder: '$(build.artifactstagingdirectory)/testcloud'
-      CleanTargetFolder: true
-      OverWrite: true
-      flattenFolders: true
-
-
-  - task: CopyFiles@2
-    displayName: 'Copy iOS Files for UITest'
-    condition: eq(variables['buildForVS2017'], 'false')
-    inputs:
-      Contents: |
-       **/$(IpaName)
-       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
-       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
-       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
-       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
-
-      TargetFolder: '$(build.artifactstagingdirectory)/ios'
-      CleanTargetFolder: true
-      flattenFolders: true
+    - task: XamariniOS@2
+      displayName: 'Build Xamarin.iOS solution $(slnPath)'
+      inputs:
+        solutionFile: $(slnPath)
+        configuration: $(buildConfiguration)
+        args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
 
 
-  - task: CopyFiles@2
-    displayName: 'Copy Android Files for UITest'
-    condition: eq(variables['buildForVS2017'], 'false')
-    inputs:
-      Contents: |
-       Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-       Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/nunit.*
-       Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
-       Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Plugin.*
-       Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
-       
-      TargetFolder: '$(build.artifactstagingdirectory)/android'
-      CleanTargetFolder: true
-      flattenFolders: true
+    - task: CopyFiles@2
+      displayName: 'Copy test-cloud.exe'
+      condition: eq(variables['buildForVS2017'], 'false')
+      inputs:
+        Contents: '**/Xamarin.UITest.*/tools/test-cloud.exe'
+        TargetFolder: '$(build.artifactstagingdirectory)/testcloud'
+        CleanTargetFolder: true
+        OverWrite: true
+        flattenFolders: true
 
 
-  - task: PublishBuildArtifacts@1
-    displayName: 'Publish Artifact: iOS'
-    condition: always()
-    inputs:
-      PathtoPublish: '$(build.artifactstagingdirectory)'
-      ArtifactName: OSXArtifacts
+    - task: CopyFiles@2
+      displayName: 'Copy iOS Files for UITest'
+      condition: eq(variables['buildForVS2017'], 'false')
+      inputs:
+        Contents: |
+          **/$(IpaName)
+          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
+          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
+          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
+          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
+          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
+
+          TargetFolder: '$(build.artifactstagingdirectory)/ios'
+          CleanTargetFolder: true
+          flattenFolders: true
+
+
+    - task: CopyFiles@2
+      displayName: 'Copy Android Files for UITest'
+      condition: eq(variables['buildForVS2017'], 'false')
+      inputs:
+        Contents: |
+          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
+          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/nunit.*
+          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
+          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Plugin.*
+          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
+          
+          TargetFolder: '$(build.artifactstagingdirectory)/android'
+          CleanTargetFolder: true
+          flattenFolders: true
+
+
+    - task: PublishBuildArtifacts@1
+      displayName: 'Publish Artifact: iOS'
+      condition: always()
+      inputs:
+        PathtoPublish: '$(build.artifactstagingdirectory)'
+        ArtifactName: OSXArtifacts

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -105,10 +105,9 @@ jobs:
           Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
           Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
           Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
-
-          TargetFolder: '$(build.artifactstagingdirectory)/ios'
-          CleanTargetFolder: true
-          flattenFolders: true
+        TargetFolder: '$(build.artifactstagingdirectory)/ios'
+        CleanTargetFolder: true
+        flattenFolders: true
 
 
     - task: CopyFiles@2
@@ -121,10 +120,9 @@ jobs:
           Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
           Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Plugin.*
           Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
-          
-          TargetFolder: '$(build.artifactstagingdirectory)/android'
-          CleanTargetFolder: true
-          flattenFolders: true
+        TargetFolder: '$(build.artifactstagingdirectory)/android'
+        CleanTargetFolder: true
+        flattenFolders: true
 
 
     - task: PublishBuildArtifacts@1


### PR DESCRIPTION
### Description of Change ###

- add releaseChannel arg to cake
- force vs2017 build to always use cake regardless of the provision settings
- update provisionator to latest stable bits
- setup OSX Phase to use macOSXVmImage variable
