### PR TITLE
[Android,Maps] Set initial MapRegion when map is ready

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml
@@ -29,6 +29,8 @@
             Grid.Row="4" />
         <ScrollView Grid.Row="5">
             <StackLayout>
+                <Button Clicked="GetMapRegionClicked"
+                        Text="Map Region" />
                 <Button Clicked="MapTypeClicked"
                         Text="Map Type" />
                 <Button Clicked="ZoomInClicked"

--- a/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapGallery.xaml.cs
@@ -67,6 +67,15 @@ namespace Xamarin.Forms.Controls
 			};
 		}
 
+
+		void GetMapRegionClicked(object sender, EventArgs e)
+		{
+			if (Map.VisibleRegion == null)
+				DisplayAlert(":(", "VisibleRegion is null, move the map to get it!", "OK");
+			else
+				DisplayAlert(":)", $"Lat: {Map.VisibleRegion.Center.Latitude}, Long: {Map.VisibleRegion.Center.Longitude}, move the map to get it!", "OK");
+		}
+
 		void MarkerClicked(object sender, PinClickedEventArgs e)
 		{
 			LastMarkerClickLabel.Text = $"Last Marker Clicked: {((Pin)sender).Label}";

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -213,14 +213,15 @@ namespace Xamarin.Forms.Maps.Android
 			}
 			else if (changed)
 			{
-				if (NativeMap != null)
-				{
-					UpdateVisibleRegion(NativeMap.CameraPosition.Target);
-				}
-
 				if (Element.MoveToLastRegionOnLayoutChange)
 					MoveToRegion(Element.LastMoveToRegion, false);
 			}
+
+			if (NativeMap != null)
+			{
+				UpdateVisibleRegion(NativeMap.CameraPosition.Target);
+			}
+
 		}
 
 		protected virtual void OnMapReady(GoogleMap map)


### PR DESCRIPTION
### Description of Change ###

Call the UpdateVisibleRegion when the map loads

### Issues Resolved ### 

- fixes #10146

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Map region should be available when map loads

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Go to map gallery and click the Map Region button, it should show the values for lat/long and MapSpan

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
