### PR TITLE
Fixing null reference exception on Xamarin.Forms.Platform.Android\Ren…

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -1317,6 +1317,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateIsOpen(bool isOpen)
 		{
+			if (Element == null) 
+				return;
+
 			((ISwipeViewController)Element).IsOpen = isOpen;
 		}
 


### PR DESCRIPTION
I've been experiencing a NullReferenceException on my Xamarin.Forms while running on Android.
It happend when I've tapped a SwipeView and immediately try to navigate to another page.
 
### Description of Change ###

just added an if statement to prevent the crash.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - Nothing

Changed:
 - Xamarin.Forms.Platform.Android.SwipeViewRenderer
 
 Removed:
 - Nothing
 
 -->


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
No behavioral changes

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
I have created a local nuget package on my machine and installed it on my App and now the crash is gone.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
