### PR TITLE
Rename AppTheme enum to OSAppTheme

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.Core.UnitTests/MockPlatformServices.cs
@@ -219,7 +219,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			return new SizeRequest(new Size (100, 20));
 		}
 
-		public AppTheme RequestedTheme { get; set; }
+		public OSAppTheme RequestedTheme { get; set; }
 	}
 
 	internal class MockDeserializer : Internals.IDeserializer

--- a/Xamarin.Forms.Core/AppThemeChangedEventArgs.cs
+++ b/Xamarin.Forms.Core/AppThemeChangedEventArgs.cs
@@ -4,9 +4,9 @@ namespace Xamarin.Forms
 {
     public class AppThemeChangedEventArgs : EventArgs
     {
-        public AppThemeChangedEventArgs(AppTheme appTheme) =>
+        public AppThemeChangedEventArgs(OSAppTheme appTheme) =>
             RequestedTheme = appTheme;
 
-        public AppTheme RequestedTheme { get; }
+        public OSAppTheme RequestedTheme { get; }
     }
 }

--- a/Xamarin.Forms.Core/AppThemeColor.cs
+++ b/Xamarin.Forms.Core/AppThemeColor.cs
@@ -51,9 +51,9 @@ namespace Xamarin.Forms
 			switch (Application.Current?.RequestedTheme)
 			{
 				default:
-				case AppTheme.Light:
+				case OSAppTheme.Light:
 					return appThemeColor.IsSet(LightProperty) ? appThemeColor.Light : (appThemeColor.IsSet(DefaultProperty) ? appThemeColor.Default : default(Color));
-				case AppTheme.Dark:
+				case OSAppTheme.Dark:
 					return appThemeColor.IsSet(DarkProperty) ? appThemeColor.Dark : (appThemeColor.IsSet(DefaultProperty) ? appThemeColor.Default : default(Color));
 			}
 		}
@@ -64,10 +64,10 @@ namespace Xamarin.Forms
 			switch (Application.Current?.RequestedTheme)
 			{
 				default:
-				case AppTheme.Light:
+				case OSAppTheme.Light:
 					appThemeColor.Value = appThemeColor.IsSet(LightProperty) ? appThemeColor.Light : (appThemeColor.IsSet(DefaultProperty) ? appThemeColor.Default : default(Color));
 					break;
-				case AppTheme.Dark:
+				case OSAppTheme.Dark:
 					appThemeColor.Value = appThemeColor.IsSet(DarkProperty) ? appThemeColor.Dark : (appThemeColor.IsSet(DefaultProperty) ? appThemeColor.Default : default(Color));
 					break;
 			}

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public AppTheme RequestedTheme => Device.PlatformServices.RequestedTheme;
+		public OSAppTheme RequestedTheme => Device.PlatformServices.RequestedTheme;
 
 		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
 		{

--- a/Xamarin.Forms.Core/IPlatformServices.cs
+++ b/Xamarin.Forms.Core/IPlatformServices.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Internals
 
 		Color GetNamedColor(string name);
 
-		AppTheme RequestedTheme { get; }
+		OSAppTheme RequestedTheme { get; }
 
 		Task<Stream> GetStreamAsync(Uri uri, CancellationToken cancellationToken);
 

--- a/Xamarin.Forms.Core/OSAppTheme.cs
+++ b/Xamarin.Forms.Core/OSAppTheme.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms
 {
-	public enum AppTheme
+	public enum OSAppTheme
 	{
 		Unspecified,
 		Light,

--- a/Xamarin.Forms.Core/OnAppTheme.cs
+++ b/Xamarin.Forms.Core/OnAppTheme.cs
@@ -2,7 +2,7 @@
 
 namespace Xamarin.Forms
 {
-	public class OnAppTheme<T> : BindableObject, IDisposable
+	public class OnAppTheme<T> : BindableObject
 	{
 		public OnAppTheme()
 		{
@@ -38,9 +38,9 @@ namespace Xamarin.Forms
 			switch (Application.Current?.RequestedTheme)
 			{
 				default:
-				case AppTheme.Light:
+				case OSAppTheme.Light:
 					return onAppTheme.IsSet(LightProperty) ? onAppTheme.Light : (onAppTheme.IsSet(DefaultProperty) ? onAppTheme.Default : default(T));
-				case AppTheme.Dark:
+				case OSAppTheme.Dark:
 					return onAppTheme.IsSet(DarkProperty) ? onAppTheme.Dark : (onAppTheme.IsSet(DefaultProperty) ? onAppTheme.Default : default(T));
 			}
 		}
@@ -56,21 +56,16 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public void Dispose()
-		{
-			Application.Current.RequestedThemeChanged -= RequestedThemeChanged;
-		}
-
 		static void UpdateActualValue(BindableObject bo)
 		{
 			var appThemeColor = bo as OnAppTheme<T>;
 			switch (Application.Current?.RequestedTheme)
 			{
 				default:
-				case AppTheme.Light:
+				case OSAppTheme.Light:
 					appThemeColor.ActualValue = appThemeColor.IsSet(LightProperty) ? appThemeColor.Light : (appThemeColor.IsSet(DefaultProperty) ? appThemeColor.Default : default(T));
 					break;
-				case AppTheme.Dark:
+				case OSAppTheme.Dark:
 					appThemeColor.ActualValue = appThemeColor.IsSet(DarkProperty) ? appThemeColor.Dark : (appThemeColor.IsSet(DefaultProperty) ? appThemeColor.Default : default(T));
 					break;
 			}

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Forms
 			return OnBackButtonPressed();
 		}
 
-		protected override void OnRequestedThemeChanged(AppTheme newValue)
+		protected override void OnRequestedThemeChanged(OSAppTheme newValue)
 		{
 			base.OnRequestedThemeChanged(newValue);
 

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -272,7 +272,7 @@ namespace Xamarin.Forms
 				Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
 		}
 
-		protected virtual void OnRequestedThemeChanged(AppTheme newValue)
+		protected virtual void OnRequestedThemeChanged(OSAppTheme newValue)
 		{
 			ExperimentalFlags.VerifyFlagEnabled(nameof(VisualElement), ExperimentalFlags.AppThemeExperimental, nameof(OnRequestedThemeChanged));
 		}

--- a/Xamarin.Forms.DualScreen.UnitTests/MockPlatformServices.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/MockPlatformServices.cs
@@ -214,7 +214,7 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 			return new SizeRequest(new Size(100, 20));
 		}
 
-		public AppTheme RequestedTheme => AppTheme.Unspecified;
+		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 	}
 
 	internal class MockDeserializer : Internals.IDeserializer

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -930,24 +930,22 @@ namespace Xamarin.Forms
 				return Platform.Android.Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 			}
 
-			#region Replace with Essentials API
-			public AppTheme RequestedTheme
-			{
-				get
-				{
-					var nightMode = _context.Resources.Configuration.UiMode & UiMode.NightMask;
-					switch (nightMode)
-					{
-						case UiMode.NightYes:
-							return AppTheme.Dark;
-						case UiMode.NightNo:
-							return AppTheme.Light;
-						default:
-							return AppTheme.Unspecified;
+			public OSAppTheme RequestedTheme
+            {
+                get
+                {
+                    var nightMode = _context.Resources.Configuration.UiMode & UiMode.NightMask;
+                    switch (nightMode)
+                    {
+                        case UiMode.NightYes:
+                            return OSAppTheme.Dark;
+                        case UiMode.NightNo:
+                            return OSAppTheme.Light;
+                        default:
+                            return OSAppTheme.Unspecified;
 					};
 				}
 			}
-			#endregion
 
 			public class _IsolatedStorageFile : IIsolatedStorageFile
 			{

--- a/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
+++ b/Xamarin.Forms.Platform.GTK/GtkPlatformServices.cs
@@ -126,6 +126,6 @@ namespace Xamarin.Forms.Platform.GTK
 			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 
-		public AppTheme RequestedTheme => AppTheme.Unspecified;
+		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -265,7 +265,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 
-		public AppTheme RequestedTheme => AppTheme.Unspecified;
+		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 
 		static MD5 CreateChecksum()
 		{

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -259,6 +259,6 @@ namespace Xamarin.Forms.Platform.UWP
 			return await taskCompletionSource.Task;
 		}
 
-		public AppTheme RequestedTheme => Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Dark ? AppTheme.Dark : AppTheme.Light;
+		public OSAppTheme RequestedTheme => Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Dark ? OSAppTheme.Dark : OSAppTheme.Light;
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -167,6 +167,6 @@ namespace Xamarin.Forms.Platform.WPF
 			return Platform.GetNativeSize(view, widthConstraint, heightConstraint);
 		}
 
-		public AppTheme RequestedTheme => AppTheme.Unspecified;
+		public OSAppTheme RequestedTheme => OSAppTheme.Unspecified;
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -501,14 +501,13 @@ namespace Xamarin.Forms
 #endif
 			}
 
-			#region Remove with Essentials API
-			public AppTheme RequestedTheme
-			{
-				get
-				{
+			public OSAppTheme RequestedTheme
+            {
+                get
+                {
 #if __IOS__ || __TVOS__
 					if (!IsiOS13OrNewer)
-						return AppTheme.Unspecified;
+						return OSAppTheme.Unspecified;
 #if __XCODE11__
 					var uiStyle = GetCurrentUIViewController()?.TraitCollection?.UserInterfaceStyle ??
 						UITraitCollection.CurrentTraitCollection.UserInterfaceStyle;
@@ -516,17 +515,17 @@ namespace Xamarin.Forms
 					switch (uiStyle)
 					{
 						case UIUserInterfaceStyle.Light:
-							return AppTheme.Light;
+							return OSAppTheme.Light;
 						case UIUserInterfaceStyle.Dark:
-							return AppTheme.Dark;
+							return OSAppTheme.Dark;
 						default:
-							return AppTheme.Unspecified;
+							return OSAppTheme.Unspecified;
 					};
 #else
-					return AppTheme.Unspecified;
+					return OSAppTheme.Unspecified;
 #endif
 #else
-					return AppTheme.Unspecified;
+                    return OSAppTheme.Unspecified;
 #endif
 				}
 			}
@@ -568,6 +567,5 @@ namespace Xamarin.Forms
 			}
 #endif
 		}
-		#endregion
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/OnPlatformTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/OnPlatformTests.cs
@@ -157,14 +157,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml"" TextColor=""{OnAppTheme Light = Green, Dark = Red}
 			"">This text is green or red depending on Light (or default) or Dark</Label>";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Light;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Light;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Dark;
-			label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Red, label.TextColor);
-		}
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Dark;
+            label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Red, label.TextColor);
+        }
 
 		[Test]
 		public void OnAppThemeLightDarkColor()
@@ -179,14 +179,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label.TextColor>
 			</Label> ";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Light;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Light;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Dark;
-			label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Red, label.TextColor);
-		}
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Dark;
+            label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Red, label.TextColor);
+        }
 
 		[Test]
 		public void OnAppThemeUnspecifiedThemeDefaultsToLightColor()
@@ -201,10 +201,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label.TextColor>
 			</Label> ";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Unspecified;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
-		}
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Unspecified;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
+        }
 
 		[Test]
 		public void OnAppThemeUnspecifiedLightColorDefaultsToDefault()
@@ -219,10 +219,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label.TextColor>
 			</Label> ";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Light;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
-		}
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Light;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
+        }
 
 		[Test]
 		public void AppThemeColorLightDark()
@@ -237,14 +237,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label.TextColor>
 			</Label> ";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Light;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Light;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Dark;
-			label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Red, label.TextColor);
-		}
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Dark;
+            label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Red, label.TextColor);
+        }
 
 		[Test]
 		public void AppThemeColorUnspecifiedThemeDefaultsToLightColor()
@@ -259,10 +259,10 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label.TextColor>
 			</Label> ";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Unspecified;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
-		}
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Unspecified;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
+        }
 
 		[Test]
 		public void AppThemeColorUnspecifiedLightColorDefaultsToDefault()
@@ -277,9 +277,9 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				</Label.TextColor>
 			</Label> ";
 
-			((MockPlatformServices)Device.PlatformServices).RequestedTheme = AppTheme.Unspecified;
-			var label = new Label().LoadFromXaml(xaml);
-			Assert.AreEqual(Color.Green, label.TextColor);
-		}
-	}	
+            ((MockPlatformServices)Device.PlatformServices).RequestedTheme = OSAppTheme.Unspecified;
+            var label = new Label().LoadFromXaml(xaml);
+            Assert.AreEqual(Color.Green, label.TextColor);
+        }
+    }
 }

--- a/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
@@ -124,9 +124,9 @@ namespace Xamarin.Forms.Xaml
 			switch (Application.Current?.RequestedTheme)
 			{
 				default:
-				case AppTheme.Light:
+				case OSAppTheme.Light:
 					return Light ?? Default;
-				case AppTheme.Dark:
+				case OSAppTheme.Dark:
 					return Dark ?? Default;
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

To prevent name clashing with Essentials, rename our enum

### API Changes ###

Changed:
 - enum AppTheme => enum OSAppTheme

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

No more naming conflicts (thus build errors) when upgrading to 4.6 and Essentials installed using their `AppTheme`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
