### PR TITLE
Indicator shows # of indicators = MaximumVisible even when there are fewer items

### DIFF
--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -300,7 +300,7 @@ namespace Xamarin.Forms.Controls
 				new GalleryPageFactory(() => new RadioButtonCoreGalleryPage(), "RadioButton Core Gallery"),
 				new GalleryPageFactory(() => new FontImageSourceGallery(), "Font ImageSource"),
 				new GalleryPageFactory(() => new ExpanderGalleries(), "Expander Gallery"),
-				new GalleryPageFactory(() => new IndicatorsSample(), "Indicator Gallery"),
+				new GalleryPageFactory(() => new IndicatorGalleries(), "IndicatorView Gallery"),				
 				new GalleryPageFactory(() => new CarouselViewGallery(), "CarouselView Gallery"),
 				new GalleryPageFactory(() => new CarouselViewCoreGalleryPage(), "CarouselView Core Gallery"),
 				new GalleryPageFactory(() => new CollectionViewGallery(), "CollectionView Gallery"),

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselItemsGallery.cs
@@ -210,23 +210,29 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			}
 		}
 
+		readonly Random _random = new Random();
+
 		void SetSource(bool empty)
 		{
-			var random = new Random();
 
 			var source = new List<CarouselData>();
 			if (!empty)
 			{
 				for (int n = 0; n < 5; n++)
 				{
-					source.Add(new CarouselData
-					{
-						Color = Color.FromRgb(random.Next(0, 255), random.Next(0, 255), random.Next(0, 255)),
-						Name = $"{n + 1}"
-					});
+					source.Add(GetItem(n));
 				}
 			}
 			Items = new ObservableCollection<CarouselData>(source);
+		}
+
+		public CarouselData GetItem(int currentCount)
+		{
+			return new CarouselData
+			{
+				Color = Color.FromRgb(_random.Next(0, 255), _random.Next(0, 255), _random.Next(0, 255)),
+				Name = $"{currentCount + 1}"
+			};
 		}
 
 		public ObservableCollection<CarouselData> Items

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorGalleries.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorGalleries.cs
@@ -1,0 +1,49 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages
+{
+	public class IndicatorGalleries : ContentPage
+	{
+		public IndicatorGalleries()
+		{
+			var descriptionLabel =
+				   new Label { Text = "IndicatorView Galleries", Margin = new Thickness(2, 2, 2, 2) };
+
+			Title = "IndicatorView Galleries";
+
+			var button = new Button
+			{
+				Text = "Enable IndicatorView",
+				AutomationId = "EnableIndicator"
+			};
+			button.Clicked += ButtonClicked;
+
+			Content = new ScrollView
+			{
+				Content = new StackLayout
+				{
+					Children =
+					{
+						descriptionLabel,
+						button,
+						GalleryBuilder.NavButton("IndicatorView Gallery", () =>
+							new IndicatorsSample(), Navigation),
+						GalleryBuilder.NavButton("Indicator MaxVisible Gallery", () =>
+							new IndicatorsSampleMaximumVisible(), Navigation)
+					}
+				}
+			};
+		}
+
+		void ButtonClicked(object sender, EventArgs e)
+		{
+			var button = sender as Button;
+
+			button.Text = "IndicatorView Enabled!";
+			button.TextColor = Color.Black;
+			button.IsEnabled = false;
+
+			Device.SetFlags(new[] { ExperimentalFlags.IndicatorViewExperimental });
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSample.xaml.cs
@@ -1,12 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
-using Xamarin.Forms;
-using Xamarin.Forms.Internals;
-using Xamarin.Forms.Xaml;
+﻿using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls
 {
@@ -15,7 +7,6 @@ namespace Xamarin.Forms.Controls
 	{
 		public IndicatorsSample()
 		{
-			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
 			InitializeComponent();
 			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel(false, false);
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml
@@ -15,6 +15,7 @@
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
@@ -26,7 +27,11 @@
         
         <Button Grid.Row="1" Text="MaximumVisible--" Clicked="MaximumVisibleClicked"></Button>
         <Button Grid.Row="2" Text="Set MaximumVisible> ItemCount" Clicked="MaximumVisibleAboveItemCountClicked"></Button>
-        <CarouselView x:Name="carousel" ItemsSource="{Binding Items}" Grid.Row="4" Grid.RowSpan="3" IndicatorView="indicators">
+        <StackLayout HorizontalOptions="Center" Grid.Row="3" Orientation="Horizontal">
+            <Button Text="ItemsSource--" Clicked="ItemsSourceMinusClicked"></Button>
+            <Button Text="ItemsSource++" Clicked="ItemsSourcePlusClicked"></Button>
+        </StackLayout>
+        <CarouselView x:Name="carousel" ItemsSource="{Binding Items}" Grid.Row="5" Grid.RowSpan="3" IndicatorView="indicators">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <Frame BackgroundColor="{Binding Color}">
@@ -37,8 +42,8 @@
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
-        <IndicatorView x:Name="indicators" Grid.Row="5" IndicatorColor="Gray" SelectedIndicatorColor="White" HorizontalOptions="Center" />
-        <IndicatorView x:Name="indicatorsForms" Grid.Row="6" IndicatorColor="Gray"
+        <IndicatorView x:Name="indicators" Grid.Row="6" IndicatorColor="Gray" SelectedIndicatorColor="White" HorizontalOptions="Center" />
+        <IndicatorView x:Name="indicatorsForms" Grid.Row="7" IndicatorColor="Gray"
                        ItemsSource="{Binding Path=ItemsSource, Source={x:Reference carousel}}"
                        Position="{Binding Path=Position, Source={x:Reference carousel}}"
                        SelectedIndicatorColor="White" HorizontalOptions="Center" >

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml
@@ -12,12 +12,21 @@
     <Grid>
         <Grid.RowDefinitions>
             <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
+            <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
             <RowDefinition Height="Auto"></RowDefinition>
         </Grid.RowDefinitions>
-        <Button Text="Change MaximumVisible" Clicked="MaximumVisibleClicked"></Button>
-        <CarouselView x:Name="carousel" ItemsSource="{Binding Items}" Grid.Row="1" Grid.RowSpan="3" IndicatorView="indicators">
+        <StackLayout Grid.Row="0">
+            <Label Text="When the MaximumVisible is set above the item count of the collection, the max item count should be visible instead of MaximumVisible"></Label>
+            <Label x:Name="CurrentCount"></Label>
+        </StackLayout>
+        
+        <Button Grid.Row="1" Text="MaximumVisible--" Clicked="MaximumVisibleClicked"></Button>
+        <Button Grid.Row="2" Text="Set MaximumVisible> ItemCount" Clicked="MaximumVisibleAboveItemCountClicked"></Button>
+        <CarouselView x:Name="carousel" ItemsSource="{Binding Items}" Grid.Row="4" Grid.RowSpan="3" IndicatorView="indicators">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <Frame BackgroundColor="{Binding Color}">
@@ -28,8 +37,8 @@
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
-        <IndicatorView x:Name="indicators" Grid.Row="2" IndicatorColor="Gray" SelectedIndicatorColor="White" HorizontalOptions="Center" />
-        <IndicatorView x:Name="indicatorsForms" Grid.Row="3" IndicatorColor="Gray"
+        <IndicatorView x:Name="indicators" Grid.Row="5" IndicatorColor="Gray" SelectedIndicatorColor="White" HorizontalOptions="Center" />
+        <IndicatorView x:Name="indicatorsForms" Grid.Row="6" IndicatorColor="Gray"
                        ItemsSource="{Binding Path=ItemsSource, Source={x:Reference carousel}}"
                        Position="{Binding Path=Position, Source={x:Reference carousel}}"
                        SelectedIndicatorColor="White" HorizontalOptions="Center" >

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml.cs
@@ -31,6 +31,18 @@ namespace Xamarin.Forms.Controls
 			UpdateCurrentCount();
 		}
 
+		void ItemsSourceMinusClicked(object sender, EventArgs e)
+		{
+			_vm.Items.RemoveAt(0);
+			UpdateCurrentCount();
+		}
+
+		void ItemsSourcePlusClicked(object sender, EventArgs e)
+		{
+			_vm.Items.Add(_vm.GetItem(_vm.Items.Count));
+			UpdateCurrentCount();
+		}
+
 		void UpdateCurrentCount()
 		{
 			CurrentCount.Text = $"MaximumVisible: {_maxVisible}, item count: {_vm.Items.Count}";

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorsSampleMaximumVisible.xaml.cs
@@ -1,25 +1,39 @@
 ﻿using System;
-using System.Collections.Generic;
-
-using Xamarin.Forms;
+using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries;
 
 namespace Xamarin.Forms.Controls
 {
 	public partial class IndicatorsSampleMaximumVisible : ContentPage
 	{
-		int maxVisible = 3;
+		int _maxVisible = 3;
+		readonly CarouselItemsGalleryViewModel _vm = new CarouselItemsGalleryViewModel(false, false);
 
 		public IndicatorsSampleMaximumVisible()
-		{
-			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
+		{			
 			InitializeComponent();
-			BindingContext = new GalleryPages.CollectionViewGalleries.CarouselViewGalleries.CarouselItemsGalleryViewModel(false, false);
+			BindingContext = _vm;
+			indicators.MaximumVisible = indicatorsForms.MaximumVisible = _maxVisible;
+
+			UpdateCurrentCount();
 		}
 
-		public void MaximumVisibleClicked(object sender, EventArgs e)
+		void MaximumVisibleClicked(object sender, EventArgs e)
 		{
-			indicators.MaximumVisible = indicatorsForms.MaximumVisible = maxVisible;
-			maxVisible--;
+			_maxVisible--;
+			indicators.MaximumVisible = indicatorsForms.MaximumVisible = _maxVisible;
+			UpdateCurrentCount();
+		}
+
+		void MaximumVisibleAboveItemCountClicked(object sender, EventArgs e)
+		{
+			_maxVisible = _vm.Items.Count + 1;
+			indicators.MaximumVisible = indicatorsForms.MaximumVisible = _maxVisible;
+			UpdateCurrentCount();
+		}
+
+		void UpdateCurrentCount()
+		{
+			CurrentCount.Text = $"MaximumVisible: {_maxVisible}, item count: {_vm.Items.Count}";
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -67,6 +67,9 @@
     <Compile Update="TabIndexTest\DaysOfWeekView.xaml.cs">
       <DependentUpon>DaysOfWeekView.xaml</DependentUpon>
     </Compile>
+    <Compile Update="GalleryPages\IndicatorViewGalleries\IndicatorGalleries.cs">
+      <SubType></SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Update="TabIndexTest\DayView.xaml">

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections;
+﻿using System;
+using System.Collections;
 using System.Collections.Specialized;
 using Xamarin.Forms.Platform;
 
@@ -18,7 +19,7 @@ namespace Xamarin.Forms
 			=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicatorCount((int)oldValue));
 
 		public static readonly BindableProperty MaximumVisibleProperty = BindableProperty.Create(nameof(MaximumVisible), typeof(int), typeof(IndicatorView), int.MaxValue, propertyChanged: (bindable, oldValue, newValue)
-		=> (((IndicatorView) bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicators());
+		=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicators(), coerceValue: CoerceMaximumVisible);
 
 		public static readonly BindableProperty IndicatorTemplateProperty = BindableProperty.Create(nameof(IndicatorTemplate), typeof(DataTemplate), typeof(IndicatorView), default(DataTemplate), propertyChanging: (bindable, oldValue, newValue)
 			=> UpdateIndicatorLayout((IndicatorView)bindable, newValue));
@@ -161,6 +162,12 @@ namespace Xamarin.Forms
 				count++;
 			}
 			Count = count;
+		}
+
+		static object CoerceMaximumVisible(BindableObject bindable, object value)
+		{
+			var minValue = Math.Min((int)value, ((IndicatorView)bindable).Count);
+			return minValue <= 0 ? 0 : minValue;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms
 			=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicatorCount((int)oldValue));
 
 		public static readonly BindableProperty MaximumVisibleProperty = BindableProperty.Create(nameof(MaximumVisible), typeof(int), typeof(IndicatorView), int.MaxValue, propertyChanged: (bindable, oldValue, newValue)
-		=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicators(), coerceValue: CoerceMaximumVisible);
+		=> (((IndicatorView)bindable).IndicatorLayout as IndicatorStackLayout)?.ResetIndicators());
 
 		public static readonly BindableProperty IndicatorTemplateProperty = BindableProperty.Create(nameof(IndicatorTemplate), typeof(DataTemplate), typeof(IndicatorView), default(DataTemplate), propertyChanging: (bindable, oldValue, newValue)
 			=> UpdateIndicatorLayout((IndicatorView)bindable, newValue));
@@ -70,6 +70,15 @@ namespace Xamarin.Forms
 		{
 			get => (int)GetValue(MaximumVisibleProperty);
 			set => SetValue(MaximumVisibleProperty, value);
+		}
+
+		public int ActualMaximumVisible
+		{
+			get
+			{
+				var minValue = Math.Min(MaximumVisible, Count);
+				return minValue <= 0 ? 0 : minValue;
+			}
 		}
 
 		public DataTemplate IndicatorTemplate
@@ -162,12 +171,6 @@ namespace Xamarin.Forms
 				count++;
 			}
 			Count = count;
-		}
-
-		static object CoerceMaximumVisible(BindableObject bindable, object value)
-		{
-			var minValue = Math.Min((int)value, ((IndicatorView)bindable).Count);
-			return minValue <= 0 ? 0 : minValue;
 		}
 	}
 }

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -72,15 +72,6 @@ namespace Xamarin.Forms
 			set => SetValue(MaximumVisibleProperty, value);
 		}
 
-		public int ActualMaximumVisible
-		{
-			get
-			{
-				var minValue = Math.Min(MaximumVisible, Count);
-				return minValue <= 0 ? 0 : minValue;
-			}
-		}
-
 		public DataTemplate IndicatorTemplate
 		{
 			get => (DataTemplate)GetValue(IndicatorTemplateProperty);

--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 		AView ITabStop.TabStop => this;
 
-		protected IndicatorView IndicatorsView;
+		protected IndicatorView IndicatorView;
 
 		int? _defaultLabelFor;
 		bool _disposed;
@@ -36,7 +36,7 @@ namespace Xamarin.Forms.Platform.Android
 		AColor _pageIndicatorTintColor;
 		bool IsVisible => Visibility != ViewStates.Gone;
 
-		public VisualElement Element => IndicatorsView;
+		public VisualElement Element => IndicatorView;
 
 		public VisualElementTracker Tracker => _visualElementTracker;
 
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.Android
 				throw new ArgumentException($"{nameof(element)} must be of type {typeof(IndicatorView).Name}");
 			}
 
-			var oldElement = IndicatorsView;
+			var oldElement = IndicatorView;
 			var newElement = (IndicatorView)element;
 
 			TearDownOldElement(oldElement);
@@ -181,13 +181,13 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (newElement == null)
 			{
-				IndicatorsView = null;
+				IndicatorView = null;
 				return;
 			}
 
-			IndicatorsView = newElement;
+			IndicatorView = newElement;
 
-			IndicatorsView.PropertyChanged += OnElementPropertyChanged;
+			IndicatorView.PropertyChanged += OnElementPropertyChanged;
 
 			if (Tracker == null)
 			{
@@ -198,7 +198,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateBackgroundColor();
 
-			if (IndicatorsView.IndicatorTemplate != null)
+			if (IndicatorView.IndicatorTemplate != null)
 				UpdateIndicatorTemplate();
 			else
 				UpdateItemsSource();
@@ -210,8 +210,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateSelectedIndicator()
 		{
-			var maxVisible = IndicatorsView.ActualMaximumVisible;
-			var position = IndicatorsView.Position;
+			var maxVisible = GetMaximumVisible();
+			var position = IndicatorView.Position;
 			_selectedIndex = position >= maxVisible ? maxVisible - 1 : position;
 			UpdateIndicators();
 		}
@@ -237,10 +237,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (!IsVisible)
 				return;
 
-			var count = IndicatorsView.Count;
-
-			if (IndicatorsView.MaximumVisible != int.MaxValue)
-				count = IndicatorsView.ActualMaximumVisible;
+			var count = GetMaximumVisible();
 
 			var childCount = ChildCount;
 
@@ -262,7 +259,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				RemoveViewAt(ChildCount - 1);
 			}
-			IndicatorsView.NativeSizeChanged();
+			IndicatorView.NativeSizeChanged();
 		}
 
 		void ResetIndicators()
@@ -270,13 +267,13 @@ namespace Xamarin.Forms.Platform.Android
 			if (!IsVisible)
 				return;
 
-			_pageIndicatorTintColor = IndicatorsView.IndicatorColor.ToAndroid();
-			_currentPageIndicatorTintColor = IndicatorsView.SelectedIndicatorColor.ToAndroid();
-			_shapeType = IndicatorsView.IndicatorsShape == IndicatorShape.Circle ? AShapeType.Oval : AShapeType.Rectangle;
+			_pageIndicatorTintColor = IndicatorView.IndicatorColor.ToAndroid();
+			_currentPageIndicatorTintColor = IndicatorView.SelectedIndicatorColor.ToAndroid();
+			_shapeType = IndicatorView.IndicatorsShape == IndicatorShape.Circle ? AShapeType.Oval : AShapeType.Rectangle;
 			_pageShape = null;
 			_currentPageShape = null;
 
-			if (IndicatorsView.IndicatorTemplate == null)
+			if (IndicatorView.IndicatorTemplate == null)
 				UpdateShapes();
 			else
 				UpdateIndicatorTemplate();
@@ -286,17 +283,17 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateIndicatorTemplate()
 		{
-			if (IndicatorsView.IndicatorLayout == null)
+			if (IndicatorView.IndicatorLayout == null)
 				return;
 
-			var renderer = IndicatorsView.IndicatorLayout.GetRenderer() ?? Platform.CreateRendererWithContext(IndicatorsView.IndicatorLayout, Context);
-			Platform.SetRenderer(IndicatorsView.IndicatorLayout, renderer);
+			var renderer = IndicatorView.IndicatorLayout.GetRenderer() ?? Platform.CreateRendererWithContext(IndicatorView.IndicatorLayout, Context);
+			Platform.SetRenderer(IndicatorView.IndicatorLayout, renderer);
 
 			RemoveAllViews();
 			AddView(renderer.View);
 
-			var indicatorLayoutSizeRequest = IndicatorsView.IndicatorLayout.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
-			IndicatorsView.IndicatorLayout.Layout(new Rectangle(0, 0, indicatorLayoutSizeRequest.Request.Width, indicatorLayoutSizeRequest.Request.Height));
+			var indicatorLayoutSizeRequest = IndicatorView.IndicatorLayout.Measure(double.PositiveInfinity, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+			IndicatorView.IndicatorLayout.Layout(new Rectangle(0, 0, indicatorLayoutSizeRequest.Request.Width, indicatorLayoutSizeRequest.Request.Height));
 		}
 
 		void UpdateIndicators()
@@ -327,7 +324,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		Drawable GetShape(AColor color)
 		{
-			var indicatorSize = IndicatorsView.IndicatorSize;
+			var indicatorSize = IndicatorView.IndicatorSize;
 			ShapeDrawable shape;
 
 			if (_shapeType == AShapeType.Oval)
@@ -340,6 +337,12 @@ namespace Xamarin.Forms.Platform.Android
 			shape.Paint.Color = color;
 
 			return shape;
+		}
+
+		int GetMaximumVisible()
+		{
+			var minValue = Math.Min(IndicatorView.MaximumVisible, IndicatorView.Count);
+			return minValue <= 0 ? 0 : minValue;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -210,7 +210,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateSelectedIndicator()
 		{
-			var maxVisible = IndicatorsView.MaximumVisible;
+			var maxVisible = IndicatorsView.ActualMaximumVisible;
 			var position = IndicatorsView.Position;
 			_selectedIndex = position >= maxVisible ? maxVisible - 1 : position;
 			UpdateIndicators();
@@ -240,7 +240,7 @@ namespace Xamarin.Forms.Platform.Android
 			var count = IndicatorsView.Count;
 
 			if (IndicatorsView.MaximumVisible != int.MaxValue)
-				count = IndicatorsView.MaximumVisible;
+				count = IndicatorsView.ActualMaximumVisible;
 
 			var childCount = ChildCount;
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -160,6 +160,11 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateItemsSource();
 			}
+			else if (changedProperty.Is(IndicatorView.MaximumVisibleProperty))
+			{
+				UpdateIndicatorCount();
+				ResetIndicators();
+			}
 		}
 
 		protected virtual void UpdateBackgroundColor(Color? color = null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using CoreGraphics;
 using UIKit;
 using static Xamarin.Forms.IndicatorView;
@@ -172,7 +173,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			_updatingPosition = true;
-			var maxVisible = Element.MaximumVisible;
+			var maxVisible = Element.ActualMaximumVisible;
 			var position = Element.Position;
 			var index = position >= maxVisible ? maxVisible - 1 : position;
 			UIPager.CurrentPage = index;
@@ -185,7 +186,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (UIPager == null)
 				return;
 
-			var maxCount = Element.MaximumVisible;
+			var maxCount = Element.ActualMaximumVisible;
 			var count = Element.Count;
 
 			UIPager.Pages = maxCount != int.MaxValue ? maxCount : count;

--- a/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			_updatingPosition = true;
-			var maxVisible = Element.ActualMaximumVisible;
+			var maxVisible = GetMaximumVisible();
 			var position = Element.Position;
 			var index = position >= maxVisible ? maxVisible - 1 : position;
 			UIPager.CurrentPage = index;
@@ -186,10 +186,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (UIPager == null)
 				return;
 
-			var maxCount = Element.ActualMaximumVisible;
-			var count = Element.Count;
-
-			UIPager.Pages = maxCount != int.MaxValue ? maxCount : count;
+			UIPager.Pages = GetMaximumVisible();
 		}
 
 		void UpdateHidesForSinglePage()
@@ -222,6 +219,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			UpdatePages();
 			UpdateCurrentPage();
+		}
+
+		int GetMaximumVisible()
+		{
+			var minValue = Math.Min(Element.MaximumVisible, Element.Count);
+			return minValue <= 0 ? 0 : minValue;
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###

Adds functionality to coerce the `MaximumVisible` and `ItemsSource.Count` value. If `ItemsSource.Count` is lower than `MaximumVisible` it will show `MaximumVisible` and vice versa.

In addition rearranged some pages in the gallery app to make it more logical and added this specific case.

### Issues Resolved ### 

- fixes #9826

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Users already using this should see the right amount of maximum indicators after updating. This _can_ be less than they would see before, because before it would _always_ show the number set in `MaximumVisible` even thought there weren't even that many items.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Go to the `IndicatorView` gallery and choose the "Indicator MaxVisible Gallery" option. There is a button to decrease the `MaximumVisible` value and a button to set the `MaximumValue` to `ItemsSource.Count`+1. There is also a button to add/remove items from the bound collection.

When ItemsSource.Count > MaximumVisible -> MaximumVisible should be shown
When ItemsSource.Count == MaximumVisible -> Doesn't matter, whichever one should be shown
When ItemsSource.Count < MaximumVisible -> ItemsSource.Count should be shown

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
