### PR TITLE
[Bug] NavigationPage.BackButtonTitle doesn't work with MacOS

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.MacOS/NativeToolbarTracker.cs
@@ -206,11 +206,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			var items = new List<ToolbarItem>();
 			if (ShowBackButton(forceShowBackButton))
 			{
-				bool isBackButtonTextSet = _navigation.IsSet(NavigationPage.BackButtonTitleProperty);
-				var backButtonTitle = isBackButtonTextSet ? NavigationPage.GetBackButtonTitle(_navigation) : GetPreviousPageTitle();
 				var backButtonItem = new ToolbarItem
 				{
-					Text = backButtonTitle,
+					Text = GetBackButtonText(),
 					Command = new Command(async () => await NavigateBackFrombackButton())
 				};
 				items.Add(backButtonItem);
@@ -297,12 +295,15 @@ namespace Xamarin.Forms.Platform.MacOS
 			return _navigation.Peek(0).Title ?? "";
 		}
 
-		string GetPreviousPageTitle()
+		string GetBackButtonText()
 		{
 			if (_navigation == null || _navigation.StackDepth <= 1)
 				return string.Empty;
 
-			return _navigation.Peek(1).Title ?? _defaultBackButtonTitle;
+			var page = _navigation.Peek(1);
+			return NavigationPage.GetBackButtonTitle(page)
+				?? page.Title
+				?? _defaultBackButtonTitle;
 		}
 
 		List<ToolbarItem> GetToolbarItems()


### PR DESCRIPTION
### Description of Change ###
Fixed NavigationPage.BackButtonTitle for macOs

### Issues Resolved ### 
- fixes #10424 

### API Changes ###
None

### Platforms Affected ### 
- macOs

### Behavioral/Visual Changes ###
Now BackButtonTitle changes the back button text as it should.

### Before/After Screenshots ### 
![May-15-2020 01-35-51](https://user-images.githubusercontent.com/10124814/81992574-73a38a80-964c-11ea-9d4c-adc222745cb7.gif)


### Testing Procedure ###
See the test-cases attached to the original bug-ticket.

