### PR TITLE
[iOS] Update RefreshViewRenderer.cs

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -118,9 +118,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (scrollView.ContentOffset.Y < 0)
 					return true;
-
+				
 				if (refreshing)
-					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY - _refreshControlHeight), true);
+ 					//fixed bug initial tint color is default
+                    scrollView.ContentOffset = (new CGPoint(0, _originalY - _refreshControl.Frame.Size.Height * 2.0));
 				else
 					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY), true);
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -118,10 +118,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (scrollView.ContentOffset.Y < 0)
 					return true;
-				
+
 				if (refreshing)
- 					//fixed bug initial tint color is default
-                    scrollView.ContentOffset = (new CGPoint(0, _originalY - _refreshControl.Frame.Size.Height * 2.0));
+					//fixed bug initial tint color is default
+					scrollView.ContentOffset = (new CoreGraphics.CGPoint(0, _originalY - _refreshControl.Frame.Size.Height * 2.0));
 				else
 					scrollView.SetContentOffset(new CoreGraphics.CGPoint(0, _originalY), true);
 


### PR DESCRIPTION
like described here:
https://stackoverflow.com/questions/19026351/ios-7-uirefreshcontrol-tintcolor-not-working-for-beginrefreshing
fix

<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/.github/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes (workaround) ios bug: the refresh color is ios default on first run, instead of explicitly set color
 
 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

 
- iOS
 
### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

- fixes the refresh color is ios default on first run, instead of explicitly set color#
 

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
