### PR TITLE
Revert #8090 Android scrollbar flashes

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.Android
 		LayoutDirection _prevLayoutDirection = LayoutDirection.Ltr;
 		bool _checkedForRtlScroll = false;
 
-		public ScrollViewRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.NestedScrollBarStyle))
+		public ScrollViewRenderer(Context context) : base(context)
 		{
 		}
 

--- a/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/styles.xml
@@ -4,7 +4,4 @@
   <style name="collectionViewStyle" android:id="@+id/collectionViewStyle">
     <item name="android:scrollbars">vertical|horizontal</item>
   </style>
-  <style name="NestedScrollBarStyle" android:id="@+id/nestedScrollViewStyle">
-    <item name="android:scrollbars">vertical|horizontal</item>
-  </style>
 </resources>


### PR DESCRIPTION
### Description of Change ###

Reverts the changes of #8090. Caused too much regression on other controls inside of a `ScrollView`. Reverting the changes for now and reopening #8015 to find a new solution for the initial problem.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9591
- fixes #9423
- fixes #9019
- fixes #8986

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

No more scrollbar flashes on controls in a `ScrollView`. On the other hand, the `ScrollView` scrollbar visibility will be broken again,

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
There are multiple scenarios where you can find this. You can go to the Material Entry gallery and whenever you focus one entry you see the scrollbar flash on the right.

If you go to the label gallery and go through the `MaxLines` cases you will also see a scrollbar flash.

With this change, that should not be visible anymore

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
