### PR TITLE
Add UWP Box View Color Property Support

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml
@@ -7,34 +7,57 @@
              mc:Ignorable="d"
              x:Class="Xamarin.Forms.Controls.Issues.Issue4459">
     <ContentPage.Content>
-        <StackLayout>
-            <Label>Enter a corner radius for each corner and the box view below should update.</Label>
-            <StackLayout Orientation="Horizontal">
-                <Label Text="Top Left"></Label>
-                <Entry x:Name="TopLeft" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
-            </StackLayout>
+        <ScrollView>
+            <StackLayout>
+                <Label>Enter a corner radius for each corner and the box view below should update.</Label>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Top Left"></Label>
+                    <Entry x:Name="TopLeft" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
+                </StackLayout>
 
-            <StackLayout Orientation="Horizontal">
-                <Label Text="Top Right"></Label>
-                <Entry x:Name="TopRight" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
-            </StackLayout>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Top Right"></Label>
+                    <Entry x:Name="TopRight" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
+                </StackLayout>
 
-            <StackLayout Orientation="Horizontal">
-                <Label Text="Bottom Right"></Label>
-                <Entry x:Name="BottomRight" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
-            </StackLayout>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Bottom Right"></Label>
+                    <Entry x:Name="BottomRight" Text="10" TextChanged="InputView_OnTextChanged"></Entry>
+                </StackLayout>
 
-            <StackLayout Orientation="Horizontal">
-                <Label Text="Bottom Left"></Label>
-                <Entry x:Name="BottomLeft" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
-            </StackLayout>
+                <StackLayout Orientation="Horizontal">
+                    <Label Text="Bottom Left"></Label>
+                    <Entry x:Name="BottomLeft" Text="0" TextChanged="InputView_OnTextChanged"></Entry>
+                </StackLayout>
 
-            <BoxView x:Name="BoxView" BackgroundColor="#CC3300"
-                     WidthRequest="200"
-                     HeightRequest="100"
-                     CornerRadius="10,0,0,10"
-                     Margin="50"
-            />
-        </StackLayout>
+                <BoxView x:Name="BoxView" BackgroundColor="#CC3300"
+                         WidthRequest="200"
+                         HeightRequest="100"
+                         CornerRadius="10,0,0,10"
+                         Margin="50" />
+
+                <Label>Setting Color Property Left Orange, Right Red backgrounds</Label>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+
+                    <BoxView x:Name="Color1" Grid.Column="0" Color="Orange"></BoxView>
+                    <BoxView x:Name="Color2" Grid.Column="1" Color="Red"></BoxView>
+                </Grid>
+
+                <Label>Setting BackgroundColor Property Left Orange, Right Red backgrounds</Label>
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+
+                    <BoxView x:Name="Color3" Grid.Column="0" BackgroundColor="Orange"></BoxView>
+                    <BoxView x:Name="Color4" Grid.Column="1" BackgroundColor="Red"></BoxView>
+                </Grid>
+
+            </StackLayout></ScrollView>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4459.xaml.cs
@@ -23,6 +23,18 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 			BoxView.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
 			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
+
+			Color1.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
+			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
+
+			Color2.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
+			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
+
+			Color3.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
+			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
+
+			Color4.CornerRadius = new CornerRadius(double.Parse(TopLeft.Text), double.Parse(TopRight.Text),
+			double.Parse(BottomLeft.Text), double.Parse(BottomRight.Text));
 #endif
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
@@ -36,6 +36,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (e.PropertyName == BoxView.CornerRadiusProperty.PropertyName)
 				SetCornerRadius(Element.CornerRadius);
+			if(e.PropertyName == BoxView.ColorProperty.PropertyName)
+				UpdateBackgroundColor();
 		}
 
 		protected override AutomationPeer OnCreateAutomationPeer()
@@ -56,8 +58,12 @@ namespace Xamarin.Forms.Platform.UWP
 			//as the background would be applied to the renderer's FrameworkElement
 			if (Control == null)
 				return;
-			Color backgroundColor = Element.BackgroundColor;
-			Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
+
+			Color colorToSet = Element.Color;
+
+			if (colorToSet == Color.Default)
+				colorToSet = Element.BackgroundColor;
+			Control.Background = colorToSet.IsDefault ? null : colorToSet.ToBrush();
 		}
 
 		void SetCornerRadius(CornerRadius cornerRadius)

--- a/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/BoxViewBorderRenderer.cs
@@ -16,14 +16,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (Control == null)
 				{
-					var rect = new Border
+					var border = new Border
 					{
 						DataContext = Element
 					};
-
-					rect.SetBinding(Shape.FillProperty, new Windows.UI.Xaml.Data.Binding { Converter = new ColorConverter(), Path = new PropertyPath("Color") });
-
-					SetNativeControl(rect);
+					SetNativeControl(border);
 				}
 
 				SetCornerRadius(Element.CornerRadius);


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10528 - Adds support for the Color Property

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
Setting the Color property will now update the color of the Border control used to represent a BoxView on UWP

### Before/After Screenshots ### 
Before:
![image](https://user-images.githubusercontent.com/15127788/80984853-0a25af80-8df4-11ea-802a-e5011fdc168f.png)


After:
![image](https://user-images.githubusercontent.com/15127788/80984726-d9de1100-8df3-11ea-9533-db5cb00543a9.png)


### Testing Procedure ###
Open the Issue 4459 test page in the control gallery and make sure the colors are correct.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
