### PR TITLE
Setup Xcode provisioning through variables and switch to channels

### DIFF
--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -30,4 +30,10 @@
     <AndroidTargetFrameworks Condition="'$(Use2017)' == 'true'">MonoAndroid90;</AndroidTargetFrameworks>
     <AndroidTargetFrameworks Condition="'$(Use2017)' == 'false'">MonoAndroid90;MonoAndroid10.0;</AndroidTargetFrameworks>
   </PropertyGroup>
+
+  <!-- Auto install any missing Android SDKs -->
+  <PropertyGroup Condition="'$(CI)' == 'true'">
+    <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">True</AndroidRestoreOnBuild>
+    <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">True</AcceptAndroidSDKLicenses>
+  </PropertyGroup>
 </Project>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,7 +138,8 @@ stages:
           name: $(vs2019VmPool)
           vmImage: $(vs2019VmImage)
           demands: 
-            msbuild
+            - Agent.OS -equals Windows_NT
+            - msbuild
         variables:
           FormsIdAppend: ''
           buildConfiguration: $(DefaultBuildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -188,7 +188,7 @@ stages:
     - job: osx_2017
       workspace:
         clean: all
-      displayName: OSX Phase 201
+      displayName: OSX Phase 2017
       pool:
         name:  $(osx2017VmPool)
         vmImage: 'macOS-10.14'

--- a/build.cake
+++ b/build.cake
@@ -44,11 +44,12 @@ bool buildForVS2017 = Convert.ToBoolean(Argument("buildForVS2017", "false"));
 
 string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
-    (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
+    (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : System.IO.Path.GetFullPath("~/Library/Developer/Xamarin/android-sdk-macosx"));
 
 string[] androidSdkManagerInstalls = new [] { "platforms;android-24", "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
 
 
+Information ("ANDROID_HOME: {0}", ANDROID_HOME);
 Information ("Team Project: {0}", teamProject);
 Information ("buildForVS2017: {0}", buildForVS2017);
 

--- a/build.cake
+++ b/build.cake
@@ -111,12 +111,21 @@ if(String.IsNullOrWhiteSpace(monoSDK_macos))
         monoSDK_macos = $"https://download.mono-project.com/archive/{monoMajorVersion}/macos-10-universal/MonoFramework-MDK-{monoVersion}.macos10.xamarin.universal.pkg";
     }
 }
-    
 
-string androidSDK = IsRunningOnWindows() ? "" : androidSDK_macos;
-string monoSDK = IsRunningOnWindows() ? "" : monoSDK_macos;
-string iosSDK = IsRunningOnWindows() ? "" : iOSSDK_macos;
-string macSDK  = IsRunningOnWindows() ? "" : macSDK_macos;
+androidSDK_macos = Argument("ANDROID_SDK_MAC", androidSDK_macos);
+iOSSDK_macos = Argument("IOS_SDK_MAC", iOSSDK_macos);
+monoSDK_macos = Argument("MONO_SDK_MAC", monoSDK_macos);
+macSDK_macos = Argument("MAC_SDK_MAC", macSDK_macos);
+
+string androidSDK_windows = Argument("ANDROID_SDK_WINDOWS", "");
+string iOSSDK_windows = Argument("IOS_SDK_WINDOWS", "");
+string monoSDK_windows = Argument("MONO_SDK_WINDOWS", "");
+string macSDK_windows = Argument("MAC_SDK_WINDOWS", "");
+
+string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
+string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;
+string iosSDK = IsRunningOnWindows() ? iOSSDK_windows : iOSSDK_macos;
+string macSDK  = IsRunningOnWindows() ? macSDK_windows : macSDK_macos;
 
 //////////////////////////////////////////////////////////////////////
 // TASKS

--- a/build.cake
+++ b/build.cake
@@ -117,10 +117,10 @@ iOSSDK_macos = Argument("IOS_SDK_MAC", iOSSDK_macos);
 monoSDK_macos = Argument("MONO_SDK_MAC", monoSDK_macos);
 macSDK_macos = Argument("MAC_SDK_MAC", macSDK_macos);
 
-string androidSDK_windows = Argument("ANDROID_SDK_WINDOWS", "");
-string iOSSDK_windows = Argument("IOS_SDK_WINDOWS", "");
-string monoSDK_windows = Argument("MONO_SDK_WINDOWS", "");
-string macSDK_windows = Argument("MAC_SDK_WINDOWS", "");
+string androidSDK_windows = EnvironmentVariable("ANDROID_SDK_WINDOWS", "");
+string iOSSDK_windows = EnvironmentVariable("IOS_SDK_WINDOWS", "");
+string monoSDK_windows = EnvironmentVariable("MONO_SDK_WINDOWS", "");
+string macSDK_windows = EnvironmentVariable("MAC_SDK_WINDOWS", "");
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build.cake
+++ b/build.cake
@@ -43,8 +43,8 @@ var teamProject = Argument("TeamProject", "");
 bool buildForVS2017 = Convert.ToBoolean(Argument("buildForVS2017", "false"));
 
 string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
-var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
-    (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : System.IO.Path.GetFullPath("~/Library/Developer/Xamarin/android-sdk-macosx"));
+var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??
+    (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : System.IO.Path.Combine(EnvironmentVariable("HOME"), "/Library/Developer/Xamarin/android-sdk-macosx"));
 
 string[] androidSdkManagerInstalls = new [] { "platforms;android-24", "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
 

--- a/build.cake
+++ b/build.cake
@@ -44,7 +44,7 @@ bool buildForVS2017 = Convert.ToBoolean(Argument("buildForVS2017", "false"));
 
 string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??
-    (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : System.IO.Path.Combine(EnvironmentVariable("HOME"), "/Library/Developer/Xamarin/android-sdk-macosx"));
+    (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
 string[] androidSdkManagerInstalls = new [] { "platforms;android-24", "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
 
@@ -164,9 +164,11 @@ Task("provision-androidsdk")
         if(androidSdkManagerInstalls.Length > 0)
         {
             var androidSdkSettings = new AndroidSdkManagerToolSettings {
-                SdkRoot = ANDROID_HOME,
                 SkipVersionCheck = true
             };
+
+            if(!String.IsNullOrWhiteSpace(ANDROID_HOME))            
+                androidSdkSettings.SdkRoot = ANDROID_HOME;
 
             AcceptLicenses (androidSdkSettings);
             AndroidSdkManagerUpdateAll (androidSdkSettings);

--- a/build.cake
+++ b/build.cake
@@ -127,6 +127,12 @@ string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;
 string iosSDK = IsRunningOnWindows() ? iOSSDK_windows : iOSSDK_macos;
 string macSDK  = IsRunningOnWindows() ? macSDK_windows : macSDK_macos;
 
+
+Information ("androidSDK: {0}", androidSDK);
+Information ("monoSDK: {0}", monoSDK);
+Information ("macSDK: {0}", macSDK);
+Information ("iosSDK: {0}", iosSDK);
+
 //////////////////////////////////////////////////////////////////////
 // TASKS
 //////////////////////////////////////////////////////////////////////
@@ -150,6 +156,8 @@ Task("provision-macsdk")
             else
                 await Boots (Product.XamarinMac, releaseChannel);
         }
+        else if(!String.IsNullOrWhiteSpace(macSDK))
+            await Boots(macSDK);
     });
 
 Task("provision-iossdk")
@@ -162,6 +170,8 @@ Task("provision-iossdk")
             else
                 await Boots (Product.XamariniOS, releaseChannel);
         }
+        else if(!String.IsNullOrWhiteSpace(iosSDK))
+            await Boots(iosSDK);
     });
 
 Task("provision-androidsdk")
@@ -191,6 +201,8 @@ Task("provision-androidsdk")
             else
                 await Boots (Product.XamarinAndroid, releaseChannel);
         }
+        else if(!String.IsNullOrWhiteSpace(androidSDK))
+            await Boots(androidSDK);
     });
 
 Task("provision-monosdk")
@@ -204,6 +216,8 @@ Task("provision-monosdk")
             else
                 await Boots (Product.Mono, releaseChannel);
         }
+        else if(!String.IsNullOrWhiteSpace(monoSDK))
+            await Boots(monoSDK);
     });
 
 Task("provision")

--- a/build.cake
+++ b/build.cake
@@ -46,7 +46,7 @@ string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (st
 var ANDROID_HOME = EnvironmentVariable ("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
-string[] androidSdkManagerInstalls = new string[0];//new [] { "platforms;android-24", "platforms;android-28"};
+string[] androidSdkManagerInstalls = new [] { "platforms;android-24", "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
 
 
 Information ("Team Project: {0}", teamProject);

--- a/build.cake
+++ b/build.cake
@@ -46,7 +46,7 @@ string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (st
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
 
-string[] androidSdkManagerInstalls = new [] { "platforms;android-24", "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
+string[] androidSdkManagerInstalls = new string[0]; //new [] { "platforms;android-24", "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
 
 
 Information ("ANDROID_HOME: {0}", ANDROID_HOME);

--- a/build.cake
+++ b/build.cake
@@ -37,8 +37,8 @@ PowerShell:
 var target = Argument("target", "Default");
 var configuration = Argument("configuration", "Debug");
 var packageVersion = Argument("packageVersion", "");
-var releaseChannelArg = Argument("releaseChannel", "Stable");
-releaseChannelArg = EnvironmentVariable("releaseChannel") ?? releaseChannelArg;
+var releaseChannelArg = Argument("CHANNEL", "Stable");
+releaseChannelArg = EnvironmentVariable("CHANNEL") ?? releaseChannelArg;
 var teamProject = Argument("TeamProject", "");
 bool buildForVS2017 = Convert.ToBoolean(Argument("buildForVS2017", "false"));
 

--- a/build.cake
+++ b/build.cake
@@ -112,15 +112,23 @@ if(String.IsNullOrWhiteSpace(monoSDK_macos))
     }
 }
 
-androidSDK_macos = Argument("ANDROID_SDK_MAC", androidSDK_macos);
-iOSSDK_macos = Argument("IOS_SDK_MAC", iOSSDK_macos);
-monoSDK_macos = Argument("MONO_SDK_MAC", monoSDK_macos);
-macSDK_macos = Argument("MAC_SDK_MAC", macSDK_macos);
+string androidSDK_windows = "";
+string iOSSDK_windows = "";
+string monoSDK_windows = "";
+string macSDK_windows = "";
 
-string androidSDK_windows = EnvironmentVariable("ANDROID_SDK_WINDOWS", "");
-string iOSSDK_windows = EnvironmentVariable("IOS_SDK_WINDOWS", "");
-string monoSDK_windows = EnvironmentVariable("MONO_SDK_WINDOWS", "");
-string macSDK_windows = EnvironmentVariable("MAC_SDK_WINDOWS", "");
+if(!buildForVS2017)
+{
+    androidSDK_macos = EnvironmentVariable("ANDROID_SDK_MAC", androidSDK_macos);
+    iOSSDK_macos = EnvironmentVariable("IOS_SDK_MAC", iOSSDK_macos);
+    monoSDK_macos = EnvironmentVariable("MONO_SDK_MAC", monoSDK_macos);
+    macSDK_macos = EnvironmentVariable("MAC_SDK_MAC", macSDK_macos);
+
+    androidSDK_windows = EnvironmentVariable("ANDROID_SDK_WINDOWS", "");
+    iOSSDK_windows = EnvironmentVariable("IOS_SDK_WINDOWS", "");
+    monoSDK_windows = EnvironmentVariable("MONO_SDK_WINDOWS", "");
+    macSDK_windows = EnvironmentVariable("MAC_SDK_WINDOWS", "");
+}
 
 string androidSDK = IsRunningOnWindows() ? androidSDK_windows : androidSDK_macos;
 string monoSDK = IsRunningOnWindows() ? monoSDK_windows : monoSDK_macos;

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -13,18 +13,18 @@ string iOSSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 
 
-string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");
-
-if(releaseChannel == "Preview")
-{
-	XamarinChannel("Preview");
-}
-else{
-	XamarinChannel("Stable");
-}
-
 if (IsMac)
 {
+	string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");
+
+	if(releaseChannel == "Preview")
+	{
+		XamarinChannel("Preview");
+	}
+	else{
+		XamarinChannel("Stable");
+	}
+
   	if(!String.IsNullOrEmpty(monoSDK_macos))
     	Item ("Mono", monoVersion)
       		.Source (_ => monoSDK_macos);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -26,7 +26,7 @@ if (IsMac)
 	ForceJavaCleanup();
 	Item (XreItem.Java_OpenJDK_1_8_0_25);
 
-	string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");
+	string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");
 
 	if(releaseChannel == "Preview")
 	{

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -51,17 +51,6 @@ if (IsMac)
 	if(!String.IsNullOrEmpty(macSDK_macos))
 		Item ("Xamarin.Mac", "6.16.0.11")
       		.Source (_ => macSDK_macos);
-
-    /*var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
-    if (!string.IsNullOrEmpty(dotnetVersion))
-	  {
-		// VSTS installs into a non-default location. Let's hardcode it here because why not.
-		var vstsBaseInstallPath = Path.Combine (Environment.GetEnvironmentVariable ("HOME"), ".dotnet", "sdk");
-		var vstsInstallPath = Path.Combine (vstsBaseInstallPath, dotnetVersion);
-		var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
-		if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
-			ln (defaultInstallLocation, vstsInstallPath);
-	  }*/
 }
 else
 {
@@ -83,14 +72,8 @@ else
 
 }
 
-// Item(XreItem.Java_OpenJDK_1_8_0_25);
-AndroidSdk ().ApiLevel((AndroidApiLevel)24);
-AndroidSdk ().ApiLevel((AndroidApiLevel)28);
-AndroidSdk ().ApiLevel((AndroidApiLevel)29);
-
-void ln (string source, string destination)
-{
-	Console.WriteLine ($"ln -sf {source} {destination}");
-	if (!Config.DryRun)
-		Exec ("/bin/ln", "-sf", source, destination);
-}
+AndroidSdk()
+	.ApiLevel((AndroidApiLevel)24)
+	.ApiLevel((AndroidApiLevel)28)
+	.ApiLevel((AndroidApiLevel)29)
+	.SdkManagerPackage ("build-tools;29.0.3");

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -7,31 +7,39 @@ string androidSDK_windows = "";//"https://download.visualstudio.microsoft.com/do
 string iOSSDK_windows = "";
 string macSDK_windows = "";
 
-string androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-string monoSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/cf7090bee19401076987a57cd12f11e5/xamarin.ios-13.16.0.11.pkg";
-string macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
+string androidSDK_macos = "";//"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
+string monoSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+string iOSSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/cf7090bee19401076987a57cd12f11e5/xamarin.ios-13.16.0.11.pkg";
+string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 
+
+string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");
+
+if(releaseChannel == "Preview")
+{
+	XamarinChannel("Preview");
+}
+else{
+	XamarinChannel("Stable");
+}
 
 if (IsMac)
 {
-	// Item (XreItem.Xcode_11_4_0).XcodeSelect ();
-
   	if(!String.IsNullOrEmpty(monoSDK_macos))
     	Item ("Mono", monoVersion)
-      	.Source (_ => monoSDK_macos);
+      		.Source (_ => monoSDK_macos);
 
 	if(!String.IsNullOrEmpty(androidSDK_macos))
 		Item ("Xamarin.Android", "10.2.0.100")
-      .Source (_ => androidSDK_macos);
+      		.Source (_ => androidSDK_macos);
 
 	if(!String.IsNullOrEmpty(iOSSDK_macos))
 		Item ("Xamarin.iOS", "13.16.0.11")
-      .Source (_ => iOSSDK_macos);
+      		.Source (_ => iOSSDK_macos);
 
 	if(!String.IsNullOrEmpty(macSDK_macos))
 		Item ("Xamarin.Mac", "6.16.0.11")
-      .Source (_ => macSDK_macos);
+      		.Source (_ => macSDK_macos);
     
 	ForceJavaCleanup();
 
@@ -50,19 +58,19 @@ else
 {
 	if(!String.IsNullOrEmpty(androidSDK_windows))
 		Item ("Xamarin.Android", "10.0.0.43")
-      .Source (_ => androidSDK_windows);
+      		.Source (_ => androidSDK_windows);
 
 	if(!String.IsNullOrEmpty(iOSSDK_windows))
 		Item ("Xamarin.iOS", "13.2.0.42")
-      .Source (_ => iOSSDK_windows);
+      		.Source (_ => iOSSDK_windows);
 
 	if(!String.IsNullOrEmpty(macSDK_windows))
 		Item ("Xamarin.Mac", "6.2.0.42")
-      .Source (_ => macSDK_windows);
+      		.Source (_ => macSDK_windows);
 
 	if(!String.IsNullOrEmpty(monoSDK_windows))
-    Item ("Mono", monoVersion)
-      .Source (_ => monoSDK_windows);
+		Item ("Mono", monoVersion)
+			.Source (_ => monoSDK_windows);
 
 }
 

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -52,7 +52,7 @@ if (IsMac)
 		Item ("Xamarin.Mac", "6.16.0.11")
       		.Source (_ => macSDK_macos);
 
-    var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
+    /*var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
     if (!string.IsNullOrEmpty(dotnetVersion))
 	  {
 		// VSTS installs into a non-default location. Let's hardcode it here because why not.
@@ -61,7 +61,7 @@ if (IsMac)
 		var defaultInstallLocation = Path.Combine ("/usr/local/share/dotnet/sdk/", dotnetVersion);
 		if (Directory.Exists (vstsBaseInstallPath) && !Directory.Exists (vstsInstallPath))
 			ln (defaultInstallLocation, vstsInstallPath);
-	  }
+	  }*/
 }
 else
 {

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -13,6 +13,13 @@ string iOSSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 
 
+if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono"))
+{
+	Item ("Mono", "6.8.0.105")
+		.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.105.macos10.xamarin.universal.pkg");
+}
+
+
 if (IsMac)
 {
 	string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -13,10 +13,10 @@ string iOSSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 
 
-if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono"))
+if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/"))
 {
-	//Item ("Mono", "6.8.0.123")
-	//	.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.123.macos10.xamarin.universal.pkg");
+	Item ("Mono", "6.8.0.123")
+		.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.123.macos10.xamarin.universal.pkg");
 }
 
 

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -22,6 +22,10 @@ if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Comm
 
 if (IsMac)
 {
+    
+	ForceJavaCleanup();
+	Item (XreItem.Java_OpenJDK_1_8_0_25);
+	
 	string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");
 
 	if(releaseChannel == "Preview")
@@ -47,8 +51,6 @@ if (IsMac)
 	if(!String.IsNullOrEmpty(macSDK_macos))
 		Item ("Xamarin.Mac", "6.16.0.11")
       		.Source (_ => macSDK_macos);
-    
-	ForceJavaCleanup();
 
     var dotnetVersion = System.Environment.GetEnvironmentVariable("DOTNET_VERSION");
     if (!string.IsNullOrEmpty(dotnetVersion))

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -15,8 +15,8 @@ string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 
 if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/mono"))
 {
-	Item ("Mono", "6.8.0.105")
-		.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.105.macos10.xamarin.universal.pkg");
+	//Item ("Mono", "6.8.0.123")
+	//	.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.123.macos10.xamarin.universal.pkg");
 }
 
 
@@ -25,7 +25,7 @@ if (IsMac)
     
 	ForceJavaCleanup();
 	Item (XreItem.Java_OpenJDK_1_8_0_25);
-	
+
 	string releaseChannel = Environment.GetEnvironmentVariable ("releaseChannel");
 
 	if(releaseChannel == "Preview")

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -13,15 +13,14 @@ string iOSSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
 
 
-if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/"))
-{
-	Item ("Mono", "6.8.0.123")
-		.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.123.macos10.xamarin.universal.pkg");
-}
-
 
 if (IsMac)
 {
+	if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/"))
+	{
+		Item ("Mono", "6.8.0.123")
+			.Source (_ => "https://download.mono-project.com/archive/6.8.0/macos-10-universal/MonoFramework-MDK-6.8.0.123.macos10.xamarin.universal.pkg");
+	}
     
 	ForceJavaCleanup();
 	Item (XreItem.Java_OpenJDK_1_8_0_25);

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -1,4 +1,5 @@
 using System;
+using System.Linq;
 
 var desiredXcode = Environment.GetEnvironmentVariable ("REQUIRED_XCODE");
 if (string.IsNullOrEmpty (desiredXcode)) {
@@ -6,7 +7,12 @@ if (string.IsNullOrEmpty (desiredXcode)) {
 	Environment.Exit (1);
 }
 
-var xreItem = (XreItem) Enum.Parse (typeof (XreItem), desiredXcode);
+XreItem xreItem = null;
+
+if(desiredXcode == "Latest")
+	xreItem = (XreItem)Enum.GetValues(typeof(XreItem)).Cast<int>().Max();
+else
+	xreItem = (XreItem) Enum.Parse (typeof (XreItem), desiredXcode);
 
 var item = Item (xreItem);
 Console.WriteLine ("InstallPath: {0}", item.Version);

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -7,7 +7,7 @@ if (string.IsNullOrEmpty (desiredXcode)) {
 	Environment.Exit (1);
 }
 
-XreItem xreItem = null;
+XreItem xreItem;
 
 if(desiredXcode == "Latest")
 	xreItem = (XreItem)Enum.GetValues(typeof(XreItem)).Cast<int>().Max();

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -1,0 +1,13 @@
+using System;
+
+var desiredXcode = Environment.GetEnvironmentVariable ("REQUIRED_XCODE");
+if (string.IsNullOrEmpty (desiredXcode)) {
+	Console.WriteLine ("The environment variable 'REQUIRED_XCODE' must be exported and the value must be a valid value from the 'XreItem' enumeration.");
+	Environment.Exit (1);
+}
+
+var xreItem = (XreItem) Enum.Parse (typeof (XreItem), desiredXcode);
+
+var item = Item (xreItem);
+Console.WriteLine ("InstallPath: {0}", item.Version);
+item.XcodeSelect ();

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -52,7 +52,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target provision --TeamProject="$(System.TeamProject)" --releaseChannel=$(releaseChannel)
+          arguments: --target provision --TeamProject="$(System.TeamProject)" --CHANNEL=$(CHANNEL)
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -52,7 +52,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target provision --TeamProject="$(System.TeamProject)" --CHANNEL=$(CHANNEL)
+          arguments: --target provision --TeamProject="$(System.TeamProject)" --CHANNEL=$(CHANNEL) --ANDROID_SDK_MAC=$(ANDROID_SDK_MAC) --IOS_SDK_MAC=$(IOS_SDK_MAC) --MONO_SDK_MAC=$(MONO_SDK_MAC) --MAC_SDK_MAC=$(MAC_SDK_MAC)
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -52,7 +52,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target provision --TeamProject="$(System.TeamProject)" --CHANNEL=$(CHANNEL) --ANDROID_SDK_MAC=$(ANDROID_SDK_MAC) --IOS_SDK_MAC=$(IOS_SDK_MAC) --MONO_SDK_MAC=$(MONO_SDK_MAC) --MAC_SDK_MAC=$(MAC_SDK_MAC)
+          arguments: --target provision --TeamProject="$(System.TeamProject)"
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -25,7 +25,7 @@ steps:
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'
-    condition: ne(variables['DOTNET_VERSION'], '')
+    condition: and(ne(variables['DOTNET_VERSION'], ''), eq(variables['provisioning'], 'false'))
     inputs:
       version: $(DOTNET_VERSION)
       packageType: 'sdk'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -17,8 +17,9 @@ steps:
 
   - script: |
       echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
+      echo "##vso[task.prependpath]~/Library/Developer/Xamarin/android-sdk-macosx"
     displayName: 'Setup Mono Path'
-    condition: or(eq(variables['provisioning'], 'true'), eq(variables['provisioningCake'], 'true'))
+    condition: and(ne(variables['osx2019VmPool'], 'Azure Pipelines'), eq(variables['buildForVS2017'], 'false'))
 
   - task: Bash@3
     displayName: 'Cake Provision'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -17,7 +17,8 @@ steps:
 
   - script: |
       echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
-    condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
+    displayName: 'Setup Mono Path'
+    condition: or(eq(variables['provisioning'], 'true'), eq(variables['provisioningCake'], 'true'))
 
   - task: Bash@3
     displayName: 'Cake Provision'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -27,7 +27,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target provision --buildForVS2017=$(buildForVS2017) --CHANNEL=$(CHANNEL)
+      arguments: --target provision --buildForVS2017=$(buildForVS2017)
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -3,17 +3,21 @@ steps:
     clean: true
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
+    displayName: 'Provision Xcode'
+    condition: and(ne(variables['REQUIRED_XCODE'], ''), eq(variables['buildForVS2017'], 'false'))
+    inputs:
+      provisioning_script: 'build/provisioning/xcode.csx'
+
+  - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provisionator'
     condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
     inputs:
       provisioning_script: $(provisionator.osxPath)
       provisioning_extra_args: $(provisionator.extraArguments) --v
 
-  - task: xamops.azdevex.provisionator-task.provisionator@1
-    displayName: 'Provision Xcode'
-    condition: and(ne(variables['REQUIRED_XCODE'], ''), eq(variables['buildForVS2017'], 'false'))
-    inputs:
-      provisioning_script: 'build/provisioning/xcode.csx'
+  - script: |
+      echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
+    condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
 
   - task: Bash@3
     displayName: 'Cake Provision'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -7,7 +7,7 @@ steps:
     condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
     inputs:
       provisioning_script: $(provisionator.osxPath)
-      provisioning_extra_args: $(provisionator.extraArguments)
+      provisioning_extra_args: $(provisionator.extraArguments) --v
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -27,7 +27,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target provision --buildForVS2017=$(buildForVS2017) --releaseChannel=$(releaseChannel)
+      arguments: --target provision --buildForVS2017=$(buildForVS2017) --CHANNEL=$(CHANNEL) --ANDROID_SDK_MAC=$(ANDROID_SDK_MAC) --IOS_SDK_MAC=$(IOS_SDK_MAC) --MONO_SDK_MAC=$(MONO_SDK_MAC) --MAC_SDK_MAC=$(MAC_SDK_MAC)
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -9,6 +9,12 @@ steps:
       provisioning_script: $(provisionator.osxPath)
       provisioning_extra_args: $(provisionator.extraArguments)
 
+  - task: xamops.azdevex.provisionator-task.provisionator@1
+    displayName: 'Provision Xcode'
+    condition: eq(variables['REQUIRED_XCODE'], 'true')
+    inputs:
+      provisioning_script: 'build/provisioning/xcode.csx'
+
   - task: Bash@3
     displayName: 'Cake Provision'
     condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -31,7 +31,7 @@ steps:
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'
-    condition: and(ne(variables['DOTNET_VERSION'], ''), eq(variables['provisioning'], 'false'))
+    condition: ne(variables['DOTNET_VERSION'], '')
     inputs:
       version: $(DOTNET_VERSION)
       packageType: 'sdk'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -27,7 +27,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target provision --buildForVS2017=$(buildForVS2017) --CHANNEL=$(CHANNEL) --ANDROID_SDK_MAC=$(ANDROID_SDK_MAC) --IOS_SDK_MAC=$(IOS_SDK_MAC) --MONO_SDK_MAC=$(MONO_SDK_MAC) --MAC_SDK_MAC=$(MAC_SDK_MAC)
+      arguments: --target provision --buildForVS2017=$(buildForVS2017) --CHANNEL=$(CHANNEL)
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -18,7 +18,7 @@ steps:
   - script: |
       echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"
       echo "##vso[task.prependpath]~/Library/Developer/Xamarin/android-sdk-macosx"
-    displayName: 'Setup Mono Path'
+    displayName: 'Setup SDK Paths'
     condition: and(ne(variables['osx2019VmPool'], 'Azure Pipelines'), eq(variables['buildForVS2017'], 'false'))
 
   - task: Bash@3

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -11,7 +11,7 @@ steps:
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'
-    condition: eq(variables['REQUIRED_XCODE'], 'true')
+    condition: and(ne(variables['REQUIRED_XCODE'], ''), eq(variables['buildForVS2017'], 'false'))
     inputs:
       provisioning_script: 'build/provisioning/xcode.csx'
 

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
   - checkout: self
     clean: true
-  - script: build.cmd -Target provision
+  - script: build.cmd -Target provision '-ANDROID_SDK_WINDOWS="$(ANDROID_SDK_WINDOWS)"' '-IOS_SDK_WINDOWS="$(IOS_SDK_WINDOWS)"' '-MONO_SDK_WINDOWS="$(MONO_SDK_WINDOWS)"' '-MAC_SDK_WINDOWS="$(MAC_SDK_WINDOWS)"'
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')
 

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -17,7 +17,7 @@ parameters:
 steps:
   - checkout: self
     clean: true
-  - script: build.cmd -Target provision '-ANDROID_SDK_WINDOWS="$(ANDROID_SDK_WINDOWS)"' '-IOS_SDK_WINDOWS="$(IOS_SDK_WINDOWS)"' '-MONO_SDK_WINDOWS="$(MONO_SDK_WINDOWS)"' '-MAC_SDK_WINDOWS="$(MAC_SDK_WINDOWS)"'
+  - script: build.cmd -Target provision
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')
 


### PR DESCRIPTION
### Description of Change ###

- Setup a pipeline variable we can use to provision the specific version of XCode we want to use
- Switch provisionator file to work off of stable/release channels when provisioning sdk stuff

### Testing Procedure ###
verify builds 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
