### PR TITLE
[iOS] NavigationPage.HideNavigationBarSeparator doesn't work on iOS 13

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10438.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10438.cs
@@ -1,0 +1,66 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Navigation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10438, "NavigationPage.HideNavigationBarSeparator doesn't work on iOS 13.4", PlatformAffected.iOS)]
+	public class Issue10438 : TestNavigationPage
+	{
+		public Issue10438()
+		{
+			BarBackgroundColor = Color.Cornsilk;
+			On<iOS>().SetPrefersLargeTitles(true);
+
+			var page = new ContentPage
+			{
+				Title = "Issue 10438"
+			};
+
+			var layout = new StackLayout();
+
+			var hideButton = new Button
+			{
+				Text = "Hide NavigationBarSeparator"
+			};
+
+			hideButton.Clicked += (sender, args) =>
+			{
+				On<iOS>().SetHideNavigationBarSeparator(true);
+			};
+
+			var showButton = new Button
+			{
+				Text = "Hide NavigationBarSeparator"
+			};
+
+			showButton.Clicked += (sender, args) =>
+			{
+				On<iOS>().SetHideNavigationBarSeparator(false);
+			};
+
+			layout.Children.Add(hideButton);
+			layout.Children.Add(showButton);
+
+			page.Content = layout;
+
+			PushAsync(page);
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1298,6 +1298,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8272.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8964.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9794.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10438.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">


### PR DESCRIPTION
### Description of Change ###

I have been able to verify the issue in the reproduction sample but after testing in 4.5 branch it seems that the issue have been fixed in recent changes. For that reason, this PR only include the sample in Core Gallery.

### Issues Resolved ### 

- fixes #10438

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![issue10438](https://user-images.githubusercontent.com/6755973/80362036-397f6e00-8882-11ea-9c84-c1b28d28849e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 10438. Verify that you can hide and show the NavigationBar separator.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
