### PR TITLE
Fixed issue with nonexistent resource in AppTheme XAML sample

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeXamlGallery.xaml
@@ -14,8 +14,7 @@
                 </Label.TextColor>
             </Label>
             <Label Style="{DynamicResource Key=OSThemeStyle}">DynamicResource Style</Label>
-            <Label TextColor="{DynamicResource MyColor}">DynamicResource Color</Label>
-            <Label TextColor="{StaticResource MyColor}">StaticResource</Label>
+            <Label TextColor="{AppThemeBinding Light=HotPink, Dark=Yellow}">Color using AppThemeBinding</Label>
             <Label>Image with OnAppThemeExtension</Label>
             <Image Source="{AppThemeBinding Light=xamarinlogo.png, Dark=Fruits.jpg}" />
         </StackLayout>


### PR DESCRIPTION
### Description of Change ###

Fixed issue with nonexistent resource in AppTheme XAML sample. MyColor was:
<AppThemeColor x:Key="MyColor" Light="HotPink" Dark="Yellow" />
And now, this has changed. Changed to use `AppThemeBinding`.

### Issues Resolved ### 

- fixes #10968

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the AppThemes Galleries. Select the AppTheme XAML Gallery and verify that the Label is using different colors by theme.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
