### PR TITLE
Finish updating Forms layout information before invoking native layout

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ExampleTemplates.cs
@@ -14,7 +14,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 				{
 					RowDefinitions = new RowDefinitionCollection { new RowDefinition(), new RowDefinition() },
 					WidthRequest = 200,
-					HeightRequest = 100
+					HeightRequest = 100,
+					BackgroundColor = Color.White
 				};
 
 				var image = new Image

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TemplateCodeCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TemplateCodeCollectionViewGallery.cs
@@ -19,7 +19,8 @@
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
-				AutomationId = "collectionview"
+				AutomationId = "collectionview",
+				BackgroundColor = Color.Red
 			};
 
 			var generator = new ItemsSourceGenerator(collectionView, initialItems: 20);

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -410,9 +410,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			AToolbar bar = _toolbar;
 			// make sure bar stays on top of everything
 			bar.BringToFront();
-
-			base.OnLayout(changed, l, t, r, b);
-
+			
 			int barHeight = ActionBarHeight();
 
 			if (Element.IsSet(BarHeightProperty))
@@ -435,6 +433,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			// Potential for optimization here, the exact conditions by which you don't need to do this are complex
 			// and the cost of doing when it's not needed is moderate to low since the layout will short circuit pretty fast
 			Element.ForceLayout();
+
+			base.OnLayout(changed, l, t, r, b);
 
 			bool toolbarLayoutCompleted = false;
 			for (var i = 0; i < ChildCount; i++)


### PR DESCRIPTION
### Description of Change ###

On an orientation change, NavigationPageRenderer is calling the base layout method before actually updating the size information for the current page; this results in an extra layout pass with incorrect size information. In most cases, this is corrected by a later layout pass, but some controls which are still a valid size in the new constraints won't be remeasured and rearranged. This results in controls remaining portrait-sized and aligned to the left of the screen.

This change moves the layout update after the child control size updates.

### Issues Resolved ### 

- fixes #6869

### API Changes ###
 
None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

With the device in portrait orientation, navigate to 
CollectionView Gallery -> DataTemplate Galleries -> Vertical List (Code)

Rotate the device to landscape. If the images are not centered or the red background of the CollectionView is visible, the test has failed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
