### PR TITLE
[Tizen] Improve the SwitchCell performance

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
@@ -59,6 +59,13 @@ namespace Xamarin.Forms.Platform.Tizen
 				{
 					nativeView.PropagateEvents = false;
 				}
+
+				_cacheCandidate[nativeView] = toggle;
+				nativeView.Deleted += (sender, e) =>
+				{
+					_cacheCandidate.Remove(sender as EvasObject);
+				};
+
 				return nativeView;
 			}
 			return null;


### PR DESCRIPTION
### Description of Change ###
This PR improves `SwitchCell` performance by caching the item for reuse. As a result, the scrolling performance of `ListView` using `SwitchCell` has been improved from about 20~30 FPS to about 60 FPS. (when measured on a Galaxy Watch).

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
