### PR TITLE
 IndicatorView not updating to current page when CarouselView is bound to custom DataType

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8958.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8958.xaml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    x:Name="Issue8958Page"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8958"
+    Title="Issue 8958">
+    <ContentPage.Content>
+        <Grid
+            BackgroundColor="Navy"
+			BindingContext="{x:Reference Name=Issue8958Page}">
+			<Grid.RowDefinitions>
+				<RowDefinition Height="*" />
+				<RowDefinition Height="Auto" />
+			</Grid.RowDefinitions>
+			<CarouselView
+                IndicatorView="Indicator"
+                ItemsSource="{Binding Items}">
+				<CarouselView.ItemTemplate>
+					<DataTemplate>
+						<Grid
+                            HorizontalOptions="Center"
+							VerticalOptions="Center"
+							BackgroundColor="Teal">
+							<Label
+                                Text="{Binding Title}"
+								TextColor="White"
+								HorizontalOptions="Center"
+								VerticalOptions="Center"
+								FontSize="Large" />
+						</Grid>
+					</DataTemplate>
+				</CarouselView.ItemTemplate>
+			</CarouselView>
+			<IndicatorView
+                x:Name="Indicator"
+                Grid.Row="1"
+				Padding="10"
+				IndicatorColor="LightGray"
+				SelectedIndicatorColor="Black"
+				IndicatorSize="10"
+				HorizontalOptions="Center" />
+		</Grid>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8958.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8958.xaml.cs
@@ -1,0 +1,57 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.IndicatorView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8958, "[Bug] IndicatorView not updating to current page when CarouselView is bound to custom DataType",
+		PlatformAffected.Android)]
+	public partial class Issue8958 : TestContentPage
+	{
+		public Issue8958()
+		{
+#if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "IndicatorView_Experimental" });
+			InitializeComponent();
+#endif
+		}
+
+		public List<Issue8958Model> Items { get; private set; }
+
+		protected override void Init()
+		{
+			var item1 = new Issue8958Model()
+			{
+				Title = "Item 1",
+			};
+
+			var item2 = new Issue8958Model()
+			{
+				Title = "Item 2",
+			};
+
+			var item3 = new Issue8958Model()
+			{
+				Title = "Item 3",
+			};
+
+			Items = new List<Issue8958Model>() { item1, item2, item3 };
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public struct Issue8958Model
+	{
+		public string Title { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1346,6 +1346,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9794.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10438.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8958.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1532,6 +1533,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9417.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8958.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

The problem more than in the IndicatorView is in an error updating the position of the CarouselView. We did changes in the logic to update the CarouselView Position and CurrentItem from 4.4 to 4.6. The issue is fixed in 4.6. Therefore this PR only include a sample to validate the case. @rmarinho Should we update the logic related with CarouselView Position in 4.4 to fix the issue in a 4.4 release?. I have a branch prepared with those changes if necessary.

### Issues Resolved ### 

- fixes #8958 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![issue8958](https://user-images.githubusercontent.com/6755973/81167950-66c0d000-8f96-11ea-8571-0f63594c7c61.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 8958. Change the CarouselView Position and verify that the IndicatorView position is updated too.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
