### PR TITLE
Moved classes to Xamarin.Forms.Shapes

### DIFF
--- a/Xamarin.Forms.Core/Shapes/FillRule.cs
+++ b/Xamarin.Forms.Core/Shapes/FillRule.cs
@@ -1,4 +1,4 @@
-﻿namespace Xamarin.Forms
+﻿namespace Xamarin.Forms.Shapes
 {
     public enum FillRule
     {

--- a/Xamarin.Forms.Core/Shapes/PenLineCap.cs
+++ b/Xamarin.Forms.Core/Shapes/PenLineCap.cs
@@ -1,4 +1,4 @@
-﻿namespace Xamarin.Forms
+﻿namespace Xamarin.Forms.Shapes
 {
     public enum PenLineCap
     {

--- a/Xamarin.Forms.Core/Shapes/PenLineJoin.cs
+++ b/Xamarin.Forms.Core/Shapes/PenLineJoin.cs
@@ -1,4 +1,4 @@
-﻿namespace Xamarin.Forms
+﻿namespace Xamarin.Forms.Shapes
 {
     public enum PenLineJoin
     {

--- a/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Graphics.Drawables.Shapes;
+using Xamarin.Forms.Shapes;
 using AColor = Android.Graphics.Color;
 using AMatrix = Android.Graphics.Matrix;
 using APath = Android.Graphics.Path;

--- a/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System.ComponentModel;
+using Xamarin.Forms.Shapes;
 using Shape = Xamarin.Forms.Shapes.Shape;
 
 #if WINDOWS_UWP

--- a/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
@@ -2,6 +2,7 @@
 using System.ComponentModel;
 using CoreAnimation;
 using CoreGraphics;
+using Xamarin.Forms.Shapes;
 using Shape = Xamarin.Forms.Shapes.Shape;
 
 #if __MOBILE__


### PR DESCRIPTION
### Description of Change ###

Moved classes to Xamarin.Forms.Shapes:
- `FillRule`
- `PenLineCap`
- `PenLineJoin`

(Also moved to the Shapes folder)

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
