### PR TITLE
Parse URL  for cookie processing just in case URL is too long

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10744.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10744.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10744, "[Android] WebView.Eval crashes on Android with long string",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.WebView)]
+#endif
+	public class Issue10744 : TestContentPage
+	{
+		Label _navigatedLabel;
+		WebView _webView;
+
+		protected override void Init()
+		{
+			_navigatedLabel = new Label()
+			{
+				AutomationId = "navigatedLabel"
+			};
+
+			_webView = new WebView()
+			{
+				Source = "https://dotnet.microsoft.com/apps/xamarin",
+				Cookies = new System.Net.CookieContainer()
+			};
+
+			_webView.Navigating += (_, __) =>
+			{
+			};
+
+			_webView.Navigated += (_, __) =>
+			{
+				if (_navigatedLabel.Text == "Navigated")
+					return;
+
+				_webView.Eval($"javascript:{String.Join(":", Enumerable.Range(0, 900000).ToArray())}");
+				_navigatedLabel.Text = "Navigated";
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label(){ Text = "If App hasn't crashed after navigating to the web page then this test has passed"},
+					_navigatedLabel,
+					_webView
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void UpdatingSourceOfDisposedListViewDoesNotCrash()
+		{
+			RunningApp.WaitForElement("navigatedLabel");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,9 +12,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10110.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
       <DependentUpon>Issue10672.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,7 +12,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10110.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
-    <Compile Include="$(MSBuildThisFileDirectory)Issue10672.xaml.cs">
       <DependentUpon>Issue10672.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
### Description of Change ###

- when creating a url for cookies just parse it down to 2000 characters if it's over 2000 characters so that new Url() doesn't throw an exception
- stop firing navigating on android for eval requests. Android was the only platform firing Eval
- UWP I added a try catch for the InvokeScript since it's async/void to avoid total failure

### Issues Resolved ### 
- fixes #10744


### Platforms Affected ### 
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
- When you call EVAL on Android it will no longer fire the navigating event which brings it inline with ios and uwp


### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
