### PR TITLE
[WPF] Implements CursorPosition on WPF Platform

### DIFF
--- a/Xamarin.Forms.Platform.WPF/FormsPanel.cs
+++ b/Xamarin.Forms.Platform.WPF/FormsPanel.cs
@@ -82,6 +82,13 @@ namespace Xamarin.Forms.Platform.WPF
 			if (double.IsInfinity(elementDesiredWidth) || double.IsPositiveInfinity(elementDesiredHeight))
 			{
 				Size request = Element.Measure(elementDesiredWidth, elementDesiredHeight, MeasureFlags.IncludeMargins).Request;
+				
+				if (request.Width == -1)
+					request.Width = 0.0;
+
+				if (request.Height == -1)
+					request.Height = 0.0;
+
 				result = new System.Windows.Size(request.Width, request.Height);
 			}
 			else

--- a/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
@@ -285,6 +285,7 @@ namespace Xamarin.Forms.Platform.WPF
 					Control.LostFocus -= OnTextBoxUnfocused;
 					Control.TextChanged -= TextBoxOnTextChanged;
 					Control.KeyUp -= TextBoxOnKeyUp;
+					Control.SelectionChanged -= TextBoxOnSelectionChanged;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/EntryRenderer.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Platform.WPF
 					Control.LostFocus += OnTextBoxUnfocused;
 					Control.TextChanged += TextBoxOnTextChanged;
 					Control.KeyUp += TextBoxOnKeyUp;
+					Control.SelectionChanged += TextBoxOnSelectionChanged;
 				}
 
 				// Update Control properties
@@ -38,6 +39,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdatePlaceholderColor();
 				UpdateMaxLength();
 				UpdateIsReadOnly();
+				UpdateCursorPosition();
 			}
 
 			base.OnElementChanged(e);
@@ -70,12 +72,14 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateVerticalTextAlignment();
 			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
 				UpdatePlaceholderColor();
+			else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
+				UpdateCursorPosition();
 			else if (e.PropertyName == InputView.MaxLengthProperty.PropertyName)
 				UpdateMaxLength();
 			else if (e.PropertyName == InputView.IsReadOnlyProperty.PropertyName)
 				UpdateIsReadOnly();
 		}
-		
+
 		internal override void OnModelFocusChangeRequested(object sender, VisualElement.FocusRequestArgs args)
 		{
 			if (args.Focus)
@@ -128,6 +132,12 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 
 			_ignoreTextChange = false;
+		}
+
+		private void TextBoxOnSelectionChanged(object sender, RoutedEventArgs e)
+		{
+			if (Control != null && Element != null)
+				Element.CursorPosition = Control.CaretIndex;
 		}
 
 		void UpdateHorizontalTextAlignment()
@@ -200,7 +210,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			Control.InputScope = Element.Keyboard.ToInputScope();
 		}
-		
+
 		void UpdateIsPassword()
 		{
 			Control.IsPassword = Element.IsPassword;
@@ -219,7 +229,7 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				if (_placeholderDefaultBrush == null)
 				{
-					_placeholderDefaultBrush = (Brush)WControl.ForegroundProperty.GetMetadata(typeof(FormsTextBox)).DefaultValue; 
+					_placeholderDefaultBrush = (Brush)WControl.ForegroundProperty.GetMetadata(typeof(FormsTextBox)).DefaultValue;
 				}
 
 				// Use the cached default brush
@@ -285,6 +295,12 @@ namespace Xamarin.Forms.Platform.WPF
 		void UpdateIsReadOnly()
 		{
 			Control.IsReadOnly = Element.IsReadOnly;
+		}
+
+		void UpdateCursorPosition()
+		{
+			if (Control.CaretIndex != Element.CursorPosition)
+				Control.CaretIndex = Element.CursorPosition;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.WPF
 	{
 		public bool IsInvokeRequired
 		{
-			get { return !System.Windows.Application.Current.Dispatcher.CheckAccess(); }
+			get { return System.Windows.Application.Current == null ? false : !System.Windows.Application.Current.Dispatcher.CheckAccess(); }
 		}
 
 		public string RuntimePlatform => Device.WPF;
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			System.Diagnostics.Process.Start(uri.AbsoluteUri);
 		}
-		
+
 		public void BeginInvokeOnMainThread(Action action)
 		{
 			System.Windows.Application.Current?.Dispatcher.BeginInvoke(action);
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			return new WPFIsolatedStorageFile(IsolatedStorageFile.GetUserStoreForAssembly());
 		}
-		
+
 		public void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
 			var timer = new DispatcherTimer(DispatcherPriority.Background, System.Windows.Application.Current.Dispatcher) { Interval = interval };


### PR DESCRIPTION
### Description of Change ###

Implements CursorPosition on WPF Platform

### Issues Resolved ###

Fixes #10548 Entry.CursorPosition not implemented on WPF

### API Changes ###

Modify EntryRenderer.cs on WPF Platform to include CursorPosition Property Changes

OnElementChanged()
{
    Control.SelectionChanged += TextBoxOnSelectionChanged;
    UpdateCursorPosition();
}

OnElementPropertyChanged()
{
    else if (e.PropertyName == Entry.CursorPositionProperty.PropertyName)
        UpdateCursorPosition();
}

void TextBoxOnSelectionChanged(object sender, RoutedEventArgs e)
{
    if (Control != null && Element != null)
        Element.CursorPosition = Control.CaretIndex;
}

void UpdateCursorPosition()
{
    if (Control.CaretIndex != Element.CursorPosition)
        Control.CaretIndex = Element.CursorPosition;
}

### Platforms Affected ###

- WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ###

Not applicable

### Testing Procedure ###
- Add an Entry to a Xamarin.Forms Project;
- Run WPF platform;
- Add some text to Entry, and monitor CursorPosition changing accordingly;
- Done;

### PR Checklist ###
- [ X ] Targets the correct branch
- [ X ] Tests are passing (or failures are unrelated)