### PR TITLE
[Android] CustomRenderer object was created twice using SwipeView

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -132,6 +132,7 @@
     <Compile Include="ApiLabelRenderer.cs" />
     <Compile Include="Issue7249SwitchRenderer.cs" />
     <Compile Include="_9087CustomRenderer.cs" />
+    <Compile Include="_10940CustomRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\default.css" />

--- a/Xamarin.Forms.ControlGallery.Android/_10940CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_10940CustomRenderer.cs
@@ -1,0 +1,27 @@
+﻿using Android.Content;
+using Xamarin.Forms;
+using Xamarin.Forms.ControlGallery.Android;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Platform.Android;
+
+[assembly: ExportRenderer(typeof(CustomEntry), typeof(CustomEntryRenderer))]
+[assembly: ExportRenderer(typeof(CustomSwipeView), typeof(CustomSwipeViewRenderer))]
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class CustomEntryRenderer : EntryRenderer
+    {
+        public CustomEntryRenderer(Context context) : base(context)
+        {
+            System.Diagnostics.Debug.WriteLine("Create CustomEntry");
+        }
+    }
+
+    public class CustomSwipeViewRenderer : SwipeViewRenderer
+    {
+
+        public CustomSwipeViewRenderer(Context context) : base(context)
+        {
+
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10940.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10940.cs
@@ -1,0 +1,89 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10940,
+		"[Android]CustomRenderer object was created twice for single control when add custom control in SwipeView item",
+		PlatformAffected.Android)]
+	public class Issue10940 : TestContentPage
+	{
+		public Issue10940()
+		{
+#if APP
+			Device.SetFlags(new List<string> { ExperimentalFlags.SwipeViewExperimental });
+#endif
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 10940";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Swipe to the left and verify that opening the SwipeView the CustomEntry is created only one time."
+			};
+
+			var customSwipeView = new CustomSwipeView
+			{
+				BackgroundColor = Color.LightGray,
+				HeightRequest = 200
+			};
+
+			var swipeItemView = new SwipeItemView();
+
+			var swipeItemViewContent = new Grid
+			{
+				BackgroundColor = Color.White,
+				WidthRequest = 150
+			};
+
+			var customEntry = new CustomEntry
+			{
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			swipeItemViewContent.Children.Add(customEntry);
+
+			swipeItemView.Content = swipeItemViewContent;
+
+			customSwipeView.RightItems = new SwipeItems
+			{
+				swipeItemView
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(customSwipeView);
+
+			Content = layout;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class CustomEntry : Entry
+	{
+
+	}
+
+	[Preserve(AllMembers = true)]
+	public class CustomSwipeView : SwipeView
+	{
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1413,6 +1413,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9555.xaml.cs">
       <DependentUpon>Issue9555.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10940.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">


### PR DESCRIPTION
### Description of Change ###

CustomRenderer object was created twice for single control when add custom control in SwipeView item. The issue is present in Xamarin.Forms 4.5 but fixed since the last 4.6 version. This PR therefore only adds the sample test to Core Gallery.

### Issues Resolved ### 
- fixes #10940 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android


### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 
![issue10940](https://user-images.githubusercontent.com/6755973/84496047-8a211e00-acac-11ea-9fad-cc8782a64966.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10940. Verify that the `CustomEntry` is only created once when opening the SwipeView. 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
