### PR TITLE
Fix query string for ".." and renavigating

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -313,6 +313,62 @@ namespace Xamarin.Forms.Core.UnitTests
 			*/
 		}
 
+
+		[Test]
+		public async Task DotDotNavigationPassesParameters()
+		{
+			Routing.RegisterRoute(nameof(DotDotNavigationPassesParameters), typeof(ContentPage));
+			var shell = new Shell();
+			var one = new ShellItem { Route = "one" };
+
+			var tabone = MakeSimpleShellSection("tabone", "content");
+
+			one.Items.Add(tabone);
+
+			shell.Items.Add(one);
+
+			one.CurrentItem.CurrentItem.ContentTemplate = new DataTemplate(() =>
+			{
+				ShellTestPage pagetoTest = new ShellTestPage();
+				pagetoTest.BindingContext = pagetoTest;
+				return pagetoTest;
+			});
+
+			var page = (ShellTestPage)(one.CurrentItem.CurrentItem as IShellContentController).GetOrCreateContent();
+			Assert.AreEqual(null, page.SomeQueryParameter);
+			await shell.GoToAsync(nameof(DotDotNavigationPassesParameters));
+			await shell.GoToAsync($"..?{nameof(ShellTestPage.SomeQueryParameter)}=1234");
+			Assert.AreEqual("1234", page.SomeQueryParameter);
+
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public async Task ReNavigatingToCurrentLocationPassesParameters(bool useDataTemplates)
+		{
+			var shell = new Shell();
+			ShellTestPage pagetoTest = new ShellTestPage();
+			pagetoTest.BindingContext = pagetoTest;		
+			var one = CreateShellItem(pagetoTest, shellContentRoute: "content", templated: useDataTemplates);
+			shell.Items.Add(one);
+			ShellTestPage page = null;
+			if (useDataTemplates)
+			{
+				page = (ShellTestPage)(one.CurrentItem.CurrentItem as IShellContentController).GetOrCreateContent();
+			}
+			else
+			{
+				page = (ShellTestPage)one.CurrentItem.CurrentItem.Content;
+			}
+
+			Assert.AreEqual(null, page.SomeQueryParameter);
+			await shell.GoToAsync($"//content?{nameof(ShellTestPage.SomeQueryParameter)}=1234");
+			Assert.AreEqual("1234", page.SomeQueryParameter);
+			await shell.GoToAsync($"//content?{nameof(ShellTestPage.SomeQueryParameter)}=4321");
+			Assert.AreEqual("4321", page.SomeQueryParameter);
+
+		}
+
 		[Test]
 		public async Task RoutePathDefaultRemovalWithGlobalRoutesKeepsOneDefaultRoute()
 		{

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -366,7 +366,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("1234", page.SomeQueryParameter);
 			await shell.GoToAsync($"//content?{nameof(ShellTestPage.SomeQueryParameter)}=4321");
 			Assert.AreEqual("4321", page.SomeQueryParameter);
-
+			await shell.GoToAsync($"//content?{nameof(ShellTestPage.SomeQueryParameter)}");
+			Assert.AreEqual(null, page.SomeQueryParameter);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -236,7 +236,7 @@ namespace Xamarin.Forms
 			base.ApplyQueryAttributes(query);
 			SetValue(QueryAttributesProperty, query);
 
-			if (Content is BindableObject bindable)
+			if (ContentCache is BindableObject bindable)
 				bindable.SetValue(QueryAttributesProperty, query);
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -242,12 +242,14 @@ namespace Xamarin.Forms
 
 		static void OnQueryAttributesPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (newValue is IDictionary<string, string> query && oldValue is IDictionary<string, string> oldQuery)
-				ApplyQueryAttributes(bindable, query, oldQuery);
+			ApplyQueryAttributes(bindable, newValue as IDictionary<string, string>, oldValue as IDictionary<string, string>);
 		}
 
 		static void ApplyQueryAttributes(object content, IDictionary<string, string> query, IDictionary<string, string> oldQuery)
 		{
+			query = query ?? new Dictionary<string, string>();
+			oldQuery = oldQuery ?? new Dictionary<string, string>();
+
 			if (content is IQueryAttributable attributable)
 				attributable.ApplyQueryAttributes(query);
 

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -242,17 +242,17 @@ namespace Xamarin.Forms
 
 		static void OnQueryAttributesPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			if (newValue is IDictionary<string, string> query)
-				ApplyQueryAttributes(bindable, query);
+			if (newValue is IDictionary<string, string> query && oldValue is IDictionary<string, string> oldQuery)
+				ApplyQueryAttributes(bindable, query, oldQuery);
 		}
 
-		static void ApplyQueryAttributes(object content, IDictionary<string, string> query)
+		static void ApplyQueryAttributes(object content, IDictionary<string, string> query, IDictionary<string, string> oldQuery)
 		{
 			if (content is IQueryAttributable attributable)
 				attributable.ApplyQueryAttributes(query);
 
 			if (content is BindableObject bindable && bindable.BindingContext != null && content != bindable.BindingContext)
-				ApplyQueryAttributes(bindable.BindingContext, query);
+				ApplyQueryAttributes(bindable.BindingContext, query, oldQuery);
 
 			var type = content.GetType();
 			var typeInfo = type.GetTypeInfo();
@@ -271,6 +271,13 @@ namespace Xamarin.Forms
 
 					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
 						prop.SetValue(content, value);
+				}
+				else if (oldQuery.TryGetValue(attrib.QueryId, out var oldValue))
+				{
+					PropertyInfo prop = type.GetRuntimeProperty(attrib.Name);
+
+					if (prop != null && prop.CanWrite && prop.SetMethod.IsPublic)
+						prop.SetValue(content, null);
 				}
 			}
 		}

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms
 			{
 				var result = Path.Combine(shell.CurrentState.FullLocation.OriginalString, path.OriginalString);
 				var returnValue = ConvertToStandardFormat("scheme", "host", null, new Uri(result, UriKind.Relative));
-				return new Uri(FormatUri(returnValue.AbsolutePath), UriKind.Relative);
+				return new Uri(FormatUri(returnValue.PathAndQuery), UriKind.Relative);
 			}
 
 			if (path.IsAbsoluteUri)


### PR DESCRIPTION
### Description of Change ###

- fix it so you can navigate back with GotoASync("..?param=thing") and the param will pass
- fix it so renavigating to the same route will pass any new parameters
- if query string parameter is removed then set the mapped property to null

### Issues Resolved ### 
- fixes #9975

### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
