### PR TITLE
Added StrokeMiterLimit property in Shape

### DIFF
--- a/Xamarin.Forms.Core/Shapes/Shape.cs
+++ b/Xamarin.Forms.Core/Shapes/Shape.cs
@@ -29,6 +29,9 @@
         public static readonly BindableProperty StrokeLineJoinProperty =
 			BindableProperty.Create(nameof(StrokeLineJoin), typeof(PenLineJoin), typeof(Shape), PenLineJoin.Miter);
 
+        public static readonly BindableProperty StrokeMiterLimitProperty =
+            BindableProperty.Create(nameof(StrokeMiterLimit), typeof(double), typeof(Shape), 10.0);
+
         public static readonly BindableProperty AspectProperty =
 			BindableProperty.Create(nameof(Aspect), typeof(Stretch), typeof(Shape), Stretch.None);
 
@@ -72,6 +75,12 @@
         {
             set { SetValue(StrokeLineJoinProperty, value); }
             get { return (PenLineJoin)GetValue(StrokeLineJoinProperty); }
+        }
+
+        public double StrokeMiterLimit
+        {
+            set { SetValue(StrokeMiterLimitProperty, value); }
+            get { return (double)GetValue(StrokeMiterLimitProperty); }
         }
 
         public Stretch Aspect

--- a/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms.Platform.Android
                 UpdateStrokeDashArray();
                 UpdateStrokeLineCap();
                 UpdateStrokeLineJoin();
+                UpdateStrokeMiterLimit();
             }
         }
 
@@ -69,6 +70,8 @@ namespace Xamarin.Forms.Platform.Android
                 UpdateStrokeLineCap();
             else if (args.PropertyName == Shape.StrokeLineJoinProperty.PropertyName)
                 UpdateStrokeLineJoin();
+            else if (args.PropertyName == Shape.StrokeMiterLimitProperty.PropertyName)
+                UpdateStrokeMiterLimit();
         }
 
         public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
@@ -151,6 +154,11 @@ namespace Xamarin.Forms.Platform.Android
             }
 
             Control.UpdateStrokeLineJoin(aLineJoin);
+        }
+
+        void UpdateStrokeMiterLimit()
+        {
+            Control.UpdateStrokeMiterLimit((float)Element.StrokeMiterLimit);
         }
     }
 
@@ -300,6 +308,12 @@ namespace Xamarin.Forms.Platform.Android
         {
             _drawable.Paint.StrokeJoin = strokeJoin;
             Invalidate();
+        }
+
+        public void UpdateStrokeMiterLimit(float strokeMiterLimit)
+        {
+            _drawable.Paint.StrokeMiter = strokeMiterLimit * 2;
+            UpdatePathStrokeBounds();
         }
 
         public void UpdateSize(double width, double height)

--- a/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateStrokeDashOffset();
 				UpdateStrokeLineCap();
 				UpdateStrokeLineJoin();
+				UpdateStrokeMiterLimit();
 			}
 		}
 
@@ -66,6 +67,8 @@ namespace Xamarin.Forms.Platform.WPF
 				UpdateStrokeLineCap();
 			else if (args.PropertyName == Shape.StrokeLineJoinProperty.PropertyName)
 				UpdateStrokeLineJoin();
+			else if (args.PropertyName == Shape.StrokeMiterLimitProperty.PropertyName)
+				UpdateStrokeMiterLimit();
 		}
 		
 #if !WINDOWS_UWP
@@ -200,6 +203,11 @@ namespace Xamarin.Forms.Platform.WPF
 			}
 
 			Control.StrokeLineJoin = wLineJoin;
+		}
+
+		void UpdateStrokeMiterLimit()
+		{
+			Control.StrokeMiterLimit = Element.StrokeMiterLimit;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
@@ -451,7 +451,7 @@ namespace Xamarin.Forms.Platform.MacOS
         void UpdatePathStrokeBounds()
         {
             if (_path != null)
-                _pathStrokeBounds = _path.CopyByStrokingPath(_strokeWidth, _strokeLineCap, _strokeLineJoin, StrokeMiterLimit).PathBoundingBox;
+                _pathStrokeBounds = _path.CopyByStrokingPath(_strokeWidth, _strokeLineCap, _strokeLineJoin, _strokeMiterLimit).PathBoundingBox;
             else
                 _pathStrokeBounds = new CGRect();
 

--- a/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Platform.MacOS
                 UpdateStrokeDashOffset();
                 UpdateStrokeLineCap();
                 UpdateStrokeLineJoin();
+                UpdateStrokeMiterLimit();
             }
         }
 
@@ -68,6 +69,8 @@ namespace Xamarin.Forms.Platform.MacOS
                 UpdateStrokeLineCap();
             else if (args.PropertyName == Shape.StrokeLineJoinProperty.PropertyName)
                 UpdateStrokeLineJoin();
+            else if (args.PropertyName == Shape.StrokeMiterLimitProperty.PropertyName)
+                UpdateStrokeMiterLimit();
         }
 
         public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
@@ -156,6 +159,11 @@ namespace Xamarin.Forms.Platform.MacOS
 
             Control.ShapeLayer.UpdateStrokeLineJoin(iLineJoin);
         }
+
+        void UpdateStrokeMiterLimit()
+        {
+            Control.ShapeLayer.UpdateStrokeMiterLimit(new nfloat(Element.StrokeMiterLimit));
+        }
     }
 
     public class ShapeView
@@ -190,8 +198,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
     public class ShapeLayer : CALayer
     {
-        const float StrokeMiterLimit = 10f;
-
         CGPath _path;
         CGRect _pathFillBounds;
         CGRect _pathStrokeBounds;
@@ -211,6 +217,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		CGLineCap _strokeLineCap;
         CGLineJoin _strokeLineJoin;
+        nfloat _strokeMiterLimit;
 
         public ShapeLayer()
         {
@@ -218,6 +225,7 @@ namespace Xamarin.Forms.Platform.MacOS
             _stretch = Stretch.None;
             _strokeLineCap = CGLineCap.Butt;
             _strokeLineJoin = CGLineJoin.Miter;
+            _strokeMiterLimit = 10;
         }
 
         public override void DrawInContext(CGContext ctx)
@@ -303,6 +311,13 @@ namespace Xamarin.Forms.Platform.MacOS
         public void UpdateStrokeLineJoin(CGLineJoin strokeLineJoin)
         {
             _strokeLineJoin = strokeLineJoin;
+            UpdatePathStrokeBounds();
+            SetNeedsDisplay();
+        }
+
+        public void UpdateStrokeMiterLimit(nfloat strokeMiterLimit)
+        {
+            _strokeMiterLimit = strokeMiterLimit;
             UpdatePathStrokeBounds();
             SetNeedsDisplay();
         }
@@ -423,7 +438,7 @@ namespace Xamarin.Forms.Platform.MacOS
             graphics.SetLineDash(_dashOffset * _strokeWidth, lengths);
             graphics.SetLineCap(_strokeLineCap);
             graphics.SetLineJoin(_strokeLineJoin);
-            graphics.SetMiterLimit(StrokeMiterLimit * _strokeWidth / 4);
+            graphics.SetMiterLimit(_strokeMiterLimit * _strokeWidth / 4);
 
             graphics.AddPath(_renderPath);
             graphics.SetStrokeColor(_stroke);


### PR DESCRIPTION
### Description of Change ###

Added `StrokeMiterLimit` property in Shape.

### API Changes ###

Added:
 - `double  Shape.StrokeMiterLimit{ get; set; } //Bindable Property`

Gets or sets a limit on the ratio of the miter length to half the StrokeThickness of a Shape element.

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- macOS
- UWP
- WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)