### PR TITLE
[iOS] Add preserve to RadioButton

### DIFF
--- a/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
@@ -77,6 +77,7 @@ namespace Xamarin.Forms.Core.UITests
 		public static readonly string Picker = "UITextField";
 		public static readonly string Pin = "MKPinAnnotationView";
 		public static readonly string ProgressBar = "UIProgressView";
+		public static readonly string RadioButton = "Xamarin_Forms_Platform_iOS_RadioButtonRenderer";
 		public static readonly string SearchBar = "UISearchBar";
 		public static readonly string Slider = "UISlider";
 		public static readonly string Stepper = "UIStepper";

--- a/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/PlatformQueries.cs
@@ -103,6 +103,7 @@ namespace Xamarin.Forms.Core.UITests
 		public static readonly string Picker = "android.widget.EditText";
 		public static readonly string Pin = "android.gms.maps.model.Marker";
 		public static readonly string ProgressBar = "android.widget.ProgressBar";
+		public static readonly string RadioButton = "android.widget.RadioButton";
 		public static readonly string SearchBar = "android.widget.SearchView";
 		public static readonly string Slider = "android.widget.SeekBar";
 		public static readonly string Stepper = "button marked:'+'";

--- a/Xamarin.Forms.Core.UITests.Shared/Queries.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Queries.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms.Core.UITests
 		public const string OpenGLViewGallery = "* marked:'OpenGLView Gallery'";
 		public const string PickerGallery = "* marked:'Picker Gallery'";
 		public const string ProgressBarGallery = "* marked:'ProgressBar Gallery'";
+		public const string RadioButtonGallery = "* marked:'RadioButton Core Gallery'";
 		public const string ScrollViewGallery = "* marked:'ScrollView Gallery'";
 		public const string ScrollViewGalleryHorizontal = "* marked:'ScrollView Gallery Horizontal'";
 		public const string SearchBarGallery = "* marked:'SearchBar Gallery'";
@@ -47,7 +48,6 @@ namespace Xamarin.Forms.Core.UITests
 		public const string RootPagesGallery = "* marked:'RootPages Gallery'";
 		public const string AppearingGallery = "* marked:'Appearing Gallery'";
 		public const string PlatformAutomatedTestsGallery = "* marked:'Platform Automated Tests'";
-		
 
 		// Legacy galleries
 		public const string CellsGalleryLegacy = "* marked:'Cells Gallery - Legacy'";
@@ -97,6 +97,7 @@ namespace Xamarin.Forms.Core.UITests
 		public static readonly string Picker = PlatformViews.Picker;
 		public static readonly string Pin = PlatformViews.Pin;
 		public static readonly string ProgressBar = PlatformViews.ProgressBar;
+		public static readonly string RadioButton = PlatformViews.RadioButton;
 		public static readonly string SearchBar = PlatformViews.SearchBar;
 		public static readonly string Slider = PlatformViews.Slider;
 		public static readonly string Stepper = PlatformViews.Stepper;

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/RadioButtonUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/RadioButtonUITests.cs
@@ -2,7 +2,7 @@
 using NUnit.Framework;
 using Xamarin.Forms.CustomAttributes;
 
-namespace Xamarin.Forms.Core.UITests.Shared.Tests
+namespace Xamarin.Forms.Core.UITests
 {
 	[TestFixture]
 	[Category(UITestCategories.RadioButton)]

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/RadioButtonUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/RadioButtonUITests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using NUnit.Framework;
+using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Core.UITests.Shared.Tests
+{
+	[TestFixture]
+	[Category(UITestCategories.RadioButton)]
+	internal class RadioButtonUITests : _ViewUITests
+	{
+		public RadioButtonUITests()
+		{
+			PlatformViewType = Views.RadioButton;
+		}
+
+		protected override void NavigateToGallery()
+		{
+			App.NavigateToGallery(GalleryQueries.RadioButtonGallery);
+		}
+
+		[UiTestExempt(ExemptReason.CannotTest, "Invalid interaction")]
+		public override void _Focus()
+		{
+			throw new NotImplementedException();
+		}
+
+		// TODO
+		public override void _GestureRecognizers()
+		{
+			throw new NotImplementedException();
+		}
+
+		[UiTestExempt(ExemptReason.CannotTest, "Invalid interaction")]
+		public override void _IsFocused()
+		{
+			throw new NotImplementedException();
+		}
+
+		[UiTestExempt(ExemptReason.CannotTest, "Invalid interaction")]
+		public override void _UnFocus()
+		{
+			throw new NotImplementedException();
+		}
+
+		// TODO
+		// Implement control specific ui tests
+		protected override void FixtureTeardown()
+		{
+			App.NavigateBack();
+			base.FixtureTeardown();
+		}
+
+#if __ANDROID__ || __IOS__
+		[Ignore("This is covered by the platform  tests")]
+		public override void _Opacity() { }
+#endif
+
+#if __ANDROID__ || __IOS__ || __WINDOWS__
+		[Ignore("This is covered by the platform tests")]
+		public override void _IsEnabled() { }
+#endif
+
+#if __ANDROID__ || __IOS__ || __WINDOWS__
+		[Ignore("This is covered by the platform tests")]
+		public override void _Rotation() { }
+
+		[Ignore("This is covered by the platform tests")]
+		public override void _RotationX() { }
+
+		[Ignore("This is covered by the platform tests")]
+		public override void _RotationY() { }
+#endif
+
+#if __ANDROID__
+		[Ignore("This is covered by the platform tests")]
+		public override void _TranslationX() { }
+
+		[Ignore("This is covered by the platform tests")]
+		public override void _TranslationY() { }
+#endif
+
+#if __IOS__ || __WINDOWS__
+		[Ignore("This is covered by the platform tests")]
+		public override void _Scale() { }
+#endif
+
+#if __ANDROID__ || __IOS__
+		[Ignore("This is covered by the platform tests")]
+		public override void _IsVisible() { }
+#endif
+	}
+}

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -63,5 +63,6 @@
 		public const string Bugzilla = "Bugzilla";
 		public const string Github5000 = "Github5000";
 		public const string Github10000 = "Github10000";
+		public const string RadioButton = "RadioButton";
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Xamarin.Forms.Core.UITests.projitems
+++ b/Xamarin.Forms.Core.UITests.Shared/Xamarin.Forms.Core.UITests.projitems
@@ -62,5 +62,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Utilities\ViewInspector.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\CollectionViewUITests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Tests\CarouselViewUITests.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Tests\RadioButtonUITests.cs" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RadioButtonRenderer.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public bool IsDisposed { get; private set; }
 
+		[Preserve(Conditional = true)]
 		public RadioButtonRenderer() : base()
 		{
 			BorderElementManager.Init(this);


### PR DESCRIPTION
### Description of Change ###

Adds a preserve attribute to `RadioButtonRenderer` so it doesn't crash when linking is enabled. Additionally adds a UI test that loads the gallery to make sure this never ever happens again.

### Issues Resolved ### 

- fixes #10868

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
If the UI Test runs is successful and the RadioButton test is actually in there, hooray! It worked! You might double check by taking the NuGets and add them to a new project where linking is enabled

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
- [x] Removed all comment blocks to make notifications channel happy