### PR TITLE
[UWP] Reuse the element when recycling an ItemContentControl

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
@@ -137,6 +137,23 @@ namespace Xamarin.Forms.Platform.UWP
 			Content = _renderer.ContainerElement;
 
 			itemsView?.AddLogicalChild(_view);
+			if (_renderer?.ContainerElement == null)
+			{
+				var view = FormsDataTemplate.CreateContent(dataContext, container) as View;
+				view.BindingContext = dataContext;
+				_renderer = Platform.CreateRenderer(view);
+				Platform.SetRenderer(view, _renderer);
+				Content = _renderer.ContainerElement;
+				itemsView?.AddLogicalChild(view);
+			}
+			else
+			{
+				// We are reusing this ItemContentControl and we can reuse the Element
+				var view = _renderer.Element;
+				view.BindingContext = dataContext;
+				Content = _renderer.ContainerElement;
+				itemsView?.AddLogicalChild(view);
+			}
 		}
 
 		internal void UpdateIsSelected(bool isSelected)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemContentControl.cs
@@ -9,8 +9,9 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class ItemContentControl : ContentControl
 	{
-		View _view;
+		VisualElement _visualElement;
 		IVisualElementRenderer _renderer;
+		DataTemplate _currentTemplate;
 
 		public ItemContentControl()
 		{
@@ -104,11 +105,11 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnContentChanged(oldContent, newContent);
 
-			if (oldContent != null && _view != null)
-				_view.MeasureInvalidated -= OnViewMeasureInvalidated;
+			if (oldContent != null && _visualElement != null)
+				_visualElement.MeasureInvalidated -= OnViewMeasureInvalidated;
 
-			if (newContent != null && _view != null)
-				_view.MeasureInvalidated += OnViewMeasureInvalidated;
+			if (newContent != null && _visualElement != null)
+				_visualElement.MeasureInvalidated += OnViewMeasureInvalidated;
 		}
 
 		internal void Realize()
@@ -129,31 +130,28 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 
-			_view = FormsDataTemplate.CreateContent(dataContext, container) as View;
-			_view.BindingContext = dataContext;
-			_renderer = Platform.CreateRenderer(_view);
-			Platform.SetRenderer(_view, _renderer);
-
-			Content = _renderer.ContainerElement;
-
-			itemsView?.AddLogicalChild(_view);
-			if (_renderer?.ContainerElement == null)
+			if (_renderer?.ContainerElement == null || _currentTemplate != formsTemplate)
 			{
-				var view = FormsDataTemplate.CreateContent(dataContext, container) as View;
-				view.BindingContext = dataContext;
-				_renderer = Platform.CreateRenderer(view);
-				Platform.SetRenderer(view, _renderer);
-				Content = _renderer.ContainerElement;
-				itemsView?.AddLogicalChild(view);
+				// If the content has never been realized (i.e., this is a new instance), 
+				// or if we need to switch DataTemplates (because this instance is being recycled)
+				// then we'll need to create the content from the template 
+				_visualElement = formsTemplate.CreateContent(dataContext, container) as VisualElement;
+				_visualElement.BindingContext = dataContext;
+				_renderer = Platform.CreateRenderer(_visualElement);
+				Platform.SetRenderer(_visualElement, _renderer);
+
+				// Keep track of the template in case this instance gets reused later
+				_currentTemplate = formsTemplate;
 			}
 			else
 			{
 				// We are reusing this ItemContentControl and we can reuse the Element
-				var view = _renderer.Element;
-				view.BindingContext = dataContext;
-				Content = _renderer.ContainerElement;
-				itemsView?.AddLogicalChild(view);
+				_visualElement = _renderer.Element;
+				_visualElement.BindingContext = dataContext;
 			}
+
+			Content = _renderer.ContainerElement;
+			itemsView?.AddLogicalChild(_visualElement);
 		}
 
 		internal void UpdateIsSelected(bool isSelected)


### PR DESCRIPTION
### Description of Change ###

ItemContentControl is currently re-creating the hosted Element and its children when it's reused, rather than using the previously created content.

This change fixes that issue, so the CollectionView won't create new elements for every single item as it scrolls. 

### Issues Resolved ### 

- fixes #9051

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery -> CollectionView Galleries -> DataTemplate Gallery -> DataTemplateSelector Gallery
If you scroll around and the weekday items remain the same while the weekend items are different, then this is working.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
