### PR TITLE
[HR] register sourceinfo before triggering change

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/CreateObjectVisitor.cs
@@ -58,7 +58,7 @@ namespace Xamarin.Forms.Build.Tasks
 				Context.Body.Variables.Add(vardef);
 
 				Context.IL.Append(PushValueFromLanguagePrimitive(typedef, node));
-				Context.IL.Emit(OpCodes.Stloc, vardef);
+				Context.IL.Emit(Stloc, vardef);
 				return;
 			}
 
@@ -80,13 +80,15 @@ namespace Xamarin.Forms.Build.Tasks
 				Context.Body.Variables.Add(vardef);
 
 				Context.IL.Append(il);
-				Context.IL.Emit(OpCodes.Stloc, vardef);
+				Context.IL.Emit(Stloc, vardef);
 
 				//clean the node as it has been fully exhausted
 				foreach (var prop in node.Properties)
 					if (!node.SkipProperties.Contains(prop.Key))
 						node.SkipProperties.Add(prop.Key);
 				node.CollectionItems.Clear();
+
+				Context.IL.Append(RegisterSourceInfo(Context, node));
 				return;
 			}
 
@@ -219,9 +221,11 @@ namespace Xamarin.Forms.Build.Tasks
 						if (!node.SkipProperties.Contains(prop.Key))
 							node.SkipProperties.Add(prop.Key);
 					node.CollectionItems.Clear();
+					Context.IL.Append(RegisterSourceInfo(Context, node));
 
 					return;
 				}
+				Context.IL.Append(RegisterSourceInfo(Context, node));
 			}
 		}
 
@@ -238,6 +242,7 @@ namespace Xamarin.Forms.Build.Tasks
 			Context.Body.Variables.Add(vardef);
 			Context.IL.Emit(OpCodes.Ldarg_0);
 			Context.IL.Emit(OpCodes.Stloc, vardef);
+			Context.IL.Append(RegisterSourceInfo(Context, node));
 		}
 
 		public void Visit(ListNode node, INode parentNode)
@@ -536,6 +541,54 @@ namespace Xamarin.Forms.Build.Tasks
 				}
 				break;
 			}
+		}
+
+		internal static IEnumerable<Instruction> RegisterSourceInfo(ILContext context, INode valueNode)
+		{
+			if (!context.DefineDebug)
+				yield break;
+			if (!(valueNode is IXmlLineInfo lineInfo))
+				yield break;
+			if (!(valueNode is IElementNode elementNode))
+				yield break;
+			if (context.Variables[elementNode].VariableType.IsValueType)
+				yield break;
+
+			var module = context.Body.Method.Module;
+
+			yield return Create(Ldloc, context.Variables[elementNode]);     //target
+
+			yield return Create(Ldstr, context.XamlFilePath);
+			yield return Create(Ldstr, ";assembly=");
+			yield return Create(Ldstr, context.Module.Assembly.Name.Name);
+			yield return Create(Call, module.ImportMethodReference(("mscorlib", "System", "String"),
+																   methodName: "Concat",
+																   parameterTypes: new[] {
+																	   ("mscorlib", "System", "String"),
+																	   ("mscorlib", "System", "String"),
+																	   ("mscorlib", "System", "String"),
+																   },
+																   isStatic: true));
+
+
+			yield return Create(Ldc_I4, (int)UriKind.RelativeOrAbsolute);
+			yield return Create(Newobj, module.ImportCtorReference(("System", "System", "Uri"),
+																   parameterTypes: new[] {
+																	   ("mscorlib", "System", "String"),
+																	   ("System", "System", "UriKind"),
+																   }));     //uri
+
+			yield return Create(Ldc_I4, lineInfo.LineNumber);               //lineNumber
+			yield return Create(Ldc_I4, lineInfo.LinePosition);             //linePosition
+
+			yield return Create(Call, module.ImportMethodReference(("Xamarin.Forms.Core", "Xamarin.Forms.Xaml.Diagnostics", "VisualDiagnostics"),
+																   methodName: "RegisterSourceInfo",
+																   parameterTypes: new[] {
+																	   ("mscorlib", "System", "Object"),
+																	   ("System", "System", "Uri"),
+																	   ("mscorlib", "System", "Int32"),
+																	   ("mscorlib", "System", "Int32")},
+																   isStatic: true));
 		}
 	}
 }

--- a/Xamarin.Forms.Build.Tasks/XamlCTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlCTask.cs
@@ -345,8 +345,6 @@ namespace Xamarin.Forms.Build.Tasks
 				rootnode.Accept(new SetResourcesVisitor(visitorContext), null);
 				rootnode.Accept(new SetPropertiesVisitor(visitorContext, true), null);
 
-				il.Append(SetPropertiesVisitor.RegisterSourceInfo(visitorContext, rootnode));
-
 				il.Emit(Ret);
 				initComp.Body = body;
 				exception = null;

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh10803.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh10803.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh10803">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="PersonTemplate">
+                <ViewCell>
+                    <StackLayout Orientation="Horizontal" Margin="5">
+                        <Label Text="{Binding FirstName}" />
+                        <Label Text="{Binding LastName}" />
+                    </StackLayout>
+                </ViewCell>
+            </DataTemplate>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ListView x:Name="listview" ItemsSource="{Binding Persons}" ItemTemplate="{StaticResource Key=PersonTemplate}" WidthRequest="400" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh10803.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh10803.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+using Xamarin.Forms.Xaml.Diagnostics;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh10803 : ContentPage
+	{
+		public Gh10803() => InitializeComponent();
+		public Gh10803(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			bool debuggerinitialstate;
+			int failures = 0;
+
+			[SetUp]
+			public void Setup()
+			{
+				Device.PlatformServices = new MockPlatformServices();
+				VisualDiagnostics.VisualTreeChanged += VTChanged;
+				debuggerinitialstate = Xamarin.Forms.Xaml.Diagnostics.DebuggerHelper._mockDebuggerIsAttached;
+				DebuggerHelper._mockDebuggerIsAttached = true;
+			}
+
+			[TearDown]
+			public void TearDown()
+			{
+				DebuggerHelper._mockDebuggerIsAttached = debuggerinitialstate;
+				Device.PlatformServices = null;
+				VisualDiagnostics.VisualTreeChanged -= VTChanged;
+				failures = 0;
+			}
+
+			[Test]
+			public void SourceInfoForElementsInDT([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new Gh10803(useCompiledXaml);
+				var listview = layout.listview;
+				var cell = listview.ItemTemplate.CreateContent();
+				Assert.That(failures, Is.EqualTo(0), "one or more element without source info");
+			}
+
+			void VTChanged(object sender, VisualTreeChangeEventArgs e)
+			{
+				var parentSourInfo = e.Parent == null ? null : VisualDiagnostics.GetXamlSourceInfo(e.Parent);
+				var childSourInfo = VisualDiagnostics.GetXamlSourceInfo(e.Child);
+				if (childSourInfo == null)
+					failures++;
+				if (e.Parent != null && parentSourInfo == null)
+					failures++;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
+++ b/Xamarin.Forms.Xaml/ApplyPropertiesVisitor.cs
@@ -344,27 +344,17 @@ namespace Xamarin.Forms.Xaml
 			if (xpe == null && TrySetBinding(xamlelement, property, localName, value, lineInfo, out xpe))
 				return;
 
-			var assemblyName = (context.RootAssembly ?? rootElement.GetType().GetTypeInfo().Assembly)?.GetName().Name;
 			//If it's a BindableProberty, SetValue
-			if (xpe == null && TrySetValue(xamlelement, property, attached, value, lineInfo, serviceProvider, out xpe)) {
-				if (!(node is ValueNode) && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(context.RootElement) is string path)
-					VisualDiagnostics.RegisterSourceInfo(value, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+			if (xpe == null && TrySetValue(xamlelement, property, attached, value, lineInfo, serviceProvider, out xpe))
 				return;
-			}
 
 			//If we can assign that value to a normal property, let's do it
-			if (xpe == null && TrySetProperty(xamlelement, localName, value, lineInfo, serviceProvider, context, out xpe)) {
-				if (!(node is ValueNode) && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(context.RootElement) is string path)
-					VisualDiagnostics.RegisterSourceInfo(value, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+			if (xpe == null && TrySetProperty(xamlelement, localName, value, lineInfo, serviceProvider, context, out xpe))
 				return;
-			}
 
 			//If it's an already initialized property, add to it
-			if (xpe == null && TryAddToProperty(xamlelement, propertyName, value, xKey, lineInfo, serviceProvider, context, out xpe)) {
-				if (!(node is ValueNode) && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(context.RootElement) is string path)
-					VisualDiagnostics.RegisterSourceInfo(value, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+			if (xpe == null && TryAddToProperty(xamlelement, propertyName, value, xKey, lineInfo, serviceProvider, context, out xpe))
 				return;
-			}
 
 			xpe = xpe ?? new XamlParseException($"Cannot assign property \"{localName}\": Property does not exist, or is not assignable, or mismatching type between value and property", lineInfo);
 			if (context.ExceptionHandler != null)

--- a/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
+++ b/Xamarin.Forms.Xaml/CreateValuesVisitor.cs
@@ -150,6 +150,11 @@ namespace Xamarin.Forms.Xaml
 					name = name.Substring(name.LastIndexOf(':') + 1);
 				XamlLoader.ValueCreatedCallback(new XamlLoader.CallbackTypeInfo { XmlNamespace = node.XmlType.NamespaceUri, XmlTypeName = name }, value);
 			}
+
+			var assemblyName = (Context.RootAssembly ?? Context.RootElement?.GetType().GetTypeInfo().Assembly)?.GetName().Name;
+			if (assemblyName != null && value != null && !value.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
+				Diagnostics.VisualDiagnostics.RegisterSourceInfo(value, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
+
 		}
 
 		public void Visit(RootNode node, INode parentNode)
@@ -163,6 +168,10 @@ namespace Xamarin.Forms.Xaml
 				else
 					NameScope.SetNameScope(bindable, node.NameScopeRef?.NameScope);
 			}
+
+			var assemblyName = (Context.RootAssembly ?? Context.RootElement.GetType().GetTypeInfo().Assembly)?.GetName().Name;
+			if (rnode.Root != null && !rnode.Root.GetType().GetTypeInfo().IsValueType && XamlFilePathAttribute.GetFilePathForObject(Context.RootElement) is string path)
+				Diagnostics.VisualDiagnostics.RegisterSourceInfo(rnode.Root, new Uri($"{path};assembly={assemblyName}", UriKind.Relative), ((IXmlLineInfo)node).LineNumber, ((IXmlLineInfo)node).LinePosition);
 		}
 
 		public void Visit(ListNode node, INode parentNode)

--- a/Xamarin.Forms.Xaml/XamlLoader.cs
+++ b/Xamarin.Forms.Xaml/XamlLoader.cs
@@ -91,10 +91,6 @@ namespace Xamarin.Forms.Xaml
 					}
 
 					var rootnode = new RuntimeRootNode(new XmlType(reader.NamespaceURI, reader.Name, null), view, (IXmlNamespaceResolver)reader) { LineNumber = ((IXmlLineInfo)reader).LineNumber, LinePosition = ((IXmlLineInfo)reader).LinePosition };
-					if (XamlFilePathAttribute.GetFilePathForObject(view) is string path) {
-						VisualDiagnostics.RegisterSourceInfo(view, new Uri($"{path};assembly={view.GetType().GetTypeInfo().Assembly.GetName().Name}", UriKind.Relative), ((IXmlLineInfo)rootnode).LineNumber, ((IXmlLineInfo)rootnode).LinePosition);
-						VisualDiagnostics.SendVisualTreeChanged(null, view);
-					}
 					XamlParser.ParseXaml(rootnode, reader);
 #pragma warning disable 0618
 					var doNotThrow = ResourceLoader.ExceptionHandler2 != null || Internals.XamlLoader.DoNotThrowOnExceptions;
@@ -105,6 +101,9 @@ namespace Xamarin.Forms.Xaml
 						RootAssembly = rootAssembly ?? view.GetType().GetTypeInfo().Assembly,
 						ExceptionHandler = doNotThrow ? ehandler : (Action<Exception>)null
 					}, useDesignProperties);
+
+					VisualDiagnostics.SendVisualTreeChanged(null, view);
+
 					break;
 				}
 			}
@@ -141,14 +140,10 @@ namespace Xamarin.Forms.Xaml
 					var cvv = new CreateValuesVisitor(visitorContext);
 					cvv.Visit((ElementNode)rootnode, null);
 					inflatedView = rootnode.Root = visitorContext.Values[rootnode];
-					if (XamlFilePathAttribute.GetFilePathForObject(inflatedView) is string path)
-					{
-						VisualDiagnostics.RegisterSourceInfo(inflatedView, new Uri($"{path};assembly={inflatedView.GetType().GetTypeInfo().Assembly.GetName().Name}", UriKind.Relative), ((IXmlLineInfo)rootnode).LineNumber, ((IXmlLineInfo)rootnode).LinePosition);
-						VisualDiagnostics.SendVisualTreeChanged(null, inflatedView);
-					}
 					visitorContext.RootElement = inflatedView as BindableObject;
 
 					Visit(rootnode, visitorContext, useDesignProperties);
+					VisualDiagnostics.SendVisualTreeChanged(null, inflatedView);
 					break;
 				}
 			}


### PR DESCRIPTION
### Description of Change ###

Register SourceInfo before triggering VisualStateChanged events.

Note that this flips a coin on a previously sketchy behaviour for types being ValuesProvider. Before this the value provided was registered (but doesn't match to any actual xaml element), now the xaml element is registered (and it doesn't match objects in the visual tree). This affects very little real life cases anyway.

previous behaviour was to register source info on the actual binding, now this will 
### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10803

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)

> VS bug [#1135102](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1135102)