### PR TITLE
Increase pool timeout, provision less for osx builds, specify Android pools

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -203,7 +203,7 @@ stages:
       - template: build/steps/build-android.yml
         parameters:
           vmPool: $[variables.macAndroid2019VmPool]
-          vmImage: $[variables.macAndroid2019VmImage]
+          vmImage: $[coalesce(variables.macAndroid2019VmImage, 'macOS-10.15') ]
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,8 +202,8 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: coalesce(variables['macAndroid2019VmPool'], 'Azure Pipelines')
-          vmImage: coalesce(variables['macAndroid2019VmImage'], 'macOS-10.15')
+          vmPool: ${{ variables.macAndroid2019VmPool }}
+          vmImage: ${{ variables.macAndroid2019VmImage }}
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)
@@ -218,7 +218,7 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: coalesce(variables['macAndroid2017VmPool'], 'Azure Pipelines')
+          vmPool: ${{ variables.macAndroid2017VmPool }}
           vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,8 +202,8 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: $[variables.macAndroid2019VmPool]
-          vmImage: $[coalesce(variables.macAndroid2019VmImage, 'macOS-10.15') ]
+          vmPool: $[coalesce(variables.macAndroid2019VmPool, 'Azure Pipelines')]
+          vmImage: $[coalesce(variables.macAndroid2019VmImage, 'macOS-10.15')]
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)
@@ -218,7 +218,7 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: $[variables.macAndroid2017VmPool]
+          vmPool: $[coalesce(variables.macAndroid2017VmPool, 'Azure Pipelines')]
           vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,7 +202,8 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmImage: $(macOSXVmImage)
+          vmPool: $(macAndroid2019VmPool)
+          vmImage: $(macAndroid2019VmImage)
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)
@@ -217,6 +218,7 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
+          vmPool: $(macAndroid2017VmPool)
           vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true
@@ -230,6 +232,8 @@ stages:
       dependsOn: []
     jobs:
       - job: osx
+        ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
+          timeoutInMinutes: 120
         workspace:
           clean: all
         displayName: OSX Phase

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,8 +202,8 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: ${{ variables.macAndroid2019VmPool }}
-          vmImage: ${{ variables.macAndroid2019VmImage }}
+          vmPool: $[variables.macAndroid2019VmPool]
+          vmImage: $[variables.macAndroid2019VmImage]
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)
@@ -218,7 +218,7 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: ${{ variables.macAndroid2017VmPool }}
+          vmPool: $[variables.macAndroid2017VmPool]
           vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -202,8 +202,8 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: $(macAndroid2019VmPool)
-          vmImage: $(macAndroid2019VmImage)
+          vmPool: coalesce(variables['macAndroid2019VmPool'], 'Azure Pipelines')
+          vmImage: coalesce(variables['macAndroid2019VmImage'], 'macOS-10.15')
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)
@@ -218,7 +218,7 @@ stages:
     jobs:
       - template: build/steps/build-android.yml
         parameters:
-          vmPool: $(macAndroid2017VmPool)
+          vmPool: coalesce(variables['macAndroid2017VmPool'], 'Azure Pipelines')
           vmImage: 'macOS-10.14'
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: true

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -56,10 +56,10 @@ if (IsMac)
 		if(releaseChannel == "Beta")
 		{
 			Item ("Xamarin.Mac")
-				.Source (_ => Environment.GetEnvironmentVariable ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-5-xcode11.5/PKG-Xamarin.Mac-notarized"));
+				.Source (_ => "https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-5-xcode11.5/PKG-Xamarin.Mac-notarized");
 
 			Item ("Xamarin.iOS")
-				.Source (_ => Environment.GetEnvironmentVariable ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-android/master/PKG-Xamarin.iOS-notarized"));
+				.Source (_ => "https://xamci.azurewebsites.net/dl/xamarin/xamarin-android/master/PKG-Xamarin.iOS-notarized");
 
 		}
 		else if(releaseChannel == "Preview")

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -66,7 +66,8 @@ if (IsMac)
 		{
 			XamarinChannel("Preview");
 		}
-		else{
+		else if(releaseChannel == "Stable")
+		{
 			XamarinChannel("Stable");
 		}
 	}

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -1,5 +1,3 @@
-Console.WriteLine ("buildForVS2017: {0}", Environment.GetEnvironmentVariable ("buildForVS2017"));
-
 if (IsMac)
 {
 	if (!Directory.Exists ("/Library/Frameworks/Mono.framework/Versions/Current/Commands/"))
@@ -55,7 +53,16 @@ if (IsMac)
 	
 	if(!specificSdkSet)
 	{
-		if(releaseChannel == "Preview")
+		if(releaseChannel == "Beta")
+		{
+			Item ("Xamarin.Mac")
+				.Source (_ => Environment.GetEnvironmentVariable ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-5-xcode11.5/PKG-Xamarin.Mac-notarized"));
+
+			Item ("Xamarin.iOS")
+				.Source (_ => Environment.GetEnvironmentVariable ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-android/master/PKG-Xamarin.iOS-notarized"));
+
+		}
+		else if(releaseChannel == "Preview")
 		{
 			XamarinChannel("Preview");
 		}

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -1,19 +1,3 @@
-string monoMajorVersion = "6.8.0";
-string monoPatchVersion = "123";
-string monoVersion = $"{monoMajorVersion}.{monoPatchVersion}";
-
-string monoSDK_windows = "";//$"https://download.mono-project.com/archive/{monoMajorVersion}/windows-installer/mono-{monoVersion}-x64-0.msi";
-string androidSDK_windows = "";//"https://download.visualstudio.microsoft.com/download/pr/1131a8f5-99f5-4326-93b1-f5827b54ecd5/e7bd0f680004131157a22982c389b05f2d3698cc04fab3901ce2d7ded47ad8e0/Xamarin.Android.Sdk-10.0.0.43.vsix";
-string iOSSDK_windows = "";
-string macSDK_windows = "";
-
-string androidSDK_macos = "";//"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-string monoSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
-string iOSSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/cf7090bee19401076987a57cd12f11e5/xamarin.ios-13.16.0.11.pkg";
-string macSDK_macos = "";//$"https://download.visualstudio.microsoft.com/download/pr/6e56949e-1beb-4550-abf9-ff404868de82/547895e66c0543faccb25933d8691371/xamarin.mac-6.16.0.11.pkg";
-
-
-
 Console.WriteLine ("buildForVS2017: {0}", Environment.GetEnvironmentVariable ("buildForVS2017"));
 
 if (IsMac)
@@ -32,46 +16,53 @@ if (IsMac)
 	Console.WriteLine ("IOS_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
 	Console.WriteLine ("MONO_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));
 	Console.WriteLine ("MAC_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
+	Console.WriteLine ("releaseChannel: {0}", releaseChannel);
 
-	if(releaseChannel == "Preview")
-	{
-		XamarinChannel("Preview");
-	}
-	else{
-		XamarinChannel("Stable");
-	}
-
-	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC")))
-		Item ("Xamarin.Android")
-      		.Source (_ => Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
-
-	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("IOS_SDK_MAC")))
-		Item ("Xamarin.iOS")
-      		.Source (_ => Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
+	bool specificSdkSet = false;
 
 	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MONO_SDK_MAC")))
+	{
 		Item ("Mono")
       		.Source (_ => Environment.GetEnvironmentVariable ("MONO_SDK_MAC"));
 
+		specificSdkSet = true;
+	}
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC")))
+	{
+		Item ("Xamarin.Android")
+      		.Source (_ => Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
+
+		specificSdkSet = true;
+	}
+
+	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("IOS_SDK_MAC")))
+	{
+		Item ("Xamarin.iOS")
+      		.Source (_ => Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
+
+
+		specificSdkSet = true;
+	}
+
 	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MAC_SDK_MAC")))
+	{
 		Item ("Xamarin.Mac")
       		.Source (_ => Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
 
-  	if(!String.IsNullOrEmpty(monoSDK_macos))
-    	Item ("Mono", monoVersion)
-      		.Source (_ => monoSDK_macos);
-
-	if(!String.IsNullOrEmpty(androidSDK_macos))
-		Item ("Xamarin.Android", "10.2.0.100")
-      		.Source (_ => androidSDK_macos);
-
-	if(!String.IsNullOrEmpty(iOSSDK_macos))
-		Item ("Xamarin.iOS", "13.16.0.11")
-      		.Source (_ => iOSSDK_macos);
-
-	if(!String.IsNullOrEmpty(macSDK_macos))
-		Item ("Xamarin.Mac", "6.16.0.11")
-      		.Source (_ => macSDK_macos);
+		specificSdkSet = true;
+	}
+	
+	if(!specificSdkSet)
+	{
+		if(releaseChannel == "Preview")
+		{
+			XamarinChannel("Preview");
+		}
+		else{
+			XamarinChannel("Stable");
+		}
+	}
 }
 else
 {
@@ -91,22 +82,6 @@ else
 	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MAC_SDK_WINDOWS")))
 		Item ("Xamarin.Mac")
       		.Source (_ => Environment.GetEnvironmentVariable ("MAC_SDK_WINDOWS"));
-			  
-	if(!String.IsNullOrEmpty(androidSDK_windows))
-		Item ("Xamarin.Android", "10.0.0.43")
-      		.Source (_ => androidSDK_windows);
-
-	if(!String.IsNullOrEmpty(iOSSDK_windows))
-		Item ("Xamarin.iOS", "13.2.0.42")
-      		.Source (_ => iOSSDK_windows);
-
-	if(!String.IsNullOrEmpty(macSDK_windows))
-		Item ("Xamarin.Mac", "6.2.0.42")
-      		.Source (_ => macSDK_windows);
-
-	if(!String.IsNullOrEmpty(monoSDK_windows))
-		Item ("Mono", monoVersion)
-			.Source (_ => monoSDK_windows);
 
 }
 

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -59,7 +59,7 @@ if (IsMac)
 				.Source (_ => "https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-5-xcode11.5/PKG-Xamarin.Mac-notarized");
 
 			Item ("Xamarin.iOS")
-				.Source (_ => "https://xamci.azurewebsites.net/dl/xamarin/xamarin-android/master/PKG-Xamarin.iOS-notarized");
+				.Source (_ => "https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-5-xcode11.5/PKG-Xamarin.iOS-notarized");
 
 		}
 		else if(releaseChannel == "Preview")

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -21,8 +21,8 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120
     pool:
-      name: ${{ parameters.vmPool }}
-      vmImage: ${{ parameters.vmImage }}
+      name: ${{ coalesce(parameters.vmPool, 'Azure Pipelines') }}
+      vmImage: ${{ coalesce(parameters.vmImage, 'macOS-10.15') }}
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -21,8 +21,8 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120
     pool:
-      name: ${{ coalesce(parameters.vmPool, 'Azure Pipelines') }}
-      vmImage: ${{ coalesce(parameters.vmImage, 'macOS-10.15') }}
+      name: parameters.vmPool
+      vmImage: parameters.vmImage
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -21,8 +21,8 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120
     pool:
-      name: parameters.vmPool
-      vmImage: parameters.vmImage
+      name: ${{ coalesce(parameters.vmPool, 'Azure Pipelines') }}
+      vmImage: ${{ coalesce(parameters.vmImage, 'macOS-10.15') }}
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -1,8 +1,8 @@
 parameters:
   name: ''            # in the form type_platform_host
   displayName: ''     # the human name
-  vmImage: ''         # the VM image
-  vmPool: ''         # the VM pool
+  vmImage: 'macOS-10.15'         # the VM image
+  vmPool: 'Azure Pipelines'         # the VM pool
   dependsOn: []       # the dependiencies
   preBuildSteps: []   # any steps to run before the build
   postBuildSteps: []  # any additional steps to run after the build
@@ -14,8 +14,6 @@ parameters:
   monoVersion: $(MONO_VERSION)
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''
-  vmPool: 'Azure Pipelines'
-  vmImage: 'macOS-10.15'
 jobs:
   - job: ${{ parameters.name }}
     workspace:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -14,7 +14,8 @@ parameters:
   monoVersion: $(MONO_VERSION)
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''
-
+  vmPool: 'Azure Pipelines'
+  vmImage: 'macOS-10.15'
 jobs:
   - job: ${{ parameters.name }}
     workspace:
@@ -22,6 +23,7 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120
     pool:
+      name: ${{ parameters.vmPool }}
       vmImage: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     strategy:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -22,7 +22,7 @@ jobs:
     timeoutInMinutes: 120
     pool:
       name: ${{ parameters.vmPool }}
-      vmImage: ${{ coalesce(parameters.vmImage, 'macOS-10.15') }}
+      vmImage: ${{ parameters.vmImage }}
     dependsOn: ${{ parameters.dependsOn }}
     strategy:
       matrix:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -21,7 +21,7 @@ jobs:
     displayName: ${{ parameters.displayName }}
     timeoutInMinutes: 120
     pool:
-      name: ${{ coalesce(parameters.vmPool, 'Azure Pipelines') }}
+      name: ${{ parameters.vmPool }}
       vmImage: ${{ coalesce(parameters.vmImage, 'macOS-10.15') }}
     dependsOn: ${{ parameters.dependsOn }}
     strategy:


### PR DESCRIPTION
### Description of Change ###

- variables to set the android pool specifically
- increase the timeout of the osx job when running on devdiv
- change provisioning.csx to only use channels if sdks aren't specified
- add beta channel ios for local install

### Testing Procedure ###
- make sure builds run

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
