### PR TITLE
Use FlyoutBehavior on Shell if user sets it

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -92,27 +92,44 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		protected ShellItem CreateShellItem(
-			TemplatedPage page = null, 
-			bool asImplicit = false, 
-			string shellContentRoute = null, 
-			string shellSectionRoute = null, 
+			TemplatedPage page = null,
+			bool asImplicit = false,
+			string shellContentRoute = null,
+			string shellSectionRoute = null,
 			string shellItemRoute = null,
 			bool templated = false)
 		{
-			ShellItem item = null;
+			return CreateShellItem<ShellItem>(
+				page,
+				asImplicit,
+				shellContentRoute,
+				shellSectionRoute,
+				shellItemRoute,
+				templated);
+		}
+
+		protected T CreateShellItem<T>(
+			TemplatedPage page = null,
+			bool asImplicit = false,
+			string shellContentRoute = null,
+			string shellSectionRoute = null,
+			string shellItemRoute = null,
+			bool templated = false) where T : ShellItem
+		{
+			T item = null;
 			var section = CreateShellSection(page, asImplicit, shellContentRoute, shellSectionRoute, templated: templated);
 
 			if (!String.IsNullOrWhiteSpace(shellItemRoute))
 			{
-				item = new ShellItem();
+				item = Activator.CreateInstance<T>();
 				item.Route = shellItemRoute;
 				item.Items.Add(section);
 			}
 			else if (asImplicit)
-				item = ShellItem.CreateFromShellSection(section);
+				item = (T)ShellItem.CreateFromShellSection(section);
 			else
 			{
-				item = new ShellItem();
+				item = Activator.CreateInstance<T>();
 				item.Items.Add(section);
 			}
 
@@ -120,27 +137,42 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		protected ShellSection CreateShellSection(
+			TemplatedPage page = null,
+			bool asImplicit = false,
+			string shellContentRoute = null,
+			string shellSectionRoute = null,
+			bool templated = false)
+		{
+			return CreateShellSection<ShellSection>(
+				page, 
+				asImplicit, 
+				shellContentRoute,
+				shellSectionRoute, 
+				templated);
+		}
+
+		protected T CreateShellSection<T>(
 			TemplatedPage page = null, 
 			bool asImplicit = false, 
 			string shellContentRoute = null, 
 			string shellSectionRoute = null,
-			bool templated = false)
+			bool templated = false) where T : ShellSection
 		{
 			var content = CreateShellContent(page, asImplicit, shellContentRoute, templated: templated);
 
-			ShellSection section = null;
+			T section = null;
 
 			if (!String.IsNullOrWhiteSpace(shellSectionRoute))
 			{
-				section = new ShellSection();
+				section = Activator.CreateInstance<T>();
 				section.Route = shellSectionRoute;
 				section.Items.Add(content);
 			}
 			else if (asImplicit)
-				section = ShellSection.CreateFromShellContent(content);
+				section = (T)ShellSection.CreateFromShellContent(content);
 			else
 			{
-				section = new ShellSection();
+				section = Activator.CreateInstance<T>();
 				section.Items.Add(content);
 			}
 

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -896,6 +896,33 @@ namespace Xamarin.Forms.Core.UnitTests
 
 
 		[Test]
+		public async Task ShellFlyoutChangeableOnShellWithFlyoutItem()
+		{
+			Shell shell = new Shell();
+			var flyoutItem = CreateShellItem<FlyoutItem>();
+			shell.Items.Add(flyoutItem);
+			Assert.AreEqual(FlyoutBehavior.Flyout, shell.GetEffectiveFlyoutBehavior());
+			shell.FlyoutBehavior = FlyoutBehavior.Locked;
+			Assert.AreEqual(FlyoutBehavior.Locked, shell.GetEffectiveFlyoutBehavior());
+			shell.FlyoutBehavior = FlyoutBehavior.Disabled;
+			Assert.AreEqual(FlyoutBehavior.Disabled, shell.GetEffectiveFlyoutBehavior());
+		}
+
+		[Test]
+		public async Task ShellFlyoutChangeableOnShellWithTabBar()
+		{
+			Shell shell = new Shell();
+			var tabBarItem = CreateShellItem<TabBar>();
+			shell.Items.Add(tabBarItem);
+			Assert.AreEqual(FlyoutBehavior.Disabled, shell.GetEffectiveFlyoutBehavior());
+			shell.FlyoutBehavior = FlyoutBehavior.Flyout;
+			Assert.AreEqual(FlyoutBehavior.Flyout, shell.GetEffectiveFlyoutBehavior());
+			shell.FlyoutBehavior = FlyoutBehavior.Locked;
+			Assert.AreEqual(FlyoutBehavior.Locked, shell.GetEffectiveFlyoutBehavior());
+		}
+
+
+		[Test]
 		public async Task ShellFlyoutBehaviorCalculation()
 		{
 			Shell shell = new Shell();
@@ -927,21 +954,21 @@ namespace Xamarin.Forms.Core.UnitTests
 		public async Task TabBarAutoCreation()
 		{
 			Shell shell = new Shell();
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
 
 			Assert.AreEqual(1, shell.Items.Count);
 			Assert.AreEqual(3, shell.Items[0].Items.Count);
 
-			Assert.AreEqual(FlyoutBehavior.Disabled, Shell.GetFlyoutBehavior(shell.Items[0]));
+			Assert.AreEqual(FlyoutBehavior.Disabled, shell.GetEffectiveFlyoutBehavior());
 
 
 			shell = new Shell();
 			shell.Items.Add(new TabBar());
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
 
 			Assert.AreEqual(2, shell.Items.Count);
 			Assert.AreEqual(0, shell.Items[0].Items.Count);
@@ -949,13 +976,13 @@ namespace Xamarin.Forms.Core.UnitTests
 
 
 			shell = new Shell();
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
 			shell.Items.Add(new TabBar());
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
-			shell.Items.Add(ShellItem.CreateFromShellSection(new Tab()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
+			shell.Items.Add(ShellItem.CreateFromShellSection(CreateShellSection<Tab>()));
 
 			Assert.AreEqual(3, shell.Items.Count);
 			Assert.AreEqual(3, shell.Items[0].Items.Count);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -811,6 +811,9 @@ namespace Xamarin.Forms
 			set => SetValue(CurrentItemProperty, value);
 		}
 
+		internal ShellContent CurrentContent => CurrentItem?.CurrentItem?.CurrentItem;
+		internal ShellSection CurrentSection => CurrentItem?.CurrentItem;
+
 		public ShellNavigationState CurrentState => (ShellNavigationState)GetValue(CurrentStateProperty);
 
 		[TypeConverter(typeof(ImageSourceConverter))]
@@ -1170,21 +1173,48 @@ namespace Xamarin.Forms
 			return lookupDict;
 		}
 
-		internal FlyoutBehavior GetEffectiveFlyoutBehavior() => GetEffectiveValue(Shell.FlyoutBehaviorProperty, FlyoutBehavior);
+		internal FlyoutBehavior GetEffectiveFlyoutBehavior()
+		{
+			ShellItem rootItem = null;
+			return GetEffectiveValue(Shell.FlyoutBehaviorProperty, 
+				() =>
+				{
+					if (this.IsSet(FlyoutBehaviorProperty))
+						return FlyoutBehavior;
+
+					if (rootItem is FlyoutItem)
+						return FlyoutBehavior.Flyout;
+					else if (rootItem is TabBar)
+						return FlyoutBehavior.Disabled;
+
+					return FlyoutBehavior;
+				},
+				(o) => rootItem = rootItem ?? o as ShellItem);
+		}
 
 		T GetEffectiveValue<T>(BindableProperty property, T defaultValue)
 		{
-			Element element = GetVisiblePage();
+			return GetEffectiveValue(property, () => defaultValue, null);
+		}
+		
+		T GetEffectiveValue<T>(BindableProperty property, Func<T> defaultValue, Action<Element> observer)
+		{
+			Element element = GetVisiblePage() ?? CurrentContent;
 
 			while (element != this && element != null)
 			{
+				observer?.Invoke(element);
+
 				if (element.IsSet(property))
 					return (T)element.GetValue(property);
 
 				element = element.Parent;
 			}
 
-			return defaultValue;
+			if (defaultValue == null)
+				return default(T);
+
+			return defaultValue();
 		}
 
 		ShellAppearance GetAppearanceForPivot(Element pivot)

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms
 
 		public FlyoutItem()
 		{
-			Shell.SetFlyoutBehavior(this, FlyoutBehavior.Flyout);
+
 		}
 	}
 
@@ -28,7 +28,6 @@ namespace Xamarin.Forms
 	{
 		public TabBar()
 		{
-			Shell.SetFlyoutBehavior(this, FlyoutBehavior.Disabled);
 		}
 	}
 


### PR DESCRIPTION

### Description of Change ###

When using a TabBar or FlyoutItem the implicit behavior of the Flyout is different on one vs the other. This was implemented by just setting the attached property on the Item. The problem with doing it that way is that it doesn't let the user set the FlyoutItem at the Shell level



### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included
- Play with setting in Control Gallery

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
