### PR TITLE
Fire OnBackButtonPressed on the currently Displayed Page

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.ComponentModel;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -73,8 +74,10 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
+		[QueryProperty("CancelNavigationOnBackButtonPressed", "CancelNavigationOnBackButtonPressed")]
 		public class ShellTestPage : ContentPage
 		{
+			public string CancelNavigationOnBackButtonPressed { get; set; }
 			public ShellTestPage()
 			{
 			}
@@ -88,6 +91,14 @@ namespace Xamarin.Forms.Core.UnitTests
 			protected override void OnParentSet()
 			{
 				base.OnParentSet();
+			}
+
+			protected override bool OnBackButtonPressed()
+			{
+				if (CancelNavigationOnBackButtonPressed == "true")
+					return false;
+
+				return base.OnBackButtonPressed();
 			}
 		}
 
@@ -195,6 +206,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			public int OnNavigatingCount;
 			public int NavigatedCount;
 			public int NavigatingCount;
+			public int OnBackButtonPressedCount;
 
 			public TestShell()
 			{
@@ -216,9 +228,19 @@ namespace Xamarin.Forms.Core.UnitTests
 				OnNavigatingCount++;
 			}
 
+			protected override bool OnBackButtonPressed()
+			{
+				OnBackButtonPressedCount++;
+				return base.OnBackButtonPressed();
+			}
+
 			public void Reset()
 			{
-				OnNavigatedCount = OnNavigatingCount = NavigatedCount = NavigatingCount = 0;
+				OnNavigatedCount = 
+					OnNavigatingCount = 
+					NavigatedCount = 
+					NavigatingCount =
+					OnBackButtonPressedCount = 0;
 			}
 
 			public void TestCount(int count, string message = null)

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -590,6 +590,17 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assume.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//one/tabone/content"));
 		}
 
+
+		[Test]
+		public async Task OnBackbuttonPressedFiresOnPage()
+		{
+			Shell shell = new Shell();
+			Routing.RegisterRoute("OnBackbuttonPressedFiresOnPage", typeof(ShellTestPage));
+			shell.Items.Add(CreateShellItem());
+			await shell.GoToAsync($"OnBackbuttonPressedFiresOnPage?CancelNavigationOnBackButtonPressed=true");
+			Assert.AreEqual(false, shell.SendBackButtonPressed());
+		}
+
 		[Test]
 		public void BackButtonBehaviorSet()
 		{

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -292,6 +292,9 @@ namespace Xamarin.Forms
 
 		protected virtual bool OnBackButtonPressed()
 		{
+			if (RealParent is BaseShellItem || RealParent is Shell)
+				return true;
+
 			var application = RealParent as Application;
 			if (application == null || this == application.MainPage)
 				return false;

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -989,6 +989,14 @@ namespace Xamarin.Forms
 
 		protected override bool OnBackButtonPressed()
 		{
+			if(GetVisiblePage() is Page page)
+			{
+				if(!page.SendBackButtonPressed())
+				{
+					return false;
+				}
+			}
+
 			var currentContent = CurrentItem?.CurrentItem;
 			if (currentContent != null && currentContent.Stack.Count > 1)
 			{


### PR DESCRIPTION
### Description of Change ###

Propagate OnBackButtonPressed from Shell down to currently displayed page

### Issues Resolved ### 
- fixes #7072


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
