### PR TITLE
[iOS] Fix crash using an empty button image (unverified)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1230,11 +1230,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 				UIGraphics.BeginImageContext(size);
 				var context = UIGraphics.GetCurrentContext();
-				context.SetFillColor(1, 1, 1, 0);
-				context.FillRect(rect);
+				context?.SetFillColor(1, 1, 1, 0);
+				context?.FillRect(rect);
 
 				var empty = UIGraphics.GetImageFromCurrentImageContext();
-				context.Dispose();
+				context?.Dispose();
 
 				return empty;
 			}


### PR DESCRIPTION
### Description of Change ###

After doing some tests I have not been able to reproduce the issue. Probably the problem is that the Context is null. This PR avoids the crash in this case.

### Issues Resolved ### 

- fixes #10854 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
