### PR TITLE
Setup more specific 2017 apk/ipas for testing lanes

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Nuget2019.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Nuget2019.Build.targets
@@ -1,7 +1,7 @@
 <Project>
     <ItemGroup>
         <PackageReference Include="Xamarin.Build.Download">
-            <Version>0.7.1</Version>
+            <Version>0.10.0</Version>
         </PackageReference>
     </ItemGroup>
     <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v10.0'">

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,7 @@ stages:
 
   - stage: android_2017
     displayName: Build Android 2017
-    # condition: eq(variables['System.TeamProject'], 'devdiv') }
+    condition: eq(variables['System.TeamProject'], 'devdiv') }
     ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
       dependsOn: windows
     ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,6 +206,18 @@ stages:
         parameters:
           vmImage: $(macOSXVmImage)
           provisionatorPath : 'build/provisioning/provisioning.csx'
+          buildForVS2017: false
+
+  - stage: android_2017
+    displayName: Build Android
+    condition: eq(variables['System.TeamProject'], 'devdiv') }
+    dependsOn: windows
+    jobs:
+      - template: build/steps/build-android.yml
+        parameters:
+          vmImage: $(macOSXVmImage)
+          provisionatorPath : 'build/provisioning/provisioning.csx'
+          buildForVS2017: true
 
   - stage: build_osx
     displayName: Build OSX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -210,7 +210,7 @@ stages:
 
   - stage: android_2017
     displayName: Build Android
-    condition: eq(variables['System.TeamProject'], 'devdiv') }
+    # condition: eq(variables['System.TeamProject'], 'devdiv') }
     dependsOn: windows
     jobs:
       - template: build/steps/build-android.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -205,6 +205,7 @@ stages:
           vmImage: $(macOSXVmImage)
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
+          buildConfiguration: $(DefaultBuildConfiguration)
 
   - stage: android_2017
     displayName: Build Android 2017
@@ -219,6 +220,7 @@ stages:
           vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true
+          buildConfiguration: $(DefaultBuildConfiguration)
 
   - stage: build_osx
     displayName: Build OSX

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -289,6 +289,6 @@ stages:
               msbuild
           steps:
             - template: build/steps/build-sign.yml
-          condition: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+          condition: and(succeeded(), ne(variables['signVmImage'], ''), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
 
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -209,7 +209,7 @@ stages:
 
   - stage: android_2017
     displayName: Build Android 2017
-    condition: eq(variables['System.TeamProject'], 'devdiv') }
+    condition: eq(variables['System.TeamProject'], 'devdiv')
     ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
       dependsOn: windows
     ${{ if eq(variables['System.TeamProject'], 'public') }}:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,10 @@ stages:
   - stage: android_2017
     displayName: Build Android
     # condition: eq(variables['System.TeamProject'], 'devdiv') }
-    dependsOn: windows
+    ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+      dependsOn: windows
+    ${{ if eq(variables['System.TeamProject'], 'public') }}:
+      dependsOn: []
     jobs:
       - template: build/steps/build-android.yml
         parameters:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -215,7 +215,7 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmImage: $(macOSXVmImage)
+          vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,4 @@
 variables:
-- name: DefaultBuildConfiguration
-  value: Debug
 - name: DefaultBuildPlatform
   value: 'any cpu'
 - name: ApkName
@@ -209,7 +207,7 @@ stages:
           buildForVS2017: false
 
   - stage: android_2017
-    displayName: Build Android
+    displayName: Build Android 2017
     # condition: eq(variables['System.TeamProject'], 'devdiv') }
     ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
       dependsOn: windows

--- a/build.cake
+++ b/build.cake
@@ -40,7 +40,7 @@ var packageVersion = Argument("packageVersion", "");
 var releaseChannelArg = Argument("CHANNEL", "Stable");
 releaseChannelArg = EnvironmentVariable("CHANNEL") ?? releaseChannelArg;
 var teamProject = Argument("TeamProject", "");
-bool buildForVS2017 = Convert.ToBoolean(Argument("buildForVS2017", "false"));
+bool buildForVS2017 = EnvironmentVariable("buildForVS2017") ?? Convert.ToBoolean(Argument("buildForVS2017", "false"));
 
 string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??
@@ -69,7 +69,7 @@ string monoPatchVersion = "";
 string monoMajorVersion = "";
 string monoVersion = "";
 
-if(buildForVS2017 || teamProject == "DevDiv")
+if(buildForVS2017)
 {
     // VS2017
     monoMajorVersion = "5.18.1";
@@ -144,6 +144,14 @@ Information ("iosSDK: {0}", iosSDK);
 //////////////////////////////////////////////////////////////////////
 // TASKS
 //////////////////////////////////////////////////////////////////////
+
+Task("SetEnvironentVariables")
+    .Description("This Sets Environment Variables for later scripts to use")
+    .Does(() =>
+{
+    Environment.SetEnvironment("buildForVS2017", buildForVS2017);
+});
+
 
 Task("Clean")
     .Description("Deletes all the obj/bin directories")

--- a/build.cake
+++ b/build.cake
@@ -145,14 +145,6 @@ Information ("iosSDK: {0}", iosSDK);
 // TASKS
 //////////////////////////////////////////////////////////////////////
 
-Task("SetEnvironentVariables")
-    .Description("This Sets Environment Variables for later scripts to use")
-    .Does(() =>
-{
-    Environment.SetEnvironment("buildForVS2017", buildForVS2017);
-});
-
-
 Task("Clean")
     .Description("Deletes all the obj/bin directories")
     .Does(() =>

--- a/build.cake
+++ b/build.cake
@@ -40,7 +40,9 @@ var packageVersion = Argument("packageVersion", "");
 var releaseChannelArg = Argument("CHANNEL", "Stable");
 releaseChannelArg = EnvironmentVariable("CHANNEL") ?? releaseChannelArg;
 var teamProject = Argument("TeamProject", "");
-bool buildForVS2017 = EnvironmentVariable("buildForVS2017") ?? Convert.ToBoolean(Argument("buildForVS2017", "false"));
+
+var buildForVS2017Arg = EnvironmentVariable("buildForVS2017") ?? Argument("buildForVS2017", "false");
+bool buildForVS2017 = Convert.ToBoolean(buildForVS2017Arg);
 
 string artifactStagingDirectory = Argument("Build_ArtifactStagingDirectory", (string)null) ?? EnvironmentVariable("Build.ArtifactStagingDirectory") ?? EnvironmentVariable("Build_ArtifactStagingDirectory") ?? ".";
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??

--- a/build.cake
+++ b/build.cake
@@ -54,6 +54,8 @@ string[] androidSdkManagerInstalls = new string[0]; //new [] { "platforms;androi
 Information ("ANDROID_HOME: {0}", ANDROID_HOME);
 Information ("Team Project: {0}", teamProject);
 Information ("buildForVS2017: {0}", buildForVS2017);
+Information ("EnvironmentVariable buildForVS2017: {0}", EnvironmentVariable("buildForVS2017"));
+Information ("Argument buildForVS2017: {0}", Argument("buildForVS2017", "not set"));
 
 var releaseChannel = ReleaseChannel.Stable;
 if(releaseChannelArg == "Preview")

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -35,6 +35,22 @@ if (IsMac)
 		XamarinChannel("Stable");
 	}
 
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC")))
+		Item ("Xamarin.Android")
+      		.Source (_ => Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("IOS_SDK_MAC")))
+		Item ("Xamarin.iOS")
+      		.Source (_ => Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MONO_SDK_MAC")))
+		Item ("Mono")
+      		.Source (_ => Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MAC_SDK_MAC")))
+		Item ("Xamarin.Mac")
+      		.Source (_ => Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
+
   	if(!String.IsNullOrEmpty(monoSDK_macos))
     	Item ("Mono", monoVersion)
       		.Source (_ => monoSDK_macos);
@@ -53,6 +69,23 @@ if (IsMac)
 }
 else
 {
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("ANDROID_SDK_WINDOWS")))
+		Item ("Xamarin.Android")
+      		.Source (_ => Environment.GetEnvironmentVariable ("ANDROID_SDK_WINDOWS"));
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("IOS_SDK_WINDOWS")))
+		Item ("Xamarin.iOS")
+      		.Source (_ => Environment.GetEnvironmentVariable ("IOS_SDK_WINDOWS"));
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MONO_SDK_WINDOWS")))
+		Item ("Mono")
+      		.Source (_ => Environment.GetEnvironmentVariable ("MONO_SDK_WINDOWS"));
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MAC_SDK_WINDOWS")))
+		Item ("Xamarin.Mac")
+      		.Source (_ => Environment.GetEnvironmentVariable ("MAC_SDK_WINDOWS"));
+			  
 	if(!String.IsNullOrEmpty(androidSDK_windows))
 		Item ("Xamarin.Android", "10.0.0.43")
       		.Source (_ => androidSDK_windows);

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -14,6 +14,8 @@ string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 
 
 
+Console.WriteLine ("buildForVS2017", Environment.GetEnvironmentVariable ("buildForVS2017"));
+
 if (IsMac)
 {
 	if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/"))
@@ -26,6 +28,10 @@ if (IsMac)
 	Item (XreItem.Java_OpenJDK_1_8_0_25);
 
 	string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");
+	Console.WriteLine ("ANDROID_SDK_MAC", Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
+	Console.WriteLine ("IOS_SDK_MAC", Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
+	Console.WriteLine ("MONO_SDK_MAC", Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));
+	Console.WriteLine ("MAC_SDK_MAC", Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
 
 	if(releaseChannel == "Preview")
 	{

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -14,7 +14,7 @@ string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/downloa
 
 
 
-Console.WriteLine ("buildForVS2017", Environment.GetEnvironmentVariable ("buildForVS2017"));
+Console.WriteLine ("buildForVS2017: {0}", Environment.GetEnvironmentVariable ("buildForVS2017"));
 
 if (IsMac)
 {
@@ -28,10 +28,10 @@ if (IsMac)
 	Item (XreItem.Java_OpenJDK_1_8_0_25);
 
 	string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");
-	Console.WriteLine ("ANDROID_SDK_MAC", Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
-	Console.WriteLine ("IOS_SDK_MAC", Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
-	Console.WriteLine ("MONO_SDK_MAC", Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));
-	Console.WriteLine ("MAC_SDK_MAC", Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
+	Console.WriteLine ("ANDROID_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
+	Console.WriteLine ("IOS_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
+	Console.WriteLine ("MONO_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));
+	Console.WriteLine ("MAC_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
 
 	if(releaseChannel == "Preview")
 	{

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -46,10 +46,6 @@ jobs:
       - checkout: self
         clean: true
 
-      - script: |
-          echo "##vso[task.setvariable variable=buildForVS2017]$(buildForVS2017)"
-        displayName: 'Setup Environment Variables'
-
       - task: xamops.azdevex.provisionator-task.provisionator@1
         displayName: 'Provisionator'
         condition: eq(variables['provisioning'], 'true')

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -47,7 +47,7 @@ jobs:
         clean: true
 
       - script: |
-          echo "##vso[task.setvariable buildForVS2017=$(buildForVS2017)]$COMMAND"
+          echo "##vso[task.setvariable variable=buildForVS2017]$(buildForVS2017)"
         displayName: 'Setup Environment Variables'
 
       - task: xamops.azdevex.provisionator-task.provisionator@1

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -48,18 +48,18 @@ jobs:
 
       - task: xamops.azdevex.provisionator-task.provisionator@1
         displayName: 'Provisionator'
-        condition: eq(variables['provisioning'], 'true')
+        condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
         inputs:
           provisioning_script: ${{ parameters.provisionatorPath }}
           provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
 
       - task: Bash@3
         displayName: 'Cake Provision'
-        condition: eq(variables['provisioningCake'], 'true')
+        condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target provision --TeamProject="$(System.TeamProject)"
+          arguments: --target provision --TeamProject="$(System.TeamProject)" --buildForVS2017=$(buildForVS2017)
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -29,15 +29,29 @@ jobs:
         android_legacy:
           renderers: 'LEGACY'
           outputfolder: 'legacyRenderers'
+          buildForVS2017: 'false'
         android_preAppCompat:
           renderers: 'PREAPPCOMPAT'
           outputfolder: 'preAppCompat'
+          buildForVS2017: 'false'
         android_newRenderers:
           renderers: 'FAST'
           outputfolder: 'newRenderers'
+          buildForVS2017: 'false'
+        android_newRenderers_2017:
+          renderers: 'FAST'
+          outputfolder: 'newRenderers'
+          buildForVS2017: 'true'
     steps:
       - checkout: self
         clean: true
+
+      - task: Bash@3
+        displayName: 'Setup Environment Variables'        
+        inputs:
+          targetType: 'filePath'
+          filePath: 'build.sh'
+          arguments: --target SetEnvironentVariables --buildForVS2017="$(buildForVS2017)"
 
       - task: xamops.azdevex.provisionator-task.provisionator@1
         displayName: 'Provisionator'
@@ -115,10 +129,20 @@ jobs:
 
       - task: CopyFiles@2
         displayName: 'Copy Android apk $(renderers) for UITest'
+        condition: eq(variables['buildForVS2017'], 'false')
         inputs:
           Contents: |
             Xamarin.Forms.ControlGallery.Android/$(outputfolder)/$(ApkName)
           TargetFolder: '$(build.artifactstagingdirectory)/androidApp'
+          CleanTargetFolder: true
+
+      - task: CopyFiles@2
+        displayName: 'Copy Android apk $(renderers) for UITest 2017'
+        condition: eq(variables['buildForVS2017'], 'true')
+        inputs:
+          Contents: |
+            Xamarin.Forms.ControlGallery.Android/$(outputfolder)/$(ApkName)
+          TargetFolder: '$(build.artifactstagingdirectory)/androidApp_2017'
           CleanTargetFolder: true
 
       - task: PublishBuildArtifacts@1

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -46,12 +46,9 @@ jobs:
       - checkout: self
         clean: true
 
-      - task: Bash@3
-        displayName: 'Setup Environment Variables'        
-        inputs:
-          targetType: 'filePath'
-          filePath: 'build.sh'
-          arguments: --target SetEnvironentVariables --buildForVS2017="$(buildForVS2017)"
+      - script: |
+          echo "##vso[task.setvariable buildForVS2017=$(buildForVS2017)]$COMMAND"
+        displayName: 'Setup Environment Variables'
 
       - task: xamops.azdevex.provisionator-task.provisionator@1
         displayName: 'Provisionator'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -29,19 +29,15 @@ jobs:
         android_legacy:
           renderers: 'LEGACY'
           outputfolder: 'legacyRenderers'
-          buildForVS2017: 'false'
+          buildForVS2017: ${{ parameters.buildForVS2017 }}
         android_preAppCompat:
           renderers: 'PREAPPCOMPAT'
           outputfolder: 'preAppCompat'
-          buildForVS2017: 'false'
+          buildForVS2017: ${{ parameters.buildForVS2017 }}
         android_newRenderers:
           renderers: 'FAST'
           outputfolder: 'newRenderers'
-          buildForVS2017: 'false'
-        android_newRenderers_2017:
-          renderers: 'FAST'
-          outputfolder: 'newRenderers'
-          buildForVS2017: 'true'
+          buildForVS2017: ${{ parameters.buildForVS2017 }}
     steps:
       - checkout: self
         clean: true
@@ -109,7 +105,7 @@ jobs:
         inputs:
           solution: ${{ parameters.androidProjectPath }}
           configuration: ${{ parameters.buildConfiguration }}
-          msbuildArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="$(renderers)" /bl:$(Build.ArtifactStagingDirectory)/android-$(renderers).binlog'
+          msbuildArguments: '/t:"Rebuild;SignAndroidPackage" /p:ANDROID_RENDERERS="$(renderers)" /bl:$(Build.ArtifactStagingDirectory)/android-$(renderers)-2017_$(buildForVS2017).binlog'
 
       - task: CopyFiles@2
         displayName: 'Copy $(renderers)'

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -64,7 +64,7 @@ steps:
       packDestination: '$(Build.ArtifactStagingDirectory)/nuget/release'
       versioningScheme: byEnvVar
       versionEnvVar: nugetPackageVersion
-    condition: and(succeeded(), or(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: and(succeeded(), or(eq(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -53,7 +53,7 @@ steps:
        }
     failOnStderr: true
     displayName: 'Update nuspecs'
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: and(succeeded(), or(eq(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: NuGetCommand@2
     displayName: 'Make NuGet Package Release'
@@ -64,7 +64,7 @@ steps:
       packDestination: '$(Build.ArtifactStagingDirectory)/nuget/release'
       versioningScheme: byEnvVar
       versionEnvVar: nugetPackageVersion
-    condition: and(succeeded(), or(eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: and(succeeded(), or(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/master'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -3,7 +3,7 @@ steps:
     clean: true
 
   - script: |
-      echo "##vso[task.setvariable buildForVS2017=$(buildForVS2017)]$COMMAND"
+      echo "##vso[task.setvariable variable=buildForVS2017]$(buildForVS2017)"
     displayName: 'Setup Environment Variables'
 
   - task: xamops.azdevex.provisionator-task.provisionator@1

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -31,7 +31,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target provision --TeamProject="$(System.TeamProject)" --buildForVS2017=$(buildForVS2017)
+      arguments: --target provision --TeamProject="$(System.TeamProject)"
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -2,6 +2,13 @@ steps:
   - checkout: self
     clean: true
 
+  - task: Bash@3
+    displayName: 'Setup Environment Variables'        
+    inputs:
+      targetType: 'filePath'
+      filePath: 'build.sh'
+      arguments: --target SetEnvironentVariables --buildForVS2017="$(buildForVS2017)"
+
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'
     condition: and(ne(variables['REQUIRED_XCODE'], ''), eq(variables['buildForVS2017'], 'false'))
@@ -112,7 +119,6 @@ steps:
       OverWrite: true
       flattenFolders: true
 
-
   - task: CopyFiles@2
     displayName: 'Copy iOS Files for UITest'
     condition: eq(variables['buildForVS2017'], 'false')
@@ -129,6 +135,21 @@ steps:
       CleanTargetFolder: true
       flattenFolders: true
 
+  - task: CopyFiles@2
+    displayName: 'Copy iOS Files for UITest 2017'
+    condition: eq(variables['buildForVS2017'], 'true')
+    inputs:
+      Contents: |
+       **/$(IpaName)
+       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
+       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
+       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
+       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
+       Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
+
+      TargetFolder: '$(build.artifactstagingdirectory)/ios_2017'
+      CleanTargetFolder: true
+      flattenFolders: true
 
   - task: CopyFiles@2
     displayName: 'Copy Android Files for UITest'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -3,7 +3,8 @@ steps:
     clean: true
 
   - script: |
-      echo "##vso[task.setvariable variable=buildForVS2017]$(buildForVS2017)"
+      echo '##vso[task.setvariable variable=buildForVS2017;]'$buildForVS2017
+      echo '##vso[task.setvariable variable=buildForVS2017;]$buildForVS2017
     displayName: 'Setup Environment Variables'
 
   - task: xamops.azdevex.provisionator-task.provisionator@1

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -3,7 +3,7 @@ steps:
     clean: true
 
   - script: |
-      echo '##vso[task.setvariable variable=buildForVS2017;]$buildForVS2017
+      echo "##vso[task.setvariable variable=buildForVS2017;]$buildForVS2017"
     displayName: 'Setup Environment Variables'
 
   - task: xamops.azdevex.provisionator-task.provisionator@1

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -2,12 +2,9 @@ steps:
   - checkout: self
     clean: true
 
-  - task: Bash@3
-    displayName: 'Setup Environment Variables'        
-    inputs:
-      targetType: 'filePath'
-      filePath: 'build.sh'
-      arguments: --target SetEnvironentVariables --buildForVS2017="$(buildForVS2017)"
+  - script: |
+      echo "##vso[task.setvariable buildForVS2017=$(buildForVS2017)]$COMMAND"
+    displayName: 'Setup Environment Variables'
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -2,10 +2,6 @@ steps:
   - checkout: self
     clean: true
 
-  - script: |
-      echo "##vso[task.setvariable variable=buildForVS2017;]$buildForVS2017"
-    displayName: 'Setup Environment Variables'
-
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'
     condition: and(ne(variables['REQUIRED_XCODE'], ''), eq(variables['buildForVS2017'], 'false'))
@@ -31,7 +27,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target provision --TeamProject="$(System.TeamProject)"
+      arguments: --target provision --TeamProject="$(System.TeamProject)" --buildForVS2017=$(buildForVS2017)
 
   - task: UseDotNet@2
     displayName: 'Install .net core $(DOTNET_VERSION)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -3,7 +3,6 @@ steps:
     clean: true
 
   - script: |
-      echo '##vso[task.setvariable variable=buildForVS2017;]'$buildForVS2017
       echo '##vso[task.setvariable variable=buildForVS2017;]$buildForVS2017
     displayName: 'Setup Environment Variables'
 

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -68,6 +68,7 @@ steps:
     displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
     inputs:
       solution: Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj
+      configuration: $(buildConfiguration)
       msbuildArguments: /bl:$(Build.ArtifactStagingDirectory)/tasks.binlog
 
   - task: InstallAppleCertificate@2


### PR DESCRIPTION
### Description of Change ###

- Add build 2017 stage so we can build android CG with 2017 to run through UI Tests
- update provisionator to use passed in URLS for sdks
- copy 2017 apk/ipas to separate folder for their own lane


### Testing Procedure ###
- make sure test lanes all run successfully 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
