### PR TITLE
[iOS] Fix disable and enable RefreshView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10699.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10699.cs
@@ -1,0 +1,56 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10699, "RefreshView IsEnabled Binding not updating", PlatformAffected.iOS)]
+	public class Issue10699 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var refreshView = new RefreshView();
+
+			var layout = new StackLayout
+			{
+				Padding = new Thickness(30)
+			};
+
+			var checkbox = new CheckBox
+			{
+				IsChecked = refreshView.IsEnabled
+			};
+
+			checkbox.CheckedChanged += (s, e) =>
+			{
+				refreshView.IsEnabled = checkbox.IsChecked;
+			};
+
+			layout.Children.Add(new Label { Text = "Pull to refresh, then uncheck and check the checkbox. Trying pull to refresh again should work" });
+			layout.Children.Add(checkbox);
+
+			refreshView.Content = new ScrollView
+			{
+				Content = layout
+			};
+
+			refreshView.Command = new Command(async () =>
+			{
+				await Task.Delay(1000);
+				refreshView.IsRefreshing = false;
+			});
+
+			Content = refreshView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -795,6 +795,7 @@
       <SubType>Code</SubType>
       <DependentUpon>Issue9827.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10699.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -145,6 +145,34 @@ namespace Xamarin.Forms.Platform.iOS
 			return false;
 		}
 
+		bool TryRemoveRefresh(UIView view, int index = 0)
+		{
+			_refreshControlParent = view;
+
+			if (_refreshControl.Superview != null)
+				_refreshControl.RemoveFromSuperview();
+
+			if (view is UIScrollView scrollView)
+			{
+				if (CanUseRefreshControlProperty())
+					scrollView.RefreshControl = null;
+
+				return true;
+			}
+
+			if (view.Subviews == null)
+				return false;
+
+			for (int i = 0; i < view.Subviews.Length; i++)
+			{
+				var control = view.Subviews[i];
+				if (TryRemoveRefresh(control, i))
+					return true;
+			}
+
+			return false;
+		}
+
 		bool TryInsertRefresh(UIView view, int index = 0)
 		{
 			_refreshControlParent = view;
@@ -212,10 +240,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (isRefreshViewEnabled)
 				TryInsertRefresh(_refreshControlParent);
 			else
-			{
-				if (_refreshControl.Superview != null)
-					_refreshControl.RemoveFromSuperview();
-			}
+				TryRemoveRefresh(_refreshControlParent);
 
 			UserInteractionEnabled = true;
 		}


### PR DESCRIPTION
### Description of Change ###

We were removing the RefreshControl from the SuperView but not clearing the `RefreshControl` property on the `UIScrollView`, 

### Issues Resolved ### 

- fixes #10699 

### API Changes ###

 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

RefreshView should work after disable and enable it on ScrollView.
Gto to Issue 10699
Pull to refresh
Uncheck and check the checkox (this will toggle the RefreshView to Disable and Enable)
Try Pull to refresh again 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
