### PR TITLE
Fix FontFile namespace

### DIFF
--- a/Xamarin.Forms.Core/FontFile.cs
+++ b/Xamarin.Forms.Core/FontFile.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 
-namespace Xamarin.Forms.Core
+namespace Xamarin.Forms
 {
 	public class FontFile
 	{


### PR DESCRIPTION
### Description of Change ###

Just move FontFile.cs from Xamarin.Forms.Core namespace to Xamarin.Forms.

### Issues Resolved ### 

- fixes #10495

### API Changes ###
 
 None

### Platforms Affected ### 

- Core

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
