### PR TITLE
Alignment fixes for CollectionView grid layouts on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -101,6 +101,16 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var layoutAttributesForRectElements = base.LayoutAttributesForElementsInRect(rect);
 
+			if (NeedsSingleItemHorizontalAlignmentAdjustment(layoutAttributesForRectElements))
+			{
+				// If there's exactly one item in a vertically scrolling grid, for some reason UICollectionViewFlowLayout
+				// tries to center it. This corrects that issue.
+				var currentFrame = layoutAttributesForRectElements[0].Frame;
+				var newFrame = new CGRect(CollectionView.Frame.Left + CollectionView.ContentInset.Right,
+				currentFrame.Top, currentFrame.Width, currentFrame.Height);
+				layoutAttributesForRectElements[0].Frame = newFrame;
+			}
+
 			if (!NeedsPartialColumnAdjustment())
 			{
 				return layoutAttributesForRectElements;
@@ -127,6 +137,92 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return layoutAttributesForAllCells;
+		}
+
+		public override UICollectionViewLayoutInvalidationContext GetInvalidationContext(UICollectionViewLayoutAttributes preferredAttributes, UICollectionViewLayoutAttributes originalAttributes)
+		{
+			var invalidationContext = base.GetInvalidationContext(preferredAttributes, originalAttributes);
+
+			if (invalidationContext.InvalidatedItemIndexPaths == null)
+			{
+				return invalidationContext;
+			}
+
+			if (invalidationContext.InvalidatedItemIndexPaths.Length == 0)
+			{
+				return invalidationContext;
+			}
+
+			if (ScrollDirection == UICollectionViewScrollDirection.Horizontal
+				&& preferredAttributes.Frame.Width - originalAttributes.Frame.Width > 1)
+			{
+				// If this is a horizontal grid and we're laying out or adjusting a cell 
+				// and we've decided it needs to be wider, then this might throw off the alignment of
+				// any cells above it in the layout. We'll need to recenter those cells
+				CenterAlignCellsInColumn(preferredAttributes);
+
+				// (Technically speaking, we _could_ simply add the cells above the current cell to the invalidationContext;
+				// after invalidation, they would be realigned correctly. But doing that causes subsequent calls to 
+				// GetInvalidationContext to happen every time a new column needs layout, and those calls will include
+				// _every single subsequent cell in the collection_ in the invalidation list. For very large collections,
+				// this gets really slow and the scrolling becomes jerky. This one-time realignment is much faster.
+			}
+
+			return invalidationContext;
+		}
+
+		void CenterAlignCellsInColumn(UICollectionViewLayoutAttributes preferredAttributes) 
+		{
+			// Determine the set of cells above this one
+			var index = preferredAttributes.IndexPath;
+			var span = _itemsLayout.Span;
+
+			var column = index.Item / span;
+			var start = (int)column * span;
+
+			// If this is the first cell in the column, we don't need to adjust
+			if (index.Item > start)
+			{
+				var currentCenter = preferredAttributes.Frame.GetMidX();
+
+				// Work our way through the column
+				for (int n = start; n < index.Item; n++)
+				{
+					// Get the layout attributes for each cell
+					var path = NSIndexPath.FromItemSection(n, index.Section);
+					var attr = LayoutAttributesForItem(path);
+
+					// And see if the midpoints line up with the new layout attributes for the current cell
+					var center = attr.Frame.GetMidX();
+
+					if (currentCenter - center > 1)
+					{
+						// If the midpoints don't line up (withing a tolerance), adjust the cell's frame
+						var cell = CollectionView.CellForItem(path);
+						cell.Frame = new CGRect(currentCenter - cell.Frame.Width / 2, cell.Frame.Top, cell.Frame.Width, cell.Frame.Height);
+					}
+				}
+			}
+		}
+
+		bool NeedsSingleItemHorizontalAlignmentAdjustment(UICollectionViewLayoutAttributes[] layoutAttributesForRectElements) 
+		{
+			if (ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+			{
+				return false;
+			}
+
+			if (layoutAttributesForRectElements.Length != 1)
+			{
+				return false;
+			}
+
+			if (layoutAttributesForRectElements[0].Frame.Top != CollectionView.Frame.Top + CollectionView.ContentInset.Bottom)
+			{
+				return false;
+			}
+
+			return true;
 		}
 
 		bool NeedsPartialColumnAdjustment(int section = 0)


### PR DESCRIPTION
### Description of Change ###

These changes adjust the grid layout on iOS to correct for some edge cases. 

For vertical grids with a single item, the single item was centered rather than left-aligned. These changes detect the situtation and fix the item alignment.

For horizontal grids where the items can have varying sizes, a situation can occur where larger items added lower down in a column _should_ realign the itemsw further up the column, but the initial layout would fail to update the items higher up in the column. These changes detect that situation and adjust the centering of the items.

### Issues Resolved ### 

- fixes #5455
- fixes #6851

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Before/After Screenshots ### 

Issue 5455 Before:
![5455_before](https://user-images.githubusercontent.com/538025/78686871-c7ce8880-78b0-11ea-9fcc-52d6e40ee8f8.png)

Issue 5455 After:
![5455_after](https://user-images.githubusercontent.com/538025/78686934-d7e66800-78b0-11ea-89ed-ab15fbd0c964.png)


Issue 6851 Before:
![6851_before](https://user-images.githubusercontent.com/538025/78686970-dfa60c80-78b0-11ea-933d-4fc3447b13c9.png)

Issue 6851 After:
![6851_after](https://user-images.githubusercontent.com/538025/78686995-e765b100-78b0-11ea-929d-d02addc42bfc.png)


### Testing Procedure ###

Navigate to Control Gallery -> CollectionView Gallery -> DataTemplate Galleries -> Vertical Grid (Code)
Update the Items to 1
The single item should be left-aligned. 

Navigate to Control Gallery -> CollectionView Gallery -> Item Size Galleries -> ItemSizing Strategy
Update the ItemsSizingStrategy to "MeasureAllItems"
The lighthouse photo with the blue background should be centered over the plant photo with the yellow background.


### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
