### PR TITLE
Fix vsmac uwp targets

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -115,13 +115,14 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition=" '$(OS)' == 'Windows_NT' AND $(TargetFramework.StartsWith('uap10.0'))  ">
-    <PackageReference Include="Microsoft.UI.Xaml" Condition="$(TargetPlatformMinVersion) &lt; '10.0.16299.0'">
+    <!-- Conditions duplicated on PackageReference to make VS Mac happy -->
+    <PackageReference Include="Microsoft.UI.Xaml" Condition="'$(OS)' == 'Windows_NT' AND $(TargetPlatformMinVersion) &lt; '10.0.16299.0'">
       <Version>2.1.190606001</Version>
     </PackageReference>
-    <PackageReference Include="Microsoft.UI.Xaml" Condition="$(TargetPlatformMinVersion) &gt;= '10.0.16299.0'">
+    <PackageReference Include="Microsoft.UI.Xaml" Condition="'$(OS)' == 'Windows_NT' AND $(TargetPlatformMinVersion) &gt;= '10.0.16299.0'">
       <Version>2.3.191211002</Version>
     </PackageReference>
-    <PackageReference Include="Win2D.uwp">
+    <PackageReference Include="Win2D.uwp" Condition="'$(OS)' == 'Windows_NT'">
       <Version>1.20.0</Version>
     </PackageReference>
   </ItemGroup>

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -156,9 +156,6 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Xamarin.Forms.DualScreen", "Xamarin.Forms.DualScreen", "{C97E54D4-DBC5-424E-B63F-4CF2F3EE8D13}"
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.DualScreen", "Xamarin.Forms.DualScreen\Xamarin.Forms.DualScreen.csproj", "{FB4A866A-5721-4545-9E5D-B7F7D59875A4}"
-	ProjectSection(ProjectDependencies) = postProject
-		{00D8D049-FFAA-4759-8FC9-1ECA30777F72} = {00D8D049-FFAA-4759-8FC9-1ECA30777F72}
-	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.DualScreen.UnitTests", "Xamarin.Forms.DualScreen.UnitTests\Xamarin.Forms.DualScreen.UnitTests.csproj", "{00D50743-7821-4293-92F2-7C614C256BD6}"
 EndProject

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -120,7 +120,7 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.ControlGaller
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Maps.GTK", "Xamarin.Forms.Maps.GTK\Xamarin.Forms.Maps.GTK.csproj", "{A9772BB1-0E17-42F5-A6DB-60BFCCBFDB9D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Platform.WPF", "Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj", "{140BC260-8B15-4D3A-B1B0-DDD8072918CC}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Platform.WPF", "Xamarin.Forms.Platform.WPF\Xamarin.Forms.Platform.WPF.csproj", "{140BC260-8B15-4D3A-B1B0-DDD8072918CC}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Xamarin.Forms.Maps.WPF", "Xamarin.Forms.Maps.WPF\Xamarin.Forms.Maps.WPF.csproj", "{89B0DB73-A32E-447C-9390-A2A59D89B2E4}"
 EndProject
@@ -157,9 +157,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Xamarin.Forms.DualScreen", 
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.DualScreen", "Xamarin.Forms.DualScreen\Xamarin.Forms.DualScreen.csproj", "{FB4A866A-5721-4545-9E5D-B7F7D59875A4}"
 	ProjectSection(ProjectDependencies) = postProject
-		{0E16E70A-D6DD-4323-AD5D-363ABFF42D6A} = {0E16E70A-D6DD-4323-AD5D-363ABFF42D6A}
 		{00D8D049-FFAA-4759-8FC9-1ECA30777F72} = {00D8D049-FFAA-4759-8FC9-1ECA30777F72}
-		{3B72465B-ACAE-43AE-9327-10F372FE5F80} = {3B72465B-ACAE-43AE-9327-10F372FE5F80}
 	EndProjectSection
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.DualScreen.UnitTests", "Xamarin.Forms.DualScreen.UnitTests\Xamarin.Forms.DualScreen.UnitTests.csproj", "{00D50743-7821-4293-92F2-7C614C256BD6}"


### PR DESCRIPTION
### Description of Change ###

- Add some additional conditions on the UAP project to help vsmac out
- Remove all the project dependencies associated with the dual screen info project. Just let VS figure it out


### Testing Procedure ###
- from a clean git make sure you can launch and build each of the projects on windows/vsmac
- make sure whatever issue @rmarinho and @jfversluis weren't seeing isn't seen anymore

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
