### PR TITLE
[WPF] Added null check on IsInvokeRequired on WPFPlatformServices.cs

### DIFF
--- a/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
+++ b/Xamarin.Forms.Platform.WPF/WPFPlatformServices.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.WPF
 	{
 		public bool IsInvokeRequired
 		{
-			get { return !System.Windows.Application.Current.Dispatcher.CheckAccess(); }
+			get { return System.Windows.Application.Current == null ? false : !System.Windows.Application.Current.Dispatcher.CheckAccess(); }
 		}
 
 		public string RuntimePlatform => Device.WPF;
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			System.Diagnostics.Process.Start(uri.AbsoluteUri);
 		}
-		
+
 		public void BeginInvokeOnMainThread(Action action)
 		{
 			System.Windows.Application.Current?.Dispatcher.BeginInvoke(action);
@@ -124,7 +124,7 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			return new WPFIsolatedStorageFile(IsolatedStorageFile.GetUserStoreForAssembly());
 		}
-		
+
 		public void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
 			var timer = new DispatcherTimer(DispatcherPriority.Background, System.Windows.Application.Current.Dispatcher) { Interval = interval };


### PR DESCRIPTION
### Description of Change ###

Added a Null Reference Check on WPFPlatformServices IsInvokeRequired property.

### Issues Resolved ### 

Sometimes, on closing the app on WPF Platform, a null reference exception is thrown on IsInvokeRequired property on WPFPlatformServices, i've added a null reference check to that to prevent this exception from ocurring.

### API Changes ###

Changed:

public bool IsInvokeRequired
{
  get { return System.Windows.Application.Current == null ? false : !System.Windows.Application.Current.Dispatcher.CheckAccess(); }
}

### Platforms Affected ### 
WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###


### PR Checklist ###

- [x] Targets the correct branch

