### PR TITLE
[Bug] Expander + CollectionView: Expander content keeps reopening

### DIFF
--- a/Xamarin.Forms.Core/Expander.cs
+++ b/Xamarin.Forms.Core/Expander.cs
@@ -167,7 +167,7 @@ namespace Xamarin.Forms
 		{
 			base.OnBindingContextChanged();
 			_lastVisibleHeight = -1;
-			SetContent(true);
+			SetContent(true, true);
 		}
 
 		protected override void OnSizeAllocated(double width, double height)
@@ -180,7 +180,7 @@ namespace Xamarin.Forms
 			_previousWidth = width;
 		}
 
-		void OnIsExpandedChanged()
+		void OnIsExpandedChanged(bool isBindingContextChanged = false)
 		{
 			if (Content == null || (!IsExpanded && !Content.IsVisible))
 			{
@@ -229,7 +229,7 @@ namespace Xamarin.Forms
 				_endHeight = 0;
 			}
 
-			_shouldIgnoreAnimation = Height < 0;
+			_shouldIgnoreAnimation = isBindingContextChanged || Height < 0;
 
 			if (shouldInvokeAnimation)
 			{
@@ -268,7 +268,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void SetContent(bool isForceUpdate)
+		void SetContent(bool isForceUpdate, bool isBindingContextChanged = false)
 		{
 			if (IsExpanded && (Content == null || isForceUpdate))
 			{
@@ -276,7 +276,7 @@ namespace Xamarin.Forms
 				Content = CreateContent() ?? Content;
 				_shouldIgnoreContentSetting = false;
 			}
-			OnIsExpandedChanged();
+			OnIsExpandedChanged(isBindingContextChanged);
 		}
 
 		void SetContent(View oldContent, View newContent)


### PR DESCRIPTION
### Description of Change ###

Do not run animation if IsExpanded changed due to BindingContext change.

### Issues Resolved ### 
- fixes #10229 

### API Changes ###
None

### Platforms Affected ### 
- Core

### Behavioral/Visual Changes ###
The issue has gone.

### Before/After Screenshots ### 
AFTER:

![Apr-08-2020 00-52-06](https://user-images.githubusercontent.com/10124814/78722964-33f1d080-7933-11ea-944a-2a5c67fb6812.gif)


### Testing Procedure ###
Test sample attached to the issue ticket.
