### PR TITLE
Fix local image loading on UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10961.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10961.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 10961,
+		"With Forms 4.7.0 Pre-Releases most of the the images in the UWP version of my app are not displayed",
+		PlatformAffected.UWP)]
+	public class Issue10961 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var invalidImageInstructions = new Label { Text = "The next image has an invalid local source; it should fall back to that terrible face image." };
+
+			var invalidImage = new Image 
+			{ 
+				Source = "doesnotexist.jpg",
+				ErrorPlaceholder = "crimsonsmall.jpg"
+			};
+
+			var validImageInstructions = new Label { Text = "The next image has an valid local source; it should display a pug in a sweater." };
+
+			var validImage = new Image
+			{
+				Source = "oasis.jpg",
+				ErrorPlaceholder = "crimsonsmall.jpg"
+			};
+
+			var layout = new StackLayout();
+
+			layout.Children.Add(invalidImageInstructions);
+			layout.Children.Add(invalidImage);
+			layout.Children.Add(validImageInstructions);
+			layout.Children.Add(validImage);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7015.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7015.cs
@@ -1,8 +1,7 @@
 ﻿using System;
+using System.Collections;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-using Xamarin.Forms.PlatformConfiguration;
-using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -10,72 +9,127 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 7015, "Test the placeholder implementation for Image control ")]
 	public class Issue7015 : TestContentPage
 	{
-		const string batata = "batata.png";
-		const string bank = "bank.png";
-		const string bell = "bell.png";
-		const string fromSource = "ImageSource";
-		const string fromPlaceholder = "Placeholder";
-		const string correctUrl = "https://media.licdn.com/dms/image/C4E03AQEWNdL1Usduag/profile-displayphoto-shrink_200_200/0?e=1579132800&v=beta&t=4f9CONMr5lqdT7KFq_wp5SSq__mxxaQpW_HxLq3JKYM";
-		const string wrongUrl = "http://avatars.githubusercontent.co/u/20712372?s=400&u=ecb5fe0584cba02ab4c7e159768e9366a95e3&v=4";
+		const string InvalidImageFile = "batata.png";
+		const string ErrorPlaceholderFile = "bank.png";
+		const string LoadingImageFile = "bell.png";
+		const string LegitImageFile = "coffee.png";
+
+		const string CorrectUrl = "https://raw.githubusercontent.com/xamarin/Xamarin.Forms/master/Xamarin.Forms.ControlGallery.WindowsUniversal/FlowerBuds.jpg";
+		const string WrongUrl = "http://avatars.githubusercontent.co/u/20712372?s=400&u=ecb5fe0584cba02ab4c7e159768e9366a95e3&v=4";
+		readonly UriImageSource _correctUriSource = new UriImageSource { CachingEnabled = false, Uri = new Uri(CorrectUrl) };
+		readonly UriImageSource _wrongUriSource = new UriImageSource { CachingEnabled = false, Uri = new Uri(WrongUrl) };
+
+		Image _localImage;
+		Image _remoteImage;
 
 		protected override void Init()
 		{
-			var label = new Label
+			var layout = new StackLayout
 			{
-				Text = "Press the image button and change the Source, from Image above. See the label at the end of the page to see if it's the PlaceholderImage or the ImageSource",
-				VerticalOptions = LayoutOptions.Start
+				Padding = new Thickness(15),
+				Spacing = 5
 			};
 
-			var image = new Image
+			layout.Children.Add(Examples());
+			layout.Children.Add(Toggle());
+
+			layout.Children.Add(Local());
+			layout.Children.Add(Remote());
+
+			Content = layout;
+		}
+
+		View Row(string label, Image image)
+		{
+			var row = new StackLayout { Margin = new Thickness(0, 0, 0, 20), Orientation = StackOrientation.Horizontal };
+			row.Children.Add(new Label { Text = label, VerticalTextAlignment = TextAlignment.Center });
+			row.Children.Add(image);
+			return row;
+		}
+
+		View Examples()
+		{
+			var exampleStack = new StackLayout { Margin = new Thickness(0, 0, 0, 20) };
+
+			var exampleLegitLocalImage = new Image { Source = LegitImageFile };
+			var exampleLegitRemoteImage = new Image { Source = CorrectUrl };
+			var exampleErrorImage = new Image { Source = ErrorPlaceholderFile };
+			var exampleLoadingImage = new Image { Source = LoadingImageFile };
+
+			exampleStack.Children.Add(Row("Valid local image:", exampleLegitLocalImage));
+			exampleStack.Children.Add(Row("Valid remote image:", exampleLegitRemoteImage));
+			exampleStack.Children.Add(Row("Loading placeholder:", exampleLoadingImage));
+			exampleStack.Children.Add(Row("Error placeholder:", exampleErrorImage));
+
+			return exampleStack;
+		}
+
+		View Toggle() 
+		{
+			var toggleStack = new StackLayout { Orientation = StackOrientation.Horizontal };
+
+			var currentSource = new Label
 			{
-				ErrorPlaceholder = bank,
-				Source = batata
+				Text = $"Should be displaying the error placeholder",
+				VerticalTextAlignment = TextAlignment.Center
 			};
 
-			var correctUriSource = new UriImageSource { CachingEnabled = false, Uri = new Uri(correctUrl) };
-			var wrongUriSource = new UriImageSource { CachingEnabled = false, Uri = new Uri(wrongUrl) };
-
-			var urlImage = new Image
+			var toggleButton = new Button { Text = "Toggle" };
+			toggleButton.Command = new Command(() =>
 			{
-				ErrorPlaceholder = bank,
-				Source = wrongUriSource,
-				LoadingPlaceholder = bell
+				var source = _localImage.Source.ToString();
+				var invalid = source.Contains(InvalidImageFile);
+
+				_remoteImage.Source = invalid ? _correctUriSource : _wrongUriSource;
+				_localImage.Source = invalid ? LegitImageFile : InvalidImageFile;
+
+				currentSource.Text = invalid 
+					? "Should be displaying the valid images" 
+					: "Should be displaying the error placeholders";
+			});
+
+			toggleStack.Children.Add(toggleButton);
+			toggleStack.Children.Add(currentSource);
+
+			return toggleStack;
+		}
+
+		View Local() 
+		{
+			var localImageStack = new StackLayout { Orientation = StackOrientation.Horizontal, BackgroundColor = Color.LightGreen };
+
+			_localImage = new Image
+			{
+				ErrorPlaceholder = ErrorPlaceholderFile,
+				LoadingPlaceholder = LoadingImageFile,
+				Source = InvalidImageFile
 			};
 
-			var sourceIs = new Label
+			var localImageLabel = new Label { Text = "Local image:" };
+
+			localImageStack.Children.Add(localImageLabel);
+			localImageStack.Children.Add(_localImage);
+
+			return localImageStack;
+		}
+
+		View Remote()
+		{
+			var remoteStack = new StackLayout { Orientation = StackOrientation.Horizontal, BackgroundColor = Color.LightBlue };
+
+			var urlImageLabel = new Label { Text = "Image from URL:" };
+
+			_remoteImage = new Image
 			{
-				Text = fromPlaceholder,
-				VerticalOptions = LayoutOptions.EndAndExpand,
-				HorizontalTextAlignment = TextAlignment.Center
+				ErrorPlaceholder = ErrorPlaceholderFile,
+				LoadingPlaceholder = LoadingImageFile,
+				Source = _wrongUriSource
 			};
 
-			var imageB = new ImageButton
-			{
-				Source = bank,
-				Command = new Command(() =>
-				{
-					var source = urlImage.Source.ToString();
-					urlImage.Source = (source.Contains(wrongUrl)) ? correctUriSource : wrongUriSource;
+			remoteStack.Children.Add(urlImageLabel);
+			remoteStack.Children.Add(_remoteImage);
 
-					source = image.Source.ToString();
-					image.Source = (source.Contains(batata)) ? bell : batata;
-					source = image.Source.ToString();
-					sourceIs.Text = (source.Contains(batata)) ? fromPlaceholder : fromSource;
-				})
-			};
-
-			var stack = new StackLayout
-			{
-				Padding = new Thickness(15)
-			};
-
-			stack.Children.Add(label);
-			stack.Children.Add(image);
-			stack.Children.Add(imageB);
-			stack.Children.Add(urlImage);
-			stack.Children.Add(sourceIs);
-
-			Content = stack;
+			return remoteStack;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -17,6 +17,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10961.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -78,7 +78,6 @@ namespace Xamarin.Forms.Platform.UWP
 				await TryUpdateSource().ConfigureAwait(false);
 		}
 
-
 		void OnImageOpened(object sender, RoutedEventArgs routedEventArgs)
 		{
 			if (_measured)
@@ -89,12 +88,12 @@ namespace Xamarin.Forms.Platform.UWP
 			Element?.SetIsLoading(false);
 		}
 
-		protected virtual void OnImageFailed(object sender, ExceptionRoutedEventArgs exceptionRoutedEventArgs)
+		protected virtual async void OnImageFailed(object sender, ExceptionRoutedEventArgs exceptionRoutedEventArgs)
 		{
 			Log.Warning("Image Loading", $"Image failed to load: {exceptionRoutedEventArgs.ErrorMessage}");
+			await ImageElementManager.DisplayErrorImage(this).ConfigureAwait(false);
 			Element?.SetIsLoading(false);
 		}
-
 
 		protected virtual async Task TryUpdateSource()
 		{
@@ -131,7 +130,6 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Log.Warning("Update image source after app resume", 
 					$"ImageSource failed to update after app resume: {exception.Message}");
-				
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

The placeholder image changes broke local image loading on UWP; these changes:

- use the local image loading error handler to load the error image
- a check for a null return from a remote image and display the error image

which makes the error/loading placeholder images work while also allowing local images to load.

### Issues Resolved ### 

- fixes #10961

### API Changes ###
 
None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery Issues 7015 and 10961

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
