### PR TITLE
[macOS] Implement GetNamedColor

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeGallery.cs
@@ -27,7 +27,9 @@
 						GalleryBuilder.NavButton("AppTheme Code", () =>
 							new AppThemeCodeGallery(), Navigation),
 						GalleryBuilder.NavButton("AppTheme XAML", () =>
-							new AppThemeXamlGallery(), Navigation)
+							new AppThemeXamlGallery(), Navigation),
+						GalleryBuilder.NavButton("GetNamedColor", () =>
+							new NamedPlatformColorGallery(), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/NamedPlatformColorGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/NamedPlatformColorGallery.cs
@@ -1,0 +1,198 @@
+﻿using System.Collections.Generic;
+
+namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
+{
+	public class NamedPlatformColorGallery : ContentPage
+	{
+		readonly string[] _colors;
+		readonly StackLayout _stackLayout = new StackLayout
+		{
+			Padding = new Thickness(10)
+		};
+
+		public NamedPlatformColorGallery()
+		{
+			Content = new ScrollView
+			{
+				Content = _stackLayout
+			};
+
+			_colors = GetPlatFormColorNames();
+
+			BuildColors();
+		}
+
+		protected override void OnRequestedThemeChanged(OSAppTheme newValue)
+		{
+			base.OnRequestedThemeChanged(newValue);
+
+			BuildColors();
+		}
+
+		void BuildColors()
+		{
+			if (_colors == null || _colors.Length == 0)
+				return;
+
+			_stackLayout.Children.Clear();
+
+			for (var i = 0; i < _colors.Length; i++)
+			{
+				var color = Device.GetNamedColor(_colors[i]);
+
+				var box = new Frame
+				{
+					BackgroundColor = color,
+					Content = new StackLayout
+					{
+						Children =
+						{
+							new Label { Text = _colors[i] },
+							new Label { Text = color.ToHex() }
+						}
+					},
+					HasShadow = false,
+					Margin = 10,
+					HeightRequest = 60
+				};
+
+				_stackLayout.Children.Add(box);
+			}
+		}
+
+		string[] GetPlatFormColorNames()
+		{
+			List<string> resultColors = new List<string>();
+
+			if (Device.RuntimePlatform == Device.macOS || Device.RuntimePlatform == Device.iOS)
+			{
+				resultColors.AddRange(new[] {
+					NamedPlatformColor.SystemBlue,
+					NamedPlatformColor.SystemGreen,
+					NamedPlatformColor.SystemIndigo,
+					NamedPlatformColor.SystemOrange,
+					NamedPlatformColor.SystemPink,
+					NamedPlatformColor.SystemPurple,
+					NamedPlatformColor.SystemRed,
+					NamedPlatformColor.SystemTeal,
+					NamedPlatformColor.SystemYellow,
+					NamedPlatformColor.SystemGray,
+					NamedPlatformColor.Label,
+					NamedPlatformColor.SecondaryLabel,
+					NamedPlatformColor.TertiaryLabel,
+					NamedPlatformColor.QuaternaryLabel,
+					NamedPlatformColor.PlaceholderText,
+					NamedPlatformColor.Separator,
+					NamedPlatformColor.Link
+				});
+			}
+
+			if (Device.RuntimePlatform == Device.iOS)
+			{
+				resultColors.AddRange(new[] {
+					NamedPlatformColor.SystemGray2,
+					NamedPlatformColor.SystemGray3,
+					NamedPlatformColor.SystemGray4,
+					NamedPlatformColor.SystemGray5,
+					NamedPlatformColor.SystemGray6,
+					NamedPlatformColor.OpaqueSeparator
+				});
+			}
+
+			if (Device.RuntimePlatform == Device.macOS)
+			{
+				resultColors.AddRange(new[] {
+					NamedPlatformColor.AlternateSelectedControlTextColor,
+					NamedPlatformColor.ControlAccent,
+					NamedPlatformColor.ControlBackgroundColor,
+					NamedPlatformColor.ControlColor,
+					NamedPlatformColor.ControlTextColor,
+					NamedPlatformColor.DisabledControlTextColor,
+					NamedPlatformColor.FindHighlightColor,
+					NamedPlatformColor.GridColor,
+					NamedPlatformColor.HeaderTextColor,
+					NamedPlatformColor.HighlightColor,
+					NamedPlatformColor.KeyboardFocusIndicatorColor,
+					NamedPlatformColor.LabelColor,
+					NamedPlatformColor.LinkColor,
+					NamedPlatformColor.PlaceholderTextColor,
+					NamedPlatformColor.QuaternaryLabelColor,
+					NamedPlatformColor.SecondaryLabelColor,
+					NamedPlatformColor.SelectedContentBackgroundColor,
+					NamedPlatformColor.SelectedControlColor,
+					NamedPlatformColor.SelectedControlTextColor,
+					NamedPlatformColor.SelectedMenuItemTextColor,
+					NamedPlatformColor.SelectedTextBackgroundColor,
+					NamedPlatformColor.SelectedTextColor,
+					NamedPlatformColor.SeparatorColor,
+					NamedPlatformColor.ShadowColor,
+					NamedPlatformColor.TertiaryLabelColor,
+					NamedPlatformColor.TextBackgroundColor,
+					NamedPlatformColor.TextColor,
+					NamedPlatformColor.UnderPageBackgroundColor,
+					NamedPlatformColor.UnemphasizedSelectedContentBackgroundColor,
+					NamedPlatformColor.UnemphasizedSelectedTextBackgroundColor,
+					NamedPlatformColor.UnemphasizedSelectedTextColor,
+					NamedPlatformColor.WindowBackgroundColor,
+					NamedPlatformColor.WindowFrameTextColor
+				});
+			}
+
+			if (Device.RuntimePlatform == Device.Android)
+			{
+				resultColors.AddRange(new[] {
+					NamedPlatformColor.BackgroundDark,
+					NamedPlatformColor.BackgroundLight,
+					NamedPlatformColor.Black,
+					NamedPlatformColor.DarkerGray,
+					NamedPlatformColor.HoloBlueBright,
+					NamedPlatformColor.HoloBlueDark,
+					NamedPlatformColor.HoloBlueLight,
+					NamedPlatformColor.HoloGreenDark,
+					NamedPlatformColor.HoloGreenLight,
+					NamedPlatformColor.HoloOrangeDark,
+					NamedPlatformColor.HoloOrangeLight,
+					NamedPlatformColor.HoloPurple,
+					NamedPlatformColor.HoloRedDark,
+					NamedPlatformColor.HoloRedLight,
+					NamedPlatformColor.TabIndicatorText,
+					NamedPlatformColor.Transparent,
+					NamedPlatformColor.White,
+					NamedPlatformColor.WidgetEditTextDark
+				});
+			}
+
+			if (Device.RuntimePlatform == Device.UWP)
+			{
+				resultColors.AddRange(new[] {
+					NamedPlatformColor.SystemAltLowColor,
+					NamedPlatformColor.SystemAltMediumColor,
+					NamedPlatformColor.SystemAltMediumHighColor,
+					NamedPlatformColor.SystemAltMediumLowColor,
+					NamedPlatformColor.SystemBaseHighColor,
+					NamedPlatformColor.SystemBaseLowColor,
+					NamedPlatformColor.SystemBaseMediumColor,
+					NamedPlatformColor.SystemBaseMediumHighColor,
+					NamedPlatformColor.SystemBaseMediumLowColor,
+					NamedPlatformColor.SystemChromeAltLowColor,
+					NamedPlatformColor.SystemChromeBlackHighColor,
+					NamedPlatformColor.SystemChromeBlackLowColor,
+					NamedPlatformColor.SystemChromeBlackMediumLowColor,
+					NamedPlatformColor.SystemChromeBlackMediumColor,
+					NamedPlatformColor.SystemChromeDisabledHighColor,
+					NamedPlatformColor.SystemChromeDisabledLowColor,
+					NamedPlatformColor.SystemChromeHighColor,
+					NamedPlatformColor.SystemChromeLowColor,
+					NamedPlatformColor.SystemChromeMediumColor,
+					NamedPlatformColor.SystemChromeMediumLowColor,
+					NamedPlatformColor.SystemChromeWhiteColor,
+					NamedPlatformColor.SystemListLowColor,
+					NamedPlatformColor.SystemListMediumColor,
+					NamedPlatformColor.SystemAltHighColor
+				});
+			}
+
+			return resultColors.ToArray();
+		}
+	}
+}

--- a/Xamarin.Forms.Core/NamedPlatformColor.cs
+++ b/Xamarin.Forms.Core/NamedPlatformColor.cs
@@ -2,7 +2,7 @@
 {
 	public static class NamedPlatformColor
 	{
-		// iOS
+		// iOS & macOS
 		public const string SystemBlue = "systemBlue";
 		public const string SystemGreen = "systemGreen";
 		public const string SystemIndigo = "systemIndigo";
@@ -13,19 +13,56 @@
 		public const string SystemTeal = "systemTeal";
 		public const string SystemYellow = "systemYellow";
 		public const string SystemGray = "systemGray";
-		public const string SystemGray2 = "systemGray2";
-		public const string SystemGray3 = "systemGray3";
-		public const string SystemGray4 = "systemGray4";
-		public const string SystemGray5 = "systemGray5";
-		public const string SystemGray6 = "systemGray6";
 		public const string Label = "label";
 		public const string SecondaryLabel = "secondaryLabel";
 		public const string TertiaryLabel = "tertiaryLabel";
 		public const string QuaternaryLabel = "quaternaryLabellabel";
 		public const string PlaceholderText = "placeholderText";
 		public const string Separator = "separator";
-		public const string OpaqueSeparator = "opaqueSeparator";
 		public const string Link = "link";
+
+		// iOS Only
+		public const string SystemGray2 = "systemGray2";
+		public const string SystemGray3 = "systemGray3";
+		public const string SystemGray4 = "systemGray4";
+		public const string SystemGray5 = "systemGray5";
+		public const string SystemGray6 = "systemGray6";
+		public const string OpaqueSeparator = "opaqueSeparator";
+
+		// macOS Only
+		public const string AlternateSelectedControlTextColor = "alternateSelectedControlTextColor";
+		public const string ControlAccent = "controlAccent";
+		public const string ControlBackgroundColor = "controlBackgroundColor";
+		public const string ControlColor = "controlColor";
+		public const string ControlTextColor = "controlTextColor";
+		public const string DisabledControlTextColor = "disabledControlTextColor";
+		public const string FindHighlightColor = "findHighlightColor";
+		public const string GridColor = "gridColor";
+		public const string HeaderTextColor = "headerTextColor";
+		public const string HighlightColor = "highlightColor";
+		public const string KeyboardFocusIndicatorColor = "keyboardFocusIndicatorColor";
+		public const string LabelColor = "labelColor";
+		public const string LinkColor = "linkColor";
+		public const string PlaceholderTextColor = "placeholderTextColor";
+		public const string QuaternaryLabelColor = "quaternaryLabelColor";
+		public const string SecondaryLabelColor = "secondaryLabelColor";
+		public const string SelectedContentBackgroundColor = "selectedContentBackgroundColor";
+		public const string SelectedControlColor = "selectedControlColor";
+		public const string SelectedControlTextColor = "selectedControlTextColor";
+		public const string SelectedMenuItemTextColor = "selectedMenuItemTextColor";
+		public const string SelectedTextBackgroundColor = "selectedTextBackgroundColor";
+		public const string SelectedTextColor = "selectedTextColor";
+		public const string SeparatorColor = "separatorColor";
+		public const string ShadowColor = "shadowColor";
+		public const string TertiaryLabelColor = "tertiaryLabelColor";
+		public const string TextBackgroundColor = "	textBackgroundColor";
+		public const string TextColor = "textColor";
+		public const string UnderPageBackgroundColor = "underPageBackgroundColor";
+		public const string UnemphasizedSelectedContentBackgroundColor = "unemphasizedSelectedContentBackgroundColor";
+		public const string UnemphasizedSelectedTextBackgroundColor = "unemphasizedSelectedTextBackgroundColor";
+		public const string UnemphasizedSelectedTextColor = "unemphasizedSelectedTextColor";
+		public const string WindowBackgroundColor = "windowBackgroundColor";
+		public const string WindowFrameTextColor = "windowFrameTextColor";
 
 		// Android
 		public const string BackgroundDark = "background_dark";

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -91,6 +91,30 @@ namespace Xamarin.Forms
 			}
 		}
 #else
+		static bool? s_isSierraOrNewer;
+
+		internal static bool IsSierraOrNewer
+		{
+			get
+			{
+				if (!s_isSierraOrNewer.HasValue)
+					s_isSierraOrNewer = NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 12, 0));
+				return s_isSierraOrNewer.Value;
+			}
+		}
+
+		static bool? s_isHighSierraOrNewer;
+
+		internal static bool IsHighSierraOrNewer
+		{
+			get
+			{
+				if (!s_isHighSierraOrNewer.HasValue)
+					s_isHighSierraOrNewer = NSProcessInfo.ProcessInfo.IsOperatingSystemAtLeastVersion(new NSOperatingSystemVersion(10, 13, 0));
+				return s_isHighSierraOrNewer.Value;
+			}
+		}
+
 		static bool? s_isMojaveOrNewer;
 
 		internal static bool IsMojaveOrNewer
@@ -281,6 +305,11 @@ namespace Xamarin.Forms
 #if __XCODE11__ && __IOS__
 				UIColor resultColor = null;
 
+				// If not iOS 13, but 11+ we can only get the named colors
+				if (!IsiOS13OrNewer && IsiOS11OrNewer)
+					return (resultColor = UIColor.FromName(name)) == null ? Color.Default : resultColor.ToColor();
+
+				// If iOS 13+ check all dynamic colors too
 				switch (name)
 				{
 					case NamedPlatformColor.Label:
@@ -361,6 +390,177 @@ namespace Xamarin.Forms
 					return Color.Default;
 
 				return resultColor.ToColor();
+#elif __MACOS__
+
+				NSColor resultColor = null;
+
+				switch (name)
+				{
+					case NamedPlatformColor.AlternateSelectedControlTextColor:
+						resultColor = NSColor.AlternateSelectedControlText;
+							break;
+					case NamedPlatformColor.ControlAccent:
+						if (IsMojaveOrNewer)
+							resultColor = NSColor.ControlAccentColor;
+						break;
+					case NamedPlatformColor.ControlBackgroundColor:
+						resultColor = NSColor.ControlBackground;
+						break;
+					case NamedPlatformColor.ControlColor:
+						resultColor = NSColor.Control;
+						break;
+					case NamedPlatformColor.ControlTextColor:
+						resultColor = NSColor.ControlText;
+						break;
+					case NamedPlatformColor.DisabledControlTextColor:
+						resultColor = NSColor.DisabledControlText;
+						break;
+					case NamedPlatformColor.FindHighlightColor:
+						if (IsHighSierraOrNewer)
+							resultColor = NSColor.FindHighlightColor;
+						break;
+					case NamedPlatformColor.GridColor:
+						resultColor = NSColor.Grid;
+						break;
+					case NamedPlatformColor.HeaderTextColor:
+						resultColor = NSColor.HeaderText;
+						break;
+					case NamedPlatformColor.HighlightColor:
+						resultColor = NSColor.Highlight;
+						break;
+					case NamedPlatformColor.KeyboardFocusIndicatorColor:
+						resultColor = NSColor.KeyboardFocusIndicator;
+						break;
+					case NamedPlatformColor.LabelColor:
+						resultColor = NSColor.LabelColor;
+						break;
+					case NamedPlatformColor.LinkColor:
+						resultColor = NSColor.LinkColor;
+						break;
+					case NamedPlatformColor.PlaceholderTextColor:
+						resultColor = NSColor.PlaceholderTextColor;
+						break;
+					case NamedPlatformColor.QuaternaryLabelColor:
+						resultColor = NSColor.QuaternaryLabelColor;
+						break;
+					case NamedPlatformColor.SecondaryLabelColor:
+						resultColor = NSColor.SecondaryLabelColor;
+						break;
+					case NamedPlatformColor.SelectedContentBackgroundColor:
+						resultColor = NSColor.SelectedContentBackgroundColor;
+						break;
+					case NamedPlatformColor.SelectedControlColor:
+						resultColor = NSColor.SelectedControl;
+						break;
+					case NamedPlatformColor.SelectedControlTextColor:
+						resultColor = NSColor.SelectedControlText;
+						break;
+					case NamedPlatformColor.SelectedMenuItemTextColor:
+						resultColor = NSColor.SelectedMenuItemText;
+						break;
+					case NamedPlatformColor.SelectedTextBackgroundColor:
+						resultColor = NSColor.SelectedTextBackground;
+						break;
+					case NamedPlatformColor.SelectedTextColor:
+						resultColor = NSColor.SelectedText;
+						break;
+					case NamedPlatformColor.SeparatorColor:
+						resultColor = NSColor.SeparatorColor;
+						break;
+					case NamedPlatformColor.ShadowColor:
+						resultColor = NSColor.Shadow;
+						break;
+					case NamedPlatformColor.TertiaryLabelColor:
+						resultColor = NSColor.TertiaryLabelColor;
+						break;
+					case NamedPlatformColor.TextBackgroundColor:
+						resultColor = NSColor.TextBackground;
+						break;
+					case NamedPlatformColor.TextColor:
+						resultColor = NSColor.Text;
+						break;
+					case NamedPlatformColor.UnderPageBackgroundColor:
+						resultColor = NSColor.UnderPageBackgroundColor;
+						break;
+					case NamedPlatformColor.UnemphasizedSelectedContentBackgroundColor:
+						if (IsMojaveOrNewer)
+							resultColor = NSColor.UnemphasizedSelectedContentBackgroundColor;
+						break;
+					case NamedPlatformColor.UnemphasizedSelectedTextBackgroundColor:
+						if (IsMojaveOrNewer)
+							resultColor = NSColor.UnemphasizedSelectedTextBackgroundColor;
+						break;
+					case NamedPlatformColor.UnemphasizedSelectedTextColor:
+						if (IsMojaveOrNewer)
+							resultColor = NSColor.UnemphasizedSelectedTextColor;
+						break;
+					case NamedPlatformColor.WindowBackgroundColor:
+						resultColor = NSColor.WindowBackground;
+						break;
+					case NamedPlatformColor.WindowFrameTextColor:
+						resultColor = NSColor.WindowFrameText;
+						break;
+					case NamedPlatformColor.Label:
+						resultColor = NSColor.LabelColor;
+						break;
+					case NamedPlatformColor.Link:
+						resultColor = NSColor.LinkColor;
+						break;
+					case NamedPlatformColor.PlaceholderText:
+						resultColor = NSColor.PlaceholderTextColor;
+						break;
+					case NamedPlatformColor.QuaternaryLabel:
+						resultColor = NSColor.QuaternaryLabelColor;
+						break;
+					case NamedPlatformColor.SecondaryLabel:
+						resultColor = NSColor.SecondaryLabelColor;
+						break;
+					case NamedPlatformColor.Separator:
+						if (IsMojaveOrNewer)
+							resultColor = NSColor.SeparatorColor;
+						break;
+					case NamedPlatformColor.SystemBlue:
+						resultColor = NSColor.SystemBlueColor;
+						break;
+					case NamedPlatformColor.SystemGray:
+						resultColor = NSColor.SystemGrayColor;
+						break;
+					case NamedPlatformColor.SystemGreen:
+						resultColor = NSColor.SystemGreenColor;
+						break;
+					case NamedPlatformColor.SystemIndigo:
+						resultColor = NSColor.SystemIndigoColor;
+						break;
+					case NamedPlatformColor.SystemOrange:
+						resultColor = NSColor.SystemOrangeColor;
+						break;
+					case NamedPlatformColor.SystemPink:
+						resultColor = NSColor.SystemPinkColor;
+						break;
+					case NamedPlatformColor.SystemPurple:
+						resultColor = NSColor.SystemPurpleColor;
+						break;
+					case NamedPlatformColor.SystemRed:
+						resultColor = NSColor.SystemRedColor;
+						break;
+					case NamedPlatformColor.SystemTeal:
+						resultColor = NSColor.SystemTealColor;
+						break;
+					case NamedPlatformColor.SystemYellow:
+						resultColor = NSColor.SystemYellowColor;
+						break;
+					case NamedPlatformColor.TertiaryLabel:
+						resultColor = NSColor.TertiaryLabelColor;
+						break;
+					default:
+						resultColor = NSColor.FromName(name);
+						break;
+				}
+
+				if (resultColor == null)
+					return Color.Default;
+
+				return resultColor.ToColor(NSColorSpace.GenericRGBColorSpace);
 #else
 				return Color.Default;
 #endif


### PR DESCRIPTION
### Description of Change ###

Implements new `GetNamedColor` for macOS.

Additionally added a gallery page to show this _and_ added some OS version checks to prevent NREs

### Issues Resolved ### 
N/A

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I have created a new gallery app that shows all the named colors for each platform, go there and check it out!

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
