### PR TITLE
Fix flag check inside OnRequestedThemeChanged

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -44,8 +44,6 @@ namespace Xamarin.Forms.ControlGallery.Android
 			base.OnCreate(bundle);
 
 #if TEST_EXPERIMENTAL_RENDERERS
-			// Fake_Flag is here so we can test for flag initialization issues
-			Forms.SetFlags("Fake_Flag"/*, "CollectionView_Experimental", "Shell_Experimental"*/); 
 #else
 			Forms.SetFlags("UseLegacyRenderers", "SwipeView_Experimental", "MediaElement_Experimental", "AppTheme_Experimental");
 #endif

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -169,7 +169,7 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void OnRequestedThemeChanged(AppThemeChangedEventArgs args)
 		{
-			if (Device.Flags.IndexOf(ExperimentalFlags.AppThemeExperimental) == -1)
+			if (Device.Flags == null || Device.Flags.IndexOf(ExperimentalFlags.AppThemeExperimental) == -1)
 				return;
 
 			// On iOS the event is triggered more than once.


### PR DESCRIPTION
### Description of Change ###

- I removed the Fake_Flags getting set because I think this had relevance before we had other flags we were setting. It's better to have the UI tests run with no flags set as that's the default
- Check for null flags inside `OnRequestedThemeChanged`

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10712 

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- Run Control Gallery and rotate the device see if it crashes
- install the nuget into a clean app and rotate the device

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
