### PR TITLE
[X] fix error with x:Name on shapes

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -84,7 +84,8 @@
 		Inputs="@(_XamlGInputs)"
 		Outputs="@(_XamlGOutputs)">
 		<PropertyGroup>
-			<ReferencedAssemblies>@(ReferencePath)</ReferencedAssemblies>
+			<ReferencedAssemblies Condition="'$(_ReferencedAssemblies)'==''">@(ReferencePath)</ReferencedAssemblies>
+      <ReferencedAssemblies Condition="'$(_ReferencedAssemblies)'!=''">$(_ReferencedAssemblies)</ReferencedAssemblies>
 		</PropertyGroup>
 		<XamlGTask
 			XamlFiles="@(_XamlGInputs)"

--- a/Xamarin.Forms.Build.Tasks/XamlGenerator.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGenerator.cs
@@ -352,8 +352,6 @@ namespace Xamarin.Forms.Build.Tasks
 
 		static string GetClrNamespace(string namespaceuri)
 		{
-			if (namespaceuri == XamlParser.XFUri)
-				return "Xamarin.Forms";
 			if (namespaceuri == XamlParser.X2009Uri)
 				return "System";
 			if (namespaceuri != XamlParser.X2006Uri && 

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/EllipseGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/EllipseGallery.xaml
@@ -19,7 +19,7 @@
                 Padding="12">
                 <Label
                     Text="A basic Rectangle"/>
-                <Ellipse
+                <Ellipse x:Name="ellipse"
                     Fill ="Red"
                     WidthRequest ="150"
                     HeightRequest ="50"/>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/GH2691.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/GH2691.xaml.cs
@@ -114,9 +114,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					"Release";
 #endif
 
-				var dir = IOPath.GetFullPath(
+				var references = string.Join(";",
+					IOPath.GetFullPath(
 						IOPath.Combine(
-							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll"));
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+					);
 				var xamlg = new XamlGTask()
 				{
 					BuildEngine = new DummyBuildEngine(),
@@ -124,7 +129,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					Language = "C#",
 					XamlFiles = new[] { item },
 					OutputFiles = new[] { new TaskItem(xamlOutputFile) },
-					References = dir
+					References = references
 				};
 
 				var generator = new XamlGenerator(item, xamlg.Language, xamlg.AssemblyName, xamlOutputFile, xamlg.References, null);

--- a/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/MSBuild/MSBuildTests.cs
@@ -140,7 +140,13 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 				propertyGroup.Add (NewElement ("TargetFrameworkVersion").WithValue ("v4.7"));
 				propertyGroup.Add(NewElement("RootNamespace").WithValue("test"));
 			}
+			var refpath = string.Join(";",
+				IOPath.Combine("..", "..", "Xamarin.Forms.Core.dll"),
+				IOPath.Combine("..", "..", "Xamarin.Forms.Xaml.dll"));
+			propertyGroup.Add(NewElement("_ReferencedAssemblies").WithValue($"{refpath}"));
+
 			propertyGroup.Add(NewElement("_XFBuildTasksLocation").WithValue($"{testDirectory}\\"));
+
 
 			project.Add (propertyGroup);
 

--- a/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using Xamarin.Forms.Build.Tasks;
 
 using Xamarin.Forms.Core.UnitTests;
+using IOPath = System.IO.Path;
 
 namespace Xamarin.Forms.MSBuild.UnitTests
 {
@@ -24,7 +25,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+					);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 			Assert.NotNull(generator.RootType);
 			Assert.NotNull(generator.RootClrNamespace);
@@ -51,7 +61,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 			Assert.NotNull(generator.RootType);
 			Assert.NotNull(generator.RootClrNamespace);
@@ -88,7 +107,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual (2, generator.NamedFields.Count());
@@ -118,7 +146,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 						</StackLayout>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.Contains ("included", generator.NamedFields.Select(cmf => cmf.Name).ToList());
@@ -147,7 +184,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 						</StackLayout>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.False (generator.NamedFields.Select(cmf => cmf.Name).Contains ("notincluded"));
@@ -157,7 +203,7 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		[Test]
 		public void xTypeArgumentsOnRootElement ()
 		{
-			var xaml = @"<Foo 
+			var xaml = @"<Layout 
 						    xmlns=""http://xamarin.com/schemas/2014/forms""
 						    xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 							x:Class=""FooBar"" 
@@ -165,11 +211,20 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual("FooBar", generator.RootType);
-			Assert.AreEqual ("Xamarin.Forms.Foo`1", generator.BaseType.BaseType);
+			Assert.AreEqual ("Xamarin.Forms.Layout`1", generator.BaseType.BaseType);
 			Assert.AreEqual (1, generator.BaseType.TypeArguments.Count);
 			Assert.AreEqual ("System.String", generator.BaseType.TypeArguments [0].BaseType);
 		}
@@ -177,7 +232,7 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		[Test]
 		public void MulipleXTypeArgumentsOnRootElement ()
 		{
-			var xaml = @"<Foo 
+			var xaml = @"<ObservableWrapper 
 						    xmlns=""http://xamarin.com/schemas/2014/forms""
 						    xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 							x:Class=""FooBar"" 
@@ -185,11 +240,20 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual ("FooBar", generator.RootType);
-			Assert.AreEqual ("Xamarin.Forms.Foo`2", generator.BaseType.BaseType);
+			Assert.AreEqual ("Xamarin.Forms.ObservableWrapper`2", generator.BaseType.BaseType);
 			Assert.AreEqual (2, generator.BaseType.TypeArguments.Count);
 			Assert.AreEqual ("System.String", generator.BaseType.TypeArguments [0].BaseType);
 			Assert.AreEqual ("System.Int32", generator.BaseType.TypeArguments [1].BaseType);
@@ -198,7 +262,7 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		[Test]
 		public void MulipleXTypeArgumentsOnRootElementWithWhitespace ()
 		{
-			var xaml = @"<Foo 
+			var xaml = @"<ObservableWrapper 
 						    xmlns=""http://xamarin.com/schemas/2014/forms""
 						    xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 							x:Class=""FooBar"" 
@@ -206,11 +270,20 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual ("FooBar", generator.RootType);
-			Assert.AreEqual ("Xamarin.Forms.Foo`2", generator.BaseType.BaseType);
+			Assert.AreEqual ("Xamarin.Forms.ObservableWrapper`2", generator.BaseType.BaseType);
 			Assert.AreEqual (2, generator.BaseType.TypeArguments.Count);
 			Assert.AreEqual ("System.String", generator.BaseType.TypeArguments [0].BaseType);
 			Assert.AreEqual ("System.Int32", generator.BaseType.TypeArguments [1].BaseType);
@@ -219,7 +292,7 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		[Test]
 		public void MulipleXTypeArgumentsMulitpleNamespacesOnRootElement ()
 		{
-			var xaml = @"<Foo 
+			var xaml = @"<ObservableWrapper 
 						    xmlns=""http://xamarin.com/schemas/2014/forms""
 						    xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 							x:Class=""FooBar"" 
@@ -230,11 +303,20 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual ("FooBar", generator.RootType);
-			Assert.AreEqual ("Xamarin.Forms.Foo`2", generator.BaseType.BaseType);
+			Assert.AreEqual ("Xamarin.Forms.ObservableWrapper`2", generator.BaseType.BaseType);
 			Assert.AreEqual (2, generator.BaseType.TypeArguments.Count);
 			Assert.AreEqual ("Xamarin.Forms.Xaml.UnitTests.Bugzilla24258.Interfaces.IDummyInterface", generator.BaseType.TypeArguments [0].BaseType);
 			Assert.AreEqual ("Xamarin.Forms.Xaml.UnitTests.Bugzilla24258.InterfacesTwo.IDummyInterfaceTwo", generator.BaseType.TypeArguments [1].BaseType);
@@ -243,7 +325,7 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		[Test]
 		public void MulipleXTypeArgumentsMulitpleNamespacesOnRootElementWithWhitespace ()
 		{
-			var xaml = @"<Foo 
+			var xaml = @"<ObservableWrapper 
 						    xmlns=""http://xamarin.com/schemas/2014/forms""
 						    xmlns:x=""http://schemas.microsoft.com/winfx/2009/xaml""
 							x:Class=""FooBar"" 
@@ -254,11 +336,20 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader (xaml);
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual ("FooBar", generator.RootType);
-			Assert.AreEqual ("Xamarin.Forms.Foo`2", generator.BaseType.BaseType);
+			Assert.AreEqual ("Xamarin.Forms.ObservableWrapper`2", generator.BaseType.BaseType);
 			Assert.AreEqual (2, generator.BaseType.TypeArguments.Count);
 			Assert.AreEqual ("Xamarin.Forms.Xaml.UnitTests.Bugzilla24258.Interfaces.IDummyInterface", generator.BaseType.TypeArguments [0].BaseType);
 			Assert.AreEqual ("Xamarin.Forms.Xaml.UnitTests.Bugzilla24258.InterfacesTwo.IDummyInterfaceTwo", generator.BaseType.TypeArguments [1].BaseType);
@@ -276,8 +367,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 				<Label x:Name=""label0""/>
 			</ContentPage>";
 			using (var reader = new StringReader (xaml)) {
+				var references = string.Join(";",
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+					);
 
-				var generator = new XamlGenerator();
+				var generator = new XamlGenerator(null,null,null,null,null,null, references);
 				generator.ParseXaml(reader);
 
 				Assert.IsTrue (generator.BaseType.Options.HasFlag (CodeTypeReferenceOptions.GlobalReference));
@@ -302,8 +401,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			using (var reader = new StringReader(xaml))
 			{
+				var references = string.Join(";",
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+					IOPath.GetFullPath(
+						IOPath.Combine(
+							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+					);
 
-				var generator = new XamlGenerator();
+				var generator = new XamlGenerator(null, null, null, null, null, null, references);
 				generator.ParseXaml(reader);
 
 				Assert.That(generator.NamedFields.First(cmf => cmf.Name == "privateLabel").Attributes, Is.EqualTo(MemberAttributes.Private));
@@ -323,7 +430,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		x:Name=""bar"">
 	</ContentPage>";
 
-			var generator = new XamlGenerator();
+			var references = string.Join(";",
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
+								IOPath.GetFullPath(
+									IOPath.Combine(
+										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
+								);
+
+			var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(new StringReader(xaml));
 
 			Assert.AreEqual(1, generator.NamedFields.Count());


### PR DESCRIPTION
### Description of Change ###

[X] fix error with x:Name on shapes

### Issues Resolved ### 

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
