### PR TITLE
Fixed wrong Rectangle type used in RectangleGeometry (Shapes)

### DIFF
--- a/Xamarin.Forms.Core/Shapes/RectangleGeometry.cs
+++ b/Xamarin.Forms.Core/Shapes/RectangleGeometry.cs
@@ -1,16 +1,16 @@
-﻿using Rect = Xamarin.Forms.Rectangle;
+﻿using FormsRect = Xamarin.Forms.Rectangle;
 
 namespace Xamarin.Forms.Shapes
 {
     public class RectangleGeometry : Geometry
     {
         public static readonly BindableProperty RectProperty =
-            BindableProperty.Create(nameof(Rect), typeof(Rect), typeof(RectangleGeometry), new Rect());
+            BindableProperty.Create(nameof(Rect), typeof(FormsRect), typeof(RectangleGeometry), new FormsRect());
 
-        public Rect Rect
+        public FormsRect Rect
         {
             set { SetValue(RectProperty, value); }
-            get { return (Rect)GetValue(RectProperty); }
+            get { return (FormsRect)GetValue(RectProperty); }
         }
     }
 }

--- a/Xamarin.Forms.Core/Shapes/RectangleGeometry.cs
+++ b/Xamarin.Forms.Core/Shapes/RectangleGeometry.cs
@@ -1,14 +1,16 @@
-﻿namespace Xamarin.Forms.Shapes
+﻿using Rect = Xamarin.Forms.Rectangle;
+
+namespace Xamarin.Forms.Shapes
 {
     public class RectangleGeometry : Geometry
     {
         public static readonly BindableProperty RectProperty =
-            BindableProperty.Create(nameof(Rect), typeof(Rectangle), typeof(RectangleGeometry), new Rectangle());
+            BindableProperty.Create(nameof(Rect), typeof(Rect), typeof(RectangleGeometry), new Rect());
 
-        public Xamarin.Forms.Rectangle Rect
+        public Rect Rect
         {
             set { SetValue(RectProperty, value); }
-            get { return (Xamarin.Forms.Rectangle)GetValue(RectProperty); }
+            get { return (Rect)GetValue(RectProperty); }
         }
     }
 }


### PR DESCRIPTION
### Description of Change ###

Using `RectangleGeometry` instantiated an incorrect `Rectangle` type (shape vs struct type).

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="392" alt="Captura de pantalla 2020-06-11 a las 12 13 25" src="https://user-images.githubusercontent.com/6755973/84374011-ad30cc80-abdd-11ea-9305-c90df33ec285.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Shapes Gallery. Select the Clip sample and verify that everything works without problems.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
