### PR TITLE
[iOS] Add null-check to prevent possible NRE

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -240,7 +240,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __XCODE11__
 			// Make sure the control adheres to changes in UI theme
 			if (Forms.IsiOS13OrNewer && previousTraitCollection?.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
-				Control.SetNeedsDisplay();
+				Control?.SetNeedsDisplay();
 #endif
 		}
 


### PR DESCRIPTION
### Description of Change ###

There are some cases like `RefreshView` where `Control` is null at this point for some reason. Added a null check to prevent an NRE when this happens.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10245 

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
This was specifically breaking with `RefreshView` so try if that still works whenever you switch over the appearance mode. You can also pull down the NuGet associated with this build and try that on the reproduction from the issue.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
