### PR TITLE
[X] Better error handling and reporting in XamlG

### DIFF
--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -52,10 +52,12 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				catch (XmlException xe) {
 					Log.LogError(null, null, null, xamlFile.ItemSpec, xe.LineNumber, xe.LinePosition, 0, 0, xe.Message, xe.HelpLink, xe.Source);
+					Log.LogMessage(MessageImportance.Low, xe.StackTrace);
 					success = false;
 				}
 				catch (Exception e) {
 					Log.LogError(null, null, null, xamlFile.ItemSpec, 0, 0, 0, 0, e.Message, e.HelpLink, e.Source);
+					Log.LogMessage(MessageImportance.Low, e.StackTrace);
 					success = false;
 				}
 			}

--- a/Xamarin.Forms.Build.Tasks/XamlGenerator.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGenerator.cs
@@ -408,6 +408,8 @@ namespace Xamarin.Forms.Build.Tasks
 
 		bool AssemblyIsSystem(string name)
 		{
+			if (name.StartsWith("System.Maui", StringComparison.CurrentCultureIgnoreCase))
+				return false;
 			if (name.StartsWith("System.", StringComparison.CurrentCultureIgnoreCase))
 				return true;
 			else if (name.Equals("mscorlib.dll", StringComparison.CurrentCultureIgnoreCase))
@@ -430,7 +432,7 @@ namespace Xamarin.Forms.Build.Tasks
 				(typeInfo) =>
 				{
 					ModuleDefinition module = null;
-					if (!_xmlnsModules.TryGetValue(typeInfo.AssemblyName, out module))
+					if (typeInfo.AssemblyName == null || !_xmlnsModules.TryGetValue(typeInfo.AssemblyName, out module))
 						return null;
 					string typeName = typeInfo.TypeName.Replace('+', '/'); //Nested types
 					string fullName = $"{typeInfo.ClrNamespace}.{typeInfo.TypeName}";


### PR DESCRIPTION



<!-- WAIT! Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target master.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or master, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/master/.github/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

no longer crash on missing XmlnsDefinitionAttribute
Report StackTrace on XamlG failures (verbose mode)

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10777

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
