### PR TITLE
[UITests] Comment out  Bugzilla32871 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32871.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla32871.cs
@@ -98,7 +98,7 @@ namespace Xamarin.Forms.Controls.Issues
 			this.Content = stack;
 		}
 #if UITEST
-		[Test]
+	//	[Test]
 		public void Issue32871Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked(Ids.BindButton));


### PR DESCRIPTION
### Description of Change ###

The output of this test on API27 was causing the xml to be bad generated. And only reporting back just the first 38 tests.

### Issues Resolved ### 

- none

### API Changes ###

 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

API27 regressions test run should show more than 38 tests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
