### PR TITLE
[C] Catch typeconverter exceptions on bindings

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2259,5 +2259,16 @@ namespace Xamarin.Forms.Core.UnitTests
 			page.Title = "Bar";
 			Assert.That(label.Text, Is.EqualTo("Bar"));
 		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/10405
+		public void TypeConversionExceptionIsCaughtAndLogged()
+		{
+			var label = new Label();
+			label.SetBinding(Label.TextColorProperty, "color");
+
+			Assert.DoesNotThrow(() => label.BindingContext = new { color = "" });
+			Assert.That(log.Messages.Count, Is.EqualTo(1),"No error logged");
+		}
 	}
 }

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -148,7 +148,7 @@ namespace Xamarin.Forms
 
 				if (!TryConvert(ref value, property, property.ReturnType, true))
 				{
-					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, property.ReturnType);
+					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, property.ReturnType);
 					return;
 				}
 
@@ -160,7 +160,7 @@ namespace Xamarin.Forms
 
 				if (!TryConvert(ref value, property, part.SetterType, false))
 				{
-					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, part.SetterType);
+					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, part.SetterType);
 					return;
 				}
 
@@ -431,8 +431,12 @@ namespace Xamarin.Forms
 		{
 			if (value == null)
 				return !convertTo.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(convertTo) != null;
-			if ((toTarget && targetProperty.TryConvert(ref value)) || (!toTarget && convertTo.IsInstanceOfType(value)))
-				return true;
+			try {
+				if ((toTarget && targetProperty.TryConvert(ref value)) || (!toTarget && convertTo.IsInstanceOfType(value)))
+					return true;
+			} catch (InvalidOperationException) { //that's what TypeConverters ususally throw
+				return false;
+			}
 
 			object original = value;
 			try {
@@ -455,7 +459,7 @@ namespace Xamarin.Forms
 				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
 				return true;
 			}
-			catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is OverflowException) {
+			catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is InvalidOperationException || ex is OverflowException) {
 				value = original;
 				return false;
 			}

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -212,7 +212,7 @@ namespace Xamarin.Forms.Internals
 					}
 				}
 				if (!BindingExpression.TryConvert(ref value, property, property.ReturnType, true)) {
-					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, property.ReturnType);
+					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, property.ReturnType);
 					return;
 				}
 				target.SetValueCore(property, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
@@ -223,7 +223,7 @@ namespace Xamarin.Forms.Internals
 			if (needsSetter && _setter != null && isTSource) {
 				var value = GetTargetValue(target.GetValue(property), typeof(TProperty));
 				if (!BindingExpression.TryConvert(ref value, property, typeof(TProperty), false)) {
-					Log.Warning("Binding", "{0} can not be converted to type '{1}'", value, typeof(TProperty));
+					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, typeof(TProperty));
 					return;
 				}
 				_setter((TSource)sourceObject, (TProperty)value);


### PR DESCRIPTION
### Description of Change ###

[C] Catch typeconverter exceptions on bindings

this doesn't apply to TypedBindings as you wouldn't be able to create a typed binding in this situation

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10405

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
