### PR TITLE
[Android] Set native properties from element if layout hasn't occurred 

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -57,7 +57,7 @@ using Android.Support.V4.Content;
 [assembly: ExportRenderer(typeof(Issue7249Switch), typeof(Issue7249SwitchRenderer))]
 [assembly: ExportRenderer(typeof(Issue9360.Issue9360NavigationPage), typeof(Issue9360NavigationPageRenderer))]
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.GalleryPages.TwoPaneViewGalleries.HingeAngleLabel), typeof(HingeAngleLabelRenderer))]
-[assembly: ExportRenderer(typeof(Issue8801.PopupStackLayout), typeof(CustomStackLayoutRenderer))]
+[assembly: ExportRenderer(typeof(Issue8801.PopupStackLayout), typeof(Issue8801StackLayoutRenderer))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
@@ -116,9 +116,9 @@ namespace Xamarin.Forms.ControlGallery.Android
 		}
 	}
 
-	public class CustomStackLayoutRenderer : VisualElementRenderer<StackLayout>
+	public class Issue8801StackLayoutRenderer : VisualElementRenderer<StackLayout>
 	{
-		public CustomStackLayoutRenderer(Context context) : base(context)
+		public Issue8801StackLayoutRenderer(Context context) : base(context)
 		{
 
 

--- a/Xamarin.Forms.ControlGallery.Android/Tests/PlatformTestFixture.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Tests/PlatformTestFixture.cs
@@ -1,5 +1,6 @@
 ﻿using Android.Content;
 using Android.Content.PM;
+using Android.Support.V7.Widget;
 using Android.Widget;
 using Xamarin.Forms.Platform.Android;
 
@@ -56,7 +57,7 @@ namespace Xamarin.Forms.ControlGallery.Android.Tests
 				return fastRenderer;
 			}
 
-			var viewRenderer = renderer.View as ViewRenderer<Button, global::Android.Widget.Button>;
+			var viewRenderer = renderer.View as ViewRenderer<Button, AppCompatButton>;
 			return viewRenderer.Control;
 		}
 

--- a/Xamarin.Forms.ControlGallery.Android/Tests/PlatformTestFixture.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Tests/PlatformTestFixture.cs
@@ -47,6 +47,19 @@ namespace Xamarin.Forms.ControlGallery.Android.Tests
 			return viewRenderer.Control;
 		}
 
+		protected global::Android.Widget.Button GetNativeControl(Button button)
+		{
+			var renderer = GetRenderer(button);
+
+			if (renderer is Xamarin.Forms.Platform.Android.FastRenderers.ButtonRenderer fastRenderer)
+			{
+				return fastRenderer;
+			}
+
+			var viewRenderer = renderer.View as ViewRenderer<Button, global::Android.Widget.Button>;
+			return viewRenderer.Control;
+		}
+
 		protected FormsEditText GetNativeControl(Entry entry)
 		{
 			var renderer = GetRenderer(entry);

--- a/Xamarin.Forms.ControlGallery.Android/Tests/RendererTests.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Tests/RendererTests.cs
@@ -30,5 +30,16 @@ namespace Xamarin.Forms.ControlGallery.Android.Tests
 				Assert.That(centeredVertical, Is.True);
 			}
 		}
+
+		[Test(Description = "Button Initial Measure Correct")]
+		public void ButtonInitialMeasureWithText()
+		{
+			string text = "I am a long amount of text that should measure out to a long amount of text";
+			var button = new Button { Text = text };
+			using (var nativeButton = GetNativeControl(button))
+			{				
+				Assert.AreEqual(nativeButton.Text, button.Text, text);
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -29,6 +29,7 @@ namespace Xamarin.Forms.Platform.Android
 		ILayoutChanges,
 		IDisposedState
 	{
+		bool _hasLayoutOccurred;
 		bool _inputTransparent;
 		bool _disposed;
 		bool _skipInvalidate;
@@ -76,6 +77,12 @@ namespace Xamarin.Forms.Platform.Android
 			// Tag = this;
 
 			_backgroundTracker = new BorderBackgroundManager(this, false);
+		}
+
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			base.OnLayout(changed, left, top, right, bottom);
+			_hasLayoutOccurred = true;
 		}
 
 		protected override void Dispose(bool disposing)
@@ -319,6 +326,8 @@ namespace Xamarin.Forms.Platform.Android
 		bool IBorderVisualElementRenderer.UseDefaultShadow() => false;
 		VisualElement IBorderVisualElementRenderer.Element => Element;
 		AView IBorderVisualElementRenderer.View => this;
+
+		bool ILayoutChanges.HasLayoutOccurred => _hasLayoutOccurred;
 
 		IPlatformElementConfiguration<PlatformConfiguration.Android, ImageButton> OnThisPlatform()
 		{

--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -183,6 +183,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void Update()
 		{
+			if (View?.LayoutParameters == null && _hasLayoutOccurred)
+				return;
+
 			if (!UpdateTextAndImage())
 				UpdateImage();
 			UpdatePadding();
@@ -257,9 +260,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		bool UpdateTextAndImage()
 		{
-			if (_disposed || _renderer == null || _element == null || View?.LayoutParameters == null)
+			if (_disposed || _renderer == null || _element == null)
 				return false;
 
+			if (View?.LayoutParameters == null && _hasLayoutOccurred)
+				return false;
+			
 			AppCompatButton view = View;
 			if (view == null)
 				return false;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		ButtonLayoutManager _buttonLayoutManager;
 		IPlatformElementConfiguration<PlatformConfiguration.Android, Button> _platformElementConfiguration;
 		Button _button;
+		bool _hasLayoutOccurred;
 
 		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
 		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
@@ -245,7 +246,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if(Control?.LayoutParameters == null)
+			if(Control?.LayoutParameters == null && _hasLayoutOccurred)
 			{
 				ElementPropertyChanged?.Invoke(this, e);
 				return;
@@ -275,6 +276,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			_buttonLayoutManager?.OnLayout(changed, l, t, r, b);
 			base.OnLayout(changed, l, t, r, b);
+			_hasLayoutOccurred = true;
 		}
 
 		void SetTracker(VisualElementTracker tracker)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		float _defaultCornerRadius = -1f;
 		int? _defaultLabelFor;
 
+		bool _hasLayoutOccurred;
 		bool _disposed;
 		Frame _element;
 		GradientDrawable _backgroundDrawable;
@@ -214,6 +215,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				IVisualElementRenderer renderer = Android.Platform.GetRenderer(visualElement);
 				renderer?.UpdateLayout();
 			}
+
+			_hasLayoutOccurred = true;
 		}
 
 		public override bool OnTouchEvent(MotionEvent e)
@@ -230,7 +233,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			ElementPropertyChanged?.Invoke(this, e);
 
-			if (Control?.LayoutParameters == null)
+			if (Control?.LayoutParameters == null && _hasLayoutOccurred)
 			{
 				return;
 			}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			var imageController = (IImageController)renderer.Element;
 
 
-			if (renderer?.View?.LayoutParameters == null)
+			if (renderer?.View?.LayoutParameters == null &&(renderer is ILayoutChanges lc && lc.HasLayoutOccurred))
 			{
 				return;
 			}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 	public class ImageRenderer : AImageView, IVisualElementRenderer, IImageRendererController, IViewRenderer, ITabStop,
 		ILayoutChanges
 	{
+		bool _hasLayoutOccurred;
 		bool _disposed;
 		Image _element;
 		bool _skipInvalidate;
@@ -65,6 +66,12 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 
 			base.Dispose(disposing);
+		}
+
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			base.OnLayout(changed, left, top, right, bottom);
+			_hasLayoutOccurred = true;
 		}
 
 		public override void Invalidate()
@@ -183,6 +190,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (_formsAnimationDrawable != null)
 				_formsAnimationDrawable.AnimationStopped += OnAnimationStopped;
 		}
+
+		bool ILayoutChanges.HasLayoutOccurred => _hasLayoutOccurred;
 
 		void OnAnimationStopped(object sender, FormsAnimationDrawableStateEventArgs e) =>
 			ImageElementManager.OnAnimationStopped(Element, e);

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -35,7 +35,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		VisualElementRenderer _visualElementRenderer;
 		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
 		SpannableString _spannableString;
-
+		bool _hasLayoutOccurred;
 		bool _wasFormatted;
 
 		public LabelRenderer(Context context) : base(context)
@@ -154,6 +154,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			base.OnLayout(changed, left, top, right, bottom);
 			this.RecalculateSpanPositions(Element, _spannableString, new SizeRequest(new Size(right - left, bottom - top)));
+			_hasLayoutOccurred = true;
 		}
 
 		void IVisualElementRenderer.SetElement(VisualElement element)
@@ -276,7 +277,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			ElementPropertyChanged?.Invoke(this, e);
 
-			if (Control?.LayoutParameters == null)
+			if (Control?.LayoutParameters == null && _hasLayoutOccurred)
 				return;
 
 			if (e.PropertyName == Label.HorizontalTextAlignmentProperty.PropertyName || e.PropertyName == Label.VerticalTextAlignmentProperty.PropertyName)

--- a/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
+++ b/Xamarin.Forms.Platform.Android/ILayoutChanges.cs
@@ -6,5 +6,6 @@ namespace Xamarin.Forms.Platform.Android
 	internal interface ILayoutChanges
 	{
 		event EventHandler<ALayoutChangeEventArgs> LayoutChange;
+		bool HasLayoutOccurred { get;  }
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1205,6 +1205,7 @@ namespace Xamarin.Forms.Platform.Android
 			
 			IOnTouchListener _touchListener;
 			bool _disposed;
+			bool _hasLayoutOccurred;
 
 			[Obsolete("This constructor is obsolete as of version 2.5. Please use DefaultRenderer(Context) instead.")]
 			[EditorBrowsable(EditorBrowsableState.Never)]
@@ -1303,6 +1304,14 @@ namespace Xamarin.Forms.Platform.Android
 					SetOnTouchListener(null); 
 
 				base.Dispose(disposing);
+			}
+
+			bool ILayoutChanges.HasLayoutOccurred => _hasLayoutOccurred;
+
+			protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+			{
+				base.OnLayout(changed, left, top, right, bottom);
+				_hasLayoutOccurred = true;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Regressed as part of https://github.com/xamarin/Xamarin.Forms/pull/9629
If the control hasn't performed a layout cycle yet then just allow it to set initial parameters

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10102 
- fixes #10290
- fixes #10197

### Platforms Affected ### 
- Android

### Testing Procedure ###
- UI Tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
