### PR TITLE
[macOS] Dark Theme support

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -9,8 +9,7 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	internal class CellNSView : NSView, INativeElementView
 	{
-		static readonly NSColor s_defaultChildViewsBackground = NSColor.Clear;
-		static readonly CGColor s_defaultHeaderViewsBackground = NSColor.LightGray.CGColor;
+		readonly NSColor s_defaultChildViewsBackground = NSColor.Clear;
 		Cell _cell;
 		readonly NSTableViewCellStyle _style;
 
@@ -126,7 +125,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				nativeCell.Identifier = templateId;
 
 			if (!isHeader) return nativeCell;
-			if (nativeCell.Layer != null) nativeCell.Layer.BackgroundColor = s_defaultHeaderViewsBackground;
+			if (nativeCell.Layer != null) nativeCell.Layer.BackgroundColor = ColorExtensions.GroupedBackground.CGColor;
 			return nativeCell;
 		}
 

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellNSView.cs
@@ -106,6 +106,50 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Layout();
 		}
 
+		public override void UpdateLayer()
+		{
+			base.UpdateLayer();
+
+			UpdateBackground();
+			UpdateTextColor();
+		}
+
+		void UpdateBackground()
+		{
+			if (_cell == null)
+				return;
+
+			var bgColor = ColorExtensions.ControlBackgroundColor;
+			var element = _cell.RealParent as VisualElement;
+			if (element != null)
+				bgColor = element.BackgroundColor == Color.Default ? bgColor : element.BackgroundColor.ToNSColor();
+
+			Layer.BackgroundColor = bgColor.CGColor;
+		}
+
+		void UpdateTextColor()
+		{
+			if (TextLabel == null)
+				return;
+
+			var textColor = ColorExtensions.TextColor;
+			var textCell = _cell.RealParent as TextCell;
+			if (textCell != null)
+				textColor = textCell.TextColor == Color.Default ? textColor : textCell.TextColor.ToNSColor();
+
+			TextLabel.TextColor = textColor;
+
+			if (DetailTextLabel == null)
+				return;
+
+			var detailTextColor = ColorExtensions.SecondaryLabelColor;
+			var element = _cell.RealParent as TextCell;
+			if (element != null)
+				detailTextColor = element.TextColor == Color.Default ? textColor : element.TextColor.ToNSColor();
+
+			DetailTextLabel.TextColor = detailTextColor;
+		}
+
 		internal static NSView GetNativeCell(NSTableView tableView, Cell cell, string templateId = "", bool isHeader = false,
 			bool isRecycle = false)
 		{

--- a/Xamarin.Forms.Platform.MacOS/Cells/CellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/CellRenderer.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		protected void UpdateBackground(NSView tableViewCell, Cell cell)
 		{
 			tableViewCell.WantsLayer = true;
-			var bgColor = NSColor.White;
+			var bgColor = ColorExtensions.ControlBackgroundColor;
 			var element = cell.RealParent as VisualElement;
 			if (element != null)
 				bgColor = element.BackgroundColor == Color.Default ? bgColor : element.BackgroundColor.ToNSColor();

--- a/Xamarin.Forms.Platform.MacOS/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/EntryCellRenderer.cs
@@ -1,14 +1,13 @@
 ﻿using System;
 using System.ComponentModel;
 using AppKit;
-using CoreGraphics;
 using Foundation;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
 	public class EntryCellRenderer : CellRenderer
 	{
-		static readonly Color s_defaultTextColor = Color.Black;
+		readonly Color s_defaultTextColor = ColorExtensions.TextColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
 
 		public override NSView GetCell(Cell item, NSView reusableView, NSTableView tv)
 		{
@@ -63,7 +62,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.UpdateBackgroundChild(cell, backgroundColor);
 		}
 
-		static void OnCellPropertyChanged(object sender, PropertyChangedEventArgs e)
+		void OnCellPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			var entryCell = (EntryCell)sender;
 			var realCell = (CellNSView)GetRealCell(entryCell);
@@ -84,7 +83,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateHorizontalTextAlignment(realCell, entryCell);
 		}
 
-		static void OnTextFieldTextChanged(object sender, EventArgs eventArgs)
+		void OnTextFieldTextChanged(object sender, EventArgs eventArgs)
 		{
 			var notification = (NSNotification)sender;
 			var view = (NSView)notification.Object;
@@ -101,7 +100,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				((EntryCell)realCell.Cell).Text = field.StringValue;
 		}
 
-		static void UpdateHorizontalTextAlignment(CellNSView cell, EntryCell entryCell)
+		void UpdateHorizontalTextAlignment(CellNSView cell, EntryCell entryCell)
 		{
 			IVisualElementController viewController = entryCell.Parent as VisualElement;
 
@@ -110,7 +109,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				nsTextField.Alignment = entryCell.HorizontalTextAlignment.ToNativeTextAlignment(viewController?.EffectiveFlowDirection ?? default(EffectiveFlowDirection));
 		}
 
-		static void UpdateIsEnabled(CellNSView cell, EntryCell entryCell)
+		void UpdateIsEnabled(CellNSView cell, EntryCell entryCell)
 		{
 			cell.TextLabel.Enabled = entryCell.IsEnabled;
 			var nsTextField = cell.AccessoryView.Subviews[0] as NSTextField;
@@ -118,24 +117,24 @@ namespace Xamarin.Forms.Platform.MacOS
 				nsTextField.Enabled = entryCell.IsEnabled;
 		}
 
-		static void UpdateLabel(CellNSView cell, EntryCell entryCell)
+		void UpdateLabel(CellNSView cell, EntryCell entryCell)
 		{
 			cell.TextLabel.StringValue = entryCell.Label ?? "";
 		}
 
-		static void UpdateLabelColor(CellNSView cell, EntryCell entryCell)
+		void UpdateLabelColor(CellNSView cell, EntryCell entryCell)
 		{
 			cell.TextLabel.TextColor = entryCell.LabelColor.ToNSColor(s_defaultTextColor);
 		}
 
-		static void UpdatePlaceholder(CellNSView cell, EntryCell entryCell)
+		void UpdatePlaceholder(CellNSView cell, EntryCell entryCell)
 		{
 			var nsTextField = cell.AccessoryView.Subviews[0] as NSTextField;
 			if (nsTextField != null)
 				nsTextField.PlaceholderString = entryCell.Placeholder ?? "";
 		}
 
-		static void UpdateText(CellNSView cell, EntryCell entryCell)
+		void UpdateText(CellNSView cell, EntryCell entryCell)
 		{
 			var nsTextField = cell.AccessoryView.Subviews[0] as NSTextField;
 			if (nsTextField != null && nsTextField.StringValue == entryCell.Text)

--- a/Xamarin.Forms.Platform.MacOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/TextCellRenderer.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public class TextCellRenderer : CellRenderer
 	{
-		static readonly Color s_defaultDetailColor = new Color(.32, .4, .57);
-		static readonly Color s_defaultTextColor = Color.Black;
+		static readonly Color s_defaultDetailColor = ColorExtensions.SecondaryLabelColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
+		static readonly Color s_defaultTextColor = ColorExtensions.TextColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
 
 		public override NSView GetCell(Cell item, NSView reusableView, NSTableView tv)
 		{

--- a/Xamarin.Forms.Platform.MacOS/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/TextCellRenderer.cs
@@ -5,8 +5,8 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public class TextCellRenderer : CellRenderer
 	{
-		static readonly Color s_defaultDetailColor = ColorExtensions.SecondaryLabelColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
-		static readonly Color s_defaultTextColor = ColorExtensions.TextColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
+		readonly Color s_defaultDetailColor = ColorExtensions.SecondaryLabelColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
+		readonly Color s_defaultTextColor = ColorExtensions.TextColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
 
 		public override NSView GetCell(Cell item, NSView reusableView, NSTableView tv)
 		{

--- a/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
+++ b/Xamarin.Forms.Platform.MacOS/Cells/ViewCellNSView.cs
@@ -34,6 +34,26 @@ namespace Xamarin.Forms.Platform.MacOS
 			base.Layout();
 		}
 
+		public override void UpdateLayer()
+		{
+			base.UpdateLayer();
+
+			UpdateBackground();
+		}
+
+		void UpdateBackground()
+		{
+			if (_viewCell == null)
+				return;
+
+			var bgColor = ColorExtensions.ControlBackgroundColor;
+			var element = _viewCell.RealParent as VisualElement;
+			if (element != null)
+				bgColor = element.BackgroundColor == Color.Default ? bgColor : element.BackgroundColor.ToNSColor();
+
+			Layer.BackgroundColor = bgColor.CGColor;
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (disposing)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/DatePickerRenderer.cs
@@ -30,8 +30,8 @@ namespace Xamarin.Forms.Platform.MacOS
 					};
 					_picker.ValidateProposedDateValue += HandleValueChanged;
 					(_picker as FormsNSDatePicker).FocusChanged += ControlFocusChanged;
-					_defaultTextColor = _picker.TextColor;
-					_defaultBackgroundColor = _picker.BackgroundColor;
+					_defaultTextColor = ColorExtensions.TextColor;
+					_defaultBackgroundColor = ColorExtensions.ControlBackgroundColor;
 
 					SetNativeControl(_picker);
 				}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -160,7 +160,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Control == null)
 				return;
-			Control.BackgroundColor = color == Color.Default ? NSColor.Clear : color.ToNSColor();
+			Control.BackgroundColor = color == Color.Default ? ColorExtensions.ControlBackgroundColor : color.ToNSColor();
 
 			base.SetBackgroundColor(color);
 		}
@@ -201,7 +201,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			SetNativeControl(textField);
 
-			_defaultTextColor = textField.TextColor;
+			_defaultTextColor = ColorExtensions.TextColor;
 
 			textField.Changed += OnChanged;
 			textField.EditingBegan += OnEditingBegan;
@@ -311,10 +311,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var targetColor = Element.PlaceholderColor;
 
-			// Placeholder default color is 70% gray
-			// https://developer.apple.com/library/prerelease/ios/documentation/UIKit/Reference/UITextField_Class/index.html#//apple_ref/occ/instp/UITextField/placeholder
-
-			var color = Element.IsEnabled && !targetColor.IsDefault ? targetColor : ColorExtensions.SeventyPercentGrey.ToColor();
+			var color = Element.IsEnabled && !targetColor.IsDefault ? targetColor : ColorExtensions.PlaceholderColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
 
 			Control.PlaceholderAttributedString = formatted.ToAttributed(Element, color, Element.HorizontalTextAlignment);
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ListViewRenderer.cs
@@ -109,7 +109,14 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (_table == null)
 				return;
 
-			_table.BackgroundColor = color.ToNSColor(NSColor.White);
+			_table.BackgroundColor = color.ToNSColor(ColorExtensions.ControlBackgroundColor);
+		}
+
+		// When OS Theme changes, reload data to update all the colors
+		public override void ViewDidChangeEffectiveAppearance()
+		{
+			base.ViewDidChangeEffectiveAppearance();
+			NativeTableView?.ReloadData();
 		}
 
 		protected override void SetBackground(Brush brush)

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.ComponentModel;
 using AppKit;
+using Foundation;
 using Xamarin.Forms.PlatformConfiguration.macOSSpecific;
 
 namespace Xamarin.Forms.Platform.MacOS
@@ -87,6 +88,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			Init();
 			base.ViewWillAppear();
+		}
+
+		public override void ViewDidLayout()
+		{
+			base.ViewDidLayout();
+			UpdateBackground();
 		}
 
 		protected override void Dispose(bool disposing)
@@ -187,7 +194,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					else
 					{
 						Color bgColor = Element.BackgroundColor;
-						View.Layer.BackgroundColor = bgColor.IsDefault ? NSColor.White.CGColor : bgColor.ToCGColor();
+						View.Layer.BackgroundColor = bgColor.IsDefault ? ColorExtensions.WindowBackgroundColor.CGColor : bgColor.ToCGColor();
 					}
 				}
 			});

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -22,22 +22,22 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateBackground()
 		{
-			this.ApplyNativeImageAsync(Page.BackgroundImageSourceProperty, bgImage =>
+			_renderer.ApplyNativeImageAsync(Page.BackgroundImageSourceProperty, bgImage =>
 			{
 				if (bgImage != null)
 				{
-					View.Layer.BackgroundColor = NSColor.FromPatternImage(bgImage).CGColor;
+					Layer.BackgroundColor = NSColor.FromPatternImage(bgImage).CGColor;
 				}
 				else
 				{
-					Brush background = Element.Background;
+					Brush background = _renderer.Element.Background;
 
 					if (!Brush.IsNullOrEmpty(background))
-						NativeView.UpdateBackground(Element.Background);
+						_renderer.NativeView.UpdateBackground(_renderer.Element.Background);
 					else
 					{
-						Color bgColor = Element.BackgroundColor;
-						View.Layer.BackgroundColor = bgColor.IsDefault ? ColorExtensions.WindowBackgroundColor.CGColor : bgColor.ToCGColor();
+						Color bgColor = _renderer.Element.BackgroundColor;
+						Layer.BackgroundColor = bgColor.IsDefault ? ColorExtensions.WindowBackgroundColor.CGColor : bgColor.ToCGColor();
 					}
 				}
 			});

--- a/Xamarin.Forms.Platform.MacOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SearchBarRenderer.cs
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (Control == null)
 				return;
-			Control.BackgroundColor = color == Color.Default ? NSColor.Clear : color.ToNSColor();
+			Control.BackgroundColor = color == Color.Default ? ColorExtensions.ControlBackgroundColor : color.ToNSColor();
 
 			UpdateCancelButton();
 		}
@@ -161,7 +161,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			var formatted = (FormattedString)Element.Placeholder ?? string.Empty;
 			var targetColor = Element.PlaceholderColor;
-			var color = Element.IsEnabled && !targetColor.IsDefault ? targetColor : ColorExtensions.SeventyPercentGrey.ToColor();
+			var color = Element.IsEnabled && !targetColor.IsDefault ? targetColor : ColorExtensions.PlaceholderColor.ToColor(NSColorSpace.DeviceRGBColorSpace);
 			Control.PlaceholderAttributedString = formatted.ToAttributed(Element, color);
 		}
 
@@ -173,7 +173,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextColor()
 		{
-			_defaultTextColor = _defaultTextColor ?? Control.TextColor;
+			_defaultTextColor = _defaultTextColor ?? ColorExtensions.TextColor;
 			var targetColor = Element.TextColor;
 
 			Control.TextColor = targetColor.ToNSColor(_defaultTextColor);

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -154,8 +154,74 @@ namespace Xamarin.Forms.Platform.MacOS
 #else
 		internal static readonly NSColor Black = NSColor.Black;
 		internal static readonly NSColor SeventyPercentGrey = NSColor.FromRgba(0.7f, 0.7f, 0.7f, 1);
-		internal static readonly NSColor LabelColor = NSColor.Black.UsingColorSpace("NSCalibratedRGBColorSpace");
 		internal static readonly NSColor AccentColor = Color.FromRgba(50, 79, 133, 255).ToNSColor();
+
+		internal static NSColor LabelColor
+		{
+			get
+			{
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.LabelColor;
+
+				return NSColor.Black.UsingColorSpace("NSCalibratedRGBColorSpace");
+			}
+		}
+
+		internal static NSColor TextColor
+		{
+			get
+			{
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.Text;
+
+				return NSColor.Black;
+			}
+		}
+
+		internal static NSColor ControlBackgroundColor
+		{
+			get
+			{
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.ControlBackground;
+
+				return NSColor.Clear;
+			}
+		}
+
+		internal static NSColor WindowBackgroundColor
+		{
+			get
+			{
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.WindowBackground;
+
+				return NSColor.White;
+			}
+		}
+
+		internal static NSColor PlaceholderColor
+		{
+			get
+			{
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.PlaceholderTextColor;
+
+				return SeventyPercentGrey;
+			}
+		}
+
+		internal static NSColor SecondaryLabelColor
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.SecondaryLabelColor;
+#endif
+				return new Color(.32, .4, .57).ToNSColor();
+			}
+		}
 #endif
 
 		public static CGColor ToCGColor(this Color color)

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -222,6 +222,18 @@ namespace Xamarin.Forms.Platform.MacOS
 				return new Color(.32, .4, .57).ToNSColor();
 			}
 		}
+
+		internal static NSColor GroupedBackground
+		{
+			get
+			{
+#if __XCODE11__
+				if (Forms.IsMojaveOrNewer)
+					return NSColor.SystemGrayColor;
+#endif
+				return Color.LightGray.ToNSColor();
+			}
+		}
 #endif
 
 		public static CGColor ToCGColor(this Color color)

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -158,15 +158,25 @@ namespace Xamarin.Forms
 			Device.SetIdiom(UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad ? TargetIdiom.Tablet : TargetIdiom.Phone);
 			Device.SetFlowDirection(UIApplication.SharedApplication.UserInterfaceLayoutDirection.ToFlowDirection());
 #else
+			// Subscribe to notifications in OS Theme changes
+			NSDistributedNotificationCenter.GetDefaultCenter().AddObserver((NSString)"AppleInterfaceThemeChangedNotification", (n) =>
+			{
+				var interfaceStyle = NSUserDefaults.StandardUserDefaults.StringForKey("AppleInterfaceStyle");
+
+				var aquaAppearance = NSAppearance.GetAppearance(interfaceStyle == "Dark" ? NSAppearance.NameDarkAqua : NSAppearance.NameAqua);
+				NSApplication.SharedApplication.Appearance = aquaAppearance;
+
+				Application.Current?.OnRequestedThemeChanged(new AppThemeChangedEventArgs(interfaceStyle == "Dark" ? OSAppTheme.Dark : OSAppTheme.Light));
+			});
+
 			Device.SetIdiom(TargetIdiom.Desktop);
 			Device.SetFlowDirection(NSApplication.SharedApplication.UserInterfaceLayoutDirection.ToFlowDirection());
-			var mojave = new NSOperatingSystemVersion(10, 14, 0);
-			if (NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(mojave) &&
-				typeof(NSApplication).GetProperty("Appearance") is PropertyInfo appearance &&
-				appearance != null)
+
+			if (IsMojaveOrNewer)
 			{
-				var aquaAppearance = NSAppearance.GetAppearance(NSAppearance.NameAqua);
-				appearance.SetValue(NSApplication.SharedApplication, aquaAppearance);
+				var interfaceStyle = NSUserDefaults.StandardUserDefaults.StringForKey("AppleInterfaceStyle");
+				var aquaAppearance = NSAppearance.GetAppearance(interfaceStyle == "Dark" ? NSAppearance.NameDarkAqua : NSAppearance.NameAqua);
+				NSApplication.SharedApplication.Appearance = aquaAppearance;
 			}
 #endif
 			Device.SetFlags(s_flags);
@@ -720,10 +730,26 @@ namespace Xamarin.Forms
 					return OSAppTheme.Unspecified;
 #endif
 #else
-                    return OSAppTheme.Unspecified;
+                    return AppearanceIsDark(NSApplication.SharedApplication.EffectiveAppearance) ? OSAppTheme.Dark : OSAppTheme.Light;
 #endif
 				}
 			}
+
+#if __MACOS__
+			bool AppearanceIsDark(NSAppearance appearance)
+			{
+				if (IsMojaveOrNewer)
+				{
+					var matchedAppearance = appearance.FindBestMatch(new string[] { NSAppearance.NameAqua, NSAppearance.NameDarkAqua });
+
+					return matchedAppearance == NSAppearance.NameDarkAqua;
+				}
+				else
+				{
+					return false;
+				}
+			}
+#endif
 
 #if __IOS__ || __TVOS__
 

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Forms
 				var aquaAppearance = NSAppearance.GetAppearance(interfaceStyle == "Dark" ? NSAppearance.NameDarkAqua : NSAppearance.NameAqua);
 				NSApplication.SharedApplication.Appearance = aquaAppearance;
 
-				Application.Current?.OnRequestedThemeChanged(new AppThemeChangedEventArgs(interfaceStyle == "Dark" ? OSAppTheme.Dark : OSAppTheme.Light));
+				Application.Current?.TriggerThemeChanged(new AppThemeChangedEventArgs(interfaceStyle == "Dark" ? OSAppTheme.Dark : OSAppTheme.Light));
 			});
 
 			Device.SetIdiom(TargetIdiom.Desktop);

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -573,7 +573,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				Control.TextColor = textColor.ToUIColor(ColorExtensions.LabelColor);
 #else
 			var alignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
-			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(ColorExtensions.Black), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });
+			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(ColorExtensions.TextColor), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });
 			textWithColor = textWithColor.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
 			Control.AttributedStringValue = textWithColor;
 #endif


### PR DESCRIPTION
### Description of Change ###

Add necessary bits to support both native Dark Mode from 10.14 and up and the Forms xplat APIs

### Issues Resolved ### 

- fixes #8864 
- fixes #3777

### API Changes ###
- added on macOS project: `public class FormsNSView`

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###
Some colors might be different than before when running on 10.14+. Colors where changed to use dynamic colors so the values might be different than the hard-coded ones earlier.

### Before/After Screenshots ### 

![image](https://user-images.githubusercontent.com/939291/89532618-61239200-d7f2-11ea-8d30-ebdf27542c4f.png)

![image](https://user-images.githubusercontent.com/939291/89533013-02aae380-d7f3-11ea-987e-78804628f194.png)


### Testing Procedure ###
Switch your Mac to Dark Mode and run the gallery app. Everything should look easy on the eyes.
When switching while the app is running, everything should transition back and forth

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
