### PR TITLE
PresentsWithGesture incorrectly toggled back to true when Flyout Disabled

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletShellFlyoutRenderer.cs
@@ -44,11 +44,11 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				case FlyoutBehavior.Disabled:
 					PreferredDisplayMode = UISplitViewControllerDisplayMode.PrimaryHidden;
-					PresentsWithGesture = false;
+					TryToUpdatePresentsWithGesture(false);
 					break;
 				case FlyoutBehavior.Flyout:
 					PreferredDisplayMode = UISplitViewControllerDisplayMode.PrimaryHidden;
-					PresentsWithGesture = true;
+					TryToUpdatePresentsWithGesture(true);
 					_isPresented = false;
 					_context.Shell.SetValueFromRenderer(Shell.FlyoutIsPresentedProperty, false);
 					break;
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_flyoutBehavior == FlyoutBehavior.Flyout)
 				{
 					var swipeViewTouched = IsSwipeView(view);
-					PresentsWithGesture = !swipeViewTouched;
+					TryToUpdatePresentsWithGesture(!swipeViewTouched);
 				}
 			}
 		}
@@ -157,8 +157,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.TouchesEnded(touches, evt);
 
-			if(_flyoutBehavior == FlyoutBehavior.Flyout)
-				PresentsWithGesture = true;
+			TryToUpdatePresentsWithGesture(true);
 		}
 
 		protected override void Dispose(bool disposing)
@@ -180,6 +179,20 @@ namespace Xamarin.Forms.Platform.iOS
 				_content = null;
 				_context = null;
 			}
+		}
+
+		bool TryToUpdatePresentsWithGesture(bool value)
+		{
+			if (_flyoutBehavior != FlyoutBehavior.Flyout)
+			{
+				if (PresentsWithGesture)
+					PresentsWithGesture = false;
+
+				return false;
+			}
+
+			PresentsWithGesture = value;
+			return true;
 		}
 
 		bool IsSwipeView(UIView view)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletShellFlyoutRenderer.cs
@@ -145,15 +145,20 @@ namespace Xamarin.Forms.Platform.iOS
 				if (view == null)
 					return;
 
-				var swipeViewTouched = IsSwipeView(view);
-				PresentsWithGesture = !swipeViewTouched;
+				if (_flyoutBehavior == FlyoutBehavior.Flyout)
+				{
+					var swipeViewTouched = IsSwipeView(view);
+					PresentsWithGesture = !swipeViewTouched;
+				}
 			}
 		}
 
 		public override void TouchesEnded(NSSet touches, UIEvent evt)
 		{
 			base.TouchesEnded(touches, evt);
-			PresentsWithGesture = true;
+
+			if(_flyoutBehavior == FlyoutBehavior.Flyout)
+				PresentsWithGesture = true;
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
### Description of Change ###

On an iPad the PresentsWithGesture is being incorrectly re-enabled when the flyout behavior was set to disabled

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- On an iPad run the store shell or go to the "shell Flyout Behavior" issue and play with disabling the flyout. Once you've disable it try to swipe it open with a gesture

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
