### PR TITLE
[AND] Make Shell overflow tab title "More" overridable

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
@@ -12,6 +12,7 @@ using Typeface = Android.Graphics.Typeface;
 using TypefaceStyle = Android.Graphics.TypefaceStyle;
 using Android.Graphics.Drawables;
 using System.Threading.Tasks;
+using Android.Content.Res;
 
 #if __ANDROID_29__
 using Google.Android.Material.BottomNavigation;
@@ -81,10 +82,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (showMore)
 			{
-				var moreString = new Java.Lang.String("More");
+				var moreString = context.Resources.GetText(Resource.String.overflow_tab_title);
 				var menuItem = menu.Add(0, MoreTabId, 0, moreString);
 				menuItems.Add(menuItem);
-				moreString.Dispose();
 
 				menuItem.SetIcon(Resource.Drawable.abc_ic_menu_overflow_material);
 				if (currentIndex >= maxBottomItems - 1)

--- a/Xamarin.Forms.Platform.Android/Resources/values/strings.xml
+++ b/Xamarin.Forms.Platform.Android/Resources/values/strings.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<resources>
+  <string name="overflow_tab_title">More</string>
+</resources>


### PR DESCRIPTION
### Description of Change ###

Move the hardcoded "More" for the overflow tab on Android to the `strings.xml` so it's overridable by the user

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7849

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Pull down the nugets and install them on an app where you have a "More" tab. in your `strings.xml` file add `<string name="overflow_tab_title">Meer</string>` and see if the value changes.

You can also do this in the gallery app and switch to the "Shell Store" root page and look in the bottom right

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
