### PR TITLE
If Shell Element is already wrapped up just return the implicit parent

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
@@ -25,6 +26,25 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		}
 
+		protected T FindParentOfType<T>(Element element)
+		{
+			var navPage = GetParentsPath(element)
+				.OfType<T>()
+				.FirstOrDefault();
+
+			return navPage;
+		}
+
+		protected IEnumerable<Element> GetParentsPath(Element self)
+		{
+			Element current = self;
+
+			while (!Application.IsApplicationOrNull(current.RealParent))
+			{
+				current = current.RealParent;
+				yield return current;
+			}
+		}
 
 		protected bool IsModal(BindableObject bindableObject)
 		{

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -32,6 +32,40 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That(shell.CurrentItem, Is.EqualTo(shellItem));
 		}
 
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public void SetCurrentItemWithImplicitlyWrappedShellContent(bool useShellContent)
+		{
+			var shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			BaseShellItem shellElement = null;
+
+			if(useShellContent)
+				shellElement = CreateShellContent(shellContentRoute: "TestMe");
+			else
+				shellElement = CreateShellSection(shellSectionRoute: "TestMe");
+
+			if (useShellContent)
+				shell.Items.Add((ShellContent)shellElement);
+			else
+				shell.Items.Add((ShellSection)shellElement);
+
+			var item2 = shell.Items[1];
+
+			Assert.AreEqual(FindParentOfType<ShellItem>(shellElement), item2);
+
+			if (useShellContent)
+				shell.CurrentItem = (ShellContent)shellElement;
+			else
+				shell.CurrentItem = (ShellSection)shellElement;
+
+			Assert.AreEqual(2, shell.Items.Count);
+			Assert.AreEqual(FindParentOfType<ShellItem>(shellElement), item2);
+			Assert.AreEqual(item2, shell.CurrentItem);
+		}
+
 		[Test]
 		public void ShellChildrenBindingContext()
 		{

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -85,7 +85,7 @@ namespace Xamarin.Forms
 		}
 
 		// we want the list returned from here to remain point in time accurate
-		ReadOnlyCollection<ShellSection> IShellItemController.GetItems() => 
+		ReadOnlyCollection<ShellSection> IShellItemController.GetItems() =>
 			new ReadOnlyCollection<ShellSection>(((ShellSectionCollection)Items).VisibleItems.ToList());
 
 		event NotifyCollectionChangedEventHandler IShellItemController.ItemsCollectionChanged
@@ -154,6 +154,11 @@ namespace Xamarin.Forms
 
 		internal static ShellItem CreateFromShellSection(ShellSection shellSection)
 		{
+			if (shellSection.Parent != null)
+			{
+				return (ShellItem)shellSection.Parent;
+			}
+
 			ShellItem result = null;
 
 			if (shellSection is Tab)
@@ -168,13 +173,10 @@ namespace Xamarin.Forms
 			result.SetBinding(IconProperty, new Binding(nameof(Icon), BindingMode.OneWay, source: shellSection));
 			result.SetBinding(FlyoutDisplayOptionsProperty, new Binding(nameof(FlyoutDisplayOptions), BindingMode.OneTime, source: shellSection));
 			result.SetBinding(FlyoutIconProperty, new Binding(nameof(FlyoutIcon), BindingMode.OneWay, source: shellSection));
-			
+
 			return result;
 		}
 
-#if DEBUG
-		[Obsolete ("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(ShellSection shellSection)
 		{
 			return CreateFromShellSection(shellSection);
@@ -195,19 +197,10 @@ namespace Xamarin.Forms
 			return result;
 		}
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(ShellContent shellContent) => (ShellSection)shellContent;
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(TemplatedPage page) => (ShellSection)(ShellContent)page;
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(MenuItem menuItem) => new MenuShellItem(menuItem);
 
 		public IPlatformElementConfiguration<T, ShellItem> On<T>() where T : IConfigPlatform
@@ -278,7 +271,7 @@ namespace Xamarin.Forms
 		internal override void SendAppearing()
 		{
 			base.SendAppearing();
-			if(CurrentItem != null && Parent is Shell shell && shell.CurrentItem == this)
+			if (CurrentItem != null && Parent is Shell shell && shell.CurrentItem == this)
 			{
 				CurrentItem.SendAppearing();
 			}

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -286,6 +286,11 @@ namespace Xamarin.Forms
 
 		internal static ShellSection CreateFromShellContent(ShellContent shellContent)
 		{
+			if(shellContent.Parent != null)
+			{
+				return (ShellSection)shellContent.Parent;
+			}
+
 			var shellSection = new ShellSection();
 
 			var contentRoute = shellContent.Route;
@@ -306,17 +311,11 @@ namespace Xamarin.Forms
 			return CreateFromShellContent((ShellContent)page);
 		}
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellSection(ShellContent shellContent)
 		{
 			return CreateFromShellContent(shellContent);
 		}
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellSection(TemplatedPage page)
 		{
 			return (ShellSection)(ShellContent)page;


### PR DESCRIPTION
### Description of Change ###

If the user doesn't specify all elements in the hierarchy of a Shell

```XAML
<Shell
     <ShellContent Route="route1"
     <ShellContent Route="route2"
```

Then in code behind they should be allowed to do this

```C#
shell.CurrentItem = route2;
```

When a BaseShellItem is implicitly being converted up to a ShellItem these changes make it so if a BaseShellItem has already been parented than just return the parent instead of creating a new BaseShellItem

### Issues Resolved ### 
- fixes #10308 


### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
