### PR TITLE
FontImageSource now uses Embedded Fonts on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return UIFont.SystemFontOfSize(size);
 		}
 
-		static string CleanseFontName(string fontName)
+		internal static string CleanseFontName(string fontName)
 		{
 
 			//First check Alias

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -261,7 +261,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var fontsource = imagesource as FontImageSource;
 			if (fontsource != null)
 			{
-				var font = UIFont.FromName(fontsource.FontFamily ?? string.Empty, (float)fontsource.Size) ??
+				//This will allow lookup from the Embedded Fonts
+				var cleansedname = FontExtensions.CleanseFontName(fontsource.FontFamily);
+				var font = UIFont.FromName(cleansedname ?? string.Empty, (float)fontsource.Size) ??
 					UIFont.SystemFontOfSize((float)fontsource.Size);
 				var iconcolor = fontsource.Color.IsDefault ? _defaultColor : fontsource.Color;
 				var attString = new NSAttributedString(fontsource.Glyph, font: font, foregroundColor: iconcolor.ToUIColor());


### PR DESCRIPTION
### Description of Change ###
FontImageSource now uses the embedded font loader on iOS

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

fixes #10312 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

