### PR TITLE
[Android] Fix scrollbar flash issue on CollectionView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10497.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10497.cs
@@ -1,0 +1,105 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10497, "[Bug] Controls inside CollectionView might flash scrollbar while they're not scrollable", PlatformAffected.Android)]
+	public class Issue10497 : TestContentPage
+	{
+		public Issue10497()
+		{
+			Title = "Issue 10497";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If loading the page you don't see the scrollbar in each CollectionView Item, the test has passed."
+			};
+
+			var scrollBarVisibilityPicker = new Picker
+			{
+				Title = "VerticalScrollBarVisibility",
+				ItemsSource = new List<string>
+				{
+					"Default",
+					"Always",
+					"Never"
+				},
+				SelectedIndex = 0	
+			};
+
+			var collectionView = new CollectionView
+			{
+				Margin = new Thickness(0, 0, 50, 0)
+			};
+
+			collectionView.ItemsSource = new List<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3",
+				"Item 4",
+				"Item 5",
+				"Lorem ipsum dolor sit amet, consectetur adipiscing elit",
+				"Item 7",
+				"Item 8",
+				"Item 9",
+				"Item 10"
+			};
+
+			collectionView.ItemTemplate = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					HeightRequest = 60,
+					FontSize = 75
+				};
+
+				label.SetBinding(Label.TextProperty, ".");
+
+				return label;
+			});
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(scrollBarVisibilityPicker);
+			layout.Children.Add(collectionView);
+
+			Content = layout;
+
+			scrollBarVisibilityPicker.SelectedIndexChanged += (sender, args) =>
+			{
+				switch (scrollBarVisibilityPicker.SelectedIndex)
+				{
+					case 0:
+						collectionView.VerticalScrollBarVisibility = ScrollBarVisibility.Default;
+						break;
+					case 1:
+						collectionView.VerticalScrollBarVisibility = ScrollBarVisibility.Always;
+						break;
+					case 2:
+						collectionView.VerticalScrollBarVisibility = ScrollBarVisibility.Never;
+						break;
+				}
+			};
+		}
+
+		protected override void Init()
+		{
+	
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1357,6 +1357,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10438.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8958.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10497.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -188,7 +188,7 @@ namespace Xamarin.Forms.Platform.Android
 			var oldItemViewAdapter = ItemsViewAdapter;
 			UnsubscribeCollectionItemsSourceChanged(oldItemViewAdapter);
 
-			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView,
+			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView, ItemsContext,
 				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
 			
 			_gotoPosition = -1;

--- a/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewAdapter.cs
@@ -14,8 +14,8 @@ namespace Xamarin.Forms.Platform.Android
 		where TItemsView : GroupableItemsView
 		where TItemsViewSource : IGroupableItemsViewSource
 	{
-		internal GroupableItemsViewAdapter(TItemsView groupableItemsView, 
-			Func<View, Context, ItemContentView> createView = null) : base(groupableItemsView, createView)
+		internal GroupableItemsViewAdapter(TItemsView groupableItemsView, Context itemsContext,
+			Func<View, Context, ItemContentView> createView = null) : base(groupableItemsView, itemsContext, createView)
 		{
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/GroupableItemsViewRenderer.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override TAdapter CreateAdapter()
 		{
-			return (TAdapter)new GroupableItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView);
+			return (TAdapter)new GroupableItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView, ItemsContext);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.Platform.Android
 		where TItemsView : ItemsView
 		where TItemsViewSource : IItemsViewSource
 	{
+		Context _itemsContext;
+
 		protected readonly TItemsView ItemsView;
 		readonly Func<View, Context, ItemContentView> _createItemContentView;
 		internal TItemsViewSource ItemsSource;
@@ -23,9 +25,11 @@ namespace Xamarin.Forms.Platform.Android
 		bool _disposed;
 		bool _usingItemTemplate = false;
 
-		internal ItemsViewAdapter(TItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
+		internal ItemsViewAdapter(TItemsView itemsView, Context itemsContext, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
 			ItemsView = itemsView ?? throw new ArgumentNullException(nameof(itemsView));
+
+			_itemsContext = itemsContext;
 
 			UpdateUsingItemTemplate();
 
@@ -82,7 +86,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
 		{
-			var context = parent.Context;
+			var context = _itemsContext;
 
 			if (viewType == ItemViewType.TextItem)
 			{

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -30,6 +30,8 @@ namespace Xamarin.Forms.Platform.Android
 		int? _defaultLabelFor;
 		bool _disposed;
 
+		protected Context ItemsContext { get; private set; }
+
 		protected TItemsView ItemsView;
 		protected IItemsLayout ItemsLayout { get; private set; }
 
@@ -48,6 +50,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public ItemsViewRenderer(Context context) : base(new ContextThemeWrapper(context, Resource.Style.collectionViewStyle))
 		{
+			ItemsContext = context;
+
 			_automationPropertiesProvider = new AutomationPropertiesProvider(this);
 			_effectControlProvider = new EffectControlProvider(this);
 
@@ -270,7 +274,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual TAdapter CreateAdapter()
 		{
-			return (TAdapter)new ItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView);
+			return (TAdapter)new ItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView, ItemsContext);
 		}
 
 		protected virtual void UpdateAdapter()

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewAdapter.cs
@@ -17,8 +17,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		List<SelectableViewHolder> _currentViewHolders = new List<SelectableViewHolder>();
 
-		internal SelectableItemsViewAdapter(TItemsView selectableItemsView,
-			Func<View, Context, ItemContentView> createView = null) : base(selectableItemsView, createView)
+		internal SelectableItemsViewAdapter(TItemsView selectableItemsView, Context itemsContext,
+			Func<View, Context, ItemContentView> createView = null) : base(selectableItemsView, itemsContext, createView)
 		{
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableItemsViewRenderer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override TAdapter CreateAdapter()
 		{
-			return (TAdapter)new SelectableItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView);
+			return (TAdapter)new SelectableItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView, ItemsContext);
 		}
 
 		void UpdateNativeSelection()

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewAdapter.cs
@@ -17,8 +17,8 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		Size? _size;
 
-		internal StructuredItemsViewAdapter(TItemsView itemsView, 
-			Func<View, Context, ItemContentView> createItemContentView = null) : base(itemsView, createItemContentView)
+		internal StructuredItemsViewAdapter(TItemsView itemsView, Context itemsContext,
+			Func<View, Context, ItemContentView> createItemContentView = null) : base(itemsView, itemsContext, createItemContentView)
 		{
 			UpdateHasHeader();
 			UpdateHasFooter();

--- a/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/StructuredItemsViewRenderer.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override TAdapter CreateAdapter()
 		{
-			return (TAdapter)new StructuredItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView);
+			return (TAdapter)new StructuredItemsViewAdapter<TItemsView, TItemsViewSource>(ItemsView, ItemsContext);
 		}
 
 		protected override void SetUpNewElement(TItemsView newElement)


### PR DESCRIPTION
### Description of Change ###

 Fixed the _"scrollbar flash"_ issue on CollectionView.

The problem was in the Context used. When creating `ItemsViewRenderer` we were creating a context that used a style with scrollbars. This context was used when creating `ItemContentView`. So by default `ItemContentView` (and its content) had `VerticalScrollBarEnabled` set to true.

### Issues Resolved ### 

- fixes #8626
- fixes #10497
- fixes #7281
- fixes #8361
- fixes #10294
- fixes #9947? (I think I don't understand exactly what happens in the issue, so I'm not sure but could be related)

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![80528280-fa424180-8995-11ea-9c20-56eedf971b2f](https://user-images.githubusercontent.com/6755973/81689818-ebaa5e80-945a-11ea-967c-e5013728c727.png)

#### After
![fix10497](https://user-images.githubusercontent.com/6755973/81689555-b00f9480-945a-11ea-82ca-4aaa597f70f9.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 10497. If loading the page you don't see the scrollbar in each CollectionView Item, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
