### PR TITLE
[C] MultiBinding throw on missing conv or format

### DIFF
--- a/Xamarin.Forms.Core/MultiBinding.cs
+++ b/Xamarin.Forms.Core/MultiBinding.cs
@@ -116,6 +116,9 @@ namespace Xamarin.Forms
 			if (_bindings == null)
 				throw new InvalidOperationException("Bindings is null");
 
+			if (Converter == null && StringFormat == null)
+				throw new InvalidOperationException("Cannot apply MultiBinding because both Converter and StringFormat are null.");
+
 			base.Apply(context, targetObject, targetProperty, fromBindingContextChanged);
 
 			if (!ReferenceEquals(_targetObject, targetObject)) {


### PR DESCRIPTION
### Description of Change ###

[C] MultiBinding throw on missing conv or format

throw if none of StringFormat or Converter are assigned.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11019
### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
