### PR TITLE
[Tizen] Changed CarouselView scroll logic according to the Core change.

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -124,9 +124,7 @@ namespace Xamarin.Forms.Platform
 	internal class _CheckBoxRenderer { }
 #endif
 
-#if !TIZEN4_0
 	[RenderWith(typeof(IndicatorViewRenderer))]
-#endif
 	internal class _IndicatorViewRenderer { }
 
 #if __IOS__

--- a/Xamarin.Forms.ControlGallery.Tizen/ControlGallery.Tizen.cs
+++ b/Xamarin.Forms.ControlGallery.Tizen/ControlGallery.Tizen.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.ControlGallery.Tizen
 		{
 			var app = new MainApplication();
 			FormsMaps.Init("HERE", "write-your-API-key-here");
-			Forms.SetFlags("CollectionView_Experimental", "Shell_Experimental", "MediaElement_Experimental");
+			Forms.SetFlags("CollectionView_Experimental", "Shell_Experimental", "MediaElement_Experimental", "IndicatorView_Experimental");
 			Forms.Init(app);
 			FormsMaterial.Init();
 			app.Run(args);

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		SnapPointsType _snapPoints;
 		ESize _itemSize = new ESize(-1, -1);
 
+		public event EventHandler<ItemsViewScrolledEventArgs> Scrolled;
+
 		public CollectionView(EvasObject parent) : base(parent)
 		{
 			SetLayoutCallback(OnLayout);
@@ -522,9 +524,24 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			_innerLayout.MinimumHeight = size.Height;
 		}
 
+		int _previousHorizontalOffset = 0;
+		int _previousVerticalOffset = 0;
 		void OnScrolled(object sender, EventArgs e)
 		{
-			_layoutManager.LayoutItems(Scroller.CurrentRegion);
+			_layoutManager.LayoutItems(ViewPort);
+			var args = new ItemsViewScrolledEventArgs();
+			args.FirstVisibleItemIndex = _layoutManager.GetVisibleItemIndex(ViewPort.X, ViewPort.Y);
+			args.CenterItemIndex = _layoutManager.GetVisibleItemIndex(ViewPort.X + (ViewPort.Width / 2), ViewPort.Y + (ViewPort.Height / 2));
+			args.LastVisibleItemIndex = _layoutManager.GetVisibleItemIndex(ViewPort.X + ViewPort.Width, ViewPort.Y + ViewPort.Height);
+			args.HorizontalOffset = ViewPort.X;
+			args.HorizontalDelta = ViewPort.X - _previousHorizontalOffset;
+			args.VerticalOffset = ViewPort.Y;
+			args.VerticalDelta = ViewPort.Y - _previousVerticalOffset;
+
+			Scrolled?.Invoke(this, args);
+
+			_previousHorizontalOffset = ViewPort.X;
+			_previousVerticalOffset = ViewPort.Y;
 		}
 
 		void UpdateSnapPointsType(SnapPointsType snapPoints)

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/GridLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/GridLayoutManager.cs
@@ -338,6 +338,29 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 		}
 
+		public int GetVisibleItemIndex(int x, int y)
+		{
+			int index = 0;
+			if (x < 0 || y < 0)
+				return index;
+			if (_scrollCanvasSize.Width < x || _scrollCanvasSize.Height < y)
+				return CollectionView.Count - 1;
+
+			int first = (IsHorizontal ? x : y) / BaseItemSize;
+			if (_hasUnevenRows)
+				first = _accumulatedItemSizes.FindIndex(current => (IsHorizontal ? x : y) <= current);
+
+			int second = (IsHorizontal ? y : x) / ColumnSize;
+			if (second == Span)
+				second -= 1;
+
+			index = (first * Span) + second;
+
+			if (index < CollectionView.Count)
+				return index;
+			return CollectionView.Count - 1;
+		}
+
 		void InitializeMeasureCache()
 		{
 			_baseItemSize = 0;

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ICollectionViewLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ICollectionViewLayoutManager.cs
@@ -28,5 +28,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		void Reset();
 
 		void ItemMeasureInvalidated(int index);
+
+		int GetVisibleItemIndex(int x, int y);
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/IndicatorView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/IndicatorView.cs
@@ -1,0 +1,80 @@
+using System;
+using System.Collections.Generic;
+using ElmSharp;
+
+namespace Xamarin.Forms.Platform.Tizen.Native
+{
+	public class IndicatorView : Index
+	{
+		List<IndexItem> _list = new List<IndexItem>();
+
+		public IndicatorView(EvasObject parent) : base(parent)
+		{
+			AutoHide = false;
+			IsHorizontal = true;
+			Style = "pagecontrol";
+			if (Device.Idiom == TargetIdiom.Watch)
+				Style = "circle";
+		}
+
+		public event EventHandler<SelectedPositionChangedEventArgs> SelectedPosition;
+
+		public void UpdateSelectedIndex(int index)
+		{
+			if (index > -1 && index < _list.Count)
+			{
+				_list[index].Select(true);
+			}
+		}
+
+		public void AppendIndex(int count = 1)
+		{
+			for (int i = 0; i < count; i++)
+			{
+				var item = Append(null);
+				item.Selected += OnSelected;
+				_list.Add(item);
+			}
+			if (Device.Idiom == TargetIdiom.Watch)
+				ApplyStyle();
+		}
+
+		public void ClearIndex()
+		{
+			foreach (var item in _list)
+			{
+				item.Selected -= OnSelected;
+			}
+			_list.Clear();
+			Clear();
+		}
+
+		void ApplyStyle()
+		{
+			foreach (var item in _list)
+			{
+				int center = 10;
+				int start = center - (_list.Count / 2);
+				int index = _list.IndexOf(item);
+				int position = start + index;
+				if (_list.Count % 2 == 0)
+				{
+					string itemStyle = "item/even_" + position;
+					item.Style = itemStyle;
+				}
+				else
+				{
+					string itemStyle = "item/odd_" + position;
+					item.Style = itemStyle;
+				}
+			}
+		}
+
+		void OnSelected(object sender, EventArgs e)
+		{
+			var index = _list.IndexOf((IndexItem)sender);
+			SelectedPosition?.Invoke(this, new SelectedPositionChangedEventArgs(index));
+			UpdateSelectedIndex(index);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
@@ -296,6 +296,22 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 		}
 
+		public int GetVisibleItemIndex(int x, int y)
+		{
+			int coordinate = IsHorizontal ? x : y;
+			int canvasSize = IsHorizontal ? _scrollCanvasSize.Width : _scrollCanvasSize.Height;
+
+			if (coordinate < 0)
+				return 0;
+			if (canvasSize < coordinate)
+				return CollectionView.Count - 1;
+
+			if (!_hasUnevenRows)
+				return coordinate / BaseItemSize;
+			else
+				return _accumulatedItemSizes.FindIndex(current => coordinate <= current);
+		}
+
 		void InitializeMeasureCache()
 		{
 			_baseItemSize = 0;

--- a/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
@@ -30,6 +30,7 @@ using Xamarin.Forms.Platform.Tizen;
 [assembly: ExportRenderer(typeof(ListView), typeof(ListViewRenderer))]
 [assembly: ExportRenderer(typeof(BoxView), typeof(BoxViewRenderer))]
 [assembly: ExportRenderer(typeof(ActivityIndicator), typeof(ActivityIndicatorRenderer))]
+[assembly: ExportRenderer(typeof(IndicatorView), typeof(IndicatorViewRenderer))]
 [assembly: ExportRenderer(typeof(SearchBar), typeof(SearchBarRenderer))]
 [assembly: ExportRenderer(typeof(Entry), typeof(EntryRenderer))]
 [assembly: ExportRenderer(typeof(Editor), typeof(EditorRenderer))]
@@ -42,6 +43,7 @@ using Xamarin.Forms.Platform.Tizen;
 [assembly: ExportRenderer(typeof(SwipeView), typeof(SwipeViewRenderer))]
 [assembly: ExportRenderer(typeof(RefreshView), typeof(RefreshViewRenderer))]
 [assembly: ExportRenderer(typeof(MediaElement), typeof(MediaElementRenderer))]
+[assembly: ExportRenderer(typeof(IndicatorView), typeof(IndicatorViewRenderer))]
 
 [assembly: ExportImageSourceHandler(typeof(FileImageSource), typeof(FileImageSourceHandler))]
 [assembly: ExportImageSourceHandler(typeof(StreamImageSource), typeof(StreamImageSourceHandler))]

--- a/Xamarin.Forms.Platform.Tizen/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/IndicatorViewRenderer.cs
@@ -1,0 +1,59 @@
+﻿using System.Collections;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class IndicatorViewRenderer : ViewRenderer<IndicatorView, Native.IndicatorView>
+	{
+		public IndicatorViewRenderer()
+		{
+			RegisterPropertyHandler(IndicatorView.CountProperty, UpdateItemsSource);
+			RegisterPropertyHandler(IndicatorView.PositionProperty, UpdatePosition);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<IndicatorView> e)
+		{
+			if (Control == null)
+			{
+				SetNativeControl(new Native.IndicatorView(Forms.NativeParent));
+			}
+			if (e.NewElement != null)
+			{
+				Control.SelectedPosition += OnSelectedPosition;
+			}
+			if (e.OldElement != null)
+			{
+				Control.SelectedPosition -= OnSelectedPosition;
+			}
+			base.OnElementChanged(e);
+		}
+
+		void OnSelectedPosition(object sender, SelectedPositionChangedEventArgs e)
+		{
+			Element.SetValueFromRenderer(IndicatorView.PositionProperty, (int)e.SelectedPosition);
+		}
+
+		void UpdateItemsSource()
+		{
+			Control.ClearIndex();
+			int count = 0;
+			if (Element.ItemsSource is ICollection collection)
+			{
+				count = collection.Count;
+			}
+			else
+			{
+				var enumerator = Element.ItemsSource.GetEnumerator();
+				while (enumerator?.MoveNext() ?? false)
+				{
+					count++;
+				}
+			}
+			Control.AppendIndex(count);
+		}
+
+		void UpdatePosition()
+		{
+			Control.UpdateSelectedIndex(Element.Position);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Specialized;
+﻿using System;
+using System.Collections.Specialized;
 using System.Linq;
 
 using Xamarin.Forms.Platform.Tizen.Native;
@@ -26,6 +27,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control == null)
 			{
 				SetNativeControl(CreateNativeControl(Forms.NativeParent));
+				Control.Scrolled += OnScrolled;
 			}
 			if (e.NewElement != null)
 			{
@@ -44,6 +46,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				{
 					Element.ScrollToRequested -= OnScrollToRequest;
 					ItemsLayout.PropertyChanged -= OnLayoutPropertyChanged;
+					Control.Scrolled -= OnScrolled;
 				}
 				if (_observableSource != null)
 				{
@@ -91,6 +94,11 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		protected virtual void OnItemSelectedFromUI(object sender, SelectedItemChangedEventArgs e)
 		{
+		}
+
+		void OnScrolled(object sender, ItemsViewScrolledEventArgs e)
+		{
+			Element.SendScrolled(e);
 		}
 
 		void OnScrollToRequest(object sender, ScrollToRequestEventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			Registered.Register(typeof(SwipeView), () => new SwipeViewRenderer());
 			Registered.Register(typeof(RefreshView), () => new RefreshViewRenderer());
 			Registered.Register(typeof(MediaElement), () => new MediaElementRenderer());
+			Registered.Register(typeof(IndicatorView), () => new IndicatorViewRenderer());
 
 			//ImageSourceHandlers
 			Registered.Register(typeof(FileImageSource), () => new FileImageSourceHandler());


### PR DESCRIPTION
### Description of Change ###

1. Invoke ItemsView.Scrolled event.
2. Changed the CarouselView Tizen renderer scroll logic.
3. Add IndicatorView for Tizen.


### Platforms Affected ### 

- Tizen


### Testing Procedure ###

Xamarin.Forms.ControlGallery - CarouselView Gallery - IndicatorView Gallery


### Before/After Screenshots ### 

![ind-mob1](https://user-images.githubusercontent.com/10704816/78524858-34457b00-7810-11ea-85c8-7ffdfbffcf33.gif)
![ind-mob2](https://user-images.githubusercontent.com/10704816/78524860-360f3e80-7810-11ea-9857-9ed20b643c86.gif)
![ind-watch](https://user-images.githubusercontent.com/10704816/78524862-37406b80-7810-11ea-81b5-b75f03276004.gif)


### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
