### PR TITLE
[Tizen] Fix dependency service registration correctly

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/IVideoOutput.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/IVideoOutput.cs
@@ -42,7 +42,10 @@ namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
 		event EventHandler PlaybackStarted;
 		event EventHandler PlaybackStopped;
 
-		}
+		Task<bool> Start();
+		void Stop();
+		void Pause();
+	}
 
 	public interface IPlatformMediaPlayer : IDisposable
 	{

--- a/Xamarin.Forms.Platform.Tizen/Native/EmbeddingControls.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EmbeddingControls.cs
@@ -177,7 +177,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		async void OnImageButtonClicked(object sender, EventArgs e)
 		{
-			if (BindingContext is MediaPlayer player)
+			if (BindingContext is IMediaPlayer player)
 			{
 				if (player.State == PlayerState.Playing)
 				{

--- a/Xamarin.Forms.Platform.Tizen/Native/MediaPlayerImpl.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/MediaPlayerImpl.cs
@@ -6,7 +6,6 @@ using System.Threading.Tasks;
 using Tizen.Multimedia;
 using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
 
-[assembly: Xamarin.Forms.Dependency(typeof(IPlatformMediaPlayer))]
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
 	public class MediaPlayerImpl : IPlatformMediaPlayer

--- a/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
@@ -1,10 +1,12 @@
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Tizen;
+using MediaPlayerImpl = Xamarin.Forms.Platform.Tizen.Native.MediaPlayerImpl;
 
 [assembly: Dependency(typeof(ResourcesProvider))]
 [assembly: Dependency(typeof(Deserializer))]
 [assembly: Dependency(typeof(NativeBindingService))]
 [assembly: Dependency(typeof(NativeValueConverterService))]
+[assembly: Dependency(typeof(MediaPlayerImpl))]
 
 [assembly: ExportRenderer(typeof(Layout), typeof(LayoutRenderer))]
 [assembly: ExportRenderer(typeof(ScrollView), typeof(ScrollViewRenderer))]


### PR DESCRIPTION
### Description of Change ###
This PR fix `MediaPlayerImpl` dependency service registration correctly.

### Issues Resolved ### 
None

### API Changes ###
Below methods are added into `Xamarin.Forms.PlatformConfiguration.TizenSpecific.IMediaPlayer` interface.
- Task<bool> Start();
- void Stop();
- void Pause();

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
