### PR TITLE
Make Color property work on UWP BoxView

### DIFF
--- a/Xamarin.Forms.Platform.UAP.UnitTests/BackgroundColorTests.cs
+++ b/Xamarin.Forms.Platform.UAP.UnitTests/BackgroundColorTests.cs
@@ -102,5 +102,23 @@ namespace Xamarin.Forms.Platform.UAP.UnitTests
 
 			Assert.That(actualColor, Is.EqualTo(expectedColor));
 		}
+
+		[Test, Category("Color"), Category("BoxView")]
+		public async Task BoxViewColorConsistent() 
+		{
+			var box = new BoxView() { Color = Color.PapayaWhip };
+			var expectedColor = box.Color.ToWindowsColor();
+
+			var actualColor = await Device.InvokeOnMainThreadAsync(() =>
+			{
+				var renderer = GetRenderer(box);
+				var nativeElement = renderer.GetNativeElement() as Border;
+
+				var backgroundBrush = nativeElement.Background as SolidColorBrush;
+				return backgroundBrush.Color;
+			});
+
+			Assert.That(actualColor, Is.EqualTo(expectedColor));
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
@@ -21,8 +21,6 @@ namespace Xamarin.Forms.Platform.UWP
 						DataContext = Element
 					};
 
-					rect.SetBinding(Shape.FillProperty, new Windows.UI.Xaml.Data.Binding { Converter = new ColorConverter(), Path = new PropertyPath("Color") });
-
 					SetNativeControl(rect);
 				}
 
@@ -36,6 +34,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (e.PropertyName == BoxView.CornerRadiusProperty.PropertyName)
 				SetCornerRadius(Element.CornerRadius);
+			else if (e.PropertyName == BoxView.ColorProperty.PropertyName)
+				UpdateBackgroundColor();
+			
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer()
@@ -56,7 +57,12 @@ namespace Xamarin.Forms.Platform.UWP
 			//as the background would be applied to the renderer's FrameworkElement
 			if (Control == null)
 				return;
-			Color backgroundColor = Element.BackgroundColor;
+			Color backgroundColor = Element.Color;
+			if (backgroundColor.IsDefault)
+			{
+				backgroundColor = Element.BackgroundColor;
+			}
+
 			Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
 		}
 


### PR DESCRIPTION
### Description of Change ###

In the move from using a Rectangle to a Border for UWP's BoxView renderer, the Color property (which does the same thing as the BackgroundColor) was lost. This change restores that property.

### Issues Resolved ### 

- fixes #10535

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
