### PR TITLE
[iOS] Fix CollectionView disposing of Delegator 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10222.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10222.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Content = new Button
 				{
+					AutomationId = "goTo",
 					Text = "Go",
 					Command = new Command(async () => await Navigation.PushAsync(new CarouselViewTestPage()))
 				}
@@ -39,6 +40,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				cv = new CollectionView
 				{
+					AutomationId = "collectionView",
 					Margin = new Thickness(0,40),
 					ItemTemplate = new DataTemplate(() =>
 					{
@@ -83,10 +85,10 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue10222Test() 
 		{
-			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
-			RunningApp.Screenshot("I am at Issue1");
-			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));
-			RunningApp.Screenshot("I see the Label");
+			RunningApp.WaitForElement(q => q.Marked("goTo"));
+			RunningApp.Tap("goTo");
+			RunningApp.WaitForElement(q => q.Marked("collectionView"));
+			RunningApp.WaitForElement(q => q.Marked("goTo"));
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10222.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10222.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10222, "[CollectionView] ObjectDisposedException if the page is closed during scrolling", PlatformAffected.iOS)]
+	public class Issue10222 : TestNavigationPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			// Initialize ui here instead of ctor
+			Navigation.PushAsync(new ContentPage
+			{
+				Content = new Button
+				{
+					Text = "Go",
+					Command = new Command(async () => await Navigation.PushAsync(new CarouselViewTestPage()))
+				}
+			});
+		}
+
+		class CarouselViewTestPage : ContentPage
+		{
+			CollectionView cv;
+			public CarouselViewTestPage()
+			{
+				cv = new CollectionView
+				{
+					Margin = new Thickness(0,40),
+					ItemTemplate = new DataTemplate(() =>
+					{
+						var label = new Label
+						{
+							HorizontalTextAlignment = TextAlignment.Center,
+							Margin = new Thickness(0, 100)
+						};
+						label.SetBinding(Label.TextProperty, new Binding("."));
+						return label;
+					})
+				};
+				Content = cv;
+				InitCV();
+			}
+
+			async void InitCV()
+			{
+				var items = new List<string>();
+				for (int i = 0; i < 10; i++)
+				{
+					items.Add($"items{i}");
+				}
+
+				cv.ItemsSource = items;
+
+				//give the cv time to draw the items
+				await Task.Delay(1000);
+
+				cv.ScrollTo(items.Count - 1);
+
+				//give the cv time to scroll
+				var rand = new Random();
+				await Task.Delay(rand.Next(10, 200));
+
+				await Navigation.PopAsync(false);
+
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void Issue10222Test() 
+		{
+			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
+			RunningApp.Screenshot("I am at Issue1");
+			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));
+			RunningApp.Screenshot("I see the Label");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -750,6 +750,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue7371.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8145.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10222.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -60,6 +60,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disposing)
 			{
 				ItemsSource?.Dispose();
+				Delegator?.Dispose();
 
 				_emptyUIView?.Dispose();
 				_emptyUIView = null;


### PR DESCRIPTION
### Description of Change ###

Make sure to dispose the delegator so it doesn't fire the scrolled when we are disposing the page while scrolling 

### Issues Resolved ### 

- fixes #10222 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
