### PR TITLE
[Android] Fixed previous image being loaded after source change.

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -34,6 +34,7 @@ namespace Xamarin.Forms.Platform.Android
 		bool _disposed;
 		bool _skipInvalidate;
 		int? _defaultLabelFor;
+		ImageElementManager _imageManager;
 		VisualElementTracker _tracker;
 		VisualElementRenderer _visualElementRenderer;
 		BorderBackgroundManager _backgroundTracker;
@@ -103,7 +104,8 @@ namespace Xamarin.Forms.Platform.Android
 				SetOnTouchListener(null);
 				OnFocusChangeListener = null;
 
-				ImageElementManager.Dispose(this);
+				_imageManager?.Dispose();
+				_imageManager = null;
 
 				_tracker?.Dispose();
 				_tracker = null;
@@ -179,8 +181,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_tracker == null)
 			{
 				_tracker = new VisualElementTracker(this);
-				ImageElementManager.Init(this);
-
+				_imageManager = new ImageElementManager(this);
 			}
 
 			if (_visualElementRenderer == null)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageElementManager.cs
@@ -17,8 +17,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 	public class ImageElementManager : IDisposable
 	{
 		readonly IVisualElementRenderer renderer;
-		bool disposedValue;
-		CancellationTokenSource currentImageLoadCancellationSource;
+		CancellationTokenSource _currentImageLoadCancellationSource;
+		bool _disposed;
 
 		public ImageElementManager(IVisualElementRenderer renderer)
 		{
@@ -178,12 +178,12 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		{
 			var sameImageSource = newImage.Source != null && Equals(previous?.Source, newImage.Source);
 
-			if (sameImageSource && currentImageLoadCancellationSource != null)
-				return currentImageLoadCancellationSource.Token;
+			if (sameImageSource && _currentImageLoadCancellationSource != null)
+				return _currentImageLoadCancellationSource.Token;
 
-			currentImageLoadCancellationSource?.Cancel();
-			currentImageLoadCancellationSource = new CancellationTokenSource();
-			return currentImageLoadCancellationSource.Token;
+			_currentImageLoadCancellationSource?.Cancel();
+			_currentImageLoadCancellationSource = new CancellationTokenSource();
+			return _currentImageLoadCancellationSource.Token;
 		}
 
 		internal static void OnAnimationStopped(IElementController image, FormsAnimationDrawableStateEventArgs e)
@@ -205,14 +205,14 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		protected virtual void Dispose(bool disposing)
 		{
-			if (!disposedValue)
+			if (!_disposed)
 			{
 				if (disposing)
 				{
 					Unregister();
 				}
 
-				disposedValue = true;
+				_disposed = true;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/ImageRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		Image _element;
 		bool _skipInvalidate;
 		int? _defaultLabelFor;
+		ImageElementManager _imageManager;
 		VisualElementTracker _visualElementTracker;
 		VisualElementRenderer _visualElementRenderer;
 		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
@@ -43,7 +44,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 					_element.PropertyChanged -= OnElementPropertyChanged;
 				}
 
-				ImageElementManager.Dispose(this);
+				_imageManager?.Dispose();
+				_imageManager = null;
+
 				BackgroundManager.Dispose(this);
 
 				if (_visualElementTracker != null)
@@ -145,7 +148,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			{
 				_visualElementRenderer = new VisualElementRenderer(this);
 				BackgroundManager.Init(this);
-				ImageElementManager.Init(this);
+				_imageManager = new ImageElementManager(this);
 			}
 
 			Performance.Stop(reference);


### PR DESCRIPTION
### Description of Change ###

Using cancellation token for async image load operations performed by renderer.

### Issues Resolved ### 
- fixes #10039

### API Changes ###

Removed:
- Xamarin.Forms.Platform.Android.FastRenderers.ImageElementManager.Init ();

Added:
- Xamarin.Forms.Platform.Android.FastRenderers.ImageElementManager..ctor (IVisualElementRenderer renderer)

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I've reproduced the bug with the [attached project](https://github.com/xamarin/Xamarin.Forms/files/4360129/FormsBug.zip) on the [issue](https://github.com/xamarin/Xamarin.Forms/issues/10039) reported.
I am not familiar with creating a platform specific test case to reproduce this issue.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
