### PR TITLE
[Android] Fix changing CarouselView using CurrentItem

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -62,6 +62,26 @@ namespace Xamarin.Forms.Core.UITests
 
 
 		[TestCase("CarouselView (XAML, Horizontal)")]
+		public void CarouselViewGoToNextCurrentItem(string subgallery)
+		{
+			VisitSubGallery(subgallery);
+
+			CheckPositionValue("lblPosition", "0");
+			CheckPositionValue("lblCurrentItem", "0");
+			App.Tap(x => x.Marked("btnNext"));
+			CheckPositionValue("lblPosition", "1");
+			CheckPositionValue("lblCurrentItem", "1");
+			CheckPositionValue("lblSelected", "1");
+			App.Tap(x => x.Marked("btnPrev"));
+			CheckPositionValue("lblPosition", "0");
+			CheckPositionValue("lblCurrentItem", "0");
+			CheckPositionValue("lblSelected", "0");
+
+			App.Back();
+		}
+
+
+		[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewRemoveLastCurrentItem(string subgallery)
 		{
 			VisitSubGallery(subgallery);

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -190,12 +190,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView,
 				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
-			
+
 			_gotoPosition = -1;
 
-			
+
 			SwapAdapter(ItemsViewAdapter, false);
-			
+
 			if (_oldPosition > 0)
 				UpdateInitialPosition();
 
@@ -252,7 +252,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			_gotoPosition = -1;
-		
+
 			SetCurrentItem(carouselPosition);
 			UpdatePosition(carouselPosition);
 
@@ -298,7 +298,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			_oldPosition = position;
 
-			_gotoPosition = _oldPosition;
+			if (_oldPosition > 0)
+				_gotoPosition = _oldPosition;
 
 			SetCurrentItem(_oldPosition);
 			Carousel.ScrollTo(_oldPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
@@ -415,7 +416,7 @@ namespace Xamarin.Forms.Platform.Android
 				_oldPosition = carouselPosition;
 				return;
 			}
-				
+
 
 			if (carouselPosition >= itemCount || carouselPosition < 0)
 				throw new IndexOutOfRangeException($"Can't set CarouselView to position {carouselPosition}. ItemsSource has {itemCount} items.");


### PR DESCRIPTION
### Description of Change ###

Fix a regression when trying to set initial position , 
We should only set the variable `_gotoPosition`  if we need to scroll to the position.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10745 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

should be able to go change the CurrentItem and have the item scroll to it

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

Added UITest - `CarouselViewGoToNextCurrentItem`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
