### PR TITLE
Embedded font's now cache lookup to prevent double setups. fixes #10208

### DIFF
--- a/Xamarin.Forms.Core/FontRegistrar.cs
+++ b/Xamarin.Forms.Core/FontRegistrar.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Internals
 	public static class FontRegistrar
 	{
 		internal static readonly Dictionary<string, (ExportFontAttribute attribute, Assembly assembly)> EmbeddedFonts = new Dictionary<string, (ExportFontAttribute attribute, Assembly assembly)>();
-
+		static Dictionary<string, (bool, string)> fontLookupCache = new Dictionary<string, (bool, string)>();
 		public static void Register(ExportFontAttribute fontAttribute, Assembly assembly)
 		{
 			EmbeddedFonts[fontAttribute.FontFileName] = (fontAttribute, assembly);
@@ -29,18 +29,23 @@ namespace Xamarin.Forms.Internals
 					return (false, null);
 				}
 
+				if (fontLookupCache.TryGetValue(font, out var foundResult))
+					return foundResult;
+
+
 				var fontStream = GetEmbeddedResourceStream(foundFont.assembly, foundFont.attribute.FontFileName);
 
 				var type = Registrar.Registered.GetHandlerType(typeof(EmbeddedFont));
 				var fontHandler = (IEmbeddedFontLoader)Activator.CreateInstance(type);
-				return fontHandler.LoadFont(new EmbeddedFont { FontName = foundFont.attribute.FontFileName, ResourceStream = fontStream });
+				var result = fontHandler.LoadFont(new EmbeddedFont { FontName = foundFont.attribute.FontFileName, ResourceStream = fontStream });
+				return fontLookupCache[font] = result;
 
 			}
 			catch (Exception ex)
 			{
 				Debug.WriteLine(ex);
 			}
-			return (false, null);
+			return fontLookupCache[font] = (false, null);
 		}
 
 		static Stream GetEmbeddedResourceStream(Assembly assembly, string resourceFileName)

--- a/Xamarin.Forms.Platform.iOS/EmbeddedFontLoader.cs
+++ b/Xamarin.Forms.Platform.iOS/EmbeddedFontLoader.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using CoreGraphics;
 using CoreText;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -21,6 +22,12 @@ namespace Xamarin.Forms.Platform.iOS
 				if (CTFontManager.RegisterGraphicsFont(cGFont, out var error))
 				{
 					return (true, name);
+				}
+				else //Lets check if the font is already registered
+				{
+					var uiFont = UIFont.FromName(name, 10);
+					if (uiFont != null)
+						return (true, name);
 				}
 				Debug.WriteLine(error.Description);
 			}


### PR DESCRIPTION
### Description of Change ###

iOS verifies a font is installed, if it fails to register the font.
FontLoader now caches the lookups to prevent double looking, and is faster for subsequent lookups since it no longer hits native after the first lookup.

### Issues Resolved ### 

- fixes #10208
- fixes #10226

### Affected Platforms ###

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
