### PR TITLE
Fix has VSM check to not use IsSet

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/VisualStateManagerTests.cs
@@ -130,6 +130,10 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var label1 = new Label();
 			Assert.False(label1.HasVisualStateGroups());
+			var vsg = VisualStateManager.GetVisualStateGroups(label1);
+			Assert.False(label1.HasVisualStateGroups());
+			vsg.Add(new VisualStateGroup());
+			Assert.True(label1.HasVisualStateGroups());
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -844,6 +844,9 @@ namespace Xamarin.Forms
 
 		internal void InvalidateStateTriggers(bool attach)
 		{
+			if (!this.HasVisualStateGroups())
+				return;
+
 			var groups = (IList<VisualStateGroup>)GetValue(VisualStateManager.VisualStateGroupsProperty);
 
 			if (groups.Count == 0)

--- a/Xamarin.Forms.Core/VisualStateManager.cs
+++ b/Xamarin.Forms.Core/VisualStateManager.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Forms
 
 		public static bool HasVisualStateGroups(this VisualElement element)
 		{
-			if (!element.IsSet(VisualStateGroupsProperty, true))
+			if (!element.IsSet(VisualStateGroupsProperty))
 				return false;
 
 			if (GetVisualStateGroups(element) is VisualStateGroupList vsgl)

--- a/Xamarin.Forms.Core/VisualStateManager.cs
+++ b/Xamarin.Forms.Core/VisualStateManager.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty VisualStateGroupsProperty =
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged,
-				defaultValueCreator: bindable => new VisualStateGroupList { VisualElement = (VisualElement)bindable });
+				defaultValueCreator: bindable => new VisualStateGroupList(true) { VisualElement = (VisualElement)bindable });
 
 		static void VisualStateGroupsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -50,7 +50,7 @@ namespace Xamarin.Forms
 
 		public static bool GoToState(VisualElement visualElement, string name)
 		{
-			if (!visualElement.IsSet(VisualStateGroupsProperty))
+			if (!visualElement.HasVisualStateGroups())
 			{
 				return false;
 			}
@@ -98,7 +98,13 @@ namespace Xamarin.Forms
 
 		public static bool HasVisualStateGroups(this VisualElement element)
 		{
-			return element.IsSet(VisualStateGroupsProperty);
+			if (!element.IsSet(VisualStateGroupsProperty, true))
+				return false;
+
+			if (GetVisualStateGroups(element) is VisualStateGroupList vsgl)
+				return !vsgl.IsDefault;
+
+			return true;
 		}
 
 		internal static void UpdateStateTriggers(VisualElement visualElement)
@@ -116,6 +122,7 @@ namespace Xamarin.Forms
 	public class VisualStateGroupList : IList<VisualStateGroup>
 	{
 		readonly IList<VisualStateGroup> _internalList;
+		internal bool IsDefault { get; private set; }
 
 		// Used to check for duplicate names; we keep it around because it's cheaper to create it once and clear it
 		// than to create one every time we need to validate
@@ -167,8 +174,13 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public VisualStateGroupList()
+		public VisualStateGroupList() : this(false)
 		{
+		}
+
+		public VisualStateGroupList(bool isDefault)
+		{
+			IsDefault = isDefault;
 			_internalList = new WatchAddList<VisualStateGroup>(ValidateAndNotify);
 		}
 
@@ -179,6 +191,9 @@ namespace Xamarin.Forms
 
 		void ValidateAndNotify(IList<VisualStateGroup> groups)
 		{
+			if(groups.Count > 0)
+				IsDefault = false;
+
 			Validate(groups);
 			OnStatesChanged();
 		}

--- a/Xamarin.Forms.Platform.Android.UnitTests/ButtonTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/ButtonTests.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms.CustomAttributes;
+using AColor = Android.Graphics.Color;
+
+namespace Xamarin.Forms.Platform.Android.UnitTests
+{
+
+	[TestFixture]
+	public class ButtonTests : PlatformTestFixture
+	{
+		[Test, Category("Button")]
+		[Description("Default Button Disabled color on Android doesn't look disabled after retrieving default VSM")]
+		[Issue(IssueTracker.Github, 10040, "[Bug] Button IsEnabled color Android")]
+		public async Task ButtonDisabledColorWorks()
+		{
+			Button myButton = new Button()
+			{
+				BackgroundColor = Color.Green,
+				TextColor = Color.White
+			};
+
+			var vsm = myButton.GetValue(VisualStateManager.VisualStateGroupsProperty);
+			var textColors = await GetControlProperty(myButton, (b) => b.TextColors);
+			var disabledColor = textColors.GetColorForState(new[] { -global::Android.Resource.Attribute.StateEnabled }, AColor.Green);
+
+			int compareTo = Color.White.ToAndroid();
+			Assert.AreNotEqual(compareTo, disabledColor);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android.UnitTests/ButtonTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/ButtonTests.cs
@@ -18,7 +18,10 @@ namespace Xamarin.Forms.Platform.Android.UnitTests
 			Button myButton = new Button()
 			{
 				BackgroundColor = Color.Green,
-				TextColor = Color.White
+				TextColor = Color.White,
+				BindingContext = new object(),
+				Text = "test text",
+				IsEnabled = false
 			};
 
 			var vsm = myButton.GetValue(VisualStateManager.VisualStateGroupsProperty);

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -64,6 +64,7 @@
     <Compile Include="TestClasses\_5560Model.cs" />
     <Compile Include="TextTests.cs" />
     <Compile Include="TranslationTests.cs" />
+    <Compile Include="ButtonTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="NUnit">


### PR DESCRIPTION
### Description of Change ###

VisualStateGroupsProperty has a defaultValueCreator which makes IsSet unreliable. 

- Convert the HasVSG check over to not using IsSet so that if someone retrieves the property the toggling of isSet to true won't change behavior

### Issues Resolved ### 
- fixes #10040

### Platforms Affected ### 
- Android


### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
