### PR TITLE
Propagate StyleClass from Items correctly

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1127,7 +1127,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			shell.Items.Add(shellItem);
 
-			var flyoutItemTemplate = Shell.GetItemTemplate(shellItem);
+			var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellItem);
 			var thing = (Element)flyoutItemTemplate.CreateContent();
 			thing.Parent = shell;
 
@@ -1154,7 +1154,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			shell.Items.Add(shellItem);
 
-			var flyoutItemTemplate = Shell.GetItemTemplate(shellItem);
+			var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellItem);
 			var thing = (Element)flyoutItemTemplate.CreateContent();
 			thing.Parent = shell;
 
@@ -1182,7 +1182,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.Items.Add(shellItem);
 			shell.Items.Add(shellMenuItem);
 
-			var flyoutItemTemplate = Shell.GetItemTemplate(shellMenuItem);
+			var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellMenuItem);
 			var thing = (Element)flyoutItemTemplate.CreateContent();
 			thing.Parent = shell;
 
@@ -1198,7 +1198,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Setters = {
 					new Setter { Property = Label.VerticalTextAlignmentProperty, Value = TextAlignment.Start }
 				},
-				Class = "FlyoutItemLabelStyle",
+				Class = FlyoutItem.LabelStyle,
 			};
 
 			Shell shell = new Shell();
@@ -1207,7 +1207,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			shell.Items.Add(shellItem);
 
-			var flyoutItemTemplate = Shell.GetItemTemplate(shellItem);
+			var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellItem);
 			var thing = (Element)flyoutItemTemplate.CreateContent();
 			thing.Parent = shell;
 
@@ -1310,7 +1310,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		//	shell.Items.Add(shellItem);
 
-		//	var flyoutItemTemplate = Shell.GetItemTemplate(shellItem);
+		//	var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellItem);
 		//	var thing = (Element)flyoutItemTemplate.CreateContent();
 		//	thing.Parent = shell;
 
@@ -1339,7 +1339,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		//	shell.Items.Add(shellItem);
 		//	shell.Items.Add(shellMenuItem);
 
-		//	var flyoutItemTemplate = Shell.GetItemTemplate(shellMenuItem);
+		//	var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellMenuItem);
 		//	var thing = (Element)flyoutItemTemplate.CreateContent();
 		//	thing.Parent = shell;
 

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -320,8 +320,9 @@ namespace Xamarin.Forms
 					Class = DefaultFlyoutItemLayoutStyle,
 				};
 
+				
 				var groups = new VisualStateGroupList();
-
+				
 				var commonGroup = new VisualStateGroup();
 				commonGroup.Name = "CommonStates";
 				groups.Add(commonGroup);

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellFlyoutItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellFlyoutItemRenderer.cs
@@ -40,21 +40,14 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			var bo = (BindableObject)DataContext;
-			DataTemplate dataTemplate;
-			if (bo is IMenuItemController)
-			{
-				dataTemplate = Shell.GetMenuItemTemplate(bo);
-			}
-			else
-			{
-				dataTemplate = Shell.GetItemTemplate(bo);
-			}
+			var shell = (bo as Element)?.FindParent<Shell>();
+			DataTemplate dataTemplate = (shell as IShellController)?.GetFlyoutItemDataTemplate(bo);
 
 			if(dataTemplate != null)
 			{
 				_content = (View)dataTemplate.CreateContent();
 				_content.BindingContext = bo;
-				_content.Parent = (bo as Element)?.FindParent<Shell>();
+				_content.Parent = shell;
 				Content = new ViewToRendererConverter.WrapperControl(_content);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

StyleClass set on ShellItem wasn't propagating from the ShellItem to the template correctly

### Issues Resolved ### 
- fixes #10382

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
