### PR TITLE
[UWP] Propagate CollectionView BindingContext to EmptyView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9833.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9833.cs
@@ -1,0 +1,114 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Windows.Input;
+using System.Collections.ObjectModel;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9833, "[Bug] [UWP] Propagate CollectionView BindingContext to EmptyView",	
+		PlatformAffected.UWP)]
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	public class Issue9833 : TestContentPage
+	{
+		public Issue9833()
+		{
+			Title = "Issue 9833";
+			
+			BindingContext = new Issue9833ViewModel();
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Text = "If can execute the command from the EmptyView, the test has passed.",
+				BackgroundColor = Color.Black,
+				TextColor = Color.White
+			};
+
+			var collectionView = new CollectionView();
+			collectionView.SetBinding(ItemsView.ItemsSourceProperty, "Model.Items");
+
+			var emptyView = new StackLayout
+			{
+				BackgroundColor = Color.LightGray
+			};
+
+			var emptyButton = new Button
+			{
+				Text = "Execute Command (EmptyView)"
+			};
+
+			emptyButton.SetBinding(Button.CommandProperty, "Model.Command");
+
+			emptyView.Children.Add(emptyButton);
+
+			collectionView.EmptyView = emptyView;
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(collectionView);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue9833Model
+	{
+		int _counter;
+
+		public Issue9833Model()
+		{
+			Command = new Command(Execute);
+		}
+
+		public ObservableCollection<string> Items { get; set; }
+		public ICommand Command  { get; set; }
+
+		void Execute()
+		{
+			_counter++;
+			Console.WriteLine($"Issue9833: {_counter}");
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue9833ViewModel : BindableObject
+	{
+		Issue9833Model _model;
+
+		public Issue9833ViewModel()
+		{
+			LoadData();
+		}
+
+		public Issue9833Model Model
+		{
+			get { return _model; }
+			set
+			{
+				_model = value;
+				OnPropertyChanged();
+			}
+		}
+
+		void LoadData()
+		{
+			Model = new Issue9833Model();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -196,6 +196,7 @@
       <SubType>Code</SubType>
       <DependentUpon>Issue9771.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9833.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />


### PR DESCRIPTION
### Description of Change ###

Propagate CollectionView BindingContext to EmptyView.

_NOTE: Tested on Android and iOS and it is working correctly._

### Issues Resolved ### 

- fixes #9833

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="1205" alt="Captura de pantalla 2020-05-05 a las 10 53 14" src="https://user-images.githubusercontent.com/6755973/81050228-ea5bbd80-8ebf-11ea-8780-ef28820e71f0.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 9833. Verify that the EmptyView BindingContext is not null.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
