### PR TITLE
[UWP] Open DatePicker and TimePicker Popup getting the focus

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10909.cs
@@ -1,0 +1,67 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.DatePicker)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10909, "[Bug] UWP DatePicker and TimePicker Focus() function does not open the popup to set the date/time",
+		PlatformAffected.UWP)]
+	public class Issue10909 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 10909";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				Text = "If pressing the buttons opens the popup of both DatePicker and TimePicker, the test has passed.",
+				BackgroundColor = Color.Black,
+				TextColor = Color.White
+			};
+
+			var datePickerFocusButton = new Button
+			{
+				Text = "Set focus on DatePicker"
+			};
+
+			var datepicker = new DatePicker();
+
+			var timePickerFocusButton = new Button
+			{
+				Text = "Set focus on TimePicker"
+			};
+
+			var timePicker = new TimePicker();
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(datePickerFocusButton);
+			layout.Children.Add(datepicker);
+			layout.Children.Add(timePickerFocusButton);
+			layout.Children.Add(timePicker);
+
+			Content = layout;
+
+			datePickerFocusButton.Clicked += (sender, args) =>
+			{
+				datepicker.Focus();
+			};
+
+			timePickerFocusButton.Clicked += (sender, args) =>
+			{
+				timePicker.Focus();
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -16,6 +16,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/TimePickerRenderer.cs
@@ -6,6 +6,7 @@ using Windows.UI.Xaml.Controls;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
+using Windows.UI.Xaml.Controls.Primitives;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -50,6 +51,18 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateCharacterSpacing();
 				UpdateFlowDirection();
 			}
+		}
+
+		internal override void OnElementFocusChangeRequested(object sender, VisualElement.FocusRequestArgs args)
+		{
+			base.OnElementFocusChangeRequested(sender, args);
+
+			// Show a picker fly out on focus to match iOS and Android behavior
+			var flyout = new TimePickerFlyout { Placement = FlyoutPlacementMode.Bottom, Time = Control.Time };
+			flyout.TimePicked += (p, e) => Control.Time = p.Time;
+			if (!Element.IsVisible)
+				flyout.Placement = FlyoutPlacementMode.Full;
+			flyout.ShowAt(Control);
 		}
 
 		void ControlOnLoaded(object sender, RoutedEventArgs routedEventArgs)


### PR DESCRIPTION
### Description of Change ###

 Open DatePicker and TimePicker Popup getting the focus on UWP. In this way the behavior is the same as in Android and iOS.

### Issues Resolved ### 

- fixes #10909 

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

Not applicable

### Before/After Screenshots ### 
![fix10909](https://user-images.githubusercontent.com/6755973/83418573-1ec18b80-a424-11ea-957a-006ba728f745.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10909. If pressing the buttons opens the popup of both DatePicker and TimePicker, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
