### PR TITLE
Runtime updating of AppTheme values

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeCodeGallery.cs
@@ -2,12 +2,6 @@
 {
 	public class AppThemeCodeGallery : ContentPage
 	{
-		AppThemeColor color = new AppThemeColor { Light = Color.Green, Dark = Color.Red };
-		public Color TheColor
-		{
-			get => color.Value;
-		}
-
 		public AppThemeCodeGallery()
 		{
 			var currentThemeLabel = new Label
@@ -18,22 +12,34 @@
 			Application.Current.RequestedThemeChanged += (s, a) =>
 			{
 				currentThemeLabel.Text = Application.Current.RequestedTheme.ToString();
-				OnPropertyChanged(nameof(TheColor));
 			};
 
 			var onThemeLabel = new Label
 			{
-				Text = "This text is green or red depending on Light (or default) or Dark"
+				Text = "TextColor through SetBinding"
 			};
 
-			onThemeLabel.SetBinding(Label.TextColorProperty, new Binding(nameof(TheColor)));
-			BindingContext = this;
+			var onThemeLabel1 = new Label
+			{
+				Text = "TextColor through SetAppTheme"
+			};
+
+			var onThemeLabel2 = new Label
+			{
+				Text = "TextColor through SetAppThemeColor"
+			};
+
+			onThemeLabel.SetBinding(Label.TextColorProperty, new AppThemeColor() { Light = Color.Green, Dark = Color.Red } );
+
+			onThemeLabel1.SetAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
+
+			onThemeLabel2.SetAppThemeColor(Label.TextColorProperty, Color.Green, Color.Red);
 
 			var stackLayout = new StackLayout
 			{
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center,
-				Children = { currentThemeLabel, onThemeLabel }
+				Children = { currentThemeLabel, onThemeLabel , onThemeLabel1, onThemeLabel2 }
 			};
 
 			Content = stackLayout;

--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeCodeGallery.cs
@@ -1,18 +1,19 @@
-﻿namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
 {
 	public class AppThemeCodeGallery : ContentPage
 	{
+		Label _currentThemeLabel;
+
 		public AppThemeCodeGallery()
 		{
-			var currentThemeLabel = new Label
+			_currentThemeLabel = new Label
 			{
 				Text = Application.Current.RequestedTheme.ToString()
 			};
 
-			Application.Current.RequestedThemeChanged += (s, a) =>
-			{
-				currentThemeLabel.Text = Application.Current.RequestedTheme.ToString();
-			};
+			Application.Current.RequestedThemeChanged += Current_RequestedThemeChanged;
 
 			var onThemeLabel = new Label
 			{
@@ -29,9 +30,9 @@
 				Text = "TextColor through SetAppThemeColor"
 			};
 
-			onThemeLabel.SetBinding(Label.TextColorProperty, new AppThemeColor() { Light = Color.Green, Dark = Color.Red } );
+			onThemeLabel.SetBinding(Label.TextColorProperty, new AppThemeColor() { Light = Color.Green, Dark = Color.Red });
 
-			onThemeLabel1.SetAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
+			onThemeLabel1.SetOnAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
 
 			onThemeLabel2.SetAppThemeColor(Label.TextColorProperty, Color.Green, Color.Red);
 
@@ -39,10 +40,15 @@
 			{
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center,
-				Children = { currentThemeLabel, onThemeLabel , onThemeLabel1, onThemeLabel2 }
+				Children = { _currentThemeLabel, onThemeLabel , onThemeLabel1,onThemeLabel2 }
 			};
 
 			Content = stackLayout;
+		}
+
+		private void Current_RequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+		{
+			_currentThemeLabel.Text = Application.Current.RequestedTheme.ToString();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:gallerypages="clr-namespace:Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries" x:Class="Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries.AppThemeXamlGallery" BackgroundColor="{OnAppTheme Light=Lightgray, Dark=Darkgray}">
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:gallerypages="clr-namespace:Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries" x:Class="Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries.AppThemeXamlGallery" BackgroundColor="{OnAppTheme Light=Lightgray, Dark=Black}">
     <ContentPage.Resources>
         <AppThemeColor x:Key="MyColor" Light="HotPink" Dark="Yellow" />
         <Style x:Key="OSThemeStyle" TargetType="Label">
@@ -26,19 +26,19 @@
     </ContentPage.Resources>
     <ScrollView>
         <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
-            <Label TextColor="{OnAppTheme Light=Green, Dark=Red}">This text is green or red depending on Light (or default) or Dark</Label>
-            <Label Text="Testing 1, 2, 3">
+            <Label TextColor="{OnAppTheme Light=Green, Dark=Red}">OnAppThemeExtension</Label>
+            <Label Text="OnAppTheme XAML tag">
                 <Label.TextColor>
                     <OnAppTheme x:TypeArguments="Color" Light="Green" Dark="Red" />
                 </Label.TextColor>
             </Label>
-            <Label Style="{DynamicResource Key=OSThemeStyle}">This text is green or red depending on Light (or default) or Dark (through style)</Label>
-            <Label TextColor="{DynamicResource MyColor}">This text is HotPink or Yellow depending on Light (or default) or Dark (through DynamicResource)</Label>
-            <Label TextColor="{StaticResource MyColor}">This text is HotPink or Yellow depending on Light (or default) or Dark (through StaticResource)</Label>
+            <Label Style="{DynamicResource Key=OSThemeStyle}">DynamicResource Style</Label>
+            <Label TextColor="{DynamicResource MyColor}">DynamicResource Color</Label>
+            <Label TextColor="{StaticResource MyColor}">StaticResource</Label>
             <!--<Label x:Name="cssStyledLabel">This text is Purple or Orange depending on Light (or default) or Dark (through CSS)</Label>-->
-            <Label>The image below is a Xamarin logo or fruits depending on Light (or default) or Dark</Label>
+            <Label>Image with OnAppThemeExtension</Label>
             <Image Source="{OnAppTheme Light=xamarinlogo.png, Dark=Fruits.jpg}" />
-            <gallerypages:CustomControl TextColor="Brown" Text="This custom control should have brown text" />
+            <!--<gallerypages:CustomControl TextColor="Brown" Text="This custom control should have brown text" />-->
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:gallerypages="clr-namespace:Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries" x:Class="Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries.AppThemeXamlGallery" BackgroundColor="{OnAppTheme Light=Lightgray, Dark=Black}">
     <ContentPage.Resources>
+        <ResourceDictionary>
+            <gallerypages:FooConverter x:Key="fooConv"/>
+        </ResourceDictionary>
         <AppThemeColor x:Key="MyColor" Light="HotPink" Dark="Yellow" />
         <Style x:Key="OSThemeStyle" TargetType="Label">
             <Setter Property="TextColor" Value="{OnAppTheme Black, Light=Green, Dark=Red}" />
@@ -39,6 +42,8 @@
             <Label>Image with OnAppThemeExtension</Label>
             <Image Source="{OnAppTheme Light=xamarinlogo.png, Dark=Fruits.jpg}" />
             <!--<gallerypages:CustomControl TextColor="Brown" Text="This custom control should have brown text" />-->
+            <Label TextColor="{OnAppTheme Light=1, Dark=2, Converter={StaticResource fooConv}}">With ValueConverter</Label>
+
         </StackLayout>
     </ScrollView>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml.cs
@@ -11,47 +11,47 @@ namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
         }
 	}
 
-	public class CustomControl : ContentView
-    {
-        public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(CustomControl), (Color)new AppThemeColor() { Light = Color.Red, Dark = Color.Green });
-        public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(CustomControl));
-        public static readonly BindableProperty BoxColorProperty = BindableProperty.Create(nameof(BoxColor), typeof(Color), typeof(CustomControl), Color.Yellow);
+	//public class CustomControl : ContentView
+ //   {
+ //       public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(CustomControl), (Color)new AppThemeColor() { Light = Color.Red, Dark = Color.Green });
+ //       public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(CustomControl));
+ //       public static readonly BindableProperty BoxColorProperty = BindableProperty.Create(nameof(BoxColor), typeof(Color), typeof(CustomControl), Color.Yellow);
 
-        private StackLayout layout = new StackLayout();
-        public CustomControl()
-        {
-            var label = new Label();
-            label.SetBinding(Label.TextProperty, new Binding(nameof(Text), source: this));
-            label.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this, mode: BindingMode.TwoWay));
-            label.SetDynamicResource(Label.TextColorProperty, "MyColor");
-            this.layout.Children.Add(label);
+ //       private StackLayout layout = new StackLayout();
+ //       public CustomControl()
+ //       {
+ //           var label = new Label();
+ //           label.SetBinding(Label.TextProperty, new Binding(nameof(Text), source: this));
+ //           label.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this, mode: BindingMode.TwoWay));
+ //           label.SetDynamicResource(Label.TextColorProperty, "MyColor");
+ //           this.layout.Children.Add(label);
 
-            var box = new BoxView();
-            box.SetBinding(BoxView.ColorProperty, new Binding(nameof(BoxColor), source: this, mode: BindingMode.TwoWay));
-            box.WidthRequest = 24;
-            box.HeightRequest = 24;
-            this.layout.Children.Add(box);
+ //           var box = new BoxView();
+ //           box.SetBinding(BoxView.ColorProperty, new Binding(nameof(BoxColor), source: this, mode: BindingMode.TwoWay));
+ //           box.WidthRequest = 24;
+ //           box.HeightRequest = 24;
+ //           this.layout.Children.Add(box);
 
-            this.layout.Orientation = StackOrientation.Horizontal;
-            this.Content = this.layout;
-        }
+ //           this.layout.Orientation = StackOrientation.Horizontal;
+ //           this.Content = this.layout;
+ //       }
 
-        public Color TextColor
-        {
-            get { return (Color)this.GetValue(TextColorProperty); }
-            set { this.SetValue(TextColorProperty, value); }
-        }
+ //       public Color TextColor
+ //       {
+ //           get { return (Color)this.GetValue(TextColorProperty); }
+ //           set { this.SetValue(TextColorProperty, value); }
+ //       }
 
-        public string Text
-        {
-            get { return (string)this.GetValue(TextProperty); }
-            set { this.SetValue(TextProperty, value); }
-        }
+ //       public string Text
+ //       {
+ //           get { return (string)this.GetValue(TextProperty); }
+ //           set { this.SetValue(TextProperty, value); }
+ //       }
 
-        public Color BoxColor
-        {
-            get { return (Color)this.GetValue(BoxColorProperty); }
-            set { this.SetValue(BoxColorProperty, value); }
-        }
-    } 
+ //       public Color BoxColor
+ //       {
+ //           get { return (Color)this.GetValue(BoxColorProperty); }
+ //           set { this.SetValue(BoxColorProperty, value); }
+ //       }
+ //   } 
 }

--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml.cs
@@ -1,4 +1,7 @@
-﻿using Xamarin.Forms.Xaml;
+﻿using System;
+using System.Globalization;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
 {
@@ -11,47 +14,62 @@ namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
         }
 	}
 
+	[Preserve(AllMembers = true)]
+	class FooConverter : IValueConverter
+	{
+		public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			var val = value as string;
+			return val == "1" ? Color.Green : Color.Red;
+		}
+
+		public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+		{
+			throw new NotSupportedException("Only one way bindings are supported with this converter");
+		}
+	}
+
 	//public class CustomControl : ContentView
- //   {
- //       public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(CustomControl), (Color)new AppThemeColor() { Light = Color.Red, Dark = Color.Green });
- //       public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(CustomControl));
- //       public static readonly BindableProperty BoxColorProperty = BindableProperty.Create(nameof(BoxColor), typeof(Color), typeof(CustomControl), Color.Yellow);
+	//   {
+	//       public static readonly BindableProperty TextColorProperty = BindableProperty.Create(nameof(TextColor), typeof(Color), typeof(CustomControl), (Color)new AppThemeColor() { Light = Color.Red, Dark = Color.Green });
+	//       public static readonly BindableProperty TextProperty = BindableProperty.Create(nameof(Text), typeof(string), typeof(CustomControl));
+	//       public static readonly BindableProperty BoxColorProperty = BindableProperty.Create(nameof(BoxColor), typeof(Color), typeof(CustomControl), Color.Yellow);
 
- //       private StackLayout layout = new StackLayout();
- //       public CustomControl()
- //       {
- //           var label = new Label();
- //           label.SetBinding(Label.TextProperty, new Binding(nameof(Text), source: this));
- //           label.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this, mode: BindingMode.TwoWay));
- //           label.SetDynamicResource(Label.TextColorProperty, "MyColor");
- //           this.layout.Children.Add(label);
+	//       private StackLayout layout = new StackLayout();
+	//       public CustomControl()
+	//       {
+	//           var label = new Label();
+	//           label.SetBinding(Label.TextProperty, new Binding(nameof(Text), source: this));
+	//           label.SetBinding(Label.TextColorProperty, new Binding(nameof(TextColor), source: this, mode: BindingMode.TwoWay));
+	//           label.SetDynamicResource(Label.TextColorProperty, "MyColor");
+	//           this.layout.Children.Add(label);
 
- //           var box = new BoxView();
- //           box.SetBinding(BoxView.ColorProperty, new Binding(nameof(BoxColor), source: this, mode: BindingMode.TwoWay));
- //           box.WidthRequest = 24;
- //           box.HeightRequest = 24;
- //           this.layout.Children.Add(box);
+	//           var box = new BoxView();
+	//           box.SetBinding(BoxView.ColorProperty, new Binding(nameof(BoxColor), source: this, mode: BindingMode.TwoWay));
+	//           box.WidthRequest = 24;
+	//           box.HeightRequest = 24;
+	//           this.layout.Children.Add(box);
 
- //           this.layout.Orientation = StackOrientation.Horizontal;
- //           this.Content = this.layout;
- //       }
+	//           this.layout.Orientation = StackOrientation.Horizontal;
+	//           this.Content = this.layout;
+	//       }
 
- //       public Color TextColor
- //       {
- //           get { return (Color)this.GetValue(TextColorProperty); }
- //           set { this.SetValue(TextColorProperty, value); }
- //       }
+	//       public Color TextColor
+	//       {
+	//           get { return (Color)this.GetValue(TextColorProperty); }
+	//           set { this.SetValue(TextColorProperty, value); }
+	//       }
 
- //       public string Text
- //       {
- //           get { return (string)this.GetValue(TextProperty); }
- //           set { this.SetValue(TextProperty, value); }
- //       }
+	//       public string Text
+	//       {
+	//           get { return (string)this.GetValue(TextProperty); }
+	//           set { this.SetValue(TextProperty, value); }
+	//       }
 
- //       public Color BoxColor
- //       {
- //           get { return (Color)this.GetValue(BoxColorProperty); }
- //           set { this.SetValue(BoxColorProperty, value); }
- //       }
- //   } 
+	//       public Color BoxColor
+	//       {
+	//           get { return (Color)this.GetValue(BoxColorProperty); }
+	//           set { this.SetValue(BoxColorProperty, value); }
+	//       }
+	//   } 
 }

--- a/Xamarin.Forms.Core.UnitTests/AppThemeTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AppThemeTests.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	public class AppThemeTests : BaseTestFixture
+	{
+		[SetUp]
+		public override void Setup()
+		{
+			base.Setup();
+			Application.Current = new MockApplication();
+
+			Device.SetFlags(new[] { ExperimentalFlags.AppThemeExperimental });
+		}
+
+		[Test]
+		public void ThemeChangeUsingSetAppThemeColor()
+		{
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+
+			label.SetAppThemeColor(Label.TextColorProperty, Color.Green, Color.Red);
+			Assert.AreEqual(Color.Green, label.TextColor);
+
+			SetAppTheme(OSAppTheme.Dark);
+
+			Assert.AreEqual(Color.Red, label.TextColor);
+		}
+
+		[Test]
+		public void ThemeChangeUsingSetAppTheme()
+		{
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+
+			label.SetAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
+			Assert.AreEqual(Color.Green, label.TextColor);
+
+			SetAppTheme(OSAppTheme.Dark);
+
+			Assert.AreEqual(Color.Red, label.TextColor);
+		}
+
+		[Test]
+		public void ThemeChangeUsingSetBinding()
+		{
+			var label = new Label
+			{
+				Text = "Green on Light, Red on Dark"
+			};
+
+			label.SetBinding(Label.TextColorProperty, new OnAppTheme<Color> { Light = Color.Green, Dark = Color.Red });
+			Assert.AreEqual(Color.Green, label.TextColor);
+
+			SetAppTheme(OSAppTheme.Dark);
+
+			Assert.AreEqual(Color.Red, label.TextColor);
+		}
+
+		void SetAppTheme(OSAppTheme theme)
+		{
+			((MockPlatformServices)Device.PlatformServices).RequestedTheme = theme;
+			Application.Current.OnRequestedThemeChanged(new AppThemeChangedEventArgs(theme));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/AppThemeTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AppThemeTests.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Text = "Green on Light, Red on Dark"
 			};
 
-			label.SetAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
+			label.SetOnAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
 			Assert.AreEqual(Color.Green, label.TextColor);
 
 			SetAppTheme(OSAppTheme.Dark);

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -238,6 +238,7 @@
     <Compile Include="FlexLayoutAlignSelfTests.cs" />
     <Compile Include="FlexOrderTests.cs" />
     <Compile Include="FontAttributeConverterUnitTests.cs" />
+    <Compile Include="AppThemeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
@@ -249,7 +250,7 @@
       <Name>Xamarin.Forms.Maps</Name>
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">
-      <Project>{67f9d3a8-f71e-4428-913f-c37ae82cdb24}</Project>
+      <Project>{D31A6537-ED9C-4EBD-B231-A8D4FE44126A}</Project>
       <Name>Xamarin.Forms.Platform</Name>
     </ProjectReference>
     <ProjectReference Include="..\Xamarin.Forms.Xaml\Xamarin.Forms.Xaml.csproj">
@@ -274,7 +275,7 @@
   <ItemGroup />
   <Target Name="_CopyNUnitTestAdapterFiles" AfterTargets="Build">
     <ItemGroup>
-      <_NUnitTestAdapterFiles Include="$(NuGetPackageRoot)NUnit3TestAdapter\%(Version)\build\net35\**" Condition="@(PackageReference -> '%(Identity)') == 'NUnit3TestAdapter'" InProject="False" />
+      <_NUnitTestAdapterFiles Include="$(NuGetPackageRoot)NUnit3TestAdapter\%(Version)\build\net35\**" Condition="@(PackageReference -&gt; '%(Identity)') == 'NUnit3TestAdapter'" InProject="False" />
     </ItemGroup>
     <Copy SourceFiles="@(_NUnitTestAdapterFiles)" DestinationFolder="$(SolutionDir)packages\NUnitTestAdapter.AnyVersion\tools\%(RecursiveDir)" ContinueOnError="true" Retries="0" />
     <Copy SourceFiles="@(_NUnitTestAdapterFiles)" DestinationFolder="$(SolutionDir)packages\NUnitTestAdapter.AnyVersion\build\%(RecursiveDir)" ContinueOnError="true" Retries="0" />

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -159,20 +159,31 @@ namespace Xamarin.Forms
 
 		public OSAppTheme RequestedTheme => Device.PlatformServices.RequestedTheme;
 
-		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
-		{
-			add
-			{
-				ExperimentalFlags.VerifyFlagEnabled(nameof(Application), ExperimentalFlags.AppThemeExperimental, nameof(RequestedThemeChanged));
+		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged;
+		// Doesn't work on iOS
+		//{
+		//	add => _weakEventManager.AddEventHandler(value);
+		//	remove => _weakEventManager.RemoveEventHandler(value);
+		//}
 
-				_weakEventManager.AddEventHandler(value);
-			}
-			remove => _weakEventManager.RemoveEventHandler(value);
-		}
+		bool _themeChangedFiring;
+		OSAppTheme _lastAppTheme;
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void OnRequestedThemeChanged(AppThemeChangedEventArgs args)
-			=> _weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+		{
+			if (!_themeChangedFiring && RequestedTheme != _lastAppTheme)
+			{
+				_themeChangedFiring = true;
+				_lastAppTheme = RequestedTheme;
+
+				// Doesn't work on iOS
+				//_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+
+				RequestedThemeChanged.Invoke(this, args);
+				_themeChangedFiring = false;
+			}
+		}
 
 		public event EventHandler<ModalPoppedEventArgs> ModalPopped;
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -159,7 +159,12 @@ namespace Xamarin.Forms
 
 		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
 		{
-			add => _weakEventManager.AddEventHandler(value);
+			add
+			{
+				ExperimentalFlags.VerifyFlagEnabled(nameof(Application), ExperimentalFlags.AppThemeExperimental, nameof(RequestedThemeChanged));
+
+				_weakEventManager.AddEventHandler(value);
+			}
 			remove => _weakEventManager.RemoveEventHandler(value);
 		}
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -173,11 +173,17 @@ namespace Xamarin.Forms
 			// To minimize that for us, we only do it when the theme actually changes and it's not currently firing
 			if (!_themeChangedFiring && RequestedTheme != _lastAppTheme)
 			{
-				_themeChangedFiring = true;
-				_lastAppTheme = RequestedTheme;
+				try
+				{
+					_themeChangedFiring = true;
+					_lastAppTheme = RequestedTheme;
 
-				_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
-				_themeChangedFiring = false;
+					_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+				}
+				finally
+				{
+					_themeChangedFiring = false;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -169,6 +169,9 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void OnRequestedThemeChanged(AppThemeChangedEventArgs args)
 		{
+			if (Device.Flags.IndexOf(ExperimentalFlags.AppThemeExperimental) == -1)
+				return;
+
 			// On iOS the event is triggered more than once.
 			// To minimize that for us, we only do it when the theme actually changes and it's not currently firing
 			if (!_themeChangedFiring && RequestedTheme != _lastAppTheme)

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -6,8 +6,6 @@ using System.ComponentModel;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
-using System.Diagnostics;
-using Xamarin.Forms.Core;
 
 namespace Xamarin.Forms
 {
@@ -59,7 +57,7 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public static void SetCurrentApplication(Application value) => Current = value; 
+		public static void SetCurrentApplication(Application value) => Current = value;
 
 		public static Application Current { get; set; }
 
@@ -159,12 +157,11 @@ namespace Xamarin.Forms
 
 		public OSAppTheme RequestedTheme => Device.PlatformServices.RequestedTheme;
 
-		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged;
-		// Doesn't work on iOS
-		//{
-		//	add => _weakEventManager.AddEventHandler(value);
-		//	remove => _weakEventManager.RemoveEventHandler(value);
-		//}
+		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
+		{
+			add => _weakEventManager.AddEventHandler(value);
+			remove => _weakEventManager.RemoveEventHandler(value);
+		}
 
 		bool _themeChangedFiring;
 		OSAppTheme _lastAppTheme;
@@ -172,15 +169,14 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void OnRequestedThemeChanged(AppThemeChangedEventArgs args)
 		{
+			// On iOS the event is triggered more than once.
+			// To minimize that for us, we only do it when the theme actually changes and it's not currently firing
 			if (!_themeChangedFiring && RequestedTheme != _lastAppTheme)
 			{
 				_themeChangedFiring = true;
 				_lastAppTheme = RequestedTheme;
 
-				// Doesn't work on iOS
-				//_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
-
-				RequestedThemeChanged.Invoke(this, args);
+				_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
 				_themeChangedFiring = false;
 			}
 		}

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -159,12 +159,7 @@ namespace Xamarin.Forms
 
 		public event EventHandler<AppThemeChangedEventArgs> RequestedThemeChanged
 		{
-			add
-			{
-				ExperimentalFlags.VerifyFlagEnabled(nameof(Application), ExperimentalFlags.AppThemeExperimental, nameof(RequestedThemeChanged));
-
-				_weakEventManager.AddEventHandler(value);
-			}
+			add => _weakEventManager.AddEventHandler(value);
 			remove => _weakEventManager.RemoveEventHandler(value);
 		}
 

--- a/Xamarin.Forms.Core/BindableObjectExtensions.cs
+++ b/Xamarin.Forms.Core/BindableObjectExtensions.cs
@@ -67,5 +67,17 @@ namespace Xamarin.Forms
 
 			return returnIfNotSet;
 		}
+
+		public static void SetAppTheme<T>(this BindableObject self, BindableProperty targetProperty, T light, T dark)
+		{
+			var appTheme = new OnAppTheme<T> { Light = light, Dark = dark };
+			self.SetBinding(targetProperty, appTheme);
+		}
+
+		public static void SetAppThemeColor(this BindableObject self, BindableProperty targetProperty, Color light, Color dark)
+		{
+			var appTheme = new AppThemeColor { Light = light, Dark = dark };
+			self.SetBinding(targetProperty, appTheme);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/BindableObjectExtensions.cs
+++ b/Xamarin.Forms.Core/BindableObjectExtensions.cs
@@ -68,15 +68,19 @@ namespace Xamarin.Forms
 			return returnIfNotSet;
 		}
 
-		public static void SetAppTheme<T>(this BindableObject self, BindableProperty targetProperty, T light, T dark)
+		public static void SetOnAppTheme<T>(this BindableObject self, BindableProperty targetProperty, T light, T dark, T defaultValue = default)
 		{
-			var appTheme = new OnAppTheme<T> { Light = light, Dark = dark };
+			ExperimentalFlags.VerifyFlagEnabled(nameof(BindableObjectExtensions), ExperimentalFlags.AppThemeExperimental, nameof(BindableObjectExtensions), nameof(SetOnAppTheme));
+
+			var appTheme = new OnAppTheme<T> { Light = light, Dark = dark, Default = defaultValue };
 			self.SetBinding(targetProperty, appTheme);
 		}
 
-		public static void SetAppThemeColor(this BindableObject self, BindableProperty targetProperty, Color light, Color dark)
+		public static void SetAppThemeColor(this BindableObject self, BindableProperty targetProperty, Color light, Color dark, Color defaultValue = default)
 		{
-			var appTheme = new AppThemeColor { Light = light, Dark = dark };
+			ExperimentalFlags.VerifyFlagEnabled(nameof(BindableObjectExtensions), ExperimentalFlags.AppThemeExperimental, nameof(BindableObjectExtensions), nameof(SetAppThemeColor));
+
+			var appTheme = new AppThemeColor { Light = light, Dark = dark, Default = defaultValue };
 			self.SetBinding(targetProperty, appTheme);
 		}
 	}

--- a/Xamarin.Forms.Core/OnAppTheme.cs
+++ b/Xamarin.Forms.Core/OnAppTheme.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms
 		}
 		internal override BindingBase Clone()
 		{
-			throw new NotImplementedException();
+			return new OnAppTheme<T> { Light = Light, Dark = Dark };
 		}
 
 		internal override void Apply(object context, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)

--- a/Xamarin.Forms.Core/OnAppTheme.cs
+++ b/Xamarin.Forms.Core/OnAppTheme.cs
@@ -19,15 +19,17 @@ namespace Xamarin.Forms
 		public new BindingMode Mode
 		{
 			get => base.Mode;
-			set
-			{
-				// TODO
-				throw new Exception();
-			}
+			private set { }
 		}
 		internal override BindingBase Clone()
 		{
-			return new OnAppTheme<T> { Light = Light, Dark = Dark };
+			return new OnAppTheme<T> { Light = Light, Dark = Dark, Default = Default };
+		}
+
+		internal override void Apply(bool fromTarget)
+		{
+			base.Apply(fromTarget);
+			ApplyCore();
 		}
 
 		internal override void Apply(object context, BindableObject bindObj, BindableProperty targetProperty, bool fromBindingContextChanged = false)
@@ -43,7 +45,7 @@ namespace Xamarin.Forms
 			if (_weakTarget == null || !_weakTarget.TryGetTarget(out var target))
 				return;
 
-			target.SetValue(_targetProperty, Application.Current.RequestedTheme == OSAppTheme.Dark ? Dark : Light);
+			target?.SetValue(_targetProperty, GetValue());
 		}
 
 		T _light;

--- a/Xamarin.Forms.Core/OnAppTheme.cs
+++ b/Xamarin.Forms.Core/OnAppTheme.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms
 	{
 		WeakReference<BindableObject> _weakTarget;
 		BindableProperty _targetProperty;
-
+		
 		public OnAppTheme()
 		{
 			Application.Current.RequestedThemeChanged += ThemeChanged;
@@ -39,13 +39,12 @@ namespace Xamarin.Forms
 			base.Apply(context, bindObj, targetProperty, fromBindingContextChanged);
 			ApplyCore();
 		}
-
 		void ApplyCore()
 		{
 			if (_weakTarget == null || !_weakTarget.TryGetTarget(out var target))
 				return;
 
-			target?.SetValue(_targetProperty, GetValue());
+			target?.SetValueCore(_targetProperty, GetValue());
 		}
 
 		T _light;

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -275,8 +275,7 @@ namespace Xamarin.Forms
 
 		internal VisualElement()
 		{
-			if (Device.Flags?.IndexOf(ExperimentalFlags.AppThemeExperimental) > 0)
-				Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
+			Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
 		}
 
 		protected virtual void OnRequestedThemeChanged(OSAppTheme newValue)

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -275,7 +275,8 @@ namespace Xamarin.Forms
 
 		internal VisualElement()
 		{
-			Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
+			if (Device.Flags?.IndexOf(ExperimentalFlags.AppThemeExperimental) > 0)
+				Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
 		}
 
 		protected virtual void OnRequestedThemeChanged(OSAppTheme newValue)

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -275,7 +275,8 @@ namespace Xamarin.Forms
 
 		internal VisualElement()
 		{
-			Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
+			if (Application.Current != null)
+				Application.Current.RequestedThemeChanged += (s, a) => OnRequestedThemeChanged(a.RequestedTheme);
 		}
 
 		protected virtual void OnRequestedThemeChanged(OSAppTheme newValue)

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -363,7 +363,6 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 		}
-
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -363,6 +363,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 		}
+
 		public override void TraitCollectionDidChange(UITraitCollection previousTraitCollection)
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);

--- a/Xamarin.Forms.Xaml.UnitTests/OnPlatformTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/OnPlatformTests.cs
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 			Text=""This text is green or red depending on Light(or default) or Dark"">
                 <Label.TextColor>
-                    <OnAppTheme x:DataType=""Color"" Light=""Green"" Dark=""Red"" />
+                    <OnAppTheme x:TypeArguments=""Color"" Light=""Green"" Dark=""Red"" />
 				</Label.TextColor>
 			</Label> ";
 
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 			Text=""This text is green or red depending on Light(or default) or Dark"">
                 <Label.TextColor>
-                    <OnAppTheme x:DataType=""Color"" Light=""Green"" Dark=""Red"" />
+                    <OnAppTheme x:TypeArguments=""Color"" Light=""Green"" Dark=""Red"" />
 				</Label.TextColor>
 			</Label> ";
 
@@ -215,7 +215,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 			Text=""This text is green or red depending on Light(or default) or Dark"">
                 <Label.TextColor>
-                    <OnAppTheme x:DataType=""Color"" Default=""Green"" Dark=""Red"" />
+                    <OnAppTheme x:TypeArguments=""Color"" Default=""Green"" Dark=""Red"" />
 				</Label.TextColor>
 			</Label> ";
 

--- a/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
@@ -103,7 +103,11 @@ namespace Xamarin.Forms.Xaml
 					}
 				}
 
-				return converterProvider.Convert(value, propertyType, minforetriever, serviceProvider);
+				var light = converterProvider.Convert(Light, propertyType, minforetriever, serviceProvider);
+
+				var dark = converterProvider.Convert(Dark, propertyType, minforetriever, serviceProvider);
+
+				return new OnAppTheme<object> { Light = light, Dark = dark };
 			}
 			if (converterProvider != null)
 				return converterProvider.Convert(value, propertyType, () => pi, serviceProvider);
@@ -111,7 +115,7 @@ namespace Xamarin.Forms.Xaml
 			var ret = value.ConvertTo(propertyType, () => pi, serviceProvider, out Exception exception);
 			if (exception != null)
 				throw exception;
-			return ret;
+			return new OnAppTheme<object> { Light = Light, Dark = Dark };
 		}
 
 		object GetValue()

--- a/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
@@ -1,13 +1,11 @@
 ﻿using System;
-using System.ComponentModel;
 using System.Globalization;
 using System.Reflection;
-using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms.Xaml
 {
 	[ContentProperty(nameof(Default))]
-	public class OnAppThemeExtension : IMarkupExtension, INotifyPropertyChanged
+	public class OnAppThemeExtension : IMarkupExtension<BindingBase>
 	{
 		public OnAppThemeExtension()
 		{
@@ -16,31 +14,37 @@ namespace Xamarin.Forms.Xaml
 			Application.Current.RequestedThemeChanged += RequestedThemeChanged;
 		}
 
-		public event PropertyChangedEventHandler PropertyChanged;
-
-		protected void OnPropertyChanged([CallerMemberName] string propName = null)
-			=> PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propName));
-
 		public object Default { get; set; }
 		public object Light { get; set; }
 		public object Dark { get; set; }
-
-		private object _value;
-		public object Value
-		{
-			get => _value;
-			private set
-			{
-				_value = value;
-				OnPropertyChanged();
-			}
-		}
+		public object Value	{ get; private set;	}
 
 		public IValueConverter Converter { get; set; }
-
 		public object ConverterParameter { get; set; }
 
 		public object ProvideValue(IServiceProvider serviceProvider)
+		{
+			return (this as IMarkupExtension<BindingBase>).ProvideValue(serviceProvider);
+		}
+
+		object GetValue()
+		{
+			switch (Application.Current?.RequestedTheme)
+			{
+				default:
+				case OSAppTheme.Light:
+					return Light ?? Default;
+				case OSAppTheme.Dark:
+					return Dark ?? Default;
+			}
+		}
+
+		void RequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+		{
+			Value = GetValue();
+		}
+
+		BindingBase IMarkupExtension<BindingBase>.ProvideValue(IServiceProvider serviceProvider)
 		{
 			if (Default == null
 				&& Light == null
@@ -66,13 +70,20 @@ namespace Xamarin.Forms.Xaml
 							  ?? pi?.PropertyType
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
-			var value = GetValue();
-			var info = propertyType.GetTypeInfo();
-			if (value == null && info.IsValueType)
-				return Activator.CreateInstance(propertyType);
+			//var value = GetValue();
+			//var info = propertyType.GetTypeInfo();
+			//if (value == null && info.IsValueType)
+			//	return Activator.CreateInstance(propertyType);
 
 			if (Converter != null)
-				return Converter.Convert(value, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+			{
+				var light = Converter.Convert(Light, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+
+				var dark = Converter.Convert(Dark, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+				var def = Converter.Convert(Dark, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);
+
+				return new OnAppTheme<object> { Light = light, Dark = dark, Default = def };
+			}
 
 			var converterProvider = serviceProvider?.GetService<IValueConverterProvider>();
 			if (converterProvider != null)
@@ -106,33 +117,36 @@ namespace Xamarin.Forms.Xaml
 				var light = converterProvider.Convert(Light, propertyType, minforetriever, serviceProvider);
 
 				var dark = converterProvider.Convert(Dark, propertyType, minforetriever, serviceProvider);
+				var def = converterProvider.Convert(Dark, propertyType, minforetriever, serviceProvider);
 
-				return new OnAppTheme<object> { Light = light, Dark = dark };
+				return new OnAppTheme<object> { Light = light, Dark = dark, Default = def };
 			}
 			if (converterProvider != null)
-				return converterProvider.Convert(value, propertyType, () => pi, serviceProvider);
-
-			var ret = value.ConvertTo(propertyType, () => pi, serviceProvider, out Exception exception);
-			if (exception != null)
-				throw exception;
-			return new OnAppTheme<object> { Light = Light, Dark = Dark };
-		}
-
-		object GetValue()
-		{
-			switch (Application.Current?.RequestedTheme)
 			{
-				default:
-				case OSAppTheme.Light:
-					return Light ?? Default;
-				case OSAppTheme.Dark:
-					return Dark ?? Default;
-			}
-		}
+				var light = converterProvider.Convert(Light, propertyType, () => pi, serviceProvider);
 
-		void RequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
-		{
-			Value = GetValue();
+				var dark = converterProvider.Convert(Dark, propertyType, () => pi, serviceProvider);
+				var def = converterProvider.Convert(Default, propertyType, () => pi, serviceProvider);
+
+				return new OnAppTheme<object> { Light = light, Dark = dark, Default = def };
+			}
+
+			var lightConverted = Light.ConvertTo(propertyType, () => pi, serviceProvider, out Exception lightException);
+			
+			if (lightException != null)
+				throw lightException;
+
+			var darkConverted = Dark.ConvertTo(propertyType, () => pi, serviceProvider, out Exception darkException);
+
+			if (darkException != null)
+				throw darkException;
+
+			var defaultConverted = Dark.ConvertTo(propertyType, () => pi, serviceProvider, out Exception defaultException);
+
+			if (defaultException != null)
+				throw defaultException;
+
+			return new OnAppTheme<object> { Light = Light, Dark = Dark, Default = defaultConverted };
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/OnAppThemeExtension.cs
@@ -70,11 +70,6 @@ namespace Xamarin.Forms.Xaml
 							  ?? pi?.PropertyType
 							  ?? throw new InvalidOperationException("Cannot determine property to provide the value for.");
 
-			//var value = GetValue();
-			//var info = propertyType.GetTypeInfo();
-			//if (value == null && info.IsValueType)
-			//	return Activator.CreateInstance(propertyType);
-
 			if (Converter != null)
 			{
 				var light = Converter.Convert(Light, propertyType, ConverterParameter, CultureInfo.CurrentUICulture);


### PR DESCRIPTION
### Description of Change ###

This implements the runtime updating of AppTheme values.

### Issues Resolved ### 

- fixes #10391

### API Changes ###

Added:
 - void BindableObject.SetOnAppTheme<T>(T Light, T Dark, T Default = default);
 - void BindableObject.SetAppThemeColor(Color Light, Color Dark, Color Default = default);

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

The `INotifyPropertyChanged` was removed from the API. It doesn't make much sense to have that on there (anymore). People that were using that might see breaks.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

#### iOS
![ezgif com-video-to-gif](https://user-images.githubusercontent.com/939291/80230189-de673480-8651-11ea-861d-ab1e4c4673bd.gif)

#### Android
![ezgif com-video-to-gif (1)](https://user-images.githubusercontent.com/939291/80231424-a2cd6a00-8653-11ea-8e69-a1c5c32047a6.gif)


### Testing Procedure ###
Go to the right gallery page(s) and switch appearance

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
