### PR TITLE
Fix coloring of UWP Entry buttons

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsAutoSuggestBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsAutoSuggestBoxStyle.xaml
@@ -128,7 +128,7 @@
                               BorderThickness="{TemplateBinding BorderThickness}"
                               Background="{ThemeResource TextBoxButtonBackgroundThemeBrush}">
 													<TextBlock x:Name="GlyphElement"
-                                   Foreground="{ThemeResource SystemControlBackgroundChromeBlackMediumBrush}"
+                                   Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                                    VerticalAlignment="Center"
                                    HorizontalAlignment="Center"
                                    FontStyle="Normal"
@@ -189,6 +189,7 @@
                               BorderThickness="{TemplateBinding BorderThickness}"
                               Background="{ThemeResource TextBoxButtonBackgroundThemeBrush}">
 													<ContentPresenter x:Name="ContentPresenter"
+                                          Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}"
                                           Content="{TemplateBinding Content}"
                                           ContentTransitions="{TemplateBinding ContentTransitions}"
                                           ContentTemplate="{TemplateBinding ContentTemplate}"

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -67,7 +67,7 @@
 													</VisualStateGroup>
 												</VisualStateManager.VisualStateGroups>
 												<TextBlock x:Name="GlyphElement" AutomationProperties.AccessibilityView="Raw"
-												           Foreground="{ThemeResource SystemControlForegroundChromeBlackMediumBrush}" FontStyle="Normal"
+												           Foreground="{ThemeResource SystemControlForegroundBaseHighBrush}" FontStyle="Normal"
 												           FontSize="12" FontFamily="{ThemeResource SymbolThemeFontFamily}" HorizontalAlignment="Center"
 												           Text="&#xE10A;" VerticalAlignment="Center" />
 											</Grid>


### PR DESCRIPTION
### Description of Change ###

Makes sure the clear and search button on UWP also get the right color when switching between light and dark

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- related #10150 (this issue was mentioned in a comment there)

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

#### Before (notice no clear and search button in the entry)
![](https://user-images.githubusercontent.com/939291/78037056-51d79800-736b-11ea-8616-1c251e1a3e91.png)

#### After

![image](https://user-images.githubusercontent.com/939291/79235458-ecf06780-7e6b-11ea-88e0-05c1b73931ea.png)

### Testing Procedure ###
Open gallery app, switch Windows to dark and see if the icons in the entry still are visible when focused, not focused etc.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
