### PR TITLE
On requested theme changed android

### DIFF
--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -39,6 +39,8 @@ namespace Xamarin.Forms
 			SystemResources = DependencyService.Get<ISystemResourcesProvider>().GetSystemResources();
 			SystemResources.ValuesChanged += OnParentResourcesChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
+			// Initialize this value, when the app loads
+			LastAppTheme = RequestedTheme;
 		}
 
 		public void Quit()
@@ -170,9 +172,39 @@ namespace Xamarin.Forms
 			remove => _weakEventManager.RemoveEventHandler(value);
 		}
 
+		bool _themeChangedFiring;
+		public OSAppTheme LastAppTheme { get; private set; }
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void OnRequestedThemeChanged(AppThemeChangedEventArgs args)
-			=> _weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+		{
+			if (Device.Flags.IndexOf(ExperimentalFlags.AppThemeExperimental) == -1)
+				return;
+
+			// On iOS the event is triggered more than once.
+			// To minimize that for us, we only do it when the theme actually changes and it's not currently firing
+			if (!_themeChangedFiring && RequestedTheme != LastAppTheme)
+			{
+				try
+				{
+					_themeChangedFiring = true;
+					LastAppTheme = RequestedTheme;
+
+					_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+				}
+				finally
+				{
+					_themeChangedFiring = false;
+				}
+			}
+
+			if (LastAppTheme == args.RequestedTheme)
+				return;
+
+			LastAppTheme = args.RequestedTheme;
+
+			_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+		}
 
 		public event EventHandler<ModalPoppedEventArgs> ModalPopped;
 

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms
 			SystemResources.ValuesChanged += OnParentResourcesChanged;
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Application>>(() => new PlatformConfigurationRegistry<Application>(this));
 			// Initialize this value, when the app loads
-			LastAppTheme = RequestedTheme;
+			_lastAppTheme = RequestedTheme;
 		}
 
 		public void Quit()
@@ -166,7 +166,7 @@ namespace Xamarin.Forms
 		}
 
 		bool _themeChangedFiring;
-		public OSAppTheme LastAppTheme { get; private set; }
+		OSAppTheme _lastAppTheme;
 
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -177,13 +177,13 @@ namespace Xamarin.Forms
 
 			// On iOS the event is triggered more than once.
 			// To minimize that for us, we only do it when the theme actually changes and it's not currently firing
-			if (_themeChangedFiring || RequestedTheme == LastAppTheme)
+			if (_themeChangedFiring || RequestedTheme == _lastAppTheme)
 				return;
 
 			try
 			{
 				_themeChangedFiring = true;
-				LastAppTheme = RequestedTheme;
+				_lastAppTheme = RequestedTheme;
 
 				_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
 			}

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -177,19 +177,19 @@ namespace Xamarin.Forms
 
 			// On iOS the event is triggered more than once.
 			// To minimize that for us, we only do it when the theme actually changes and it's not currently firing
-			if (!_themeChangedFiring && RequestedTheme != LastAppTheme)
-			{
-				try
-				{
-					_themeChangedFiring = true;
-					LastAppTheme = RequestedTheme;
+			if (_themeChangedFiring || RequestedTheme == LastAppTheme)
+				return;
 
-					_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
-				}
-				finally
-				{
-					_themeChangedFiring = false;
-				}
+			try
+			{
+				_themeChangedFiring = true;
+				LastAppTheme = RequestedTheme;
+
+				_weakEventManager.HandleEvent(this, args, nameof(RequestedThemeChanged));
+			}
+			finally
+			{
+				_themeChangedFiring = false;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -87,11 +87,7 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnConfigurationChanged(newConfig);
 			ConfigurationChanged?.Invoke(this, new EventArgs());
 
-			var current = Xamarin.Forms.Application.Current;
-			var requestedTheme = current?.RequestedTheme;
-
-			if (requestedTheme != null && current.LastAppTheme != requestedTheme)
-				current?.OnRequestedThemeChanged(new AppThemeChangedEventArgs(requestedTheme.Value));
+			Xamarin.Forms.Application.Current?.OnRequestedThemeChanged(new AppThemeChangedEventArgs(Xamarin.Forms.Application.Current.RequestedTheme));
 		}
 
 		public override bool OnOptionsItemSelected(IMenuItem item)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -87,7 +87,11 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnConfigurationChanged(newConfig);
 			ConfigurationChanged?.Invoke(this, new EventArgs());
 
-			Xamarin.Forms.Application.Current?.OnRequestedThemeChanged(new AppThemeChangedEventArgs(Xamarin.Forms.Application.Current.RequestedTheme));
+			var current = Xamarin.Forms.Application.Current;
+			var requestedTheme = current?.RequestedTheme;
+
+			if (requestedTheme != null && current.LastAppTheme != requestedTheme)
+				current?.OnRequestedThemeChanged(new AppThemeChangedEventArgs(requestedTheme.Value));
 		}
 
 		public override bool OnOptionsItemSelected(IMenuItem item)


### PR DESCRIPTION
### Description of Change ###

The event `Xamarin.Forms.Application.RequestedThemeChanged` is fired when the device rotates. 

### Issues Resolved ### 

Fire the event `Xamarin.Forms.Application.RequestedThemeChanged` only when the theme change

- fixes #

### API Changes ###

none

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

- On the App.cs subscribe to the event `Xamarin.Forms.Application.RequestedThemeChanged`
- Rotate the device
- The event will be fired

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
