### PR TITLE
[iOS, Android] Fix when we call ReloadData on CollectionView, Fix issue adding item to start of Collection on ANdroid

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
@@ -1,0 +1,177 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Collections.ObjectModel;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CarouselView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10300, "ObservableCollection.RemoveAt(index) with a valid index raises ArgementOutOfRangeException", PlatformAffected.iOS)]
+	public class Issue10300 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		CarouselView carousel;
+
+		public class ModalPage : ContentPage
+		{
+			public ModalPage()
+			{
+				var btn = new Button
+				{
+					Text = "Close",
+					TextColor = Color.White,
+					BackgroundColor = Color.Red,
+					VerticalOptions = LayoutOptions.End
+				};
+				btn.Clicked += OnCloseClicked;
+				Content = btn;
+			}
+
+			private void OnCloseClicked(object sender, EventArgs e)
+			{
+				this.Navigation.PopModalAsync();
+				MessagingCenter.Instance.Send<Page>(this, "Delete");
+			}
+		}
+
+		protected override void Init()
+		{
+			Items = new ObservableCollection<ModelIssue10300>(new[]
+															{
+																new ModelIssue10300("1", Color.Aqua),
+																new ModelIssue10300("2", Color.BlueViolet),
+																new ModelIssue10300("3", Color.Coral),
+																new ModelIssue10300("4", Color.DarkGoldenrod),
+																new ModelIssue10300("5", Color.Fuchsia),
+																new ModelIssue10300("6", Color.Gold),
+																new ModelIssue10300("7", Color.HotPink),
+																new ModelIssue10300("8", Color.IndianRed),
+																new ModelIssue10300("9", Color.Khaki),
+															});
+			carousel = new CarouselView();
+			carousel.ItemTemplate = new DataTemplate(() =>
+			{
+				var l = new Grid();
+				l.SetBinding(Grid.BackgroundColorProperty, new Binding("Color"));
+				var label = new Label
+				{
+					HorizontalTextAlignment = TextAlignment.Center,
+					VerticalTextAlignment = TextAlignment.Center
+				};
+				label.SetBinding(Label.TextProperty, new Binding("Text"));
+				l.Children.Add(label);
+				return l;
+			});
+			carousel.CurrentItemChanged += Carousel_CurrentItemChanged;
+			carousel.PositionChanged += Carousel_PositionChanged;
+
+			Grid.SetColumnSpan(carousel, 2);
+
+
+			carousel.SetBinding(CarouselView.ItemsSourceProperty, new Binding("Items"));
+			carousel.BindingContext = this;
+
+			var grd = new Grid
+			{
+				Margin = new Thickness(5)
+			};
+			grd.RowDefinitions.Add(new RowDefinition());
+			grd.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+
+			var btn = new Button
+			{
+				Text = "Delete",
+				BackgroundColor = Color.Red,
+				TextColor = Color.White
+			};
+			var btnAdd = new Button
+			{
+				Text = "Add",
+				BackgroundColor = Color.Red,
+				TextColor = Color.White
+			};
+			btn.Clicked += OnDeleteClicked;
+			Grid.SetRow(btn, 1);
+			Grid.SetColumn(btn, 0);
+
+			btnAdd.Clicked += OnAddlicked;
+			Grid.SetRow(btnAdd, 1);
+			Grid.SetColumn(btnAdd, 1);
+
+			grd.Children.Add(carousel);
+			grd.Children.Add(btn);
+			grd.Children.Add(btnAdd);
+			Content = grd;
+			MessagingCenter.Instance.Subscribe<Page>(this, "Delete", Callback);
+		}
+
+		void Carousel_PositionChanged(object sender, PositionChangedEventArgs e)
+		{
+			System.Diagnostics.Debug.WriteLine($"Position old {e.PreviousPosition} Position new {e.CurrentPosition}");
+		}
+
+		void Carousel_CurrentItemChanged(object sender, CurrentItemChangedEventArgs e)
+		{
+			System.Diagnostics.Debug.WriteLine($"Current old {e.PreviousItem} Current new {e.CurrentItem}");
+		}
+
+		void Callback(Page page)
+		{
+			var index = Items.IndexOf(carousel.CurrentItem as ModelIssue10300);
+			System.Diagnostics.Debug.WriteLine($"Delete {index}");
+			Items.RemoveAt(index);
+		}
+
+		public ObservableCollection<ModelIssue10300> Items { get; set; }
+
+
+		async void OnDeleteClicked(object sender, EventArgs e)
+		{
+			await Navigation.PushModalAsync(new ModalPage());
+		}
+
+		void OnAddlicked(object sender, EventArgs e)
+		{
+			Items.Insert(0, new ModelIssue10300("0", Color.PaleGreen));
+		}
+
+#if UITEST
+		[Test]
+		public void Issue10300Test() 
+		{
+			RunningApp.Tap("Add");
+			RunningApp.Tap("Delete");
+			RunningApp.WaitForElement("Close");
+			RunningApp.Tap("Close");
+			RunningApp.WaitForElement(q => q.Marked("2"));
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ModelIssue10300
+	{
+		public string Text { get; set; }
+
+		public Color Color { get; set; }
+
+		public ModelIssue10300(string text, Color color)
+		{
+			this.Text = text;
+			this.Color = color;
+		}
+
+		public override string ToString()
+		{
+			return Text;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1344,6 +1344,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8964.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9951.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9794.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10300.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -245,10 +245,13 @@ namespace Xamarin.Forms.Platform.Android
 				&& currentItemPosition != -1)
 			{
 				carouselPosition = currentItemPosition;
+				//if we are adding a item and we want to stay on the same position
+				//we don't need to scroll
+				_noNeedForScroll = true;
 			}
 
 			_gotoPosition = -1;
-
+		
 			SetCurrentItem(carouselPosition);
 			UpdatePosition(carouselPosition);
 
@@ -258,6 +261,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateItemDecoration();
 			}
+
 			UpdateVisualStates();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -284,7 +284,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			// If the UICollectionView hasn't actually been loaded, then calling InsertItems or DeleteItems is 
 			// going to crash or get in an unusable state; instead, ReloadData should be used
-			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
+			return !_collectionViewController.IsViewLoaded;
 		}
 
 		bool ReloadRequired()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -284,7 +284,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			// If the UICollectionView hasn't actually been loaded, then calling InsertItems or DeleteItems is 
 			// going to crash or get in an unusable state; instead, ReloadData should be used
-			return !_collectionViewController.IsViewLoaded;
+			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
 		}
 
 		bool ReloadRequired()
@@ -320,10 +320,7 @@ namespace Xamarin.Forms.Platform.iOS
 			},
 					(_) =>
 					{
-						if (_batchUpdating.CurrentCount > 0)
-						{
-							_batchUpdating.Release();
-						}
+						_batchUpdating.Release();
 					});
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -320,7 +320,10 @@ namespace Xamarin.Forms.Platform.iOS
 			},
 					(_) =>
 					{
-						_batchUpdating.Release();
+						if (_batchUpdating.CurrentCount == 0)
+						{
+							_batchUpdating.Release();
+						}
 					});
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

I found that #9911 introduced a new concept of Reload the CollectionView if it wasn't visible and an update to the items was in progress.
Seems this approach doesn't work well when we push a modal on top of the CollectionView  and then on dispose we add/remove items from the CollectionView. This was actually preventing the item from being removed. So my first try was to remove the check for `_collectionViewController.View.Window == null` , this worked but was going around the real problem.

It seems that also the `_batchUpdating.WaitAsync()` on the Reload method isn't working as expected, it was getting stuck because there were no available threads on the `_batchUpdating` semaphore. The problem was after a BatchUpdates was executed (for example add a item) the semaphore wasn't releasing and making the threads available. So the next time for example if it wanted to Reload it was getting stuck.

Fix issue on Android that Scrolling to the current position when adding an item would scroll the last item. 

This is actual a regression from previous versions. 

### Issues Resolved ### 

- fixes #10300

### API Changes ###
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added UITest 10300
Click Add
Click Delete
Click Close,
You should see the item `2`


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
