### PR TITLE
[Tizen] Adds RadioButton

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -54,11 +54,7 @@ namespace Xamarin.Forms.Platform
 	[RenderWith(typeof(ImageButtonRenderer))]
 	internal class _ImageButtonRenderer { }
 
-#if __ANDROID__
 	[RenderWith(typeof(RadioButtonRenderer))]
-#elif !TIZEN4_0
-	[RenderWith(typeof(RadioButtonRenderer))]
-#endif
 	internal class _RadioButtonRenderer { }
 
 	[RenderWith (typeof (TableViewRenderer))]

--- a/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
@@ -44,6 +44,7 @@ using Xamarin.Forms.Platform.Tizen;
 [assembly: ExportRenderer(typeof(RefreshView), typeof(RefreshViewRenderer))]
 [assembly: ExportRenderer(typeof(MediaElement), typeof(MediaElementRenderer))]
 [assembly: ExportRenderer(typeof(IndicatorView), typeof(IndicatorViewRenderer))]
+[assembly: ExportRenderer(typeof(RadioButton), typeof(RadioButtonRenderer))]
 
 [assembly: ExportImageSourceHandler(typeof(FileImageSource), typeof(FileImageSourceHandler))]
 [assembly: ExportImageSourceHandler(typeof(StreamImageSource), typeof(StreamImageSourceHandler))]

--- a/Xamarin.Forms.Platform.Tizen/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/RadioButtonRenderer.cs
@@ -1,0 +1,117 @@
+using System;
+using ElmSharp;
+using ESize = ElmSharp.Size;
+using TSpan = Xamarin.Forms.Platform.Tizen.Native.Span;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class RadioButtonRenderer : ViewRenderer<RadioButton, Radio>
+	{
+		readonly TSpan _span = new TSpan();
+		public RadioButtonRenderer()
+		{
+			RegisterPropertyHandler(RadioButton.IsCheckedProperty, UpdateIsChecked);
+			RegisterPropertyHandler(RadioButton.TextProperty, UpdateText);
+			RegisterPropertyHandler(RadioButton.TextColorProperty, UpdateTextColor);
+			RegisterPropertyHandler(RadioButton.FontProperty, UpdateFont);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<RadioButton> e)
+		{
+			if (Control == null)
+			{
+				SetNativeControl(new Radio(Forms.NativeParent) { StateValue = 1 });
+				Control.ValueChanged += OnValueChanged;
+			}
+			base.OnElementChanged(e);
+			ApplyTextAndStyle();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				if (Control != null)
+				{
+					Control.ValueChanged -= OnValueChanged;
+				}
+			}
+			base.Dispose(disposing);
+		}
+
+		protected override Size MinimumSize()
+		{
+			return Measure(Control.MinimumWidth, Control.MinimumHeight).ToDP();
+		}
+
+		protected override ESize Measure(int availableWidth, int availableHeight)
+		{
+			var size = Control.Geometry;
+			Control.Resize(availableWidth, size.Height);
+			var formattedSize = Control.EdjeObject["elm.text"].TextBlockFormattedSize;
+			Control.Resize(size.Width, size.Height);
+			return new ESize()
+			{
+				Width = Control.MinimumWidth + formattedSize.Width,
+				Height = Math.Max(Control.MinimumHeight, formattedSize.Height),
+			};
+		}
+
+		void OnValueChanged(object sender, EventArgs e)
+		{
+			Element.SetValueFromRenderer(RadioButton.IsCheckedProperty, Control.GroupValue == 1 ? true : false);
+		}
+		
+		void UpdateIsChecked()
+		{
+			Control.GroupValue = Element.IsChecked ? 1 : 0;
+		}
+
+		void UpdateText(bool isInitialized)
+		{
+			_span.Text = Element.Text;
+			if (!isInitialized)
+				ApplyTextAndStyle();
+		}
+
+		void UpdateTextColor(bool isInitialized)
+		{
+			_span.ForegroundColor = Element.TextColor.ToNative();
+			if (!isInitialized)
+				ApplyTextAndStyle();
+		}
+
+		void UpdateFont(bool isInitialized)
+		{
+			_span.FontSize = Element.FontSize;
+			_span.FontAttributes = Element.FontAttributes;
+			_span.FontFamily = Element.FontFamily;
+			if (!isInitialized)
+				ApplyTextAndStyle();
+		}
+
+		void ApplyTextAndStyle()
+		{
+			SetInternalTextAndStyle(_span.GetDecoratedText(), _span.GetStyle());
+		}
+
+		void SetInternalTextAndStyle(string formattedText, string textStyle)
+		{
+			string emission = "elm,state,text,visible";
+			if (string.IsNullOrEmpty(formattedText))
+			{
+				formattedText = null;
+				textStyle = null;
+				emission = "elm,state,text,hidden";
+			}
+			Control.Text = formattedText;
+
+			var textblock = Control.EdjeObject["elm.text"];
+			if (textblock != null)
+			{
+				textblock.TextStyle = textStyle;
+			}
+			Control.EdjeObject.EmitSignal(emission, "elm");
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -105,6 +105,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			Registered.Register(typeof(RefreshView), () => new RefreshViewRenderer());
 			Registered.Register(typeof(MediaElement), () => new MediaElementRenderer());
 			Registered.Register(typeof(IndicatorView), () => new IndicatorViewRenderer());
+			Registered.Register(typeof(RadioButton), () => new RadioButtonRenderer());
 
 			//ImageSourceHandlers
 			Registered.Register(typeof(FileImageSource), () => new FileImageSourceHandler());


### PR DESCRIPTION
### Description of Change ###
This PR is a Tizen implementation of RadioButton (#8910).

- Mobile
<img src="https://user-images.githubusercontent.com/1029134/78660036-5c63d580-7907-11ea-8d73-6cc47da591f3.gif" width=240/>

- Weaarable
<img src="https://user-images.githubusercontent.com/1029134/78659936-2c1c3700-7907-11ea-8a0c-190a59470267.png" width=240/>

#### Limitations and Known Issues
- `Text` property is ignored on Tizen 4.0 wearable profile.

### Issues Resolved ### 
- fixes #2404 for Tizen

### API Changes ###
**` namespace Xamarin.Forms.Platform.Tizen `** 

Added:
 - public class RadioButtonRenderer

### Platforms Affected ### 
- Tizen

### Testing Procedure ###
Go `RadioButtonGallery` 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
