### PR TITLE
Set Current Item correctly after items cleared

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6738.cs
@@ -93,10 +93,7 @@ namespace Xamarin.Forms.Controls.Issues
 			});
 		}
 
-#if UITEST
-#if !(__ANDROID__ || __IOS__)
-		[Ignore("Shell test is only supported on Android and iOS")]
-#endif
+#if UITEST && __SHELL__
 		[Test]
 		public void FlyoutNavigationBetweenItemsWithNavigationStacks()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -105,6 +105,16 @@ namespace Xamarin.Forms.Controls.Issues
 								this.Items.Clear();
 								SetupShell();
 							})
+						},
+						new Button()
+						{
+							Text = "Clear and Recreate Shell Content",
+							AutomationId = "ClearAndRecreateShellContent",
+							Command = new Command(() =>
+							{
+								Items[0].Items[0].Items.Clear();
+								AddTopTabs();
+							})
 						}
 					}
 				}
@@ -120,8 +130,8 @@ namespace Xamarin.Forms.Controls.Issues
 			item2.Title = "Item2 Flyout";
 			item2.Route = "Item2";
 
-			AddTopTab("Top Tab 1").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 1" } } };
-			AddTopTab("Top Tab 2").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 2" } } };
+			AddTopTabs();
+
 
 			pageItem1.SetBinding(Page.IsVisibleProperty, "Item1");
 			pageItem2.SetBinding(Page.IsVisibleProperty, "Item2");
@@ -134,6 +144,12 @@ namespace Xamarin.Forms.Controls.Issues
 					this.FlyoutIsPresented = false;
 				})
 			}));
+
+			void AddTopTabs()
+			{
+				AddTopTab("Top Tab 1").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 1" } } };
+				AddTopTab("Top Tab 2").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 2" } } };
+			}
 		}
 
 		[Preserve(AllMembers = true)]
@@ -200,7 +216,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("ClearAndRecreate");
 			RunningApp.Tap("ClearAndRecreate");
 		}
-
+		
 
 		[Test]
 		public void ClearAndRecreateFromSecondaryPage()
@@ -210,6 +226,28 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("Item2 Flyout");
 			RunningApp.Tap("ToggleItem1");
 			RunningApp.Tap("ClearAndRecreate");
+			RunningApp.Tap("Top Tab 2");
+			RunningApp.Tap("Top Tab 1");
+		}
+
+		[Test]
+		public void ClearAndRecreateShellContent()
+		{
+			RunningApp.WaitForElement("ClearAndRecreateShellContent");
+			RunningApp.Tap("ClearAndRecreateShellContent");
+			RunningApp.WaitForElement("ClearAndRecreate");
+			RunningApp.Tap("ClearAndRecreate");
+		}
+
+
+		[Test]
+		public void ClearAndRecreateShellContentFromSecondaryPage()
+		{
+			RunningApp.WaitForElement("ClearAndRecreateShellContent");
+			ShowFlyout();
+			RunningApp.Tap("Item2 Flyout");
+			RunningApp.Tap("ToggleItem1");
+			RunningApp.Tap("ClearAndRecreateShellContent");
 			RunningApp.Tap("Top Tab 2");
 			RunningApp.Tap("Top Tab 1");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -147,8 +147,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			void AddTopTabs()
 			{
-				AddTopTab("Top Tab 1").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 1" } } };
-				AddTopTab("Top Tab 2").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 2" } } };
+				AddTopTab($"Top Tab 1").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 1" } } };
+				AddTopTab($"Top Tab 2").Content = new StackLayout() { Children = { new Label { Text = "Welcome to Tab 2" } } };
 			}
 		}
 
@@ -237,19 +237,6 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("ClearAndRecreateShellContent");
 			RunningApp.WaitForElement("ClearAndRecreate");
 			RunningApp.Tap("ClearAndRecreate");
-		}
-
-
-		[Test]
-		public void ClearAndRecreateShellContentFromSecondaryPage()
-		{
-			RunningApp.WaitForElement("ClearAndRecreateShellContent");
-			ShowFlyout();
-			RunningApp.Tap("Item2 Flyout");
-			RunningApp.Tap("ToggleItem1");
-			RunningApp.Tap("ClearAndRecreateShellContent");
-			RunningApp.Tap("Top Tab 2");
-			RunningApp.Tap("Top Tab 1");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -619,7 +619,11 @@ namespace Xamarin.Forms.Controls
 
 		public ContentPage AddTopTab(string title, string icon = null)
 		{
-			var page = new ContentPage();
+			var page = new ContentPage()
+			{
+				Title = title
+			};
+
 			AddTopTab(page, title, icon);
 			return page;
 		}

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1326,6 +1326,50 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(Color.Green, label.BackgroundColor);
 		}
 
+		[Test]
+		public void ClearingShellContentAndReAddingSetsCurrentItem()
+		{
+			Shell shell = new Shell();
+			var item = CreateShellItem();
+			item.CurrentItem.Items.Add(CreateShellContent());
+			item.CurrentItem.Items.Add(CreateShellContent());
+			var item2 = CreateShellItem();
+
+			shell.Items.Add(item);
+			shell.Items.Add(item2);
+
+			item.Items[0].Items.Clear();
+
+			var content = CreateShellContent();
+			item.Items[0].Items.Add(content);
+			item.Items[0].Items.Add(CreateShellContent());
+
+			Assert.IsNotNull(item.CurrentItem);
+			Assert.IsNotNull(item.CurrentItem.CurrentItem);
+		}
+
+		[Test]
+		public void ClearingShellSectionAndReAddingSetsCurrentItem()
+		{
+			Shell shell = new Shell();
+			var item = CreateShellItem();
+			item.CurrentItem.Items.Add(CreateShellContent());
+			item.CurrentItem.Items.Add(CreateShellContent());
+			var item2 = CreateShellItem();
+
+			shell.Items.Add(item);
+			shell.Items.Add(item2);
+
+			item.Items.Clear();
+
+			var section = CreateShellSection();
+			item.Items.Add(section);
+			item.Items.Add(CreateShellSection());
+
+			Assert.IsNotNull(item.CurrentItem);
+			Assert.IsNotNull(item.CurrentItem.CurrentItem);
+		}
+
 
 		//[Test]
 		//public void FlyoutItemLabelStyleCanBeChangedAfterRendered()

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1052,6 +1052,9 @@ namespace Xamarin.Forms
 			if (oldValue is ShellItem oldShellItem)
 				oldShellItem.SendDisappearing();
 
+			if (newValue == null)
+				return;
+
 			if (newValue is ShellItem newShellItem)
 				newShellItem.SendAppearing();
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -242,12 +242,20 @@ namespace Xamarin.Forms
 
 			((ShellContentCollection)Items).VisibleItemsChangedInternal += (_, args) =>
 			{
-				if (args.OldItems == null)
-					return;
-
-				foreach(Element item in args.OldItems)
+				if (args.OldItems != null)
 				{
-					OnVisibleChildRemoved(item);
+					foreach (Element item in args.OldItems)
+					{
+						OnVisibleChildRemoved(item);
+					}
+				}
+
+				if(args.NewItems != null)
+				{
+					foreach (Element item in args.NewItems)
+					{
+						OnVisibleChildAdded(item);
+					}
 				}
 			};
 
@@ -483,7 +491,7 @@ namespace Xamarin.Forms
 
 		internal void SendStructureChanged()
 		{
-			if (Parent?.Parent is Shell shell)
+			if (Parent?.Parent is Shell shell && IsVisibleSection)
 			{
 				shell.SendStructureChanged();
 			}
@@ -516,17 +524,22 @@ namespace Xamarin.Forms
 		protected override void OnChildAdded(Element child)
 		{
 			base.OnChildAdded(child);
-			if (CurrentItem == null && ((IShellSectionController)this).GetItems().Contains(child))
-				SetValueFromRenderer(CurrentItemProperty, child);
-
-			if(CurrentItem != null)
-				UpdateDisplayedPage();
+			OnVisibleChildAdded(child);
 		}
 
 		protected override void OnChildRemoved(Element child)
 		{
 			base.OnChildRemoved(child);
 			OnVisibleChildRemoved(child);
+		}
+
+		void OnVisibleChildAdded(Element child)
+		{
+			if (CurrentItem == null && ((IShellSectionController)this).GetItems().Contains(child))
+				SetValueFromRenderer(CurrentItemProperty, child);
+
+			if (CurrentItem != null)
+				UpdateDisplayedPage();
 		}
 
 		void OnVisibleChildRemoved(Element child)
@@ -815,15 +828,20 @@ namespace Xamarin.Forms
 			if (oldValue is ShellContent oldShellItem)
 				oldShellItem.SendDisappearing();
 
+			if (newValue == null)
+				return;
+
 			shellSection.PresentedPageAppearing();
 
-			if (shellSection.Parent?.Parent is IShellController shell)
+			if (shellSection.Parent?.Parent is IShellController shell && shellSection.IsVisibleSection)
 			{
 				shell.UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
 			}
 
 			shellSection.SendStructureChanged();
-			((IShellController)shellSection?.Parent?.Parent)?.AppearanceChanged(shellSection, false);
+
+			if(shellSection.IsVisibleSection)
+				((IShellController)shellSection?.Parent?.Parent)?.AppearanceChanged(shellSection, false);
 
 			shellSection.UpdateDisplayedPage();
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -267,6 +267,10 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var newIndex = SectionController.GetItems().IndexOf(ShellSection.CurrentItem);
 
+
+				if (SectionController.GetItems().Count != _viewPager.ChildCount)
+					_viewPager.Adapter.NotifyDataSetChanged();
+
 				if (newIndex >= 0)
 				{
 					_viewPager.CurrentItem = newIndex;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -124,7 +124,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					var renderer = kvp.Value;
 					RemoveRenderer(renderer);
-					renderer.Dispose();
 				}
 
 				if (_displayedPage != null)
@@ -345,6 +344,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (_sectionRenderers.Remove(renderer.ViewController))
 				renderer.ShellSection.PropertyChanged -= OnShellSectionPropertyChanged;
+
+			renderer?.Dispose();
+
+			if (CurrentRenderer == renderer)
+				CurrentRenderer = null;
 		}
 
 		IShellSectionRenderer RendererForShellContent(ShellSection shellSection)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -109,6 +109,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillAppear(bool animated)
 		{
+			if (_disposed)
+				return;
+
 			UpdateFlowDirection();
 			base.ViewWillAppear(animated);
 		}
@@ -121,6 +124,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLayoutSubviews()
 		{
+			if (_disposed)
+				return;
+
 			base.ViewDidLayoutSubviews();
 
 			_appearanceTracker.UpdateLayout(this);
@@ -134,6 +140,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLoad()
 		{
+			if (_disposed)
+				return;
+
 			base.ViewDidLoad();
 			InteractivePopGestureRecognizer.Delegate = new GestureDelegate(this, ShouldPop);
 			UpdateFlowDirection();
@@ -149,6 +158,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
+				this.RemoveFromParentViewController();
 				_disposed = true;
 				_renderer.Dispose();
 				_appearanceTracker.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -153,9 +153,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_disposed)
 				return;
 
-			base.Dispose(disposing);
-
-
 			if (disposing)
 			{
 				this.RemoveFromParentViewController();
@@ -177,7 +174,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (tracker == null)
 						continue;
 
-					DisposePage(tracker);
+					DisposePage(tracker, true);
 				}
 			}
 
@@ -187,6 +184,8 @@ namespace Xamarin.Forms.Platform.iOS
 			_appearanceTracker = null;
 			_renderer = null;
 			_context = null;
+
+			base.Dispose(disposing);
 		}
 
 		protected virtual void HandleShellPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -405,11 +404,11 @@ namespace Xamarin.Forms.Platform.iOS
 			});
 		}
 
-		void DisposePage(Page page)
+		void DisposePage(Page page, bool calledFromDispose = false)
 		{
 			if (_trackers.TryGetValue(page, out var tracker))
 			{
-				if(tracker.ViewController != null && ViewControllers.Contains(tracker.ViewController))
+				if(!calledFromDispose && tracker.ViewController != null && ViewControllers.Contains(tracker.ViewController))
 					ViewControllers = ViewControllers.Remove(_trackers[page].ViewController);
 
 				tracker.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -161,6 +161,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLoad()
 		{
+			if (_isDisposed)
+				return;
+
 			base.ViewDidLoad();
 
 			CollectionView.ScrollsToTop = false;
@@ -271,6 +274,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnShellSectionItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if (_isDisposed)
+				return;
+
 			CollectionView.ReloadData();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -149,6 +149,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLayoutSubviews()
 		{
+			if (_isDisposed)
+				return;
+
 			base.ViewDidLayoutSubviews();
 
 			LayoutBar();
@@ -209,6 +212,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				ShellSection = null;
 				_bar.RemoveFromSuperview();
+				this.RemoveFromParentViewController();
 				_bar.Dispose();
 				_bar = null;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -120,8 +120,13 @@ namespace Xamarin.Forms.Platform.iOS
 				foreach (var renderer in _renderers)
 				{
 					var oldRenderer = renderer.Value;
-					oldRenderer.NativeView.RemoveFromSuperview();
-					oldRenderer.ViewController.RemoveFromParentViewController();
+
+					if(oldRenderer.NativeView != null)
+						oldRenderer.NativeView.RemoveFromSuperview();
+
+					if (oldRenderer.ViewController != null)
+						oldRenderer.ViewController.RemoveFromParentViewController();
+
 					var element = oldRenderer.Element;
 					oldRenderer.Dispose();
 					element?.ClearValue(Platform.RendererProperty);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -258,16 +258,20 @@ namespace Xamarin.Forms.Platform.iOS
 				_isAnimating = true;
 
 				currentRenderer.NativeView.Frame = new CGRect(-motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
-				oldRenderer.NativeView.Frame = _containerArea.Bounds;
+
+				if(oldRenderer.NativeView != null)
+					oldRenderer.NativeView.Frame = _containerArea.Bounds;
 
 				UIView.Animate(.25, 0, UIViewAnimationOptions.CurveEaseOut, () =>
 				{
 					currentRenderer.NativeView.Frame = _containerArea.Bounds;
-					oldRenderer.NativeView.Frame = new CGRect(motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
+
+					if (oldRenderer.NativeView != null)
+						oldRenderer.NativeView.Frame = new CGRect(motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
 				},
 				() =>
 				{
-					if(_renderers.ContainsKey(oldContent))
+					if(oldRenderer.NativeView != null && _renderers.ContainsKey(oldContent))
 						oldRenderer.NativeView.RemoveFromSuperview();
 
 					_isAnimating = false;
@@ -276,8 +280,12 @@ namespace Xamarin.Forms.Platform.iOS
 					if (!ShellSectionController.GetItems().Contains(oldContent) && _renderers.ContainsKey(oldContent))
 					{
 						_renderers.Remove(oldContent);
-						oldRenderer.ViewController.RemoveFromParentViewController();
-						oldRenderer.Dispose();
+
+						if (oldRenderer.NativeView != null)
+						{
+							oldRenderer.ViewController.RemoveFromParentViewController();
+							oldRenderer.Dispose();
+						}
 					}
 				});
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -32,7 +32,12 @@ namespace Xamarin.Forms.Platform.iOS
 		Thickness _lastInset;
 		bool _isDisposed;
 
-		ShellSection ShellSection { get; set; }
+		ShellSection ShellSection
+		{
+			get;
+			set;
+		}
+
 		IShellSectionController ShellSectionController => ShellSection;
 
 		public ShellSectionRootRenderer(ShellSection shellSection, IShellContext shellContext)
@@ -56,6 +61,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidLoad()
 		{
+			if (_isDisposed)
+				return;
+
 			if (ShellSection.CurrentItem == null)
 				throw new InvalidOperationException($"Content not found for active {ShellSection}. Title: {ShellSection.Title}. Route: {ShellSection.Route}.");
 
@@ -92,12 +100,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewWillAppear(bool animated)
 		{
-			UpdateFlowDirection();
+			if (_isDisposed)
+				return;
+
+				UpdateFlowDirection();
 			base.ViewWillAppear(animated);
 		}
 
 		public override void ViewSafeAreaInsetsDidChange()
 		{
+			if (_isDisposed)
+				return;
+
 			base.ViewSafeAreaInsetsDidChange();
 
 			LayoutHeader();
@@ -113,6 +127,9 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				ShellSection.PropertyChanged -= OnShellSectionPropertyChanged;
 				ShellSectionController.ItemsCollectionChanged -= OnShellSectionItemsChanged;
+
+
+				this.RemoveFromParentViewController();
 
 				_header?.Dispose();
 				_tracker?.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnShellPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == Shell.FlyoutHeaderBehaviorProperty.PropertyName)
+			if (e.Is(Shell.FlyoutHeaderBehaviorProperty))
 			{
 				SetHeaderContentInset();
 				LayoutParallax();


### PR DESCRIPTION
### Description of Change ###
- re-adding items wasn't correctly resetting CurrentItem up the hierarchy
- don't propagate structure changes from items that aren't visible
- null check renderer on iOS in case it's already been disposed of

Changes aren't perfect. The Collections should more conservatively propagate themselves to the renderers while they are in flux, but that's a different PR for the next official release.

This should fix some additional rough edges on 4.6 for now


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- click around on the shell is visible tests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
