### PR TITLE
[Bug] Disabled Expander doesn't change its visual appearance

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ExpanderGalleries/ExpanderGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ExpanderGalleries/ExpanderGallery.xaml
@@ -13,9 +13,13 @@
                                 Command="{Binding Path=Command, Source={x:Reference page}}"
                                 CommandParameter="{Binding .}">
                         <Expander.Header>
-                            <Label Text="{Binding Name}" FontSize="35" FontAttributes="Bold"/>
+                            <StackLayout Orientation="Horizontal" Spacing="0">
+                                <Label Text="{Binding Name}" HorizontalOptions="FillAndExpand" FontSize="32" FontAttributes="Bold"/>
+                                <Label Text="Enable nested:" FontSize="13" VerticalOptions="CenterAndExpand" />
+                                <Switch IsToggled="{Binding IsEnabled}" />
+                            </StackLayout>
                         </Expander.Header>
-                        <Expander>
+                        <Expander IsEnabled="{Binding IsEnabled}">
                             <Expander.Header>
                                 <Label Text="Expander Level 2" FontSize="30" FontAttributes="Bold"/>
                             </Expander.Header>

--- a/Xamarin.Forms.Controls/GalleryPages/ExpanderGalleries/ExpanderGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ExpanderGalleries/ExpanderGallery.xaml.cs
@@ -58,6 +58,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.ExpanderGalleries
 		public sealed class Item: INotifyPropertyChanged {
 			public event PropertyChangedEventHandler PropertyChanged;
 			bool _isExpanded;
+			bool _isEnabled = true;
 
 			public string Name { get; set; }
 			public bool IsExpanded
@@ -66,14 +67,25 @@ namespace Xamarin.Forms.Controls.GalleryPages.ExpanderGalleries
 				set
 				{
 					if(value == _isExpanded)
-					{
 						return;
-					}
+
 					_isExpanded = value;
 					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsExpanded)));
 				}
 			}
 
+			public bool IsEnabled
+			{
+				get => _isEnabled;
+				set
+				{
+					if (value == _isEnabled)
+						return;
+
+					_isEnabled = value;
+					PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(IsEnabled)));
+				}
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Expander.cs
+++ b/Xamarin.Forms.Core/Expander.cs
@@ -60,7 +60,6 @@ namespace Xamarin.Forms
 			ExpanderLayout = new StackLayout { Spacing = Spacing };
 			ForceUpdateSizeCommand = new Command(ForceUpdateSize);
 			InternalChildren.Add(ExpanderLayout);
-			OnIsEnabledChanged();
 		}
 
 		internal static void VerifyExperimental([CallerMemberName] string memberName = "", string constructorHint = null)

--- a/Xamarin.Forms.Core/Expander.cs
+++ b/Xamarin.Forms.Core/Expander.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms
 	{
 		const string ExpandAnimationName = nameof(ExpandAnimationName);
 		const uint DefaultAnimationLength = 250;
+		const double EnabledOpacity = 1;
+		const double DisabledOpacity = .6;
 
 		public event EventHandler Tapped;
 
@@ -58,6 +60,7 @@ namespace Xamarin.Forms
 			ExpanderLayout = new StackLayout { Spacing = Spacing };
 			ForceUpdateSizeCommand = new Command(ForceUpdateSize);
 			InternalChildren.Add(ExpanderLayout);
+			OnIsEnabledChanged();
 		}
 
 		internal static void VerifyExperimental([CallerMemberName] string memberName = "", string constructorHint = null)
@@ -180,6 +183,13 @@ namespace Xamarin.Forms
 			base.OnBindingContextChanged();
 			_lastVisibleHeight = -1;
 			SetContent(true, true);
+		}
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+			if (propertyName == IsEnabledProperty.PropertyName)
+				OnIsEnabledChanged();
 		}
 
 		protected override void OnSizeAllocated(double width, double height)
@@ -363,5 +373,8 @@ namespace Xamarin.Forms
 					State = ExpanderState.Expanded;
 				});
 		}
+
+		void OnIsEnabledChanged()
+			=> ExpanderLayout.Opacity = IsEnabled ? EnabledOpacity: DisabledOpacity;
 	}
 }


### PR DESCRIPTION
### Description of Change ###
Change the visual appearance of disabled Expander

### Issues Resolved ### 
- fixes #10362 

### API Changes ###
None

### Platforms Affected ### 
- Core

### Behavioral/Visual Changes ###
The disabled state of Expander is different from the regular one.

### Before/After Screenshots ### 

Now Disabled Expander looks grayed out.

![image](https://user-images.githubusercontent.com/10124814/80322865-66a33080-8830-11ea-87b4-92c4b8ad2937.png)


### Testing Procedure ###
Set IsEnabled to False fo expander and compare enabled and disabled expanders.

