### PR TITLE
Give elements inside flyout a namescope for VSM

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1162,6 +1162,61 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("MenuItemTemplate", ((Label)sc.GetFlyoutItemDataTemplate(menuItem.MenuItem).CreateContent()).Text);
 		}
 
+		[Test]
+		public void FlyoutItemLabelVisualStateManager()
+		{
+			var groups = new VisualStateGroupList();
+			var commonGroup = new VisualStateGroup();
+			commonGroup.Name = "CommonStates";
+			groups.Add(commonGroup);
+			var normalState = new VisualState();
+			normalState.Name = "Normal";
+			var selectedState = new VisualState();
+			selectedState.Name = "Selected";
+
+			normalState.Setters.Add(new Setter
+			{
+				Property = Label.BackgroundColorProperty,
+				Value = Color.Red,
+				TargetName = "FlyoutItemLabel"
+			});
+
+			selectedState.Setters.Add(new Setter
+			{
+				Property = Label.BackgroundColorProperty,
+				Value = Color.Green,
+				TargetName = "FlyoutItemLabel"
+			});
+
+			commonGroup.States.Add(normalState);
+			commonGroup.States.Add(selectedState);
+
+			var classStyle = new Style(typeof(Grid))
+			{
+				Setters = {
+					new Setter 
+					{
+						Property = VisualStateManager.VisualStateGroupsProperty,
+						Value = groups 
+					}
+				},
+				Class = FlyoutItem.LayoutStyle,
+			};
+
+			Shell shell = new Shell();
+			shell.Resources = new ResourceDictionary { classStyle };
+			var shellItem = CreateShellItem();
+			shell.Items.Add(shellItem);
+			var flyoutItemTemplate = (shell as IShellController).GetFlyoutItemDataTemplate(shellItem);
+			var grid = (VisualElement)flyoutItemTemplate.CreateContent();
+			grid.Parent = shell;
+			var label = grid.LogicalChildren.OfType<Label>().First();
+
+			Assert.AreEqual(Color.Red, label.BackgroundColor);
+			Assert.IsTrue(VisualStateManager.GoToState(grid, "Selected"));
+			Assert.AreEqual(Color.Green, label.BackgroundColor);
+		}
+
 
 		//[Test]
 		//public void FlyoutItemLabelStyleCanBeChangedAfterRendered()

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -383,11 +383,15 @@ namespace Xamarin.Forms
 					defaultImageClass.Setters.Add(new Setter { Property = Image.MarginProperty, Value = new Thickness(12, 0, 12, 0) });					
 				}
 
-				image.SetBinding(Image.SourceProperty, iconBinding);
+				Binding imageBinding = new Binding(iconBinding);
+				defaultImageClass.Setters.Add(new Setter { Property = Image.SourceProperty, Value = imageBinding });
+
 				grid.Children.Add(image);
 
 				var label = new Label();
-				label.SetBinding(Label.TextProperty, textBinding);
+				Binding labelBinding = new Binding(textBinding);
+				defaultLabelClass.Setters.Add(new Setter { Property = Label.TextProperty, Value = labelBinding });
+
 				grid.Children.Add(label, 1, 0);
 
 				if (Device.RuntimePlatform == Device.Android)

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -275,7 +275,7 @@ namespace Xamarin.Forms
 				DefaultFlyoutItemLayoutStyle,
 				FlyoutItem.LabelStyle,
 				FlyoutItem.ImageStyle,
-				FlyoutItem.GridStyle };
+				FlyoutItem.LayoutStyle };
 
 			if (source?.Classes != null)
 				foreach (var styleClass in source.Classes)
@@ -407,6 +407,12 @@ namespace Xamarin.Forms
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.HorizontalOptionsProperty, Value = LayoutOptions.Start });
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.HorizontalTextAlignmentProperty, Value = TextAlignment.Start });
 				}
+
+				INameScope nameScope = new NameScope();
+				NameScope.SetNameScope(grid, nameScope);
+				nameScope.RegisterName("FlyoutItemLayout", grid);
+				nameScope.RegisterName("FlyoutItemImage", image);
+				nameScope.RegisterName("FlyoutItemLabel", label);
 
 				UpdateFlyoutItemStyles(grid, styleSelectable);
 				grid.Resources = new ResourceDictionary() { defaultGridClass, defaultLabelClass, defaultImageClass };

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -14,7 +14,7 @@ namespace Xamarin.Forms
 	{
 		public const string LabelStyle = "FlyoutItemLabelStyle";
 		public const string ImageStyle = "FlyoutItemImageStyle";
-		public const string GridStyle = "FlyoutItemGridStyle";
+		public const string LayoutStyle = "FlyoutItemLayoutStyle";
 
 		public FlyoutItem()
 		{


### PR DESCRIPTION

### Description of Change ###
Give the elements created for the flyout template a namescope so you can set them on the VSM

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10382

### API Changes ###


### Platforms Affected ### 
- Core/XAML (all platforms)



### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
