### PR TITLE
Added OrangeColor

### DIFF
--- a/Xamarin.Forms.Core/NamedPlatformColor.cs
+++ b/Xamarin.Forms.Core/NamedPlatformColor.cs
@@ -6,6 +6,7 @@
 		public const string SystemBlue = "systemBlue";
 		public const string SystemGreen = "systemGreen";
 		public const string SystemIndigo = "systemIndigo";
+		public const string SystemOrange = "systemOrange";
 		public const string SystemPink = "systemPink";
 		public const string SystemPurple = "systemPurple";
 		public const string SystemRed = "systemRed";

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -331,6 +331,9 @@ namespace Xamarin.Forms
 					case NamedPlatformColor.SystemIndigo:
 						resultColor = UIColor.SystemIndigoColor;
 						break;
+					case NamedPlatformColor.SystemOrange:
+						resultColor = UIColor.SystemOrangeColor;
+						break;
 					case NamedPlatformColor.SystemPink:
 						resultColor = UIColor.SystemPinkColor;
 						break;


### PR DESCRIPTION
### Description of Change ###

While implementing the platform dynamic colors I seem to have forgotten SystemOrange on iOS

### Issues Resolved ### 
N/A

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use `GetNamedColor` to find the `systemOrange` color on iOS and see that it works!

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
