### PR TITLE
Slider value updates with Talk Back activated and volume buttons correctly

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1625.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github1625.cs
@@ -4,13 +4,17 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 1625, "Slider value is not changed for the first position change", PlatformAffected.Android)]
-	public class Github1625 : TestContentPage // or TestMasterDetailPage, etc ...
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Slider)]
+#endif
+	public class Github1625 : TestContentPage
 	{
 		protected override void Init()
 		{
@@ -19,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 			slider.Minimum = 1;
 			slider.Value = 5;
 
-			var valueLabel = new Label();
+			var valueLabel = new Label() { AutomationId = "LabelValue" };
 			var stack = new StackLayout { Orientation = StackOrientation.Vertical, Spacing = 15 };
 
 			valueLabel.SetBinding(Label.TextProperty, new Binding("Value", source: slider));
@@ -29,8 +33,10 @@ namespace Xamarin.Forms.Controls.Issues
 			var button = new Button
 			{
 				Text = "Set to 7",
+				AutomationId = "SetTo7",
 				Command = new Command(() => slider.Value = 7)
 			};
+
 			stack.Children.Add(button);
 
 			var label = new Label
@@ -39,7 +45,27 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 			stack.Children.Add(label);
 
+			var labelAccessibility = new Label
+			{
+				Text = "Turn on a screen reader and use the volume buttons to modify the slider value. Ensure that the slider value on the label updates correctly."
+			};
+			stack.Children.Add(labelAccessibility);
+
 			Content = stack;
 		}
+
+
+
+#if UITEST
+		[Test]
+		public void SettingSliderToSpecificValueWorks()
+		{
+			RunningApp.WaitForElement("LabelValue");
+			Assert.AreEqual("5", RunningApp.WaitForElement("LabelValue")[0].ReadText());
+			RunningApp.Tap("SetTo7");
+			Assert.AreEqual("7", RunningApp.WaitForElement("LabelValue")[0].ReadText());
+		}
+#endif
+
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -12,7 +12,6 @@ namespace Xamarin.Forms.Platform.Android
 	public class SliderRenderer : ViewRenderer<Slider, SeekBar>, SeekBar.IOnSeekBarChangeListener
 	{
 		double _max, _min;
-		bool _isTrackingChange;
 		ColorStateList defaultprogresstintlist, defaultprogressbackgroundtintlist;
 		ColorFilter defaultthumbcolorfilter;
 		Drawable defaultthumb;
@@ -38,19 +37,17 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SeekBar.IOnSeekBarChangeListener.OnProgressChanged(SeekBar seekBar, int progress, bool fromUser)
 		{
-			if (_isTrackingChange)
+			if (fromUser)
 				((IElementController)Element).SetValueFromRenderer(Slider.ValueProperty, Value);
 		}
 
 		void SeekBar.IOnSeekBarChangeListener.OnStartTrackingTouch(SeekBar seekBar)
 		{
-			_isTrackingChange = true;
 			((ISliderController)Element)?.SendDragStarted();
 		}
 
 		void SeekBar.IOnSeekBarChangeListener.OnStopTrackingTouch(SeekBar seekBar)
 		{
-			_isTrackingChange = false;
 			((ISliderController)Element)?.SendDragCompleted();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Changes here https://github.com/xamarin/Xamarin.Forms/pull/1756 made it so the slider value would only update when physically interacted with. When TalkBack is on the progressbar is updated via the volume buttons which won't trigger those listeners. 

This PR changes the listener to check the `fromUser` to determine whether it should update or not. I tested the scenarios outlined on the issue that regressed this and the talkback scenario. It seems like using `fromUser` is reliable in all relevant scenarios.

The material slider already works like this as well.

### Issues Resolved ### 
- fixes #2800 


### Platforms Affected ### 
- Android

### Testing Procedure ###
- test any slider with talk back on. The included issue has a slider.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
