### PR TITLE
Update ItemsUpdatingScrollMode when element loaded on iOS

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCodeCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCodeCollectionViewGallery.cs
@@ -3,7 +3,7 @@
 	internal class ObservableCodeCollectionViewGallery : ContentPage
 	{
 		public ObservableCodeCollectionViewGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical,
-			bool grid = true, int initialItems = 1000, bool addItemsWithTimer = false)
+			bool grid = true, int initialItems = 1000, bool addItemsWithTimer = false, ItemsUpdatingScrollMode scrollMode = ItemsUpdatingScrollMode.KeepItemsInView)
 		{
 			var layout = new Grid
 			{
@@ -26,7 +26,7 @@
 			var itemTemplate = ExampleTemplates.PhotoTemplate();
 
 			var collectionView = new CollectionView {ItemsLayout = itemsLayout, ItemTemplate = itemTemplate,
-				AutomationId = "collectionview", Header = "This is the header" };
+				AutomationId = "collectionview", Header = "This is the header", ItemsUpdatingScrollMode = scrollMode};
 
 			var generator = new ItemsSourceGenerator(collectionView, initialItems, ItemsSourceType.ObservableCollection);
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionGallery.cs
@@ -41,7 +41,16 @@
 						GalleryBuilder.NavButton("Reset", () => new ObservableCollectionResetGallery(), Navigation),
 
 						GalleryBuilder.NavButton("Add Items with timer to Empty Collection", () =>
-							new ObservableCodeCollectionViewGallery(grid: false, initialItems: 0, addItemsWithTimer: true), Navigation)
+							new ObservableCodeCollectionViewGallery(grid: false, initialItems: 0, addItemsWithTimer: true), Navigation),
+
+						GalleryBuilder.NavButton("Scroll mode Keep items in view", () =>
+                            new ObservableCodeCollectionViewGallery(grid: false, initialItems: 0, addItemsWithTimer: true, scrollMode: ItemsUpdatingScrollMode.KeepItemsInView), Navigation),
+
+						GalleryBuilder.NavButton("Scroll mode Keep scroll offset", () =>
+							new ObservableCodeCollectionViewGallery(grid: false, initialItems: 0, addItemsWithTimer: true, scrollMode: ItemsUpdatingScrollMode.KeepScrollOffset), Navigation),
+
+						GalleryBuilder.NavButton("Scroll mode Keep last item in view", () =>
+							new ObservableCodeCollectionViewGallery(grid: false, initialItems: 0, addItemsWithTimer: true, scrollMode: ItemsUpdatingScrollMode.KeepLastItemInView), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -91,11 +91,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UpdateLayout();
 			Controller = CreateController(newElement, _layout);
-			 
 			SetNativeControl(Controller.View);
 			Controller.CollectionView.BackgroundColor = UIColor.Clear;
 			UpdateHorizontalScrollBarVisibility();
 			UpdateVerticalScrollBarVisibility();
+			UpdateItemsUpdatingScrollMode();
 
 			// Listen for ScrollTo requests
 			newElement.ScrollToRequested += ScrollToRequested;
@@ -123,6 +123,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void UpdateItemsSource()
 		{
+			UpdateItemsUpdatingScrollMode();
 			Controller.UpdateItemsSource();
 		}
 


### PR DESCRIPTION
### Description of Change ###

The ItemsViewRenderer on iOS will now update the ItemsUpdatingScrollMode upon loading the element. 

### Issues Resolved ### 

- fixes #7788

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

The ItemsViewRenderer on iOS will now update the ItemsUpdatingScrollMode upon loading the element. 
There seems to be a timing issue where setting the ItemsUpdatingScrollMode right after creating the CollectionView doesn't fire the OnElementPropertyChanged method in the ItemsViewRenderer. 

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I've added the different ItemsUpdatingScrollMode modes to the ObservableCodeCollectionViewGallery
### PR Checklist ###
<!-- To be completed by reviewers -->

- [X] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
