### PR TITLE
Retain TextColor and Font properties when using HTML Label on iOS

### DIFF
--- a/Xamarin.Forms.Platform.iOS.UnitTests/AssertionExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/AssertionExtensions.cs
@@ -64,23 +64,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			return pixel;
 		}
 
-		static bool ARGBEquivalent(UIColor color1, UIColor color2) 
-		{
-			color1.GetRGBA(out nfloat red1, out nfloat green1, out nfloat blue1, out nfloat alpha1);
-			color2.GetRGBA(out nfloat red2, out nfloat green2, out nfloat blue2, out nfloat alpha2);
-
-			const double tolerance = 0.000001;
-
-			return Equal(red1, red2, tolerance)
-				&& Equal(green1, green2, tolerance)
-				&& Equal(blue1, blue2, tolerance) 
-				&& Equal(alpha1, alpha2, tolerance);
-		}
-
-		static bool Equal(nfloat v1, nfloat v2, double tolerance) 
-		{
-			return Math.Abs(v1 - v2) <= tolerance;
-		}
+		
 
 		public static UIImage AssertColorAtPoint(this UIImage bitmap, UIColor expectedColor, int x, int y)
 		{
@@ -88,12 +72,12 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			{
 				var cap = bitmap.ColorAtPoint(x, y);
 
-				if (!ARGBEquivalent(cap, expectedColor))
+				if (!ColorComparison.ARGBEquivalent(cap, expectedColor))
 				{
 					System.Diagnostics.Debug.WriteLine("Here");
 				}
 
-				Assert.That(cap, Is.EqualTo(expectedColor).Using<UIColor>(ARGBEquivalent),
+				Assert.That(cap, Is.EqualTo(expectedColor).Using<UIColor>(ColorComparison.ARGBEquivalent),
 					() => bitmap.CreateColorAtPointError(expectedColor, x, y));
 
 				return bitmap;

--- a/Xamarin.Forms.Platform.iOS.UnitTests/ColorComparison.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/ColorComparison.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	internal static class ColorComparison
+	{
+		public static bool ARGBEquivalent(UIColor color1, UIColor color2)
+		{
+			color1.GetRGBA(out nfloat red1, out nfloat green1, out nfloat blue1, out nfloat alpha1);
+			color2.GetRGBA(out nfloat red2, out nfloat green2, out nfloat blue2, out nfloat alpha2);
+
+			const double tolerance = 0.000001;
+
+			return Equal(red1, red2, tolerance)
+				&& Equal(green1, green2, tolerance)
+				&& Equal(blue1, blue2, tolerance)
+				&& Equal(alpha1, alpha2, tolerance);
+		}
+
+		static bool Equal(nfloat v1, nfloat v2, double tolerance)
+		{
+			return Math.Abs(v1 - v2) <= tolerance;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
@@ -1,4 +1,5 @@
-﻿using System.Threading.Tasks;
+﻿using System;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using UIKit;
 
@@ -12,6 +13,28 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		public async Task LabelTextColorAppliesToHtml()
 		{
 			var label = new Label { TextColor = Color.Red, Text = "<p>Hello</p>", TextType = TextType.Html };
+			var expected = Color.Red.ToUIColor();
+			var actual = await GetControlProperty(label, uiLabel => uiLabel.TextColor);
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+
+		[Test, Category("Text"), Category("Label"), Category("Color")]
+		[Description("If Label does not specify a TextColor, HTML colors should work")]
+		public async Task LabelDefaultTextColorDefersToHtml()
+		{
+			var label = new Label { Text = "<p style='color:blue;font-size:72pt'>Hello</p>", TextType = TextType.Html, 
+				VerticalOptions = LayoutOptions.Center };
+			var expected = Color.Blue.ToUIColor();
+
+			var actual = await GetControlProperty(label, uiLabel => uiLabel.TextColor);
+			Assert.That(actual, Is.EqualTo(expected).Using<UIColor>(ColorComparison.ARGBEquivalent));
+		}
+
+		[Test, Category("Text"), Category("Label"), Category("Color")]
+		[Description("If Label specifies a TextColor, it should override HTML colors")]
+		public async Task LabelTextColorOverridesHtmlColors()
+		{
+			var label = new Label { Text = "<p style='color:blue;'>Hello</p>", TextType = TextType.Html, TextColor = Color.Red };
 			var expected = Color.Red.ToUIColor();
 			var actual = await GetControlProperty(label, uiLabel => uiLabel.TextColor);
 			Assert.That(actual, Is.EqualTo(expected));
@@ -40,6 +63,23 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 
 			Assert.That(actualFont.FontDescriptor.SymbolicTraits & UIFontDescriptorSymbolicTraits.Italic, Is.Not.Zero);
 			Assert.That(actualFont.Name, Is.EqualTo(expectedFontFamily));
+			Assert.That(actualFont.PointSize, Is.EqualTo(expectedFontSize));
+		}
+
+		[Test, Category("Text"), Category("Label"), Category("Font")]
+		[Description("If Label Font is not set HTML fonts should apply")]
+		public async Task LabelFontDefaultDefersToHtml()
+		{
+			var label = new Label
+			{
+				Text = "<p style='font-size:3em'>Hello</p>",
+				TextType = TextType.Html
+			};
+
+			nfloat expectedFontSize = 36; // 12pt * 3em
+
+			var actualFont = await GetControlProperty(label, uiLabel => uiLabel.Font);
+
 			Assert.That(actualFont.PointSize, Is.EqualTo(expectedFontSize));
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
@@ -1,0 +1,46 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture]
+	public class HtmlLabelTests : PlatformTestFixture
+	{
+		[Test, Category("Text"), Category("Label"), Category("Color")]
+		[Description("Label text color should apply in HTML mode")]
+		public async Task LabelTextColorAppliesToHtml()
+		{
+			var label = new Label { TextColor = Color.Red, Text = "<p>Hello</p>", TextType = TextType.Html };
+			var expected = Color.Red.ToUIColor();
+			var actual = await GetControlProperty(label, uiLabel => uiLabel.TextColor);
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+
+		[Test, Category("Text"), Category("Label"), Category("Color")]
+		[Description("Label background color should apply in HTML mode")]
+		public async Task LabelBackgroundColorAppliesToHtml()
+		{
+			var label = new Label { BackgroundColor = Color.Red, Text = "<p>Hello</p>", TextType = TextType.Html };
+			var expected = Color.Red.ToUIColor();
+			var actual = await GetRendererProperty(label, r => r.NativeView.BackgroundColor);
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+
+		[Test, Category("Text"), Category("Label"), Category("Font")]
+		[Description("Label Font should apply in HTML mode")]
+		public async Task LabelFontAppliesToHtml()
+		{
+			var label = new Label { FontFamily = "MarkerFelt-Thin", FontSize = 24, FontAttributes = FontAttributes.Italic, 
+				Text = "<p>Hello</p>", TextType = TextType.Html };
+			var expectedFontFamily = label.FontFamily;
+			var expectedFontSize = (System.nfloat)label.FontSize;
+			
+			var actualFont = await GetControlProperty(label, uiLabel => uiLabel.Font);
+
+			Assert.That(actualFont.FontDescriptor.SymbolicTraits & UIFontDescriptorSymbolicTraits.Italic, Is.Not.Zero);
+			Assert.That(actualFont.Name, Is.EqualTo(expectedFontFamily));
+			Assert.That(actualFont.PointSize, Is.EqualTo(expectedFontSize));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -55,6 +55,7 @@
     </Compile>
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BackgroundColorTests.cs" />
+    <Compile Include="ColorComparison.cs" />
     <Compile Include="CornerRadiusTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="CornerRadiusTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
+    <Compile Include="HtmlLabelTests.cs" />
     <Compile Include="ImageButtonTests.cs" />
     <Compile Include="IsEnabledTests.cs" />
     <Compile Include="IsVisibleTests.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -489,11 +489,43 @@ namespace Xamarin.Forms.Platform.MacOS
 			};
 		}
 
+		static bool FontIsDefault(Label label) 
+		{
+			if (label.IsSet(Label.FontAttributesProperty))
+			{
+				return false;
+			}
+
+			if (label.IsSet(Label.FontFamilyProperty))
+			{
+				return false;
+			}
+
+			if (label.IsSet(Label.FontSizeProperty))
+			{
+				return false;
+			}
+
+			return true;
+		}
+
 		void UpdateFont()
 		{
+			if(Element == null)
+			{
+				return;
+			}
+
 			if (IsTextFormatted)
 			{
 				UpdateFormattedText();
+				return;
+			}
+
+			if (Element.TextType == TextType.Html && FontIsDefault(Element))
+			{
+				// If no explicit font properties have been specified and we're display HTML,
+				// let the HTML determine the typeface
 				return;
 			}
 
@@ -515,9 +547,16 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			var textColor = (Color)Element.GetValue(Label.TextColorProperty);
 
-			// default value of color documented to be black in iOS docs
+			if (textColor.IsDefault && Element.TextType == TextType.Html)
+			{
+				// If no explicit text color has been specified and we're displaying HTML, 
+				// let the HTML determine the colors
+				return;		
+			}
+
+				// default value of color documented to be black in iOS docs
 #if __MOBILE__
-			Control.TextColor = textColor.ToUIColor(ColorExtensions.LabelColor);
+				Control.TextColor = textColor.ToUIColor(ColorExtensions.LabelColor);
 #else
 			var alignment = Element.HorizontalTextAlignment.ToNativeTextAlignment(((IVisualElementController)Element).EffectiveFlowDirection);
 			var textWithColor = new NSAttributedString(Element.Text ?? "", font: Element.ToNSFont(), foregroundColor: textColor.ToNSColor(ColorExtensions.Black), paragraphStyle: new NSMutableParagraphStyle() { Alignment = alignment });

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -474,6 +474,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			Control.AttributedStringValue = new NSAttributedString(htmlData, attr, out _);
 #endif
 			_perfectSizeValid = false;
+
+			// Setting AttributedText will reset style-related properties, so we'll need to update them again
+			UpdateTextColor();
+			UpdateFont();
 		}
 
 		protected virtual NSAttributedStringDocumentAttributes GetNSAttributedStringDocumentAttributes()
@@ -487,9 +491,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateFont()
 		{
-			if (Element?.TextType != TextType.Text)
-				return;
-
 			if (IsTextFormatted)
 			{
 				UpdateFormattedText();
@@ -506,9 +507,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		void UpdateTextColor()
 		{
-			if (Element?.TextType != TextType.Text)
-				return;
-
 			if (IsTextFormatted)
 			{
 				UpdateFormattedText();
@@ -528,6 +526,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 			UpdateLayout();
 		}
+
 		void UpdateLayout()
 		{
 #if __MOBILE__


### PR DESCRIPTION
### Description of Change ###

Setting AttributedText on a UILabel clears out other formatting properties. So when a user sets the `TextColor` and `Font` properties of a `Label` and subsequently sets the `Label`'s `TextType` to HTML, the properties are wiped out. 

This change re-applies the TextColor and Font properties (if they have been set) after setting the HTML text. 

### Issues Resolved ### 

- fixes #10588

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None 

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated platform tests.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
