### PR TITLE
Avoid NullReferenceException for MaterialActivityIndicatorRenderer

### DIFF
--- a/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
@@ -78,6 +78,7 @@ namespace Xamarin.Forms.Material.iOS
 		{
 			base.LayoutSubviews();
 
+			if (Control == null) return;
 			// try get the radius for this size
 			var min = NMath.Min(Control.Bounds.Width, Control.Bounds.Height);
 			var stroke = min / _strokeRatio;


### PR DESCRIPTION
Under some conditions, possibly related to `ActivityIndicator` visibility, `Control` may be null at time of call to `LayoutSubviews()`. This caused crash due to `NullReferenceException`. This null check avoids that problem.

Note: this is the second PR for the same; was accidentally merging from master to 4.6.0 on the first one.

### Description of Change ###
Null check for `Control` in `Xamarin.Forms.Material.iOS.MaterialActivityIndicatorRenderer.LayoutSubviews()` 

### Issues Resolved ### 
I noticed that at times I was seeing crashes due to `NullReferenceException` following Shell's `GoToAsync` method. On further investigation it was due to attempted access on a null `Control`. This null check solved the problem.

### API Changes ###
None.

### Platforms Affected ### 
- iOS only

### Behavioral/Visual Changes ###
Resolution of `NullReferenceException` crashes

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
I wasn't able to come up with a simple repro, however the issue was reliably reproducible in my production app. It occurred on returning to a `ShellItem` via `GoToAsync` for a _second time_. May have something to do with `ActivityIndicator` visibility.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
