### PR TITLE
[WPF] Fix TimeFormat on TimePicker

### DIFF
--- a/Xamarin.Forms.Platform.WPF/FormsTimePicker.cs
+++ b/Xamarin.Forms.Platform.WPF/FormsTimePicker.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				var dateTime = new DateTime(Time.Value.Ticks);
 				
-				String text = dateTime.ToString(String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat.ToLower());
+				String text = dateTime.ToString(String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat);
 				if (text.CompareTo(Text) != 0)
 					Text = text;
 			}
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.WPF
 		private void SetTime()
 		{
 			DateTime dateTime = DateTime.MinValue;
-			String timeFormat = String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat.ToLower();
+			String timeFormat = String.IsNullOrWhiteSpace(TimeFormat) ? @"hh\:mm" : TimeFormat;
 
 			if (DateTime.TryParseExact(Text, timeFormat, null, System.Globalization.DateTimeStyles.None, out dateTime))
 			{


### PR DESCRIPTION
### Description of Change ###

The TimeFormat can't be set to lower , because casing is important for example to get 24H values 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10758

### API Changes ###
 
 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###

Show allow to set a TimeFormat like HH:mm

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

add 
```
new TimePicker {
	Time = new TimeSpan(19,00,00),
	Format = "HH:mm"
}
```

And it should renderer 19:00
### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
