### PR TITLE
[iOS] Reinstate ContextAction IsDestructive red bg

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				if (Forms.IsiOS13OrNewer)
 					return UIColor.SystemRedColor;
 #endif
-				return UIColor.FromRGBA(1, 0, 0, 1);
+				return UIColor.FromRGBA(255, 0, 0, 255);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Using the right value with the right overload in `UIColor.FromRGBA(255, 0, 0, 255);` to make ContextAction.IsDestructive red again on pre-iOS13.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10612 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Go to the ContextActions gallery page on a pre-iOS13 device and notice that the destructive ones have a red background once more

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
