### PR TITLE
BaseShellItem IsVisible and FlyoutItem.IsVisible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -94,6 +94,15 @@ namespace Xamarin.Forms.Controls.Issues
 						},
 						new Button()
 						{
+							Text = "Toggle Flyout Item 3",
+							AutomationId = "ToggleFlyoutItem3",
+							Command = new Command(() =>
+							{
+								vm.Item3 = !vm.Item3;
+							})
+						},
+						new Button()
+						{
 							Text = "Clear and Recreate",
 							AutomationId = "ClearAndRecreate",
 							Command = new Command(async () =>
@@ -124,17 +133,21 @@ namespace Xamarin.Forms.Controls.Issues
 			var item1 = AddContentPage(pageItem1);
 			var pageItem2 = createPage("Item 2");
 			var item2 = AddContentPage(pageItem2);
+			var pageItem3 = createPage("Item 3");
+			var item3 = AddContentPage(pageItem3);
 
 			item1.Title = "Item1 Flyout";
 			item1.Route = "Item1";
 			item2.Title = "Item2 Flyout";
 			item2.Route = "Item2";
+			item3.Title = "Item3 Flyout";
+			item3.Route = "Item3";
 
 			AddTopTabs();
 
-
 			pageItem1.SetBinding(Page.IsVisibleProperty, "Item1");
 			pageItem2.SetBinding(Page.IsVisibleProperty, "Item2");
+			item3.SetBinding(FlyoutItem.IsVisibleProperty, "Item3");
 
 			this.Items.Add(new MenuShellItem(new MenuItem()
 			{
@@ -157,6 +170,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			bool _item1 = true;
 			bool _item2 = true;
+			bool _item3 = true;
 
 			public event PropertyChangedEventHandler PropertyChanged;
 
@@ -172,11 +186,21 @@ namespace Xamarin.Forms.Controls.Issues
 
 			public bool Item2
 			{
-				get => _item2; 
+				get => _item2;
 				set
 				{
 					_item2 = value;
 					OnPropertyChanged(nameof(Item2));
+				}
+			}
+
+			public bool Item3
+			{
+				get => _item3;
+				set
+				{
+					_item3 = value;
+					OnPropertyChanged(nameof(Item3));
 				}
 			}
 
@@ -185,6 +209,15 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST && (__SHELL__)
+
+		[Test]
+		public void FlyoutItemVisible()
+		{
+			RunningApp.Tap("ToggleFlyoutItem3");
+			ShowFlyout();
+			RunningApp.WaitForElement("Item2 Flyout");
+			RunningApp.WaitForNoElement("Item3 Flyout");
+		}
 
 		[Test]
 		public void HideActiveShellContent()

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1043,7 +1043,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task ShellItemNotVisible()
+		public async Task ShellItemNotVisibleWhenContentPageNotVisible()
 		{
 			var shell = new Shell();
 			var item1 = CreateShellItem(new ContentPage() { IsVisible = false });
@@ -1054,6 +1054,74 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.IsFalse(GetItems(shell).Contains(item1));
 			Assert.IsTrue(GetItems(shell).Contains(item2));
+		}
+
+		[Test]
+		public async Task BaseShellItemNotVisible()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem();
+			var item2 = CreateShellItem();
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			item1.IsVisible = false;
+			Assert.IsFalse(GetItems(shell).Contains(item1));
+			Assert.IsTrue(GetItems(shell).Contains(item2));
+
+			item1.IsVisible = true;
+			Assert.IsTrue(GetItems(shell).Contains(item1));
+
+			item1.Items[0].IsVisible = false;
+			Assert.IsFalse(GetItems(shell).Contains(item1));
+			item1.Items[0].IsVisible = true;
+			Assert.IsTrue(GetItems(shell).Contains(item1));
+
+			item1.Items[0].Items[0].IsVisible = false;
+			Assert.IsFalse(GetItems(shell).Contains(item1));
+			item1.Items[0].Items[0].IsVisible = true;
+			Assert.IsTrue(GetItems(shell).Contains(item1));
+		}
+
+		[Test]
+		public async Task CanStillNavigateToNotVisibleShellItem()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem(shellItemRoute:"NotVisible");
+			var item2 = CreateShellItem();
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			item1.IsVisible = false;
+
+			shell.GoToAsync("//NotVisible");
+
+			Assert.AreEqual("//NotVisible", shell.CurrentState.Location.ToString());
+		}
+
+
+		[Test]
+		public async Task FlyoutItemVisible()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem<FlyoutItem>(shellItemRoute: "NotVisible");
+			var item2 = CreateShellItem();
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			FlyoutItem.SetIsVisible(item1, false);
+			Assert.IsTrue(GetItems(shell).Contains(item1));
+
+			bool hasFlyoutItem =
+				(shell as IShellController)
+					.GenerateFlyoutGrouping()
+					.SelectMany(i => i)
+					.Contains(item1);
+
+			Assert.IsFalse(hasFlyoutItem);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1497,6 +1497,29 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsNotNull(item.CurrentItem.CurrentItem);
 		}
 
+		[Test]
+		public async Task HotReloadStaysOnActiveItem()
+		{
+			Shell shell = new Shell();
+
+			shell.Items.Add(CreateShellItem(shellItemRoute: "item1"));
+			shell.Items.Add(CreateShellItem(shellItemRoute: "item2"));
+			shell.Items.Add(CreateShellItem(shellItemRoute: "item3"));
+
+			await shell.GoToAsync("//item3");
+			Assert.AreEqual("//item3", shell.CurrentState.Location.ToString());
+
+			shell.Items.Add(CreateShellItem(shellItemRoute: "item1"));
+			shell.Items.Add(CreateShellItem(shellItemRoute: "item2"));
+			shell.Items.Add(CreateShellItem(shellItemRoute: "item3"));
+
+			shell.Items.RemoveAt(0);
+			shell.Items.RemoveAt(0);
+			shell.Items.RemoveAt(0);
+
+			Assert.AreEqual("//item3", shell.CurrentState.Location.ToString());
+		}
+
 		[TestCase("ContentPage")]
 		[TestCase("ShellItem")]
 		[TestCase("Shell")]

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -1085,7 +1085,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task CanStillNavigateToNotVisibleShellItem()
+		public async Task CantNavigateToNotVisibleShellItem()
 		{
 			var shell = new Shell();
 			var item1 = CreateShellItem(shellItemRoute:"NotVisible");
@@ -1096,9 +1096,9 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			item1.IsVisible = false;
 
-			shell.GoToAsync("//NotVisible");
+			Assert.That(async () => await shell.GoToAsync($"//NotVisible"), Throws.Exception);
 
-			Assert.AreEqual("//NotVisible", shell.CurrentState.Location.ToString());
+			Assert.AreEqual(shell.CurrentItem, item2);
 		}
 
 

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -57,6 +57,9 @@ namespace Xamarin.Forms
 									propertyChanged: OnTabStopPropertyChanged,
 									defaultValueCreator: TabStopDefaultValueCreator);
 
+		public static readonly BindableProperty IsVisibleProperty =
+			BindableProperty.Create(nameof(IsVisible), typeof(bool), typeof(BaseShellItem), true);
+
 		static void OnTabIndexPropertyChanged(BindableObject bindable, object oldValue, object newValue) =>
 			((BaseShellItem)bindable).OnTabIndexPropertyChanged((int)oldValue, (int)newValue);
 
@@ -115,6 +118,12 @@ namespace Xamarin.Forms
 		{
 			get => (bool)GetValue(IsTabStopProperty);
 			set => SetValue(IsTabStopProperty, value);
+		}
+
+		public bool IsVisible
+		{
+			get => (bool)GetValue(IsVisibleProperty);
+			set => SetValue(IsVisibleProperty, value);
 		}
 
 		internal virtual void SendAppearing()

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -126,6 +126,16 @@ namespace Xamarin.Forms
 			set => SetValue(IsVisibleProperty, value);
 		}
 
+		internal bool IsPartOfVisibleTree()
+		{
+			if (Parent is IShellController shell)
+				return shell.GetItems().Contains(this);
+			else if (Parent is ShellGroupItem sgi)
+				return sgi.ShellElementCollection.Contains(this);
+
+			return false;
+		}
+
 		internal virtual void SendAppearing()
 		{
 			if (_hasAppearing)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -952,18 +952,27 @@ namespace Xamarin.Forms
 
 			foreach (var shellItem in ShellController.GetItems())
 			{
+				if (!FlyoutItem.GetIsVisible(shellItem))
+					continue;
+
 				if (shellItem.FlyoutDisplayOptions == FlyoutDisplayOptions.AsMultipleItems)
 				{
 					IncrementGroup();
 
 					foreach (var shellSection in (shellItem as IShellItemController).GetItems())
 					{
+						if (!FlyoutItem.GetIsVisible(shellSection))
+							continue;
+
 						if (shellSection.FlyoutDisplayOptions == FlyoutDisplayOptions.AsMultipleItems)
 						{
 							IncrementGroup();
 
 							foreach (var shellContent in shellSection.Items)
 							{
+								if (!FlyoutItem.GetIsVisible(shellContent))
+									continue;
+
 								currentGroup.Add(shellContent);
 								if (shellContent == shellSection.CurrentItem)
 								{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -769,10 +769,31 @@ namespace Xamarin.Forms
 					try
 					{
 						var location = CurrentState.Location;
-						if (ShellUriHandler.GetNavigationRequest(this, ((ShellNavigationState)location).FullLocation, false) != null)
-							await GoToAsync(location, false);
+						var navRequest = ShellUriHandler.GetNavigationRequest(this, ((ShellNavigationState)location).FullLocation, false);
 
-						return;
+						if (navRequest != null)
+						{
+							var item = navRequest.Request.Item;
+							var section = navRequest.Request.Section;
+							var Content = navRequest.Request.Content;
+
+							if (IsValidRoute(item) && IsValidRoute(section) && IsValidRoute(Content))
+							{
+								await GoToAsync(location, false);
+								return;
+							}
+
+							bool IsValidRoute(BaseShellItem baseShellItem)
+							{
+								if (baseShellItem == null)
+									return true;
+
+								if (!baseShellItem.IsVisible)
+									return false;
+
+								return baseShellItem.IsPartOfVisibleTree();
+							}
+						}
 					}
 					catch (Exception exc)
 					{

--- a/Xamarin.Forms.Core/Shell/ShellContentCollection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContentCollection.cs
@@ -26,12 +26,14 @@ namespace Xamarin.Forms
 
 		protected override void OnElementControllerInserting(IElementController element)
 		{
+			base.OnElementControllerInserting(element);
 			if (element is IShellContentController controller)
 				controller.IsPageVisibleChanged += OnIsPageVisibleChanged;
 		}
 
 		protected override void OnElementControllerRemoving(IElementController element)
 		{
+			base.OnElementControllerRemoving(element);
 			if (element is IShellContentController controller)
 				controller.IsPageVisibleChanged -= OnIsPageVisibleChanged;
 		}

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -23,11 +23,18 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly new BindableProperty IsVisibleProperty =
-			BindableProperty.CreateAttached(nameof(IsVisible), typeof(bool), typeof(FlyoutItem), true);
+			BindableProperty.CreateAttached(nameof(IsVisible), typeof(bool), typeof(FlyoutItem), true, propertyChanged: OnFlyoutItemIsVisibleChanged);
 
 		public static bool GetIsVisible(BindableObject obj) => (bool)obj.GetValue(IsVisibleProperty);
 		public static void SetIsVisible(BindableObject obj, bool isVisible) => obj.SetValue(IsVisibleProperty, isVisible);
 
+		static void OnFlyoutItemIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is Element element)
+				element
+					.FindParentOfType<Shell>()
+					?.SendStructureChanged();
+		}
 	}
 
 	[EditorBrowsable(EditorBrowsableState.Always)]

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -21,6 +21,13 @@ namespace Xamarin.Forms
 		{
 
 		}
+
+		public static readonly new BindableProperty IsVisibleProperty =
+			BindableProperty.CreateAttached(nameof(IsVisible), typeof(bool), typeof(FlyoutItem), true);
+
+		public static bool GetIsVisible(BindableObject obj) => (bool)obj.GetValue(IsVisibleProperty);
+		public static void SetIsVisible(BindableObject obj, bool isVisible) => obj.SetValue(IsVisibleProperty, isVisible);
+
 	}
 
 	[EditorBrowsable(EditorBrowsableState.Always)]

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -513,17 +513,20 @@ namespace Xamarin.Forms
 			IEnumerable results = null;
 			switch (node)
 			{
-				case Shell shell:
-					results = shell.Items;
+				case IShellController shell:
+					results = shell.GetItems();
 					break;
-				case ShellGroupItem sgi:
-					results = sgi.ShellElementCollection;
+				case IShellItemController item:
+					results = item.GetItems();
+					break;
+				case IShellSectionController section:
+					results = section.GetItems();
 					break;
 				case ShellContent content:
 					results = new object[0];
 					break;
-				case GlobalRouteItem routeITem:
-					results = routeITem.Items;
+				case GlobalRouteItem routeItem:
+					results = routeItem.Items;
 					break;
 			}
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -513,14 +513,11 @@ namespace Xamarin.Forms
 			IEnumerable results = null;
 			switch (node)
 			{
-				case IShellController shell:
-					results = shell.GetItems();
+				case Shell shell:
+					results = shell.Items;
 					break;
-				case IShellItemController item:
-					results = item.GetItems();
-					break;
-				case IShellSectionController section:
-					results = section.GetItems();
+				case ShellGroupItem sgi:
+					results = sgi.ShellElementCollection;
 					break;
 				case ShellContent content:
 					results = new object[0];

--- a/Xamarin.Forms.Core/ViewExtensions.cs
+++ b/Xamarin.Forms.Core/ViewExtensions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace Xamarin.Forms
@@ -158,6 +160,27 @@ namespace Xamarin.Forms
 				(f, a) => tcs.SetResult(a));
 
 			return tcs.Task;
+		}
+
+		internal static T FindParentOfType<T>(this Element element)
+		{
+			var navPage = element
+				.GetParentsPath()
+				.OfType<T>()
+				.FirstOrDefault();
+
+			return navPage;
+		}
+
+		internal static IEnumerable<Element> GetParentsPath(this Element self)
+		{
+			Element current = self;
+
+			while (!Application.IsApplicationOrNull(current.RealParent))
+			{
+				current = current.RealParent;
+				yield return current;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -25,6 +25,7 @@ namespace Xamarin.Forms.Platform.UWP
 		Shell _shell;
 
 		ShellItemRenderer ItemRenderer { get; }
+		IShellController ShellController => (IShellController)_shell;
 
 		public ShellRenderer()
 		{
@@ -80,7 +81,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			var item = args.InvokedItemContainer?.DataContext as Element;
 			if (item != null)
-				((IShellController)Element).OnFlyoutItemSelected(item);
+				ShellController.OnFlyoutItemSelected(item);
 		}
 
 		#region IVisualElementRenderer
@@ -213,7 +214,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (_shell != null)
 			{
-				(_shell as IShellController).ItemsCollectionChanged -= OnItemsCollectionChanged;
+				ShellController.ItemsCollectionChanged -= OnItemsCollectionChanged;
 			}
 
 			_shell = shell;
@@ -226,11 +227,17 @@ namespace Xamarin.Forms.Platform.UWP
 			MenuItemsSource = IterateItems();
 			SwitchShellItem(shell.CurrentItem, false);
 			IsPaneOpen = Shell.FlyoutIsPresented;
-			((IShellController)Element).AddFlyoutBehaviorObserver(this);
-			((IShellController)shell).AddAppearanceObserver(this, shell);
-			(shell as IShellController).ItemsCollectionChanged += OnItemsCollectionChanged;
+			ShellController.AddFlyoutBehaviorObserver(this);
+			ShellController.AddAppearanceObserver(this, shell);
+			ShellController.ItemsCollectionChanged += OnItemsCollectionChanged;
+			ShellController.StructureChanged += OnStructureChanged;
 			UpdateFlyoutBackgroundColor();
 			UpdateFlyoutBackdropColor();
+		}
+
+		void OnStructureChanged(object sender, EventArgs e)
+		{
+			MenuItemsSource = IterateItems();
 		}
 
 		void OnItemsCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
### Description of Change ###
- Add IsVisible property to BaseShellItem which will hide that particular shell element from all UI structures and the element will be treated as if it doesn't exist

- Add FlyoutItem.IsVisible which will just hide the item from the flyout menu


### Issues Resolved ### 
- partially fixes #5232

### API Changes ###
Added:

```C#
public class FlyoutItem
{
      public new bool IsVisible //BP
}
```

```C#
public class BaseShellItem
{
      public bool IsVisible //BP
}
```

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Testing Procedure ###
- Automated Tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
