### PR TITLE
Fixed navigation events for custom WebView on Android.

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -136,6 +136,7 @@
     </Compile>
     <Compile Include="ApiLabelRenderer.cs" />
     <Compile Include="Issue7249SwitchRenderer.cs" />
+    <Compile Include="_8954CustomRenderer.cs" />
     <Compile Include="_9087CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/_8954CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_8954CustomRenderer.cs
@@ -1,0 +1,28 @@
+﻿using Android.Content;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(_8954WebView), typeof(_8954CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class _8954CustomRenderer : WebViewRenderer
+	{
+		private readonly Context _context;
+		public _8954CustomRenderer(Context context) : base(context)
+		{
+			_context = context;
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<WebView> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				Control.Settings.UserAgentString = "Custom user agent string";
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
@@ -1,60 +1,37 @@
-﻿using Xamarin.Forms.CustomAttributes;
+﻿using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-
-#if UITEST
-using Xamarin.Forms.Core.UITests;
-using Xamarin.UITest;
-using NUnit.Framework;
-#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
-#if UITEST
-	[Category(UITestCategories.ManualReview)]
-#endif
+	public class _8954WebView : WebView
+	{
+
+	}
+
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 1, "Issue Description", PlatformAffected.Default)]
-	public class Issue1 : TestContentPage // or TestMasterDetailPage, etc ...
+	[Issue(IssueTracker.Github, 8954, "Navigated event fired at startup for custom WebView on Android", PlatformAffected.Android)]
+	public class Issue8954 : TestContentPage
 	{
 		protected override void Init()
 		{
-			// Initialize ui here instead of ctor
-			Content = new Label
+			var webView = new _8954WebView()
 			{
-				AutomationId = "Issue1Label",
-				Text = "See if I'm here"
+				Source = "https://www.microsoft.com/en-us/",
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+			webView.Navigating += (object sender, WebNavigatingEventArgs e) =>
+			{
+				Debug.WriteLine("Navigating");
+			};
+			webView.Navigated += (object sender, WebNavigatedEventArgs e) =>
+			{
+				Debug.WriteLine("Navigated");
 			};
 
-			BindingContext = new ViewModelIssue1();
-		}
-
-#if UITEST
-		[Test]
-		public void Issue1Test() 
-		{
-			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
-			RunningApp.Screenshot("I am at Issue1");
-			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));
-			RunningApp.Screenshot("I see the Label");
-		}
-#endif
-	}
-
-	[Preserve(AllMembers = true)]
-	public class ViewModelIssue1
-	{
-		public ViewModelIssue1()
-		{
-
-		}
-	}
-
-	[Preserve(AllMembers = true)]
-	public class ModelIssue1
-	{
-		public ModelIssue1()
-		{
-
+			var stackLayout = new StackLayout();
+			stackLayout.Children.Add(webView);
+			Content = stackLayout;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			var cancel = false;
-			if (!url.Equals(_renderer.UrlCanceled, StringComparison.OrdinalIgnoreCase))
+			if (_renderer.UrlCanceled != null && !url.Equals(_renderer.UrlCanceled, StringComparison.OrdinalIgnoreCase))
 				cancel = SendNavigatingCanceled(url);
 			_renderer.UrlCanceled = null;
 
@@ -56,6 +56,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnPageFinished(WView view, string url)
 		{
+			if (view.Progress != 100)
+			{
+				return;
+			}
+
 			if (_renderer?.Element == null || url == WebViewRenderer.AssetBaseUrl)
 				return;
 


### PR DESCRIPTION
### Description of Change ###
This PR fixes a bug on Android when using custom renderer for WebView. When you have a custom renderer for WebView,  the **Navigating** and **Navigated** events are called twice at the start. The worst thing with this bug is the fact that the first call of the **Navigated** event happens before even the WebView is visible on the page.

### Issues Resolved ### 
- fixes #8954

### API Changes ###
 None

### Platforms Affected ### 
Only Android

### Testing Procedure ###
1. Go to the gallery page with this issue.
2. Look at the "Application output". First, the "Navigating" event should be logged to the console. Then when the WebView page has loaded completely, the "Navigated" event should be logged.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
