### PR TITLE
[iOS] Shell fix clear of ShellSection 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -120,8 +120,8 @@ namespace Xamarin.Forms.Controls.Issues
 			item2.Title = "Item2 Flyout";
 			item2.Route = "Item2";
 
-			AddTopTab("Top Tab 1");
-			AddTopTab("Top Tab 2");
+			AddTopTab("Top Tab 1").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 1" } } };
+			AddTopTab("Top Tab 2").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 2" } } };
 
 			pageItem1.SetBinding(Page.IsVisibleProperty, "Item1");
 			pageItem2.SetBinding(Page.IsVisibleProperty, "Item2");
@@ -169,6 +169,15 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST && (__SHELL__)
+
+		[Test]
+		public void HideActiveShellContent()
+		{
+			RunningApp.Tap("ToggleItem1");
+			RunningApp.WaitForElement("Welcome to Tab 1");
+			RunningApp.WaitForNoElement("Item 1");
+			RunningApp.WaitForNoElement("ToggleItem1");
+		}
 
 		[Test]
 		public void HideFlyoutItem()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -120,6 +120,9 @@ namespace Xamarin.Forms.Controls.Issues
 			item2.Title = "Item2 Flyout";
 			item2.Route = "Item2";
 
+			AddTopTab("Top Tab 1");
+			AddTopTab("Top Tab 2");
+
 			pageItem1.SetBinding(Page.IsVisibleProperty, "Item1");
 			pageItem2.SetBinding(Page.IsVisibleProperty, "Item2");
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -175,12 +175,13 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("ToggleItem1");
 			ShowFlyout();
-			RunningApp.WaitForElement("Item1 Flyout");
-			RunningApp.Tap("Hide Flyout");
+			RunningApp.WaitForElement("Item2 Flyout");
+			RunningApp.Tap("Item2 Flyout");
 			RunningApp.Tap("AllVisible");
-			RunningApp.Tap("ToggleItem1");
+			RunningApp.Tap("ToggleItem2");
 			ShowFlyout();
-			RunningApp.WaitForNoElement("Item1 Flyout");
+			RunningApp.WaitForElement("Item1 Flyout");
+			RunningApp.WaitForNoElement("Item2 Flyout");
 		}
 
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -192,6 +192,18 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("ClearAndRecreate");
 			RunningApp.Tap("ClearAndRecreate");
 		}
+
+
+		[Test]
+		public void ClearAndRecreateFromSecondaryPage()
+		{
+			RunningApp.WaitForElement("ClearAndRecreate");
+			ShowFlyout();
+			RunningApp.Tap("Item2 Flyout");
+			RunningApp.Tap("ToggleItem1");
+			RunningApp.Tap("ClearAndRecreate");
+			RunningApp.WaitForElement("Top Tab 1");
+		}
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -202,7 +202,8 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("Item2 Flyout");
 			RunningApp.Tap("ToggleItem1");
 			RunningApp.Tap("ClearAndRecreate");
-			RunningApp.WaitForElement("Top Tab 1");
+			RunningApp.Tap("Top Tab 2");
+			RunningApp.Tap("Top Tab 1");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -110,7 +110,7 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 
-			var pageItem1 = createPage("Item 1");
+			var pageItem1 = createPage("Item Title Page");
 			var item1 = AddContentPage(pageItem1);
 			var pageItem2 = createPage("Item 2");
 			var item2 = AddContentPage(pageItem2);
@@ -175,7 +175,6 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.Tap("ToggleItem1");
 			RunningApp.WaitForElement("Welcome to Tab 1");
-			RunningApp.WaitForNoElement("Item 1");
 			RunningApp.WaitForNoElement("ToggleItem1");
 		}
 

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1027,6 +1027,81 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task ShellVisibleItemsReAddedIntoSameOrder()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem();
+			shell.Items.Add(item1);
+			var shellSection = item1.Items[0];
+			var shellSectionController = (IShellSectionController)shellSection;
+			ContentPage hideMe = new ContentPage();
+			var shellContent = CreateShellContent(hideMe);
+
+
+			shellSection.Items.Insert(0, shellContent);
+
+			Assert.AreEqual(0, shellSection.Items.IndexOf(shellContent));
+			Assert.AreEqual(0, shellSectionController.GetItems().IndexOf(shellContent));
+
+			hideMe.IsVisible = false;
+
+			Assert.AreEqual(0, shellSection.Items.IndexOf(shellContent));
+			Assert.AreEqual(-1, shellSectionController.GetItems().IndexOf(shellContent));
+
+			hideMe.IsVisible = true;
+
+			Assert.AreEqual(0, shellSection.Items.IndexOf(shellContent));
+			Assert.AreEqual(0, shellSectionController.GetItems().IndexOf(shellContent));
+		}
+
+		[Test]
+		public async Task HidingShellItemSetsNewCurrentItem()
+		{
+			var shell = new Shell();
+			ContentPage contentPage = new ContentPage();
+			var item1 = CreateShellItem(contentPage);
+			shell.Items.Add(item1);
+			var item2 = CreateShellItem();
+			shell.Items.Add(item2);
+
+			Assert.AreEqual(shell.CurrentItem, item1);
+			contentPage.IsVisible = false;
+			Assert.AreEqual(shell.CurrentItem, item2);
+		}
+
+
+		[Test]
+		public async Task HidingShellSectionSetsNewCurrentItem()
+		{
+			var shell = new Shell();
+			ContentPage contentPage = new ContentPage();
+			var item1 = CreateShellItem(contentPage);
+			shell.Items.Add(item1);
+			var shellSection2 = CreateShellSection();
+			item1.Items.Add(shellSection2);
+
+			Assert.AreEqual(shell.CurrentItem.CurrentItem, item1.Items[0]);
+			contentPage.IsVisible = false;
+			Assert.AreEqual(shell.CurrentItem.CurrentItem, shellSection2);
+		}
+
+
+		[Test]
+		public async Task HidingShellContentSetsNewCurrentItem()
+		{
+			var shell = new Shell();
+			ContentPage contentPage = new ContentPage();
+			var item1 = CreateShellItem(contentPage);
+			shell.Items.Add(item1);
+			var shellContent2 = CreateShellContent();
+			item1.Items[0].Items.Add(shellContent2);
+
+			Assert.AreEqual(shell.CurrentItem.CurrentItem.CurrentItem, item1.Items[0].Items[0]);
+			contentPage.IsVisible = false;
+			Assert.AreEqual(shell.CurrentItem.CurrentItem.CurrentItem, shellContent2);
+		}
+
+		[Test]
 		public async Task ShellLocationRestoredWhenItemsAreReAdded()
 		{
 			var shell = new Shell();

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -428,7 +428,8 @@ namespace Xamarin.Forms
 
 			ProcessNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
 		}
-		ReadOnlyCollection<ShellItem> IShellController.GetItems() => ((ShellItemCollection)Items).VisibleItems;
+		ReadOnlyCollection<ShellItem> IShellController.GetItems() =>
+			new ReadOnlyCollection<ShellItem>(((ShellItemCollection)Items).VisibleItems.ToList());
 
 		event NotifyCollectionChangedEventHandler IShellController.ItemsCollectionChanged
 		{

--- a/Xamarin.Forms.Core/Shell/ShellContentCollection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContentCollection.cs
@@ -10,10 +10,11 @@ namespace Xamarin.Forms
 	internal sealed class ShellContentCollection : IList<ShellContent>, INotifyCollectionChanged
 	{
 		public event NotifyCollectionChangedEventHandler VisibleItemsChanged;
+		public event NotifyCollectionChangedEventHandler VisibleItemsChangedInternal;
+		public ReadOnlyCollection<ShellContent> VisibleItems { get; }
+
 		ObservableCollection<ShellContent> _inner = new ObservableCollection<ShellContent>();
 		ObservableCollection<ShellContent> _visibleContents = new ObservableCollection<ShellContent>();
-
-		public ReadOnlyCollection<ShellContent> VisibleItems { get; }
 		bool _pauseCollectionChanged;
 		List<NotifyCollectionChangedEventArgs> _notifyCollectionChangedEventArgs;
 
@@ -30,8 +31,14 @@ namespace Xamarin.Forms
 					return;
 				}
 
-				VisibleItemsChanged?.Invoke(VisibleItems, args);
+				OnVisibleItemsChanged(args);
 			};
+		}
+
+		void OnVisibleItemsChanged(NotifyCollectionChangedEventArgs args)
+		{
+			VisibleItemsChangedInternal?.Invoke(VisibleItems, args);
+			VisibleItemsChanged?.Invoke(VisibleItems, args);
 		}
 
 		void PauseCollectionChanged() => _pauseCollectionChanged = true;
@@ -43,8 +50,8 @@ namespace Xamarin.Forms
 			var pendingEvents = _notifyCollectionChangedEventArgs.ToList();
 			_notifyCollectionChangedEventArgs.Clear();
 
-			foreach(var arg in pendingEvents)
-				VisibleItemsChanged?.Invoke(VisibleItems, arg);
+			foreach(var args in pendingEvents)
+				OnVisibleItemsChanged(args);
 		}
 
 		void InnerCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using System.ComponentModel;
 using System.Runtime.CompilerServices;
+using System.Linq;
 
 namespace Xamarin.Forms
 {
@@ -83,7 +84,9 @@ namespace Xamarin.Forms
 			return accept;
 		}
 
-		ReadOnlyCollection<ShellSection> IShellItemController.GetItems() => ((ShellSectionCollection)Items).VisibleItems;
+		// we want the list returned from here to remain point in time accurate
+		ReadOnlyCollection<ShellSection> IShellItemController.GetItems() => 
+			new ReadOnlyCollection<ShellSection>(((ShellSectionCollection)Items).VisibleItems.ToList());
 
 		event NotifyCollectionChangedEventHandler IShellItemController.ItemsCollectionChanged
 		{

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -113,7 +113,19 @@ namespace Xamarin.Forms
 
 		public ShellItem()
 		{
-			ShellItemController.ItemsCollectionChanged += (_, __) => SendStructureChanged();
+			ShellItemController.ItemsCollectionChanged += (_, args) =>
+			{
+				if (args.OldItems == null)
+					return;
+
+				foreach (Element item in args.OldItems)
+				{
+					OnVisibleChildRemoved(item);
+				}
+
+				SendStructureChanged();
+			};
+
 			(Items as INotifyCollectionChanged).CollectionChanged += ItemsCollectionChanged;
 
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<ShellItem>>(() => new PlatformConfigurationRegistry<ShellItem>(this));
@@ -210,6 +222,11 @@ namespace Xamarin.Forms
 		protected override void OnChildRemoved(Element child)
 		{
 			base.OnChildRemoved(child);
+			OnVisibleChildRemoved(child);
+		}
+
+		void OnVisibleChildRemoved(Element child)
+		{
 			if (CurrentItem == child)
 			{
 				if (ShellItemController.GetItems().Count == 0)

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -541,7 +541,7 @@ namespace Xamarin.Forms
 					Device.BeginInvokeOnMainThread(() =>
 					{
 						var contentItems = ShellSectionController.GetItems();
-						if (contentItems.Count > 0)
+						if (contentItems.Count > 0 && CurrentItem == null)
 							SetValueFromRenderer(CurrentItemProperty, contentItems[0]);
 					});
 				}

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -238,7 +238,7 @@ namespace Xamarin.Forms
 		{
 			(Items as INotifyCollectionChanged).CollectionChanged += ItemsCollectionChanged;
 
-			ShellSectionController.ItemsCollectionChanged += (_, args) =>
+			((ShellContentCollection)Items).VisibleItemsChangedInternal += (_, args) =>
 			{
 				if (args.OldItems == null)
 					return;
@@ -532,18 +532,14 @@ namespace Xamarin.Forms
 		{
 			if (CurrentItem == child)
 			{
-				var items = ShellSectionController.GetItems();
-				if (items.Count == 0)
+				var contentItems = ShellSectionController.GetItems();
+				if (contentItems.Count == 0)
+				{
 					ClearValue(CurrentItemProperty);
+				}
 				else
 				{
-					// We want to delay invoke this because the renderer may handle this instead
-					Device.BeginInvokeOnMainThread(() =>
-					{
-						var contentItems = ShellSectionController.GetItems();
-						if (contentItems.Count > 0 && (CurrentItem == null || !contentItems.Contains(CurrentItem)))
-							SetValueFromRenderer(CurrentItemProperty, contentItems[0]);
-					});
+					SetValueFromRenderer(CurrentItemProperty, contentItems[0]);
 				}
 			}
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -179,7 +179,9 @@ namespace Xamarin.Forms
 			SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
-		ReadOnlyCollection<ShellContent> IShellSectionController.GetItems() => ((ShellContentCollection)Items).VisibleItems;
+		// we want the list returned from here to remain point in time accurate
+		ReadOnlyCollection<ShellContent> IShellSectionController.GetItems() 
+			=> new ReadOnlyCollection<ShellContent>(((ShellContentCollection)Items).VisibleItems.ToList());
 
 		[Obsolete]
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -541,7 +541,7 @@ namespace Xamarin.Forms
 					Device.BeginInvokeOnMainThread(() =>
 					{
 						var contentItems = ShellSectionController.GetItems();
-						if (contentItems.Count > 0 && CurrentItem == null)
+						if (contentItems.Count > 0 && (CurrentItem == null || !contentItems.Contains(CurrentItem)))
 							SetValueFromRenderer(CurrentItemProperty, contentItems[0]);
 					});
 				}

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -237,6 +237,18 @@ namespace Xamarin.Forms
 		public ShellSection()
 		{
 			(Items as INotifyCollectionChanged).CollectionChanged += ItemsCollectionChanged;
+
+			ShellSectionController.ItemsCollectionChanged += (_, args) =>
+			{
+				if (args.OldItems == null)
+					return;
+
+				foreach(Element item in args.OldItems)
+				{
+					OnVisibleChildRemoved(item);
+				}
+			};
+
 			Navigation = new NavigationImpl(this);
 		}
 				
@@ -513,6 +525,11 @@ namespace Xamarin.Forms
 		protected override void OnChildRemoved(Element child)
 		{
 			base.OnChildRemoved(child);
+			OnVisibleChildRemoved(child);
+		}
+
+		void OnVisibleChildRemoved(Element child)
+		{
 			if (CurrentItem == child)
 			{
 				var items = ShellSectionController.GetItems();
@@ -523,8 +540,9 @@ namespace Xamarin.Forms
 					// We want to delay invoke this because the renderer may handle this instead
 					Device.BeginInvokeOnMainThread(() =>
 					{
-						if (CurrentItem == null)
-							SetValueFromRenderer(CurrentItemProperty, items[0]);
+						var contentItems = ShellSectionController.GetItems();
+						if (contentItems.Count > 0)
+							SetValueFromRenderer(CurrentItemProperty, contentItems[0]);
 					});
 				}
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -33,6 +33,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void ViewPager.IOnPageChangeListener.OnPageScrolled(int position, float positionOffset, int positionOffsetPixels)
 		{
+			if(!_selecting && ShellSection?.CurrentItem != null)
+			{
+				UpdateCurrentItem(ShellSection.CurrentItem);
+			}
 		}
 
 		void ViewPager.IOnPageChangeListener.OnPageScrollStateChanged(int state)
@@ -163,8 +167,19 @@ namespace Xamarin.Forms.Platform.Android
 
 			_tablayout.SetupWithViewPager(_viewPager);
 
-			var currentPage = ((IShellContentController)shellSection.CurrentItem).GetOrCreateContent();
-			var currentIndex = SectionController.GetItems().IndexOf(ShellSection.CurrentItem);
+			Page currentPage = null;
+			int currentIndex = -1;
+			var currentItem = ShellSection.CurrentItem;
+
+			while (currentIndex < 0 && SectionController.GetItems().Count > 0 && ShellSection.CurrentItem != null)
+			{
+				currentItem = ShellSection.CurrentItem;
+				currentPage = ((IShellContentController)shellSection.CurrentItem).GetOrCreateContent();
+
+				// current item hasn't changed
+				if(currentItem == shellSection.CurrentItem)
+					currentIndex = SectionController.GetItems().IndexOf(currentItem);
+			}
 
 			_toolbarTracker = _shellContext.CreateTrackerForToolbar(_toolbar);
 			_toolbarTracker.Page = currentPage;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -222,6 +222,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (SelectedIndex < 0)
 				return;
 
+			if (ShellSectionController.GetItems().IndexOf(ShellSection.CurrentItem) != SelectedIndex)
+				return;
+
 			var layout = CollectionView.GetLayoutAttributesForItem(NSIndexPath.FromItemSection((int)SelectedIndex, 0));
 
 			if (layout == null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -57,6 +57,7 @@ namespace Xamarin.Forms.Platform.iOS
 		UIView _bottomShadow;
 		Color _selectedColor;
 		Color _unselectedColor;
+		bool _isDisposed;
 
 		[Internals.Preserve(Conditional = true)]
 		public ShellSectionRootHeader()
@@ -197,7 +198,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
+			if (_isDisposed)
+				return;
 
 			if (disposing)
 			{
@@ -210,11 +212,20 @@ namespace Xamarin.Forms.Platform.iOS
 				_bar.Dispose();
 				_bar = null;
 			}
+
+			_isDisposed = true;
+			base.Dispose(disposing);
 		}
 
 		protected void LayoutBar()
 		{
+			if (SelectedIndex < 0)
+				return;
+
 			var layout = CollectionView.GetLayoutAttributesForItem(NSIndexPath.FromItemSection((int)SelectedIndex, 0));
+
+			if (layout == null)
+				return;
 
 			var frame = layout.Frame;
 
@@ -238,7 +249,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void UpdateSelectedIndex(bool animated = false)
 		{
+			if (ShellSection.CurrentItem == null)
+				return;
+
 			SelectedIndex = ShellSectionController.GetItems().IndexOf(ShellSection.CurrentItem);
+
+			if (SelectedIndex < 0)
+				return;
+
 			LayoutBar();
 
 			CollectionView.SelectItem(NSIndexPath.FromItemSection((int)SelectedIndex, 0), false, UICollectionViewScrollPosition.CenteredHorizontally);
@@ -246,6 +264,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnShellSectionItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if (ShellSection.CurrentItem == null || ShellSectionController.GetItems().Count == 0)
+				return;
+
 			CollectionView.ReloadData();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -264,9 +264,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnShellSectionItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (ShellSection.CurrentItem == null || ShellSectionController.GetItems().Count == 0)
-				return;
-
 			CollectionView.ReloadData();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -207,7 +207,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var oldRenderer = _renderers[oldContent];
 
 				// this means the currently visible item has been removed
-				if(oldIndex == -1 && _currentIndex <= newIndex)
+				if (oldIndex == -1 && _currentIndex <= newIndex)
 				{
 					newIndex++;
 				}
@@ -237,7 +237,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_isAnimating = false;
 					_tracker.Page = ((IShellContentController)newContent).Page;
 
-					if(!ShellSectionController.GetItems().Contains(oldContent))
+					if (!ShellSectionController.GetItems().Contains(oldContent))
 					{
 						_renderers.Remove(oldContent);
 						oldRenderer.ViewController.RemoveFromParentViewController();
@@ -292,6 +292,26 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			// Make sure we do this after the header has a chance to react
 			Device.BeginInvokeOnMainThread(UpdateHeaderVisibility);
+
+			if (e.OldItems != null)
+			{
+				foreach (ShellContent oldItem in e.OldItems)
+				{
+					// if current item is removed will be handled by the currentitem property changed event
+					// That way the render is swapped out cleanly once the new current item is set
+					if (_currentContent == oldItem)
+						continue;
+
+					if (e.OldStartingIndex < _currentIndex)
+						_currentIndex--;
+
+					var oldRenderer = _renderers[oldItem];
+					_renderers.Remove(oldItem);
+					oldRenderer.NativeView.RemoveFromSuperview();
+					oldRenderer.ViewController.RemoveFromParentViewController();
+					oldRenderer.Dispose();
+				}
+			}
 
 			if (e.NewItems != null)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -164,13 +164,30 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void LoadRenderers()
 		{
-			var currentItem = ShellSection.CurrentItem;
-			for (int i = 0; i < ShellSectionController.GetItems().Count; i++)
+			Dictionary<ShellContent, Page> createdPages = new Dictionary<ShellContent, Page>();
+			var contentItems = ShellSectionController.GetItems();
+
+			// pre create all the pages in case the visibility of a page
+			// removes the page from shell
+			for (int i = 0; i < contentItems.Count; i++)
 			{
-				ShellContent item = ShellSectionController.GetItems()[i];
+				ShellContent item = contentItems[i];
 				var page = ((IShellContentController)item).GetOrCreateContent();
-				if (!page.IsVisible)
-					continue;
+				createdPages.Add(item, page);
+			}
+
+			var currentItem = ShellSection.CurrentItem;
+			contentItems = ShellSectionController.GetItems();
+
+			for (int i = 0; i < contentItems.Count; i++)
+			{
+				ShellContent item = contentItems[i];
+				Page page = null;
+				if(!createdPages.TryGetValue(item, out page))
+				{
+					page = ((IShellContentController)item).GetOrCreateContent();
+					contentItems = ShellSectionController.GetItems();
+				}
 
 				var renderer = Platform.CreateRenderer(page);
 				Platform.SetRenderer(page, renderer);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -3,6 +3,7 @@ using CoreGraphics;
 using System;
 using UIKit;
 using System.ComponentModel;
+using System.Collections.Specialized;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -16,6 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		double _headerSize;
 		bool _isDisposed;
 		Action<Element> _onElementSelected;
+		IShellController ShellController => ((IShellController)_context.Shell);
 
 		public ShellTableViewController(IShellContext context, UIContainerView headerView, Action<Element> onElementSelected)
 		{
@@ -24,10 +26,11 @@ namespace Xamarin.Forms.Platform.iOS
 			_headerView = headerView;
 			_source = CreateShellTableViewSource();
 			_source.ScrolledEvent += OnScrolled;
+
 			if (_headerView != null)
 				_headerView.HeaderSizeChanged += OnHeaderSizeChanged;
-			((IShellController)_context.Shell).StructureChanged += OnStructureChanged;
 
+			ShellController.StructureChanged += OnStructureChanged;
 			_context.Shell.PropertyChanged += OnShellPropertyChanged;
 		}
 


### PR DESCRIPTION
### Description of Change ###
- iOS ShellSectionRenderers aren't reacting to clear properly
- iOS ShellSectionRenderers weren't reacting to elements being removed and then updating to the proper renderer correctly
- Shell Elements weren't updating current item properly when the Current Item became non visible

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS


### Testing Procedure ###
- unit tests included
- test the included gallery page for different permutations of hiding and showing things

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
