### PR TITLE
Fix #9711 Failed to marshal HeaderWrapperView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9711.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9711.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue9711"
+             >
+    <ListView x:Name="TestListView"
+              IsGroupingEnabled="True"
+              CachingStrategy="RecycleElement"
+              SelectionMode="None"
+              SeparatorVisibility="None"
+              HasUnevenRows="True">
+        <ListView.ItemTemplate>
+            <DataTemplate>
+                <ViewCell>
+                    <Label Text="{Binding ., Mode=OneTime}" />
+                </ViewCell>
+            </DataTemplate>
+        </ListView.ItemTemplate>
+        <ListView.GroupHeaderTemplate>
+            <DataTemplate>
+                <ViewCell BindingContextChanged="ViewCell_OnBindingContextChanged">
+                    <ContentView BackgroundColor="Red">
+                        <ContentView.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="TapGestureRecognizer_OnTapped" />
+                        </ContentView.GestureRecognizers>
+                        <Label Text="{Binding Title, Mode=OneTime}"
+                               IsVisible="{Binding IsExpanded}"
+                               AutomationId="{Binding AutomationId}" />
+                    </ContentView>
+                </ViewCell>
+            </DataTemplate>
+        </ListView.GroupHeaderTemplate>
+    </ListView>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9711.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9711.xaml.cs
@@ -1,0 +1,128 @@
+﻿﻿using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+using CategoryAttribute = NUnit.Framework.CategoryAttribute;
+
+// Thanks to GitHub user [@Matmork](https://github.com/Matmork) for this reproducible test case.
+// https://github.com/xamarin/Xamarin.Forms/issues/9711#issuecomment-602520024
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9711, "[Bug] iOS Failed to marshal the Objective-C object HeaderWrapperView", PlatformAffected.iOS)]
+	public partial class Issue9711 : TestContentPage
+	{
+		protected override void Init()
+		{
+#if APP
+			InitializeComponent();
+
+			List<ListGroup<string>> groups = new List<ListGroup<string>>();
+			for (int i = 0; i < 105; i++)
+			{
+				var group = new ListGroup<string> { Title = $"Group{i}" };
+				for (int j = 0; j < 5; j++)
+				{
+					group.Add($"Group {i} Item {j}");
+				}
+
+				groups.Add(group);
+			}
+
+			TestListView.AutomationId = "9711TestListView";
+			TestListView.ItemsSource = groups;
+#endif
+		}
+
+		private void ViewCell_OnBindingContextChanged(object sender, EventArgs e)
+		{
+			if (sender is ViewCell cell && cell.BindingContext is ListGroup<string> list)
+			{
+				list.Cell = cell;
+			}
+		}
+
+		private async void TapGestureRecognizer_OnTapped(object sender, EventArgs e)
+		{
+			if (sender is ContentView cnt && cnt.BindingContext is ListGroup<string> list)
+			{
+				for (int i = 0; i <= 50; i++)
+				{
+					await Task.Delay(25);
+					list.IsExpanded = !list.IsExpanded;
+				}
+			}
+		}
+
+
+#if UITEST		
+		[Category(UITestCategories.ListView)]
+		[Test]
+		public void TestTappingHeaderDoesNotCrash()
+		{
+			// Usually, tapping one header is sufficient to produce the exception.
+			// However, sometimes it takes two taps, and rarely, three.  If the app
+			// crashes, one of the RunningApp queries will throw, failing the test.
+			Assert.DoesNotThrowAsync(async () =>
+			{
+				RunningApp.Tap(x => x.Marked("Group2"));
+				await Task.Delay(3000);
+				RunningApp.Tap(x => x.Marked("Group1"));
+				await Task.Delay(3000);
+				RunningApp.Tap(x => x.Marked("Group0"));
+				await Task.Delay(3000);
+				RunningApp.Query(x => x.Marked("9711TestListView"));
+			});
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public sealed class ListGroup<T> : List<T>, INotifyPropertyChanged, INotifyCollectionChanged
+	{
+		public string Title { get; set; }
+		public string AutomationId => Title;
+		private bool _isExpanded = true;
+
+		public bool IsExpanded
+		{
+			get => _isExpanded;
+			set
+			{
+				if (_isExpanded == value)
+					return;
+
+				if (Cell != null)
+					Cell.Height = value ? 75 : 40;
+
+				_isExpanded = value;
+				OnPropertyChanged();
+				OnCollectionChanged();
+			}
+		}
+
+		public ViewCell Cell { get; set; }
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		private void OnCollectionChanged()
+		{
+			CollectionChanged?.Invoke(this, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+		}
+
+		private void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1360,6 +1360,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10438.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8958.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9711.xaml.cs">
+      <DependentUpon>Issue9711.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1558,6 +1562,7 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9711.xaml" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla27417Xaml.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -1104,10 +1104,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			public override UIView GetViewForHeader(UITableView tableView, nint section)
 			{
-				UIView view = null;
-
 				if (!List.IsGroupingEnabled)
-					return view;
+					return null;
 
 				var cell = TemplatedItemsView.TemplatedItems[(int)section];
 				if (cell.HasContextActions)
@@ -1118,8 +1116,7 @@ namespace Xamarin.Forms.Platform.iOS
 				header.Cell = cell;
 
 				var renderer = (CellRenderer)Internals.Registrar.Registered.GetHandlerForObject<IRegisterable>(cell);
-				header.TableViewCell = renderer.GetCell(cell, null, tableView);
-				// header.TableViewCell = renderer.GetCell(cell, header.TableViewCell, tableView);
+				header.SetTableViewCell(renderer.GetCell(cell, null, tableView));
 
 				return header;
 			}
@@ -1460,29 +1457,22 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 	}
 
-	internal class HeaderWrapperView : UITableViewHeaderFooterView
+	class HeaderWrapperView : UITableViewHeaderFooterView
 	{
 		public HeaderWrapperView(string reuseIdentifier) : base((NSString)reuseIdentifier)
 		{
-			Console.WriteLine($"Constructing HeaderWrapperView:{guid}");
 		}
-
-		public Guid guid = Guid.NewGuid();
 
 		UITableViewCell _tableViewCell;
 
 		public Cell Cell { get; set; }
 
-		public UITableViewCell TableViewCell
+		public void SetTableViewCell(UITableViewCell value)
 		{
-			get => _tableViewCell;
-			set
-			{
-				if (ReferenceEquals(_tableViewCell, value)) return;
-				_tableViewCell?.RemoveFromSuperview();
-				_tableViewCell = value;
-				AddSubview(value);
-			}
+			if (ReferenceEquals(_tableViewCell, value)) return;
+			_tableViewCell?.RemoveFromSuperview();
+			_tableViewCell = value;
+			AddSubview(value);
 		}
 
 		public override void LayoutSubviews()
@@ -1490,12 +1480,6 @@ namespace Xamarin.Forms.Platform.iOS
 			base.LayoutSubviews();
 			foreach (var item in Subviews)
 				item.Frame = Bounds;
-		}
-
-		protected override void Dispose(bool disposing)
-		{
-			base.Dispose(disposing);
-			Console.WriteLine($"Disposing HeaderWrapperView:{guid}");
 		}
 	}
 


### PR DESCRIPTION
### Description of Change ###

Crash appears to be occurring due to the premature disposal of a `HeaderWrapperView` instance.

Crash occurs in `VisualElementRenderer::UpdateParentPageAccessibilityElements()`. As it walks up the superview chain from the `UILabel` that was tapped on in the test, it arrives at a superview whose `NSObject` cannot be retrieved. That superview happens to be a `HeaderWrapperView` instance. In `Runtime.cs:1249`, the call to `TryGetNSObject()` to retrieve this `HeaderWrapperView` returns `null`.  In the debugger, I manually called `TryGetNSObject()` with `true` for the `evenInFinalizerQueue` parameter, which returned the expected instance -- confirming that the instance has been unexpectedly garbage collected.

The resulting exception claims that it was not "possible to create a new managed instance (because the type 'Xamarin.Forms.Platform.iOS.HeaderWrapperView' does not have a constructor that takes one IntPtr argument)".  In my first attempted workaround, I added the missing constructors.  This got me past the initial problem, only to reveal another -- a call to `ShouldReceiveTouch()` with a `HeaderWrapperView` instance passed as the `UITouch` parameter.  That looked to me like a dangling pointer problem, so I decided to look elsewhere.

I'm very new to Xamarin/.NET, so someone with more context might be able to discover why this `HeaderWrapperView` instance was garbage collected. But I do know iOS, and when I looked into where and how `HeaderWrapperView` is used I saw some suspect code.  Typically, when implementing section headers with custom views in a `UITableView`, you want to use the same kind of reuse that you do for table view cells.  That is, you should use `UITableView.dequeueReusableHeaderFooterView()` to retrieve the section header view.  However, the current implementation creates a new `HeaderWrapperView` on each call to `ListViewDataSource.GetViewForHeader()`. In the test case, this happens each time the state changes in response to the tap on a section header.

To work around the problem, I used `UITableView.dequeueReusableHeaderFooterView()` to attempt reuse of `HeaderFooterView` so a new instance isn't created each time.  This appears to be sufficient to avoid the original issue.

**Additional considerations**

This header reuse only applies to `HeaderWrapperView`, and not to its subviews.  It would be better for scrolling performance if all subviews of `HeaderWrapperView` could be reused. I attempted to implement that (See commented out line at [`ListViewRenderer.cs:1122`](https://github.com/humblehacker/Xamarin.Forms/blob/3b8b1755e440cef4df352929d9597205b697bc16/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs#L1122)), but was unable to get the subviews to refresh properly. Again someone with more Xamarin experience and context might be able to make this work.

### Issues Resolved ### 

- fixes #9711 

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not Applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

* Set project execution options to Xamarin.Forms.ControlGallery.iOS/Debug | iPhoneSimulator | iPhone SE (2nd generation)
* Build and run
* Open Unit Tests pad
* Run UITests → Xamarin.Forms.Core.iOS.UITests → Xamarin.Forms.Controls.Issues → Issue9711 → TestTappingHeaderDoesNotCrash

**Examples**

* [Test run before fix](https://www.icloud.com/iclouddrive/0CgGpTckHv9GazRUjWtHVF9dw#9711-before-fix)
* [Test run after fix](https://www.icloud.com/iclouddrive/0d_bSYkHEmGgixZ5TQVj0B6ew#9711-after-fix)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
