### PR TITLE
[X] TypeConverter on Grid Col/Row Definitions

### DIFF
--- a/Xamarin.Forms.Core/ColumnDefinitionCollectionTypeConverter.cs
+++ b/Xamarin.Forms.Core/ColumnDefinitionCollectionTypeConverter.cs
@@ -1,0 +1,22 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	[Xaml.TypeConversion(typeof(ColumnDefinitionCollection))]
+	public class ColumnDefinitionCollectionTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				var lengths = value.Split(',');
+				var coldefs = new ColumnDefinitionCollection();
+				var converter = new GridLengthTypeConverter();
+				foreach (var length in lengths)
+					coldefs.Add(new ColumnDefinition { Width = (GridLength)converter.ConvertFromInvariantString(length) });
+				return coldefs;
+			}
+
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(ColumnDefinitionCollection)));
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Grid.cs
+++ b/Xamarin.Forms.Core/Grid.cs
@@ -71,6 +71,7 @@ namespace Xamarin.Forms
 			get { return _children; }
 		}
 
+		[TypeConverter(typeof(ColumnDefinitionCollectionTypeConverter))]
 		public ColumnDefinitionCollection ColumnDefinitions
 		{
 			get { return (ColumnDefinitionCollection)GetValue(ColumnDefinitionsProperty); }
@@ -83,6 +84,7 @@ namespace Xamarin.Forms
 			set { SetValue(ColumnSpacingProperty, value); }
 		}
 
+		[TypeConverter(typeof(RowDefinitionCollectionTypeConverter))]
 		public RowDefinitionCollection RowDefinitions
 		{
 			get { return (RowDefinitionCollection)GetValue(RowDefinitionsProperty); }

--- a/Xamarin.Forms.Core/RowDefinitionCollectionTypeConverter.cs
+++ b/Xamarin.Forms.Core/RowDefinitionCollectionTypeConverter.cs
@@ -1,0 +1,23 @@
+﻿using System;
+
+namespace Xamarin.Forms
+{
+	[Xaml.TypeConversion(typeof(RowDefinitionCollection))]
+	public class RowDefinitionCollectionTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			if (value != null) {
+				var lengths = value.Split(',');
+				var coldefs = new RowDefinitionCollection();
+				var converter = new GridLengthTypeConverter();
+				foreach (var length in lengths)
+					coldefs.Add(new RowDefinition { Height = (GridLength)converter.ConvertFromInvariantString(length) });
+				return coldefs;
+			}
+
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(RowDefinitionCollection)));
+		}
+
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/DefinitionCollectionTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/DefinitionCollectionTests.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.DefinitionCollectionTests">
+    <Grid x:Name="grid" ColumnDefinitions="1*, 2*, Auto, *, 300" RowDefinitions="1*, Auto, 25, 14, 20"/>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/DefinitionCollectionTests.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/DefinitionCollectionTests.xaml.cs
@@ -1,0 +1,50 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT License.
+using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class DefinitionCollectionTests : ContentPage
+	{
+		public DefinitionCollectionTests() => InitializeComponent();
+		public DefinitionCollectionTests(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void DefinitionCollectionsParsedFromMarkup([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new DefinitionCollectionTests(useCompiledXaml);
+				var coldef = layout.grid.ColumnDefinitions;
+				var rowdef = layout.grid.RowDefinitions;
+
+				Assert.That(coldef.Count, Is.EqualTo(5));
+				
+				Assert.That(coldef[0].Width, Is.EqualTo(new GridLength(1, GridUnitType.Star)));
+				Assert.That(coldef[1].Width, Is.EqualTo(new GridLength(2, GridUnitType.Star)));
+				Assert.That(coldef[2].Width, Is.EqualTo(new GridLength(1, GridUnitType.Auto)));
+				Assert.That(coldef[3].Width, Is.EqualTo(new GridLength(1, GridUnitType.Star)));
+				Assert.That(coldef[4].Width, Is.EqualTo(new GridLength(300, GridUnitType.Absolute)));
+
+				Assert.That(rowdef.Count, Is.EqualTo(5));
+				Assert.That(rowdef[0].Height, Is.EqualTo(new GridLength(1, GridUnitType.Star)));
+				Assert.That(rowdef[1].Height, Is.EqualTo(new GridLength(1, GridUnitType.Auto)));
+				Assert.That(rowdef[2].Height, Is.EqualTo(new GridLength(25, GridUnitType.Absolute)));
+				Assert.That(rowdef[3].Height, Is.EqualTo(new GridLength(14, GridUnitType.Absolute)));
+				Assert.That(rowdef[4].Height, Is.EqualTo(new GridLength(20, GridUnitType.Absolute)));
+
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###
Simplify Grid Column and Row Definitions by using markup extensions.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7302
- closes #4997


### API Changes ###

Added:
 - ColumnDefinitionCollectionTypeConverter
 - RowDefinitionCollectionTypeConverter


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
