### PR TITLE
[iOS] Fix NamedPlatformColor typo

### DIFF
--- a/Xamarin.Forms.Core/NamedPlatformColor.cs
+++ b/Xamarin.Forms.Core/NamedPlatformColor.cs
@@ -20,7 +20,7 @@
 		public const string Label = "label";
 		public const string SecondaryLabel = "secondaryLabel";
 		public const string TertiaryLabel = "tertiaryLabel";
-		public const string QuaternaryLabel = "quaternaryLabellabel";
+		public const string QuaternaryLabel = "quaternaryLabel";
 		public const string PlaceholderText = "placeholderText";
 		public const string Separator = "separator";
 		public const string OpaqueSeparator = "opaqueSeparator";


### PR DESCRIPTION
### Description of Change ###

Noticed a typo in one of the `NamedPlatformColor` identifiers

### Issues Resolved ### 
N/A

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
While this is in core, it only affects iOS 

- iOS

### Behavioral/Visual Changes ###

People that use the actual string value for this will now not get a color returned. But I guess if someone was using it like this they would've reported the weird looking identifier 🤷‍♂️

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
N/A

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
