### PR TITLE
[Tizen] Fix exception updating empty OverlayContent

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -173,9 +173,15 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateOverlayContent()
 		{
-			var renderer = Platform.GetOrCreateRenderer(Specific.GetOverlayContent(_application));
-			(renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
-			Forms.BaseLayout.SetPartContent("elm.swallow.overlay", renderer?.NativeView);
+			EvasObject nativeView = null;
+			var content = Specific.GetOverlayContent(_application);
+			if(content != null)
+			{
+				var renderer = Platform.GetOrCreateRenderer(content);
+				(renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
+				nativeView = renderer?.NativeView;
+			}
+			Forms.BaseLayout.SetPartContent("elm.swallow.overlay", nativeView);
 		}
 
 		void SetPage(Page page)


### PR DESCRIPTION
### Description of Change ###

This PR fixes the corner case of https://github.com/xamarin/Xamarin.Forms/pull/10310 which can occur an exception when `OverlayContent` is empty.

### Issues Resolved ### 
- fixes the possible corner case of https://github.com/xamarin/Xamarin.Forms/pull/10310.

### API Changes ###

 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
