### PR TITLE
Change API check to Oreo for coloring TextViews on ToolBar

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
 
-			if (!Forms.IsLollipopOrNewer && (tintColor != null && tintColor != Color.Default))
+			if (!Forms.IsOreoOrNewer && (tintColor != null && tintColor != Color.Default))
 			{
 				var view = toolbar.FindViewById(menuitem.ItemId);
 				if (view is ATextView textView)


### PR DESCRIPTION
### Description of Change ###

The spannable string coloring only appears to work on API >= 26

### Platforms Affected ### 
- Android

### Testing Procedure ###
- run the platform tests on API 19,25,26,29 and whatever else will make you sleep better at night

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
