### PR TITLE
Fix previewer flakiness on Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -37,7 +37,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			renderer.View.SetCameraDistance(3600);
 
-			renderer.View.AddOnAttachStateChangeListener(AttachTracker.Instance);
+			if(_context.IsDesignerContext())
+			{
+				renderer.View.ViewAttachedToWindow += (_, __) => HandleViewAttachedToWindow();
+			}
+			else
+			{
+				renderer.View.AddOnAttachStateChangeListener(AttachTracker.Instance);
+			}
 		}
 
 		public void Dispose()

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _initialUpdateNeeded = true;
 		bool _layoutNeeded;
 		IVisualElementRenderer _renderer;
-
+		AttachTracker _attachTracker;
 		public VisualElementTracker(IVisualElementRenderer renderer)
 		{
 			_batchCommittedHandler = HandleRedrawNeeded;
@@ -37,12 +37,10 @@ namespace Xamarin.Forms.Platform.Android
 
 			renderer.View.SetCameraDistance(3600);
 
-			if(_context.IsDesignerContext())
+			if(!_context.IsDesignerContext())
 			{
-			}
-			else
-			{
-				renderer.View.AddOnAttachStateChangeListener(AttachTracker.Instance);
+				_attachTracker = AttachTracker.Instance;
+				renderer.View.AddOnAttachStateChangeListener(_attachTracker);
 			}
 		}
 
@@ -66,7 +64,13 @@ namespace Xamarin.Forms.Platform.Android
 				if (_renderer != null)
 				{
 					_renderer.ElementChanged -= RendererOnElementChanged;
-					_renderer.View.RemoveOnAttachStateChangeListener(AttachTracker.Instance);
+
+					if (_renderer.View.IsAlive() && _attachTracker.IsAlive())
+					{
+						_renderer.View.RemoveOnAttachStateChangeListener(_attachTracker);
+						_attachTracker = null;
+					}
+
 					_renderer = null;
 					_context = null;
 				}

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -42,6 +42,10 @@ namespace Xamarin.Forms.Platform.Android
 				_attachTracker = AttachTracker.Instance;
 				renderer.View.AddOnAttachStateChangeListener(_attachTracker);
 			}
+			else
+			{
+				_attachTracker = new AttachTracker();
+			}
 		}
 
 		public void Dispose()

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -39,7 +39,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			if(_context.IsDesignerContext())
 			{
-				renderer.View.ViewAttachedToWindow += (_, __) => HandleViewAttachedToWindow();
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

Don't use the global layout listener if you're in designer mode. The designer just goes nuts and disposes of everything so global listeners will sometimes cause disposal exceptions


### Platforms Affected ### 
- Android

### Testing Procedure ###
- tests pass
- pull down the nuget and test the previewer on vsmac and vs windows

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
