### PR TITLE
Add RTL support to SwipeView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10366.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10366.cs
@@ -1,0 +1,136 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10366, "[Enhancement] Change SwipeView to Support RTL", PlatformAffected.Android)]
+	public class Issue10366 : TestContentPage
+	{
+		const string SwipeViewId = "SwipeViewId";
+
+		public Issue10366()
+		{
+			Title = "Issue 10366";
+
+			var layout = new StackLayout
+			{
+				Padding = 12
+			};
+
+			var addSwipeItem = new SwipeItem { BackgroundColor = Color.Green, Text = "Add", IconImageSource = "calculator.png" };
+			var editSwipeItem = new SwipeItem { BackgroundColor = Color.Orange, Text = "Favourite", IconImageSource = "bell.png" };
+			var deleteSwipeItem = new SwipeItem { BackgroundColor = Color.Red, Text = "Delete", IconImageSource = "coffee.png" };
+
+			addSwipeItem.Invoked += (sender, e) =>
+			{
+				DisplayAlert("SwipeView", "Add Invoked", "OK");
+			};
+
+			editSwipeItem.Invoked += (sender, e) =>
+			{
+				DisplayAlert("SwipeView", "Favourite Invoked", "OK");
+			};
+
+			deleteSwipeItem.Invoked += (sender, e) =>
+			{
+				DisplayAlert("SwipeView", "Delete Invoked", "OK");
+			};
+
+			var swipeView = new SwipeView
+			{
+				AutomationId = SwipeViewId,
+				HeightRequest = 60,
+				BackgroundColor = Color.LightGray,
+				LeftItems = new SwipeItems(new List<SwipeItem> { addSwipeItem, editSwipeItem })
+				{
+					Mode = SwipeMode.Reveal
+				},
+				RightItems = new SwipeItems(new List<SwipeItem> { deleteSwipeItem })
+				{
+					Mode = SwipeMode.Reveal
+				}
+			};
+
+			var content = new Grid
+			{
+				BackgroundColor = Color.LightGoldenrodYellow
+			};
+
+			var info = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to the Left or Right"
+			};
+
+			content.Children.Add(info);
+
+			swipeView.Content = content;
+
+			var flowDirectionLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var flowDirectionButton = new Button
+			{
+				Text = "Change FlowDirection",
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var flowDirectionInfo = new Label
+			{
+				Text = swipeView.FlowDirection.ToString(),
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			flowDirectionLayout.Children.Add(flowDirectionButton);
+			flowDirectionLayout.Children.Add(flowDirectionInfo);
+
+			layout.Children.Add(swipeView);
+			layout.Children.Add(flowDirectionLayout);
+
+			Content = layout;
+
+			flowDirectionButton.Clicked += (sender, args) =>
+			{
+				if (swipeView.FlowDirection == FlowDirection.RightToLeft)
+					swipeView.FlowDirection = FlowDirection.LeftToRight;
+				else
+					swipeView.FlowDirection = FlowDirection.RightToLeft;
+
+				flowDirectionInfo.Text = swipeView.FlowDirection.ToString();
+			};
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+#if UITEST
+		[Test]
+		public void Issue10366TestSwipeViewRTL()
+		{
+			RunningApp.WaitForElement(x => x.Marked(SwipeViewId));
+			RunningApp.SwipeRightToLeft(SwipeViewId);
+			RunningApp.Screenshot("LTR SwipeView");
+			RunningApp.Tap(x => x.Marked("Change FlowDirection"));
+			RunningApp.SwipeRightToLeft(SwipeViewId);
+			RunningApp.WaitForElement (q => q.Marked ("RightToLeft"));
+			RunningApp.Screenshot("RTL SwipeView");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1878,6 +1878,7 @@
       <DependentUpon>Issue15100.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue13790.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10366.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewFlowDirectionGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewFlowDirectionGallery.xaml
@@ -1,0 +1,117 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.SwipeViewFlowDirectionGallery"
+    Title="SwipeView FlowDirection Gallery">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Style x:Key="TitleStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="14" />
+                <Setter Property="TextColor" Value="Black" />
+                <Setter Property="Margin" Value="6, 0, 6, 6" />
+            </Style>
+
+            <Style x:Key="DateStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="DarkGray" />
+                <Setter Property="FontSize" Value="10" />
+                <Setter Property="Margin" Value="6, 0, 6, 6" />
+            </Style>
+
+            <Style x:Key="SubTitleStyle" TargetType="Label">
+                <Setter Property="TextColor" Value="DarkGray" />
+                <Setter Property="FontSize" Value="12" />
+                <Setter Property="Margin" Value="6, 0" />
+            </Style>
+
+            <DataTemplate x:Key="MessageTemplate">
+                <SwipeView
+                    HeightRequest="80">
+                    <SwipeView.LeftItems>
+                        <SwipeItems>
+                            <SwipeItem
+                                Text="Favourite"
+                                Icon="calculator.png"
+                                BackgroundColor="Yellow"
+                                Command="{Binding Source={x:Reference SwipeCollectionView}, Path=BindingContext.FavouriteCommand}"/>
+                        </SwipeItems>
+                    </SwipeView.LeftItems>
+                    <SwipeView.RightItems>
+                            <SwipeItems
+                                Mode="Execute">
+                                <SwipeItem
+                                    Text="Delete"
+                                    Icon="coffee.png"
+                                    BackgroundColor="Red"
+                                    Command="{Binding Source={x:Reference SwipeCollectionView}, Path=BindingContext.DeleteCommand}"/>
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                    <SwipeView.Content>
+                        <Grid
+                            BackgroundColor="White"
+                            RowSpacing="0">
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="Auto" />
+                            </Grid.ColumnDefinitions>
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Label
+                                Grid.Column="0"
+                                Grid.Row="0"
+                                Text="{Binding Title}"
+                                Style="{StaticResource TitleStyle}"/>
+                            <Label
+                                Grid.Column="1"
+                                Grid.Row="0"
+                                Text="{Binding Date}"
+                                Style="{StaticResource DateStyle}"/>
+                            <Label
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                Grid.Row="1"
+                                Text="{Binding SubTitle}"
+                                Style="{StaticResource SubTitleStyle}"/>
+                            <Label
+                                Grid.Column="0"
+                                Grid.ColumnSpan="2"
+                                Grid.Row="2"
+                                Text="{Binding Description}"
+                                Style="{StaticResource SubTitleStyle}"/>
+                        </Grid>
+                    </SwipeView.Content>
+                </SwipeView>
+            </DataTemplate>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <StackLayout
+                Orientation="Horizontal">
+                <Button
+                    Text="Change FlowDirection"
+                    VerticalOptions="Center"
+                    Clicked="OnChangeFlowDirectionClicked"/>
+                <Label
+                    x:Name="FlowDirectionInfo"
+                    VerticalOptions="Center"/>
+            </StackLayout>
+            <CollectionView
+                Grid.Row="1"
+                x:Name="SwipeCollectionView"
+                ItemsSource="{Binding Messages}"
+                ItemTemplate="{StaticResource MessageTemplate}"
+                SelectionMode="Single"
+                SelectionChanged="OnSwipeCollectionViewSelectionChanged"/>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewFlowDirectionGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewFlowDirectionGallery.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class SwipeViewFlowDirectionGallery : ContentPage
+	{
+		public SwipeViewFlowDirectionGallery()
+		{
+			InitializeComponent();
+			BindingContext = new SwipeViewGalleryViewModel();
+
+			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "favourite", sender => { DisplayAlert("SwipeView", "Favourite", "Ok"); });
+			MessagingCenter.Subscribe<SwipeViewGalleryViewModel>(this, "delete", sender => { DisplayAlert("SwipeView", "Delete", "Ok"); });
+
+			FlowDirectionInfo.Text = SwipeCollectionView.FlowDirection.ToString();
+		}
+
+		async void OnSwipeCollectionViewSelectionChanged(object sender, SelectionChangedEventArgs args)
+		{
+			await DisplayAlert("OnSwipeCollectionViewSelectionChanged", "CollectionView SelectionChanged", "Ok");
+		}
+
+		void OnChangeFlowDirectionClicked(object sender, EventArgs e)
+		{
+			if (SwipeCollectionView.FlowDirection == FlowDirection.RightToLeft)
+				SwipeCollectionView.FlowDirection = FlowDirection.LeftToRight;
+			else
+				SwipeCollectionView.FlowDirection = FlowDirection.RightToLeft;
+
+			FlowDirectionInfo.Text = SwipeCollectionView.FlowDirection.ToString();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
@@ -36,7 +36,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 						GalleryBuilder.NavButton("SwipeTransitionMode Gallery", () => new SwipeTransitionModeGallery(), Navigation),
 						GalleryBuilder.NavButton("Add/Remove SwipeItems Gallery", () => new AddRemoveSwipeItemsGallery(), Navigation),
 						GalleryBuilder.NavButton("Open/Close SwipeView Gallery", () => new OpenCloseSwipeGallery(), Navigation),
-						GalleryBuilder.NavButton("SwipeItems Dispose Gallery", () => new SwipeItemsDisposeGallery(), Navigation)
+						GalleryBuilder.NavButton("SwipeItems Dispose Gallery", () => new SwipeItemsDisposeGallery(), Navigation),
+						GalleryBuilder.NavButton("SwipeView FlowDirection Gallery", () => new SwipeViewFlowDirectionGallery(), Navigation)
 					}
 				}
 			};


### PR DESCRIPTION
### Description of Change ###

Add RTL support to SwipeView.
![swipeview-flowdirection](https://user-images.githubusercontent.com/6755973/81578687-703da400-93ab-11ea-9c0b-903c1af9f85b.gif)

_To facilitate understanding the SwipeView behavior especially in cases where RTL etc is used, should we **rename** LeftItems, RightItems, etc?_

### Issues Resolved ###

- fixes #10366
- fixes #10387

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![issue10366-droid](https://user-images.githubusercontent.com/6755973/81578673-6c118680-93ab-11ea-8996-70c4ea3d0e92.gif)
![issue10366-ios](https://user-images.githubusercontent.com/6755973/81578678-6d42b380-93ab-11ea-8c2c-a1d5d049f023.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 10366. Press the "Change FlowDirection" button to change the flow direction between LTR and RTL. Verify that the SwipeItems are moved to the expected direction.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
