### PR TITLE
[UWP] Fix NRE resizing Window using CarouselView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage 
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issue10672"
+    Title="Issue 10672">
+    <controls:TestContentPage.Content>
+        <CollectionView
+            ItemsSource="{Binding Items}">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid 
+                        Margin="10"
+                        BackgroundColor="Maroon"
+                        Padding="10">
+                        <CarouselView 
+                            ItemsSource="{Binding Images}"
+                            IsScrollAnimated="False">
+                            <CarouselView.ItemTemplate>
+                                <DataTemplate>
+                                    <Image Source="{Binding}" />
+                                </DataTemplate>
+                            </CarouselView.ItemTemplate>
+                        </CarouselView>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </controls:TestContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml.cs
@@ -22,7 +22,9 @@ namespace Xamarin.Forms.Controls
 	{
 		public Issue10672()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 
 		public ObservableCollection<CarouselItemViewModel> Items { get; } = new ObservableCollection<CarouselItemViewModel>();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml.cs
@@ -38,19 +38,20 @@ namespace Xamarin.Forms.Controls
 		}
 	}
 
+	[Preserve(AllMembers = true)]
 	public class CarouselItemViewModel : BindableObject
 	{
 		static string RandomImage(int w = 1000, int h = 1000) => $"https://picsum.photos/{w}/{h}?{Guid.NewGuid()}";
 
 		public ObservableCollection<string> Images { get; } = new ObservableCollection<string>();
 
-		int _Position;
+		int _position;
 		public int Position
 		{
-			get { return _Position; }
+			get { return _position; }
 			set
 			{
-				_Position = value;
+				_position = value;
 				OnPropertyChanged();
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10672.xaml.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls
+{
+#if UITEST
+	[Category(UITestCategories.CarouselView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10672, "[Bug] Setting CarouselView.IsScrollAnimated To False Throws Exception On UWP When Resizing The Window", PlatformAffected.UWP)]
+	public partial class Issue10672 : TestContentPage
+	{
+		public Issue10672()
+		{
+			InitializeComponent();
+		}
+
+		public ObservableCollection<CarouselItemViewModel> Items { get; } = new ObservableCollection<CarouselItemViewModel>();
+
+		protected override void Init()
+		{
+			for (int i = 0; i < 5; i++)
+				Items.Add(new CarouselItemViewModel());
+			
+			BindingContext = this;
+		}
+	}
+
+	public class CarouselItemViewModel : BindableObject
+	{
+		static string RandomImage(int w = 1000, int h = 1000) => $"https://picsum.photos/{w}/{h}?{Guid.NewGuid()}";
+
+		public ObservableCollection<string> Images { get; } = new ObservableCollection<string>();
+
+		int _Position;
+		public int Position
+		{
+			get { return _Position; }
+			set
+			{
+				_Position = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public CarouselItemViewModel()
+		{
+			Images.Add(RandomImage());
+			Images.Add(RandomImage());
+			Images.Add(RandomImage());
+		}
+
+		public ICommand Next => new Command(() =>
+		{
+			Position = (Position + 1) % Images.Count;
+		});
+
+		public ICommand Prev => new Command(() =>
+		{
+			var count = Images.Count;
+			Position = (count + Position - 1) % count;
+		});
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,9 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs"> 
+      <DependentUpon>Issue10672.xaml</DependentUpon>
       <SubType>Code</SubType>
-      <DependentUpon>%(Filename)</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
@@ -1359,7 +1359,6 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10672.xaml">
-      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1497.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,10 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
+      <SubType>Code</SubType>
+      <DependentUpon>%(Filename)</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />
@@ -1352,6 +1356,10 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10672.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue1497.xaml">

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -303,9 +303,10 @@ namespace Xamarin.Forms.Platform.UWP
 										_scrollViewer.VerticalOffset > _previousVerticalOffset;
 
 			var position = ListViewBase.GetVisibleIndexes(CarouselItemsLayout.Orientation, goingNext).centerItemIndex;
+		
 			if (position == -1)
 				return;
-			System.Diagnostics.Debug.WriteLine(position);
+
 			UpdatePosition(position);
 		}
 

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ScrollHelpers.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ScrollHelpers.cs
@@ -85,7 +85,10 @@ namespace Xamarin.Forms.Platform.UWP
 		static async Task AdjustToEndAsync(ListViewBase list, ScrollViewer scrollViewer, object targetItem)
 		{
 			var point = new UWPPoint(scrollViewer.HorizontalOffset, scrollViewer.VerticalOffset);
-			var targetContainer = list.ContainerFromItem(targetItem) as UIElement;
+
+			if (!(list.ContainerFromItem(targetItem) is UIElement targetContainer))
+				return;
+
 			point = AdjustToEnd(point, targetContainer.DesiredSize, scrollViewer);
 			await JumpToOffsetAsync(scrollViewer, point.X, point.Y);
 		}
@@ -115,7 +118,10 @@ namespace Xamarin.Forms.Platform.UWP
 		static async Task AdjustToCenterAsync(ListViewBase list, ScrollViewer scrollViewer, object targetItem)
 		{
 			var point = new UWPPoint(scrollViewer.HorizontalOffset, scrollViewer.VerticalOffset);
-			var targetContainer = list.ContainerFromItem(targetItem) as UIElement;
+
+			if (!(list.ContainerFromItem(targetItem) is UIElement targetContainer))
+				return;
+
 			point = AdjustToCenter(point, targetContainer.DesiredSize, scrollViewer);
 			await JumpToOffsetAsync(scrollViewer, point.X, point.Y);
 		}


### PR DESCRIPTION
### Description of Change ###

Fixed NullReferenceException resizing the Window using the CarouselView (getting the UIElement child to update the position).

### Issues Resolved ### 

- fixes #10672 
- fixes #10673 
- fixes #10674 (2 of 3 linked issues).

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10672. Then resize the Window size several times and verify that everything continue working as expected (no exception).

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
