### PR TITLE
[Enhancement] Cancel Event on Xamarin.forms.Button (#5043)

### DIFF
--- a/Xamarin.Forms.Core/Button.cs
+++ b/Xamarin.Forms.Core/Button.cs
@@ -184,6 +184,9 @@ namespace Xamarin.Forms
 		public void SendReleased() => ButtonElement.ElementReleased(this, this);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCanceled() => ButtonElement.ElementCanceled(this, this);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		void IButtonElement.PropagateUpClicked() => Clicked?.Invoke(this, EventArgs.Empty);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
@@ -191,6 +194,9 @@ namespace Xamarin.Forms
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		void IButtonElement.PropagateUpReleased() => Released?.Invoke(this, EventArgs.Empty);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		void IButtonElement.PropagateUpCanceled() => Canceled?.Invoke(this, EventArgs.Empty);
 
 		public FontAttributes FontAttributes
 		{
@@ -221,6 +227,7 @@ namespace Xamarin.Forms
 		public event EventHandler Pressed;
 
 		public event EventHandler Released;
+		public event EventHandler Canceled;
 
 		public Button()
 		{

--- a/Xamarin.Forms.Core/ButtonElement.cs
+++ b/Xamarin.Forms.Core/ButtonElement.cs
@@ -82,5 +82,16 @@ namespace Xamarin.Forms
 				ButtonElementManager.PropagateUpReleased();
 			}
 		}
+
+		public static void ElementCanceled(VisualElement visualElement, IButtonElement ButtonElementManager)
+		{
+			if (visualElement.IsEnabled == true)
+			{
+				IButtonController buttonController = ButtonElementManager as IButtonController;
+				ButtonElementManager.SetIsPressed(false);
+				visualElement.ChangeVisualStateInternal();
+				ButtonElementManager.PropagateUpCanceled();
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Core/IButtonController.cs
+++ b/Xamarin.Forms.Core/IButtonController.cs
@@ -8,5 +8,6 @@ namespace Xamarin.Forms
 		void SendClicked();
 		void SendPressed();
 		void SendReleased();
+		void SendCanceled();
 	}
 }

--- a/Xamarin.Forms.Core/IButtonElement.cs
+++ b/Xamarin.Forms.Core/IButtonElement.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Internals
 		void PropagateUpClicked();
 		void PropagateUpPressed();
 		void PropagateUpReleased();
+		void PropagateUpCanceled();
 		void SetIsPressed(bool isPressed);
 		void OnCommandCanExecuteChanged(object sender, EventArgs e);
 		bool IsEnabledCore { set; }

--- a/Xamarin.Forms.Core/ImageButton.cs
+++ b/Xamarin.Forms.Core/ImageButton.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms
 		public event EventHandler Clicked;
 		public event EventHandler Pressed;
 		public event EventHandler Released;
+		public event EventHandler Canceled;
 
 		readonly Lazy<PlatformConfigurationRegistry<ImageButton>> _platformConfigurationRegistry;
 
@@ -163,6 +164,10 @@ namespace Xamarin.Forms
 		public void SendReleased() =>
 			ButtonElement.ElementReleased(this, this);
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void SendCanceled() =>
+			ButtonElement.ElementCanceled(this, this);
+
 		public void PropagateUpClicked() =>
 			Clicked?.Invoke(this, EventArgs.Empty);
 
@@ -171,6 +176,9 @@ namespace Xamarin.Forms
 
 		public void PropagateUpReleased() =>
 			Released?.Invoke(this, EventArgs.Empty);
+
+		public void PropagateUpCanceled() =>
+			Canceled?.Invoke(this, EventArgs.Empty);
 
 		public void RaiseImageSourcePropertyChanged() =>
 			OnPropertyChanged(nameof(Source));

--- a/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms.Material.iOS
 			{
 				Control.TouchUpInside -= OnButtonTouchUpInside;
 				Control.TouchDown -= OnButtonTouchDown;
+				Control.TouchCancel -= OnButtonTouchCancel;
 				_buttonLayoutManager?.Dispose();
 				_buttonLayoutManager = null;
 			}
@@ -69,6 +70,7 @@ namespace Xamarin.Forms.Material.iOS
 
 					Control.TouchUpInside += OnButtonTouchUpInside;
 					Control.TouchDown += OnButtonTouchDown;
+					Control.TouchCancel += OnButtonTouchCancel;
 				}
 
 				UpdateFont();
@@ -149,6 +151,11 @@ namespace Xamarin.Forms.Material.iOS
 				return;
 
 			base.SetAccessibilityLabel();
+		}
+
+		void OnButtonTouchCancel(object sender, EventArgs eventArgs)
+		{
+			Element?.SendCanceled();
 		}
 
 		void OnButtonTouchUpInside(object sender, EventArgs eventArgs)

--- a/Xamarin.Forms.Platform.Android/ButtonElementManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonElementManager.cs
@@ -15,6 +15,9 @@ namespace Xamarin.Forms.Platform.Android
 				case MotionEventActions.Up:
 					buttonController?.SendReleased();
 					break;
+				case MotionEventActions.Cancel:
+					buttonController?.SendCanceled();
+					break;
 			}
 
 			return false;

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -344,6 +344,10 @@ namespace Xamarin.Forms.Platform.Android
 					{
 						buttonController?.SendReleased();
 					}
+					else if (e.Action == AMotionEventActions.Cancel)
+					{
+						buttonController?.SendCanceled();
+					}
 				}
 				return false;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonElementManager.cs
@@ -34,8 +34,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			control.TouchUpInside -= TouchUpInside;
 			control.TouchDown -= TouchDown;
+			control.TouchCancel -= TouchCancel;
 			control.TouchUpInside += TouchUpInside;
 			control.TouchDown += TouchDown;
+			control.TouchCancel += TouchCancel;
 		}
 
 		static void TouchUpInside(object sender, EventArgs eventArgs)
@@ -52,12 +54,20 @@ namespace Xamarin.Forms.Platform.iOS
 			OnButtonTouchDown(renderer.Element as IButtonController);
 		}
 
+		static void TouchCancel(object sender, EventArgs eventArgs)
+		{
+			var button = sender as UIButton;
+			var renderer = button.Superview as IVisualNativeElementRenderer;
+			OnButtonTouchCancel(renderer.Element as IButtonController);
+		}
+
 		public static void Dispose(IVisualNativeElementRenderer renderer)
 		{
 			var control = (UIButton)renderer.Control;
 			renderer.ElementPropertyChanged -= OnElementPropertyChanged;
 			control.TouchUpInside -= TouchUpInside;
 			control.TouchDown -= TouchDown;
+			control.TouchCancel -= TouchCancel;
 		}
 
 		static void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
@@ -84,6 +94,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			element?.SendReleased();
 			element?.SendClicked();
+		}
+
+		internal static void OnButtonTouchCancel(IButtonController element)
+		{
+			element?.SendCanceled();
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

For Now Button got 3 events: Clicked Pressed Released.
This PR add the Canceled Event that is fired on iOS and Android Buttons.
This event is not fired up on other platforms.

### Issues Resolved ### 
#5043

### API Changes ###

New event:

`````
 public event EventHandler Canceled;
`````

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS
- Android
- Xamarin.forms

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
- Create a Button inside a scrollView.
- Press the Button and move the scrollView before release the button
- The Canceled Event is fired up.

PS: no event was fire in this case, not even the release event in xamarin.forms.
Because the touch has been canceled.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
