### PR TITLE
Avoid using the dequeue mechanism to retrieve header/footer measurement cells on iOS 10

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -166,6 +166,11 @@ namespace Xamarin.Forms.Platform.iOS
 				return CGSize.Empty;
 			}
 
+			if (section > ItemsSource.GroupCount - 1)
+			{
+				return CGSize.Empty;
+			}
+
 			if (!Forms.IsiOS11OrNewer)
 			{
 				// iOS 10 crashes if we try to dequeue a cell for measurement

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -12,6 +12,12 @@ namespace Xamarin.Forms.Platform.iOS
 		// BindableProperty all the time 
 		bool _isGrouped;
 
+		// Keep out header measurement cells for iOS handy so we don't have to
+		// create new ones all the time. For other versions, the reusable cells
+		// queueing mechanism does this for us.
+		TemplatedCell _measurementCellTemplated;
+		DefaultCell _measurementCellDefault;
+
 		Action _scrollAnimationEndedCallback;
 
 		public GroupableItemsViewController(TItemsView groupableItemsView, ItemsViewLayout layout) 
@@ -160,9 +166,11 @@ namespace Xamarin.Forms.Platform.iOS
 				return CGSize.Empty;
 			}
 
-			if (ItemsSource.GroupCount < 1)
+			if (!Forms.IsiOS11OrNewer)
 			{
-				return CGSize.Empty;
+				// iOS 10 crashes if we try to dequeue a cell for measurement
+				// so we'll use an alternate method
+				return MeasureSupplementaryView(elementKind, section);
 			}
 
 			var cell = GetViewForSupplementaryElement(collectionView, elementKind,
@@ -234,5 +242,68 @@ namespace Xamarin.Forms.Platform.iOS
 			return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left,
 				uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 		}
+
+		// These measurement methods are only necessary for iOS 10 and lower
+
+		CGSize MeasureTemplatedSupplementaryCell(NSString elementKind, nint section, NSString reuseId)
+		{
+			if (_measurementCellTemplated == null)
+			{
+				if (reuseId == HorizontalSupplementaryView.ReuseId)
+				{
+					_measurementCellTemplated = new HorizontalSupplementaryView(CGRect.Empty);
+				}
+				else if (reuseId == VerticalSupplementaryView.ReuseId)
+				{
+					_measurementCellTemplated = new VerticalSupplementaryView(CGRect.Empty);
+				}
+			}
+
+			if (_measurementCellTemplated == null)
+			{
+				return CGSize.Empty;
+			}
+
+			UpdateTemplatedSupplementaryView(_measurementCellTemplated, elementKind, NSIndexPath.FromItemSection(0, section));
+			return _measurementCellTemplated.Measure();
+		}
+
+		CGSize MeasureDefaultSupplementaryCell(NSString elementKind, nint section, NSString reuseId)
+		{
+			if (_measurementCellDefault == null)
+			{
+				if (reuseId == HorizontalDefaultSupplementalView.ReuseId)
+				{
+					_measurementCellDefault = new HorizontalDefaultSupplementalView(CGRect.Empty);
+				}
+				else if (reuseId == VerticalDefaultSupplementalView.ReuseId)
+				{
+					_measurementCellDefault = new VerticalDefaultSupplementalView(CGRect.Empty);
+				}
+			}
+
+			if (_measurementCellDefault == null)
+			{
+				return CGSize.Empty;
+			}
+
+			UpdateDefaultSupplementaryView(_measurementCellDefault, elementKind, NSIndexPath.FromItemSection(0, section));
+			return _measurementCellDefault.Measure();
+		}
+
+		CGSize MeasureSupplementaryView(NSString elementKind, nint section)
+		{
+			var reuseId = (NSString)DetermineViewReuseId(elementKind);
+
+			if (reuseId == HorizontalDefaultSupplementalView.ReuseId
+				|| reuseId == VerticalDefaultSupplementalView.ReuseId)
+			{
+				return MeasureDefaultSupplementaryCell(elementKind, section, reuseId);
+			}
+
+			return MeasureTemplatedSupplementaryCell(elementKind, section, reuseId);
+		}
+
+		// end of iOS 10 workaround stuff
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -179,19 +179,6 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 			}
 
-			if (Forms.IsiOS11OrNewer)
-			{
-				return base.ShouldInvalidateLayout(preferredAttributes, originalAttributes);
-			}
-
-			// For iOS 10 and lower, we have to invalidate on header/footer changes here; otherwise, all of the 
-			// headers and footers will draw on top of one another
-			if (preferredAttributes.RepresentedElementKind == UICollectionElementKindSectionKey.Header
-				|| preferredAttributes.RepresentedElementKind == UICollectionElementKindSectionKey.Footer)
-			{
-				return true;
-			}
-
 			return base.ShouldInvalidateLayout(preferredAttributes, originalAttributes);
 		}
 
@@ -399,22 +386,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return invalidationContext;
-
-			// On iOS 10 though any group headers/footers will initially draw in the wrong location. It's possible to 
-			// work around this problem by forcing a full layout update after the headers/footers have been 
-			// drawn in the wrong places
-		}
-
-		public override UICollectionViewLayoutAttributes LayoutAttributesForSupplementaryView(NSString kind, NSIndexPath indexPath)
-		{
-			if (Forms.IsiOS11OrNewer)
-			{
-				return base.LayoutAttributesForSupplementaryView(kind, indexPath);
-			}
-
-			// iOS 10 and lower doesn't create these and will throw an exception in GetViewForSupplementaryElement 
-			// without them, so we need to do it manually here
-			return UICollectionViewLayoutAttributes.CreateForSupplementaryView(kind, indexPath);
 		}
 
 		public override void PrepareLayout()


### PR DESCRIPTION
### Description of Change ###

On iOS 10 the UICollectionViewFlowLayout erroneously attempts to retrieve layout attributes for supplementary views (i.e., group headers and footers) when we retrieve supplementary cells in order to measure the header/footer sizes. This crashes. 

These changes avoid that situation by manually constructing measurement cells for headers and footers on iOS 10 and skipping the dequeue method during measurement entirely.

Side benefit: this also fixes an issue where group headers/footers on iOS 10 would initially layout out at 0,0 instead of above/below their groups.

### Issues Resolved ### 

- fixes failing test for Issue 9686 on 4.7.0.

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test 9686.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
