### PR TITLE
Fix 7757 [WPF] ImageButtonRenderer fails with cross thread access

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/ImageButtonRenderer.cs
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Platform.WPF
 				if (Element.BorderWidth != 0)
 					UpdateBorderWidth();
 
-				await TryUpdateSource().ConfigureAwait(false);
+				await TryUpdateSource();
 				UpdateAspect();
 
 				if (Element.IsSet(Button.PaddingProperty))


### PR DESCRIPTION
### Description of Change ###

WPF ImageButtonRendeder is not safe and can cause cross-thread exceptions

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7757


### Platforms Affected ### 

- WPF

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
