### PR TITLE
Shell fix modal onappearing and hardware back button

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellLifeCycleTests.cs
@@ -562,12 +562,31 @@ namespace Xamarin.Forms.Core.UnitTests
 			Routing.RegisterRoute("LifeCyclePage", typeof(LifeCyclePage));
 		}
 
-		class ShellLifeCycleState
+		public class ShellLifeCycleState
 		{
-			public bool ItemAppearing;
-			public bool SectionAppearing;
-			public bool ContentAppearing;
-			public bool PageAppearing;
+			public bool ItemAppearing
+			{
+				get;
+				set;
+			}
+
+			public bool SectionAppearing
+			{
+				get;
+				set;
+			}
+
+			public bool ContentAppearing
+			{
+				get;
+				set;
+			}
+
+			public bool PageAppearing
+			{
+				get;
+				set;
+			}
 
 			public ShellLifeCycleState(Shell shell)
 			{
@@ -608,6 +627,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Assert.IsFalse(ContentAppearing);
 				Assert.IsFalse(PageAppearing);
 			}
+
 			public void AllTrue()
 			{
 				Assert.IsTrue(ItemAppearing);

--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -269,7 +270,25 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.IsTrue(invalidOperationThrown);
 		}
-		
+
+
+		[Test]
+		public async Task AppearingAndDisappearingFiresOnShellWithModal()
+		{
+			Shell shell = new Shell();
+			shell.NavigationProxy.Inner = new NavigationProxy();
+			var lifeCyclePage = new ShellLifeCycleTests.LifeCyclePage();
+			shell.Items.Add(CreateShellItem(lifeCyclePage, shellItemRoute: "item", shellSectionRoute: "section", shellContentRoute: "content"));
+
+			var shellLifeCycleState = new ShellLifeCycleTests.ShellLifeCycleState(shell);
+			await shell.GoToAsync("ModalTestPage");
+			await shell.Navigation.ModalStack[0].Navigation.PopModalAsync();
+			shellLifeCycleState.AllTrue();
+			await shell.GoToAsync("ModalTestPage");
+			shellLifeCycleState.AllFalse();
+		}
+
+
 		[Test]
 		public async Task IsAppearingFiredOnLastModalPageOnly()
 		{
@@ -339,6 +358,17 @@ namespace Xamarin.Forms.Core.UnitTests
 			public ModalTestPageBase()
 			{
 				Shell.SetPresentationMode(this, PresentationMode.Modal);
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+			}
+			
+
+			protected override void OnParentSet()
+			{
+				base.OnParentSet();
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -431,7 +431,7 @@ namespace Xamarin.Forms
 		internal async Task GoToAsync(ShellNavigationState state, bool? animate, bool enableRelativeShellRoutes)
 		{
 			// FIXME: This should not be none, we need to compute the delta and set flags correctly
-			var accept = ProposeNavigation(ShellNavigationSource.Unknown, state, true);
+			var accept = ProposeNavigation(ShellNavigationSource.Unknown, state, this.CurrentState != null);
 			if (!accept)
 				return;
 
@@ -948,7 +948,10 @@ namespace Xamarin.Forms
 				currentContent.Navigation.PopAsync();
 				return true;
 			}
-			return false;
+
+			var args = new ShellNavigatingEventArgs(this.CurrentState, "", ShellNavigationSource.Pop, true);
+			OnNavigating(args);
+			return args.Cancelled;
 		}
 
 		bool ValidDefaultShellItem(Element child) => !(child is MenuShellItem);
@@ -1298,22 +1301,26 @@ namespace Xamarin.Forms
 
 			protected override void OnRemovePage(Page page) => SectionProxy.RemovePage(page);
 
-			protected override Task<Page> OnPopModal(bool animated)
+			protected override async Task<Page> OnPopModal(bool animated)
 			{
 				if (ModalStack.Count > 0)
 					ModalStack[ModalStack.Count - 1].SendDisappearing();
 
 				if (!_shell.CurrentItem.CurrentItem.IsPoppingModalStack)
 				{
-					if (ModalStack.Count == 1)
-						_shell.CurrentItem.SendAppearing();
-					else if (ModalStack.Count > 1)
+					if (ModalStack.Count > 1)
 						ModalStack[ModalStack.Count - 2].SendAppearing();
 				}
 
-				return base.OnPopModal(animated);
+				var modalPopped =  await base.OnPopModal(animated);
+				
+				if (ModalStack.Count == 0 && !_shell.CurrentItem.CurrentItem.IsPoppingModalStack)
+					_shell.CurrentItem.SendAppearing();
+				
+				return modalPopped;
 			}
-			protected override Task OnPushModal(Page modal, bool animated)
+			
+			protected override async Task OnPushModal(Page modal, bool animated)
 			{
 				if (ModalStack.Count == 0)
 					_shell.CurrentItem.SendDisappearing();
@@ -1321,8 +1328,27 @@ namespace Xamarin.Forms
 				if (!_shell.CurrentItem.CurrentItem.IsPushingModalStack)
 					modal.SendAppearing();
 
-				return base.OnPushModal(modal, animated);
+				await base.OnPushModal(modal, animated);
+
+				modal.NavigationProxy.Inner = new NavigationImplWrapper(modal.NavigationProxy.Inner,  this);
 			}
+			
+			
+			class NavigationImplWrapper : NavigationProxy
+			{
+				readonly INavigation _shellProxy;
+
+				public NavigationImplWrapper(INavigation proxy, INavigation shellProxy)
+				{
+					Inner = proxy;
+					_shellProxy = shellProxy;				
+
+				}
+
+				protected override Task<Page> OnPopModal(bool animated) => _shellProxy.PopModalAsync(animated);
+
+				protected override Task OnPushModal(Page modal, bool animated) => _shellProxy.PushModalAsync(modal, animated);
+			}			
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -889,26 +889,6 @@ namespace Xamarin.Forms
 			protected override Task OnPushAsync(Page page, bool animated) => _owner.OnPushAsync(page, animated);
 
 			protected override void OnRemovePage(Page page) => _owner.OnRemovePage(page);
-
-			protected override Task<Page> OnPopModal(bool animated)
-			{
-				if(ModalStack.Count == 1)
-				{
-					_owner.PresentedPageAppearing();
-				}
-
-				return base.OnPopModal(animated);
-			}
-
-			protected override Task OnPushModal(Page modal, bool animated)
-			{
-				if (ModalStack.Count == 0)
-				{
-					_owner.PresentedPageDisappearing();
-				}
-
-				return base.OnPushModal(modal, animated);
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -59,8 +59,9 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateCurrentItem(shellContent);
 			}
-			else
+			else if(shellSection?.CurrentItem != null)
 			{
+				var currentPosition = SectionController.GetItems().IndexOf(shellSection.CurrentItem);
 				_selecting = true;
 
 				// Android doesn't really appreciate you calling SetCurrentItem inside a OnPageSelected callback.
@@ -69,10 +70,10 @@ namespace Xamarin.Forms.Platform.Android
 
 				Device.BeginInvokeOnMainThread(() =>
 				{
-					if (position < _viewPager.ChildCount && _toolbarTracker != null)
+					if (currentPosition < _viewPager.ChildCount && _toolbarTracker != null)
 					{
-						_viewPager.SetCurrentItem(position, false);
-						UpdateCurrentItem(shellContent);
+						_viewPager.SetCurrentItem(currentPosition, false);
+						UpdateCurrentItem(shellSection.CurrentItem);
 					}
 
 					_selecting = false;


### PR DESCRIPTION
### Description of Change ###

- Inject the shell proxy into the modal pages so that the shell navproxy handles navigation
- wire up the back button pressed to navigating
- Cancel Top Nav Bar navigation

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10108

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
