### PR TITLE
[UWP] Changed default ScrollBarVisibility in CollectionView

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/FormsListView.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/FormsListView.cs
@@ -1,7 +1,8 @@
 ﻿using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
-using UWPApp = Windows.UI.Xaml.Application;
-using UWPControlTemplate = Windows.UI.Xaml.Controls.ControlTemplate;
+using UwpApp = Windows.UI.Xaml.Application;
+using UwpControlTemplate = Windows.UI.Xaml.Controls.ControlTemplate;
+using UwpScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -13,7 +14,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 		public FormsListView()
 		{
-			Template = (UWPControlTemplate)UWPApp.Current.Resources["FormsListViewTemplate"];
+			Template = (UwpControlTemplate)UwpApp.Current.Resources["FormsListViewTemplate"];
+
+			ScrollViewer.SetHorizontalScrollBarVisibility(this, UwpScrollBarVisibility.Disabled);
+			ScrollViewer.SetVerticalScrollBarVisibility(this, UwpScrollBarVisibility.Auto);
 		}
 
 		public static readonly DependencyProperty EmptyViewVisibilityProperty =


### PR DESCRIPTION
### Description of Change ###

Changed default ScrollBarVisibility in CollectionView on UWP. 

In FormsGridView the default value of `VerticalScrollBarVisibility` is `Auto` while in FormsListView it is `Visible` (it will always be visible, even when it is not necessary). This PR changes the FormsListView behavior to be the same as FormsGridView.

### Issues Resolved ### 

- fixes #10817

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the CollectionView galleries. Select a gallery with a small number of items (scroll no necessary). Verify that the scroll is not visible if is not necessary by default.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
