### PR TITLE
Don't apply foreground color to secondary menu items

### DIFF
--- a/Xamarin.Forms.Platform.Android.UnitTests/ToolbarExtensionsTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/ToolbarExtensionsTests.cs
@@ -112,6 +112,40 @@ namespace Xamarin.Forms.Platform.Android.UnitTests
 				Assert.Fail(exc.ToString());
 			}
 		}
+				
+		[Test, Category("ToolbarExtensions")]
+		[Description("Secondary ToolBarItems don't Change Color based on ForegroundColor")]
+		public void SecondaryToolbarItemsDontChangeColor()
+		{
+			List<ToolbarItem> sortedItems = new List<ToolbarItem>()
+			{
+				new ToolbarItem() { IsEnabled = true, Text = "a", Order = ToolbarItemOrder.Secondary },
+			};
+
+			var settings = new ToolbarSettings(sortedItems) { TintColor = Color.Red };
+			SetupToolBar(settings, Context);
+			AToolBar aToolBar = settings.ToolBar;
+			IMenuItem menuItem = settings.MenuItemsCreated.First();
+
+			MenuItemImpl menuItemImpl = (MenuItemImpl)menuItem;
+			Assert.IsNotNull(menuItemImpl, "menuItem is not of type MenuItemImpl");
+
+			if(menuItemImpl.TitleFormatted is SpannableString tf)
+			{
+				var colorSpan =
+					tf.GetSpans(0, tf.Length(), Java.Lang.Class.FromType(typeof(ForegroundColorSpan)))
+					.OfType<ForegroundColorSpan>()
+					.FirstOrDefault();
+
+				if (colorSpan != null)
+				{
+					Assert.AreNotEqual(
+						colorSpan.ForegroundColor,
+						(int)Color.Red.ToAndroid(),
+						"Secondary Menu Item Incorrectly set to ForegroundColor");
+				}
+			}
+		}
 
 		static void SetupToolBar(ToolbarSettings settings, Context context)
 		{

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (!String.IsNullOrWhiteSpace(item.Text))
 			{
-				if (tintColor != null && tintColor != Color.Default)
+				if (item.Order != ToolbarItemOrder.Secondary && tintColor != null && tintColor != Color.Default)
 				{
 					var color = item.IsEnabled ? tintColor.Value.ToAndroid() : tintColor.Value.MultiplyAlpha(0.302).ToAndroid();
 					SpannableString titleTinted = new SpannableString(item.Text);

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
 
-			if (item.Order == ToolbarItemOrder.Primary && !Forms.IsOreoOrNewer && (tintColor != null && tintColor != Color.Default))
+			if (item.Order != ToolbarItemOrder.Secondary && !Forms.IsOreoOrNewer && (tintColor != null && tintColor != Color.Default))
 			{
 				var view = toolbar.FindViewById(menuitem.ItemId);
 				if (view is ATextView textView)

--- a/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/ToolbarExtensions.cs
@@ -126,7 +126,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			menuitem.SetOnMenuItemClickListener(new GenericMenuClickListener(((IMenuItemController)item).Activate));
 
-			if (!Forms.IsOreoOrNewer && (tintColor != null && tintColor != Color.Default))
+			if (item.Order == ToolbarItemOrder.Primary && !Forms.IsOreoOrNewer && (tintColor != null && tintColor != Color.Default))
 			{
 				var view = toolbar.FindViewById(menuitem.ItemId);
 				if (view is ATextView textView)


### PR DESCRIPTION
### Description of Change ###

In 4.6 we improved the Menu Item tinting to use a SpannableString instead of searching for a textview but this caused the default foreground color (white) to get applied to the secondary menu items. Which causes white on white text for the secondary menu.

### Issues Resolved ### 
- fixes #10617 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
