### PR TITLE
Calculate TabBarIsVisible correctly

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -348,7 +348,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var shell = new Shell();
 			ShellTestPage pagetoTest = new ShellTestPage();
-			pagetoTest.BindingContext = pagetoTest;		
+			pagetoTest.BindingContext = pagetoTest;
 			var one = CreateShellItem(pagetoTest, shellContentRoute: "content", templated: useDataTemplates);
 			shell.Items.Add(one);
 			ShellTestPage page = null;
@@ -1269,10 +1269,10 @@ namespace Xamarin.Forms.Core.UnitTests
 			var classStyle = new Style(typeof(Grid))
 			{
 				Setters = {
-					new Setter 
+					new Setter
 					{
 						Property = VisualStateManager.VisualStateGroupsProperty,
-						Value = groups 
+						Value = groups
 					}
 				},
 				Class = FlyoutItem.LayoutStyle,
@@ -1290,6 +1290,57 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(Color.Red, label.BackgroundColor);
 			Assert.IsTrue(VisualStateManager.GoToState(grid, "Selected"));
 			Assert.AreEqual(Color.Green, label.BackgroundColor);
+		}
+
+
+		[TestCase("ContentPage")]
+		[TestCase("ShellItem")]
+		[TestCase("Shell")]
+		public void TabBarIsVisible(string test)
+		{
+			Shell shell = new Shell();
+			ContentPage page = new ContentPage();
+			var shellItem = CreateShellItem(page);
+			shell.Items.Add(shellItem);
+
+			switch (test)
+			{
+				case "ContentPage":
+					Shell.SetTabBarIsVisible(page, false);
+					break;
+				case "ShellItem":
+					Shell.SetTabBarIsVisible(shellItem, false);
+					break;
+				case "Shell":
+					Shell.SetTabBarIsVisible(shell, false);
+					break;
+			}
+
+			Assert.IsFalse((shellItem as IShellItemController).ShowTabs);
+		}
+
+		[Test]
+		public void SendStructureChangedFiresWhenAddingItems()
+		{
+			Shell shell = new Shell();
+			shell.Items.Add(CreateShellItem());
+
+			int count = 0;
+			int previousCount = 0;
+			(shell as IShellController).StructureChanged += (_, __) => count++;
+
+
+			shell.Items.Add(CreateShellItem());
+			Assert.Greater(count, previousCount, "StructureChanged not fired when adding Shell Item");
+
+			previousCount = count;
+			shell.CurrentItem.Items.Add(CreateShellSection());
+			Assert.Greater(count, previousCount, "StructureChanged not fired when adding Shell Section");
+
+			previousCount = count;
+			shell.CurrentItem.CurrentItem.Items.Add(CreateShellContent());
+			Assert.Greater(count, previousCount, "StructureChanged not fired when adding Shell Content");
+			
 		}
 
 

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>

--- a/Xamarin.Forms.Core/Shell/IShellItemController.cs
+++ b/Xamarin.Forms.Core/Shell/IShellItemController.cs
@@ -9,5 +9,6 @@ namespace Xamarin.Forms
 
 		ReadOnlyCollection<ShellSection> GetItems();
 		event NotifyCollectionChangedEventHandler ItemsCollectionChanged;
+		bool ShowTabs { get; }
 	}
 }

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1169,10 +1169,13 @@ namespace Xamarin.Forms
 
 		internal FlyoutBehavior GetEffectiveFlyoutBehavior() => GetEffectiveValue(Shell.FlyoutBehaviorProperty, FlyoutBehavior);
 
-		T GetEffectiveValue<T>(BindableProperty property, T defaultValue)
+		internal T GetEffectiveValue<T>(BindableProperty property, T defaultValue)
 		{
-			Element element = GetVisiblePage();
+			return GetEffectiveValue<T>(property, defaultValue, GetVisiblePage());
+		}
 
+		internal T GetEffectiveValue<T>(BindableProperty property, T defaultValue, Element element)
+		{
 			while (element != this && element != null)
 			{
 				if (element.IsSet(property))

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -94,6 +94,23 @@ namespace Xamarin.Forms
 			remove { ((ShellSectionCollection)Items).VisibleItemsChanged -= value; }
 		}
 
+		bool IShellItemController.ShowTabs
+		{
+			get
+			{
+				var displayedPage = CurrentItem?.DisplayedPage;
+				if (displayedPage == null)
+					return true;
+
+				Shell shell = Parent as Shell;
+				if (shell == null)
+					return true;
+
+				bool defaultShow = ShellItemController.GetItems().Count > 1;
+				return shell.GetEffectiveValue<bool>(Shell.TabBarIsVisibleProperty, defaultShow, displayedPage);
+			}
+		}
+
 		#endregion IShellItemController
 
 		#region IPropertyPropagationController
@@ -119,7 +136,10 @@ namespace Xamarin.Forms
 			ShellItemController.ItemsCollectionChanged += (_, args) =>
 			{
 				if (args.OldItems == null)
+				{
+					SendStructureChanged();
 					return;
+				}
 
 				foreach (Element item in args.OldItems)
 				{
@@ -172,9 +192,6 @@ namespace Xamarin.Forms
 			return result;
 		}
 
-#if DEBUG
-		[Obsolete ("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(ShellSection shellSection)
 		{
 			return CreateFromShellSection(shellSection);
@@ -195,19 +212,10 @@ namespace Xamarin.Forms
 			return result;
 		}
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(ShellContent shellContent) => (ShellSection)shellContent;
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(TemplatedPage page) => (ShellSection)(ShellContent)page;
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellItem(MenuItem menuItem) => new MenuShellItem(menuItem);
 
 		public IPlatformElementConfiguration<T, ShellItem> On<T>() where T : IConfigPlatform

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -243,12 +243,17 @@ namespace Xamarin.Forms
 			((ShellContentCollection)Items).VisibleItemsChangedInternal += (_, args) =>
 			{
 				if (args.OldItems == null)
+				{
+					SendStructureChanged();
 					return;
+				}
 
 				foreach(Element item in args.OldItems)
 				{
 					OnVisibleChildRemoved(item);
 				}
+
+				SendStructureChanged();
 			};
 
 			Navigation = new NavigationImpl(this);
@@ -266,7 +271,7 @@ namespace Xamarin.Forms
 
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
 
-		Page DisplayedPage
+		internal Page DisplayedPage
 		{
 			get { return _displayedPage; }
 			set
@@ -306,17 +311,11 @@ namespace Xamarin.Forms
 			return CreateFromShellContent((ShellContent)page);
 		}
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellSection(ShellContent shellContent)
 		{
 			return CreateFromShellContent(shellContent);
 		}
 
-#if DEBUG
-		[Obsolete("Please dont use this in core code... its SUPER hard to debug when this happens", true)]
-#endif
 		public static implicit operator ShellSection(TemplatedPage page)
 		{
 			return (ShellSection)(ShellContent)page;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -56,6 +56,7 @@ namespace Xamarin.Forms.Platform.Android
 		BottomNavigationViewTracker _bottomNavigationTracker;
 		BottomSheetDialog _bottomSheetDialog;
 		bool _disposed;
+		public IShellItemController ShellItemController => ShellItem;
 
 		public ShellItemRenderer(IShellContext shellContext) : base(shellContext)
 		{
@@ -418,7 +419,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (DisplayedPage == null)
 				return;
 
-			bool visible = Shell.GetTabBarIsVisible(DisplayedPage);
+			bool visible = ShellItemController.ShowTabs;
 			using (var menu = _bottomView.Menu)
 			{
 				if (menu.Size() == 1)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -207,7 +207,7 @@ namespace Xamarin.Forms.Platform.iOS
 					GoTo(ShellItem.CurrentItem);
 			}
 
-			SetTabBarHidden(ViewControllers.Length == 1);
+			UpdateTabBarHidden();
 		}
 
 		protected virtual void OnShellItemSet(ShellItem shellItem)
@@ -272,9 +272,7 @@ namespace Xamarin.Forms.Platform.iOS
 			ViewControllers = viewControllers;
 			CustomizableViewControllers = Array.Empty<UIViewController>();
 
-			// No sense showing a bar that has a single icon
-			if (ViewControllers.Length == 1)
-				SetTabBarHidden(true);
+			UpdateTabBarHidden();
 
 			// Make sure we are at the right item
 			GoTo(ShellItem.CurrentItem);
@@ -366,9 +364,12 @@ namespace Xamarin.Forms.Platform.iOS
 			return null;
 		}
 
-		void SetTabBarHidden(bool hidden)
+		void UpdateTabBarHidden()
 		{
-			TabBar.Hidden = hidden;
+			if (ShellItemController == null)
+				return;
+
+			TabBar.Hidden = !ShellItemController.ShowTabs;
 
 			if (CurrentRenderer == null)
 				return;
@@ -382,18 +383,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// and quick as a whip we return it back to what it was with its insets being all proper
 			CurrentRenderer.ViewController.View.Frame = View.Bounds;
-		}
-
-		void UpdateTabBarHidden()
-		{
-			if (_displayedPage == null || ShellItem == null)
-				return;
-
-			var hidden = !Shell.GetTabBarIsVisible(_displayedPage);
-			if (ShellItemController.GetItems().Count > 1)
-			{
-				SetTabBarHidden(hidden);
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

- Moved code to calculate TabBar Visibility into shell so it's centralized
- Calculate Tab Bar visibility up the hierarchy instead of just on the page
- changed iOS to always check this opposed to just randomly setting visibility
- Send Structure Change when new Shell Items are added

### Issues Resolved ### 
- fixes #10126
- fixes #6373


### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- unit tests included
- play with shell gallery

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
