### PR TITLE
[Android] Fix border clipping calculations

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4606.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4606.cs
@@ -84,6 +84,54 @@ namespace Xamarin.Forms.Controls.Issues
 								Source = "coffee.png"
 							}
 						}
+					},
+					new Label()
+					{
+						Text = "The box view height should match the button border width"
+					},
+					new BoxView()
+					{
+						BackgroundColor = Color.Red,
+						HeightRequest = 2
+					},
+					new Button()
+					{
+						BorderColor = Color.Red,
+						BackgroundColor = Color.White,
+						CornerRadius = 25,
+						BorderWidth = 2
+					},
+					new Label()
+					{
+						Text = "The box view height should match the button border width"
+					},
+					new BoxView()
+					{
+						BackgroundColor = Color.Red,
+						HeightRequest = 5
+					},
+					new Button()
+					{
+						BorderColor = Color.Red,
+						BackgroundColor = Color.White,
+						CornerRadius = 25,
+						BorderWidth = 5
+					},
+					new Label()
+					{
+						Text = "The box view height should match the button border width"
+					},
+					new BoxView()
+					{
+						BackgroundColor = Color.Red,
+						HeightRequest = 1
+					},
+					new Button()
+					{
+						BorderColor = Color.Red,
+						BackgroundColor = Color.White,
+						CornerRadius = 25,
+						BorderWidth = 1
 					}
 				}
 			};

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -240,8 +240,8 @@ namespace Xamarin.Forms.Platform.Android
 					// adjust border radius so outer edge of stroke is same radius as border radius of background
 					float borderRadius = Math.Max(ConvertCornerRadiusToPixels() - inset, 0);
 
-					RectF rect = new RectF(0, 0, width, height);
-					rect.Inset(inset + PaddingLeft, inset + PaddingTop);
+					RectF rect = new RectF(0, 0, width , height);
+					rect.Inset(PaddingLeft, PaddingTop);
 					path.AddRoundRect(rect, borderRadius, borderRadius, Path.Direction.Ccw);
 
 					canvas.Save();


### PR DESCRIPTION
### Description of Change ###
Don't inset the clipping path by the border width

### Issues Resolved ### 
- fixes #10269 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Check included ui test

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
