### PR TITLE
Use ShouldManageCookies in WkWebViewRenderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
 			NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri));
 
-			if (WebView.Cookies != null)
+			if (WebView.Cookies != null && WebView.ShouldManageCookies)
 			{
 				if (Forms.IsiOS11OrNewer)
 				{


### PR DESCRIPTION
### Description of Change ###

This is to resolve an oversight on my part in an earlier pull request, #10429. I forgot that iOS has two web view renderers. This enables the opt-in cookie behavior I added to the other web view renderers for `WkWebViewRenderer`.

fixes #10318

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I was unable to test this change as I am not able to build Forms in Visual Studio for Mac.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
