### PR TITLE
[Maps] Add pin drag & drop

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/MapWithItemsSourceGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/MapWithItemsSourceGallery.xaml
@@ -11,7 +11,8 @@
                     <DataTemplate>
                         <map:Pin Position="{Binding Position}"
                                  Address="{Binding Address}"
-                                 Label="{Binding Description}" />
+                                 Label="{Binding Description}" 
+                                 IsDraggable="{Binding Draggable}"/>
                     </DataTemplate>
                 </local:MapItemTemplateSelector.DataTemplate>
             </local:MapItemTemplateSelector>

--- a/Xamarin.Forms.Controls/GalleryPages/MapWithItemsSourceGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/MapWithItemsSourceGallery.xaml.cs
@@ -129,7 +129,8 @@ namespace Xamarin.Forms.Controls.GalleryPages
 				return new Place(
 					$"Pin {_pinCreatedCount}",
 					$"Desc {_pinCreatedCount}",
-					RandomPosition.Next(startPosition, 8, 19));
+					RandomPosition.Next(startPosition, 8, 19),
+					true);
 			}
 		}
 
@@ -144,6 +145,8 @@ namespace Xamarin.Forms.Controls.GalleryPages
 
 			public string Description { get; }
 
+			public bool Draggable { get; }
+
 			public Position Position
 			{
 				get => _position;
@@ -157,11 +160,12 @@ namespace Xamarin.Forms.Controls.GalleryPages
 				}
 			}
 
-			public Place(string address, string description, Position position)
+			public Place(string address, string description, Position position, bool draggable = false)
 			{
 				Address = address;
 				Description = description;
 				Position = position;
+				Draggable = draggable;
 			}
 		}
 	}

--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -108,6 +108,7 @@ namespace Xamarin.Forms.Maps.Android
 					NativeMap.MarkerClick -= OnMarkerClick;
 					NativeMap.InfoWindowClick -= OnInfoWindowClick;
 					NativeMap.MapClick -= OnMapClick;
+					NativeMap.MarkerDragEnd -= OnMarkerDrag;
 					NativeMap.Dispose();
 					NativeMap = null;
 				}
@@ -153,6 +154,7 @@ namespace Xamarin.Forms.Maps.Android
 					NativeMap.MarkerClick -= OnMarkerClick;
 					NativeMap.InfoWindowClick -= OnInfoWindowClick;
 					NativeMap.MapClick -= OnMapClick;
+					NativeMap.MarkerDragEnd -= OnMarkerDrag;
 					NativeMap = null;
 				}
 
@@ -240,6 +242,7 @@ namespace Xamarin.Forms.Maps.Android
 			map.MarkerClick += OnMarkerClick;
 			map.InfoWindowClick += OnInfoWindowClick;
 			map.MapClick += OnMapClick;
+			map.MarkerDragEnd += OnMarkerDrag;
 
 			map.TrafficEnabled = Map.TrafficEnabled;
 			map.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
@@ -248,13 +251,14 @@ namespace Xamarin.Forms.Maps.Android
 			SetUserVisible();
 			SetMapType();
 		}
-
+		
 		protected virtual MarkerOptions CreateMarker(Pin pin)
 		{
 			var opts = new MarkerOptions();
 			opts.SetPosition(new LatLng(pin.Position.Latitude, pin.Position.Longitude));
 			opts.SetTitle(pin.Label);
 			opts.SetSnippet(pin.Address);
+			opts.Draggable(pin.IsDraggable);
 
 			return opts;
 		}
@@ -307,6 +311,10 @@ namespace Xamarin.Forms.Maps.Android
 			else if (e.PropertyName == Pin.PositionProperty.PropertyName)
 			{
 				marker.Position = new LatLng(pin.Position.Latitude, pin.Position.Longitude);
+			}
+			else if(e.PropertyName == Pin.IsDraggableProperty.PropertyName)
+			{
+				marker.Draggable = pin.IsDraggable;
 			}
 		}
 
@@ -387,6 +395,12 @@ namespace Xamarin.Forms.Maps.Android
 		void OnMapClick(object sender, GoogleMap.MapClickEventArgs e)
 		{
 			Map.SendMapClicked(new Position(e.Point.Latitude, e.Point.Longitude));
+		}
+
+		void OnMarkerDrag(object sender, GoogleMap.MarkerDragEndEventArgs e)
+		{
+			var pin = GetPinForMarker(e.Marker);
+			pin?.SetValueFromRenderer(Pin.PositionProperty, new Position(e.Marker.Position.Latitude, e.Marker.Position.Longitude));
 		}
 
 		void MoveToRegion(MapSpan span, bool animate)

--- a/Xamarin.Forms.Maps/Pin.cs
+++ b/Xamarin.Forms.Maps/Pin.cs
@@ -12,6 +12,9 @@ namespace Xamarin.Forms.Maps
 		public static readonly BindableProperty AddressProperty = BindableProperty.Create("Address", typeof(string), typeof(Pin), default(string));
 
 		public static readonly BindableProperty LabelProperty = BindableProperty.Create("Label", typeof(string), typeof(Pin), default(string));
+
+		public static readonly BindableProperty IsDraggableProperty = BindableProperty.Create("IsDraggable", typeof(bool), typeof(Pin), false);
+
 		private object _markerId;
 		private object _id;
 
@@ -39,6 +42,11 @@ namespace Xamarin.Forms.Maps
 			set { SetValue(TypeProperty, value); }
 		}
 
+		public bool IsDraggable
+		{
+			get { return (bool)GetValue(IsDraggableProperty); }
+			set { SetValue(IsDraggableProperty, value); }
+		}
 
 		// introduced to store the unique id for Android markers
 		[Obsolete("This property is obsolete as of 4.0.0. Please use MarkerId instead.")]


### PR DESCRIPTION
### Description of Change ###

Add drag & drop functionality to map pins.

### Issues Resolved ### 

- fixes #5786 

### API Changes ###

Added:
 - public static readonly BindableProperty Pin.IsDraggableProperty
 - public bool Pin.IsDraggable { get; set; }

### Platforms Affected ### 

- Maps (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

Default value of IsDraggable is false so no behavioral changes without code changes by consumers of the library.

### Before/After Screenshots ### 

Demo videos - [DraggablePins.zip](https://github.com/xamarin/Xamarin.Forms/files/4691829/DraggablePins.zip)

### Testing Procedure ###

1. Run Control Gallery app.
2. Go to "Map With Items Source Gallery - Legacy" page.
3. Click the Add button to add a new pin to the map.
4. Press and hold the added pin for ~1/2 second.
5. Pin will animate lifting off the map and you can drag and drop in a new position.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
