### PR TITLE
[Enhancement] Switch: Added OffColor property

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/SwitchCoreGalleryPage.cs
@@ -21,7 +21,6 @@ namespace Xamarin.Forms.Controls
 			var isToggledContainer = new ValueViewContainer<Switch>(Test.Switch.IsToggled, new Switch(), "IsToggled", value => value.ToString());
 
 			var onColoredSwitch = new Switch() { OnColor = Color.HotPink };
-
 			var onColorContainer = new ValueViewContainer<Switch>(Test.Switch.OnColor, onColoredSwitch, "OnColor", value => value.ToString());
 			var changeOnColorButton = new Button
 			{
@@ -31,10 +30,25 @@ namespace Xamarin.Forms.Controls
 			{
 				Text = "Clear OnColor"
 			};
-			changeOnColorButton.Clicked += (s, a) => { onColoredSwitch.OnColor = Color.Red; };
+			changeOnColorButton.Clicked += (s, a) => { onColoredSwitch.OnColor = Color.Gold; };
 			clearOnColorButton.Clicked += (s, a) => { onColoredSwitch.OnColor = Color.Default; };
 			onColorContainer.ContainerLayout.Children.Add(changeOnColorButton);
 			onColorContainer.ContainerLayout.Children.Add(clearOnColorButton);
+
+			var offColoredSwitch = new Switch() { OffColor = Color.Purple };
+			var offColorContainer = new ValueViewContainer<Switch>(Test.Switch.OffColor, offColoredSwitch, "OffColor", value => value.ToString());
+			var changeOffColorButton = new Button
+			{
+				Text = "Change OffColor"
+			};
+			var clearOffColorButton = new Button
+			{
+				Text = "Clear OffColor"
+			};
+			changeOffColorButton.Clicked += (s, a) => { offColoredSwitch.OffColor = Color.Green; };
+			clearOffColorButton.Clicked += (s, a) => { offColoredSwitch.OffColor = Color.Default; };
+			offColorContainer.ContainerLayout.Children.Add(changeOffColorButton);
+			offColorContainer.ContainerLayout.Children.Add(clearOffColorButton);
 
 			var thumbColorSwitch = new Switch() { ThumbColor = Color.Yellow };
 			var thumbColorContainer = new ValueViewContainer<Switch>(Test.Switch.ThumbColor, thumbColorSwitch, nameof(Switch.ThumbColor), value => value.ToString());
@@ -45,6 +59,7 @@ namespace Xamarin.Forms.Controls
 
 			Add(isToggledContainer);
 			Add(onColorContainer);
+			Add(offColorContainer);
 			Add(thumbColorContainer);
 		}
 	}

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -117,6 +117,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("-xf-visual", typeof(VisualElement), nameof(VisualElement.VisualProperty))]
 [assembly: StyleProperty("-xf-vertical-text-alignment", typeof(Label), nameof(TextAlignmentElement.VerticalTextAlignmentProperty))]
 [assembly: StyleProperty("-xf-thumb-color", typeof(Switch), nameof(Switch.ThumbColorProperty))]
+[assembly: StyleProperty("-xf-off-color", typeof(Switch), nameof(Switch.OffColorProperty))]
 
 //shell
 [assembly: StyleProperty("-xf-flyout-background", typeof(Shell), nameof(Shell.FlyoutBackgroundColorProperty))]

--- a/Xamarin.Forms.Core/Switch.cs
+++ b/Xamarin.Forms.Core/Switch.cs
@@ -17,12 +17,20 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty OnColorProperty = BindableProperty.Create(nameof(OnColor), typeof(Color), typeof(Switch), Color.Default);
 
+		public static readonly BindableProperty OffColorProperty = BindableProperty.Create(nameof(OffColor), typeof(Color), typeof(Switch), Color.Default);
+
 		public static readonly BindableProperty ThumbColorProperty = BindableProperty.Create(nameof(ThumbColor), typeof(Color), typeof(Switch), Color.Default);
 
 		public Color OnColor
 		{
 			get { return (Color)GetValue(OnColorProperty); }
 			set { SetValue(OnColorProperty, value); }
+		}
+
+		public Color OffColor
+		{
+			get => (Color)GetValue(OffColorProperty);
+			set => SetValue(OffColorProperty, value);
 		}
 
 		public Color ThumbColor

--- a/Xamarin.Forms.CustomAttributes/TestAttributes.cs
+++ b/Xamarin.Forms.CustomAttributes/TestAttributes.cs
@@ -747,6 +747,7 @@ namespace Xamarin.Forms.CustomAttributes
 		{
 			IsToggled,
 			OnColor,
+			OffColor,
 			ThumbColor
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 		void CompoundButton.IOnCheckedChangeListener.OnCheckedChanged(CompoundButton buttonView, bool isChecked)
 		{
 			((IViewController)Element).SetValueFromRenderer(Switch.IsToggledProperty, isChecked);
-			UpdateOnColor();
+			UpdateOnOffColor();
 		}
 
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
@@ -101,7 +101,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				e.NewElement.Toggled += HandleToggled;
 				Control.Checked = e.NewElement.IsToggled;
-				UpdateOnColor();
+				UpdateOnOffColor();
 				UpdateThumbColor();
 			}
 		}
@@ -115,32 +115,35 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Switch.OnColorProperty.PropertyName)
-				UpdateOnColor();
+			if (e.PropertyName == Switch.OnColorProperty.PropertyName ||
+				e.PropertyName == Switch.OffColorProperty.PropertyName)
+				UpdateOnOffColor();
 			else if (e.PropertyName == Slider.ThumbColorProperty.PropertyName)
 				UpdateThumbColor();
 		}
 
-		void UpdateOnColor()
+		void UpdateOnOffColor()
 		{
 			if (Element == null || Control == null)
 				return;
+
+			Control.TrackDrawable?.ClearColorFilter();
 
 			if (Control.Checked)
 			{
 				if (Element.OnColor == Color.Default)
 				{
 					Control.TrackDrawable = _defaultTrackDrawable;
+					return;
 				}
-				else
-				{
-					Control.TrackDrawable?.SetColorFilter(Element.OnColor, FilterMode.SrcAtop);
-				}
+				Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), FilterMode.SrcAtop);
+				return;
 			}
-			else
-			{
-				Control.TrackDrawable?.ClearColorFilter();
-			}
+
+			if (Element.OffColor == Color.Default)
+				return;
+
+			Control.TrackDrawable?.SetColorFilter(Element.OffColor.ToAndroid(), FilterMode.SrcAtop);
 		}
 
 		void UpdateThumbColor()

--- a/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwitchRenderer.cs
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Platform.Android
 		void CompoundButton.IOnCheckedChangeListener.OnCheckedChanged(CompoundButton buttonView, bool isChecked)
 		{
 			((IViewController)Element).SetValueFromRenderer(Switch.IsToggledProperty, isChecked);
-			UpdateOnColor();
+			UpdateOnOffColor();
 		}
 
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
@@ -92,7 +92,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				e.NewElement.Toggled += HandleToggled;
 				Control.Checked = e.NewElement.IsToggled;
-				UpdateOnColor();
+				UpdateOnOffColor();
 				UpdateThumbColor();
 			}
 		}
@@ -101,35 +101,39 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Switch.OnColorProperty.PropertyName)
-				UpdateOnColor();
+			if (e.PropertyName == Switch.OnColorProperty.PropertyName ||
+				e.PropertyName == Switch.OffColorProperty.PropertyName)
+				UpdateOnOffColor();
 			else if (e.PropertyName == Slider.ThumbColorProperty.PropertyName)
 				UpdateThumbColor();
 		}
 
-		void UpdateOnColor()
+		void UpdateOnOffColor()
 		{
-			if (Element != null)
+			if (Element == null || Control == null)
+				return;
+
+			Control.TrackDrawable?.ClearColorFilter();
+
+			if (Control.Checked)
 			{
-				if (Control.Checked)
+				if (Element.OnColor == Color.Default)
 				{
-					if (Element.OnColor == Color.Default)
-					{
-						Control.TrackDrawable = _defaultTrackDrawable;
-					}
-					else
-					{
-						if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
-						{
-							Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), FilterMode.SrcAtop);
-						}
-					}
+					Control.TrackDrawable = _defaultTrackDrawable;
+					return;
 				}
-				else
-				{
-					Control.TrackDrawable?.ClearColorFilter();
-				}
+
+				if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
+					Control.TrackDrawable?.SetColorFilter(Element.OnColor.ToAndroid(), FilterMode.SrcAtop);
+				
+				return;
 			}
+
+			if (Element.OffColor == Color.Default)
+				return;
+
+			if (Forms.SdkInt >= BuildVersionCodes.JellyBean)
+				Control.TrackDrawable?.SetColorFilter(Element.OffColor.ToAndroid(), FilterMode.SrcAtop);
 		}
 
 		void UpdateThumbColor()

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
@@ -69,13 +69,11 @@ namespace Xamarin.Forms.Platform.iOS
 			if (IsElementOrControlEmpty)
 				return;
 
-			if (!Forms.IsiOS13OrNewer)
-			{
-				HandleOffColorForOlderSystemVersions(Element.BackgroundColor);
-				return;
-			}
+			UIView offColorView = Control;
+			var subviewDepth = Forms.IsiOS13OrNewer ? 2 : 3;
+			for (var i = 0; i < subviewDepth; i++)
+				offColorView = offColorView?.Subviews?.FirstOrDefault();
 
-			var offColorView = Control.Subviews.FirstOrDefault()?.Subviews.FirstOrDefault();
 			if (offColorView == null)
 				return;
 			
@@ -102,35 +100,6 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnElementToggled(object sender, EventArgs e)
 		{
 			Control.SetState(Element.IsToggled, true);
-		}
-
-		protected override void SetBackgroundColor(Color color)
-		{
-			if (IsElementOrControlEmpty)
-				return;
-
-			if (!Forms.IsiOS13OrNewer)
-			{
-				HandleOffColorForOlderSystemVersions(Element.BackgroundColor);
-				return;
-			}
-
-			base.SetBackgroundColor(color);
-		}
-
-		void HandleOffColorForOlderSystemVersions(Color backgroundColor)
-		{
-			if (Element.OffColor == Color.Default || backgroundColor != Color.Default)
-			{
-				Control.TintColor = _defaultOffColor;
-				Control.Layer.CornerRadius = 0;
-				base.SetBackgroundColor(backgroundColor);
-				return;
-			}
-			var offColor = Element.OffColor.ToUIColor();
-			Control.TintColor = offColor;
-			Control.BackgroundColor = offColor;
-			Control.Layer.CornerRadius = Control.Bounds.Height / 2;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###
Added possibility to set "Off" color of Switch control.

**Note: iOS versions less than 13**
Off-color is a TintColor + Background colors, that's why the code looks like it looks.
If BackgroundColor is set for a switch on, we ignore OffColor for backward compatibility.
But since iOS 13 Off-color works independently from BackgroundColor.

Some info I found: https://medium.com/@myshkinasasha/ios-13-uiswitch-modal-presentation-8e91c9add7f1

### Issues Resolved ### 
- fixes #10341 

### API Changes ###
Added:
 - Color Switch.OffColor { get; set; } //Bindable Property

### Platforms Affected ### 
- Core
- iOS
- Android

### Behavioral/Visual Changes ###
![Apr-17-2020 04-01-07](https://user-images.githubusercontent.com/10124814/79521096-fd1d6800-8060-11ea-9a7f-d5b2eb401fd8.gif)

### Testing Procedure ###
The playground
```csharp
MainPage = new ContentPage
{
	Content = new StackLayout
	{
		Padding = new Thickness(100),
		Children =
		{
			new Label { Text = "Regular" },
			new Switch(),
			new Label { Text = "With On Color only" },
			new Switch { OnColor = Color.Gold },
			new Label { Text = "With Off Color only" },
			new Switch { OffColor = Color.Aqua },
			new Label { Text = "With On/Off" },
			new Switch { OnColor = Color.Gold, OffColor = Color.Aqua }
		}
	}
};
```


