### PR TITLE
[Tizen] Applying new style on SwitchCell

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
@@ -11,10 +11,10 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 		}
 
-		public SwitchCellRenderer() : this("default")
+		public SwitchCellRenderer() : this(Device.Idiom == TargetIdiom.Watch ? "1text.1icon.1" : "default")
 		{
 			MainPart = "elm.text";
-			SwitchPart = "elm.swallow.end";
+			SwitchPart = Device.Idiom == TargetIdiom.Watch ? "elm.icon" : "elm.swallow.end";
 		}
 
 		protected string MainPart { get; set; }


### PR DESCRIPTION
### Description of Change ###

There used to be only one `SwitchCell` style on Tizen platform which has no fish-eye effect and no text sliding when the text is longer than a cell size.
This PR is about applying a new `SwitchCell` style to `Watch` target idiom. This style includes the fish-eye effect and text sliding effect.


### Issues Resolved ### 

- N/A

### API Changes ###

 None

### Platforms Affected ### 

- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Now the `SwitchCell` on Watch target idiom has fish-eye and text sliding effects as default.

### Before/After Screenshots ### 
|As-is|To-be|
|--|--|
|Fisheye Effect Off & Text slide Off | Fisheye Effect On & Text slide On|
|![switchcell_default2](https://user-images.githubusercontent.com/14328614/79452424-1bfd0980-8023-11ea-8e4a-a9a907aa84da.gif) |![switchcell_styleonwatch](https://user-images.githubusercontent.com/14328614/79452463-28816200-8023-11ea-8c3e-a12d719f118c.gif)|



### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
