### PR TITLE
[iOS]Fix dispose of all events on CarouselViewRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10234.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10234.cs
@@ -1,0 +1,169 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
+using System.ComponentModel;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10234, "CarouselView disposed on iOS when navigating back in Shell ", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue10234 : TestShell
+	{
+		protected override void Init()
+		{
+			TabBar tabBar = new TabBar
+			{
+				Title = "Main",
+				Route = "main",
+				Items =
+				{
+					new Tab
+					{
+						Route = "tab1",
+						Title = "Tab 1",
+						Items =
+						{
+							new ShellContent()
+							{
+								ContentTemplate = new DataTemplate(() => new ContentPage
+								{
+									Content  = new StackLayout
+									{
+										Children =
+										{
+											new Label { Text = "Hej" },
+											new Button {
+												AutomationId = "goToShow",
+												Text = "Show",
+												Command = new Command(async () => await GoToAsync("//photos?id=1"))
+											}
+										}
+									}
+		}),
+							}
+						}
+					}
+				}
+			};
+
+			TabBar photosTab = new TabBar()
+			{
+				Title = "Photos",
+				Route = "photos",
+				Items =
+				{
+					new ShellSection()
+					{
+						Items =
+						{
+							new ShellContent()
+							{
+								ContentTemplate = new DataTemplate(() => new PhotosPage()),
+							}
+						}
+					}
+				}
+			};
+
+			Items.Add(tabBar);
+			Items.Add(photosTab);
+		}
+
+		class PhotosPage : ContentPage
+		{
+
+			CarouselView Photos;
+			public PhotosPage()
+			{
+				//InitializeComponent();
+				Photos = new CarouselView
+				{
+					ItemTemplate = new DataTemplate(
+						() =>
+						{
+							var image = new Image();
+							image.SetBinding(Image.SourceProperty, new Binding("."));
+							return image;
+						}
+					)
+				};
+
+				var grid = new Grid();
+				grid.RowDefinitions.Add(new RowDefinition());
+				grid.RowDefinitions.Add(new RowDefinition());
+				var btn = new Button
+				{
+					Text = "Go back",
+					AutomationId = "goToBack",
+					Command = new Command(async () => await Shell.Current.GoToAsync("//main"))
+				};
+				Grid.SetRow(Photos, 0);
+				Grid.SetRow(btn, 1);
+				grid.Children.Add(Photos);
+				grid.Children.Add(btn);
+				Content = grid;
+			}
+
+			public ObservableCollection<string> Items { get; set; }
+
+			public void LoadData()
+			{
+				var images = new List<string>();
+
+				images.Add("FlowerBuds.jpg");
+				images.Add("Fruits.jpg");
+				images.Add("Legumes.jpg");
+				images.Add("Vegetables.jpg");
+
+
+				Items = new ObservableCollection<string>(images);
+				Photos.ItemsSource = Items;
+			}
+
+			protected override void OnAppearing()
+			{
+				base.OnAppearing();
+
+				LoadData();
+			}
+
+			public int PageId
+			{
+				get; set;
+			}
+		}
+
+
+#if UITEST && __IOS__
+
+		[Test]
+		public void PaddingWithoutSafeArea()
+		{
+			RunningApp.WaitForElement("goToShow");
+			RunningApp.Tap("goToShow");
+			RunningApp.WaitForElement("goToBack");
+			RunningApp.Tap("goToBack");
+			RunningApp.WaitForElement("goToShow");
+			RunningApp.Tap("goToShow");
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10234.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10234.cs
@@ -1,15 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.Text;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 using System.Linq;
-using Xamarin.Forms.PlatformConfiguration;
-using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
-using System.Threading;
-using System.ComponentModel;
-
 
 #if UITEST
 using Xamarin.UITest;
@@ -95,6 +89,7 @@ namespace Xamarin.Forms.Controls.Issues
 				//InitializeComponent();
 				Photos = new CarouselView
 				{
+					AutomationId = "carouselView",
 					ItemTemplate = new DataTemplate(
 						() =>
 						{
@@ -154,14 +149,27 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST && __IOS__
 
 		[Test]
-		public void PaddingWithoutSafeArea()
+		public void ScrollCarouselViewAfterDispose()
 		{
 			RunningApp.WaitForElement("goToShow");
 			RunningApp.Tap("goToShow");
 			RunningApp.WaitForElement("goToBack");
+			ScrollNextItem();
 			RunningApp.Tap("goToBack");
 			RunningApp.WaitForElement("goToShow");
 			RunningApp.Tap("goToShow");
+			ScrollNextItem();
+			RunningApp.WaitForElement("goToBack");
+			RunningApp.Tap("goToBack");
+			RunningApp.WaitForElement("goToShow");
+		}
+
+		void ScrollNextItem()
+		{
+			var rect = RunningApp.Query(c => c.Marked("carouselView")).First().Rect;
+			var centerX = rect.CenterX;
+			var rightX = rect.X - 5;
+			RunningApp.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
 		}
 
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -202,6 +202,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7339.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellAppearanceChange.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10234.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellModal.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBehavior.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7128.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -101,6 +101,7 @@ namespace Xamarin.Forms.Platform.iOS
 		internal void TearDown()
 		{
 			Carousel.PropertyChanged -= CarouselViewPropertyChanged;
+			Carousel.Scrolled -= CarouselViewScrolled;
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Make sure to unsubscribe the Scrolled event on CarouselViewRenderer

### Issues Resolved ### 

- fixes #10234 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added UITest, go to a CarouselVIew and scroll 2 times should work.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
