### PR TITLE
Make managed cookies opt-in

### DIFF
--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -38,6 +38,8 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty CanGoForwardProperty = CanGoForwardPropertyKey.BindableProperty;
 
+		public static readonly BindableProperty ShouldManageCookiesProperty = BindableProperty.Create(nameof(ShouldManageCookies), typeof(bool), typeof(WebView), false);
+
 		public static readonly BindableProperty CookiesProperty = BindableProperty.Create(nameof(Cookies), typeof(CookieContainer), typeof(WebView), default(string));
 
 		readonly Lazy<PlatformConfigurationRegistry<WebView>> _platformConfigurationRegistry;
@@ -69,6 +71,12 @@ namespace Xamarin.Forms
 		public bool CanGoForward
 		{
 			get { return (bool)GetValue(CanGoForwardProperty); }
+		}
+
+		public bool ShouldManageCookies
+		{
+			get { return (bool)GetValue(ShouldManageCookiesProperty); }
+			set { SetValue(ShouldManageCookiesProperty, value); }
 		}
 
 		public CookieContainer Cookies

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -37,16 +37,19 @@ namespace Xamarin.Forms.Platform.Android
 			if (_renderer == null || string.IsNullOrWhiteSpace(url) || url == WebViewRenderer.AssetBaseUrl)
 				return;
 
-			var cookieManager = CookieManager.Instance;
-			cookieManager.SetAcceptCookie(true);
-			cookieManager.RemoveAllCookie();
-			var cookies = _renderer.Element.Cookies?.GetCookies(new System.Uri(url));
-			for (var i = 0; i < (cookies?.Count ?? -1); i++)
+			if (_renderer?.Element?.ShouldManageCookies == true)
 			{
-				string cookieValue = cookies[i].Value;
-				string cookieDomain = cookies[i].Domain;
-				string cookieName = cookies[i].Name;
-				cookieManager.SetCookie(cookieDomain, cookieName + "=" + cookieValue);
+				var cookieManager = CookieManager.Instance;
+				cookieManager.SetAcceptCookie(true);
+				cookieManager.RemoveAllCookie();
+				var cookies = _renderer.Element.Cookies?.GetCookies(new System.Uri(url));
+				for (var i = 0; i < (cookies?.Count ?? -1); i++)
+				{
+					string cookieValue = cookies[i].Value;
+					string cookieDomain = cookies[i].Domain;
+					string cookieName = cookies[i].Name;
+					cookieManager.SetCookie(cookieDomain, cookieName + "=" + cookieValue);
+				}
 			}
 
 			var cancel = false;

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -70,7 +70,7 @@ if(bases.length == 0){
 				uri = new Uri(LocalScheme + url, UriKind.RelativeOrAbsolute);
 			}
 
-			if (Element.Cookies?.Count > 0)
+			if (Element.ShouldManageCookies && Element.Cookies?.Count > 0)
 			{
 				//Set the Cookies...
 				var filter = new Windows.Web.Http.Filters.HttpBaseProtocolFilter();

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -274,27 +274,30 @@ namespace Xamarin.Forms.Platform.iOS
 				var lastUrl = request.Url.ToString();
 				var args = new WebNavigatingEventArgs(navEvent, new UrlWebViewSource { Url = lastUrl }, lastUrl);
 
-				// Set cookies here
-				var cookieJar = NSHttpCookieStorage.SharedStorage;
-				cookieJar.AcceptPolicy = NSHttpCookieAcceptPolicy.Always;
-
-				//clean up old cookies
-				foreach (var aCookie in cookieJar.Cookies)
+				if (WebView.ShouldManageCookies == true)
 				{
-					cookieJar.DeleteCookie(aCookie);
-				}
-				//set up the new cookies
-				if (WebView.Cookies != null)
-				{
-					var jCookies = WebView.Cookies.GetCookies(request.Url);
-					IList<NSHttpCookie> eCookies =
-						(from object jCookie in jCookies
-						 where jCookie != null
-						 select (Cookie)jCookie
-						 into netCookie
-						 select new NSHttpCookie(netCookie)).ToList();
+					// Set cookies here
+					var cookieJar = NSHttpCookieStorage.SharedStorage;
+					cookieJar.AcceptPolicy = NSHttpCookieAcceptPolicy.Always;
 
-					cookieJar.SetCookies(eCookies.ToArray(), request.Url, request.Url);
+					//clean up old cookies
+					foreach (var aCookie in cookieJar.Cookies)
+					{
+						cookieJar.DeleteCookie(aCookie);
+					}
+					//set up the new cookies
+					if (WebView.Cookies != null)
+					{
+						var jCookies = WebView.Cookies.GetCookies(request.Url);
+						IList<NSHttpCookie> eCookies =
+							(from object jCookie in jCookies
+							 where jCookie != null
+							 select (Cookie)jCookie
+							 into netCookie
+							 select new NSHttpCookie(netCookie)).ToList();
+
+						cookieJar.SetCookies(eCookies.ToArray(), request.Url, request.Url);
+					}
 				}
 
 				WebView.SendNavigating(args);


### PR DESCRIPTION
### Description ###

Added a new bound property that controls whether or not Xamarin Forms manages web view cookies on iOS, Android, and UAP.

### Issues Resolved ### 

- fixes #10318 

### API Changes ###

Added:
 - bool WebView.ShouldManageCookies { get; set; } // Bindable Property

### Platforms Affected ### 

- Core

### Behavioral/Visual Changes ###

This will impact users on the pre-release 4.6.0 version of Forms; the cookie management behavior introduced in #8169 will no longer be automatic; it is now opt-in.

### Testing Procedure ###

I was unable to build Xamarin Forms on my MacBook, so I wasn't able to build a test case; a simple project with a webview that requires cookies would suffice.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
