### PR TITLE
Android Beta Builds

### DIFF
--- a/ControlGallery.Build.props
+++ b/ControlGallery.Build.props
@@ -1,0 +1,7 @@
+<Project>
+  <PropertyGroup>
+    <CGLangVersion Condition="'$(CGLangVersion)' == ''">7.3</CGLangVersion>
+    <LangVersion Condition="'$(Use2017)' == 'true'">7.3</LangVersion>
+    <LangVersion Condition="'$(LangVersion)' == ''">$(CGLangVersion)</LangVersion>
+  </PropertyGroup>
+</Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,6 @@
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
     <Company>Microsoft</Company>
     <Product>Xamarin.Forms</Product>
-    <LangVersion>7.3</LangVersion>
     <ProduceReferenceAssembly Condition="'$(UsingMicrosoftNETSdk)' == 'True' AND '$(Configuration)' == 'Debug'">True</ProduceReferenceAssembly>
   </PropertyGroup>
   

--- a/EmbeddingTestBeds/Embedding.Droid/Android10.Build.targets
+++ b/EmbeddingTestBeds/Embedding.Droid/Android10.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v10.0'">
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' != 'v9.0'">
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.0.1</Version>
     </PackageReference>

--- a/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
+++ b/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="Android10.Build.targets" Condition="'$(TargetFrameworkVersion)' == 'v10.0'" />
+  <Import Project="Android10.Build.targets" Condition="'$(TargetFrameworkVersion)' != 'v9.0'" />
 </Project>

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -19,7 +19,8 @@
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == '' AND '$(Use2017)' == 'true'">v9.0</AndroidTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v10.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
-    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0.99'">Properties\AndroidManifest30.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v9.0'">Properties\AndroidManifest28.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>

--- a/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest28.xml
+++ b/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest28.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Embedding.Droid.Embedding.Droid" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="16" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 	<application android:label="Embedding.Droid"></application>
 </manifest>

--- a/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest30.xml
+++ b/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest30.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Embedding.Droid.Embedding.Droid" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
 	<application android:label="Embedding.Droid"></application>
 </manifest>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -1,10 +1,8 @@
 <Project>
+
   <PropertyGroup>
     <EnvironmentBuildPropsImported>true</EnvironmentBuildPropsImported>
   </PropertyGroup>
-
-
-
 
   <PropertyGroup Condition="'$(CI)' == ''">
     <CI>false</CI>
@@ -35,6 +33,12 @@
     <Use2017 Condition="'$(Use2017)' == '' AND '$(MSBuildAssemblyVersion)' &lt; '16.0'">true</Use2017>
     <Use2017 Condition="'$(Use2017)' == ''">false</Use2017>
   </PropertyGroup>
+  
+  <PropertyGroup>
+    <LangVersion Condition="'$(Use2017)' == 'true'">7.3</LangVersion>
+    <LangVersion Condition="'$(LangVersion)' == ''">7.3</LangVersion>
+  </PropertyGroup>
+
   <!-- This is used by the libraries -->
   <PropertyGroup Condition="'$(AndroidTargetFrameworks)' == ''">
     <AndroidTargetFrameworks Condition="'$(Use2017)' == 'true'">MonoAndroid90;</AndroidTargetFrameworks>

--- a/PagesGallery/PagesGallery.Droid/Android10.Build.targets
+++ b/PagesGallery/PagesGallery.Droid/Android10.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v10.0'">
+  <ItemGroup Condition="'$(TargetFrameworkVersion)' != 'v9.0'">
     <PackageReference Include="Xamarin.AndroidX.Migration">
       <Version>1.0.0.1</Version>
     </PackageReference>

--- a/PagesGallery/PagesGallery.Droid/Directory.Build.targets
+++ b/PagesGallery/PagesGallery.Droid/Directory.Build.targets
@@ -1,3 +1,3 @@
 <Project>
-  <Import Project="Android10.Build.targets" Condition="'$(TargetFrameworkVersion)' == 'v10.0'" />
+  <Import Project="Android10.Build.targets" Condition="'$(TargetFrameworkVersion)' != 'v9.0'" />
 </Project>

--- a/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
+++ b/PagesGallery/PagesGallery.Droid/PagesGallery.Droid.csproj
@@ -18,7 +18,8 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == '' AND '$(Use2017)' == 'true'">v9.0</AndroidTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v10.0</AndroidTargetFrameworkVersion>
-    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0.99'">Properties\AndroidManifest30.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v9.0'">Properties\AndroidManifest28.xml</AndroidManifest>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <NuGetPackageImportStamp>

--- a/PagesGallery/PagesGallery.Droid/Properties/AndroidManifest28.xml
+++ b/PagesGallery/PagesGallery.Droid/Properties/AndroidManifest28.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
 	<application></application>
 </manifest>

--- a/PagesGallery/PagesGallery.Droid/Properties/AndroidManifest30.xml
+++ b/PagesGallery/PagesGallery.Droid/Properties/AndroidManifest30.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
 	<application></application>
 </manifest>

--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -12,6 +12,11 @@
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Xamarin.Forms.Platform</AssemblyName>
     <PackageId>Xamarin.Forms.Platform.iOSForwarders</PackageId>
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.ControlGallery.Android/Android10.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Android10.Build.targets
@@ -1,8 +1,6 @@
 <Project>
   <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v10.0'">
-    <PackageReference Include="Xamarin.AndroidX.Migration">
-      <Version>1.0.0.1</Version>
-    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Migration" Version="1.0.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.0.0.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.0.0.1" />

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
@@ -1,5 +1,5 @@
 <Project>
-  <Import Project="Android10.Build.targets" Condition="'$(TargetFrameworkVersion)' == 'v10.0'" />
+  <Import Project="Android10.Build.targets" Condition="'$(TargetFrameworkVersion)' != 'v9.0'" />
   <Import Condition="'$(Use2017)' == 'true'" Project="Nuget2017.Build.targets" />
   <Import Condition="'$(Use2017)' != 'true'" Project="Nuget2019.Build.targets" />
   <Import Project="..\Nuget.targets" Condition="'$(FromSource)' == 'false'" />

--- a/Xamarin.Forms.ControlGallery.Android/Nuget2019.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Nuget2019.Build.targets
@@ -4,7 +4,7 @@
             <Version>0.10.0</Version>
         </PackageReference>
     </ItemGroup>
-    <ItemGroup Condition="'$(TargetFrameworkVersion)' == 'v10.0'">
+    <ItemGroup Condition="'$(TargetFrameworkVersion)' != 'v9.0'">
         <PackageReference Include="Xamarin.AndroidX.Migration">
             <Version>1.0.0</Version>
         </PackageReference>

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="AndroidControlGallery.AndroidControlGallery" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="15" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest30.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest30.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="AndroidControlGallery.AndroidControlGallery" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="28" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\ControlGallery.Build.props" />
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\Environment.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -19,7 +20,8 @@
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == '' AND '$(Use2017)' == 'true'">v9.0</AndroidTargetFrameworkVersion>
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v10.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
-    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) != 'v9.0'">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0.99'">Properties\AndroidManifest30.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v9.0'">Properties\AndroidManifest28.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Xamarin.Forms.ControlGallery.MacOS/Xamarin.Forms.ControlGallery.MacOS.csproj
+++ b/Xamarin.Forms.ControlGallery.MacOS/Xamarin.Forms.ControlGallery.MacOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\ControlGallery.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>

--- a/Xamarin.Forms.ControlGallery.WPF/Xamarin.Forms.ControlGallery.WPF.csproj
+++ b/Xamarin.Forms.ControlGallery.WPF/Xamarin.Forms.ControlGallery.WPF.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\ControlGallery.Build.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\ControlGallery.Build.props" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -1,5 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="..\ControlGallery.Build.props" />
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\Environment.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -100,6 +100,7 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MtouchLink>Full</MtouchLink>
+    <BuildIpa>True</BuildIpa>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
     <MtouchLink>Full</MtouchLink>

--- a/Xamarin.Forms.Maps.GTK/Xamarin.Forms.Maps.GTK.csproj
+++ b/Xamarin.Forms.Maps.GTK/Xamarin.Forms.Maps.GTK.csproj
@@ -12,6 +12,11 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
+++ b/Xamarin.Forms.Maps.MacOS/Xamarin.Forms.Maps.macOS.csproj
@@ -11,6 +11,11 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Maps.WPF/Xamarin.Forms.Maps.WPF.csproj
+++ b/Xamarin.Forms.Maps.WPF/Xamarin.Forms.Maps.WPF.csproj
@@ -13,6 +13,11 @@
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
     <TargetFrameworkProfile />
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -11,6 +11,11 @@
     <RootNamespace>Xamarin.Forms.Maps.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <AssemblyName>Xamarin.Forms.Maps.iOS</AssemblyName>
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
+++ b/Xamarin.Forms.Material.iOS/Xamarin.Forms.Material.iOS.csproj
@@ -10,6 +10,11 @@
     <AssemblyName>Xamarin.Forms.Material</AssemblyName>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
     <PackageId>Xamarin.Forms.Material.iOS</PackageId>
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -15,6 +15,11 @@
     <TargetFrameworkVersion>v4.7</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -16,6 +16,11 @@
     <TargetFrameworkVersion>v2.0</TargetFrameworkVersion>
     <TargetFrameworkIdentifier>Xamarin.Mac</TargetFrameworkIdentifier>
     <MonoMacResourcePrefix>Resources</MonoMacResourcePrefix>
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -13,6 +13,11 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Forms.Platform.iOS</RootNamespace>
     <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <!-- 
+        This is needed for non SDK style project so the IDE will pick the correct LangVersion.
+        Once this is an SDK style project it will pick this up from the Directory.Build.Props file correctly
+     -->
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -211,7 +211,7 @@ stages:
 
   - stage: android_2017
     displayName: Build Android 2017
-    condition: eq(variables['System.TeamProject'], 'devdiv')
+    condition: and(succeeded(), eq(variables['System.TeamProject'], 'devdiv'))
     dependsOn: windows
     jobs:
       - template: build/steps/build-android.yml

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -206,14 +206,13 @@ stages:
           provisionatorPath : 'build/provisioning/provisioning.csx'
           buildForVS2017: false
           buildConfiguration: $(DefaultBuildConfiguration)
+          ${{ if ne(variables['MSBuildArguments_cg_android'], '') }}:
+            MSBuildArguments_cg_android: $(MSBuildArguments_cg_android)
 
   - stage: android_2017
     displayName: Build Android 2017
     condition: eq(variables['System.TeamProject'], 'devdiv')
-    ${{ if eq(variables['System.TeamProject'], 'devdiv') }}:
-      dependsOn: windows
-    ${{ if eq(variables['System.TeamProject'], 'public') }}:
-      dependsOn: []
+    dependsOn: windows
     jobs:
       - template: build/steps/build-android.yml
         parameters:
@@ -233,6 +232,7 @@ stages:
         workspace:
           clean: all
         displayName: OSX Phase
+        timeoutInMinutes: 120
         pool:
           name:  $(osx2019VmPool)
           vmImage: $(macOSXVmImage)

--- a/build.cake
+++ b/build.cake
@@ -639,24 +639,6 @@ Task("VSMAC")
     });
 
 Task("cg-android")
-    .Description("Builds Android Control Gallery and open VS")
-    .IsDependentOn("BuildTasks")
-    .Does(() => 
-    {
-        MSBuild("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", GetMSBuildSettings().WithRestore());
-        StartVisualStudio();
-    });
-
-Task("cg-ios")
-    .Description("Builds iOS Control Gallery and open VS")
-    .IsDependentOn("BuildTasks")
-    .Does(() =>
-    {   
-        MSBuild("./Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj", GetMSBuildSettings().WithRestore());
-        StartVisualStudio();
-    });
-
-Task("cg-android")
     .Description("Builds Android Control Gallery")
     .IsDependentOn("WriteGoogleMapsAPIKey")
     .IsDependentOn("BuildTasks")

--- a/build.cake
+++ b/build.cake
@@ -51,7 +51,25 @@ string artifactStagingDirectory = EnvironmentVariable("BUILD_ARTIFACTSTAGINGDIRE
 
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??
     (IsRunningOnWindows () ? "C:\\Program Files (x86)\\Android\\android-sdk\\" : "");
-string[] androidSdkManagerInstalls = new [] { "platforms;android-28", "platforms;android-29", "build-tools;29.0.3"};
+
+string MSBuildArgumentsENV = EnvironmentVariable("MSBuildArguments", "");
+string MSBuildArgumentsARGS = Argument("MSBuildArguments", "");
+string MSBuildArguments;
+
+if(buildForVS2017)
+    MSBuildArguments = String.Empty;
+else
+    MSBuildArguments = $"{MSBuildArgumentsENV} {MSBuildArgumentsARGS}";
+    
+Information("MSBuildArguments: {0}", MSBuildArguments);
+
+string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platforms;android-28,platforms;android-29,build-tools;29.0.3");
+
+if(buildForVS2017)
+    androidSdks = "platforms;android-28,platforms;android-29,build-tools;29.0.3";
+
+Information("ANDROID_API_SDKS: {0}", androidSdks);
+string[] androidSdkManagerInstalls = androidSdks.Split(',');
 
 var IOS_BUILD_IPA = Argument("IOS_BUILD_IPA", false || isCIBuild);
 
@@ -235,6 +253,7 @@ Task("provision-androidsdk")
 
         if(androidSdkManagerInstalls.Length > 0)
         {
+            Information("Updating Android SDKs");
             var androidSdkSettings = new AndroidSdkManagerToolSettings {
                 SkipVersionCheck = true
             };
@@ -245,32 +264,48 @@ Task("provision-androidsdk")
             try{
                 AcceptLicenses (androidSdkSettings);
             }
-            catch{}
+            catch(Exception exc)
+            {
+                Information("AcceptLicenses: {0}", exc);
+            }
 
             try{
                 AndroidSdkManagerUpdateAll (androidSdkSettings);
             }
-            catch{}
+            catch(Exception exc)
+            {
+                Information("AndroidSdkManagerUpdateAll: {0}", exc);
+            }
             
             try{
                 AcceptLicenses (androidSdkSettings);
             }
-            catch{}
+            catch(Exception exc)
+            {
+                Information("AcceptLicenses: {0}", exc);
+            }
 
             try{
                 AndroidSdkManagerInstall (androidSdkManagerInstalls, androidSdkSettings);
             }
-            catch{}
+            catch(Exception exc)
+            {
+                Information("AndroidSdkManagerInstall: {0}", exc);
+            }
         }
 
         if (!IsRunningOnWindows ()) {
             if(!String.IsNullOrWhiteSpace(androidSDK))
+            {
                 await Boots (androidSDK);
+            }
             else
                 await Boots (Product.XamarinAndroid, releaseChannel);
         }
         else if(!String.IsNullOrWhiteSpace(androidSDK))
-            await Boots(androidSDK);
+        {
+            await Boots (androidSDK);
+        }
     });
 
 Task("provision-monosdk")
@@ -478,7 +513,6 @@ Task("_NuGetPack")
         NuGetPack(nugetFilePaths, nuGetPackSettings);
     });
 
-
 Task("Restore")
     .Description("Restore target on Xamarin.Forms.sln")
     .Does(() =>
@@ -590,17 +624,36 @@ Task("Android100")
     .Description("Builds Monodroid10.0 targets")
     .Does(() =>
     {
-            MSBuild("Xamarin.Forms.sln",
-                    GetMSBuildSettings()
-                        .WithRestore()
-                        .WithProperty("AndroidTargetFrameworks", "MonoAndroid90;MonoAndroid10.0"));
+        MSBuild("Xamarin.Forms.sln",
+                GetMSBuildSettings()
+                    .WithRestore()
+                    .WithProperty("AndroidTargetFrameworks", "MonoAndroid90;MonoAndroid10.0"));
     });
 
 Task("VSMAC")
     .Description("Builds projects necessary so solution compiles on VSMAC")
+    .IsDependentOn("BuildTasks")
     .Does(() =>
     {
-        StartProcess("open", new ProcessSettings{ Arguments = "Xamarin.Forms.sln" });
+        StartVisualStudio();
+    });
+
+Task("cg-android")
+    .Description("Builds Android Control Gallery and open VS")
+    .IsDependentOn("BuildTasks")
+    .Does(() => 
+    {
+        MSBuild("./Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj", GetMSBuildSettings().WithRestore());
+        StartVisualStudio();
+    });
+
+Task("cg-ios")
+    .Description("Builds iOS Control Gallery and open VS")
+    .IsDependentOn("BuildTasks")
+    .Does(() =>
+    {   
+        MSBuild("./Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj", GetMSBuildSettings().WithRestore());
+        StartVisualStudio();
     });
 
 Task("cg-android")
@@ -758,7 +811,7 @@ MSBuildSettings GetMSBuildSettings(PlatformTarget? platformTarget = PlatformTarg
         buildSettings = buildSettings.WithProperty("XamarinFormsVersion", XamarinFormsVersion);
     }
     
-    buildSettings.ArgumentCustomization = args => args.Append("/nowarn:VSX1000");
+    buildSettings.ArgumentCustomization = args => args.Append($"/nowarn:VSX1000 {MSBuildArguments}");
     return buildSettings;
 }
 

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -98,8 +98,22 @@ else
 
 }
 
-AndroidSdk()
-	.ApiLevel((AndroidApiLevel)24)
-	.ApiLevel((AndroidApiLevel)28)
-	.ApiLevel((AndroidApiLevel)29)
-	.SdkManagerPackage ("build-tools;29.0.3");
+string ANDROID_API_SDKS = Environment.GetEnvironmentVariable ("ANDROID_API_SDKS");
+
+if(String.IsNullOrWhiteSpace(ANDROID_API_SDKS))
+{
+	AndroidSdk()
+		.ApiLevel((AndroidApiLevel)24)
+		.ApiLevel((AndroidApiLevel)28)
+		.ApiLevel((AndroidApiLevel)29)
+		.SdkManagerPackage ("build-tools;29.0.3");
+}
+else{
+
+	var androidSDK = AndroidSdk();
+	foreach(var sdk in ANDROID_API_SDKS.Split(','))
+	{
+		Console.WriteLine("Installing SDK: {0}", sdk);
+		androidSDK = androidSDK.SdkManagerPackage (sdk);
+	}
+}

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -14,6 +14,7 @@ parameters:
   monoVersion: $(MONO_VERSION)
   provisionatorPath: 'build/provisioning/provisioning.csx'
   provisionatorExtraArguments: ''
+  MSBuildArguments_cg_android: ''
 
 jobs:
   - job: ${{ parameters.name }}
@@ -42,13 +43,6 @@ jobs:
       - checkout: self
         clean: true
 
-      - task: xamops.azdevex.provisionator-task.provisionator@1
-        displayName: 'Provisionator'
-        condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
-        inputs:
-          provisioning_script: ${{ parameters.provisionatorPath }}
-          provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
-
       - task: Bash@3
         displayName: 'Cake Provision'
         condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
@@ -56,6 +50,13 @@ jobs:
           targetType: 'filePath'
           filePath: 'build.sh'
           arguments: --target provision --TeamProject="$(System.TeamProject)" --buildForVS2017=$(buildForVS2017)
+
+      - task: xamops.azdevex.provisionator-task.provisionator@1
+        displayName: 'Provisionator'
+        condition: and(eq(variables['provisioning'], 'true'), eq(variables['buildForVS2017'], 'false'))
+        inputs:
+          provisioning_script: ${{ parameters.provisionatorPath }}
+          provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
 
       - task: UseDotNet@2
         displayName: 'Install .net core $(DOTNET_VERSION)'
@@ -72,7 +73,7 @@ jobs:
         condition: ne(variables['NUGET_VERSION'], '')
         inputs:
           versionSpec: $(NUGET_VERSION)
-  
+
       - task: DownloadBuildArtifacts@0
         displayName: 'Download build artifact nuget'
         condition: eq(variables['System.TeamProject'], 'DevDiv')
@@ -87,10 +88,19 @@ jobs:
           SourceFolder: 'Nuget/nuget/${{ parameters.buildConfiguration }}'
           TargetFolder: 'Nuget'
 
+      - bash: |
+          echo "##vso[task.setvariable variable=NUGET_RESTORE_MSBUILD_ARGS]${{ parameters.MSBuildArguments_cg_android }}"
+        displayName: 'Set NUGET_RESTORE_MSBUILD_ARGS for Nuget'
+
+      - bash: |
+          env | grep NUGET_RESTORE_MSBUILD_ARGS
+        displayName: 'Display NUGET_RESTORE_MSBUILD_ARGS for Nuget'
+
       - task: NuGetCommand@2
         displayName: 'NuGet restore ${{ parameters.slnPath }}'
         inputs:
-          restoreSolution:  ${{ parameters.slnPath }}
+          command: restore
+          restoreSolution: 'Xamarin.Forms.sln'
           feedsToUse: config
           nugetConfigPath: 'DevopsNuget.config'
 
@@ -99,7 +109,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target cg-android --ANDROID_RENDERERS="$(renderers)" --GoogleMapsAPIKey="$(GoogleMapsAPIKey)" --buildForVS2017=false --BUILD_CONFIGURATION=${{ parameters.buildConfiguration }} --MSBuildArguments='${{ variables.MSBuildArguments_cg_android }}'
+          arguments: --target cg-android --ANDROID_RENDERERS="$(renderers)" --GoogleMapsAPIKey="$(GoogleMapsAPIKey)" --buildForVS2017=$(buildForVS2017) --BUILD_CONFIGURATION=${{ parameters.buildConfiguration }} --MSBuildArguments='${{ variables.MSBuildArguments_cg_android }}'
 
       - task: CopyFiles@2
         displayName: 'Copy $(renderers)'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -113,6 +113,7 @@ steps:
       Contents: |
         **/XamarinFormsControlGalleryiOS.ipa
         **/*.dSYM
+        **/*.dSYM/**/*.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -112,8 +112,6 @@ steps:
     inputs:
       Contents: |
         **/XamarinFormsControlGalleryiOS.ipa
-        **/*.dSYM
-        **/*.dSYM/**/*.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
@@ -122,6 +120,16 @@ steps:
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
       CleanTargetFolder: true
       flattenFolders: true
+
+  - task: CopyFiles@2
+    displayName: 'Copy iOS dSYM'
+    condition: eq(variables['buildForVS2017'], 'false')
+    inputs:
+      Contents: |
+        **/*.dSYM/**/*.*
+      TargetFolder: '$(build.artifactstagingdirectory)/ios'
+      CleanTargetFolder: false
+      flattenFolders: false
 
   - task: CopyFiles@2
     displayName: 'Copy iOS Files for UITest 2017'


### PR DESCRIPTION
### Description of Change ###
- setup properties so we can build Control Gallery against Beta android versions
- added CG cake targets so you can build android/ios cg from CLI and it'll open VS
- Added build property CGLangVersion so we can build CG with C# 8,0 which is required for Android 10.4
- Setup Manifests and various other properties so that I can build Android v10.0.99
- upped the the minimum target to 19 on CGs
- added ControlGallery.Build.props to specify properties to only apply to CG's. This is currently used to pivot the LangVers based on build properties
- Added Pipeline property ANDROID_API_SDKS so you can install additional android apis
- Added Pipeline MSBuildArguments_cg_android  for adding additional msbuild properties to CG Android. This is currently used to add CGLangVersion and to set the TargetFrameworks for android to V10.0.99


### Testing Procedure ###
- make sure builds work

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
