### PR TITLE
[iOS] Fix BackgroundColor issue with Frame

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11031.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11031.cs
@@ -1,0 +1,53 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11031,
+		"[Bug] Regression in 4.7-pre4: Frames are broken",
+		PlatformAffected.Android)]
+	public class Issue11031 : TestContentPage
+	{
+		public Issue11031()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 11031";
+
+			var layout = new StackLayout();
+
+			var frame = new Frame
+			{
+				BackgroundColor = Color.Red,
+				BorderColor = Color.Black,
+				CornerRadius = 24,
+				Margin = 12
+			};
+
+			var label = new Label
+			{
+				HorizontalTextAlignment = TextAlignment.Center,
+				TextColor = Color.White,
+				Text = "Issue 11031"
+			};
+
+			frame.Content = label;
+
+			layout.Children.Add(frame);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1413,6 +1413,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9555.xaml.cs">
       <DependentUpon>Issue9555.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11031.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS.UnitTests/BackgroundColorTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/BackgroundColorTests.cs
@@ -37,9 +37,9 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		public async Task FrameBackgroundColorConsistent()
 		{
 			var frame = new Frame { BackgroundColor = Color.AliceBlue };
-			var expected = frame.BackgroundColor.ToUIColor();
-			var actual = await GetRendererProperty(frame, r => r.NativeView.BackgroundColor);
-			Assert.That(actual, Is.EqualTo(expected));
+			var expectedColor = frame.BackgroundColor.ToUIColor();
+			var screenshot = await GetRendererProperty(frame, (ver) => ver.NativeView.ToBitmap(), requiresLayout: true);
+			screenshot.AssertColorAtCenter(expectedColor);
 		}
 
 		[Test, Category("BackgroundColor"), Category("Label")]

--- a/Xamarin.Forms.Platform.iOS.UnitTests/CornerRadiusTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/CornerRadiusTests.cs
@@ -46,7 +46,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			{
 				HeightRequest = 100,
 				WidthRequest = 200,
-				CornerRadius = 30,
+				CornerRadius = 40,
 				BackgroundColor = backgroundColor,
 				BorderColor = Color.Brown,
 				Content = new Label { Text = "Hey" }

--- a/Xamarin.Forms.Platform.iOS.UnitTests/CornerRadiusTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/CornerRadiusTests.cs
@@ -38,7 +38,6 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		}
 
 		[Test, Category("CornerRadius"), Category("Frame")]
-		[Ignore("Will not pass until https://github.com/xamarin/Xamarin.Forms/issues/9265 is fixed")]
 		public async Task FrameCornerRadius()
 		{
 			var backgroundColor = Color.CadetBlue;
@@ -47,7 +46,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			{
 				HeightRequest = 100,
 				WidthRequest = 200,
-				CornerRadius = 15,
+				CornerRadius = 30,
 				BackgroundColor = backgroundColor,
 				BorderColor = Color.Brown,
 				Content = new Label { Text = "Hey" }

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -79,7 +79,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.BackgroundColor == Color.Default)
 				_actualView.Layer.BackgroundColor = ColorExtensions.BackgroundColor.CGColor;
 			else
+			{
+				// BackgroundColor gets set on the base class too which messes with
+				// the corner radius, shadow, etc. so override that behaviour here
+				BackgroundColor = null;
 				_actualView.Layer.BackgroundColor = Element.BackgroundColor.ToCGColor();
+			}
+
 
 			if (Element.BorderColor == Color.Default)
 				_actualView.Layer.BorderColor = UIColor.Clear.CGColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -67,11 +67,6 @@ namespace Xamarin.Forms.Platform.iOS
 #endif
 		}
 
-		protected override void SetBackgroundColor(Color color)
-		{
-			
-		}
-
 		public virtual void SetupLayer()
 		{
 			float cornerRadius = Element.CornerRadius;
@@ -84,7 +79,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.BackgroundColor == Color.Default)
 				_actualView.Layer.BackgroundColor = ColorExtensions.BackgroundColor.CGColor;
 			else
+			{
+				// BackgroundColor gets set on the base class too which messes with
+				// the corner radius, shadow, etc. so override that behaviour here
+				BackgroundColor = UIColor.Clear;
 				_actualView.Layer.BackgroundColor = Element.BackgroundColor.ToCGColor();
+			}
 
 			if (Element.BorderColor == Color.Default)
 				_actualView.Layer.BorderColor = UIColor.Clear.CGColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -67,6 +67,11 @@ namespace Xamarin.Forms.Platform.iOS
 #endif
 		}
 
+		protected override void SetBackgroundColor(Color color)
+		{
+			
+		}
+
 		public virtual void SetupLayer()
 		{
 			float cornerRadius = Element.CornerRadius;
@@ -79,13 +84,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Element.BackgroundColor == Color.Default)
 				_actualView.Layer.BackgroundColor = ColorExtensions.BackgroundColor.CGColor;
 			else
-			{
-				// BackgroundColor gets set on the base class too which messes with
-				// the corner radius, shadow, etc. so override that behaviour here
-				BackgroundColor = null;
 				_actualView.Layer.BackgroundColor = Element.BackgroundColor.ToCGColor();
-			}
-
 
 			if (Element.BorderColor == Color.Default)
 				_actualView.Layer.BorderColor = UIColor.Clear.CGColor;


### PR DESCRIPTION
### Description of Change ###

Fix `BackgroundColor` issue with Frame on iOS.

Caused by #11001 and #10469

### Issues Resolved ### 

- fixes #11031

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix11031](https://user-images.githubusercontent.com/6755973/84526570-de90c180-acdd-11ea-938c-4e069367a7f4.png)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11031. Verify that the Frame BackgroundColor is clipped by the CornerRadius.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
