### PR TITLE
[Tizen] Adds ActiveBezelElement to Application

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/Application.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/Application.cs
@@ -1,5 +1,6 @@
 ﻿namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
 {
+	using System.ComponentModel;
 	using FormsElement = Forms.Application;
 
 	public static class Application
@@ -27,8 +28,7 @@
 			return config;
 		}
 
-		public static readonly BindableProperty OverlayContentProperty
-		   = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(FormsElement), default(View));
+		public static readonly BindableProperty OverlayContentProperty = BindableProperty.CreateAttached("OverlayContent", typeof(View), typeof(FormsElement), default(View));
 
 		public static View GetOverlayContent(BindableObject application)
 		{
@@ -48,6 +48,31 @@
 		public static IPlatformElementConfiguration<Tizen, FormsElement> SetOverlayContent(this IPlatformElementConfiguration<Tizen, FormsElement> config, View value)
 		{
 			SetOverlayContent(config.Element, value);
+			return config;
+		}
+
+		public static readonly BindableProperty ActiveBezelInteractionElementProperty = BindableProperty.CreateAttached("ActiveBezelInteractionElement", typeof(Element), typeof(FormsElement), default(Element));
+
+		public static Element GetActiveBezelInteractionElement(BindableObject application)
+		{
+			return (Element)application.GetValue(ActiveBezelInteractionElementProperty);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static void SetActiveBezelInteractionElement(BindableObject application, Element value)
+		{
+			application.SetValue(ActiveBezelInteractionElementProperty, value);
+		}
+
+		public static Element GetActiveBezelInteractionElement(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetActiveBezelInteractionElement(config.Element);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetActiveBezelInteractionElement(this IPlatformElementConfiguration<Tizen, FormsElement> config, Element value)
+		{
+			SetActiveBezelInteractionElement(config.Element, value);
 			return config;
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ViewRenderer.cs
@@ -118,12 +118,15 @@ namespace Xamarin.Forms.Platform.Tizen
 					{
 						ri.RotaryWidget?.Activate();
 						Forms.RotaryFocusObject = Element;
+						Specific.SetActiveBezelInteractionElement(Application.Current, Element);
 					}
 					else
 					{
 						ri.RotaryWidget?.Deactivate();
 						if (Forms.RotaryFocusObject == Element)
 							Forms.RotaryFocusObject = null;
+						if (Specific.GetActiveBezelInteractionElement(Application.Current) == Element)
+							Specific.SetActiveBezelInteractionElement(Application.Current, null);
 					}
 				}
 			}


### PR DESCRIPTION
### Description of Change ###
This PR enables you to know which view is currently interact with bezel.
It can be consumed from C# using the fluent API:

```cs
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
...

var view = Application.Current.On<Tizen>().GetActiveBezelInteractionElement()
```
> **Remark**
> Make sure that `GetActiveBezelInteractionElement()` returns null if `TargetIdiom` is not `Watch` or there is no active bezel interactive elements. As of now, only `CollectionView`, `ListView`, and `ScollView` in Xamarin.Forms are bezel-interactive view in the Samsung Galaxy Watch. When these views gain focus, `ActiveBezelInteractionElement` is set by default.

### Bugs Fixed ###
None

### API Changes ###
```namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific```
Added:
 - View Application.ActiveBezelInteractionElement //BindableProperty 

### Platforms Affected ### 
- Tizen

### Behavioral Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
