### PR TITLE
[Tizen] Add ScrollView.BarColor in TizenSpecific

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/ScollView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/ScollView.cs
@@ -1,0 +1,30 @@
+namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
+{
+	using FormsElement = Forms.ScrollView;
+
+	public static class ScrollView
+	{
+		public static readonly BindableProperty BarColorProperty = BindableProperty.Create("BarColor", typeof(Color), typeof(FormsElement), Color.Default);
+
+		public static Color GetBarColor(BindableObject element)
+		{
+			return (Color)element.GetValue(BarColorProperty);
+		}
+
+		public static void SetBarColor(BindableObject element, Color color)
+		{
+			element.SetValue(BarColorProperty, color);
+		}
+
+		public static Color GetBarColor(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetBarColor(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetBarColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color)
+		{
+			SetBarColor(config.Element, color);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchScroller.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchScroller.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using ElmSharp;
 using ElmSharp.Wearable;
+using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 {
@@ -34,6 +35,18 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 		{
 			get => _circleScroller.HorizontalScrollBarVisiblePolicy;
 			set => _circleScroller.HorizontalScrollBarVisiblePolicy = value;
+		}
+
+		public EColor VerticalScrollBarColor
+		{
+			get => _circleScroller.VerticalScrollBarColor;
+			set => _circleScroller.VerticalScrollBarColor = value;
+		}
+
+		public EColor HorizontalScrollBarColor
+		{
+			get => _circleScroller.HorizontalScrollBarColor;
+			set => _circleScroller.HorizontalScrollBarColor = value;
 		}
 
 		protected override IntPtr CreateHandle(EvasObject parent)

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.ComponentModel;
 using ElmSharp;
+using Xamarin.Forms.Platform.Tizen.Native.Watch;
+using ERect = ElmSharp.Rect;
 using NScroller = Xamarin.Forms.Platform.Tizen.Native.Scroller;
 using NBox = Xamarin.Forms.Platform.Tizen.Native.Box;
-using ERect = ElmSharp.Rect;
+using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.ScrollView;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -20,6 +22,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		public ScrollViewRenderer()
 		{
 			RegisterPropertyHandler("Content", FillContent);
+			RegisterPropertyHandler(Specific.BarColorProperty, UpdateBarColor);
 		}
 
 		/// <summary>
@@ -208,9 +211,20 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateHorizontalScrollBarVisibility()
 		{
-			var orientation = Element.Orientation;
-			if (orientation == ScrollOrientation.Horizontal || orientation == ScrollOrientation.Both)
-				Control.HorizontalScrollBarVisiblePolicy = Element.HorizontalScrollBarVisibility.ToNative();
+			Control.HorizontalScrollBarVisiblePolicy = Element.HorizontalScrollBarVisibility.ToNative();
+		}
+
+		void UpdateBarColor()
+		{
+			if (Control is WatchScroller wScroller)
+			{
+				var color = Specific.GetBarColor(Element);
+				if (color != Xamarin.Forms.Color.Default)
+				{
+					wScroller.HorizontalScrollBarColor = color.ToNative();
+					wScroller.VerticalScrollBarColor = color.ToNative();
+				}
+			}
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###

This PR is to add  `ScrollView.BarColor` provided in `Tizen.CircularUI` to `Xamarin.Form` as TizenSpecific.
This API allows the app developers to change the scrollbar color to the desired color on Tizen watch

**Limitations and Known Issues**
 - `Color.Default` is not allowed. It does not work when it is set to `Color.Default`


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None

### API Changes ###

 - Added:
``` c#
public static readonly BindableProperty BarColorProperty;

public static Color GetBarColor(BindableObject element);
public static void SetBarColor(BindableObject element, Color color);

public static Color GetBarColor(this IPlatformElementConfiguration<Tizen, FormsElement> config);
public static IPlatformElementConfiguration<Tizen, FormsElement> SetBarColor(this IPlatformElementConfiguration<Tizen, FormsElement> config, Color color);

```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->
<img src="https://user-images.githubusercontent.com/20968023/81689255-11ecf000-9495-11ea-826e-2f7cb6993695.gif" width="200" />



### Testing Procedure ###


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
