### PR TITLE
[macOS] Fix NRE when using Slider min/mac track color

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
@@ -35,13 +35,24 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			// Draw min track
 			var minTrackPath = NSBezierPath.FromRoundedRect(minTrackRect, radius, radius);
-			var minTrackColor = MinimumTrackColor.IsDefault ? NSColor.ControlAccentColor : MinimumTrackColor.ToNSColor();
+
+			var defaultMinTrackColor = Color.Accent.ToNSColor();
+
+			if (Forms.IsMojaveOrNewer)
+				defaultMinTrackColor = NSColor.ControlAccentColor;
+
+			var minTrackColor = MinimumTrackColor.IsDefault ? defaultMinTrackColor : MinimumTrackColor.ToNSColor();
 			minTrackColor.SetFill();
 			minTrackPath.Fill();
 
+			var defaultMaxTrackColor = NSColor.ControlShadow;
+
+			if (Forms.IsMojaveOrNewer)
+				defaultMaxTrackColor = NSColor.SeparatorColor;
+
 			// Draw max track
 			var maxTrackPath = NSBezierPath.FromRoundedRect(maxTrackRect, radius, radius);
-			var maxTrackColor = MaximumTrackColor.IsDefault ? NSColor.ControlShadow : MaximumTrackColor.ToNSColor();
+			var maxTrackColor = MaximumTrackColor.IsDefault ? defaultMaxTrackColor : MaximumTrackColor.ToNSColor();
 			maxTrackColor.SetFill();
 			maxTrackPath.Fill();
 		}
@@ -58,11 +69,22 @@ namespace Xamarin.Forms.Platform.MacOS
 			var path = new NSBezierPath();
 			path.AppendPathWithRoundedRect(knobRect, radius, radius);
 			// Draw inside
-			var knobColor = ThumbColor.IsDefault ? NSColor.ControlLightHighlight : ThumbColor.ToNSColor();
+
+			var defaultKnobColor = NSColor.ControlLightHighlight;
+
+			if (Forms.IsMojaveOrNewer)
+				defaultKnobColor = NSColor.Highlight;
+
+			var knobColor = ThumbColor.IsDefault ? defaultKnobColor : ThumbColor.ToNSColor();
 			knobColor.SetFill();
 			path.Fill();
+
 			// Draw border
-			NSColor.ControlShadow.SetStroke();
+			if (Forms.IsMojaveOrNewer)
+				NSColor.ControlShadow.SetStroke();
+			else
+				NSColor.SeparatorColor.SetStroke();
+
 			path.Stroke();
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Guard a couple of colors in the min and max track colors for Slider because they are only available on Mojave (10.14) and up

The color usage here need to be updated when #8864 is implemented

### Issues Resolved ### 

- fixes #10581

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None, fix NRE while running on pre-10.14 macOS

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Ideally test on macOS pre10.14 and see it doesn't crash

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
