### PR TITLE
[iOS] Fix issue in NavBar setting a custom BackgroundImage

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -137,6 +137,7 @@
     <Compile Include="CustomRenderers\RoundedLabelRenderer.cs" />
     <Compile Include="ApiLabelRenderer.cs" />
     <Compile Include="CustomRenderers\CustomSearchBarRenderer.cs" />
+    <Compile Include="_9767CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.ControlGallery.iOS/_9767CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_9767CustomRenderer.cs
@@ -13,12 +13,14 @@ namespace Xamarin.Forms.ControlGallery.iOS
     {
         public _9767CustomRenderer() : base()
         {
-            UpdateColors();
+       
         }
 
         public override void ViewWillAppear(bool animated)
         {
             base.ViewWillAppear(animated);
+
+            UpdateColors();
             UpdateGradientView();
         }
 		

--- a/Xamarin.Forms.ControlGallery.iOS/_9767CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_9767CustomRenderer.cs
@@ -1,0 +1,48 @@
+﻿using CoreAnimation;
+using CoreGraphics;
+using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(Issue9767NavigationPage), typeof(_9767CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+	public class _9767CustomRenderer : NavigationRenderer
+    {
+        public _9767CustomRenderer() : base()
+        {
+            UpdateColors();
+        }
+
+        public override void ViewWillAppear(bool animated)
+        {
+            base.ViewWillAppear(animated);
+            UpdateGradientView();
+        }
+		
+		void UpdateColors()
+		{
+            UINavigationBar.Appearance.BarTintColor = UIColor.FromPatternImage(UIImage.FromFile("coffee.png"));
+            UINavigationBar.Appearance.TintColor = UIColor.Yellow;
+            UINavigationBar.Appearance.SetTitleTextAttributes(new UITextAttributes { TextColor = UIColor.Blue });
+		}
+
+        void UpdateGradientView()
+        {
+			var gradientLayer = new CAGradientLayer
+			{
+				Bounds = NavigationBar.Bounds,
+				Colors = new CGColor[] { Color.Blue.ToCGColor(), Color.Purple.ToCGColor() },
+				EndPoint = new CGPoint(0.0, 0.5),
+				StartPoint = new CGPoint(1.0, 0.5)
+			};
+			UIGraphics.BeginImageContext(gradientLayer.Bounds.Size);
+            gradientLayer.RenderInContext(UIGraphics.GetCurrentContext());
+            UIImage image = UIGraphics.GetImageFromCurrentImageContext();
+            UIGraphics.EndImageContext();
+            NavigationBar.SetBackgroundImage(image, UIBarMetrics.Default);
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9767.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9767.cs
@@ -68,10 +68,21 @@ namespace Xamarin.Forms.Controls.Issues
 				BarTextColor = Color.Default;
 			};
 
+			var navigateButton = new Button
+			{
+				Text = "Navigate"
+			};
+
+			navigateButton.Clicked += (sender, args) =>
+			{
+				Navigation.PushAsync(new Issue9767NavigationPage(new Issue9767()));
+			};
+
 			layout.Children.Add(updateBarBackgroundButton);
 			layout.Children.Add(updateBarTextButton);
 			layout.Children.Add(resetBarBackgroundButton);
 			layout.Children.Add(resetBarTextButton);
+			layout.Children.Add(navigateButton);
 
 			page.Content = layout;
 
@@ -80,7 +91,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-		
+
 		}
 
 		Color GetRandomColor()
@@ -102,4 +113,18 @@ namespace Xamarin.Forms.Controls.Issues
 			return (Color)result;
 		}
 	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue9767NavigationPage : NavigationPage
+	{
+		public Issue9767NavigationPage()
+		{
+
+		}
+
+		public Issue9767NavigationPage(Page root) : base(root)
+		{
+
+		}
+	} 
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1282,20 +1282,17 @@ namespace Xamarin.Forms.Platform.iOS
 
 			void UpdateNavigationBarBackgroundImage()
 			{
-				if (Forms.IsiOS13OrNewer)
-				{
-					if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
-						return;
+				if (!Forms.IsiOS13OrNewer)
+					return;
 
-					var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
+				if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
+					return;
 
-					if (backgroundImage == null)
-						return;
+				var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
 
-					navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
-					navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
-					navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
-				}
+				navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
+				navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
+				navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
 			}
 
 			void UpdateToolbarItems()

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1055,6 +1055,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override void ViewWillAppear(bool animated)
 			{
+				UpdateNavigationBarBackgroundImage();
 				UpdateNavigationBarVisibility(animated);
 
 				NavigationRenderer n;
@@ -1263,6 +1264,24 @@ namespace Xamarin.Forms.Platform.iOS
 					// prevent bottom content "jumping"
 					current.IgnoresContainerArea = !hasNavBar;
 					NavigationController.SetNavigationBarHidden(!hasNavBar, animated);
+				}
+			}
+
+			void UpdateNavigationBarBackgroundImage()
+			{
+				if (Forms.IsiOS13OrNewer)
+				{
+					if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
+						return;
+
+					var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
+
+					if (backgroundImage == null)
+						return;
+
+					navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
+					navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
+					navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -147,6 +147,14 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewWillAppear(animated);
 
 			SetStatusBarStyle();
+
+			if (Forms.IsiOS13OrNewer)
+			{
+				UpdateTint();
+				UpdateBarBackgroundColor();
+				UpdateBarTextColor();
+				UpdateHideNavigationBarSeparator();
+			}
 		}
 
 		public override void ViewDidDisappear(bool animated)
@@ -225,11 +233,16 @@ namespace Xamarin.Forms.Platform.iOS
 			navPage.RemovePageRequested += OnRemovedPageRequested;
 			navPage.InsertPageBeforeRequested += OnInsertPageBeforeRequested;
 
-			UpdateTint();
-			UpdateBarBackgroundColor();
-			UpdateBarTextColor();
+			if (!Forms.IsiOS13OrNewer)
+			{
+				UpdateTint();
+				UpdateBarBackgroundColor();
+				UpdateBarTextColor();
+				UpdateHideNavigationBarSeparator();
+			}
+
 			UpdateUseLargeTitles();
-			UpdateHideNavigationBarSeparator();
+
 			if (Forms.RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden)
 				SetNeedsUpdateOfHomeIndicatorAutoHidden();
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1145,11 +1145,13 @@ namespace Xamarin.Forms.Platform.iOS
 				if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
 					return;
 
+#if __XCODE11__
 				var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
 
 				navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
 				navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
 				navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
+#endif
 			}
 
 			internal void UpdateLeftBarButtonItem(Page pageBeingRemoved = null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -671,6 +671,9 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.CompactAppearance = navigationBarAppearance;
 				NavigationBar.StandardAppearance = navigationBarAppearance;
 				NavigationBar.ScrollEdgeAppearance = navigationBarAppearance;
+
+				var parentingViewController = (ParentingViewController)ViewControllers.Last();
+				parentingViewController?.UpdateNavigationBarBackgroundImage();
 			}
 			else
 #endif
@@ -1128,6 +1131,20 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateTitleArea(Child);
 			}
 
+			internal void UpdateNavigationBarBackgroundImage()
+			{
+				if (!Forms.IsiOS13OrNewer)
+					return;
+
+				if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
+					return;
+
+				var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
+
+				navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
+				navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
+				navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
+			}
 
 			internal void UpdateLeftBarButtonItem(Page pageBeingRemoved = null)
 			{
@@ -1278,21 +1295,6 @@ namespace Xamarin.Forms.Platform.iOS
 					current.IgnoresContainerArea = !hasNavBar;
 					NavigationController.SetNavigationBarHidden(!hasNavBar, animated);
 				}
-			}
-
-			void UpdateNavigationBarBackgroundImage()
-			{
-				if (!Forms.IsiOS13OrNewer)
-					return;
-
-				if (!_navigation.TryGetTarget(out NavigationRenderer navigationRenderer))
-					return;
-
-				var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
-
-				navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
-				navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
-				navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
 			}
 
 			void UpdateToolbarItems()


### PR DESCRIPTION
### Description of Change ###

Fix issue in NavBar setting a custom BackgroundImage on iOS. 

<img width="367" alt="Captura de pantalla 2020-04-03 a las 16 56 34" src="https://user-images.githubusercontent.com/6755973/78375136-a7f74600-75cc-11ea-830a-352af4911615.png">

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9767 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 9767. Press the "Navigate· button. We use a custom renderer where a background image is set for UINavigationBar. If you can see the gradient, the test has passed. Test the same in a device (or simulator) with iOS 13 and iOS 12!.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
