### PR TITLE
Fixing NullReferenceException in MotionEventHelper for Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/MotionEventHelper.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MotionEventHelper.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public bool HandleMotionEvent(IViewParent parent, MotionEvent motionEvent)
 		{
-			if (_isInViewCell || motionEvent.Action == MotionEventActions.Cancel)
+			if (_isInViewCell || _element == null || motionEvent == null || motionEvent.Action == MotionEventActions.Cancel)
 			{
 				return false;
 			}


### PR DESCRIPTION
### Description of Change ###
Fixes NullReferenceException that was reported by our Application Monitoring solution Raygun. Unfortunately we were never able to reproduce this but adding this null check fixed the exception for us.

### API Changes ### 
None

### Platforms Affected ### 
Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Tested by implementing the fix into custom XF nuget package and verifying that exception is not thrown anymore.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
