### PR TITLE
[iOS] Fix NavBar issues on iOS 13

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -138,6 +138,7 @@
     <Compile Include="ApiLabelRenderer.cs" />
     <Compile Include="CustomRenderers\CustomSearchBarRenderer.cs" />
     <Compile Include="_9767CustomRenderer.cs" />
+    <Compile Include="_10337CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.ControlGallery.iOS/_10337CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_10337CustomRenderer.cs
@@ -13,22 +13,9 @@ namespace Xamarin.Forms.ControlGallery.iOS
         {
             base.ViewDidLoad();
 
-            var isiOS13OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
-
-            if (isiOS13OrNewer)
-            {
-                var navigationBarAppearance = NavigationBar.StandardAppearance;
-                navigationBarAppearance.ConfigureWithDefaultBackground();
-                navigationBarAppearance.BackgroundColor = UIColor.Red;
-                navigationBarAppearance.ShadowImage = new UIImage();
-                navigationBarAppearance.ShadowColor = UIColor.Clear;
-                NavigationBar.StandardAppearance = navigationBarAppearance;
-                System.Diagnostics.Debug.WriteLine("_10337CustomRenderer");
-            }
-			else
-			{
-                NavigationBar.ShadowImage = new UIImage();
-            }
+            NavigationBar.ShadowImage = new UIImage();
+            UINavigationBar.Appearance.BackIndicatorImage = new UIImage();
+            UINavigationBar.Appearance.BackIndicatorTransitionMaskImage = new UIImage();
         }
     }
 }

--- a/Xamarin.Forms.ControlGallery.iOS/_10337CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_10337CustomRenderer.cs
@@ -1,0 +1,34 @@
+﻿using UIKit;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.iOS;
+
+[assembly: ExportRenderer(typeof(Issue10337NavigationPage), typeof(_10337CustomRenderer))]
+namespace Xamarin.Forms.ControlGallery.iOS
+{
+    public class _10337CustomRenderer : NavigationRenderer
+    {
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+
+            var isiOS13OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
+
+            if (isiOS13OrNewer)
+            {
+                var navigationBarAppearance = NavigationBar.StandardAppearance;
+                navigationBarAppearance.ConfigureWithDefaultBackground();
+                navigationBarAppearance.BackgroundColor = UIColor.Red;
+                navigationBarAppearance.ShadowImage = new UIImage();
+                navigationBarAppearance.ShadowColor = UIColor.Clear;
+                NavigationBar.StandardAppearance = navigationBarAppearance;
+                System.Diagnostics.Debug.WriteLine("_10337CustomRenderer");
+            }
+			else
+			{
+                NavigationBar.ShadowImage = new UIImage();
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10337.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10337.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Navigation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10337, "[Bug]iOS Renderer NavigationBar.ShadowImage = new UIImage() not remove shadow line after xamarin.forms 4.5", PlatformAffected.iOS)]
+	public class Issue10337 : TestNavigationPage
+	{
+		public Issue10337()
+		{
+			var page = new ContentPage
+			{
+				Title = "Issue 10337"
+			};
+
+			var layout = new StackLayout();
+
+			var navigateButton = new Button
+			{
+				Text = "Navigate using Custom NavigationPage"
+			};
+
+			navigateButton.Clicked += (sender, args) =>
+			{
+				Navigation.PushAsync(new Issue10337NavigationPage(new Issue10337()));
+			};
+
+			layout.Children.Add(navigateButton);
+
+			page.Content = layout;
+
+			PushAsync(page);
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10337NavigationPage : NavigationPage
+	{
+		public Issue10337NavigationPage()
+		{
+
+		}
+
+		public Issue10337NavigationPage(Page root) : base(root)
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1297,6 +1297,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9417.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8272.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8964.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10337.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1152,19 +1152,19 @@ namespace Xamarin.Forms.Platform.iOS
 				var navBar = navigationRenderer.NavigationBar;
 				var navAppearance = navBar.StandardAppearance;
 
-				if (navAppareance.BackgroundColor == null)
+				if (navAppearance.BackgroundColor == null)
 				{
 					var backgroundColor = navBar.BarTintColor;
 					navBar.CompactAppearance.BackgroundColor = navBar.StandardAppearance.BackgroundColor = navBar.ScrollEdgeAppearance.BackgroundColor = backgroundColor;
 				}
 
-				if (navAppareance.BackgroundImage == null)
+				if (navAppearance.BackgroundImage == null)
 				{
 					var backgroundImage = navBar.GetBackgroundImage(UIBarMetrics.Default);
 					navBar.CompactAppearance.BackgroundImage = navBar.StandardAppearance.BackgroundImage = navBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
 				}
 
-				if (navAppareance.ShadowImage == null)
+				if (navAppearance.ShadowImage == null)
 				{
 					var shadowImage = navBar.ShadowImage;
 					navBar.CompactAppearance.ShadowImage = navBar.StandardAppearance.ShadowImage = navBar.ScrollEdgeAppearance.ShadowImage = shadowImage;

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1150,7 +1150,7 @@ namespace Xamarin.Forms.Platform.iOS
 				// were already set to navigation bar in older versions of
 				// iOS.
 				var navBar = navigationRenderer.NavigationBar;
-				var navAppareance = navBar.StandardAppearance;
+				var navAppearance = navBar.StandardAppearance;
 
 				if (navAppareance.BackgroundColor == null)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -659,7 +659,10 @@ namespace Xamarin.Forms.Platform.iOS
 				if (barBackgroundColor == Color.Default)
 				{
 					navigationBarAppearance.ConfigureWithDefaultBackground();
-					navigationBarAppearance.BackgroundColor = UINavigationBar.Appearance.BarTintColor;
+					navigationBarAppearance.BackgroundColor = null;
+
+					var parentingViewController = GetParentingViewController();
+					parentingViewController?.SetupDefaultNavigationBarAppearance();
 				}
 				else
 				{
@@ -670,9 +673,6 @@ namespace Xamarin.Forms.Platform.iOS
 				NavigationBar.CompactAppearance = navigationBarAppearance;
 				NavigationBar.StandardAppearance = navigationBarAppearance;
 				NavigationBar.ScrollEdgeAppearance = navigationBarAppearance;
-
-				var parentingViewController = GetParentingViewController();
-				parentingViewController?.UpdateNavigationBarBackgroundImage();
 			}
 			else
 #endif
@@ -1070,7 +1070,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override void ViewWillAppear(bool animated)
 			{
-				UpdateNavigationBarBackgroundImage();
+				SetupDefaultNavigationBarAppearance();
 				UpdateNavigationBarVisibility(animated);
 
 				NavigationRenderer n;
@@ -1136,7 +1136,7 @@ namespace Xamarin.Forms.Platform.iOS
 					UpdateTitleArea(Child);
 			}
 
-			internal void UpdateNavigationBarBackgroundImage()
+			internal void SetupDefaultNavigationBarAppearance()
 			{
 				if (!Forms.IsiOS13OrNewer)
 					return;
@@ -1145,12 +1145,63 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 #if __XCODE11__
-				var backgroundImage = navigationRenderer.NavigationBar.GetBackgroundImage(UIBarMetrics.Default);
 
-				navigationRenderer.NavigationBar.CompactAppearance.BackgroundImage = backgroundImage;
-				navigationRenderer.NavigationBar.StandardAppearance.BackgroundImage = backgroundImage;
-				navigationRenderer.NavigationBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
+				// We will use UINavigationBar.Appareance to infer settings that
+				// were already set to navigation bar in older versions of
+				// iOS.
+				var navBar = navigationRenderer.NavigationBar;
+				var navAppareance = navBar.StandardAppearance;
+
+				if (navAppareance.BackgroundColor == null)
+				{
+					var backgroundColor = navBar.BarTintColor;
+					navBar.CompactAppearance.BackgroundColor = navBar.StandardAppearance.BackgroundColor = navBar.ScrollEdgeAppearance.BackgroundColor = backgroundColor;
+				}
+
+				if (navAppareance.BackgroundImage == null)
+				{
+					var backgroundImage = navBar.GetBackgroundImage(UIBarMetrics.Default);
+					navBar.CompactAppearance.BackgroundImage = navBar.StandardAppearance.BackgroundImage = navBar.ScrollEdgeAppearance.BackgroundImage = backgroundImage;
+				}
+
+				if (navAppareance.ShadowImage == null)
+				{
+					var shadowImage = navBar.ShadowImage;
+					navBar.CompactAppearance.ShadowImage = navBar.StandardAppearance.ShadowImage = navBar.ScrollEdgeAppearance.ShadowImage = shadowImage;
+
+					if (shadowImage != null && shadowImage.Size == SizeF.Empty)
+						navBar.CompactAppearance.ShadowColor = navBar.StandardAppearance.ShadowColor = navBar.ScrollEdgeAppearance.ShadowColor = UIColor.Clear;
+				}
+
+				UIImage backIndicatorImage = navBar.BackIndicatorImage;
+				UIImage backIndicatorTransitionMaskImage = navBar.BackIndicatorTransitionMaskImage;
+
+				if (backIndicatorImage != null && backIndicatorImage.Size == SizeF.Empty)
+					backIndicatorImage = GetEmptyBackIndicatorImage();
+
+				if (backIndicatorTransitionMaskImage != null && backIndicatorTransitionMaskImage.Size == SizeF.Empty)
+					backIndicatorTransitionMaskImage = GetEmptyBackIndicatorImage();
+
+				navBar.CompactAppearance.SetBackIndicatorImage(backIndicatorImage, backIndicatorTransitionMaskImage);
+				navBar.StandardAppearance.SetBackIndicatorImage(backIndicatorImage, backIndicatorTransitionMaskImage);
+				navBar.ScrollEdgeAppearance.SetBackIndicatorImage(backIndicatorImage, backIndicatorTransitionMaskImage);
 #endif
+			}
+
+			UIImage GetEmptyBackIndicatorImage()
+			{
+				var rect = RectangleF.Empty;
+				var size = rect.Size;
+
+				UIGraphics.BeginImageContext(size);
+				var context = UIGraphics.GetCurrentContext();
+				context.SetFillColor(1, 1, 1, 0);
+				context.FillRect(rect);
+
+				var empty = UIGraphics.GetImageFromCurrentImageContext();
+				context.Dispose();
+
+				return empty;
 			}
 
 			internal void UpdateLeftBarButtonItem(Page pageBeingRemoved = null)


### PR DESCRIPTION
### Description of Change ###

We are using `UINavigationBar.Appareance` to infer settings that were already set to navigation bar in older versions of iOS. This way we don't break old Custom Renderers.

### Issues Resolved ### 

- fixes #10337 
- fixes #10338

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![issue10337](https://user-images.githubusercontent.com/6755973/80512485-d7a42e80-897d-11ea-956e-f88e0740189d.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 10337. Verify that ShadowImage and BackIndicatorImage can be customized (in the sample we are hiding both).

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
