### PR TITLE
[UWP] Fix CollectionView EmptyView in Horizontal Layouts

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10110.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10110.cs
@@ -1,0 +1,58 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10110, "CollectionView EmptyView doesn't show up on UWP HorizontalList", PlatformAffected.UWP)]
+	public class Issue10110 : TestContentPage
+	{
+		public Issue10110()
+		{
+			Title = "Issue 10110";
+
+			var layout = new Grid
+			{
+				RowSpacing = 0
+			};
+
+			layout.RowDefinitions.Add(new RowDefinition());
+			layout.RowDefinitions.Add(new RowDefinition());
+
+			var verticalCollectionView = new CollectionView
+			{
+				BackgroundColor = Color.LightBlue,
+				EmptyView = "Empty Vertical List as String"
+			};
+
+			var horizontalCollectionView = new CollectionView
+			{
+				BackgroundColor = Color.LightCoral,
+				ItemsLayout = new LinearItemsLayout(ItemsLayoutOrientation.Horizontal), 
+				EmptyView = "Empty Horizontal List as String"
+			};
+
+			layout.Children.Add(verticalCollectionView);
+			Grid.SetRow(verticalCollectionView, 0);
+
+			layout.Children.Add(horizontalCollectionView);
+			Grid.SetRow(horizontalCollectionView, 1);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+			
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,7 +10,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs"> 
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10110.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
       <DependentUpon>Issue10672.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -211,7 +211,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static ListViewBase CreateHorizontalListView(LinearItemsLayout listItemsLayout)
 		{
-			var horizontalListView = new WListView()
+			var horizontalListView = new FormsListView()
 			{
 				ItemsPanel = (ItemsPanelTemplate)UWPApp.Current.Resources["HorizontalListItemsPanel"],
 				ItemContainerStyle = GetHorizontalItemContainerStyle(listItemsLayout)


### PR DESCRIPTION
### Description of Change ###

Fixed CollectionView EmptyView not working with Horizontal Layouts. The problem was that when using HorizontalLayout, UWP ListView did not implement `IEmptyView`.

### Issues Resolved ### 

- fixes #10110

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="1521" alt="Captura de pantalla 2020-05-18 a las 16 59 40" src="https://user-images.githubusercontent.com/6755973/82228375-53641c00-9929-11ea-8cec-14d959cfcc6d.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue 10110. If you can see the EmptyView in Vertical and Horizontal CollectionView, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
