### PR TITLE
Add FlyoutBackdrop Color for Shell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1917,7 +1917,7 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8263.xaml">
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -307,14 +307,24 @@ namespace Xamarin.Forms.Controls.XamStore
 			Content = new ScrollView { Content = grid };
 
 
-            grid.Children.Add(MakeButton("Hide Nav Shadow",
+			grid.Children.Add(MakeButton("FlyoutBackdrop Color",
+					() =>
+					{
+						if (Shell.GetFlyoutBackdropColor(Shell.Current) == Color.Default)
+							Shell.SetFlyoutBackdropColor(Shell.Current, Color.Purple);
+						else
+							Shell.SetFlyoutBackdropColor(Shell.Current, Color.Default);
+					}),
+				0, 21);
+
+			grid.Children.Add(MakeButton("Hide Nav Shadow",
                     () => Shell.SetNavBarHasShadow(this, false)),
                 1, 21);
 
             grid.Children.Add(MakeButton("Show Nav Shadow",
                     () => Shell.SetNavBarHasShadow(this, true)),
                 2, 21);
-        }
+		}
 
 		Switch _navBarVisibleSwitch;
 		Switch _tabBarVisibleSwitch;

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -268,7 +268,10 @@ namespace Xamarin.Forms
 		void IShellController.AddAppearanceObserver(IAppearanceObserver observer, Element pivot)
 		{
 			_appearanceObservers.Add((observer, pivot));
-			observer.OnAppearanceChanged(GetAppearanceForPivot(pivot));
+			var appearance = GetAppearanceForPivot(pivot);
+
+			if(appearance != null)
+				observer.OnAppearanceChanged(appearance);
 		}
 
 		void IShellController.AddFlyoutBehaviorObserver(IFlyoutBehaviorObserver observer)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -146,6 +146,10 @@ namespace Xamarin.Forms
 			BindableProperty.CreateAttached("UnselectedColor", typeof(Color), typeof(Shell), Color.Default,
 				propertyChanged: OnColorValueChanged);
 
+		public static readonly BindableProperty FlyoutBackdropColorProperty =
+			BindableProperty.CreateAttached("FlyoutBackdropColor", typeof(Color), typeof(Shell), Color.Default,
+				propertyChanged: OnColorValueChanged);
+
 		public static Color GetBackgroundColor(BindableObject obj) => (Color)obj.GetValue(BackgroundColorProperty);
 		public static void SetBackgroundColor(BindableObject obj, Color value) => obj.SetValue(BackgroundColorProperty, value);
 
@@ -175,6 +179,9 @@ namespace Xamarin.Forms
 
 		public static Color GetUnselectedColor(BindableObject obj) => (Color)obj.GetValue(UnselectedColorProperty);
 		public static void SetUnselectedColor(BindableObject obj, Color value) => obj.SetValue(UnselectedColorProperty, value);
+
+		public static Color GetFlyoutBackdropColor(BindableObject obj) => (Color)obj.GetValue(FlyoutBackdropColorProperty);
+		public static void SetFlyoutBackdropColor(BindableObject obj, Color value) => obj.SetValue(FlyoutBackdropColorProperty, value);
 
 		static void OnColorValueChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -830,6 +837,12 @@ namespace Xamarin.Forms
 		{
 			get => (Color)GetValue(FlyoutBackgroundColorProperty);
 			set => SetValue(FlyoutBackgroundColorProperty, value);
+		}
+
+		public Color FlyoutBackdropColor
+		{
+			get => (Color)GetValue(FlyoutBackdropColorProperty);
+			set => SetValue(FlyoutBackdropColorProperty, value);
 		}
 
 		public FlyoutBehavior FlyoutBehavior

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -268,10 +268,7 @@ namespace Xamarin.Forms
 		void IShellController.AddAppearanceObserver(IAppearanceObserver observer, Element pivot)
 		{
 			_appearanceObservers.Add((observer, pivot));
-			var appearance = GetAppearanceForPivot(pivot);
-
-			if(appearance != null)
-				observer.OnAppearanceChanged(appearance);
+			observer.OnAppearanceChanged(GetAppearanceForPivot(pivot));
 		}
 
 		void IShellController.AddFlyoutBehaviorObserver(IFlyoutBehaviorObserver observer)
@@ -323,12 +320,10 @@ namespace Xamarin.Forms
 				{
 					if (leaf == target)
 					{
-						var appearance = GetAppearanceForPivot(pivot);
-						if(appearance != null)
-							observer.OnAppearanceChanged(appearance);
-
+						observer.OnAppearanceChanged(GetAppearanceForPivot(pivot));
 						break;
 					}
+
 					leaf = leaf.Parent;
 				}
 			}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -323,7 +323,10 @@ namespace Xamarin.Forms
 				{
 					if (leaf == target)
 					{
-						observer.OnAppearanceChanged(GetAppearanceForPivot(pivot));
+						var appearance = GetAppearanceForPivot(pivot);
+						if(appearance != null)
+							observer.OnAppearanceChanged(appearance);
+
 						break;
 					}
 					leaf = leaf.Parent;

--- a/Xamarin.Forms.Core/Shell/ShellAppearance.cs
+++ b/Xamarin.Forms.Core/Shell/ShellAppearance.cs
@@ -17,7 +17,8 @@ namespace Xamarin.Forms
 			Shell.TabBarTitleColorProperty,
 			Shell.TabBarUnselectedColorProperty,
 			Shell.TitleColorProperty,
-			Shell.UnselectedColorProperty
+			Shell.UnselectedColorProperty,
+			Shell.FlyoutBackdropColorProperty
 		};
 
 		Color?[] _colorArray = new Color?[s_ingestArray.Length];
@@ -42,6 +43,8 @@ namespace Xamarin.Forms
 
 		public Color UnselectedColor => _colorArray[9].Value;
 
+		public Color FlyoutBackdropColor => _colorArray[10].Value;
+
 		Color IShellAppearanceElement.EffectiveTabBarBackgroundColor =>
 			!TabBarBackgroundColor.IsDefault ? TabBarBackgroundColor : BackgroundColor;
 
@@ -65,32 +68,25 @@ namespace Xamarin.Forms
 		public override bool Equals(object obj)
 		{
 			var appearance = obj as ShellAppearance;
-			return appearance != null &&
-				   EqualityComparer<Color>.Default.Equals(BackgroundColor, appearance.BackgroundColor) &&
-				   EqualityComparer<Color>.Default.Equals(DisabledColor, appearance.DisabledColor) &&
-				   EqualityComparer<Color>.Default.Equals(ForegroundColor, appearance.ForegroundColor) &&
-				   EqualityComparer<Color>.Default.Equals(TabBarBackgroundColor, appearance.TabBarBackgroundColor) &&
-				   EqualityComparer<Color>.Default.Equals(TabBarDisabledColor, appearance.TabBarDisabledColor) &&
-				   EqualityComparer<Color>.Default.Equals(TabBarForegroundColor, appearance.TabBarForegroundColor) &&
-				   EqualityComparer<Color>.Default.Equals(TabBarTitleColor, appearance.TabBarTitleColor) &&
-				   EqualityComparer<Color>.Default.Equals(TabBarUnselectedColor, appearance.TabBarUnselectedColor) &&
-				   EqualityComparer<Color>.Default.Equals(TitleColor, appearance.TitleColor) &&
-				   EqualityComparer<Color>.Default.Equals(UnselectedColor, appearance.UnselectedColor);
+
+			if (appearance == null)
+				return false;
+
+			for(int i = 0; i < _colorArray.Length; i++)
+			{
+				if (!EqualityComparer<Color>.Default.Equals(_colorArray[i].Value, appearance._colorArray[i].Value))
+					return false;
+			}
+
+			return true;
 		}
 
 		public override int GetHashCode()
 		{
 			var hashCode = -1988429770;
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(BackgroundColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(DisabledColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(ForegroundColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(TabBarBackgroundColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(TabBarDisabledColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(TabBarForegroundColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(TabBarTitleColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(TabBarUnselectedColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(TitleColor);
-			hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(UnselectedColor);
+			for (int i = 0; i < _colorArray.Length; i++)
+				hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(_colorArray[i].Value);
+
 			return hashCode;
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellAppearance.cs
+++ b/Xamarin.Forms.Core/Shell/ShellAppearance.cs
@@ -67,9 +67,7 @@ namespace Xamarin.Forms
 
 		public override bool Equals(object obj)
 		{
-			var appearance = obj as ShellAppearance;
-
-			if (appearance == null)
+			if(!(obj is ShellAppearance appearance))
 				return false;
 
 			for(int i = 0; i < _colorArray.Length; i++)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -12,11 +12,21 @@ using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using AView = Android.Views.View;
 using LP = Android.Views.ViewGroup.LayoutParams;
+using AColor = Android.Graphics.Color;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class ShellFlyoutRenderer : DrawerLayout, IShellFlyoutRenderer, DrawerLayout.IDrawerListener, IFlyoutBehaviorObserver
+	public class ShellFlyoutRenderer : DrawerLayout, IShellFlyoutRenderer, DrawerLayout.IDrawerListener, IFlyoutBehaviorObserver, IAppearanceObserver
 	{
+		#region IAppearanceObserver
+
+		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
+		{
+			UpdateScrimColor(appearance.FlyoutBackdropColor);
+		}
+
+		#endregion IAppearanceObserver
+
 		#region IShellFlyoutRenderer
 
 		AView IShellFlyoutRenderer.AndroidView => this;
@@ -46,10 +56,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IDrawerListener.OnDrawerStateChanged(int newState)
 		{
-			if(DrawerLayout.StateIdle == newState)
+			if (DrawerLayout.StateIdle == newState)
 			{
 				Shell.SetValueFromRenderer(Shell.FlyoutIsPresentedProperty, IsDrawerOpen(_flyoutContent.AndroidView));
-			}	
+			}
 		}
 
 		#endregion IDrawerListener
@@ -58,6 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)
 		{
+			_behavior = behavior;
 			UpdateDrawerLockMode(behavior);
 		}
 
@@ -70,15 +81,22 @@ namespace Xamarin.Forms.Platform.Android
 		int _flyoutWidth;
 		int _currentLockMode;
 		bool _disposed;
+		Color _scrimColor;
+		FlyoutBehavior _behavior;
 
 		public ShellFlyoutRenderer(IShellContext shellContext, Context context) : base(context)
 		{
+			_scrimColor = Color.Default;
 			_shellContext = shellContext;
 
 			Shell.PropertyChanged += OnShellPropertyChanged;
+
+			ShellController.AddAppearanceObserver(this, Shell);
 		}
 
 		Shell Shell => _shellContext.Shell;
+
+		IShellController ShellController => _shellContext.Shell;
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
 		{
@@ -187,9 +205,28 @@ namespace Xamarin.Forms.Platform.Android
 					break;
 			}
 
-			unchecked
+			UpdateScrimColor(_scrimColor);
+		}
+
+		void UpdateScrimColor(Color backdropColor)
+		{
+			_scrimColor = backdropColor;
+
+			if (_behavior == FlyoutBehavior.Locked)
 			{
-				SetScrimColor(behavior == FlyoutBehavior.Locked ? Color.Transparent.ToAndroid() : (int)DefaultScrimColor);
+				SetScrimColor(Color.Transparent.ToAndroid());
+			}
+			else
+			{
+				if (backdropColor == Color.Default)
+				{
+					unchecked
+					{
+						SetScrimColor((int)DefaultScrimColor);
+					}
+				}
+				else
+					SetScrimColor(_scrimColor.ToAndroid());
 			}
 		}
 
@@ -202,6 +239,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
+				ShellController.RemoveAppearanceObserver(this);
 				Shell.PropertyChanged -= OnShellPropertyChanged;
 
 				RemoveDrawerListener(this);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -22,7 +22,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
-			UpdateScrimColor(appearance.FlyoutBackdropColor);
+			if (appearance == null)
+				UpdateScrimColor(Color.Default);
+			else
+				UpdateScrimColor(appearance.FlyoutBackdropColor);
 		}
 
 		#endregion IAppearanceObserver

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -64,6 +64,8 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(TogglePaneButton, false);
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
+			UpdateFlyoutBackdropColor();
+			ShellSplitView.UpdateFlyoutBackdropColor();
 		}
 
 		void OnPaneClosed()
@@ -144,6 +146,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		#endregion IVisualElementRenderer
 
+
+		ShellSplitView ShellSplitView => (ShellSplitView)GetTemplateChild("RootSplitView");
 		protected internal Shell Element { get; set; }
 
 		internal Shell Shell => Element;
@@ -166,6 +170,21 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == Shell.FlyoutBackgroundColorProperty.PropertyName)
 			{
 				UpdateFlyoutBackgroundColor();
+			}
+			else if (e.PropertyName == Shell.FlyoutBackdropColorProperty.PropertyName)
+			{
+				UpdateFlyoutBackdropColor();
+			}
+		}
+
+		protected virtual void UpdateFlyoutBackdropColor()
+		{
+			var splitView = ShellSplitView;
+			if (splitView != null)
+			{
+				splitView.FlyoutBackdropColor = _shell.FlyoutBackdropColor;
+				if (IsPaneOpen)
+					ShellSplitView.UpdateFlyoutBackdropColor();
 			}
 		}
 
@@ -211,6 +230,7 @@ namespace Xamarin.Forms.Platform.UWP
 			((IShellController)shell).AddAppearanceObserver(this, shell);
 			(shell as IShellController).ItemsCollectionChanged += OnItemsCollectionChanged;
 			UpdateFlyoutBackgroundColor();
+			UpdateFlyoutBackdropColor();
 		}
 
 		void OnItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (value == Color.Default)
 				{
-					LightDismissOverlayMode = LightDismissOverlayMode.Value;
+					LightDismissOverlayMode = _defaultLightDismissOverlayMode ?? LightDismissOverlayMode.Auto;
 				}
 				else
 				{

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -1,0 +1,63 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
+using Windows.UI.Xaml.Media;
+using WRectangle = Windows.UI.Xaml.Shapes.Rectangle;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	public class ShellSplitView : SplitView
+	{
+		Color _flyoutBackdropColor;
+		Brush _defaultBrush;
+		LightDismissOverlayMode? _defaultLightDismissOverlayMode;
+		public ShellSplitView()
+		{
+		}
+
+
+		internal void UpdateFlyoutBackdropColor()
+		{
+			var dismissLayer = ((WRectangle)GetTemplateChild("LightDismissLayer"));
+
+			if (_defaultBrush == null)
+				_defaultBrush = dismissLayer.Fill;
+
+			if (_flyoutBackdropColor == Color.Default)
+			{
+				dismissLayer.Fill = _defaultBrush;
+			}
+			else
+			{
+				dismissLayer.Fill = _flyoutBackdropColor.ToBrush();
+			}
+		}
+
+		internal Color FlyoutBackdropColor
+		{
+			set
+			{
+				if (_flyoutBackdropColor == value)
+					return;
+
+				_flyoutBackdropColor = value;
+
+				if (_defaultLightDismissOverlayMode == null)
+					_defaultLightDismissOverlayMode = LightDismissOverlayMode;
+
+				if (value == Color.Default)
+				{
+					LightDismissOverlayMode = LightDismissOverlayMode.Value;
+				}
+				else
+				{
+					LightDismissOverlayMode = LightDismissOverlayMode.On;
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
@@ -386,7 +386,7 @@
                                     Child="{TemplateBinding ContentOverlay}" />
                             </StackPanel>
 
-                            <SplitView
+                            <xf:ShellSplitView
                                 x:Name="RootSplitView"
                                 Background="{TemplateBinding Background}"
                                 CompactPaneLength="{TemplateBinding CompactPaneLength}"
@@ -536,7 +536,7 @@
                                             Content="{TemplateBinding Content}"/>
                                     </Grid>
                                 </SplitView.Content>
-                            </SplitView>
+                            </xf:ShellSplitView>
 
                         </Grid>
                     </Grid>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -1,4 +1,6 @@
-﻿using CoreGraphics;
+﻿using CoreAnimation;
+using CoreGraphics;
+using Foundation;
 using MediaPlayer;
 using System;
 using System.ComponentModel;
@@ -6,8 +8,18 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class ShellFlyoutRenderer : UIViewController, IShellFlyoutRenderer, IFlyoutBehaviorObserver
+	public class ShellFlyoutRenderer : UIViewController, IShellFlyoutRenderer, IFlyoutBehaviorObserver, IAppearanceObserver
 	{
+		#region IAppearanceObserver
+
+		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
+		{
+			_backdropColor = appearance.FlyoutBackdropColor;
+			UpdateTapoffViewBackgroundColor();
+		}
+
+		#endregion IAppearanceObserver
+
 		#region IShellFlyoutRenderer
 
 		UIView IShellFlyoutRenderer.View => View;
@@ -23,6 +35,19 @@ namespace Xamarin.Forms.Platform.iOS
 			Shell.PropertyChanged += OnShellPropertyChanged;
 
 			PanGestureRecognizer = new UIPanGestureRecognizer(HandlePanGesture);
+			PanGestureRecognizer.ShouldRecognizeSimultaneously += (a,b) =>
+			{
+				// This handles tapping outside the open flyout
+				if(a is UIPanGestureRecognizer pr && pr.State == UIGestureRecognizerState.Failed &&
+					b is UITapGestureRecognizer && b.State == UIGestureRecognizerState.Ended && IsOpen)
+				{
+					IsOpen = false;
+					LayoutSidebar(true);
+				}
+
+				return false;
+			};
+
 			PanGestureRecognizer.ShouldReceiveTouch += (sender, touch) =>
 			{
 				if (!context.AllowFlyoutGesture || _flyoutBehavior != FlyoutBehavior.Flyout)
@@ -34,8 +59,11 @@ namespace Xamarin.Forms.Platform.iOS
 					IsSwipeView(touch.View) ||
 					(loc.X > view.Frame.Width * 0.1 && !IsOpen))
 					return false;
+
 				return true;
 			};
+						
+			ShellController.AddAppearanceObserver(this, Shell);
 		}
 
 		bool IsSwipeView(UIView view)
@@ -70,9 +98,14 @@ namespace Xamarin.Forms.Platform.iOS
 		FlyoutBehavior _flyoutBehavior;
 		bool _gestureActive;
 		bool _isOpen;
+		UIViewPropertyAnimator _flyoutAnimation;
+		Color _backdropColor;
+
 		public UIViewAnimationCurve AnimationCurve { get; set; } = UIViewAnimationCurve.EaseOut;
 
 		public int AnimationDuration { get; set; } = 250;
+
+		double AnimationDurationInSeconds => ((double)AnimationDuration) / 1000.0;
 
 		public IShellFlyoutTransition FlyoutTransition { get; set; }
 
@@ -99,13 +132,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		Shell Shell { get; set; }
 
+		IShellController ShellController => Shell;
+
 		UIView TapoffView { get; set; }
 
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
 
-			LayoutSidebar(false);
+			if(_flyoutAnimation == null)
+				LayoutSidebar(false);
 		}
 
 		public override void ViewWillAppear(bool animated)
@@ -138,6 +174,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (!_disposed)
 				{
+					ShellController.RemoveAppearanceObserver(this);
+
 					_disposed = true;
 
 					Shell.PropertyChanged -= OnShellPropertyChanged;
@@ -189,18 +227,34 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		void UpdateTapoffViewBackgroundColor()
+		{
+			if (TapoffView == null)
+				return;
+
+			
+			if (_backdropColor != Color.Default)
+				TapoffView.BackgroundColor = _backdropColor.ToUIColor();
+			else
+				TapoffView.BackgroundColor = ColorExtensions.BackgroundColor.ColorWithAlpha(0.5f);
+		}
+
 		void AddTapoffView()
 		{
 			if (TapoffView != null)
 				return;
 
 			TapoffView = new UIView(View.Bounds);
+			TapoffView.Layer.Opacity = 0;
 			View.InsertSubviewBelow(TapoffView, Flyout.ViewController.View);
-			TapoffView.AddGestureRecognizer(new UITapGestureRecognizer(t =>
+			UpdateTapoffViewBackgroundColor();
+			var recognizer = new UITapGestureRecognizer(t =>
 			{
 				IsOpen = false;
 				LayoutSidebar(true);
-			}));
+			});
+
+			TapoffView.AddGestureRecognizer(recognizer);
 		}
 
 		public void FocusSearch(bool forwardDirection)
@@ -259,6 +313,19 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				case UIGestureRecognizerState.Changed:
 					_gestureActive = true;
+
+					if (TapoffView == null)
+						AddTapoffView();
+
+					if (_flyoutAnimation != null)
+					{
+						TapoffView.Layer.RemoveAllAnimations();
+						_flyoutAnimation?.StopAnimation(true);
+						_flyoutAnimation = null;
+					}
+
+					TapoffView.Layer.Opacity = (float)openProgress;
+
 					FlyoutTransition.LayoutViews(View.Bounds, (nfloat)openProgress, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
 					break;
 
@@ -286,23 +353,94 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_gestureActive)
 				return;
 
-			if (animate)
-				UIView.BeginAnimations(FlyoutAnimationName);
+			if (animate && _flyoutAnimation != null)
+				return;
 
-			FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
-
-			if (animate)
+			if(!animate && _flyoutAnimation != null)
 			{
-				UIView.SetAnimationCurve(AnimationCurve);
-				UIView.SetAnimationDuration(AnimationDuration);
-				UIView.CommitAnimations();
-				View.LayoutIfNeeded();
+				_flyoutAnimation.StopAnimation(true);
+				_flyoutAnimation = null;
 			}
 
-			if (IsOpen && _flyoutBehavior == FlyoutBehavior.Flyout)
-				AddTapoffView();
+			if (Forms.IsiOS10OrNewer)
+			{
+				if (IsOpen)
+					UpdateTapoffView();
+
+				if (animate && TapoffView != null)
+				{
+					var tapOffViewAnimation = CABasicAnimation.FromKeyPath(@"opacity");
+					tapOffViewAnimation.BeginTime = 0;
+					tapOffViewAnimation.Duration = AnimationDurationInSeconds;
+					tapOffViewAnimation.SetFrom(NSNumber.FromFloat(TapoffView.Layer.Opacity));
+					tapOffViewAnimation.SetTo(NSNumber.FromFloat(IsOpen ? 1 : 0));
+					tapOffViewAnimation.FillMode = CAFillMode.Forwards;
+					tapOffViewAnimation.RemovedOnCompletion = false;
+
+					_flyoutAnimation = new UIViewPropertyAnimator(AnimationDurationInSeconds, UIViewAnimationCurve.EaseOut, () =>
+					{
+						FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
+
+						if (TapoffView != null)
+						{
+							TapoffView.Layer.AddAnimation(tapOffViewAnimation, "opacity");
+						}
+					});
+
+					_flyoutAnimation.AddCompletion((p) =>
+					{
+						if (p == UIViewAnimatingPosition.End)
+						{
+							if (TapoffView != null)
+							{
+								TapoffView.Layer.Opacity = IsOpen ? 1 : 0;
+								TapoffView.Layer.RemoveAllAnimations();
+							}
+
+							UpdateTapoffView();
+							_flyoutAnimation = null;
+						}
+					});
+
+					_flyoutAnimation.StartAnimation();
+					View.LayoutIfNeeded();
+				}
+				else if (_flyoutAnimation == null)
+				{
+					FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
+					UpdateTapoffView();
+
+					if (TapoffView != null)
+					{
+						TapoffView.Layer.Opacity = IsOpen ? 1 : 0;
+					}
+				}
+			}
 			else
-				RemoveTapoffView();
+			{
+
+				if (animate)
+					UIView.BeginAnimations(FlyoutAnimationName);
+
+				FlyoutTransition.LayoutViews(View.Bounds, IsOpen ? 1 : 0, Flyout.ViewController.View, Detail.View, _flyoutBehavior);
+
+				if (animate)
+				{
+					UIView.SetAnimationCurve(AnimationCurve);
+					UIView.SetAnimationDuration(AnimationDurationInSeconds);
+					UIView.CommitAnimations();
+					View.LayoutIfNeeded();
+				}
+				UpdateTapoffView();
+			}
+
+			void UpdateTapoffView()
+			{
+				if (IsOpen && _flyoutBehavior == FlyoutBehavior.Flyout)
+					AddTapoffView();
+				else
+					RemoveTapoffView();
+			}
 		}
 
 		void RemoveTapoffView()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -14,6 +14,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
+			if (appearance == null)
+				return;
+
 			_backdropColor = appearance.FlyoutBackdropColor;
 			UpdateTapoffViewBackgroundColor();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -15,9 +15,10 @@ namespace Xamarin.Forms.Platform.iOS
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
 			if (appearance == null)
-				return;
+				_backdropColor = Color.Default;
+			else
+				_backdropColor = appearance.FlyoutBackdropColor;
 
-			_backdropColor = appearance.FlyoutBackdropColor;
 			UpdateTapoffViewBackgroundColor();
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
@@ -31,12 +31,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				flyout.Frame = new CGRect(-openLimit + openPixels, 0, flyoutWidth, bounds.Height);
 			}
-
-			if (behavior != FlyoutBehavior.Locked)
-			{
-				var shellOpacity = (nfloat)(0.5 + (0.5 * (1 - openPercent)));
-				shell.Layer.Opacity = (float)shellOpacity;
-			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Add Flyout Backdrop Color to Shell Appearance structure so users can change the color of the overlay

The attached property only takes hold when applied to Shell and ShellItem

This also makes the behavior of closing the flyout when clicking off the flyout on iOS more reliable

### API Changes ###
Added:
 - Color ShellAppearance.FlyoutBackdropColor
 - Shell.FlyoutBackdropColor // Attached Property

 
 None

### Platforms Affected ### 
- iOS
- Android
- UWP 


### Before/After Screenshots ### 

#### Android
![6F1D65D4-DD8E-4C3B-A7FD-116E42C857C9](https://user-images.githubusercontent.com/5375137/80635878-c3157400-8a19-11ea-8344-ff2a5217323f.GIF)

#### iOS

On iOS there is a subtle change for the Default Behavior. The opacity is now animated by default whereas before the opacity was just set immediately when the progress > 0

![97155BF9-B74D-4B95-9C1C-321B4F829FE1](https://user-images.githubusercontent.com/5375137/80636367-94e46400-8a1a-11ea-91cd-75cd2715c8fe.GIF)

#### UWP

![image](https://user-images.githubusercontent.com/5375137/83081538-2bb63780-a03e-11ea-9c50-a54e0ab9b899.png)


### Testing Procedure ###

Play with the added BackdropColor button on the Store Shell

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
