### PR TITLE
Fix check for contextual routing with global pages

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -340,7 +340,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsNotNull(shellNavigatingEventArgs, "Shell.Navigating never fired");
 			Assert.IsNotNull(shellNavigatedEventArgs, "Shell.Navigated never fired");
 
-			Assert.AreEqual("//NewRoute/Section/Content/", shellNavigatingEventArgs.Current.FullLocation.ToString());
+			Assert.AreEqual("//NewRoute/Section/Content", shellNavigatingEventArgs.Current.FullLocation.ToString());
 			Assert.AreEqual("//NewRoute/Section/Content/ModalTestPage", shellNavigatedEventArgs.Current.FullLocation.ToString());
 
 		}

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -175,6 +175,52 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("edit", request.Request.GlobalRoutes.First());
 		}
 
+		[TestCase(true, 2)]
+		[TestCase(false, 2)]
+		[TestCase(true, 3)]
+		[TestCase(false, 3)]
+		public async Task ShellItemContentRouteWithGlobalRouteRelative(bool modal, int depth)
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
+
+			string route = "monkeys/details";
+
+			if(depth == 3)
+			{
+				route = "animals/monkeys/details";
+			}
+
+			if (modal)
+				Routing.RegisterRoute(route, typeof(ShellModalTests.ModalTestPage));
+			else
+				Routing.RegisterRoute(route, typeof(ContentPage));
+
+			shell.Items.Add(item1);
+
+			await shell.GoToAsync("details");
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//animals/monkeys/details"));
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public async Task GotoSameGlobalRoutesCollapsesUriCorrectly(bool modal)
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
+
+			if(modal)
+				Routing.RegisterRoute("details", typeof(ShellModalTests.ModalTestPage));
+			else
+				Routing.RegisterRoute("details", typeof(ContentPage));
+
+			shell.Items.Add(item1);
+
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("details");
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//animals/monkeys/details/details"));
+		}
+
 
 		[Test]
 		public async Task ShellSectionWithRelativeEditUpOneLevel()
@@ -294,6 +340,20 @@ namespace Xamarin.Forms.Core.UnitTests
 				"//animals/domestic/cats/catdetails",
 				shell.CurrentState.FullLocation.ToString()
 				);
+		}
+
+		[Test]
+		public async Task RelativeNavigationToShellElementThrows()
+		{
+			var shell = new Shell();
+
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "dogs");
+			var item2 = CreateShellItem(asImplicit: true, shellSectionRoute: "domestic", shellContentRoute: "cats", shellItemRoute: "animals");
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			Assert.That(async () => await shell.GoToAsync($"domestic"), Throws.Exception);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -631,8 +631,6 @@ namespace Xamarin.Forms
 
 		ShellNavigationState GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> sectionStack, IReadOnlyList<Page> modalStack)
 		{
-			//StringBuilder stateBuilder = new StringBuilder($"//");
-			Dictionary<string, string> queryData = new Dictionary<string, string>();
 			List<string> routeStack = new List<string>();
 
 			bool stackAtRoot = sectionStack == null || sectionStack.Count <= 1;
@@ -656,7 +654,7 @@ namespace Xamarin.Forms
 					if (!stackAtRoot)
 					{
 						for (int i = 1; i < sectionStack.Count; i++)
-						{							
+						{
 							var page = sectionStack[i];
 							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack));
 						}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -631,66 +631,90 @@ namespace Xamarin.Forms
 
 		ShellNavigationState GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> sectionStack, IReadOnlyList<Page> modalStack)
 		{
-			StringBuilder stateBuilder = new StringBuilder($"//");
+			//StringBuilder stateBuilder = new StringBuilder($"//");
 			Dictionary<string, string> queryData = new Dictionary<string, string>();
+			List<string> routeStack = new List<string>();
 
 			bool stackAtRoot = sectionStack == null || sectionStack.Count <= 1;
 
 			if (shellItem != null)
 			{
 				var shellItemRoute = shellItem.Route;
-				stateBuilder.Append(shellItemRoute);
-				stateBuilder.Append("/");
+				routeStack.Add(shellItemRoute);
 
 				if (shellSection != null)
 				{
 					var shellSectionRoute = shellSection.Route;
-					stateBuilder.Append(shellSectionRoute);
-					stateBuilder.Append("/");
+					routeStack.Add(shellSectionRoute);
 
 					if (shellContent != null)
 					{
 						var shellContentRoute = shellContent.Route;
-						stateBuilder.Append(shellContentRoute);
-						stateBuilder.Append("/");
+						routeStack.Add(shellContentRoute);
 					}
 
 					if (!stackAtRoot)
 					{
 						for (int i = 1; i < sectionStack.Count; i++)
-						{
+						{							
 							var page = sectionStack[i];
-							stateBuilder.Append(Routing.GetRoute(page));
-							if (i < sectionStack.Count - 1)
-								stateBuilder.Append("/");
+							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack));
 						}
 					}
 
 					if (modalStack != null && modalStack.Count > 0)
 					{
-						if (!stackAtRoot && sectionStack.Count > 0)
-							stateBuilder.Append("/");
-
 						for (int i = 0; i < modalStack.Count; i++)
 						{
 							var topPage = modalStack[i];
 
-							if (i > 0)
-								stateBuilder.Append("/");
-
-							stateBuilder.Append(Routing.GetRoute(topPage));
+							routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage), routeStack));
 
 							for (int j = 1; j < topPage.Navigation.NavigationStack.Count; j++)
 							{
-								stateBuilder.Append("/");
-								stateBuilder.Append(Routing.GetRoute(topPage.Navigation.NavigationStack[j]));
+								routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack));
 							}
 						}
 					}
 				}
 			}
 
-			return stateBuilder.ToString();
+			if(routeStack.Count > 0)
+				routeStack.Insert(0, "/");
+
+			return String.Join("/", routeStack);
+
+
+			List<string> CollapsePath(string myRoute, List<string> currentRouteStack)
+			{
+				for (var i = currentRouteStack.Count - 1; i >= 0; i--)
+				{
+					var route = currentRouteStack[i];
+					if (Routing.IsImplicit(route) || Routing.IsDefault(route))
+						currentRouteStack.RemoveAt(i);
+				}
+
+				var paths = myRoute.Split('/').ToList();
+
+				// collapse similar leaves
+				int walkBackCurrentStackIndex = currentRouteStack.Count - (paths.Count - 1);
+
+				while(paths.Count > 1 && walkBackCurrentStackIndex >= 0)
+				{
+					if (paths[0] == currentRouteStack[walkBackCurrentStackIndex])
+					{
+						paths.RemoveAt(0);
+					}
+					else
+					{
+						break;
+					}
+
+					walkBackCurrentStackIndex++;
+				}
+
+				return paths;
+			}
 		}
 
 		public static readonly BindableProperty CurrentItemProperty =

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -219,8 +219,13 @@ namespace Xamarin.Forms
 					{
 						// currently relative routes to shell routes isn't supported as we aren't creating navigation stacks
 						// So right now we will just throw an exception so that once this is implemented
-						// GotoAsync doesn't start acting inconsistently and all of a suddent starts creating routes
-						if (!enableRelativeShellRoutes && pureGlobalRoutesMatch[0].SegmentsMatched.Count > 0)
+						// GotoAsync doesn't start acting inconsistently and all of a sudden starts creating routes
+
+						int shellElementsMatched = 
+							pureGlobalRoutesMatch[0].SegmentsMatched.Count -
+							pureGlobalRoutesMatch[0].GlobalRouteMatches.Count;
+
+						if (!enableRelativeShellRoutes && shellElementsMatched > 0)
 						{
 							throw new Exception($"Relative routing to shell elements is currently not supported. Try prefixing your uri with ///: ///{originalRequest}");
 						}


### PR DESCRIPTION
### Description of Change ###

- Fix the check that prevents relative routes to shell parts so that it correctly takes into account contextual routes
- collapse the route path down when using a contextual route

for example if I am at

`//Animals/monkeys` 

And there's a registered route with

`monkeys/details`

Then the route path should be 
`//Animals/monkeys/details` 


### Issues Resolved ### 
- fixes #10970

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
