### PR TITLE
Bug unable to set title on date picker view 9673

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10741.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10741.cs
@@ -1,0 +1,45 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10741, "[IOS Andriod] Date Picker does not have a place holder ", PlatformAffected.Android)]
+	public class Issue10741 : TestContentPage
+	{
+
+		const string DatePicker = "DatePicker";
+		
+		protected override void Init()
+		{
+
+			var datePicker = new DatePicker
+			{
+				AutomationId = DatePicker
+				
+			};
+			datePicker.Placeholder = "Test";
+			datePicker.PlaceHolderColor = Color.LightGray;
+
+
+
+			Content = new StackLayout
+			{
+				Children =
+				{
+
+					datePicker
+					}
+
+			};
+
+
+		}
+	}
+	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10741.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/DatePickerDisabledStatesGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/VisualStateManagerGalleries/DatePickerDisabledStatesGallery.xaml
@@ -54,14 +54,15 @@
 				<DatePicker x:Name="Picker0" TextColor="Blue" BackgroundColor="Bisque" >
 				</DatePicker>
 				<Button Text="Toggle IsEnabled" x:Name="Button0" Clicked="Button0_OnClicked" />
-
-				<!-- Legacy Color Behavior turned off by the PlatformSpecific; ignores states entirely and uses 
+                
+                
+            
+                <!-- Legacy Color Behavior turned off by the PlatformSpecific; ignores states entirely and uses 
 					whatever colors are manually set for it -->
 				<Label Text="The DatePicker below has the Legacy Color Behavior disabled; it will stick with whatever colors are set, regardless of state"/>
 				<DatePicker x:Name="Picker1" TextColor="Blue" BackgroundColor="Bisque" 
-							androidSpecific:VisualElement.IsLegacyColorModeEnabled="False"
-							windowsSpecific:VisualElement.IsLegacyColorModeEnabled="False"
-							iosSpecific:VisualElement.IsLegacyColorModeEnabled="False">
+                            Placeholder="Test" PlaceHolderColor="Aqua"
+							>
 				</DatePicker>
 				<Button Text="Toggle IsEnabled" x:Name="Button1" Clicked="Button1_OnClicked" />
 

--- a/Xamarin.Forms.Controls/GalleryPages/XamlPage.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/XamlPage.xaml
@@ -1,4 +1,9 @@
 ﻿<?xml version="1.0" encoding="UTF-8"?>
 <ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.XamlPage">
-	<Label Text="Hello, Xaml" VerticalOptions="Center" HorizontalOptions="CenterAndExpand"/>
+
+    <StackLayout>
+        <Label Text="Hello, Xaml" VerticalOptions="Center" HorizontalOptions="CenterAndExpand"/>
+
+        <DatePicker Placeholder="Test"   x:Name="testDate" ></DatePicker>
+    </StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/DatePickerUnitTest.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That (() => picker.MinimumDate = new DateTime (2200, 1, 1), Throws.ArgumentException);
 		}
 
+
 		[Test]
 		public void TestMaximumDateException ()
 		{

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -12,8 +12,8 @@ namespace Xamarin.Forms
 
 		public  static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
 
+	
 		public  static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
-
 
 		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), default(DateTime), BindingMode.TwoWay,
 			coerceValue: CoerceDate,
@@ -92,7 +92,13 @@ namespace Xamarin.Forms
 			get { return (FontAttributes)GetValue(FontAttributesProperty); }
 			set { SetValue(FontAttributesProperty, value); }
 		}
-		public string PlaceHolderText
+
+		public Color PlaceHolderColor
+		{
+			get { return (Color)GetValue(PlaceholderProperty); }
+			set { SetValue(PlaceholderProperty, value); }
+		}
+		public string Placeholder
 		{
 			get { return (string)GetValue(PlaceholderProperty); }
 			set { SetValue(PlaceholderProperty, value); }

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -95,8 +95,8 @@ namespace Xamarin.Forms
 
 		public Color PlaceHolderColor
 		{
-			get { return (Color)GetValue(PlaceholderProperty); }
-			set { SetValue(PlaceholderProperty, value); }
+			get { return (Color)GetValue(PlaceholderColorProperty); }
+			set { SetValue(PlaceholderColorProperty, value); }
 		}
 		public string Placeholder
 		{
@@ -177,9 +177,10 @@ namespace Xamarin.Forms
 		static void DatePropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var datePicker = (DatePicker)bindable;
+			datePicker.Placeholder = string.Empty;
 			EventHandler<DateChangedEventArgs> selected = datePicker.DateSelected;
-
-			if (selected != null)
+			
+				if (selected != null)
 				selected(datePicker, new DateChangedEventArgs((DateTime)oldValue, (DateTime)newValue));
 		}
 

--- a/Xamarin.Forms.Core/DatePicker.cs
+++ b/Xamarin.Forms.Core/DatePicker.cs
@@ -9,6 +9,12 @@ namespace Xamarin.Forms
 	{
 		public static readonly BindableProperty FormatProperty = BindableProperty.Create(nameof(Format), typeof(string), typeof(DatePicker), "d");
 
+
+		public  static readonly BindableProperty PlaceholderProperty = InputView.PlaceholderProperty;
+
+		public  static readonly BindableProperty PlaceholderColorProperty = InputView.PlaceholderColorProperty;
+
+
 		public static readonly BindableProperty DateProperty = BindableProperty.Create(nameof(Date), typeof(DateTime), typeof(DatePicker), default(DateTime), BindingMode.TwoWay,
 			coerceValue: CoerceDate,
 			propertyChanged: DatePropertyChanged,
@@ -86,7 +92,11 @@ namespace Xamarin.Forms
 			get { return (FontAttributes)GetValue(FontAttributesProperty); }
 			set { SetValue(FontAttributesProperty, value); }
 		}
-
+		public string PlaceHolderText
+		{
+			get { return (string)GetValue(PlaceholderProperty); }
+			set { SetValue(PlaceholderProperty, value); }
+		}
 		public string FontFamily
 		{
 			get { return (string)GetValue(FontFamilyProperty); }

--- a/Xamarin.Forms.Core/View.cs
+++ b/Xamarin.Forms.Core/View.cs
@@ -152,6 +152,7 @@ namespace Xamarin.Forms
 			set { SetValue(VerticalOptionsProperty, value); }
 		}
 
+
 		protected override void OnBindingContextChanged()
 		{
 			this.PropagateBindingContext(GestureRecognizers);

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.Android
 				SetNativeControl(textField);
 				_originalHintTextColor = EditText.CurrentHintTextColor;
 			}
-
+			
 			SetDate(Element.Date);
 
 			UpdateFont();
@@ -170,6 +170,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateMinimumDate();
 			UpdateMaximumDate();
+			UpdatePlaceholder();
 			if (Forms.IsLollipopOrNewer)
 				_dialog.CancelEvent += OnCancelButtonClicked;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -72,6 +72,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateMaximumDate();
 			UpdateTextColor();
 			UpdateCharacterSpacing();
+			UpdatePlaceholderText();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -86,6 +87,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName)
 				UpdateTextColor();
+			else if (e.PropertyName == Editor.PlaceholderProperty.PropertyName)
+				UpdatePlaceholderText();
 			else if (e.PropertyName == DatePicker.CharacterSpacingProperty.PropertyName)
 				UpdateCharacterSpacing();
 			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName || e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
@@ -190,6 +193,14 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			EditText.Typeface = Element.ToTypeface();
 			EditText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
+		}
+
+		void UpdatePlaceholderText()
+		{
+			if (EditText.Hint == Element.PlaceHolderText)
+				return;
+
+			EditText.Hint = Element.PlaceHolderText;
 		}
 
 		void UpdateMaximumDate()

--- a/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/DatePickerRenderer.cs
@@ -12,6 +12,8 @@ namespace Xamarin.Forms.Platform.Android
 	public abstract class DatePickerRendererBase<TControl> : ViewRenderer<DatePicker, TControl>, IPickerRenderer
 		where TControl : global::Android.Views.View
 	{
+
+		TextColorSwitcher _hintColorSwitcher;
 		int _originalHintTextColor;
 		DatePickerDialog _dialog;
 		bool _disposed;
@@ -72,7 +74,8 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateMaximumDate();
 			UpdateTextColor();
 			UpdateCharacterSpacing();
-			UpdatePlaceholderText();
+			UpdatePlaceholderColor();
+			UpdatePlaceholder();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -88,7 +91,9 @@ namespace Xamarin.Forms.Platform.Android
 			else if (e.PropertyName == DatePicker.TextColorProperty.PropertyName)
 				UpdateTextColor();
 			else if (e.PropertyName == Editor.PlaceholderProperty.PropertyName)
-				UpdatePlaceholderText();
+				UpdatePlaceholder();
+			else if (e.PropertyName == Entry.PlaceholderColorProperty.PropertyName)
+				UpdatePlaceholderColor();
 			else if (e.PropertyName == DatePicker.CharacterSpacingProperty.PropertyName)
 				UpdateCharacterSpacing();
 			else if (e.PropertyName == DatePicker.FontAttributesProperty.PropertyName || e.PropertyName == DatePicker.FontFamilyProperty.PropertyName || e.PropertyName == DatePicker.FontSizeProperty.PropertyName)
@@ -195,14 +200,18 @@ namespace Xamarin.Forms.Platform.Android
 			EditText.SetTextSize(ComplexUnitType.Sp, (float)Element.FontSize);
 		}
 
-		void UpdatePlaceholderText()
+		void UpdatePlaceholder()
 		{
-			if (EditText.Hint == Element.PlaceHolderText)
+			if (EditText.Hint == Element.Placeholder)
 				return;
 
-			EditText.Hint = Element.PlaceHolderText;
+			EditText.Hint = Element.Placeholder;
 		}
-
+		void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher = _hintColorSwitcher ?? new TextColorSwitcher(EditText.HintTextColors, Element.UseLegacyColorManagement());
+			_hintColorSwitcher.UpdateTextColor(EditText, Element.TextColor, EditText.SetHintTextColor);
+		}
 		void UpdateMaximumDate()
 		{
 			if (_dialog != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.iOS
 		[Internals.Preserve(Conditional = true)]
 		public DatePickerRenderer()
 		{
+			
 
 		}
 
@@ -126,8 +127,6 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateMinimumDate();
 			else if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
 				UpdatePlaceholderText();
-			else if (e.PropertyName == Editor.PlaceholderColorProperty.PropertyName)
-				UpdatedPlaceHolderColor();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.CharacterSpacingProperty.PropertyName)
@@ -176,29 +175,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateAttributedPlaceholder(Control.AttributedPlaceholder.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing));
 		}
 
-		protected virtual void UpdatedPlaceHolderColor()
-		{
-
-			var formatted = (FormattedString)Element.Placeholder;
-
-			if (formatted == null)
-				return;
-
-
-			var targetColor = Element.PlaceHolderColor;
-
-			if (_useLegacyColorManagement)
-			{
-				var color = targetColor.IsDefault || !Element.IsEnabled ? _defaultPlaceholderColor : targetColor;
-				UpdateAttributedPlaceholder(formatted.ToAttributed(Element, color));
-			}
-			else
-			{
-				// Using VSM color management; take whatever is in Element.PlaceholderColor
-				var color = targetColor.IsDefault ? _defaultPlaceholderColor : targetColor;
-				UpdateAttributedPlaceholder(formatted.ToAttributed(Element, color));
-			}
-		}
+	 
 		protected virtual void UpdateAttributedPlaceholder(NSAttributedString nsAttributedString) =>
 		Control.AttributedPlaceholder = nsAttributedString;
 
@@ -217,7 +194,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_picker.Date.ToDateTime().Date != Element.Date.Date)
 				_picker.SetDate(Element.Date.ToNSDate(), animate);
 
-			Control.Text = Element.Date.ToString(Element.Format);
+			if (!string.IsNullOrEmpty(Element.Placeholder))
+				Control.Text = Element.Placeholder;
+			else
+				Control.Text = Element.Date.ToString(Element.Format);
 		}
 
 		void UpdateElementDate()

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -109,6 +109,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateTextColor();
 			UpdateCharacterSpacing();
 			UpdateFlowDirection();
+			UpdatePlaceHolderText();
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -122,6 +123,8 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else if (e.PropertyName == DatePicker.MinimumDateProperty.PropertyName)
 				UpdateMinimumDate();
+			else if (e.PropertyName == Entry.PlaceholderProperty.PropertyName)
+				UpdatePlaceHolderText();
 			else if (e.PropertyName == DatePicker.MaximumDateProperty.PropertyName)
 				UpdateMaximumDate();
 			else if (e.PropertyName == DatePicker.CharacterSpacingProperty.PropertyName)
@@ -143,6 +146,19 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UpdateElementDate();
 			}
+		}
+		protected virtual void UpdatePlaceHolderText()
+		{
+			if (Control.Placeholder == Element.PlaceHolderText)
+				return;
+
+
+			if(!string.IsNullOrEmpty(Control.Placeholder))
+			{
+				Control.Text = Element.PlaceHolderText.ToString();
+			}
+			
+			
 		}
 
 		void OnEnded(object sender, EventArgs eventArgs)
@@ -194,6 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_picker.MinimumDate = Element.MinimumDate.ToNSDate();
 		}
+	
 
 		protected internal virtual void UpdateTextColor()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -365,6 +365,8 @@ namespace Xamarin.Forms.Platform.iOS
 			// ReSharper disable once RedundantCheckBeforeAssignment
 			if (Control.Text != text)
 				Control.Text = text;
+			if (Control.Placeholder != "")
+				Control.Text = Control.Placeholder;
 		}
 
 		void UpdateCharacterSpacing()


### PR DESCRIPTION
### Description of Change ###

This adds an important feature to the Date Picker XAML  for IOS and Android within Xamarin Forms. You can now set a hint style text item called PlaceHolder and also change the colour of this text as well.

**PlaceHolder**
**PlaceHolderColor**

### Issues Resolved ### 
- fixes #9673

Added code to following files iOS and Android
Date Picker.cs in Xamarin forms core.
   
Also within each platform the following was added
DatePickerRenderer.cs
UpdatePlaceholderColor
UpdatePlaceholder


### XAML Changes ###
Now when you create a date picker you can do the following.

###Syntax Example ###

    <DatePicker x:Name="Picker1" TextColor="Blue" BackgroundColor="White"                          
     Placeholder="Test" PlaceHolderColor="Aqua" /> 

### API Changes ###
None
**Platforms Affected**
**iOS**
**Android**

**Images**
![image](https://user-images.githubusercontent.com/5619229/82165878-a8af1780-98ae-11ea-8c73-f074006eb9f6.png)
