### PR TITLE
Fix default Shell flyout item templates

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1141,14 +1141,25 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void FlyoutItemDefaultTemplatesDontCrashWhenSet()
+		public void FlyoutItemDefaultTemplates()
 		{
 			Shell shell = new Shell();
-			shell.MenuItemTemplate = new DataTemplate(() => new Label());
-			shell.ItemTemplate = new DataTemplate(() => new Label());
+			IShellController sc = (IShellController)shell;
+			shell.MenuItemTemplate = new DataTemplate(() => new Label() { Text = "MenuItemTemplate" });
+			shell.ItemTemplate = new DataTemplate(() => new Label() { Text = "ItemTemplate" });
 
 			var shellItem = CreateShellItem();
+			var menuItem = new MenuShellItem(new MenuItem());
 			shell.Items.Add(shellItem);
+			shell.Items.Add(menuItem);
+
+
+			DataTemplate triggerDefault = shell.ItemTemplate;
+			triggerDefault = shell.MenuItemTemplate;
+
+			Assert.AreEqual("ItemTemplate", ((Label)sc.GetFlyoutItemDataTemplate(shellItem).CreateContent()).Text);
+			Assert.AreEqual("MenuItemTemplate", ((Label)sc.GetFlyoutItemDataTemplate(menuItem).CreateContent()).Text);
+			Assert.AreEqual("MenuItemTemplate", ((Label)sc.GetFlyoutItemDataTemplate(menuItem.MenuItem).CreateContent()).Text);
 		}
 
 

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1060,33 +1060,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(TextAlignment.Center, label.VerticalTextAlignment);
 		}
 
-		[Test]
-		public void FlyoutItemLabelStyleCanBeChangedAfterRendered()
-		{
-			var classStyle = new Style(typeof(Label))
-			{
-				Setters = {
-					new Setter { Property = Label.VerticalTextAlignmentProperty, Value = TextAlignment.Start }
-				},
-				Class = "fooClass",
-			};
-
-			Shell shell = new Shell();
-			shell.Resources = new ResourceDictionary { classStyle };
-			var shellItem = CreateShellItem();
-
-			shell.Items.Add(shellItem);
-
-			var flyoutItemTemplate = Shell.GetItemTemplate(shellItem);
-			var thing = (Element)flyoutItemTemplate.CreateContent();
-			thing.Parent = shell;
-
-			var label = thing.LogicalChildren.OfType<Label>().First();
-			Assert.AreEqual(TextAlignment.Center, label.VerticalTextAlignment);
-			shellItem.StyleClass = new[] { "fooClass" };
-			Assert.AreEqual(TextAlignment.Start, label.VerticalTextAlignment);
-		}
-
 
 		[Test]
 		public void FlyoutItemLabelStyleCustom()
@@ -1143,35 +1116,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void MenuItemLabelStyleCanBeChangedAfterRendered()
-		{
-			var classStyle = new Style(typeof(Label))
-			{
-				Setters = {
-					new Setter { Property = Label.VerticalTextAlignmentProperty, Value = TextAlignment.Start }
-				},
-				Class = "fooClass",
-			};
-
-			Shell shell = new Shell();
-			shell.Resources = new ResourceDictionary { classStyle };
-			var shellItem = CreateShellItem();
-			var menuItem = new MenuItem();
-			var shellMenuItem = new MenuShellItem(menuItem);
-			shell.Items.Add(shellItem);
-			shell.Items.Add(shellMenuItem);
-
-			var flyoutItemTemplate = Shell.GetItemTemplate(shellMenuItem);
-			var thing = (Element)flyoutItemTemplate.CreateContent();
-			thing.Parent = shell;
-
-			var label = thing.LogicalChildren.OfType<Label>().First();
-			Assert.AreEqual(TextAlignment.Center, label.VerticalTextAlignment);
-			menuItem.StyleClass = new[] { "fooClass" };
-			Assert.AreEqual(TextAlignment.Start, label.VerticalTextAlignment);
-		}
-
-		[Test]
 		public void FlyoutItemLabelStyleDefault()
 		{
 			var classStyle = new Style(typeof(Label))
@@ -1195,6 +1139,74 @@ namespace Xamarin.Forms.Core.UnitTests
 			var label = thing.LogicalChildren.OfType<Label>().First();
 			Assert.AreEqual(TextAlignment.Start, label.VerticalTextAlignment);
 		}
+
+		[Test]
+		public void FlyoutItemDefaultTemplatesDontCrashWhenSet()
+		{
+			Shell shell = new Shell();
+			shell.MenuItemTemplate = new DataTemplate(() => new Label());
+			shell.ItemTemplate = new DataTemplate(() => new Label());
+
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+		}
+
+
+		//[Test]
+		//public void FlyoutItemLabelStyleCanBeChangedAfterRendered()
+		//{
+		//	var classStyle = new Style(typeof(Label))
+		//	{
+		//		Setters = {
+		//			new Setter { Property = Label.VerticalTextAlignmentProperty, Value = TextAlignment.Start }
+		//		},
+		//		Class = "fooClass",
+		//	};
+
+		//	Shell shell = new Shell();
+		//	shell.Resources = new ResourceDictionary { classStyle };
+		//	var shellItem = CreateShellItem();
+
+		//	shell.Items.Add(shellItem);
+
+		//	var flyoutItemTemplate = Shell.GetItemTemplate(shellItem);
+		//	var thing = (Element)flyoutItemTemplate.CreateContent();
+		//	thing.Parent = shell;
+
+		//	var label = thing.LogicalChildren.OfType<Label>().First();
+		//	Assert.AreEqual(TextAlignment.Center, label.VerticalTextAlignment);
+		//	shellItem.StyleClass = new[] { "fooClass" };
+		//	Assert.AreEqual(TextAlignment.Start, label.VerticalTextAlignment);
+		//}
+
+		//[Test]
+		//public void MenuItemLabelStyleCanBeChangedAfterRendered()
+		//{
+		//	var classStyle = new Style(typeof(Label))
+		//	{
+		//		Setters = {
+		//			new Setter { Property = Label.VerticalTextAlignmentProperty, Value = TextAlignment.Start }
+		//		},
+		//		Class = "fooClass",
+		//	};
+
+		//	Shell shell = new Shell();
+		//	shell.Resources = new ResourceDictionary { classStyle };
+		//	var shellItem = CreateShellItem();
+		//	var menuItem = new MenuItem();
+		//	var shellMenuItem = new MenuShellItem(menuItem);
+		//	shell.Items.Add(shellItem);
+		//	shell.Items.Add(shellMenuItem);
+
+		//	var flyoutItemTemplate = Shell.GetItemTemplate(shellMenuItem);
+		//	var thing = (Element)flyoutItemTemplate.CreateContent();
+		//	thing.Parent = shell;
+
+		//	var label = thing.LogicalChildren.OfType<Label>().First();
+		//	Assert.AreEqual(TextAlignment.Center, label.VerticalTextAlignment);
+		//	menuItem.StyleClass = new[] { "fooClass" };
+		//	Assert.AreEqual(TextAlignment.Start, label.VerticalTextAlignment);
+		//}
 
 	}
 }

--- a/Xamarin.Forms.Core/MenuItem.cs
+++ b/Xamarin.Forms.Core/MenuItem.cs
@@ -35,7 +35,6 @@ namespace Xamarin.Forms
 		public static void SetAccelerator(BindableObject bindable, Accelerator value) => bindable.SetValue(AcceleratorProperty, value);
 
 		internal readonly MergedStyle _mergedStyle;
-		internal event EventHandler StyleClassChanged;
 
 		public MenuItem()
 		{
@@ -100,7 +99,6 @@ namespace Xamarin.Forms
 			set 
 			{ 
 				_mergedStyle.StyleClass = value;
-				StyleClassChanged?.Invoke(this, EventArgs.Empty);
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -16,6 +16,9 @@ namespace Xamarin.Forms
 		public event EventHandler Disappearing;
 
 		bool _hasAppearing;
+		const string DefaultFlyoutItemLabelStyle = "Default_FlyoutItemLabelStyle";
+		const string DefaultFlyoutItemImageStyle = "Default_FlyoutItemImageStyle";
+		const string DefaultFlyoutItemLayoutStyle = "Default_FlyoutItemLayoutStyle";
 
 		#region PropertyKeys
 

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -16,10 +16,6 @@ namespace Xamarin.Forms
 		public event EventHandler Disappearing;
 
 		bool _hasAppearing;
-		Grid _defaultFlyoutItemCell;
-		const string DefaultFlyoutItemLabelStyle = "Default_FlyoutItemLabelStyle";
-		const string DefaultFlyoutItemImageStyle = "Default_FlyoutItemImageStyle";
-		const string DefaultFlyoutItemLayoutStyle = "Default_FlyoutItemLayoutStyle";
 
 		#region PropertyKeys
 
@@ -268,16 +264,6 @@ namespace Xamarin.Forms
 		{
 		}
 
-
-		internal override void OnStyleClassChanged()
-		{
-			if (_defaultFlyoutItemCell == null)
-				return;
-
-			base.OnStyleClassChanged();
-			UpdateFlyoutItemStyles(_defaultFlyoutItemCell, this as IStyleSelectable);
-		}
-
 		static void UpdateFlyoutItemStyles(Grid flyoutItemCell, IStyleSelectable source)
 		{
 			List<string> bindableObjectStyle = new List<string>() {
@@ -300,14 +286,11 @@ namespace Xamarin.Forms
 				.StyleClass = bindableObjectStyle;
 		}
 
-		internal DataTemplate CreateDefaultFlyoutItemCell(string textBinding, string iconBinding)
+		internal static DataTemplate CreateDefaultFlyoutItemCell(IStyleSelectable styleSelectable, string textBinding, string iconBinding)
 		{
 			return new DataTemplate(() =>
 			{
-				if (_defaultFlyoutItemCell != null)
-					return _defaultFlyoutItemCell;
-
-				var grid = _defaultFlyoutItemCell = new Grid();
+				var grid = new Grid();
 				if (Device.RuntimePlatform == Device.UWP)
 					grid.ColumnSpacing = grid.RowSpacing = 0;
 
@@ -422,7 +405,7 @@ namespace Xamarin.Forms
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.HorizontalTextAlignmentProperty, Value = TextAlignment.Start });
 				}
 
-				UpdateFlyoutItemStyles(_defaultFlyoutItemCell, this as IStyleSelectable);
+				UpdateFlyoutItemStyles(grid, styleSelectable);
 				grid.Resources = new ResourceDictionary() { defaultGridClass, defaultLabelClass, defaultImageClass };
 				return grid;
 			});

--- a/Xamarin.Forms.Core/Shell/IShellController.cs
+++ b/Xamarin.Forms.Core/Shell/IShellController.cs
@@ -49,5 +49,7 @@ namespace Xamarin.Forms
 		ReadOnlyCollection<ShellItem> GetItems();
 
 		event NotifyCollectionChangedEventHandler ItemsCollectionChanged;
+
+		DataTemplate GetFlyoutItemDataTemplate(BindableObject bo);
 	}
 }

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms
 
 			Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
 			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;
-			MenuItem.StyleClassChanged += (_, __) => OnStyleClassChanged();
 		}
 
 		IList<string> IStyleSelectable.Classes => ((IStyleSelectable)MenuItem).Classes;

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -14,7 +14,6 @@ namespace Xamarin.Forms
 			SetBinding(IconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
 			SetBinding(FlyoutIconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
 
-			Shell.SetMenuItemTemplate(this, Shell.GetMenuItemTemplate(MenuItem));
 			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;
 		}
 

--- a/Xamarin.Forms.Core/Shell/NavigableElement.cs
+++ b/Xamarin.Forms.Core/Shell/NavigableElement.cs
@@ -46,13 +46,10 @@ namespace Xamarin.Forms
 			set 
 			{ 
 				_mergedStyle.StyleClass = value; 
-				OnStyleClassChanged(); 
 			}
 		}
 
 		IList<string> IStyleSelectable.Classes => StyleClass;
-
-		internal virtual void OnStyleClassChanged() { }
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public NavigationProxy NavigationProxy {

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -60,22 +60,6 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty MenuItemTemplateProperty =
 			BindableProperty.CreateAttached(nameof(MenuItemTemplate), typeof(DataTemplate), typeof(Shell), null, BindingMode.OneTime, defaultValueCreator: OnMenuItemTemplateCreate);
 
-		static object OnMenuItemTemplateCreate(BindableObject bindable)
-		{
-			if(bindable is BaseShellItem baseShellItem)
-				return baseShellItem.CreateDefaultFlyoutItemCell("Text", "Icon");
-
-			if (bindable is MenuItem mi)
-			{
-				if (mi.Parent is BaseShellItem bsiMi)
-					return bsiMi.CreateDefaultFlyoutItemCell("Text", "Icon");
-				else
-					return null;
-			}
-
-			throw new ArgumentException($"Invalidate Menu Item Type: {bindable}", nameof(bindable));
-		}
-
 		public static DataTemplate GetMenuItemTemplate(BindableObject obj) => (DataTemplate)obj.GetValue(MenuItemTemplateProperty);
 		public static void SetMenuItemTemplate(BindableObject obj, DataTemplate menuItemTemplate) => obj.SetValue(MenuItemTemplateProperty, menuItemTemplate);
 
@@ -84,7 +68,28 @@ namespace Xamarin.Forms
 
 		static object OnItemTemplateCreator(BindableObject bindable)
 		{
-			return (bindable as BaseShellItem).CreateDefaultFlyoutItemCell("Title", "FlyoutIcon");
+			return OnFlyoutItemTemplateCreate(bindable, "Title", "FlyoutIcon");
+		}
+
+		static object OnMenuItemTemplateCreate(BindableObject bindable)
+		{
+			return OnFlyoutItemTemplateCreate(bindable, "Text", "Icon");
+		}
+
+		static object OnFlyoutItemTemplateCreate(BindableObject bindable, string textBinding, string iconBinding)
+		{
+			if (bindable is BaseShellItem baseShellItem)
+				return BaseShellItem.CreateDefaultFlyoutItemCell(baseShellItem, textBinding, iconBinding);
+			
+			if (bindable is MenuItem mi)
+			{
+				if (mi.Parent is BaseShellItem bsiMi)
+					return BaseShellItem.CreateDefaultFlyoutItemCell(bsiMi, textBinding, iconBinding);
+				else
+					return null;
+			}
+
+			return BaseShellItem.CreateDefaultFlyoutItemCell(bindable as StyleSheets.IStyleSelectable, textBinding, iconBinding);
 		}
 
 		public static DataTemplate GetItemTemplate(BindableObject obj) => (DataTemplate)obj.GetValue(ItemTemplateProperty);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -80,7 +80,7 @@ namespace Xamarin.Forms
 		{
 			if (bindable is BaseShellItem baseShellItem)
 				return BaseShellItem.CreateDefaultFlyoutItemCell(baseShellItem, textBinding, iconBinding);
-			
+
 			if (bindable is MenuItem mi)
 			{
 				if (mi.Parent is BaseShellItem bsiMi)
@@ -225,6 +225,30 @@ namespace Xamarin.Forms
 
 		List<(IAppearanceObserver Observer, Element Pivot)> _appearanceObservers = new List<(IAppearanceObserver Observer, Element Pivot)>();
 		List<IFlyoutBehaviorObserver> _flyoutBehaviorObservers = new List<IFlyoutBehaviorObserver>();
+
+		DataTemplate IShellController.GetFlyoutItemDataTemplate(BindableObject bo)
+		{
+			BindableProperty bp = null;
+
+			if (bo is IMenuItemController)
+			{
+				bp = MenuItemTemplateProperty;
+
+				if (bo is MenuItem mi && mi.Parent != null && mi.Parent.IsSet(bp))
+					bo = mi.Parent;
+				else if (bo is MenuShellItem msi && msi.MenuItem != null && msi.MenuItem.IsSet(bp))
+					bo = msi.MenuItem;
+			}
+			else
+			{
+				bp = ItemTemplateProperty;
+			}
+
+			if (bo.IsSet(bp))
+				return (DataTemplate)bo.GetValue(bp);
+
+			return (DataTemplate)GetValue(bp);
+		}
 
 		event EventHandler IShellController.StructureChanged
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_shellContext = shellContext;
 
-			((IShellController)Shell).StructureChanged += OnShellStructureChanged;
+			ShellController.StructureChanged += OnShellStructureChanged;
 
 			_listItems = GenerateItemList();
 			_selectedCallback = selectedCallback;
@@ -39,6 +39,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected Shell Shell => _shellContext.Shell;
 
+		IShellController ShellController => (IShellController)Shell;
+
 		protected virtual DataTemplate DefaultItemTemplate => null;
 
 		protected virtual DataTemplate DefaultMenuItemTemplate => null;
@@ -46,14 +48,16 @@ namespace Xamarin.Forms.Platform.Android
 		public override int GetItemViewType(int position)
 		{
 			var item = _listItems[position];
-			DataTemplate dataTemplate = null;
+			DataTemplate dataTemplate = ShellController.GetFlyoutItemDataTemplate(item.Element);
 			if (item.Element is IMenuItemController)
 			{
-				dataTemplate = Shell.GetMenuItemTemplate(item.Element) ?? DefaultMenuItemTemplate ?? Shell.MenuItemTemplate;
+				if (DefaultMenuItemTemplate != null && Shell.MenuItemTemplate == dataTemplate)
+					dataTemplate = DefaultMenuItemTemplate;
 			}
 			else
 			{
-				dataTemplate = Shell.GetItemTemplate(item.Element) ?? DefaultItemTemplate ?? Shell.ItemTemplate;
+				if (DefaultItemTemplate != null && Shell.ItemTemplate == dataTemplate)
+					dataTemplate = DefaultItemTemplate;
 			}
 
 			var template = dataTemplate.SelectDataTemplate(item.Element, Shell);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Platform.iOS
 		List<List<Element>> _groups;
 		Dictionary<Element, View> _views;
 
+		IShellController ShellController => (IShellController)_context.Shell;
+
 		public ShellTableViewSource(IShellContext context, Action<Element> onElementSelected)
 		{
 			_context = context;
@@ -81,14 +83,16 @@ namespace Xamarin.Forms.Platform.iOS
 			int row = indexPath.Row;
 			var context = Groups[section][row];
 
-			DataTemplate template = null;
+			DataTemplate template = ShellController.GetFlyoutItemDataTemplate(context);
 			if (context is IMenuItemController)
 			{
-				template = Shell.GetMenuItemTemplate(context) ?? DefaultMenuItemTemplate ?? _context.Shell.MenuItemTemplate;
+				if (DefaultMenuItemTemplate != null && _context.Shell.MenuItemTemplate == template)
+					template = DefaultMenuItemTemplate;
 			}
 			else
 			{
-				template = Shell.GetItemTemplate(context) ?? DefaultItemTemplate ?? _context.Shell.ItemTemplate;
+				if (DefaultItemTemplate != null && _context.Shell.ItemTemplate == template)
+					template = DefaultItemTemplate;
 			}
 
 			var cellId = ((IDataTemplateController)template.SelectDataTemplate(context, _context.Shell)).IdString;


### PR DESCRIPTION
### Description of Change ###

The initial implementation that moved flyout item templates up into the xplat layer didn't take into account the general templates that you can assign to shell.

This PR also breaks the ability to change the StyleClass after the template has been realized because I'm not really sure how to propagate the StyleClass from a `BaseShellItem` to the template that was created from it

### Issues Resolved ### 
- fixes #10238


### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
StylesClass on BaseShellItem's no longer support changing
https://github.com/xamarin/Xamarin.Forms/issues/10251

### Testing Procedure ###
- unit tests included
- run control gallery and make sure the flyout replaced everything as expected

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
