### PR TITLE
Make cookie handling consistent and non destructive

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Action<string> cookieExpectation = null;
 				var cookieResult = new Label()
 				{
-					Text = "",
+					Text = "Loading",
 					AutomationId = "CookieResult"
 				};
 
@@ -73,6 +73,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 				webView.Navigated += async (_, __) =>
 				{
+					if (cookieResult.Text == "Loading")
+						cookieResult.Text = "Loaded";
+
 					_currentCookieValue = await webView.EvaluateJavaScriptAsync("document.cookie");
 					cookieExpectation?.Invoke(_currentCookieValue);
 					cookieExpectation = null;
@@ -299,7 +302,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ChangeDuringNavigating()
 		{
-			RunningApp.WaitForElement("ChangeDuringNavigating");
+			RunningApp.WaitForElement("Loaded");
 			// add a couple cookies
 			RunningApp.Tap("ChangeDuringNavigating");
 			RunningApp.WaitForElement("Success");
@@ -310,7 +313,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void AddAdditionalCookieToWebView()
 		{
-			RunningApp.WaitForElement("AdditionalCookie");
+			RunningApp.WaitForElement("Loaded");
 			// add a couple cookies
 			RunningApp.Tap("AdditionalCookie");
 			RunningApp.WaitForElement("Success");
@@ -321,7 +324,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void SetToOneCookie()
 		{
-			RunningApp.WaitForElement("OneCookie");
+			RunningApp.WaitForElement("Loaded");
 			RunningApp.Tap("OneCookie");
 			RunningApp.WaitForElement("Success");
 		}
@@ -329,7 +332,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void SetCookieContainerToNullDisablesCookieManagement()
 		{
-			RunningApp.WaitForElement("AdditionalCookie");
+			RunningApp.WaitForElement("Loaded");
 			// add a cookie to verify said cookie remains
 			RunningApp.Tap("AdditionalCookie");
 			RunningApp.WaitForElement("Success");
@@ -340,7 +343,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void RemoveAllTheCookiesIAdded()
 		{
-			RunningApp.WaitForElement("AdditionalCookie");
+			RunningApp.WaitForElement("Loaded");
 			// add a cookie so you can remove a cookie
 			RunningApp.Tap("AdditionalCookie");
 			RunningApp.WaitForElement("Success");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
@@ -295,6 +295,17 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("PageWithoutCookies");
 			RunningApp.WaitForElement("PageWithoutCookies");
 		}
+		
+		[Test]
+		public void ChangeDuringNavigating()
+		{
+			RunningApp.WaitForElement("ChangeDuringNavigating");
+			// add a couple cookies
+			RunningApp.Tap("ChangeDuringNavigating");
+			RunningApp.WaitForElement("Success");
+			RunningApp.Tap("ChangeDuringNavigating");
+			RunningApp.WaitForElement("Success");
+		}
 
 		[Test]
 		public void AddAdditionalCookieToWebView()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
@@ -67,7 +67,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 				webView.Navigating += (_, __) =>
 				{
-					cookieResult.Text = String.Empty;
+					if(cookieExpectation != null)
+						cookieResult.Text = "Navigating";
 				};
 
 				webView.Navigated += async (_, __) =>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 				webView.Navigating += (_, __) =>
 				{
-					if(cookieExpectation != null)
+					if (cookieExpectation != null)
 						cookieResult.Text = "Navigating";
 				};
 
@@ -182,7 +182,14 @@ namespace Xamarin.Forms.Controls.Issues
 										webView.Cookies = cookieContainer;
 										webView.Reload();
 									})
-								},
+								}
+							}
+						},
+						new StackLayout()
+						{
+							Orientation = StackOrientation.Horizontal,
+							Children =
+							{
 								new Button()
 								{
 									Text = "Additional",
@@ -219,46 +226,46 @@ namespace Xamarin.Forms.Controls.Issues
 
 										webView.Reload();
 									})
-								}
+								},
+								new Button()
+								{
+									Text = "Add Navigating",
+									AutomationId = "ChangeDuringNavigating",
+									Command = new Command(() =>
+									{
+										webView.Cookies = cookieContainer;
+										var cookieToAdd = new Cookie
+										{
+											Name = $"TestCookie{cookieContainer.Count}",
+											Expires = DateTime.Now.AddDays(1),
+											Value = $"My Test Cookie {cookieContainer.Count}...",
+											Domain = uri.Host,
+											Path = "/"
+										};
+
+										EventHandler<WebNavigatingEventArgs> navigating = null;
+										navigating = (_, __) =>
+										{
+											cookieContainer.Add(cookieToAdd);
+										};
+
+										cookieResult.Text = String.Empty;
+										cookieExpectation = (cookieValue) =>
+										{
+											if(cookieValue.Contains(cookieToAdd.Name))
+											{
+												cookieResult.Text = "Cookie not added during navigating";
+											}
+											else
+											{
+												cookieResult.Text = "Success";
+											}
+										};
+
+										webView.Reload();
+									})
+								},
 							}
-						},
-						new Button()
-						{
-							Text = "Change Cookies During Navigating",
-							AutomationId = "ChangeDuringNavigating",
-							Command = new Command(() =>
-							{
-								webView.Cookies = cookieContainer;
-								var cookieToAdd = new Cookie
-								{
-									Name = $"TestCookie{cookieContainer.Count}",
-									Expires = DateTime.Now.AddDays(1),
-									Value = $"My Test Cookie {cookieContainer.Count}...",
-									Domain = uri.Host,
-									Path = "/"
-								};
-
-								EventHandler<WebNavigatingEventArgs> navigating = null;
-								navigating = (_, __) =>
-								{
-									cookieContainer.Add(cookieToAdd);
-								};
-
-								cookieResult.Text = String.Empty;
-								cookieExpectation = (cookieValue) =>
-								{
-									if(cookieValue.Contains(cookieToAdd.Name))
-									{
-										cookieResult.Text = "Cookie not added during navigating";
-									}
-									else
-									{
-										cookieResult.Text = "Success";
-									}
-								};
-
-								webView.Reload();
-							})
 						},
 						new Button()
 						{
@@ -298,7 +305,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("PageWithoutCookies");
 			RunningApp.WaitForElement("PageWithoutCookies");
 		}
-		
+
 		[Test]
 		public void ChangeDuringNavigating()
 		{

--- a/Xamarin.Forms.Core/WebView.cs
+++ b/Xamarin.Forms.Core/WebView.cs
@@ -38,9 +38,7 @@ namespace Xamarin.Forms
 
 		public static readonly BindableProperty CanGoForwardProperty = CanGoForwardPropertyKey.BindableProperty;
 
-		public static readonly BindableProperty ShouldManageCookiesProperty = BindableProperty.Create(nameof(ShouldManageCookies), typeof(bool), typeof(WebView), false);
-
-		public static readonly BindableProperty CookiesProperty = BindableProperty.Create(nameof(Cookies), typeof(CookieContainer), typeof(WebView), default(string));
+		public static readonly BindableProperty CookiesProperty = BindableProperty.Create(nameof(Cookies), typeof(CookieContainer), typeof(WebView), null);
 
 		readonly Lazy<PlatformConfigurationRegistry<WebView>> _platformConfigurationRegistry;
 
@@ -71,12 +69,6 @@ namespace Xamarin.Forms
 		public bool CanGoForward
 		{
 			get { return (bool)GetValue(CanGoForwardProperty); }
-		}
-
-		public bool ShouldManageCookies
-		{
-			get { return (bool)GetValue(ShouldManageCookiesProperty); }
-			set { SetValue(ShouldManageCookiesProperty, value); }
 		}
 
 		public CookieContainer Cookies

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.ComponentModel;
+using System.Net;
 using Android.Graphics;
 using Android.Runtime;
 using Android.Webkit;
@@ -37,22 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_renderer?.Element == null || string.IsNullOrWhiteSpace(url) || url == WebViewRenderer.AssetBaseUrl)
 				return;
 
-			var cookies = _renderer.Element.Cookies?.GetCookies(new System.Uri(url));
-
-			if (cookies != null)
-			{
-				var cookieManager = CookieManager.Instance;
-				cookieManager.SetAcceptCookie(true);
-				cookieManager.RemoveAllCookie();
-				for (var i = 0; i < (cookies?.Count ?? -1); i++)
-				{
-					string cookieValue = cookies[i].Value;
-					string cookieDomain = cookies[i].Domain;
-					string cookieName = cookies[i].Name;
-					cookieManager.SetCookie(cookieDomain, cookieName + "=" + cookieValue);
-				}
-			}
-
+			_renderer.SyncCookies(url);
 			var cancel = false;
 			if (!url.Equals(_renderer.UrlCanceled, StringComparison.OrdinalIgnoreCase))
 				cancel = SendNavigatingCanceled(url);
@@ -86,6 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (navigate)
 			{
 				var args = new WebNavigatedEventArgs(_renderer.GetCurrentWebNavigationEvent(), source, url, _navigationResult);
+				_renderer.SyncCookies(url);
 				_renderer.ElementController.SendNavigated(args);
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -34,15 +34,16 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnPageStarted(WView view, string url, Bitmap favicon)
 		{
-			if (_renderer == null || string.IsNullOrWhiteSpace(url) || url == WebViewRenderer.AssetBaseUrl)
+			if (_renderer?.Element == null || string.IsNullOrWhiteSpace(url) || url == WebViewRenderer.AssetBaseUrl)
 				return;
 
-			if (_renderer?.Element?.ShouldManageCookies == true)
+			var cookies = _renderer.Element.Cookies?.GetCookies(new System.Uri(url));
+
+			if (cookies != null)
 			{
 				var cookieManager = CookieManager.Instance;
 				cookieManager.SetAcceptCookie(true);
 				cookieManager.RemoveAllCookie();
-				var cookies = _renderer.Element.Cookies?.GetCookies(new System.Uri(url));
 				for (var i = 0; i < (cookies?.Count ?? -1); i++)
 				{
 					string cookieValue = cookies[i].Value;

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_renderer?.Element == null || string.IsNullOrWhiteSpace(url) || url == WebViewRenderer.AssetBaseUrl)
 				return;
 
-			_renderer.SyncCookies(url);
+			_renderer.SyncNativeCookiesToElement(url);
 			var cancel = false;
 			if (!url.Equals(_renderer.UrlCanceled, StringComparison.OrdinalIgnoreCase))
 				cancel = SendNavigatingCanceled(url);
@@ -72,7 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (navigate)
 			{
 				var args = new WebNavigatedEventArgs(_renderer.GetCurrentWebNavigationEvent(), source, url, _navigationResult);
-				_renderer.SyncCookies(url);
+				_renderer.SyncNativeCookiesToElement(url);
 				_renderer.ElementController.SendNavigated(args);
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -220,10 +220,11 @@ namespace Xamarin.Forms.Platform.Android
 			if (myCookieJar == null)
 				return;
 
-			if (!_loadedCookies.Add(url))
+			var uri = new System.Uri(url);
+
+			if (!_loadedCookies.Add(uri.Host))
 				return;
 
-			var uri = new System.Uri(url);
 			var cookies = myCookieJar.GetCookies(uri);
 
 			if (cookies != null)

--- a/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/WebViewRenderer.cs
@@ -8,6 +8,8 @@ using Xamarin.Forms.Internals;
 using MixedContentHandling = Android.Webkit.MixedContentHandling;
 using AWebView = Android.Webkit.WebView;
 using System.Threading.Tasks;
+using System.Net;
+using System.Collections.Generic;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -59,6 +61,7 @@ namespace Xamarin.Forms.Platform.Android
 				return false;
 
 			var args = new WebNavigatingEventArgs(_eventState, new UrlWebViewSource { Url = url }, url);
+			SyncCookies(url);
 			ElementController.SendNavigating(args);
 			UpdateCanGoBackForward();
 			UrlCanceled = args.Cancel ? null : url;
@@ -193,6 +196,83 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		HashSet<string> _loadedCookies = new HashSet<string>();
+
+		CookieCollection GetCookiesFromNativeStore(string url)
+		{
+			CookieContainer existingCookies = new CookieContainer();
+			var cookieManager = CookieManager.Instance;
+			var currentCookies = cookieManager.GetCookie(url);
+			var uri = new Uri(url);
+
+			if (currentCookies != null)
+			{
+				foreach(var cookie in currentCookies.Split(';'))
+					existingCookies.SetCookies(uri, cookie);
+			}
+
+			return existingCookies.GetCookies(uri);
+		}
+
+		void InitialCookiePreloadIfNecessary(string url)
+		{
+			var myCookieJar = Element.Cookies;
+			if (myCookieJar == null)
+				return;
+
+			if (!_loadedCookies.Add(url))
+				return;
+
+			var uri = new System.Uri(url);
+			var cookies = myCookieJar.GetCookies(uri);
+
+			if (cookies != null)
+			{
+				var existingCookies = GetCookiesFromNativeStore(url);
+				foreach (Cookie cookie in existingCookies)
+				{
+					if (cookies[cookie.Name] == null)
+						myCookieJar.Add(cookie);
+				}
+			}
+		}
+
+		internal void SyncCookies(string url)
+		{
+			if (String.IsNullOrWhiteSpace(url))
+				return;
+
+			var uri = new Uri(url);
+			var myCookieJar = Element.Cookies;
+			if (myCookieJar == null)
+				return;
+
+			InitialCookiePreloadIfNecessary(url);
+			var cookies = myCookieJar.GetCookies(uri);
+			if (cookies == null)
+				return;
+
+			var retrieveCurrentWebCookies = GetCookiesFromNativeStore(url);
+
+			var cookieManager = CookieManager.Instance;
+			cookieManager.SetAcceptCookie(true);
+			for (var i = 0; i < cookies.Count; i++)
+			{
+				var cookie = cookies[i];
+				var cookieString = cookie.ToString();
+				cookieManager.SetCookie(cookie.Domain, cookieString);
+			}
+
+			foreach (Cookie cookie in retrieveCurrentWebCookies)
+			{
+				if (cookies[cookie.Name] != null)
+					continue;
+
+				var cookieString = $"{cookie.Name}=; max-age=0;expires=Sun, 31 Dec 2017 00:00:00 UTC";
+				cookieManager.SetCookie(cookie.Domain, cookieString);
+			}
+		}
+
 		void Load()
 		{
 			if (IgnoreSourceChanges)
@@ -241,6 +321,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnReloadRequested(object sender, EventArgs eventArgs)
 		{
+			SyncCookies(Control.Url?.ToString());
 			_eventState = WebNavigationEvent.Refresh;
 			Control.Reload();
 		}

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -182,10 +182,11 @@ if(bases.length == 0){
 			if (myCookieJar == null)
 				return;
 
-			if (!_loadedCookies.Add(url))
+			var uri = new System.Uri(url);
+
+			if (!_loadedCookies.Add(uri.Host))
 				return;
 
-			var uri = new System.Uri(url);
 			var cookies = myCookieJar.GetCookies(uri);
 
 			if (cookies != null)

--- a/Xamarin.Forms.Platform.iOS/Extensions/CookieExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/CookieExtensions.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using Foundation;
+
+#if __MOBILE__
+namespace Xamarin.Forms.Platform.iOS
+#else
+
+namespace Xamarin.Forms.Platform.MacOS
+#endif
+{
+	internal static class CookieExtensions
+	{
+		public static Cookie ToCookie(this NSHttpCookie nscookie)
+		{
+			Cookie cookie = new Cookie()
+			{
+				Comment = nscookie.Comment,
+				CommentUri = nscookie.CommentUrl,
+				Domain = nscookie.Domain,
+				Expires = nscookie.ExpiresDate.ToDateTime(),
+				HttpOnly = nscookie.IsHttpOnly,
+				Name = nscookie.Name,
+				Path = nscookie.Path,
+				Secure = nscookie.IsSecure,
+				Value = nscookie.Value,
+				Version = (int)nscookie.Version,
+				Port = String.Join(",", nscookie.PortList.Select(x => x.ToString()))
+			};
+
+			return cookie;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Extensions/CookieExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/CookieExtensions.cs
@@ -12,13 +12,16 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	internal static class CookieExtensions
 	{
-		public static Cookie ToCookie(this NSHttpCookie nscookie)
+		public static Cookie ToCookie(this NSHttpCookie nscookie, bool setDomain = true)
 		{
+			Uri commentUri = null;
+			if (nscookie.CommentUrl != null)
+				commentUri = nscookie.CommentUrl;
+
 			Cookie cookie = new Cookie()
 			{
 				Comment = nscookie.Comment,
-				CommentUri = nscookie.CommentUrl,
-				Domain = nscookie.Domain,
+				CommentUri = commentUri,
 				Expires = nscookie.ExpiresDate.ToDateTime(),
 				HttpOnly = nscookie.IsHttpOnly,
 				Name = nscookie.Name,
@@ -28,6 +31,9 @@ namespace Xamarin.Forms.Platform.MacOS
 				Version = (int)nscookie.Version,
 				Port = String.Join(",", nscookie.PortList.Select(x => x.ToString()))
 			};
+
+			if (setDomain)
+				cookie.Domain = nscookie.Domain;
 
 			return cookie;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WebViewRenderer.cs
@@ -274,7 +274,9 @@ namespace Xamarin.Forms.Platform.iOS
 				var lastUrl = request.Url.ToString();
 				var args = new WebNavigatingEventArgs(navEvent, new UrlWebViewSource { Url = lastUrl }, lastUrl);
 
-				if (WebView.ShouldManageCookies == true)
+				var jCookies = WebView.Cookies.GetCookies(request.Url);
+
+				if (jCookies != null)
 				{
 					// Set cookies here
 					var cookieJar = NSHttpCookieStorage.SharedStorage;
@@ -285,10 +287,10 @@ namespace Xamarin.Forms.Platform.iOS
 					{
 						cookieJar.DeleteCookie(aCookie);
 					}
+
 					//set up the new cookies
 					if (WebView.Cookies != null)
 					{
-						var jCookies = WebView.Cookies.GetCookies(request.Url);
 						IList<NSHttpCookie> eCookies =
 							(from object jCookie in jCookies
 							 where jCookie != null

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -207,14 +207,15 @@ namespace Xamarin.Forms.Platform.iOS
 			if (myCookieJar == null)
 				return;
 
-			if (!_loadedCookies.Add(url))
+			var uri = new Uri(url);
+
+			if (!_loadedCookies.Add(uri.Host))
 				return;
 
 			// pre ios 11 we sync cookies after navigated
 			if (!Forms.IsiOS11OrNewer)
 				return;
 
-			var uri = new Uri(url);
 			var cookies = myCookieJar.GetCookies(uri);
 			var existingCookies = await GetCookiesFromNativeStore(url);
 			foreach (var nscookie in existingCookies)

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -103,7 +103,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
 			NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri));
 
-			if (WebView.Cookies != null)
+			var jCookies = WebView.Cookies?.GetCookies(uri);
+
+			if (jCookies != null)
 			{
 				if (Forms.IsiOS11OrNewer)
 				{
@@ -111,9 +113,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 					foreach (var cookie in existingCookies)
 						await Configuration.WebsiteDataStore.HttpCookieStore.DeleteCookieAsync(cookie);
-
-
-					var jCookies = WebView.Cookies.GetCookies(uri);
 
 					foreach (System.Net.Cookie jCookie in jCookies)
 					{

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -164,6 +164,7 @@
     <Compile Include="ExportImageSourceHandlerAttribute.cs" />
     <Compile Include="ExportRendererAttribute.cs" />
     <Compile Include="Extensions\ArrayExtensions.cs" />
+    <Compile Include="Extensions\CookieExtensions.cs" />
     <Compile Include="Extensions\FlowDirectionExtensions.cs" />
     <Compile Include="Extensions\NSObjectExtensions.cs" />
     <Compile Include="Extensions\PlatformConfigurationExtensions.cs" />


### PR DESCRIPTION
### Description of Change ###

- UWP wasn't deleting cookies at all or updating cookies on refresh
- Android was just deleting all the cookies no matter what
- iOS was only deleting when cookies > 0

Determining how to do handle Cookies on each platform was different. This PR brings all the platforms in line. If the user never sets the Cookies property than nothing ever happens.

This PR also removes the API `ShouldManageCookies` which isn't public yet. Because if the CookieContainer is null that will already act as if `ShouldManageCookies` is set false. Android was the only platform that was totally destructive even when Cookies was null

This PR keeps the Cookies property in sync with the webview cookies. After the first load of a url the Cookies container (if set) will fill with cookies. At this point if you add/remove cookies it'll try to add/remove those from the webview

I also added calls to sync cookies after the navigating call this way people can modify the cookies during navigating if they need to

### Issues Resolved ### 

- fixes #10318

### Platforms Affected ### 
- iOS
- Android
- UWP

### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
