### PR TITLE
Remove flyout backdrop color so it can come back as a brush

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -307,15 +307,15 @@ namespace Xamarin.Forms.Controls.XamStore
 			Content = new ScrollView { Content = grid };
 
 
-			grid.Children.Add(MakeButton("FlyoutBackdrop Color",
-					() =>
-					{
-						if (Shell.GetFlyoutBackdropColor(Shell.Current) == Color.Default)
-							Shell.SetFlyoutBackdropColor(Shell.Current, Color.Purple);
-						else
-							Shell.SetFlyoutBackdropColor(Shell.Current, Color.Default);
-					}),
-				0, 21);
+			//grid.Children.Add(MakeButton("FlyoutBackdrop Color",
+			//		() =>
+			//		{
+			//			if (Shell.GetFlyoutBackdropColor(Shell.Current) == Color.Default)
+			//				Shell.SetFlyoutBackdropColor(Shell.Current, Color.Purple);
+			//			else
+			//				Shell.SetFlyoutBackdropColor(Shell.Current, Color.Default);
+			//		}),
+			//	0, 21);
 
 			grid.Children.Add(MakeButton("Hide Nav Shadow",
                     () => Shell.SetNavBarHasShadow(this, false)),

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -146,9 +146,9 @@ namespace Xamarin.Forms
 			BindableProperty.CreateAttached("UnselectedColor", typeof(Color), typeof(Shell), Color.Default,
 				propertyChanged: OnColorValueChanged);
 
-		public static readonly BindableProperty FlyoutBackdropColorProperty =
-			BindableProperty.CreateAttached("FlyoutBackdropColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+		//public static readonly BindableProperty FlyoutBackdropColorProperty =
+		//	BindableProperty.CreateAttached("FlyoutBackdropColor", typeof(Color), typeof(Shell), Color.Default,
+		//		propertyChanged: OnColorValueChanged);
 
 		public static Color GetBackgroundColor(BindableObject obj) => (Color)obj.GetValue(BackgroundColorProperty);
 		public static void SetBackgroundColor(BindableObject obj, Color value) => obj.SetValue(BackgroundColorProperty, value);
@@ -180,8 +180,8 @@ namespace Xamarin.Forms
 		public static Color GetUnselectedColor(BindableObject obj) => (Color)obj.GetValue(UnselectedColorProperty);
 		public static void SetUnselectedColor(BindableObject obj, Color value) => obj.SetValue(UnselectedColorProperty, value);
 
-		public static Color GetFlyoutBackdropColor(BindableObject obj) => (Color)obj.GetValue(FlyoutBackdropColorProperty);
-		public static void SetFlyoutBackdropColor(BindableObject obj, Color value) => obj.SetValue(FlyoutBackdropColorProperty, value);
+		//public static Color GetFlyoutBackdropColor(BindableObject obj) => (Color)obj.GetValue(FlyoutBackdropColorProperty);
+		//public static void SetFlyoutBackdropColor(BindableObject obj, Color value) => obj.SetValue(FlyoutBackdropColorProperty, value);
 
 		static void OnColorValueChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -843,11 +843,11 @@ namespace Xamarin.Forms
 			set => SetValue(FlyoutBackgroundColorProperty, value);
 		}
 
-		public Color FlyoutBackdropColor
-		{
-			get => (Color)GetValue(FlyoutBackdropColorProperty);
-			set => SetValue(FlyoutBackdropColorProperty, value);
-		}
+		//public Color FlyoutBackdropColor
+		//{
+		//	get => (Color)GetValue(FlyoutBackdropColorProperty);
+		//	set => SetValue(FlyoutBackdropColorProperty, value);
+		//}
 
 		public FlyoutBehavior FlyoutBehavior
 		{

--- a/Xamarin.Forms.Core/Shell/ShellAppearance.cs
+++ b/Xamarin.Forms.Core/Shell/ShellAppearance.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms
 			Shell.TabBarUnselectedColorProperty,
 			Shell.TitleColorProperty,
 			Shell.UnselectedColorProperty,
-			Shell.FlyoutBackdropColorProperty
+			//Shell.FlyoutBackdropColorProperty
 		};
 
 		Color?[] _colorArray = new Color?[s_ingestArray.Length];
@@ -43,7 +43,7 @@ namespace Xamarin.Forms
 
 		public Color UnselectedColor => _colorArray[9].Value;
 
-		public Color FlyoutBackdropColor => _colorArray[10].Value;
+		//public Color FlyoutBackdropColor => _colorArray[10].Value;
 
 		Color IShellAppearanceElement.EffectiveTabBarBackgroundColor =>
 			!TabBarBackgroundColor.IsDefault ? TabBarBackgroundColor : BackgroundColor;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -22,10 +22,10 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
-			if (appearance == null)
+			//if (appearance == null)
 				UpdateScrimColor(Color.Default);
-			else
-				UpdateScrimColor(appearance.FlyoutBackdropColor);
+			//else
+			//	UpdateScrimColor(appearance.FlyoutBackdropColor);
 		}
 
 		#endregion IAppearanceObserver

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -171,10 +171,10 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateFlyoutBackgroundColor();
 			}
-			else if (e.PropertyName == Shell.FlyoutBackdropColorProperty.PropertyName)
-			{
-				UpdateFlyoutBackdropColor();
-			}
+			//else if (e.PropertyName == Shell.FlyoutBackdropColorProperty.PropertyName)
+			//{
+			//	UpdateFlyoutBackdropColor();
+			//}
 		}
 
 		protected virtual void UpdateFlyoutBackdropColor()
@@ -182,7 +182,7 @@ namespace Xamarin.Forms.Platform.UWP
 			var splitView = ShellSplitView;
 			if (splitView != null)
 			{
-				splitView.FlyoutBackdropColor = _shell.FlyoutBackdropColor;
+				//splitView.FlyoutBackdropColor = _shell.FlyoutBackdropColor;
 				if (IsPaneOpen)
 					ShellSplitView.UpdateFlyoutBackdropColor();
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -14,10 +14,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
-			if (appearance == null)
+			//if (appearance == null)
 				_backdropColor = Color.Default;
-			else
-				_backdropColor = appearance.FlyoutBackdropColor;
+			//else
+			//	_backdropColor = appearance.FlyoutBackdropColor;
 
 			UpdateTapoffViewBackgroundColor();
 		}


### PR DESCRIPTION
### Description of Change ###

Brushes are going to be introduced soon so it doesn't make sense to add an API now that's just going to be deprecated for the next release


### API Changes ###
- Removed Shell.FlyoutBackdropColor
 

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- everything compiles
- Shell runs without crashing and opening the flyout looks and works alright

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
