### PR TITLE
Add additional parameters to android build and fix iOS cake build

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS (Forwarders).csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{39B3457F-01D8-43D0-8E84-D8C4F73CF48D}</ProjectGuid>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -101,7 +101,7 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
     <MtouchLink>Full</MtouchLink>
-    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
+    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type --dsym=true</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
     <AppExtensionDebugBundleId />

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -40,7 +40,7 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignProvision />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <MtouchExtraArgs>--nolinkaway</MtouchExtraArgs>
+    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -3,7 +3,7 @@
   <Import Condition="'$(EnvironmentBuildPropsImported)' != 'True'" Project="..\Environment.Build.props" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">iPhone</Platform>
     <ProjectGuid>{C7131F14-274F-4B55-ACA9-E81731AD012F}</ProjectGuid>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -13,6 +13,7 @@
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <DefineConstants Condition="'$(Use2017)' != 'true'">__XCODE11__;$(DefineConstants);</DefineConstants>
+    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhoneSimulator' ">
     <DebugSymbols>true</DebugSymbols>
@@ -40,7 +41,6 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignProvision />
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -70,7 +70,6 @@
     </CodesignEntitlements>
     <MtouchLink>SdkOnly</MtouchLink>
     <MtouchProfiling>False</MtouchProfiling>
-    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
     <MtouchFastDev>False</MtouchFastDev>
     <MtouchEnableGenericValueTypeSharing>True</MtouchEnableGenericValueTypeSharing>
     <MtouchUseLlvm>False</MtouchUseLlvm>
@@ -99,11 +98,9 @@
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <MtouchLink>Full</MtouchLink>
-    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
     <MtouchLink>Full</MtouchLink>
-    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type --dsym=true</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(RunConfiguration)' == 'Default' ">
     <AppExtensionDebugBundleId />

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -98,6 +98,8 @@
     <CodesignKey>iPhone Developer</CodesignKey>
     <CodesignEntitlements>Entitlements.plist</CodesignEntitlements>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <MtouchLink>Full</MtouchLink>
+    <MtouchExtraArgs>--nolinkaway --optimize=experimental-xforms-product-type</MtouchExtraArgs>
   </PropertyGroup>
   <PropertyGroup Condition="'$(TF_BUILD)' == 'true' OR '$(CI)' == 'true'">
     <MtouchLink>Full</MtouchLink>

--- a/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
+++ b/Xamarin.Forms.Maps.iOS/Xamarin.Forms.Maps.iOS.csproj
@@ -2,7 +2,7 @@
 <Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
     <ProductVersion>8.0.30703</ProductVersion>
     <SchemaVersion>2.0</SchemaVersion>
     <ProjectGuid>{ABA078C4-F9BB-4924-8B2B-10FE0D2F5491}</ProjectGuid>

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -140,7 +140,7 @@ stages:
             - msbuild
         variables:
           FormsIdAppend: ''
-          buildConfiguration: $(DefaultBuildConfiguration)
+          buildConfiguration: variables['DefaultBuildConfiguration']
           nugetPackageVersion : $[ dependencies.win_bots.outputs['debug.winbuild.xamarinformspackageversion'] ]
         steps:
           - template: build/steps/build-nuget.yml
@@ -171,7 +171,7 @@ stages:
           - Xamarin.iOS
       variables:
         provisionator.osxPath : 'build/provisioning/provisioning.csx'
-        buildConfiguration: $(DefaultBuildConfiguration)
+        buildConfiguration: variables['DefaultBuildConfiguration']
         slnPath: $(SolutionFile)
         iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
         iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
@@ -195,7 +195,7 @@ stages:
           - Xamarin.iOS
       variables:
         provisionator.osxPath : 'build/provisioning/provisioning.csx'
-        buildConfiguration: $(DefaultBuildConfiguration)
+        buildConfiguration: ${{ variables.DefaultBuildConfiguration }}
         slnPath: $(SolutionFile)
         iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
         iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -138,7 +138,7 @@ stages:
             - msbuild
         variables:
           FormsIdAppend: ''
-          buildConfiguration: variables['DefaultBuildConfiguration']
+          buildConfiguration: $(DefaultBuildConfiguration)
           nugetPackageVersion : $[ dependencies.win_bots.outputs['debug.winbuild.xamarinformspackageversion'] ]
         steps:
           - template: build/steps/build-nuget.yml
@@ -151,7 +151,7 @@ stages:
         parameters:
           vmImage: $(macOSXVmImage)
           provisionatorPath : 'build/provisioning/provisioning.csx'
-          buildConfiguration : variables['DefaultBuildConfiguration']
+          buildConfiguration : $(DefaultBuildConfiguration)
 
 
   - stage: build_osx
@@ -194,7 +194,7 @@ stages:
           - Xamarin.iOS
       variables:
         provisionator.osxPath : 'build/provisioning/provisioning.csx'
-        buildConfiguration: variables['DefaultBuildConfiguration']
+        buildConfiguration: $(DefaultBuildConfiguration)
         slnPath: $(SolutionFile)
         iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
         iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -151,6 +151,7 @@ stages:
         parameters:
           vmImage: $(macOSXVmImage)
           provisionatorPath : 'build/provisioning/provisioning.csx'
+          buildConfiguration : variables['DefaultBuildConfiguration']
 
 
   - stage: build_osx
@@ -169,7 +170,7 @@ stages:
           - Xamarin.iOS
       variables:
         provisionator.osxPath : 'build/provisioning/provisioning.csx'
-        buildConfiguration: ${{ variables.DefaultBuildConfiguration }}
+        buildConfiguration: $(DefaultBuildConfiguration)
         slnPath: $(SolutionFile)
         iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
         iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
@@ -193,7 +194,7 @@ stages:
           - Xamarin.iOS
       variables:
         provisionator.osxPath : 'build/provisioning/provisioning.csx'
-        buildConfiguration: ${{ variables.DefaultBuildConfiguration }}
+        buildConfiguration: variables['DefaultBuildConfiguration']
         slnPath: $(SolutionFile)
         iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
         iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,6 +1,4 @@
 variables:
-- name: DefaultBuildConfiguration
-  value: Debug
 - name: DefaultBuildPlatform
   value: 'any cpu'
 - name: ApkName
@@ -171,7 +169,7 @@ stages:
           - Xamarin.iOS
       variables:
         provisionator.osxPath : 'build/provisioning/provisioning.csx'
-        buildConfiguration: variables['DefaultBuildConfiguration']
+        buildConfiguration: ${{ variables.DefaultBuildConfiguration }}
         slnPath: $(SolutionFile)
         iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
         iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,8 +5,6 @@ variables:
   value: 'any cpu'
 - name: ApkName
   value: AndroidControlGallery.AndroidControlGallery.apk
-- name: IpaName
-  value: XamarinFormsControlGalleryiOS.ipa
 - name: SolutionFile
   value: Xamarin.Forms.sln
 - name: BuildVersion

--- a/build.cake
+++ b/build.cake
@@ -34,6 +34,8 @@ PowerShell:
 // ARGUMENTS
 //////////////////////////////////////////////////////////////////////
 
+var target = Argument("target", "Default");
+
 var ANDROID_RENDERERS = Argument("ANDROID_RENDERERS", "FAST");
 var XamarinFormsVersion = Argument("XamarinFormsVersion", "");
 var configuration = Argument("BUILD_CONFIGURATION", "Debug");

--- a/build.cake
+++ b/build.cake
@@ -653,7 +653,7 @@ Task("cg-ios")
             };
 
             buildSettings.BinaryLogger = binaryLogger;
-            binaryLogger.FileName = $"{artifactStagingDirectory}/ios-cg-2017_${buildForVS2017}.binlog";
+            binaryLogger.FileName = $"{artifactStagingDirectory}/ios-cg-2017_{buildForVS2017}.binlog";
         }
         else
         {

--- a/build.cake
+++ b/build.cake
@@ -64,7 +64,9 @@ string[] androidSdkManagerInstalls = new [] { "platforms;android-28", "platforms
 string[] netFrameworkSdksLocalInstall = new string[]
 {
     "https://go.microsoft.com/fwlink/?linkid=2099470", //NET461 SDK
-    "https://go.microsoft.com/fwlink/?linkid=874338" //NET472 SDK
+    "https://go.microsoft.com/fwlink/?linkid=874338", //NET472 SDK
+    "https://go.microsoft.com/fwlink/?linkid=2099465", //NET47
+    "https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe" //net47 targeting pack
 };
 
 // these don't run on CI

--- a/build.cake
+++ b/build.cake
@@ -645,8 +645,6 @@ Task("cg-ios")
         var buildSettings = 
             GetMSBuildSettings(null)
             .WithProperty("BuildIpa", $"{IOS_BUILD_IPA}");
-        
-        var buildSettings = GetMSBuildSettings();
 
         if(isCIBuild)
         {

--- a/build.cake
+++ b/build.cake
@@ -619,7 +619,7 @@ Task("cg-android")
             };
 
             buildSettings.BinaryLogger = binaryLogger;
-            binaryLogger.FileName = $"{artifactStagingDirectory}/android-{ANDROID_RENDERERS}_${buildForVS2017}.binlog";
+            binaryLogger.FileName = $"{artifactStagingDirectory}/android-{ANDROID_RENDERERS}_{buildForVS2017}.binlog";
         }
         else
         {

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -63,9 +63,17 @@ if (IsMac)
 
 	async System.Threading.Tasks.Task ResolveUrl (string url)
 	{
-		using (var response = await client.GetAsync (url, System.Net.Http.HttpCompletionOption.ResponseHeadersRead)) {
-			response.EnsureSuccessStatusCode ();
-			Item(response.RequestMessage.RequestUri.ToString());
+		// When downloading a package using the xamci we have to use the following code to 
+		// install updates otherwise provionator can't tell the difference between a new package or an old one
+		try
+		{
+			using (var response = await client.GetAsync (url, System.Net.Http.HttpCompletionOption.ResponseHeadersRead)) {
+				response.EnsureSuccessStatusCode ();
+				Item(response.RequestMessage.RequestUri.ToString());
+			}
+		}
+		catch{
+			Item(url);
 		}
 	}
 }

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -48,8 +48,8 @@ if (IsMac)
 		if(releaseChannel == "Beta")
 		{
 			Console.WriteLine("Installing Beta Channel");			
-			await ResolveUrl ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-6/PKG-Xamarin.Mac-notarized");
-			await ResolveUrl ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-6/PKG-Xamarin.iOS-notarized");
+			await ResolveUrl ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-6-xcode11.6/PKG-Xamarin.Mac-notarized");
+			await ResolveUrl ("https://xamci.azurewebsites.net/dl/xamarin/xamarin-macios/d16-6-xcode11.6/PKG-Xamarin.iOS-notarized");
 		}
 		else if(releaseChannel == "Preview")
 		{

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -82,7 +82,7 @@ jobs:
         inputs:
           targetType: 'filePath'
           filePath: 'build.sh'
-          arguments: --target cg-android --ANDROID_RENDERERS="$(renderers)" --GoogleMapsAPIKey="$(GoogleMapsAPIKey)"
+          arguments: --target cg-android --ANDROID_RENDERERS="$(renderers)" --GoogleMapsAPIKey="$(GoogleMapsAPIKey)" --buildForVS2017=false --BUILD_CONFIGURATION=${{ parameters.buildConfiguration }} --MSBuildArguments='${{ variables.MSBuildArguments_cg_android }}'
 
       - task: CopyFiles@2
         displayName: 'Copy $(renderers)'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -9,7 +9,6 @@ parameters:
   slnPath : 'Xamarin.Forms.sln'
   buildTaskPath : 'Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
-  buildConfiguration : 'Debug'
   nugetVersion: $(NUGET_VERSION)
   monoVersion: $(MONO_VERSION)
   provisionatorPath: 'build/provisioning/provisioning.csx'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -9,7 +9,7 @@ parameters:
   slnPath : 'Xamarin.Forms.sln'
   buildTaskPath : 'Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
-  buildConfiguration : ''
+  buildConfiguration : 'Debug'
   nugetVersion: $(NUGET_VERSION)
   monoVersion: $(MONO_VERSION)
   provisionatorPath: 'build/provisioning/provisioning.csx'

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -9,6 +9,7 @@ parameters:
   slnPath : 'Xamarin.Forms.sln'
   buildTaskPath : 'Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
   androidProjectPath : 'Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj'
+  buildConfiguration : ''
   nugetVersion: $(NUGET_VERSION)
   monoVersion: $(MONO_VERSION)
   provisionatorPath: 'build/provisioning/provisioning.csx'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target BuildTasks
+      arguments: --target BuildTasks --BUILD_CONFIGURATION=${{ variables.buildConfiguration }} --buildForVS2017=$(buildForVS2017)
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -90,7 +90,8 @@ steps:
     condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       Contents: |
-        Xamarin.Forms.ControlGallery.iOS/**/*.*
+        **/XamarinFormsControlGalleryiOS.ipa
+        **/*.dSYM
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
@@ -98,7 +99,7 @@ steps:
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
       CleanTargetFolder: true
-      flattenFolders: false
+      flattenFolders: true
 
 
   - task: CopyFiles@2

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -92,7 +92,8 @@ steps:
     condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       Contents: |
-        **/$(IpaName)
+        **/XamarinFormsControlGalleryiOS.ipa
+        **/*.dSYM
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -74,6 +74,13 @@ steps:
       configuration: $(buildConfiguration)
       msbuildArguments: /bl:$(Build.ArtifactStagingDirectory)/ios-uitests-2017_$(buildForVS2017).binlog
 
+  - task: MSBuild@1
+    displayName: 'Build Android Tests'
+    inputs:
+      solution: 'Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj'
+      configuration: $(buildConfiguration)
+      msbuildArguments: /bl:$(Build.ArtifactStagingDirectory)/android-uitests-2017_$(buildForVS2017).binlog
+
   - task: CopyFiles@2
     displayName: 'Copy test-cloud.exe'
     condition: eq(variables['buildForVS2017'], 'false')
@@ -83,7 +90,6 @@ steps:
       CleanTargetFolder: true
       OverWrite: true
       flattenFolders: true
-
 
   - task: CopyFiles@2
     displayName: 'Copy iOS Files for UITest'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target BuildTasks --BUILD_CONFIGURATION1=variables['buildConfiguration'] --BUILD_CONFIGURATION=$(buildConfiguration) --BUILD_CONFIGURATION=${{ variables.buildConfiguration }} --buildForVS2017=$(buildForVS2017)
+      arguments: --target BuildTasks --BUILD_CONFIGURATION=$(buildConfiguration) --buildForVS2017=$(buildForVS2017)
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -92,8 +92,6 @@ steps:
     condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       Contents: |
-        **/XamarinFormsControlGalleryiOS.ipa
-        **/*.dSYM
         Xamarin.Forms.ControlGallery.iOS/**/*.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
@@ -102,7 +100,7 @@ steps:
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
       CleanTargetFolder: true
-      flattenFolders: true
+      flattenFolders: false
 
 
   - task: CopyFiles@2

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -94,6 +94,7 @@ steps:
       Contents: |
         **/XamarinFormsControlGalleryiOS.ipa
         **/*.dSYM
+        Xamarin.Forms.ControlGallery.iOS/**/*.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -55,7 +55,7 @@ steps:
     inputs:
       targetType: 'filePath'
       filePath: 'build.sh'
-      arguments: --target BuildTasks --BUILD_CONFIGURATION=${{ variables.buildConfiguration }} --buildForVS2017=$(buildForVS2017)
+      arguments: --target BuildTasks --BUILD_CONFIGURATION1=variables['buildConfiguration'] --BUILD_CONFIGURATION=$(buildConfiguration) --BUILD_CONFIGURATION=${{ variables.buildConfiguration }} --buildForVS2017=$(buildForVS2017)
 
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -60,13 +60,6 @@ steps:
     inputs:
       provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
 
-  - task: XamariniOS@2
-    displayName: 'Build Xamarin.iOS solution $(slnPath)'
-    inputs:
-      solutionFile: $(slnPath)
-      configuration: $(buildConfiguration)
-      args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
-
   - task: Bash@3
     displayName: 'Build Control Gallery IPA'
     inputs:

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -49,14 +49,6 @@ steps:
       feedsToUse: config
       nugetConfigPath: 'DevopsNuget.config'
 
-  - task: Bash@3
-    displayName: 'Build solution Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj'
-    condition: or(eq(variables['provisioningCake'], 'true'), eq(variables['buildForVS2017'], 'true'))
-    inputs:
-      targetType: 'filePath'
-      filePath: 'build.sh'
-      arguments: --target BuildTasks --BUILD_CONFIGURATION=$(buildConfiguration) --buildForVS2017=$(buildForVS2017)
-
   - task: InstallAppleCertificate@2
     displayName: 'Install an Apple certificate'
     inputs:
@@ -75,6 +67,19 @@ steps:
       configuration: $(buildConfiguration)
       args: /bl:$(Build.ArtifactStagingDirectory)/ios-2017_$(buildForVS2017).binlog
 
+  - task: Bash@3
+    displayName: 'Build Control Gallery IPA'
+    inputs:
+      targetType: 'filePath'
+      filePath: 'build.sh'
+      arguments: --target cg-ios --buildForVS2017=$(buildForVS2017) --BUILD_CONFIGURATION=$(buildConfiguration) --MSBuildArguments='${{ variables.MSBuildArguments_cg_ios }}'
+
+  - task: MSBuild@1
+    displayName: 'Build iOS Tests'
+    inputs:
+      solution: 'Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj'
+      configuration: $(buildConfiguration)
+      msbuildArguments: /bl:$(Build.ArtifactStagingDirectory)/ios-uitests-2017_$(buildForVS2017).binlog
 
   - task: CopyFiles@2
     displayName: 'Copy test-cloud.exe'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -48,7 +48,7 @@ steps:
       feedsToUse: config
       nugetConfigPath: 'DevopsNuget.config'
 
-  - script: build.cmd -Target BuildForNuget -ScriptArgs '-configuration="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
+  - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winbuild
     displayName: 'Build Projects For Nuget'
 


### PR DESCRIPTION
### Description of Change ###

- add missing parameters to android yaml task
- fix ios build to use release configuration correctly
- fix cg-ios cake build
- switch yaml to use cake for ios CG build
- set MtouchExtraArgs to linkout out forms by default so things are caught quicker during development
- added a few additional .net sdks to the provisioning installer file

### Testing Procedure ###
- make sure cg android tests run
- make sure cake build works from command line

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
