### PR TITLE
[iOS] Revert change that sets Frame BackgroundColor to null

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -79,12 +79,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.BackgroundColor == Color.Default)
 				_actualView.Layer.BackgroundColor = ColorExtensions.BackgroundColor.CGColor;
 			else
-			{
-				// BackgroundColor gets set on the base class too which messes with
-				// the corner radius, shadow, etc. so override that behaviour here
-				BackgroundColor = null;
 				_actualView.Layer.BackgroundColor = Element.BackgroundColor.ToCGColor();
-			}
 
 			if (Element.BorderColor == Color.Default)
 				_actualView.Layer.BorderColor = UIColor.Clear.CGColor;

--- a/Xamarin.Forms.sln
+++ b/Xamarin.Forms.sln
@@ -680,6 +680,7 @@ Global
 		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|ARM64.ActiveCfg = Debug|iPhone
 		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|iPhone.ActiveCfg = Debug|iPhone
 		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|iPhone.Build.0 = Debug|iPhone
+		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|iPhone.Deploy.0 = Debug|iPhone
 		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|iPhoneSimulator.ActiveCfg = Debug|iPhoneSimulator
 		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|iPhoneSimulator.Build.0 = Debug|iPhoneSimulator
 		{C7131F14-274F-4B55-ACA9-E81731AD012F}.Debug|x64.ActiveCfg = Debug|iPhoneSimulator


### PR DESCRIPTION
### Description of Change ###

#10469 set the base BackgroundColor to null. This caused one of the platform tests to start failing on iOS. Since this is 1. inconsistent behavior and 2. appears to not actually affect any of the test cases in the associated PR one way or another, I have reverted this change.

### Issues Resolved ### 

n/a

### API Changes ###
 
 None

### Platforms Affected ### 


- iOS


### Behavioral/Visual Changes ###


None


### Testing Procedure ###

Test the issues associated with #10469 to see if any fail again.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
