### PR TITLE
[Android] Update CurrentItem when swiping

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml
@@ -1,0 +1,55 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9827">
+    <controls:TestContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="MyTemplate">
+                <Grid Margin="10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="110"/>
+                        <ColumnDefinition Width="*"/>
+                        <ColumnDefinition Width="10"/>
+                    </Grid.ColumnDefinitions>
+                    <Image Source="https://placekitten.com/g/100/200" BackgroundColor="#5833c2" WidthRequest="100" HeightRequest="200" />
+                    <StackLayout Grid.Column="1">
+                        <StackLayout Orientation="Horizontal">
+                            <Label Text="{Binding Title}" FontSize="Subtitle" LineBreakMode="WordWrap" />
+                        </StackLayout>
+                        <Label Text="{Binding Title}" FontSize="Micro" />
+                        <Label Text="{Binding Title}" FontSize="Micro" />
+                        <Label Text="{Binding Title}" FontSize="Micro" />
+                        <Label Text="{Binding Title}" FontSize="Micro" />
+                    </StackLayout>
+                </Grid>
+            </DataTemplate>
+        </ResourceDictionary>
+    </controls:TestContentPage.Resources>
+    <Grid Padding="40">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="*" />
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="20" />
+            <RowDefinition Height="200" />
+            <RowDefinition Height="10" />
+        </Grid.RowDefinitions>
+        <Label Text="Swipe to the next item in the CarouselView. The SearchBar text should be updated to match the current item, and so should the indicator view. However, with PeekAreaInserts set to a non-0 value, the CurrentItem lags behind, so the IndicatorView and the SearchBar don't get updated. It looks like this is related to being inside of a Grid with a * row pushing the CarouselView down. O_O"></Label>
+        <StackLayout HorizontalOptions="Center" Grid.Row="1" Orientation="Horizontal">
+            <Button Command="{Binding GoPrevCommand}" Text="Back"/>
+            <Label AutomationId="lblPosition" Text="{ Binding Path=Position, Source={x:Reference cv}, StringFormat='Pos:{0}'}"/>
+            <Button Command="{Binding GoNextCommand}" Text="Next"/>
+        </StackLayout>
+        <SearchBar Grid.Row="2" x:Name="matchSearch" BindingContext="{Binding CarouselCurrentItem}" Text="{Binding Title, Mode=OneWay}" Placeholder="Title" WidthRequest="300" />
+        <CarouselView Grid.Row="3" x:Name="cv"
+                          ItemsSource="{Binding Items}" 
+                          CurrentItem="{Binding CarouselCurrentItem}" 
+                          IsSwipeEnabled="true"
+                          PeekAreaInsets="20"
+                          IndicatorView="indicators"
+                          ItemTemplate="{StaticResource MyTemplate}"
+                         />
+        <IndicatorView Grid.Row="4" x:Name="indicators" IndicatorColor="Orange" SelectedIndicatorColor="Purple" IndicatorsShape="Circle" MaximumVisible="10"/>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml
@@ -3,11 +3,12 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
-    x:Class="Xamarin.Forms.Controls.Issues.Issue9827">
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9827"
+    BackgroundColor="Blue">
     <controls:TestContentPage.Resources>
         <ResourceDictionary>
             <DataTemplate x:Key="MyTemplate">
-                <Grid Margin="10">
+                <Grid Margin="10" BackgroundColor="Blue">
                     <Grid.ColumnDefinitions>
                         <ColumnDefinition Width="110"/>
                         <ColumnDefinition Width="*"/>
@@ -27,7 +28,7 @@
             </DataTemplate>
         </ResourceDictionary>
     </controls:TestContentPage.Resources>
-    <Grid Padding="40">
+    <Grid Padding="40" BackgroundColor="LightBlue">
         <Grid.RowDefinitions>
             <RowDefinition Height="*" />
             <RowDefinition Height="Auto" />
@@ -41,7 +42,7 @@
             <Label AutomationId="lblPosition" Text="{ Binding Path=Position, Source={x:Reference cv}, StringFormat='Pos:{0}'}"/>
             <Button AutomationId="btnNext" Command="{Binding GoNextCommand}" Text="Next"/>
         </StackLayout>
-        <SearchBar Grid.Row="2" x:Name="matchSearch" BindingContext="{Binding CarouselCurrentItem}" Text="{Binding Title, Mode=OneWay}" Placeholder="Title" WidthRequest="300" />
+        <SearchBar AutomationId="searchBar" Grid.Row="2" x:Name="matchSearch" BindingContext="{Binding CarouselCurrentItem}" Text="{Binding Title, Mode=OneWay}" Placeholder="Title" WidthRequest="300" />
         <CarouselView Grid.Row="3" x:Name="cv"
                           ItemsSource="{Binding Items}" 
                           CurrentItem="{Binding CarouselCurrentItem}" 
@@ -49,6 +50,8 @@
                           PeekAreaInsets="20"
                           IndicatorView="indicators"
                           ItemTemplate="{StaticResource MyTemplate}"
+                          BackgroundColor="Pink"
+                          AutomationId="carousel"
                          />
         <IndicatorView Grid.Row="4" x:Name="indicators" IndicatorColor="Orange" SelectedIndicatorColor="Purple" IndicatorsShape="Circle" MaximumVisible="10"/>
     </Grid>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml
@@ -37,9 +37,9 @@
         </Grid.RowDefinitions>
         <Label Text="Swipe to the next item in the CarouselView. The SearchBar text should be updated to match the current item, and so should the indicator view. However, with PeekAreaInserts set to a non-0 value, the CurrentItem lags behind, so the IndicatorView and the SearchBar don't get updated. It looks like this is related to being inside of a Grid with a * row pushing the CarouselView down. O_O"></Label>
         <StackLayout HorizontalOptions="Center" Grid.Row="1" Orientation="Horizontal">
-            <Button Command="{Binding GoPrevCommand}" Text="Back"/>
+            <Button AutomationId="btnPrev" Command="{Binding GoPrevCommand}" Text="Back"/>
             <Label AutomationId="lblPosition" Text="{ Binding Path=Position, Source={x:Reference cv}, StringFormat='Pos:{0}'}"/>
-            <Button Command="{Binding GoNextCommand}" Text="Next"/>
+            <Button AutomationId="btnNext" Command="{Binding GoNextCommand}" Text="Next"/>
         </StackLayout>
         <SearchBar Grid.Row="2" x:Name="matchSearch" BindingContext="{Binding CarouselCurrentItem}" Text="{Binding Title, Mode=OneWay}" Placeholder="Title" WidthRequest="300" />
         <CarouselView Grid.Row="3" x:Name="cv"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -51,12 +51,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue9827Test()
 		{
 			RunningApp.WaitForElement("Pos:0");
-			//RunningApp.Tap(c => c.Marked("btnNext"));
-			var rect = RunningApp.Query(c => c.Marked("carousel")).First().Rect;
-			var centerX = rect.CenterX;
-			var rightX = rect.X + rect.Width - 1;
-			RunningApp.DragCoordinates(centerX, rect.CenterY, rightX, rect.CenterY);
-			var elementText = RunningApp.Query(c => c.Marked("searchBar")).First().Text;
+			RunningApp.Tap(c => c.Marked("btnNext"));
 			Assert.AreEqual("Item 1 with some additional text", elementText);
 			RunningApp.WaitForElement("Pos:1");
 		

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[XamlCompilation(XamlCompilationOptions.Compile)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 9827, "Issue Description (Markup)", PlatformAffected.Default)]
+	[Issue(IssueTracker.Github, 9827, "CarouselView doesn't update the CurrentItem on Swipe under strange condition", PlatformAffected.Android)]
 	public partial class Issue9827 : TestContentPage
 	{
 		ViewModelIssue9827 ViewModel => BindingContext as ViewModelIssue9827;
@@ -164,7 +164,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	public class ModelIssue9827 : System.ComponentModel.INotifyPropertyChanged
 	{
-		private string title;
+		string _title;
 
 		protected bool SetProperty<T>(ref T backingStore,
 									  T value,
@@ -184,15 +184,15 @@ namespace Xamarin.Forms.Controls.Issues
 
 		public string Title
 		{
-			get { return title; }
+			get { return _title; }
 			set
 			{
-				if (title == value)
+				if (_title == value)
 				{
 					return;
 				}
 
-				title = value;
+				_title = value;
 				OnPropertyChanged();
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9827, "Issue Description (Markup)", PlatformAffected.Default)]
+	public partial class Issue9827 : TestContentPage
+	{
+		ViewModelIssue9827 ViewModel => BindingContext as ViewModelIssue9827;
+		public Issue9827()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			BindingContext = new ViewModelIssue9827();
+		}
+
+		protected override void OnAppearing()
+		{
+			if (ViewModel.Items.Count == 0)
+				ViewModel.LoadItemsCommand.Execute(null);
+			base.OnAppearing();
+		}
+
+#if UITEST
+		[Test]
+		public void Issue9827Test()
+		{
+		
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue9827 : INotifyPropertyChanged
+	{
+		public ViewModelIssue9827()
+		{
+			Items = new ObservableCollection<ModelIssue9827>();
+			LoadItemsCommand = new Command(ExecuteLoadItemsCommand);
+			GoNextCommand = new Command(GoNext);
+			GoPrevCommand = new Command(GoPrev);
+		}
+
+		ModelIssue9827 carouselCurrentItem;
+
+		void GoNext()
+		{
+			var index = Items.IndexOf(carouselCurrentItem);
+			var newItem = Items[Math.Min(index + 1, Items.Count - 1)];
+			CarouselCurrentItem = newItem;
+		}
+		void GoPrev()
+		{
+			var index = Items.IndexOf(carouselCurrentItem);
+			var newItem = Items[Math.Max(0, index - 1)];
+			CarouselCurrentItem = newItem;
+		}
+		void ExecuteLoadItemsCommand()
+		{
+			if (IsBusy)
+				return;
+
+			IsBusy = true;
+
+			try
+			{
+				Items.Clear();
+
+				var items = Enumerable.Range(0, 10).Select(i => new ModelIssue9827() { Title = $"Item {i} with some additional text" });
+
+				foreach (var item in items)
+				{
+					Items.Add(item);
+				}
+			}
+			catch (Exception ex)
+			{
+				Debug.WriteLine(ex);
+			}
+			finally
+			{
+				IsBusy = false;
+			}
+		}
+
+		public ModelIssue9827 CarouselCurrentItem
+		{
+			get { return carouselCurrentItem; }
+			set { SetProperty(ref carouselCurrentItem, value); }
+		}
+
+		public ObservableCollection<ModelIssue9827> Items { get; set; }
+
+		public Command LoadItemsCommand { get; set; }
+
+		public Command GoNextCommand { get; set; }
+		public Command GoPrevCommand { get; set; }
+
+		bool isBusy = false;
+
+		string title = string.Empty;
+
+		protected bool SetProperty<T>(ref T backingStore,
+									  T value,
+									  [CallerMemberName] string propertyName = "",
+									  Action onChanged = null)
+		{
+			if (EqualityComparer<T>.Default.Equals(backingStore, value))
+				return false;
+
+			backingStore = value;
+			onChanged?.Invoke();
+			OnPropertyChanged(propertyName);
+			return true;
+		}
+
+		public bool IsBusy { get { return isBusy; } set { SetProperty(ref isBusy, value); } }
+
+		public string Title { get { return title; } set { SetProperty(ref title, value); } }
+
+		#region INotifyPropertyChanged
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+		{
+			var changed = PropertyChanged;
+			if (changed == null)
+				return;
+
+			changed.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+		#endregion
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ModelIssue9827 : INotifyPropertyChanged
+	{
+		private string title;
+
+		protected bool SetProperty<T>(ref T backingStore,
+									  T value,
+									  [CallerMemberName] string propertyName = "",
+									  Action onChanged = null)
+		{
+			if (EqualityComparer<T>.Default.Equals(backingStore, value))
+				return false;
+
+			backingStore = value;
+			onChanged?.Invoke();
+			OnPropertyChanged(propertyName);
+			return true;
+		}
+
+		public Guid Id { get; set; }
+
+		public string Title
+		{
+			get { return title; }
+			set
+			{
+				if (title == value)
+				{
+					return;
+				}
+
+				title = value;
+				OnPropertyChanged();
+			}
+		}
+
+		#region INotifyPropertyChanged
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
+		{
+			var changed = PropertyChanged;
+			if (changed == null)
+				return;
+
+			changed.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+		#endregion INotifyPropertyChanged
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -51,8 +51,15 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Issue9827Test()
 		{
 			RunningApp.WaitForElement("Pos:0");
-			RunningApp.Tap(c => c.Marked("btnNext"));
+			//RunningApp.Tap(c => c.Marked("btnNext"));
+			var rect = RunningApp.Query(c => c.Marked("carousel")).First().Rect;
+			var centerX = rect.CenterX;
+			var rightX = rect.X + rect.Width - 1;
+			RunningApp.DragCoordinates(centerX, rect.CenterY, rightX, rect.CenterY);
+			var elementText = RunningApp.Query(c => c.Marked("searchBar")).First().Text;
+			Assert.AreEqual("Item 1 with some additional text", elementText);
 			RunningApp.WaitForElement("Pos:1");
+		
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -52,7 +52,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("Pos:0");
 			RunningApp.Tap(c => c.Marked("btnNext"));
-			Assert.AreEqual("Item 1 with some additional text", elementText);
+			RunningApp.WaitForElement("Item 1 with some additional text");
 			RunningApp.WaitForElement("Pos:1");
 		
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue9827()
 		{
 #if APP
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { ExperimentalFlags.IndicatorViewExperimental, ExperimentalFlags.CarouselViewExperimental });
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
-using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -51,13 +50,15 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue9827Test()
 		{
-		
+			RunningApp.WaitForElement("Pos:0");
+			RunningApp.Tap(c => c.Marked("btnNext"));
+			RunningApp.WaitForElement("Pos:1");
 		}
 #endif
 	}
 
 	[Preserve(AllMembers = true)]
-	public class ViewModelIssue9827 : INotifyPropertyChanged
+	public class ViewModelIssue9827 : System.ComponentModel.INotifyPropertyChanged
 	{
 		public ViewModelIssue9827()
 		{
@@ -145,7 +146,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public string Title { get { return title; } set { SetProperty(ref title, value); } }
 
 		#region INotifyPropertyChanged
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
@@ -153,13 +154,13 @@ namespace Xamarin.Forms.Controls.Issues
 			if (changed == null)
 				return;
 
-			changed.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			changed.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
 		}
 		#endregion
 	}
 
 	[Preserve(AllMembers = true)]
-	public class ModelIssue9827 : INotifyPropertyChanged
+	public class ModelIssue9827 : System.ComponentModel.INotifyPropertyChanged
 	{
 		private string title;
 
@@ -196,7 +197,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		#region INotifyPropertyChanged
 
-		public event PropertyChangedEventHandler PropertyChanged;
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
 
 		protected void OnPropertyChanged([CallerMemberName] string propertyName = "")
 		{
@@ -204,7 +205,7 @@ namespace Xamarin.Forms.Controls.Issues
 			if (changed == null)
 				return;
 
-			changed.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			changed.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
 		}
 		#endregion INotifyPropertyChanged
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -789,6 +789,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8145.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10222.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4714.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9827.xaml.cs">
+      <SubType>Code</SubType>
+      <DependentUpon>Issue9827.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -1547,6 +1551,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8958.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9827.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -190,12 +190,12 @@ namespace Xamarin.Forms.Platform.Android
 
 			ItemsViewAdapter = new ItemsViewAdapter<ItemsView, IItemsViewSource>(ItemsView,
 				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
-			
+
 			_gotoPosition = -1;
 
-			
+
 			SwapAdapter(ItemsViewAdapter, false);
-			
+
 			if (_oldPosition > 0)
 				UpdateInitialPosition();
 
@@ -252,7 +252,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			_gotoPosition = -1;
-		
+
 			SetCurrentItem(carouselPosition);
 			UpdatePosition(carouselPosition);
 
@@ -298,7 +298,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			_oldPosition = position;
 
-			_gotoPosition = _oldPosition;
+			if (_oldPosition > 0)
+				_gotoPosition = _oldPosition;
 
 			SetCurrentItem(_oldPosition);
 			Carousel.ScrollTo(_oldPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: Carousel.AnimatePositionChanges);
@@ -368,6 +369,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)
 		{
+			_noNeedForScroll = false;
 			UpdatePosition(e.CenterItemIndex);
 			UpdateVisualStates();
 		}
@@ -415,7 +417,7 @@ namespace Xamarin.Forms.Platform.Android
 				_oldPosition = carouselPosition;
 				return;
 			}
-				
+
 
 			if (carouselPosition >= itemCount || carouselPosition < 0)
 				throw new IndexOutOfRangeException($"Can't set CarouselView to position {carouselPosition}. ItemsSource has {itemCount} items.");
@@ -473,7 +475,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		class CarouselViewOnScrollListener : RecyclerViewScrollListener<ItemsView, IItemsViewSource>
 		{
-			public CarouselViewOnScrollListener(ItemsView itemsView, ItemsViewAdapter<ItemsView, IItemsViewSource> itemsViewAdapter) : base(itemsView, itemsViewAdapter)
+			public CarouselViewOnScrollListener(ItemsView itemsView, ItemsViewAdapter<ItemsView, IItemsViewSource> itemsViewAdapter) : base(itemsView, itemsViewAdapter, true)
 			{
 			}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/IndicatorViewRenderer.cs
@@ -212,7 +212,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var maxVisible = GetMaximumVisible();
 			var position = IndicatorView.Position;
-			_selectedIndex = position >= maxVisible ? maxVisible - 1 : position;
+			_selectedIndex = Math.Max(0, position >= maxVisible ? maxVisible - 1 : position);
 			UpdateIndicators();
 		}
 

--- a/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/RecyclerViewScrollListener.cs
@@ -16,11 +16,18 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 		int _horizontalOffset, _verticalOffset;
 		TItemsView _itemsView;
 		ItemsViewAdapter<TItemsView, TItemsViewSource> _itemsViewAdapter;
+		bool _getCenteredItemOnXAndY = false;
 
-		public RecyclerViewScrollListener(TItemsView itemsView, ItemsViewAdapter<TItemsView, TItemsViewSource> itemsViewAdapter)
+		public RecyclerViewScrollListener(TItemsView itemsView, ItemsViewAdapter<TItemsView, TItemsViewSource> itemsViewAdapter) : this(itemsView, itemsViewAdapter, false)
+		{
+
+		}
+
+		public RecyclerViewScrollListener(TItemsView itemsView, ItemsViewAdapter<TItemsView, TItemsViewSource> itemsViewAdapter, bool getCenteredItemOnXAndY)
 		{
 			_itemsView = itemsView;
 			_itemsViewAdapter = itemsViewAdapter;
+			_getCenteredItemOnXAndY = getCenteredItemOnXAndY;
 		}
 
 		public override void OnScrolled(RecyclerView recyclerView, int dx, int dy)
@@ -42,7 +49,7 @@ namespace Xamarin.Forms.Platform.Android.CollectionView
 			{
 				firstVisibleItemIndex = linearLayoutManager.FindFirstVisibleItemPosition();
 				lastVisibleItemIndex = linearLayoutManager.FindLastVisibleItemPosition();
-				centerItemIndex = recyclerView.CalculateCenterItemIndex(firstVisibleItemIndex, linearLayoutManager);
+				centerItemIndex = recyclerView.CalculateCenterItemIndex(firstVisibleItemIndex, linearLayoutManager, _getCenteredItemOnXAndY);
 			}
 
 			var context = recyclerView.Context;

--- a/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/RecyclerExtensions.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	internal static class RecyclerExtensions
 	{
-		public static int CalculateCenterItemIndex(this RecyclerView recyclerView, int firstVisibleItemIndex, LinearLayoutManager linearLayoutManager)
+		public static int CalculateCenterItemIndex(this RecyclerView recyclerView, int firstVisibleItemIndex, LinearLayoutManager linearLayoutManager, bool lookCenteredOnXAndY)
 		{
 			// This can happen if a layout pass has not happened yet
 			if (firstVisibleItemIndex == -1)
@@ -21,12 +21,22 @@ namespace Xamarin.Forms.Platform.Android
 			if (linearLayoutManager.Orientation == LinearLayoutManager.Horizontal)
 			{
 				float centerX = recyclerView.Width / 2;
-				centerView = recyclerView.FindChildViewUnder(centerX, recyclerView.Top);
+				float centerY = recyclerView.Top;
+
+				if (lookCenteredOnXAndY)
+					centerY = recyclerView.Height / 2;
+
+				centerView = recyclerView.FindChildViewUnder(centerX, centerY);
 			}
 			else
 			{
 				float centerY = recyclerView.Height / 2;
-				centerView = recyclerView.FindChildViewUnder(recyclerView.Left, centerY);
+				float centerX = recyclerView.Left;
+
+				if (lookCenteredOnXAndY)
+					centerX = recyclerView.Width / 2;
+
+				centerView = recyclerView.FindChildViewUnder(centerX, centerY);
 			}
 
 			if (centerView != null)


### PR DESCRIPTION
### Description of Change ###

A couple of fixes, getting the real centered item. If we were using the PeakAreaInsets there were some times that center item wasn't found since it was using just 1 centered coordiante, it should use both, x and y for CarouselView.
Fix state that was blocking update CurrentItem when swiping. Fix introduced in 4.6.0 to fix scrolling to the item when added was blocking the current item to be update when swiping.

Contains also fix #10838 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #9827 
- fixes #10775

### API Changes ###

 None

### Platforms Affected ###
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Go to test case 9827, swipe to next item, check the SearchBar text is updated to "Item1 with some additional text"

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
