### PR TITLE
Add null check when tearing down element in UWP SelectableItemsViewRenderer

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.UWP
 			
 		void UpdateFormsSelection()
 		{
-			if (_ignoreNativeSelectionChange)
+			if (_ignoreNativeSelectionChange || ItemsView == null)
 			{
 				return;
 			}


### PR DESCRIPTION
### Description of Change ###

Navigating away from a page on UWP with a CollectionView which has selected items is crashing.
This change adds the missing null check to prevent that.

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Navigate to Control Gallery -> CollectionView Galleries -> Selection Galleries -> Multiple Selection, Bound. Then navigate back. If the app doesn't crash, this fix is working.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
