### PR TITLE
Only require  14393+ for UWP class libraries #10368

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -203,6 +203,9 @@
     </PropertyGroup>
     <Warning
         Text="Xamarin.Forms recommends TargetPlatformVersion &gt;= 10.0.17763.0 (current project is $(MicrosoftUIXamlTargetPlatformCheckValue))"
-        Condition="$(MicrosoftUIXamlTargetPlatformCheckValue) &lt; 17763" />
+        Condition="$(MicrosoftUIXamlTargetPlatformCheckValue) &lt; 17763 AND '$(OutputType)'!='Library'" />
+    <Warning
+        Text="Xamarin.Forms recommends TargetPlatformVersion &gt;= 10.0.14393.0 (current project is $(MicrosoftUIXamlTargetPlatformCheckValue))"
+        Condition="$(MicrosoftUIXamlTargetPlatformCheckValue) &lt; 14393 AND '$(OutputType)'=='Library'" />
   </Target>
 </Project>


### PR DESCRIPTION
### Description of Change ###
This only warns for UWP class library projects if you target less than 14393. Class libraries doesn't require being built for 17763. That's a requirement for an app. 

### Issues Resolved ### 

- fixes #10368

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
No useless warning that can't otherwise be disabled/removed

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Build a UWP class library that targets 10.0.17134 and observe the build error before/after.
Build a UWP app, and notice there's no change in warnings.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
