### PR TITLE
Prevent crash/hang when rotating CollectionView with HTML Labels

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8870.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8870.cs
@@ -1,0 +1,98 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8870, "[Bug] CollectionView with HTML Labels Freeze the Screen on Rotation",
+		PlatformAffected.iOS)]
+	public class Issue8870 : TestContentPage
+	{
+		public const string Success = "Success";
+		public const string CheckResult = "Check";
+
+		protected override void Init()
+		{
+#if APP
+			var instructions = new Label { Text = "Rotate the device, then rotate it back 3 times. If the application crashes or hangs, this test has failed." };
+
+			var button = new Button { Text = CheckResult, AutomationId = CheckResult };
+			button.Clicked += (sender, args) => { instructions.Text = Success; };
+
+			var source = new List<string>();
+			for (int n = 0; n < 100; n++)
+			{
+				source.Add($"Item: {n}");
+			}
+
+			var template = new DataTemplate(() => {
+				var label = new Label
+				{
+					TextType = TextType.Html
+				};
+
+				label.SetBinding(Label.TextProperty, new Binding(".", stringFormat: "<p style='background-color:red;'>{0}</p>"));
+
+				return label;
+			});
+
+			var cv = new CollectionView() 
+			{ 
+				ItemsSource = source,
+				ItemTemplate = template
+			};
+
+			var layout = new StackLayout();
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(button);
+			layout.Children.Add(cv);
+
+			Content = layout;
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public async Task RotatingCollectionViewWithHTMLShouldNotHangOrCrash()
+		{
+			int delay = 3000;
+
+			RunningApp.WaitForElement(CheckResult);
+
+			RunningApp.SetOrientationPortrait();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationLandscape();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationPortrait();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationLandscape();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationPortrait();
+			await Task.Delay(delay);
+
+			RunningApp.WaitForElement(CheckResult);
+			RunningApp.Tap(CheckResult);
+
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -34,6 +34,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8766.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8801.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8870.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9428.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9419.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8262.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		internal void UpdateConstraints(CGSize size)
+		internal override void UpdateConstraints(CGSize size)
 		{
 			ConstrainTo(size);
 			UpdateCellConstraints();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 				kind, VerticalDefaultSupplementalView.ReuseId);
 		}
 
-		public override UICollectionReusableView GetViewForSupplementaryElement(UICollectionView collectionView, 
+		public override UICollectionReusableView GetViewForSupplementaryElement(UICollectionView collectionView,
 			NSString elementKind, NSIndexPath indexPath)
 		{
 			var reuseId = DetermineViewReuseId(elementKind);
@@ -132,6 +132,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal CGSize GetReferenceSizeForHeader(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
 		{
+			if (!_isGrouped)
+			{
+				return CGSize.Empty;
+			}
+
 			// Currently we explicitly measure all of the headers/footers 
 			// Long-term, we might want to look at performance hints (similar to ItemSizingStrategy) for 
 			// headers/footers (if the dev knows for sure they'll all the be the same size)
@@ -140,6 +145,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal CGSize GetReferenceSizeForFooter(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
 		{
+			if (!_isGrouped)
+			{
+				return CGSize.Empty;
+			}
+
 			return GetReferenceSizeForheaderOrFooter(collectionView, ItemsView.GroupFooterTemplate, UICollectionElementKindSectionKey.Footer, section);
 		}
 
@@ -207,21 +217,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
 				{
-					return new UIEdgeInsets(itemSpacing + uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left, 
+					return new UIEdgeInsets(itemSpacing + uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left,
 						uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 				}
 
-				return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, itemSpacing + uIEdgeInsets.Left, 
+				return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, itemSpacing + uIEdgeInsets.Left,
 					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 			}
 
 			if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
 			{
-				return new UIEdgeInsets(uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left, 
+				return new UIEdgeInsets(uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left,
 					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 			}
 
-			return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left, 
+			return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left,
 				uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/HeightConstrainedTemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HeightConstrainedTemplatedCell.cs
@@ -13,8 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ConstrainTo(CGSize constraint)
 		{
-			base.ConstrainTo(constraint);
-
+			ClearConstraints();
 			ConstrainedDimension = constraint.Height;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalDefaultCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalDefaultCell.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -12,6 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public HorizontalDefaultCell(CGRect frame) : base(frame)
 		{
 			Constraint = Label.HeightAnchor.ConstraintEqualTo(Frame.Height);
+			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalDefaultSupplementalView.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalDefaultSupplementalView.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Label.Font = UIFont.PreferredHeadline;
 
 			Constraint = Label.HeightAnchor.ConstraintEqualTo(Frame.Height);
+			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}
 
@@ -28,5 +29,4 @@ namespace Xamarin.Forms.Platform.iOS
 			return new CGSize(Label.IntrinsicContentSize.Width, Constraint.Constant);
 		}
 	}
-
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -18,8 +18,6 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _emptyViewDisplayed;
 		bool _disposed;
 
-		CGSize _size;
-
 		UIView _emptyUIView;
 		VisualElement _emptyViewFormsElement;
 
@@ -144,15 +142,14 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewWillLayoutSubviews()
 		{
 			base.ViewWillLayoutSubviews();
-			
+
 			// We can't set this constraint up on ViewDidLoad, because Forms does other stuff that resizes the view
 			// and we end up with massive layout errors. And View[Will/Did]Appear do not fire for this controller
 			// reliably. So until one of those options is cleared up, we set this flag so that the initial constraints
 			// are set up the first time this method is called.
 			if (!_initialConstraintsSet)
 			{
-				_size = CollectionView.Bounds.Size;
-				ItemsViewLayout.ConstrainTo(_size);
+				ItemsViewLayout.SetInitialConstraints(CollectionView.Bounds.Size);
 				UpdateEmptyView();
 				_initialConstraintsSet = true;
 			}
@@ -160,26 +157,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				LayoutEmptyView();
 			}
-		}
-
-		
-		public override void ViewDidLayoutSubviews()
-		{
-			base.ViewDidLayoutSubviews();
-			if (CollectionView.Bounds.Size != _size)
-			{
-				_size = CollectionView.Bounds.Size;
-				BoundsSizeChanged();
-			}
-		}
-
-		protected virtual void BoundsSizeChanged()
-		{
-			//We are changing orientation and we need to tell our layout
-			//to update based on new size constrains
-			ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
-			//We call ReloadData so our VisibleCells also update their size
-			CollectionView.ReloadData();
 		}
 
 		protected virtual UICollectionViewDelegateFlowLayout CreateDelegator()
@@ -225,7 +202,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			ItemsViewLayout.PrepareCellForLayout(cell);
 		}
-
+		
 		public virtual NSIndexPath GetIndexForItem(object item)
 		{
 			return ItemsSource.GetIndexForItem(item);
@@ -411,5 +388,6 @@ namespace Xamarin.Forms.Platform.iOS
 				_emptyViewDisplayed = false;
 			}
 		}
+		
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -30,16 +30,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ConstrainTo(CGSize constraint)
 		{
+			ClearConstraints();
 			ConstrainedSize = constraint;
 		}
 
 		public override void ConstrainTo(nfloat constant)
 		{
+			ClearConstraints();
 			ConstrainedDimension = constant;
-
-			// Reset constrained size in case ItemSizingStrategy changes
-			// and we want to measure each item
-			ConstrainedSize = default(CGSize);
+		}
+		
+		protected void ClearConstraints()
+		{
+			ConstrainedSize = default;
+			ConstrainedDimension = default;
 		}
 
 		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(

--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalDefaultCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalDefaultCell.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -12,6 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public VerticalDefaultCell(CGRect frame) : base(frame)
 		{
 			Constraint = Label.WidthAnchor.ConstraintEqualTo(Frame.Width);
+			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalDefaultSupplementalView.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalDefaultSupplementalView.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.iOS
 			Label.Font = UIFont.PreferredHeadline;
 
 			Constraint = Label.WidthAnchor.ConstraintEqualTo(Frame.Width);
+			Constraint.Priority = (float)UILayoutPriority.DefaultHigh;
 			Constraint.Active = true;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/WidthConstrainedTemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/WidthConstrainedTemplatedCell.cs
@@ -13,8 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ConstrainTo(CGSize constraint)
 		{
-			base.ConstrainTo(constraint);
-
+			ClearConstraints();
 			ConstrainedDimension = constraint.Width;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Xamarin.Forms.Internals;
 
 #if __MOBILE__
@@ -90,7 +91,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			Performance.Start(out string reference);
 			if (CompressedLayout.GetIsHeadless(view))
 			{
-				var packager = new VisualElementPackager(Renderer, view, isHeadless:true);
+				var packager = new VisualElementPackager(Renderer, view, isHeadless: true);
 				view.IsPlatformEnabled = true;
 				packager.Load();
 			}
@@ -107,6 +108,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				EnsureChildrenOrder();
 			}
+
 			Performance.Stop(reference);
 		}
 


### PR DESCRIPTION
### Description of Change ###

The iOS CollectionView controller and layout have a race condition during rotation where the controller can generate a cell for layout while the layout is in prototyping mode. Because the prototype cell isn't properly constrained, if it contains a control which happens to return zero-width measurements in the right circumstances (e.g., a `Label` with `TextType.Html`) the UICollectionView's layout process can hang, which either hangs or crashes the entire application.

This change eliminates the issue and prevents the application hang/crash.

### Issues Resolved ### 

- fixes #8870

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test (8870)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
