### PR TITLE
[Tizen] Load image sync in case of FileImageSource

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
@@ -140,13 +140,20 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (Element.ImageSource != null)
 				{
 					ib.Image = new Native.Image(Control);
-					var task = ib.Image.LoadFromImageSourceAsync(Element.ImageSource);
+					if (Element.ImageSource is FileImageSource fis)
+					{
+						ib.Image.LoadFromFile(fis.File);
+					}
+					else
+					{
+						var task = ib.Image.LoadFromImageSourceAsync(Element.ImageSource);
+					}
 				}
 				else
 				{
 					ib.Image = null;
 				}
-			}			
+			}
 		}
 
 		void UpdateBorder()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ImageButtonRenderer.cs
@@ -50,7 +50,8 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		protected virtual void UpdateAfterLoading()
 		{
-			_image.IsOpaque = Element.IsOpaque;
+			if (_image.IsOpaque != Element.IsOpaque)
+				_image.IsOpaque = Element.IsOpaque;
 		}
 
 		protected override ElmSharp.Size Measure(int availableWidth, int availableHeight)
@@ -123,7 +124,16 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			if (Control != null)
 			{
-				bool success = await _image.LoadFromImageSourceAsync(source);
+				bool success;
+				if (source is FileImageSource fis)
+				{
+					success = _image.LoadFromFile(fis.File);
+				}
+				else
+				{
+					success = await _image.LoadFromImageSourceAsync(source);
+				}
+
 				if (!IsDisposed && success)
 				{
 					(Element as IVisualElementController)?.NativeSizeChanged();


### PR DESCRIPTION
### Description of Change ###
This PR is improving image loading from file for `Button.ImageSource` and `ImageButton.Source`.
In Tizen, sync file image loading is 2 to 3 times faster than async file image loading.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
