### PR TITLE
[UWP] Fixed incorrect CollectionView item padding

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -231,17 +231,23 @@ namespace Xamarin.Forms.Platform.UWP
 			var margin = new WThickness(h, v, h, v);
 
 			var style = new WStyle(typeof(GridViewItem));
+
 			style.Setters.Add(new WSetter(GridViewItem.MarginProperty, margin));
+			style.Setters.Add(new WSetter(GridViewItem.PaddingProperty, new WThickness(0)));
+
 			return style;
 		}
 
 		static WStyle GetVerticalItemContainerStyle(LinearItemsLayout layout)
 		{
 			var v = layout?.ItemSpacing ?? 0;
-			var margin = new WThickness(0, v, 0, v);	
-			
+			var margin = new WThickness(0, v, 0, v);
+
 			var style = new WStyle(typeof(ListViewItem));
+
 			style.Setters.Add(new WSetter(ListViewItem.MarginProperty, margin));
+			style.Setters.Add(new WSetter(GridViewItem.PaddingProperty, new WThickness(0)));
+
 			return style;
 		}
 
@@ -251,7 +257,9 @@ namespace Xamarin.Forms.Platform.UWP
 			var padding = new WThickness(h, 0, h, 0);
 
 			var style = new WStyle(typeof(ListViewItem));
+
 			style.Setters.Add(new WSetter(ListViewItem.PaddingProperty, padding));
+
 			return style;
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

Fixed incorrect CollectionView item padding on UWP.

### Issues Resolved ### 

- fixes #10547 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="1350" alt="Captura de pantalla 2020-05-21 a las 11 31 01" src="https://user-images.githubusercontent.com/6755973/82545210-a4a52300-9b56-11ea-9e0a-914e24fde245.png">

#### After
<img width="1350" alt="Captura de pantalla 2020-05-21 a las 11 28 46" src="https://user-images.githubusercontent.com/6755973/82545214-a7077d00-9b56-11ea-8b88-00e7ce2558f1.png">


### Testing Procedure ###
Launch Core Gallery and navigate to the CollectionView samples gallery. Select the "Datatemplate Gallery" and verify that the red background color of every CollectionView Item have no spaces left or right.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
