### PR TITLE
Adding the parameter less method to Shell.GoBackAsync()

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -317,6 +317,24 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task GoBackWithoutDotDotTests()
+		{
+			var shell = new Shell();
+
+			var item = CreateShellItem(shellSectionRoute: "section2");
+			shell.Items.Add(item);
+
+			await shell.GoToAsync(new ShellNavigationState($"ModalTestPage"));
+			var modalPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ModalTestPageBase;
+			Assert.NotNull(modalPage);
+
+			await shell.GoBackAsync();
+
+			var previousPage = (shell.CurrentItem.CurrentItem as IShellSectionController).PresentedPage as ContentPage;
+			Assert.NotNull(previousPage);
+		}
+
+		[Test]
 		public async Task NavigatingAndNavigatedFiresForShellModal()
 		{
 			Shell shell = new Shell();

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -475,6 +475,11 @@ namespace Xamarin.Forms
 			return GoToAsync(state, animate, false);
 		}
 
+		public Task GoBackAsync()
+		{
+			return GoToAsync("..");
+		}
+
 		internal async Task GoToAsync(ShellNavigationState state, bool? animate, bool enableRelativeShellRoutes)
 		{
 			// FIXME: This should not be none, we need to compute the delta and set flags correctly


### PR DESCRIPTION
### Description of Change ###

Added a handy parameter less method to Shell to allow navigating backward without having to pass ".."

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - public Task GoBackAsync() to the Shell class.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
- None

### Before/After Screenshots ### 
- Not applicable

### Testing Procedure ###
Just perform multiple forward navigation using Shell and then call 
Shell.GoBackAsync() 
and see you app navigating backward 1 time;
There's also a unit test on this PR called GoBackWithoutDotDotTests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
