### PR TITLE
[C/X] rename and ungenerify OnAppTheme

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/AppThemeGalleries/AppThemeCodeGallery.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.AppThemeGalleries
 				Text = "TextColor through SetAppThemeColor"
 			};
 
-			onThemeLabel.SetBinding(Label.TextColorProperty, new OnAppTheme<Color>() { Light = Color.Green, Dark = Color.Red });
+			onThemeLabel.SetBinding(Label.TextColorProperty, new AppThemeBinding() { Light = Color.Green, Dark = Color.Red });
 
 			onThemeLabel1.SetOnAppTheme(Label.TextColorProperty, Color.Green, Color.Red);
 

--- a/Xamarin.Forms.Core.UnitTests/AppThemeTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/AppThemeTests.cs
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				Text = "Green on Light, Red on Dark"
 			};
 
-			label.SetBinding(Label.TextColorProperty, new OnAppTheme<Color> { Light = Color.Green, Dark = Color.Red });
+			label.SetBinding(Label.TextColorProperty, new AppThemeBinding { Light = Color.Green, Dark = Color.Red });
 			Assert.AreEqual(Color.Green, label.TextColor);
 
 			SetAppTheme(OSAppTheme.Dark);

--- a/Xamarin.Forms.Core/AppThemeBinding.cs
+++ b/Xamarin.Forms.Core/AppThemeBinding.cs
@@ -2,14 +2,19 @@
 
 namespace Xamarin.Forms
 {
-	class OnAppTheme<T> : BindingBase
+	class AppThemeBinding : BindingBase
 	{
 		WeakReference<BindableObject> _weakTarget;
 		BindableProperty _targetProperty;
 
-		public OnAppTheme() => Application.Current.RequestedThemeChanged += (o,e) => Device.BeginInvokeOnMainThread(() => ApplyCore());
+		public AppThemeBinding() => Application.Current.RequestedThemeChanged += (o,e) => Device.BeginInvokeOnMainThread(() => ApplyCore());
 
-		internal override BindingBase Clone() => new OnAppTheme<T> { Light = Light, Dark = Dark, Default = Default };
+		internal override BindingBase Clone() => new AppThemeBinding {
+			Light = Light,
+			_isLightSet = _isLightSet,
+			Dark = Dark,
+			_isDarkSet = _isDarkSet,
+			Default = Default };
 
 		internal override void Apply(bool fromTarget)
 		{
@@ -40,14 +45,12 @@ namespace Xamarin.Forms
 			target?.SetValueCore(_targetProperty, GetValue());
 		}
 
-		T _light;
-		T _dark;
-		T _default;
+		object _light;
+		object _dark;
 		bool _isLightSet;
 		bool _isDarkSet;
-		bool _isDefaultSet;
 
-		public T Light
+		public object Light
 		{
 			get => _light;
 			set
@@ -57,7 +60,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public T Dark
+		public object Dark
 		{
 			get => _dark;
 			set
@@ -67,25 +70,16 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public T Default
-		{
-			get => _default;
-			set
-			{
-				_default = value;
-				_isDefaultSet = true;
-			}
-		}
+		public object Default { get; set; }
 
-		T GetValue()
+		object GetValue()
 		{
-			switch (Application.Current.RequestedTheme)
-			{
-				default:
-				case OSAppTheme.Light:
-					return _isLightSet ? Light : (_isDefaultSet ? Default : default);
-				case OSAppTheme.Dark:
-					return _isDarkSet ? Dark : (_isDefaultSet ? Default : default);
+			switch (Application.Current.RequestedTheme) {
+			default:
+			case OSAppTheme.Light:
+				return _isLightSet ? Light :  Default;
+			case OSAppTheme.Dark:
+				return _isDarkSet ? Dark : Default;
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Core/VisualElementExtensions.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms
 		public static void SetOnAppTheme<T>(this VisualElement self, BindableProperty targetProperty, T light, T dark)
 		{
 			ExperimentalFlags.VerifyFlagEnabled(nameof(BindableObjectExtensions), ExperimentalFlags.AppThemeExperimental, nameof(BindableObjectExtensions), nameof(SetOnAppTheme));
-			self.SetBinding(targetProperty, new OnAppTheme<T> { Light = light, Dark = dark});
+			self.SetBinding(targetProperty, new AppThemeBinding { Light = light, Dark = dark});
 		}
 
 		public static void SetAppThemeColor(this VisualElement self, BindableProperty targetProperty, Color light, Color dark) => SetOnAppTheme(self, targetProperty, light, dark);

--- a/Xamarin.Forms.Xaml/MarkupExtensionParser.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensionParser.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Xaml
 				markupExtension = new OnPlatformExtension();
 			else if (match == "OnIdiom")
 				markupExtension = new OnIdiomExtension();
-			else if (match == "OnAppTheme")
+			else if (match == "AppThemeBinding")
 				markupExtension = new AppThemeBindingExtension();
 			else if (match == "DataTemplate")
 				markupExtension = new DataTemplateExtension();

--- a/Xamarin.Forms.Xaml/MarkupExtensions/AppThemeBindingExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/AppThemeBindingExtension.cs
@@ -99,7 +99,7 @@ namespace Xamarin.Forms.Xaml
 				}
 			}
 
-			var binding = new OnAppTheme<object>();
+			var binding = new AppThemeBinding();
 			if (converterProvider != null)
 			{
 				if (_haslight) binding.Light = converterProvider.Convert(Light, propertyType, minforetriever, serviceProvider);


### PR DESCRIPTION
### Description of Change ###

the internal OnAppTheme class name was confusing, and not indicating
what it actually was (a binding). renaming to AppThemeBinding makes
sense.

also dropping the generic arg as it's not really used.

### Issues Resolved ### 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
