### PR TITLE
Removed useless Expander.Spacing property (Bug fix)

### DIFF
--- a/Xamarin.Forms.Core/Expander.cs
+++ b/Xamarin.Forms.Core/Expander.cs
@@ -13,9 +13,6 @@ namespace Xamarin.Forms
 
 		public event EventHandler Tapped;
 
-		public static readonly BindableProperty SpacingProperty = BindableProperty.Create(nameof(Spacing), typeof(double), typeof(Expander), 0d, propertyChanged: (bindable, oldvalue, newvalue)
-			=> ((Expander)bindable).ExpanderLayout.Spacing = (double)newvalue);
-
 		public static readonly BindableProperty HeaderProperty = BindableProperty.Create(nameof(Header), typeof(View), typeof(Expander), default(View), propertyChanged: (bindable, oldValue, newValue)
 			=> ((Expander)bindable).SetHeader((View)oldValue));
 
@@ -55,7 +52,7 @@ namespace Xamarin.Forms
 
 		public Expander()
 		{
-			ExpanderLayout = new StackLayout { Spacing = Spacing };
+			ExpanderLayout = new StackLayout { Spacing = 0 };
 			ForceUpdateSizeCommand = new Command(ForceUpdateSize);
 			InternalChildren.Add(ExpanderLayout);
 		}
@@ -89,12 +86,6 @@ namespace Xamarin.Forms
 					return heightRequest;
 				return heightRequest + layout.Padding.VerticalThickness;
 			}
-		}
-
-		public double Spacing
-		{
-			get => (double)GetValue(SpacingProperty);
-			set => SetValue(SpacingProperty, value);
 		}
 
 		public View Header


### PR DESCRIPTION
### Description of Change ###

Please firstly look through #10449 

Collapse and Expand animation are being cut off when "Spacing" property has a value.t seems that the Spacing just moves down the content by the value in the Spacing property and just leaves an empty space between the Content and Header. I do not see any use case for this. (Spacing can easily be managed by Margin/Padding and it won't cause UI glitches).

I didn't mark it as Obsolete because stable 4.6.0 is not released yet.

### Issues Resolved ### 
- fixes #10449 

### API Changes ###
Removed:
 - double Expander.Spacing
 
### Platforms Affected ### 
- Core

### Behavioral/Visual Changes ###
N/A

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
The sample is attached to the bug ticket.
