### PR TITLE
Add title to test and change async to Thread Sleep

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10134.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10134.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 			ContentPage page1 = AddTopTab("Tab 1");
+			page1.Title = "Top Bar Page 1";
 
 			for(int i = 2; i < 20; i++)
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
@@ -56,9 +56,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST && __IOS__
 		[Test]
-		public async void Issue5470Test() 
+		public void Issue5470Test() 
 		{
-			await Task.Delay(500); // give it time to crash
+			Thread.Sleep(500); // give it time to crash
 			RunningApp.WaitForElement (q => q.Marked ("IssuePageLabel"));
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5470.cs
@@ -2,6 +2,7 @@
 using Xamarin.Forms.Internals;
 using System;
 using System.Threading.Tasks;
+using System.Threading;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;


### PR DESCRIPTION
### Description of Change ###

- Set the Page title to not match the tab title so when trying to detect if the tab title is off screen we don't keep getting the page title
- changed Issue5470 to not use async because it looks like the vsmac running has issues with void async and nunit

### Testing Procedure ###
- just make sure ui tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
