### PR TITLE
Fix incorrect shadow draw with disabled button

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml
@@ -1,10 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-            xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-            x:Class="Xamarin.Forms.Controls.Issues.VisualControlsPage"
-            Visual="Material">
+<local:TestShell  
+    xmlns:local="clr-namespace:Xamarin.Forms.Controls" xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.VisualControlsPage"
+    Visual="Material">
 
-    <ContentPage.Resources>
+    <Shell.Resources>
         <ResourceDictionary>
             <Color x:Key="PrimaryColor">#673AB7</Color>
             <Color x:Key="SecondaryColor">#448AFF</Color>
@@ -12,285 +13,301 @@
             <Color x:Key="DarkRedColor">#D32F2F</Color>
             <Color x:Key="LightRedColor">#FFCDD2</Color>
         </ResourceDictionary>
-    </ContentPage.Resources>
+    </Shell.Resources>
 
-    <ScrollView>
-        <StackLayout Spacing="20" Padding="10">
+    <FlyoutItem Title="Visual Gallery">
+        <ContentPage>
+            <ScrollView>
+                <StackLayout Spacing="20" Padding="10">
 
-			<Label Text="Activity Indicators" FontSize="Large" />
+                    <Label Text="Activity Indicators" FontSize="Large" />
 
-            <Label Text="Default" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <ActivityIndicator IsRunning="true" HorizontalOptions="FillAndExpand" />
-                <ActivityIndicator IsRunning="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
+                    <Label Text="Default" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <ActivityIndicator IsRunning="true" HorizontalOptions="FillAndExpand" />
+                        <ActivityIndicator IsRunning="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
 
-            <Label Text="Custom Primary Color" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <ActivityIndicator Color="{StaticResource PrimaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
-                <ActivityIndicator Color="{StaticResource PrimaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
+                    <Label Text="Custom Primary Color" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <ActivityIndicator Color="{StaticResource PrimaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
+                        <ActivityIndicator Color="{StaticResource PrimaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
 
-            <Label Text="Custom Background Color + Height 200" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <ActivityIndicator HeightRequest="200" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
-                <ActivityIndicator HeightRequest="200" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
+                    <Label Text="Custom Background Color + Height 200" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <ActivityIndicator HeightRequest="200" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
+                        <ActivityIndicator HeightRequest="200" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
 
-            <Label Text="Custom + Height 144 (Max)" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal" BackgroundColor="Lime">
-                <ActivityIndicator HeightRequest="144" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
-                <ActivityIndicator HeightRequest="144" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
+                    <Label Text="Custom + Height 144 (Max)" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal" BackgroundColor="Lime">
+                        <ActivityIndicator HeightRequest="144" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
+                        <ActivityIndicator HeightRequest="144" Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
 
-            <Label Text="Default size" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal" BackgroundColor="Yellow">
-                <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
-                <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
+                    <Label Text="Default size" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal" BackgroundColor="Yellow">
+                        <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="true" HorizontalOptions="FillAndExpand" />
+                        <ActivityIndicator Color="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" IsRunning="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
 
-            <Label Text="Progress Bars" FontSize="Large" />
+                    <Label Text="Progress Bars" FontSize="Large" />
 
-            <Label Text="Animating" Margin="0,0,0,-10" />
-            <ProgressBar Progress="{Binding PercentageCounter}" />
+                    <Label Text="Animating" Margin="0,0,0,-10" />
+                    <ProgressBar Progress="{Binding PercentageCounter}" />
 
-            <Label Text="At 50%" Margin="0,0,0,-10" />
-            <ProgressBar Progress="0.5" />
+                    <Label Text="At 50%" Margin="0,0,0,-10" />
+                    <ProgressBar Progress="0.5" />
 
-            <Label Text="At 0%" Margin="0,0,0,-10" />
-            <ProgressBar />
+                    <Label Text="At 0%" Margin="0,0,0,-10" />
+                    <ProgressBar />
 
-            <Label Text="Custom Primary Color" Margin="0,0,0,-10" />
-            <ProgressBar Progress="0.5" ProgressColor="{StaticResource PrimaryColor}" />
+                    <Label Text="Custom Primary Color" Margin="0,0,0,-10" />
+                    <ProgressBar Progress="0.5" ProgressColor="{StaticResource PrimaryColor}" />
 
-            <Label Text="Custom Background Color" Margin="0,0,0,-10" />
-            <ProgressBar Progress="0.5" BackgroundColor="{StaticResource SecondaryColor}" />
+                    <Label Text="Custom Background Color" Margin="0,0,0,-10" />
+                    <ProgressBar Progress="0.5" BackgroundColor="{StaticResource SecondaryColor}" />
 
-            <Label Text="Custom" Margin="0,0,0,-10" />
-            <ProgressBar Progress="0.5" ProgressColor="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" />
+                    <Label Text="Custom" Margin="0,0,0,-10" />
+                    <ProgressBar Progress="0.5" ProgressColor="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" />
 
-            <Label Text="Height 20" Margin="0,0,0,-10" />
-            <ProgressBar Progress="0.5" HeightRequest="20" ProgressColor="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" />
-
-
-            <Label Text="Buttons" FontSize="Large" />
-
-            <Label Text="Default" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <Button Text="Enabled" HorizontalOptions="FillAndExpand" />
-                <Button Text="Disabled" IsEnabled="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
-
-            <Label Text="Image" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <Button Image="bank.png" Text="Enabled" HorizontalOptions="FillAndExpand" />
-                <Button Image="bank.png" Text="Disabled" IsEnabled="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
-
-            <Label Text="Custom Background" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <Button Text="Enabled" BackgroundColor="{StaticResource PrimaryColor}" HorizontalOptions="FillAndExpand" />
-                <Button Text="Disabled" BackgroundColor="{StaticResource PrimaryColor}" IsEnabled="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
-
-            <Label Text="Custom Text" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <Button Text="Enabled" TextColor="{StaticResource LightRedColor}" HorizontalOptions="FillAndExpand" />
-                <Button Text="Disabled" TextColor="{StaticResource LightRedColor}" IsEnabled="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
-
-            <Label Text="Custom Text &amp; Image" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <Button Image="bank.png" Text="Enabled" TextColor="{StaticResource LightRedColor}" HorizontalOptions="FillAndExpand" />
-                <Button Image="bank.png" Text="Disabled" TextColor="{StaticResource LightRedColor}" IsEnabled="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
-
-            <Label Text="Custom Background &amp; Border" Margin="0,0,0,-10" />
-            <StackLayout Orientation="Horizontal">
-                <Button Text="Enabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="{StaticResource SecondaryColor}" BorderWidth="1" HorizontalOptions="FillAndExpand" />
-                <Button Text="Disabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="{StaticResource SecondaryColor}" BorderWidth="1" IsEnabled="false" HorizontalOptions="FillAndExpand" />
-            </StackLayout>
+                    <Label Text="Height 20" Margin="0,0,0,-10" />
+                    <ProgressBar Progress="0.5" HeightRequest="20" ProgressColor="{StaticResource PrimaryColor}" BackgroundColor="{StaticResource SecondaryColor}" />
 
 
-            <Label Text="Cards" FontSize="Large" />
+                    <Label Text="Buttons" FontSize="Large" />
 
-            <Label Text="Default" Margin="0,0,0,-10" />
-            <Frame Padding="16">
-                <StackLayout Spacing="16">
-                    <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
-                    <Label Text="Walk below the arches" FontSize="24" />
-                    <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
+                    <Label Text="Default" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Enabled" HorizontalOptions="FillAndExpand" />
+                        <Button Text="Disabled" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+
+                    <Label Text="Image" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Image="bank.png" Text="Enabled" HorizontalOptions="FillAndExpand" />
+                        <Button Image="bank.png" Text="Disabled" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+
+                    <Label Text="Custom Background" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Enabled" BackgroundColor="{StaticResource PrimaryColor}" HorizontalOptions="FillAndExpand" />
+                        <Button Text="Disabled" BackgroundColor="{StaticResource PrimaryColor}" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+
+                    <Label Text="Custom Text" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Enabled" TextColor="{StaticResource LightRedColor}" HorizontalOptions="FillAndExpand" />
+                        <Button Text="Disabled" TextColor="{StaticResource LightRedColor}" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+
+                    <Label Text="Custom Text &amp; Image" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Image="bank.png" Text="Enabled" TextColor="{StaticResource LightRedColor}" HorizontalOptions="FillAndExpand" />
+                        <Button Image="bank.png" Text="Disabled" TextColor="{StaticResource LightRedColor}" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+
+                    <Label Text="Custom Background &amp; Border" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Enabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="{StaticResource SecondaryColor}" BorderWidth="1" HorizontalOptions="FillAndExpand" />
+                        <Button Text="Disabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="{StaticResource SecondaryColor}" BorderWidth="1" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+
+
+                    <Label Text="Cards" FontSize="Large" />
+
+                    <Label Text="Default" Margin="0,0,0,-10" />
+                    <Frame Padding="16">
+                        <StackLayout Spacing="16">
+                            <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
+                            <Label Text="Walk below the arches" FontSize="24" />
+                            <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
                            TextColor="{StaticResource SecondaryTextColor}" FontSize="14" />
-                    <Button Text="more" HorizontalOptions="End" />
-                </StackLayout>
-            </Frame>
+                            <Button Text="more" HorizontalOptions="End" />
+                        </StackLayout>
+                    </Frame>
 
-            <Label Text="Default (No Shadow)" Margin="0,0,0,-10" />
-            <Frame Padding="16" HasShadow="false">
-                <StackLayout Spacing="16">
-                    <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
-                    <Label Text="Walk below the arches" FontSize="24" />
-                    <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
+                    <Label Text="Default (No Shadow)" Margin="0,0,0,-10" />
+                    <Frame Padding="16" HasShadow="false">
+                        <StackLayout Spacing="16">
+                            <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
+                            <Label Text="Walk below the arches" FontSize="24" />
+                            <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
                            TextColor="{StaticResource SecondaryTextColor}" FontSize="14" />
-                    <Button Text="more" HorizontalOptions="End" />
-                </StackLayout>
-            </Frame>
+                            <Button Text="more" HorizontalOptions="End" />
+                        </StackLayout>
+                    </Frame>
 
-            <Label Text="Default With Border" Margin="0,0,0,-10" />
-            <Frame Padding="16" BorderColor="{StaticResource DarkRedColor}">
-                <StackLayout Spacing="16">
-                    <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
-                    <Label Text="Walk below the arches" FontSize="24" />
-                    <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
+                    <Label Text="Default With Border" Margin="0,0,0,-10" />
+                    <Frame Padding="16" BorderColor="{StaticResource DarkRedColor}">
+                        <StackLayout Spacing="16">
+                            <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
+                            <Label Text="Walk below the arches" FontSize="24" />
+                            <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
                            TextColor="{StaticResource SecondaryTextColor}" FontSize="14" />
-                    <Button Text="more" HorizontalOptions="End" />
-                </StackLayout>
-            </Frame>
+                            <Button Text="more" HorizontalOptions="End" />
+                        </StackLayout>
+                    </Frame>
 
-            <Label Text="Default With Border (No Shadow, CornerRadius 0)" Margin="0,0,0,-10" />
-            <Frame CornerRadius="0" Padding="16" BorderColor="{StaticResource DarkRedColor}" HasShadow="false">
-                <StackLayout Spacing="16">
-                    <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
-                    <Label Text="Walk below the arches" FontSize="24" />
-                    <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
+                    <Label Text="Default With Border (No Shadow, CornerRadius 0)" Margin="0,0,0,-10" />
+                    <Frame CornerRadius="0" Padding="16" BorderColor="{StaticResource DarkRedColor}" HasShadow="false">
+                        <StackLayout Spacing="16">
+                            <Image Source="photo.jpg" Margin="-16,-16,-16,0" Aspect="AspectFit" />
+                            <Label Text="Walk below the arches" FontSize="24" />
+                            <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
                            TextColor="{StaticResource SecondaryTextColor}" FontSize="14" />
-                    <Button Text="more" HorizontalOptions="End" />
-                </StackLayout>
-            </Frame>
+                            <Button Text="more" HorizontalOptions="End" />
+                        </StackLayout>
+                    </Frame>
 
-            <Label Text="No Card Padding &amp; Thin Content Padding &amp; CornerRadius 15" Margin="0,0,0,-10" />
-            <Frame CornerRadius="15" Padding="0" BorderColor="{StaticResource DarkRedColor}">
-                <StackLayout Spacing="16" BackgroundColor="{StaticResource LightRedColor}" Padding="8">
-                    <Image Source="photo.jpg" Margin="-8,-8,-8,0" Aspect="AspectFit" />
-                    <Label Text="Walk below the arches" FontSize="24" />
-                    <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
+                    <Label Text="No Card Padding &amp; Thin Content Padding &amp; CornerRadius 15" Margin="0,0,0,-10" />
+                    <Frame CornerRadius="15" Padding="0" BorderColor="{StaticResource DarkRedColor}">
+                        <StackLayout Spacing="16" BackgroundColor="{StaticResource LightRedColor}" Padding="8">
+                            <Image Source="photo.jpg" Margin="-8,-8,-8,0" Aspect="AspectFit" />
+                            <Label Text="Walk below the arches" FontSize="24" />
+                            <Label Text="Card containers hold all card elements, and their size is determined by the space those elements occupy. Card elevation is expressed by the container."
                            TextColor="{StaticResource SecondaryTextColor}" FontSize="14" />
-                    <Button Text="more" HorizontalOptions="End" />
-                </StackLayout>
-            </Frame>
+                            <Button Text="more" HorizontalOptions="End" />
+                        </StackLayout>
+                    </Frame>
 
-            <Label Text="No Padding / Spacing" Margin="0,0,0,-10" />
-            <Frame BackgroundColor="{StaticResource LightRedColor}" Margin="0" Padding="0" HasShadow="true" CornerRadius="10" BorderColor="{StaticResource DarkRedColor}">
-                <StackLayout Spacing="16" Margin="0" Padding="0">
-                    <Label Text="Customized Card" FontSize="24" />
-                    <Image Source="photo.jpg" Margin="-16,0" Aspect="AspectFit" />
-                    <Label Text="This card has a few changes to its appearance to test whether or not changing properties is supported."
+                    <Label Text="No Padding / Spacing" Margin="0,0,0,-10" />
+                    <Frame BackgroundColor="{StaticResource LightRedColor}" Margin="0" Padding="0" HasShadow="true" CornerRadius="10" BorderColor="{StaticResource DarkRedColor}">
+                        <StackLayout Spacing="16" Margin="0" Padding="0">
+                            <Label Text="Customized Card" FontSize="24" />
+                            <Image Source="photo.jpg" Margin="-16,0" Aspect="AspectFit" />
+                            <Label Text="This card has a few changes to its appearance to test whether or not changing properties is supported."
                            TextColor="{StaticResource SecondaryTextColor}" FontSize="14" />
-                    <Button Text="more" HorizontalOptions="End" BackgroundColor="{StaticResource PrimaryColor}" />
-                </StackLayout>
-            </Frame>
+                            <Button Text="more" HorizontalOptions="End" BackgroundColor="{StaticResource PrimaryColor}" />
+                        </StackLayout>
+                    </Frame>
 
 
-			<Label Text="Entries" FontSize="Large" />
-			<Label Text="Default" Margin="0,0,0,-10" />
+                    <Label Text="Entries" FontSize="Large" />
+                    <Label Text="Default" Margin="0,0,0,-10" />
 
-			<StackLayout Orientation="Horizontal">
-				<Entry Placeholder="Default Entry" Text="With Text" HorizontalOptions="FillAndExpand"  />
-				<Entry Placeholder="Default Entry" HorizontalOptions="FillAndExpand"  />
-			</StackLayout>
+                    <StackLayout Orientation="Horizontal">
+                        <Entry Placeholder="Default Entry" Text="With Text" HorizontalOptions="FillAndExpand"  />
+                        <Entry Placeholder="Default Entry" HorizontalOptions="FillAndExpand"  />
+                    </StackLayout>
 
-			<Label Text="Placeholder Color Variations" Margin="0,0,0,-10" />
+                    <Label Text="Placeholder Color Variations" Margin="0,0,0,-10" />
 
-			<StackLayout Orientation="Horizontal">
-				<Entry Placeholder="Green Placeholder" PlaceholderColor="Green" HorizontalOptions="FillAndExpand"  />
-				<Entry Placeholder="Purple Placeholder" PlaceholderColor="Purple" HorizontalOptions="FillAndExpand"  />
-			</StackLayout>
+                    <StackLayout Orientation="Horizontal">
+                        <Entry Placeholder="Green Placeholder" PlaceholderColor="Green" HorizontalOptions="FillAndExpand"  />
+                        <Entry Placeholder="Purple Placeholder" PlaceholderColor="Purple" HorizontalOptions="FillAndExpand"  />
+                    </StackLayout>
 
-			<Label Text="Text Color Variations" Margin="0,0,0,-10" />
+                    <Label Text="Text Color Variations" Margin="0,0,0,-10" />
 
-			<StackLayout Orientation="Horizontal">
-				<Entry TextColor="Green" Text="Green Text Color" HorizontalOptions="FillAndExpand"  />
-				<Entry TextColor="Purple" Text="Purple Text Color"  HorizontalOptions="FillAndExpand"  />
-			</StackLayout>
+                    <StackLayout Orientation="Horizontal">
+                        <Entry TextColor="Green" Text="Green Text Color" HorizontalOptions="FillAndExpand"  />
+                        <Entry TextColor="Purple" Text="Purple Text Color"  HorizontalOptions="FillAndExpand"  />
+                    </StackLayout>
 
-			<StackLayout Orientation="Horizontal">
-				<Entry TextColor="Green" Placeholder="Green Text Color" HorizontalOptions="FillAndExpand"  />
-				<Entry TextColor="Purple" Placeholder="Purple Text Color"  HorizontalOptions="FillAndExpand"  />
-			</StackLayout>
-
-
-			<Label Text="Background Color Variations" Margin="0,0,0,-10" />
-
-			<StackLayout Orientation="Horizontal">
-				<Entry BackgroundColor="Yellow" Text="Yellow Background Color" HorizontalOptions="FillAndExpand"  />
-				<Entry BackgroundColor="Cyan" Text="Cyan Background Color"  HorizontalOptions="FillAndExpand"  />
-			</StackLayout>
+                    <StackLayout Orientation="Horizontal">
+                        <Entry TextColor="Green" Placeholder="Green Text Color" HorizontalOptions="FillAndExpand"  />
+                        <Entry TextColor="Purple" Placeholder="Purple Text Color"  HorizontalOptions="FillAndExpand"  />
+                    </StackLayout>
 
 
+                    <Label Text="Background Color Variations" Margin="0,0,0,-10" />
 
-			<Label Text="Sliders" FontSize="Large" />
+                    <StackLayout Orientation="Horizontal">
+                        <Entry BackgroundColor="Yellow" Text="Yellow Background Color" HorizontalOptions="FillAndExpand"  />
+                        <Entry BackgroundColor="Cyan" Text="Cyan Background Color"  HorizontalOptions="FillAndExpand"  />
+                    </StackLayout>
 
 
-            <Label Text="Default" Margin="0,0,0,-10" />
-            <Slider Minimum="-100" Maximum="100" />
 
-            <Label Text="Default (Disabled)" Margin="0,0,0,-10" />
-            <Slider Minimum="-100" Maximum="100" IsEnabled="false" />
+                    <Label Text="Sliders" FontSize="Large" />
 
-            <Label Text="Custom Primary Color" Margin="0,0,0,-10" />
-            <Slider Minimum="-100" Maximum="100"
+
+                    <Label Text="Default" Margin="0,0,0,-10" />
+                    <Slider Minimum="-100" Maximum="100" />
+
+                    <Label Text="Default (Disabled)" Margin="0,0,0,-10" />
+                    <Slider Minimum="-100" Maximum="100" IsEnabled="false" />
+
+                    <Label Text="Custom Primary Color" Margin="0,0,0,-10" />
+                    <Slider Minimum="-100" Maximum="100"
                     ThumbColor="{StaticResource PrimaryColor}" MinimumTrackColor="{StaticResource PrimaryColor}" />
 
-            <Label Text="Custom Primary Color (Disabled)" Margin="0,0,0,-10" />
-            <Slider Minimum="-100" Maximum="100" IsEnabled="false"
+                    <Label Text="Custom Primary Color (Disabled)" Margin="0,0,0,-10" />
+                    <Slider Minimum="-100" Maximum="100" IsEnabled="false"
                     ThumbColor="{StaticResource PrimaryColor}" MaximumTrackColor="{StaticResource PrimaryColor}" MinimumTrackColor="{StaticResource PrimaryColor}" />
 
-            <Label Text="Custom" Margin="0,0,0,-10" />
-            <Slider Minimum="-100" Maximum="100"
+                    <Label Text="Custom" Margin="0,0,0,-10" />
+                    <Slider Minimum="-100" Maximum="100"
                     ThumbColor="{StaticResource DarkRedColor}" MaximumTrackColor="{StaticResource SecondaryColor}" MinimumTrackColor="{StaticResource PrimaryColor}" />
 
-            <Label Text="Custom (Disabled)" Margin="0,0,0,-10" />
-            <Slider Minimum="-100" Maximum="100" IsEnabled="false"
+                    <Label Text="Custom (Disabled)" Margin="0,0,0,-10" />
+                    <Slider Minimum="-100" Maximum="100" IsEnabled="false"
                     ThumbColor="{StaticResource DarkRedColor}" MaximumTrackColor="{StaticResource SecondaryColor}" MinimumTrackColor="{StaticResource PrimaryColor}" />
 
 
-            <Label Text="Pickers" FontSize="Large"></Label>
-            <Label Text="Date Picker" Margin="0,0,0,-10" />
-            <DatePicker></DatePicker>
-            <Label Text="Time Picker" Margin="0,0,0,-10" />
-            <TimePicker></TimePicker>
-            <Label Text="Picker" Margin="0,0,0,-10" />
-            <Picker Title="Select a monkey">
-                <Picker.ItemsSource>
-                    <x:Array Type="{x:Type x:String}">
-                        <x:String>Baboon</x:String>
-                        <x:String>Capuchin Monkey</x:String>
-                        <x:String>Blue Monkey</x:String>
-                        <x:String>Squirrel Monkey</x:String>
-                        <x:String>Golden Lion Tamarin</x:String>
-                        <x:String>Howler Monkey</x:String>
-                        <x:String>Japanese Macaque</x:String>
-                    </x:Array>
-                </Picker.ItemsSource>
-            </Picker>
-            
-            <Label Text="Steppers" FontSize="Large" />
-            <Label Text="Default" Margin="0,0,0,-10" />
-            <Stepper HorizontalOptions="Start" />
+                    <Label Text="Pickers" FontSize="Large"></Label>
+                    <Label Text="Date Picker" Margin="0,0,0,-10" />
+                    <DatePicker></DatePicker>
+                    <Label Text="Time Picker" Margin="0,0,0,-10" />
+                    <TimePicker></TimePicker>
+                    <Label Text="Picker" Margin="0,0,0,-10" />
+                    <Picker Title="Select a monkey">
+                        <Picker.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>Baboon</x:String>
+                                <x:String>Capuchin Monkey</x:String>
+                                <x:String>Blue Monkey</x:String>
+                                <x:String>Squirrel Monkey</x:String>
+                                <x:String>Golden Lion Tamarin</x:String>
+                                <x:String>Howler Monkey</x:String>
+                                <x:String>Japanese Macaque</x:String>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
 
-            <Label Text="Height 100" Margin="0,0,0,-10" />
-            <Stepper HeightRequest="100"></Stepper>
-            
-            <Label Text="Red background" Margin="0,0,0,-10" />
-            <Stepper BackgroundColor="Red"></Stepper>
-            
-            <Label Text="Editors" FontSize="Large"></Label>
-            <Label Text="Normal" Margin="0,0,0,-10" />
-            <Editor HeightRequest="200"></Editor>
-            <Label Text="Place Holder" Margin="0,0,0,-10" />
-            <Editor Placeholder="Place Holder" HeightRequest="200"></Editor>
+                    <Label Text="Steppers" FontSize="Large" />
+                    <Label Text="Default" Margin="0,0,0,-10" />
+                    <Stepper HorizontalOptions="Start" />
 
-            <Label Text="CheckBox" FontSize="Large"></Label>
-            <Label Text="Normal" Margin="0,0,0,-10" />
-            <CheckBox  />
-            <Label Text="Normal Checked" Margin="0,0,0,-10" />
-            <CheckBox IsChecked="True" />
-            <Label Text="Disabled" Margin="0,0,0,-10" />
-            <CheckBox IsEnabled="False" />
-            <Label Text="Disabled Checked" Margin="0,0,0,-10" />
-            <CheckBox IsEnabled="False" IsChecked="True" />
-            
-        </StackLayout>
-    </ScrollView>
+                    <Label Text="Height 100" Margin="0,0,0,-10" />
+                    <Stepper HeightRequest="100"></Stepper>
 
-</ContentPage>
+                    <Label Text="Red background" Margin="0,0,0,-10" />
+                    <Stepper BackgroundColor="Red"></Stepper>
+
+                    <Label Text="Editors" FontSize="Large"></Label>
+                    <Label Text="Normal" Margin="0,0,0,-10" />
+                    <Editor HeightRequest="200"></Editor>
+                    <Label Text="Place Holder" Margin="0,0,0,-10" />
+                    <Editor Placeholder="Place Holder" HeightRequest="200"></Editor>
+
+                    <Label Text="CheckBox" FontSize="Large"></Label>
+                    <Label Text="Normal" Margin="0,0,0,-10" />
+                    <CheckBox  />
+                    <Label Text="Normal Checked" Margin="0,0,0,-10" />
+                    <CheckBox IsChecked="True" />
+                    <Label Text="Disabled" Margin="0,0,0,-10" />
+                    <CheckBox IsEnabled="False" />
+                    <Label Text="Disabled Checked" Margin="0,0,0,-10" />
+                    <CheckBox IsEnabled="False" IsChecked="True" />
+
+                </StackLayout>
+            </ScrollView>
+        </ContentPage>
+    </FlyoutItem>
+    <FlyoutItem Title="Disabled Button Test">
+        <ContentPage>
+            <ScrollView>
+                <StackLayout Spacing="20" Padding="10" BackgroundColor="White">
+                    <Label Text="If either button looks odd this test has failed." Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Horizontal">
+                        <Button Text="Enabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="#b19cd9" BorderWidth="1" HorizontalOptions="FillAndExpand" />
+                        <Button Text="Disabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="#b19cd9" BorderWidth="1" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+                </StackLayout>
+            </ScrollView>
+        </ContentPage>
+    </FlyoutItem>
+</local:TestShell>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	public partial class VisualControlsPage : ContentPage
+	public partial class VisualControlsPage : TestShell
 	{
 		bool isVisible = false;
 		double percentage = 0.0;
@@ -20,7 +20,9 @@ namespace Xamarin.Forms.Controls.Issues
 #if APP
 			InitializeComponent();
 #endif
-
+		}
+		protected override void Init()
+		{
 			BindingContext = this;
 		}
 
@@ -61,54 +63,38 @@ namespace Xamarin.Forms.Controls.Issues
 
 			base.OnDisappearing();
 		}
-	}
 
 
 
-	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 4435, "Visual Gallery Loads",
-		PlatformAffected.iOS | PlatformAffected.Android)]
+
+		[Preserve(AllMembers = true)]
+		[Issue(IssueTracker.Github, 4435, "Visual Gallery Loads",
+			PlatformAffected.iOS | PlatformAffected.Android)]
 #if UITEST
-	[NUnit.Framework.Category(UITestCategories.Visual)]
+		[NUnit.Framework.Category(UITestCategories.Visual)]
 #endif
-	public class Issue4435 : TestNavigationPage
-	{
-		const string Success = "Success";
-		Label successLabel;
-		protected override void Init()
+		public class Issue4435 : VisualControlsPage
 		{
-			var vg = new VisualControlsPage();
-			successLabel = new Label();
-			vg.Appearing += Vg_Appearing;
-			PushAsync(new ContentPage()
+			protected override void Init()
 			{
-				Content = new StackLayout()
-				{
-					Children =
-					{
-						successLabel
-					}
-				}
-			});
-
-			PushAsync(vg);
-		}
-
-		private void Vg_Appearing(object sender, EventArgs e)
-		{
-			Device.BeginInvokeOnMainThread(() =>
-			{
-				PopAsync();
-				successLabel.Text = Success;
-			});
-		}
+			}
 
 #if UITEST && !__WINDOWS__
-		[Test]
-		public void LoadingVisualGalleryPageDoesNotCrash()
-		{
-			RunningApp.WaitForElement(Success);
-		}
+			[Test]
+			public void LoadingVisualGalleryPageDoesNotCrash()
+			{
+				RunningApp.WaitForElement("Activity Indicators");
+			}
+
+			[Test]
+			[NUnit.Framework.Category(UITestCategories.ManualReview)]
+			public void DisabledButtonTest()
+			{
+				TapInFlyout("Disabled Button Test");
+				RunningApp.WaitForElement("If either button looks odd this test has failed.");
+				RunningApp.Screenshot("If either button looks off (wrong shadow, border drawn inside button) the test has failed.");
+			}
 #endif
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementPackager.cs
@@ -187,7 +187,8 @@ namespace Xamarin.Forms.Platform.Android
 								if (elevation > elevationToSet)
 									elevationToSet = elevation;
 
-								r.View.Elevation = elevationToSet;
+								if(r.View.Elevation != elevationToSet)
+									r.View.Elevation = elevationToSet;
 							}
 						}
 


### PR DESCRIPTION
### Description of Change ###

When you set the material button to disabled the Elevation on it gets set to zero. AFAICT if you set it to disabled before it draws then it looks like a shadow still gets drawn on the parent control even though the elevation is zero. On the test case if you remove the button that's on the left the issue doesn't happen. If you make a change the XAML so it reloads the control then on the second load the button looks fine. It looks like a very specific timing issue. 

With this change if a control is initialized as disabled then I delay setting it to disabled until the first draw and then I set it to disabled. 

### Before/After Screenshots ### 
Before

![image](https://user-images.githubusercontent.com/5375137/83461705-a01a1d80-a426-11ea-8b0a-0138c19c17be.png)

After

![image](https://user-images.githubusercontent.com/5375137/83461722-a9a38580-a426-11ea-847a-665ec7088c86.png)


### Testing Procedure ###
- I've included a manual test

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
