### PR TITLE
Create ImageButton with correct Button Type

### DIFF
--- a/Xamarin.Forms.Platform.iOS.UnitTests/ImageButtonTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/ImageButtonTests.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Foundation;
+using NUnit.Framework;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture]
+	public class ImageButtonTests : PlatformTestFixture
+	{
+		[Test, Category("ImageButton")]
+		public async Task CreatedWithCorrectButtonType()
+		{
+			var imageButton = new ImageButton();
+			UIButtonType buttonType = await GetControlProperty(imageButton, uiButton => uiButton.ButtonType);
+			Assert.AreNotEqual(UIButtonType.Custom, buttonType);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/PlatformTestFixture.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/PlatformTestFixture.cs
@@ -140,6 +140,23 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			});
 		}
 
+		protected UIButton GetNativeControl(ImageButton button)
+		{
+			var renderer = GetRenderer(button);
+			var viewRenderer = renderer.NativeView as ImageButtonRenderer;
+			return viewRenderer.Control;
+		}
+
+		protected async Task<TProperty> GetControlProperty<TProperty>(ImageButton button, Func<UIButton, TProperty> getProperty)
+		{
+			return await Device.InvokeOnMainThreadAsync(() => {
+				using (var uiButton = GetNativeControl(button))
+				{
+					return getProperty(uiButton);
+				}
+			});
+		}
+
 		protected async Task<TProperty> GetRendererProperty<TProperty>(View view,
 			Func<IVisualElementRenderer, TProperty> getProperty, bool requiresLayout = false)
 		{

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="CornerRadiusTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
+    <Compile Include="ImageButtonTests.cs" />
     <Compile Include="IsEnabledTests.cs" />
     <Compile Include="IsVisibleTests.cs" />
     <Compile Include="NavigationTests.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override UIButton CreateNativeControl()
 		{			
-			return new UIButton();
+			return new UIButton(UIButtonType.System);
 		}
 
 		protected override void SetAccessibilityLabel()


### PR DESCRIPTION
### Description of Change ###

When GIF changes were rolled back from the ImageButtonRenderer the UIButtonType used for creating the UIButton wasn't correct. 

### Issues Resolved ### 

- fixes #9112


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- test included
- click on any image buttons in the gallery and make sure the animation matches the expectation in the referenced issue #9112

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
