### PR TITLE
Remove IndicatorViewExperimental flag

### DIFF
--- a/Xamarin.Forms.ControlGallery.Tizen/ControlGallery.Tizen.cs
+++ b/Xamarin.Forms.ControlGallery.Tizen/ControlGallery.Tizen.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.ControlGallery.Tizen
 		{
 			var app = new MainApplication();
 			FormsMaps.Init("HERE", "write-your-API-key-here");
-			Forms.SetFlags("CollectionView_Experimental", "Shell_Experimental", "MediaElement_Experimental", "IndicatorView_Experimental");
+			Forms.SetFlags("CollectionView_Experimental", "Shell_Experimental", "MediaElement_Experimental");
 			Forms.Init(app);
 			FormsMaterial.Init();
 			app.Run(args);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8693.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8693.cs
@@ -27,9 +27,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-#if APP
-			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "IndicatorView_Experimental" });
-#endif
 			var layout = new StackLayout();
 
 			var instructions = new Label

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8958.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8958.xaml.cs
@@ -21,7 +21,6 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue8958()
 		{
 #if APP
-			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { "IndicatorView_Experimental" });
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9827.xaml.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue9827()
 		{
 #if APP
-			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { ExperimentalFlags.IndicatorViewExperimental, ExperimentalFlags.CarouselViewExperimental });
+			Device.SetFlags(new List<string>(Device.Flags ?? new List<string>()) { ExperimentalFlags.CarouselViewExperimental });
 			InitializeComponent();
 #endif
 		}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			button.TextColor = Color.Black;
 			button.IsEnabled = false;
 
-			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental, ExperimentalFlags.IndicatorViewExperimental });
+			Device.SetFlags(new[] { ExperimentalFlags.CarouselViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorGalleries.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/IndicatorViewGalleries/IndicatorGalleries.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace Xamarin.Forms.Controls.GalleryPages
+﻿namespace Xamarin.Forms.Controls.GalleryPages
 {
 	public class IndicatorGalleries : ContentPage
 	{
@@ -11,13 +9,6 @@ namespace Xamarin.Forms.Controls.GalleryPages
 
 			Title = "IndicatorView Galleries";
 
-			var button = new Button
-			{
-				Text = "Enable IndicatorView",
-				AutomationId = "EnableIndicator"
-			};
-			button.Clicked += ButtonClicked;
-
 			Content = new ScrollView
 			{
 				Content = new StackLayout
@@ -25,7 +16,6 @@ namespace Xamarin.Forms.Controls.GalleryPages
 					Children =
 					{
 						descriptionLabel,
-						button,
 						GalleryBuilder.NavButton("IndicatorView Gallery", () =>
 							new IndicatorsSample(), Navigation),
 						GalleryBuilder.NavButton("Indicator MaxVisible Gallery", () =>
@@ -33,17 +23,6 @@ namespace Xamarin.Forms.Controls.GalleryPages
 					}
 				}
 			};
-		}
-
-		void ButtonClicked(object sender, EventArgs e)
-		{
-			var button = sender as Button;
-
-			button.Text = "IndicatorView Enabled!";
-			button.TextColor = Color.Black;
-			button.IsEnabled = false;
-
-			Device.SetFlags(new[] { ExperimentalFlags.IndicatorViewExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -10,7 +10,6 @@ namespace Xamarin.Forms
 	internal static class ExperimentalFlags
 	{
 		internal const string StateTriggersExperimental = "StateTriggers_Experimental";
-		internal const string IndicatorViewExperimental = "IndicatorView_Experimental";
 		internal const string ShellUWPExperimental = "Shell_UWP_Experimental";
 		internal const string CarouselViewExperimental = "CarouselView_Experimental";
 		internal const string SwipeViewExperimental = "SwipeView_Experimental";

--- a/Xamarin.Forms.Core/IndicatorView.cs
+++ b/Xamarin.Forms.Core/IndicatorView.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms
 
 		public IndicatorView()
 		{
-			ExperimentalFlags.VerifyFlagEnabled(nameof(IndicatorView), ExperimentalFlags.IndicatorViewExperimental);
+
 		}
 
 		public IndicatorShape IndicatorsShape


### PR DESCRIPTION
### Description of Change ###

Remove IndicatorViewExperimental flag!


### API Changes ###
`Forms.SetFlags ("IndicatorView_Experimental")` is no longer required; to use `IndicatorView`.

### Platforms Affected ### 

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the IndicatorView Gallery. Without set the flag everything should works without problems.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
