### PR TITLE
Prevent styled element creation off the main thread from crashing application

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StyleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleTests.cs
@@ -884,5 +884,31 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That(log.Messages.Count, Is.EqualTo(0),
 				"A warning was logged: " + log.Messages.FirstOrDefault());
     	}
+
+		[Test]
+		public async Task CreatingStyledElementsOffMainThreadShouldNotCrash() 
+		{
+			List<Task> tasks = new List<Task>();
+
+			var style = new Style(typeof(VisualElement))
+			{
+				Setters = {
+					new Setter { Property = Label.TextProperty, Value = "foo" },
+					new Setter { Property = VisualElement.BackgroundColorProperty, Value = Color.Pink },
+				}
+			};
+
+			for (int n = 0; n < 100000; n++)
+			{
+				tasks.Add(Task.Run(() => {
+					var label = new Label
+					{
+						Style = style
+					};
+				}));
+			}
+
+			await Task.WhenAll(tasks);
+		} 
 	}
 }

--- a/Xamarin.Forms.Core/Style.cs
+++ b/Xamarin.Forms.Core/Style.cs
@@ -106,11 +106,14 @@ namespace Xamarin.Forms
 		{
 			UnApplyCore(bindable, BasedOn ?? GetBasedOnResource(bindable));
 			bindable.RemoveDynamicResource(_basedOnResourceProperty);
-			_targets.RemoveAll(wr =>
+			lock (_targets)
 			{
-				BindableObject target;
-				return wr.TryGetTarget(out target) && target == bindable;
-			});
+				_targets.RemoveAll(wr =>
+				{
+					BindableObject target;
+					return wr.TryGetTarget(out target) && target == bindable;
+				});
+			}
 		}
 
 		internal bool CanBeAppliedTo(Type targetType)
@@ -191,8 +194,11 @@ namespace Xamarin.Forms
 				return;
 			}
 
-			_targets.RemoveAll(t => t == null || !t.TryGetTarget(out _));
-			_cleanupThreshold = _targets.Count + CleanupTrigger;
+			lock (_targets)
+			{
+				_targets.RemoveAll(t => t == null || !t.TryGetTarget(out _));
+				_cleanupThreshold = _targets.Count + CleanupTrigger;
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Creating styled elements off of the main thread can, in the right circumstances, crash when the Style attempts to clean up references to old elements which are no longer in use. This change makes the cleanup of the old reference thread-safe to avoid crashing.

### Issues Resolved ### 

- fixes #10561

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Unit test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
