### PR TITLE
Added the date picker placeholder text property this will allow ios a…

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => picker.MinimumDate = new DateTime (2200, 1, 1), Throws.ArgumentException);
 		}
 
+
 		[Test]
 		public void TestMaximumDateException ()
 		{

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -9,6 +9,12 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(DatePicker), "d");
 
+
+		public  static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
+
+		public  static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
+
+
 		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), default(DateTime), BindingMode.TwoWay,
 			coerceValue: CoerceDate,
 			propertyChanged: DatePropertyChanged,
@@ -86,7 +92,11 @@ namespace Xamarin.Forms
 			get { return (FontAttributes)GetValue(FontAttributesProperty); }
 			set { SetValue(FontAttributesProperty, value); }
 		}
-
+		public string PlaceHolderText
+		{
+			get { return (string)GetValue(PlaceholderProperty); }
+			set { SetValue(PlaceholderProperty, value); }
+		}
 		public string FontFamily
 		{
 			get { return (string)GetValue(FontFamilyProperty); }

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateMaximumDate();
 			UpdateTextColor();
 			UpdateCharacterSpacing();
+			UpdatePlaceholderText();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -86,6 +87,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Editor.PlaceholderProperty.PropertyName)
+				UpdatePlaceholderText();
 			else if (e.PropertyName == DatePicker.CharacterSpacingProperty.PropertyName)
 				UpdateCharacterSpacing();
 			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName || e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
@@ -190,6 +193,14 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			EditText.Typeface = Element.ToTypeface();
 			EditText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
+		}
+
+		void UpdatePlaceholderText()
+		{
+			if (EditText.Hint == Element.PlaceHolderText)
+				return;
+
+			EditText.Hint = Element.PlaceHolderText;
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -109,6 +109,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateTextColor();
 			UpdateCharacterSpacing();
 			UpdateFlowDirection();
+			UpdatePlaceHolderText();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -122,6 +123,8 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
 				UpdateMinimumDate();
+			else if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+				UpdatePlaceHolderText();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.CharacterSpacingProperty.PropertyName)
@@ -143,6 +146,19 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UpdateElementDate();
 			}
+		}
+		protected virtual void UpdatePlaceHolderText()
+		{
+			if (Control.Placeholder == Element.PlaceHolderText)
+				return;
+
+
+			if(!string.IsNullOrEmpty(Control.Placeholder))
+			{
+				Control.Text = Element.PlaceHolderText.ToString();
+			}
+			
+			
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
@@ -194,6 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_picker.MinimumDate = Element.MinimumDate.ToNSDate();
 		}
+	
 
 		protected internal virtual void UpdateTextColor()
 		{


### PR DESCRIPTION
### Description of Change ###

This item will allow a user in Xamarin forms ios and android to have the ability of Placeholder Text

### Issues Resolved ### 
Fixes #9673 https://github.com/xamarin/Xamarin.Forms/issues/9673
 

- fixes #

### Xaml Changes ###
A User will now be able to have a place hold text in the entry view. using the following
    <DatePicker x:Name="dpPicker" PlaceHolderText="Please select date" />

Added:
 

    public string PlaceHolderText	{get { return (string)GetValue(PlaceholderProperty); }		set { SetValue(PlaceholderProperty, value); }	}

 
     public  static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
     public  static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;


 -->
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###
Adds the Xaml Property PlaceHolderText

