### PR TITLE
Set agent os for all pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -168,25 +168,27 @@ stages:
             buildConfiguration: $(AndroidBuildConfiguration)
             provisionatorPath : 'build/provisioning/provisioning.csx'
     - job: android_preappcompact
-      - template: build/steps/build-android.yml
-        parameters:
-          name: android_preappcompact
-          displayName: Build Android [Pre-AppCompat]
-          vmImage: $(macOSXVmImage)
-          targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
-          androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="PREAPPCOMPAT" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
-          buildConfiguration: $(AndroidBuildConfiguration)
-          provisionatorPath : 'build/provisioning/provisioning.csx'
+      steps:
+        - template: build/steps/build-android.yml
+          parameters:
+            name: android_preappcompact
+            displayName: Build Android [Pre-AppCompat]
+            vmImage: $(macOSXVmImage)
+            targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
+            androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="PREAPPCOMPAT" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
+            buildConfiguration: $(AndroidBuildConfiguration)
+            provisionatorPath : 'build/provisioning/provisioning.csx'
     - job: android_fast
-      - template: build/steps/build-android.yml
-        parameters:
-          name: android_fast
-          displayName: Build Android [Fast Renderers]
-          vmImage: $(macOSXVmImage)
-          targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
-          androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="FAST" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
-          buildConfiguration: $(AndroidBuildConfiguration)
-          provisionatorPath : 'build/provisioning/provisioning.csx'
+      steps:
+        - template: build/steps/build-android.yml
+          parameters:
+            name: android_fast
+            displayName: Build Android [Fast Renderers]
+            vmImage: $(macOSXVmImage)
+            targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
+            androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="FAST" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
+            buildConfiguration: $(AndroidBuildConfiguration)
+            provisionatorPath : 'build/provisioning/provisioning.csx'
 
 
   - stage: build_osx

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -123,7 +123,7 @@ jobs:
     name: $(vs2019VmPool)
     vmImage: $(vs2019VmImage)
     demands: 
-        - Agent.OS -equals Windows_NT
+      msbuild
   variables:
     FormsIdAppend: ''
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -139,7 +139,7 @@ jobs:
     pool:
       name: $(signVmPool)
       demands: 
-          - Agent.OS -equals Windows_NT
+        msbuild
     steps:
       - template: build/steps/build-sign.yml
     condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -67,14 +67,13 @@ stages:
         condition: eq(variables['vs2019VmPool'], 'Azure Pipelines')
         workspace:
           clean: all
-        displayName: ${{ parameters.displayName }}
+        displayName: Build Windows Phase
         timeoutInMinutes: 120
         pool:
-          name: ${{ parameters.vmPool }}
-          vmImage: ${{ parameters.vmImage }}
+          name: $(vs2019VmPool)
+          vmImage: $(vs2019VmImage)
           demands: 
             msbuild
-        dependsOn: ${{ parameters.dependsOn }}
         strategy:
           matrix:
             debug:
@@ -84,9 +83,6 @@ stages:
         steps:
           - template: build/steps/build-windows.yml
             parameters:
-              displayName: Build Windows Phase
-              vmImage: $(vs2019VmImage)
-              vmPool: $(vs2019VmPool)
               provisionatorPath : 'build/provisioning/provisioning.csx'
       - job: nuget_pack_hosted
         workspace:
@@ -111,11 +107,11 @@ stages:
         condition: ne(variables['vs2019VmPool'], 'Azure Pipelines')
         workspace:
           clean: all
-        displayName: ${{ parameters.displayName }}
+        displayName: Build Windows Phase Bots
         timeoutInMinutes: 120
         pool:
-          name: ${{ parameters.vmPool }}
-          vmImage: ${{ parameters.vmImage }}
+          name: $(vs2019VmPool)
+          vmImage: $(vs2019VmImage)
           demands: 
             - Agent.OS -equals Windows_NT
             - msbuild
@@ -129,9 +125,6 @@ stages:
         steps:
           - template: build/steps/build-windows.yml
             parameters:
-              displayName: Build Windows Phase
-              vmImage: $(vs2019VmImage)
-              vmPool: $(vs2019VmPool)
               provisionatorPath : 'build/provisioning/provisioning.csx'
 
       - job: nuget_pack_bots

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -122,6 +122,8 @@ jobs:
   pool:
     name: $(vs2019VmPool)
     vmImage: $(vs2019VmImage)
+    demands: 
+        - Agent.OS -equals Windows_NT
   variables:
     FormsIdAppend: ''
     buildConfiguration: $(DefaultBuildConfiguration)
@@ -136,6 +138,8 @@ jobs:
     dependsOn: nuget_pack
     pool:
       name: $(signVmPool)
+      demands: 
+          - Agent.OS -equals Windows_NT
     steps:
       - template: build/steps/build-sign.yml
     condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -59,90 +59,177 @@ schedules:
     include:
     - master
 
-jobs:
-- template: build/steps/build-windows.yml
-  parameters:
-    name: win
-    displayName: Build Windows Phase
-    vmImage: $(vs2019VmImage)
-    vmPool: $(vs2019VmPool)
-    provisionatorPath : 'build/provisioning/provisioning.csx'
+stages:
+  - stage: windows
+    displayName: Build Windows
+    jobs:
+      - job: win_hosted
+        condition: eq(variables['vs2019VmPool'], 'Azure Pipelines')
+        workspace:
+          clean: all
+        displayName: ${{ parameters.displayName }}
+        timeoutInMinutes: 120
+        pool:
+          name: ${{ parameters.vmPool }}
+          vmImage: ${{ parameters.vmImage }}
+          demands: 
+            msbuild
+        dependsOn: ${{ parameters.dependsOn }}
+        strategy:
+          matrix:
+            debug:
+              BuildConfiguration:  'Debug'
+            release:
+              BuildConfiguration:  'Release'
+        steps:
+          - template: build/steps/build-windows.yml
+            parameters:
+              displayName: Build Windows Phase
+              vmImage: $(vs2019VmImage)
+              vmPool: $(vs2019VmPool)
+              provisionatorPath : 'build/provisioning/provisioning.csx'
+      - job: nuget_pack_hosted
+        workspace:
+          clean: all
+        displayName: Nuget Phase
+        dependsOn:
+        - win_hosted
+        condition: succeeded()
+        pool:
+          name: $(vs2019VmPool)
+          vmImage: $(vs2019VmImage)
+          demands: 
+            msbuild
+        variables:
+          FormsIdAppend: ''
+          buildConfiguration: $(DefaultBuildConfiguration)
+          nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
+        steps:
+          - template: build/steps/build-nuget.yml
 
-- template: build/steps/build-android.yml
-  parameters:
-    name: android_legacy
-    displayName: Build Android [Legacy Renderers]
-    vmImage: $(macOSXVmImage)
-    targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
-    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="LEGACY" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
-    buildConfiguration: $(AndroidBuildConfiguration)
-    provisionatorPath : 'build/provisioning/provisioning.csx'
+      - job: win_bots
+        condition: ne(variables['vs2019VmPool'], 'Azure Pipelines')
+        workspace:
+          clean: all
+        displayName: ${{ parameters.displayName }}
+        timeoutInMinutes: 120
+        pool:
+          name: ${{ parameters.vmPool }}
+          vmImage: ${{ parameters.vmImage }}
+          demands: 
+            - Agent.OS -equals Windows_NT
+            - msbuild
+        dependsOn: ${{ parameters.dependsOn }}
+        strategy:
+          matrix:
+            debug:
+              BuildConfiguration:  'Debug'
+            release:
+              BuildConfiguration:  'Release'
+        steps:
+          - template: build/steps/build-windows.yml
+            parameters:
+              displayName: Build Windows Phase
+              vmImage: $(vs2019VmImage)
+              vmPool: $(vs2019VmPool)
+              provisionatorPath : 'build/provisioning/provisioning.csx'
 
-- template: build/steps/build-android.yml
-  parameters:
-    name: android_preappcompact
-    displayName: Build Android [Pre-AppCompat]
-    vmImage: $(macOSXVmImage)
-    targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
-    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="PREAPPCOMPAT" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
-    buildConfiguration: $(AndroidBuildConfiguration)
-    provisionatorPath : 'build/provisioning/provisioning.csx'
+      - job: nuget_pack_bots
+        workspace:
+          clean: all
+        displayName: Nuget Phase
+        dependsOn:
+        - win_bots
+        condition: succeeded()
+        pool:
+          name: $(vs2019VmPool)
+          vmImage: $(vs2019VmImage)
+          demands: 
+            msbuild
+        variables:
+          FormsIdAppend: ''
+          buildConfiguration: $(DefaultBuildConfiguration)
+          nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
+        steps:
+          - template: build/steps/build-nuget.yml
 
-- template: build/steps/build-android.yml
-  parameters:
-    name: android_fast
-    displayName: Build Android [Fast Renderers]
-    vmImage: $(macOSXVmImage)
-    targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
-    androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="FAST" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
-    buildConfiguration: $(AndroidBuildConfiguration)
-    provisionatorPath : 'build/provisioning/provisioning.csx'
+  - stage: android
+    displayName: Build Android
+    jobs:
+    - job: android_legacy
+      steps:
+        - template: build/steps/build-android.yml
+          parameters:
+            name: android_legacy
+            displayName: Build Android [Legacy Renderers]
+            vmImage: $(macOSXVmImage)
+            targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
+            androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="LEGACY" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
+            buildConfiguration: $(AndroidBuildConfiguration)
+            provisionatorPath : 'build/provisioning/provisioning.csx'
+    - job: android_preappcompact
+      - template: build/steps/build-android.yml
+        parameters:
+          name: android_preappcompact
+          displayName: Build Android [Pre-AppCompat]
+          vmImage: $(macOSXVmImage)
+          targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
+          androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="PREAPPCOMPAT" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
+          buildConfiguration: $(AndroidBuildConfiguration)
+          provisionatorPath : 'build/provisioning/provisioning.csx'
+    - job: android_fast
+      - template: build/steps/build-android.yml
+        parameters:
+          name: android_fast
+          displayName: Build Android [Fast Renderers]
+          vmImage: $(macOSXVmImage)
+          targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
+          androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="FAST" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
+          buildConfiguration: $(AndroidBuildConfiguration)
+          provisionatorPath : 'build/provisioning/provisioning.csx'
 
-- template: build/steps/build-osx.yml
-  parameters:
-    vmPool: $(osx2019VmPool)
-    vmImage: $(macOSXVmImage)
-    name: osx
-    buildForVS2017: 'false'
-    displayName: 'OSX Phase'
 
-- template: build/steps/build-osx.yml
-  parameters:
-    vmPool: $(osx2017VmPool)
-    vmImage: 'macOS-10.14'
-    name: osx_2017
-    buildForVS2017: 'true'
-    displayName: 'OSX Phase 2017'
+  - stage: build_osx
+    displayName: Build OSX
+    jobs:
+    - job: osx
+      steps:
+        - template: build/steps/build-osx.yml
+          parameters:
+            vmPool: $(osx2019VmPool)
+            vmImage: $(macOSXVmImage)
+            name: osx
+            buildForVS2017: 'false'
+            displayName: 'OSX Phase'
 
-- job: nuget_pack
-  workspace:
-    clean: all
-  displayName: Nuget Phase
-  dependsOn:
-   - win
-  condition: succeeded()
-  pool:
-    name: $(vs2019VmPool)
-    vmImage: $(vs2019VmImage)
-    demands: 
-      msbuild
-  variables:
-    FormsIdAppend: ''
-    buildConfiguration: $(DefaultBuildConfiguration)
-    nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
-  steps:
-     - template: build/steps/build-nuget.yml
+
+  - stage: build_osx_2017
+    displayName: Build OSX 2017
+    jobs:
+    - job: osx
+      steps:
+        - template: build/steps/build-osx.yml
+          parameters:
+            vmPool: $(osx2017VmPool)
+            vmImage: 'macOS-10.14'
+            name: osx_2017
+            buildForVS2017: 'true'
+            displayName: 'OSX Phase 2017'
 
   # only sign using the private server
 - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-  - job: nuget_sign
-    displayName: Sign Phase
-    dependsOn: nuget_pack
-    pool:
-      name: $(signVmPool)
-      demands: 
-        msbuild
-    steps:
-      - template: build/steps/build-sign.yml
-    condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+  - stage: nuget_signing
+    dependsOn: windows
+    displayName: Sign Nuget
+    jobs:
+    - job: nuget_sign
+      displayName: Sign Phase
+      dependsOn: nuget_pack
+      pool:
+        name: $(signVmPool)
+        demands: 
+          msbuild
+      steps:
+        - template: build/steps/build-sign.yml
+      condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,6 +62,7 @@ schedules:
 stages:
   - stage: windows
     displayName: Build Windows
+    dependsOn: []
     jobs:
       - job: win_hosted
         condition: eq(variables['vs2019VmPool'], 'Azure Pipelines')
@@ -147,44 +148,17 @@ stages:
 
   - stage: android
     displayName: Build Android
+    dependsOn: []
     jobs:
-    - job: android_legacy
-      steps:
-        - template: build/steps/build-android.yml
-          parameters:
-            name: android_legacy
-            displayName: Build Android [Legacy Renderers]
-            vmImage: $(macOSXVmImage)
-            targetFolder: Xamarin.Forms.ControlGallery.Android/legacyRenderers/
-            androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="LEGACY" /bl:$(Build.ArtifactStagingDirectory)/android-legacy.binlog'
-            buildConfiguration: $(AndroidBuildConfiguration)
-            provisionatorPath : 'build/provisioning/provisioning.csx'
-    - job: android_preappcompact
-      steps:
-        - template: build/steps/build-android.yml
-          parameters:
-            name: android_preappcompact
-            displayName: Build Android [Pre-AppCompat]
-            vmImage: $(macOSXVmImage)
-            targetFolder: Xamarin.Forms.ControlGallery.Android/preAppCompat
-            androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="PREAPPCOMPAT" /bl:$(Build.ArtifactStagingDirectory)/android-preappcompact.binlog'
-            buildConfiguration: $(AndroidBuildConfiguration)
-            provisionatorPath : 'build/provisioning/provisioning.csx'
-    - job: android_fast
-      steps:
-        - template: build/steps/build-android.yml
-          parameters:
-            name: android_fast
-            displayName: Build Android [Fast Renderers]
-            vmImage: $(macOSXVmImage)
-            targetFolder: Xamarin.Forms.ControlGallery.Android/newRenderers/
-            androidProjectArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="FAST" /bl:$(Build.ArtifactStagingDirectory)/android-newrenderers.binlog'
-            buildConfiguration: $(AndroidBuildConfiguration)
-            provisionatorPath : 'build/provisioning/provisioning.csx'
+      - template: build/steps/build-android.yml
+        parameters:
+          vmImage: $(macOSXVmImage)
+          provisionatorPath : 'build/provisioning/provisioning.csx'
 
 
   - stage: build_osx
     displayName: Build OSX
+    dependsOn: []
     jobs:
     - job: osx
       steps:
@@ -199,6 +173,7 @@ stages:
 
   - stage: build_osx_2017
     displayName: Build OSX 2017
+    dependsOn: []
     jobs:
     - job: osx
       steps:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,7 +100,7 @@ stages:
         variables:
           FormsIdAppend: ''
           buildConfiguration: $(DefaultBuildConfiguration)
-          nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
+          nugetPackageVersion : $[ dependencies.win_hosted.outputs['debug.winbuild.xamarinformspackageversion'] ]
         steps:
           - template: build/steps/build-nuget.yml
 
@@ -142,7 +142,7 @@ stages:
         variables:
           FormsIdAppend: ''
           buildConfiguration: $(DefaultBuildConfiguration)
-          nugetPackageVersion : $[ dependencies.win.outputs['debug.winbuild.xamarinformspackageversion'] ]
+          nugetPackageVersion : $[ dependencies.win_bots.outputs['debug.winbuild.xamarinformspackageversion'] ]
         steps:
           - template: build/steps/build-nuget.yml
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -212,7 +212,6 @@ stages:
       jobs:
         - job: nuget_sign
           displayName: Sign Phase
-          dependsOn: nuget_pack
           pool:
             name: $(signVmPool)
             demands: 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -161,29 +161,48 @@ stages:
     dependsOn: []
     jobs:
     - job: osx
+      workspace:
+        clean: all
+      displayName: OSX Phase
+      pool:
+        name:  $(osx2019VmPool)
+        vmImage: $(macOSXVmImage)
+        demands:
+          - sh
+          - Xamarin.iOS
+      variables:
+        provisionator.osxPath : 'build/provisioning/provisioning.csx'
+        buildConfiguration: $(DefaultBuildConfiguration)
+        slnPath: $(SolutionFile)
+        iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
+        iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
+        buildForVS2017: 'false'
       steps:
         - template: build/steps/build-osx.yml
-          parameters:
-            vmPool: $(osx2019VmPool)
-            vmImage: $(macOSXVmImage)
-            name: osx
-            buildForVS2017: 'false'
-            displayName: 'OSX Phase'
-
 
   - stage: build_osx_2017
     displayName: Build OSX 2017
     dependsOn: []
     jobs:
-    - job: osx
+    - job: osx_2017
+      workspace:
+        clean: all
+      displayName: OSX Phase 201
+      pool:
+        name:  $(osx2017VmPool)
+        vmImage: 'macOS-10.14'
+        demands:
+          - sh
+          - Xamarin.iOS
+      variables:
+        provisionator.osxPath : 'build/provisioning/provisioning.csx'
+        buildConfiguration: $(DefaultBuildConfiguration)
+        slnPath: $(SolutionFile)
+        iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
+        iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
+        buildForVS2017: 'true'
       steps:
         - template: build/steps/build-osx.yml
-          parameters:
-            vmPool: $(osx2017VmPool)
-            vmImage: 'macOS-10.14'
-            name: osx_2017
-            buildForVS2017: 'true'
-            displayName: 'OSX Phase 2017'
 
   # only sign using the private server
   - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -115,7 +115,6 @@ stages:
           demands: 
             - Agent.OS -equals Windows_NT
             - msbuild
-        dependsOn: ${{ parameters.dependsOn }}
         strategy:
           matrix:
             debug:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,14 +210,14 @@ stages:
       dependsOn: windows
       displayName: Sign Nuget
       jobs:
-      - job: nuget_sign
-        displayName: Sign Phase
-        dependsOn: nuget_pack
-        pool:
-          name: $(signVmPool)
-          demands: 
-            msbuild
-        steps:
-          - template: build/steps/build-sign.yml
-        condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+        - job: nuget_sign
+          displayName: Sign Phase
+          dependsOn: nuget_pack
+          pool:
+            name: $(signVmPool)
+            demands: 
+              msbuild
+          steps:
+            - template: build/steps/build-sign.yml
+          condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,6 +100,7 @@ jobs:
 
 - template: build/steps/build-osx.yml
   parameters:
+    vmPool: $(osx2019VmPool)
     vmImage: $(macOSXVmImage)
     name: osx
     buildForVS2017: 'false'
@@ -107,6 +108,7 @@ jobs:
 
 - template: build/steps/build-osx.yml
   parameters:
+    vmPool: $(osx2017VmPool)
     vmImage: 'macOS-10.14'
     name: osx_2017
     buildForVS2017: 'true'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -219,19 +219,19 @@ stages:
             displayName: 'OSX Phase 2017'
 
   # only sign using the private server
-- ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-  - stage: nuget_signing
-    dependsOn: windows
-    displayName: Sign Nuget
-    jobs:
-    - job: nuget_sign
-      displayName: Sign Phase
-      dependsOn: nuget_pack
-      pool:
-        name: $(signVmPool)
-        demands: 
-          msbuild
-      steps:
-        - template: build/steps/build-sign.yml
-      condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+  - ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+    - stage: nuget_signing
+      dependsOn: windows
+      displayName: Sign Nuget
+      jobs:
+      - job: nuget_sign
+        displayName: Sign Phase
+        dependsOn: nuget_pack
+        pool:
+          name: $(signVmPool)
+          demands: 
+            msbuild
+        steps:
+          - template: build/steps/build-sign.yml
+        condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
 

--- a/build.cake
+++ b/build.cake
@@ -78,16 +78,24 @@ if(buildForVS2017)
     macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";
 
 }
-else
+else if(releaseChannelArg == "Stable")
 {
-    // Xcode 11.3
-    monoMajorVersion = "";
-    monoPatchVersion = "";
-    androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-    iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/21e09d8084eb7c15eaa07c970e0eccdc/xamarin.ios-13.14.1.39.pkg";
-    macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/979144aead55378df75482d35957cdc9/xamarin.mac-6.14.1.39.pkg";
-    monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+    if(IsXcodeVersionOver("11.4"))
+    {
+        // Xcode 11.4 just uses boots enums
+        Information ("XCODE 11.4");
+    }
+    else
+    {
+        // Xcode 11.3
+        monoMajorVersion = "";
+        monoPatchVersion = "";
+        androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
+        iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/21e09d8084eb7c15eaa07c970e0eccdc/xamarin.ios-13.14.1.39.pkg";
+        macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/979144aead55378df75482d35957cdc9/xamarin.mac-6.14.1.39.pkg";
+        monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
 
+    }
 }
 
 if(String.IsNullOrWhiteSpace(monoSDK_macos))
@@ -380,4 +388,31 @@ MSBuildSettings GetMSBuildSettings()
         MSBuildPlatform = Cake.Common.Tools.MSBuild.MSBuildPlatform.x86,
         Configuration = configuration,
     };
+}
+
+bool IsXcodeVersionOver(string version)
+{
+    if(IsRunningOnWindows())
+        return true;
+
+    IEnumerable<string> redirectedStandardOutput;
+    StartProcess("xcodebuild", 
+        new ProcessSettings {
+            Arguments = new ProcessArgumentBuilder().Append(@"-version"),
+            RedirectStandardOutput = true
+        },
+         out redirectedStandardOutput
+    );
+
+    foreach (var item in redirectedStandardOutput)
+    {
+        if(item.Contains("Xcode"))
+        {
+            var xcodeVersion = Version.Parse(item.Replace("Xcode", ""));
+            Information($"Xcode: {xcodeVersion}");
+            return Version.Parse(item.Replace("Xcode", "")) >= Version.Parse(version); 
+        }
+    }
+
+    return true;
 }

--- a/build.cake
+++ b/build.cake
@@ -292,6 +292,13 @@ Task("BuildForNuget")
     }
 });
 
+Task("BuildTasks")
+    .Description("Build Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj")
+    .Does(() =>
+{
+    MSBuild("./Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj", GetMSBuildSettings().WithRestore());
+});
+
 Task("Build")
     .Description("Builds all necessary projects to run Control Gallery")
     .IsDependentOn("Restore")

--- a/build.cake
+++ b/build.cake
@@ -78,7 +78,7 @@ if(buildForVS2017)
     macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";
 
 }
-else if(releaseChannelArg == "Stable")
+else if(releaseChannel == ReleaseChannel.Stable)
 {
     if(IsXcodeVersionOver("11.4"))
     {

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -27,6 +27,8 @@ jobs:
     timeoutInMinutes: 120
     pool:
       vmImage: ${{ parameters.vmImage }}
+      demands: 
+          - Agent.OS -equals Darwin
     dependsOn: ${{ parameters.dependsOn }}
     steps:
       - checkout: self

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -88,8 +88,6 @@ jobs:
         displayName: 'NuGet restore ${{ parameters.slnPath }}'
         inputs:
           restoreSolution:  ${{ parameters.slnPath }}
-          feedsToUse: config
-          nugetConfigPath: 'DevopsNuget.config'
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -69,20 +69,6 @@ jobs:
         condition: ne(variables['NUGET_VERSION'], '')
         inputs:
           versionSpec: $(NUGET_VERSION)
-  
-      - task: DownloadBuildArtifacts@0
-        displayName: 'Download build artifact nuget'
-        condition: eq(variables['System.TeamProject'], 'DevDiv')
-        inputs:
-          artifactName: 'nuget'
-          downloadPath: 'Nuget'
-
-      - task: CopyFiles@2
-        displayName: 'Copy Files to: $(System.DefaultWorkingDirectory)'
-        condition: eq(variables['System.TeamProject'], 'DevDiv')
-        inputs:
-          SourceFolder: 'Nuget/nuget/${{ parameters.buildConfiguration }}'
-          TargetFolder: 'Nuget'
 
       - task: NuGetCommand@2
         displayName: 'NuGet restore ${{ parameters.slnPath }}'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -28,7 +28,8 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmImage }}
       demands: 
-          - Agent.OS -equals Darwin
+        - sh
+        - Xamarin.Android
     dependsOn: ${{ parameters.dependsOn }}
     steps:
       - checkout: self

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -3,19 +3,15 @@ parameters:
   displayName: ''     # the human name
   vmImage: ''         # the VM image
   vmPool: ''         # the VM pool
-  targetFolder: ''    # the bootstrapper target
   dependsOn: []       # the dependiencies
   preBuildSteps: []   # any steps to run before the build
   postBuildSteps: []  # any additional steps to run after the build
   slnPath : 'Xamarin.Forms.sln'
   buildTaskPath : 'Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
-  androidPath : 'Xamarin.Forms.ControlGallery.Android'
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
-  androidProjectArguments : ''
   buildConfiguration : 'Debug'
   nugetVersion: $(NUGET_VERSION)
   monoVersion: $(MONO_VERSION)
-  apkTargetFolder: '$(build.artifactstagingdirectory)/androidApp'
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''
 
@@ -27,10 +23,18 @@ jobs:
     timeoutInMinutes: 120
     pool:
       vmImage: ${{ parameters.vmImage }}
-      demands: 
-        - sh
-        - Xamarin.Android
     dependsOn: ${{ parameters.dependsOn }}
+    strategy:
+      matrix:
+        android_legacy:
+          renderers: 'LEGACY'
+          outputfolder: 'legacyRenderers'
+        android_preAppCompat:
+          renderers: 'PREAPPCOMPAT'
+          outputfolder: 'preAppCompat'
+        android_newRenderers:
+          renderers: 'FAST'
+          outputfolder: 'newRenderers'
     steps:
       - checkout: self
         clean: true
@@ -48,7 +52,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target provision --releaseChannel=$(releaseChannel)
+          arguments: --target provision --TeamProject="$(System.TeamProject)" --releaseChannel=$(releaseChannel)
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'
@@ -65,11 +69,27 @@ jobs:
         condition: ne(variables['NUGET_VERSION'], '')
         inputs:
           versionSpec: $(NUGET_VERSION)
+  
+      - task: DownloadBuildArtifacts@0
+        displayName: 'Download build artifact nuget'
+        condition: eq(variables['System.TeamProject'], 'DevDiv')
+        inputs:
+          artifactName: 'nuget'
+          downloadPath: 'Nuget'
+
+      - task: CopyFiles@2
+        displayName: 'Copy Files to: $(System.DefaultWorkingDirectory)'
+        condition: eq(variables['System.TeamProject'], 'DevDiv')
+        inputs:
+          SourceFolder: 'Nuget/nuget/${{ parameters.buildConfiguration }}'
+          TargetFolder: 'Nuget'
 
       - task: NuGetCommand@2
         displayName: 'NuGet restore ${{ parameters.slnPath }}'
         inputs:
           restoreSolution:  ${{ parameters.slnPath }}
+          feedsToUse: config
+          nugetConfigPath: 'DevopsNuget.config'
 
       - task: MSBuild@1
         displayName: 'Build ${{ parameters.buildTaskPath  }}'
@@ -78,27 +98,27 @@ jobs:
           configuration: ${{ parameters.buildConfiguration }}
 
       - task: MSBuild@1
-        displayName: 'Build Android ${{ parameters.name }}'
+        displayName: 'Build Android $(renderers)'
         inputs:
           solution: ${{ parameters.androidProjectPath }}
           configuration: ${{ parameters.buildConfiguration }}
-          msbuildArguments: ${{ parameters.androidProjectArguments }}
+          msbuildArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="$(renderers)" /bl:$(Build.ArtifactStagingDirectory)/android-$(renderers).binlog'
 
       - task: CopyFiles@2
-        displayName: 'Copy ${{ parameters.name }}'
+        displayName: 'Copy $(renderers)'
         inputs:
-          SourceFolder: ${{ parameters.androidPath }}/bin/${{ parameters.buildConfiguration }}/
+          SourceFolder: Xamarin.Forms.ControlGallery.Android/bin/${{ parameters.buildConfiguration }}/
           Contents: '**/*.apk'
-          TargetFolder: ${{ parameters.targetFolder }}
+          TargetFolder: 'Xamarin.Forms.ControlGallery.Android/$(outputfolder)/'
           CleanTargetFolder: true
           OverWrite: true
 
       - task: CopyFiles@2
-        displayName: 'Copy Android apk ${{ parameters.name }} for UITest'
+        displayName: 'Copy Android apk $(renderers) for UITest'
         inputs:
           Contents: |
-            ${{ parameters.targetFolder }}/$(ApkName)
-          TargetFolder: ${{ parameters.apkTargetFolder }}
+            Xamarin.Forms.ControlGallery.Android/$(outputfolder)/$(ApkName)
+          TargetFolder: '$(build.artifactstagingdirectory)/androidApp'
           CleanTargetFolder: true
 
       - task: PublishBuildArtifacts@1

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -15,6 +15,7 @@ jobs:
         - sh
         - msbuild
         - Xamarin.iOS
+        - Agent.OS -equals Darwin
     variables:
       provisionator.osxPath : 'build/provisioning/provisioning.csx'
       buildConfiguration: $(DefaultBuildConfiguration)

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -12,10 +12,9 @@ jobs:
     pool:
       vmImage: ${{ parameters.vmImage }}
       demands:
-        - sh
-        - msbuild
-        - Xamarin.iOS
         - Agent.OS -equals Darwin
+        - sh
+        - Xamarin.iOS
     variables:
       provisionator.osxPath : 'build/provisioning/provisioning.csx'
       buildConfiguration: $(DefaultBuildConfiguration)

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -13,7 +13,6 @@ jobs:
       name: ${{ parameters.vmPool }}
       vmImage: ${{ parameters.vmImage }}
       demands:
-        - Agent.OS -equals Darwin
         - sh
         - Xamarin.iOS
     variables:

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -1,136 +1,112 @@
-parameters:
-  name: ''            # in the form type_platform_host
-  displayName: ''            
-  vmImage: ''         # the VM image
-  buildForVS2017: 'false'
+steps:
+  - checkout: self
+    clean: true
 
-jobs:
-  - job: ${{ parameters.name }}
-    workspace:
-      clean: all
-    displayName: ${{ parameters.displayName }}
-    pool:
-      name: ${{ parameters.vmPool }}
-      vmImage: ${{ parameters.vmImage }}
-      demands:
-        - sh
-        - Xamarin.iOS
-    variables:
-      provisionator.osxPath : 'build/provisioning/provisioning.csx'
-      buildConfiguration: $(DefaultBuildConfiguration)
-      slnPath: $(SolutionFile)
-      iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
-      iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
-      buildForVS2017: ${{ parameters.buildForVS2017 }}
-    steps:
-    - checkout: self
-      clean: true
+  - task: xamops.azdevex.provisionator-task.provisionator@1
+    displayName: 'Provisionator'
+    condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
+    inputs:
+      provisioning_script: $(provisionator.osxPath)
+      provisioning_extra_args: $(provisionator.extraArguments)
 
-    - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: 'Provisionator'
-      condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
-      inputs:
-        provisioning_script: $(provisionator.osxPath)
-        provisioning_extra_args: $(provisionator.extraArguments)
+  - task: Bash@3
+    displayName: 'Cake Provision'
+    condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
+    inputs:
+      targetType: 'filePath'
+      filePath: 'build.sh'
+      arguments: --target provision --buildForVS2017=$(buildForVS2017) --releaseChannel=$(releaseChannel)
 
-    - task: Bash@3
-      displayName: 'Cake Provision'
-      condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
-      inputs:
-        targetType: 'filePath'
-        filePath: 'build.sh'
-        arguments: --target provision --buildForVS2017=$(buildForVS2017) --releaseChannel=$(releaseChannel)
+  - task: UseDotNet@2
+    displayName: 'Install .net core $(DOTNET_VERSION)'
+    condition: ne(variables['DOTNET_VERSION'], '')
+    inputs:
+      version: $(DOTNET_VERSION)
+      packageType: 'sdk'
 
-    - task: UseDotNet@2
-      displayName: 'Install .net core $(DOTNET_VERSION)'
-      condition: ne(variables['DOTNET_VERSION'], '')
-      inputs:
-        version: $(DOTNET_VERSION)
-        packageType: 'sdk'
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet'
+    condition: ne(variables['NUGET_VERSION'], '')
+    inputs:
+      versionSpec: $(NUGET_VERSION)
 
-    - task: NuGetToolInstaller@1
-      displayName: 'Use NuGet'
-      condition: ne(variables['NUGET_VERSION'], '')
-      inputs:
-        versionSpec: $(NUGET_VERSION)
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore'
+    inputs:
+      restoreSolution: $(slnPath)
 
-    - task: NuGetCommand@2
-      displayName: 'NuGet restore'
-      inputs:
-        restoreSolution: $(slnPath)
+  - task: Bash@3
+    displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
+    condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
+    inputs:
+      targetType: 'filePath'
+      filePath: 'build.sh'
+      arguments: --target BuildTasks
 
-    - task: Bash@3
-      displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
-      condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
-      inputs:
-        targetType: 'filePath'
-        filePath: 'build.sh'
-        arguments: --target BuildTasks
+  - task: InstallAppleCertificate@2
+    displayName: 'Install an Apple certificate'
+    inputs:
+      certSecureFile: 'Xamarin Forms iOS Certificate.p12'
+      certPwd: $(P12password)
 
-    - task: InstallAppleCertificate@2
-      displayName: 'Install an Apple certificate'
-      inputs:
-        certSecureFile: 'Xamarin Forms iOS Certificate.p12'
-        certPwd: $(P12password)
+  - task: InstallAppleProvisioningProfile@1
+    displayName: 'Install an Apple provisioning profile'
+    inputs:
+      provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
 
-    - task: InstallAppleProvisioningProfile@1
-      displayName: 'Install an Apple provisioning profile'
-      inputs:
-        provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
-
-    - task: XamariniOS@2
-      displayName: 'Build Xamarin.iOS solution $(slnPath)'
-      inputs:
-        solutionFile: $(slnPath)
-        configuration: $(buildConfiguration)
-        args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
+  - task: XamariniOS@2
+    displayName: 'Build Xamarin.iOS solution $(slnPath)'
+    inputs:
+      solutionFile: $(slnPath)
+      configuration: $(buildConfiguration)
+      args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
 
 
-    - task: CopyFiles@2
-      displayName: 'Copy test-cloud.exe'
-      condition: eq(variables['buildForVS2017'], 'false')
-      inputs:
-        Contents: '**/Xamarin.UITest.*/tools/test-cloud.exe'
-        TargetFolder: '$(build.artifactstagingdirectory)/testcloud'
-        CleanTargetFolder: true
-        OverWrite: true
-        flattenFolders: true
+  - task: CopyFiles@2
+    displayName: 'Copy test-cloud.exe'
+    condition: eq(variables['buildForVS2017'], 'false')
+    inputs:
+      Contents: '**/Xamarin.UITest.*/tools/test-cloud.exe'
+      TargetFolder: '$(build.artifactstagingdirectory)/testcloud'
+      CleanTargetFolder: true
+      OverWrite: true
+      flattenFolders: true
 
 
-    - task: CopyFiles@2
-      displayName: 'Copy iOS Files for UITest'
-      condition: eq(variables['buildForVS2017'], 'false')
-      inputs:
-        Contents: |
-          **/$(IpaName)
-          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
-          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
-          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
-          Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
-        TargetFolder: '$(build.artifactstagingdirectory)/ios'
-        CleanTargetFolder: true
-        flattenFolders: true
+  - task: CopyFiles@2
+    displayName: 'Copy iOS Files for UITest'
+    condition: eq(variables['buildForVS2017'], 'false')
+    inputs:
+      Contents: |
+        **/$(IpaName)
+        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
+        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
+        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
+        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
+        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
+      TargetFolder: '$(build.artifactstagingdirectory)/ios'
+      CleanTargetFolder: true
+      flattenFolders: true
 
 
-    - task: CopyFiles@2
-      displayName: 'Copy Android Files for UITest'
-      condition: eq(variables['buildForVS2017'], 'false')
-      inputs:
-        Contents: |
-          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/nunit.*
-          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
-          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Plugin.*
-          Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
-        TargetFolder: '$(build.artifactstagingdirectory)/android'
-        CleanTargetFolder: true
-        flattenFolders: true
+  - task: CopyFiles@2
+    displayName: 'Copy Android Files for UITest'
+    condition: eq(variables['buildForVS2017'], 'false')
+    inputs:
+      Contents: |
+        Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
+        Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/nunit.*
+        Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/NUnit3.*
+        Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Plugin.*
+        Xamarin.Forms.Core.Android.UITests/bin/$(BuildConfiguration)/Xamarin.*
+      TargetFolder: '$(build.artifactstagingdirectory)/android'
+      CleanTargetFolder: true
+      flattenFolders: true
 
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: iOS'
-      condition: always()
-      inputs:
-        PathtoPublish: '$(build.artifactstagingdirectory)'
-        ArtifactName: OSXArtifacts
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: iOS'
+    condition: always()
+    inputs:
+      PathtoPublish: '$(build.artifactstagingdirectory)'
+      ArtifactName: OSXArtifacts

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -10,6 +10,7 @@ jobs:
       clean: all
     displayName: ${{ parameters.displayName }}
     pool:
+      name: ${{ parameters.vmPool }}
       vmImage: ${{ parameters.vmImage }}
       demands:
         - Agent.OS -equals Darwin

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -60,10 +60,13 @@ jobs:
       inputs:
         restoreSolution: $(slnPath)
 
-    - task: MSBuild@1
+    - task: Bash@3
       displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
+      condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
       inputs:
-        solution: Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+        targetType: 'filePath'
+        filePath: 'build.sh'
+        arguments: --target BuildTasks
 
     - task: InstallAppleCertificate@2
       displayName: 'Install an Apple certificate'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -1,7 +1,6 @@
 parameters:
   name: ''            # in the form type_platform_host
   targetFolder: ''    # the bootstrapper target
-  dependsOn: []       # the dependiencies
   preBuildSteps: []   # any steps to run before the build
   postBuildSteps: []  # any additional steps to run after the build
   slnPath : 'Xamarin.Forms.sln'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -27,6 +27,8 @@ jobs:
     pool:
       name: ${{ parameters.vmPool }}
       vmImage: ${{ parameters.vmImage }}
+      demands: 
+        - Agent.OS -equals Windows_NT
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -27,8 +27,9 @@ jobs:
     pool:
       name: ${{ parameters.vmPool }}
       vmImage: ${{ parameters.vmImage }}
-      demands: 
-        - Agent.OS -equals Windows_NT
+      ${{ if eq(parameters.vmPool, 'Azure Pipelines') }}:
+        demands: 
+          - Agent.OS -equals Windows_NT
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -1,8 +1,5 @@
 parameters:
   name: ''            # in the form type_platform_host
-  displayName: ''     # the human name
-  vmImage: ''         # the VM image
-  vmPool: ''         # the VM pool
   targetFolder: ''    # the bootstrapper target
   dependsOn: []       # the dependiencies
   preBuildSteps: []   # any steps to run before the build

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -27,9 +27,8 @@ jobs:
     pool:
       name: ${{ parameters.vmPool }}
       vmImage: ${{ parameters.vmImage }}
-      ${{ if eq(parameters.vmPool, 'Azure Pipelines') }}:
-        demands: 
-          - Agent.OS -equals Windows_NT
+      demands: 
+        msbuild
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -18,202 +18,184 @@ parameters:
   includeAndroid: 'true'
   includeNonUwpAndNonAndroid: 'true'
 
-jobs:
-  - job: ${{ parameters.name }}
-    workspace:
-      clean: all
-    displayName: ${{ parameters.displayName }}
-    timeoutInMinutes: 120
-    pool:
-      name: ${{ parameters.vmPool }}
-      vmImage: ${{ parameters.vmImage }}
-      demands: 
-        msbuild
-    dependsOn: ${{ parameters.dependsOn }}
-    strategy:
-      matrix:
-        debug:
-          BuildConfiguration:  'Debug'
-        release:
-          BuildConfiguration:  'Release'
-    steps:
-    - checkout: self
-      clean: true
-    - script: build.cmd -Target provision
-      displayName: 'Cake Provision'
-      condition: eq(variables['provisioningCake'], 'true')
+steps:
+  - checkout: self
+    clean: true
+  - script: build.cmd -Target provision
+    displayName: 'Cake Provision'
+    condition: eq(variables['provisioningCake'], 'true')
 
-    - task: xamops.azdevex.provisionator-task.provisionator@1
-      displayName: 'Provisionator'
-      condition: eq(variables['provisioning'], 'true')
-      inputs:
-        provisioning_script: ${{ parameters.provisionatorPath }}
-        provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
+  - task: xamops.azdevex.provisionator-task.provisionator@1
+    displayName: 'Provisionator'
+    condition: eq(variables['provisioning'], 'true')
+    inputs:
+      provisioning_script: ${{ parameters.provisionatorPath }}
+      provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
 
-    # - task: UseDotNet@2
-    #   displayName: "Install .net core $(DOTNET_VERSION)"
-    #   condition: ne(variables['DOTNET_VERSION'], '')
-    #   inputs:
-    #     version: $(DOTNET_VERSION)
-    #     packageType: 'sdk'
+  # - task: UseDotNet@2
+  #   displayName: "Install .net core $(DOTNET_VERSION)"
+  #   condition: ne(variables['DOTNET_VERSION'], '')
+  #   inputs:
+  #     version: $(DOTNET_VERSION)
+  #     packageType: 'sdk'
 
-    - task: NuGetToolInstaller@1
-      displayName: 'Use NuGet $(NUGET_VERSION)'
-      condition: ne(variables['NUGET_VERSION'], '')
-      inputs:
-        versionSpec: $(NUGET_VERSION)
+  - task: NuGetToolInstaller@1
+    displayName: 'Use NuGet $(NUGET_VERSION)'
+    condition: ne(variables['NUGET_VERSION'], '')
+    inputs:
+      versionSpec: $(NUGET_VERSION)
 
-    - task: NuGetCommand@2
-      displayName: 'NuGet restore ${{ parameters.slnPath }}'
-      inputs:
-        restoreSolution: ${{ parameters.slnPath }}
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore ${{ parameters.slnPath }}'
+    inputs:
+      restoreSolution: ${{ parameters.slnPath }}
 
-    - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
-      name: winbuild
-      displayName: 'Build Projects For Nuget'
+  - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
+    name: winbuild
+    displayName: 'Build Projects For Nuget'
 
-    - task: VSTest@2
-      displayName: 'Unit Tests'
-      inputs:
-        testAssemblyVer2: |
-          **/bin/$(BuildConfiguration)/Xamarin.Forms.Core.UnitTests.dll
-          **/bin/$(BuildConfiguration)/**/Xamarin.Forms.DualScreen.UnitTests.dll
-          **/bin/$(BuildConfiguration)/Xamarin.Forms.Pages.UnitTests.dll
-          **/bin/$(BuildConfiguration)/**/Xamarin.Forms.Xaml.UnitTests.dll
-        searchFolder: ${{ parameters.nunitTestFolder }}
-        codeCoverageEnabled: true
-        testRunTitle: '$(BuildConfiguration)_UnitTests'
-        configuration: '$(BuildConfiguration)'
-        diagnosticsEnabled: true
+  - task: VSTest@2
+    displayName: 'Unit Tests'
+    inputs:
+      testAssemblyVer2: |
+        **/bin/$(BuildConfiguration)/Xamarin.Forms.Core.UnitTests.dll
+        **/bin/$(BuildConfiguration)/**/Xamarin.Forms.DualScreen.UnitTests.dll
+        **/bin/$(BuildConfiguration)/Xamarin.Forms.Pages.UnitTests.dll
+        **/bin/$(BuildConfiguration)/**/Xamarin.Forms.Xaml.UnitTests.dll
+      searchFolder: ${{ parameters.nunitTestFolder }}
+      codeCoverageEnabled: true
+      testRunTitle: '$(BuildConfiguration)_UnitTests'
+      configuration: '$(BuildConfiguration)'
+      diagnosticsEnabled: true
 
-    - task: CopyFiles@2
-      displayName: 'Copy Files dlls'
-      condition: eq(${{ parameters.includeNonUwpAndNonAndroid }}, 'true')
-      inputs:
-        Contents: |
-          Stubs/**/bin/**/*.dll
-          Microsoft.XamlStandard/bin/**/*.dll
-          Microsoft.XamlStandard.Design/bin/**/*.dll
-          Xamarin.Forms.Core/bin/**/*.dll
-          Xamarin.Forms.Core/bin/**/*.pdb
-          Xamarin.Forms.Core/bin/**/*.mdb
-          Xamarin.Forms.Xaml/bin/**/*.dll
-          Xamarin.Forms.Xaml/bin/**/*.pdb
-          Xamarin.Forms.Xaml/bin/**/*.mdb
-          Xamarin.Forms.Platform/bin/**/*.dll
-          Xamarin.Forms.Build.Tasks/bin/**/*.dll
-          Xamarin.Forms.Core.Design/bin/**/*.dll
-          Xamarin.Forms.Xaml.Design/bin/**/*.dll
-          Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Material.iOS/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Material.iOS/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Material.iOS/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps.iOS/bin/iPhoneSimulator/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.MacOS/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Pages.Azure/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Pages.Azure/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Pages.Azure/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Core.UnitTests/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Xaml.UnitTests/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Pages.UnitTests/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.Tizen/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.Tizen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps.Tizen/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.Tizen/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.Tizen/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.Tizen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Build.Tasks.Core/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Build.Tasks.Core/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Build.Tasks.Core/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps.WPF/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.WPF/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps.WPF/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Maps.GTK/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.GTK/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps.GTK/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.WPF/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.WPF/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Platform.WPF/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.GTK/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.GTK/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Platform.GTK/bin/$(BuildConfiguration)/**/*.pdb
-          Microsoft.XamlStandard/bin/$(BuildConfiguration)/**/*.dll
-          Microsoft.XamlStandard/bin/$(BuildConfiguration)/**/*.mdb
-          Microsoft.XamlStandard/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.DualScreen.UnitTests/bin/$(BuildConfiguration)/**/*.dll
-          **/*.binlog
+  - task: CopyFiles@2
+    displayName: 'Copy Files dlls'
+    condition: eq(${{ parameters.includeNonUwpAndNonAndroid }}, 'true')
+    inputs:
+      Contents: |
+        Stubs/**/bin/**/*.dll
+        Microsoft.XamlStandard/bin/**/*.dll
+        Microsoft.XamlStandard.Design/bin/**/*.dll
+        Xamarin.Forms.Core/bin/**/*.dll
+        Xamarin.Forms.Core/bin/**/*.pdb
+        Xamarin.Forms.Core/bin/**/*.mdb
+        Xamarin.Forms.Xaml/bin/**/*.dll
+        Xamarin.Forms.Xaml/bin/**/*.pdb
+        Xamarin.Forms.Xaml/bin/**/*.mdb
+        Xamarin.Forms.Platform/bin/**/*.dll
+        Xamarin.Forms.Build.Tasks/bin/**/*.dll
+        Xamarin.Forms.Core.Design/bin/**/*.dll
+        Xamarin.Forms.Xaml.Design/bin/**/*.dll
+        Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.iOS/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Material.iOS/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Material.iOS/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Material.iOS/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Material.Tizen/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.MacOS/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Maps/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps.iOS/bin/iPhoneSimulator/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps.MacOS/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Pages/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Pages.Azure/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Pages.Azure/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Pages.Azure/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Core.UnitTests/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Xaml.UnitTests/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Pages.UnitTests/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps.Tizen/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps.Tizen/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps.Tizen/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.Tizen/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.Tizen/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.Tizen/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Build.Tasks.Core/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Build.Tasks.Core/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Build.Tasks.Core/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps.WPF/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps.WPF/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps.WPF/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Maps.GTK/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps.GTK/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps.GTK/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.WPF/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.WPF/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Platform.WPF/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.GTK/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.GTK/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Platform.GTK/bin/$(BuildConfiguration)/**/*.pdb
+        Microsoft.XamlStandard/bin/$(BuildConfiguration)/**/*.dll
+        Microsoft.XamlStandard/bin/$(BuildConfiguration)/**/*.mdb
+        Microsoft.XamlStandard/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.DualScreen.UnitTests/bin/$(BuildConfiguration)/**/*.dll
+        **/*.binlog
 
-        TargetFolder: ${{ parameters.artifactsTargetFolder }}
+      TargetFolder: ${{ parameters.artifactsTargetFolder }}
 
-    - task: CopyFiles@2
-      displayName: 'Copy UWP'
-      condition: eq(${{ parameters.includeUwp }}, 'true')
-      inputs:
-        Contents: |
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
-          Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
-          Xamarin.Forms.Platform.UAP/obj/$(BuildConfiguration)/**/*.xaml
-          Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
-          Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.DualScreen.UnitTests/bin/$(BuildConfiguration)/**/*.dll
+  - task: CopyFiles@2
+    displayName: 'Copy UWP'
+    condition: eq(${{ parameters.includeUwp }}, 'true')
+    inputs:
+      Contents: |
+        Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.pri
+        Xamarin.Forms.Platform.UAP/bin/$(BuildConfiguration)/**/*.xr.xml
+        Xamarin.Forms.Platform.UAP/obj/$(BuildConfiguration)/**/*.xaml
+        Xamarin.Forms.Platform.UAP/Properties/Xamarin.Forms.Platform.UAP.rd.xml
+        Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.pri
+        Xamarin.Forms.Maps.UWP/bin/$(BuildConfiguration)/**/*.xbf
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.DualScreen.UnitTests/bin/$(BuildConfiguration)/**/*.dll
 
-        TargetFolder: ${{ parameters.artifactsTargetFolder }}
+      TargetFolder: ${{ parameters.artifactsTargetFolder }}
 
-        
-    - task: CopyFiles@2
-      displayName: 'Copy Android Files dlls'
-      condition: eq('${{ parameters.includeAndroid }}', true)
-      inputs:
-        Contents: |
-          Stubs/**/bin/**/*.dll
-          Xamarin.Forms.Platform.Android/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.Android/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Material.Android/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Material.Android/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Material.Android/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.Maps.Android/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.Android.AppLinks/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.Platform.Android.AppLinks/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.Platform.Android.AppLinks/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.dll
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.pdb
-          Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.mdb
-          Xamarin.Forms.DualScreen.UnitTests/bin/$(BuildConfiguration)/**/*.dll
-          **/*.binlog
+      
+  - task: CopyFiles@2
+    displayName: 'Copy Android Files dlls'
+    condition: eq('${{ parameters.includeAndroid }}', true)
+    inputs:
+      Contents: |
+        Stubs/**/bin/**/*.dll
+        Xamarin.Forms.Platform.Android/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.Android/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.Android.FormsViewGroup/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Material.Android/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Material.Android/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Material.Android/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.Maps.Android/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.Android.AppLinks/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.Platform.Android.AppLinks/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.Platform.Android.AppLinks/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.dll
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.pdb
+        Xamarin.Forms.DualScreen/bin/$(BuildConfiguration)/**/*.mdb
+        Xamarin.Forms.DualScreen.UnitTests/bin/$(BuildConfiguration)/**/*.dll
+        **/*.binlog
 
-        TargetFolder: ${{ parameters.artifactsTargetFolder }}
+      TargetFolder: ${{ parameters.artifactsTargetFolder }}
 
-    - task: PublishBuildArtifacts@1
-      displayName: 'Publish Artifact: ${{ parameters.artifactsName }}'
-      condition: always()
-      inputs:
-        ArtifactName: ${{ parameters.artifactsName }}
+  - task: PublishBuildArtifacts@1
+    displayName: 'Publish Artifact: ${{ parameters.artifactsName }}'
+    condition: always()
+    inputs:
+      ArtifactName: ${{ parameters.artifactsName }}


### PR DESCRIPTION
### Description of Change ###

- Set the OS demand for all the pools so that everything uses the correct operating system to build. 
- Added conditional windows steps so it would use demands when using our bots opposed to pipelines
- added a check for xcode version so it'll install the correct sdks

### Testing Procedure ###
- Turn on the bots that are confusing the builds and make sure everything still builds

Internal
https://devdiv.visualstudio.com/DevDiv/_build/results?buildId=3642726&view=results

Hosted 10.15
https://dev.azure.com/xamarin/public/_build/results?buildId=16940&view=logs&j=be1d3261-c4d2-5528-aad8-51398c05403f

Bot turned on with 10.15
https://dev.azure.com/xamarin/public/_build/results?buildId=16939&view=results

Hosted 10.14 (normal run without modifying parameters)
https://dev.azure.com/xamarin/public/_build/results?buildId=16938&view=logs&j=1c8381ff-b205-54ef-ec4d-2dac1b85342d

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
