### PR TITLE
[Android] Fix issue animating StrokeDashOffset

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/AnimateShapeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/AnimateShapeGallery.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
+{
+    public class SpiralDemoPage : ContentPage
+    {
+        protected Polyline polyline;
+
+        public SpiralDemoPage()
+        {
+            polyline = new Polyline
+            {
+                Stroke = Color.Orange,
+                StrokeThickness = 5
+            };
+            Content = polyline;
+
+            SizeChanged += OnPageSizeChanged;
+        }
+
+        void OnPageSizeChanged(object sender, EventArgs e)
+        {
+            if (Width <= 0 || Height <= 0)
+            {
+                return;
+            }
+
+            polyline.Points.Clear();
+
+            double radius = Math.Min(Width / 2, Height / 2);
+            Point center = new Point(Width / 2, Height / 2);
+
+            PointCollection points = polyline.Points;
+            polyline.Points = null;
+
+            for (double angle = 0; angle < 3600; angle += 1)
+            {
+                double scaledRadius = radius * angle / 3600;
+                double radians = Math.PI * angle / 180;
+                double x = center.X + scaledRadius * Math.Cos(radians);
+                double y = center.Y + scaledRadius * Math.Sin(radians);
+                points.Add(new Point(x, y));
+            }
+
+            polyline.Points = points;
+        }
+    }
+
+    public class AnimateShapeGallery : SpiralDemoPage
+    {
+        public AnimateShapeGallery()
+        {
+            Title = "Animate Shape Gallery";
+
+            polyline.StrokeDashArray.Add(4);
+            polyline.StrokeDashArray.Add(2);
+            double total = polyline.StrokeDashArray[0] + polyline.StrokeDashArray[1];
+
+            Device.StartTimer(TimeSpan.FromMilliseconds(15), () =>
+            {
+                double secs = DateTime.Now.TimeOfDay.TotalSeconds;
+                polyline.StrokeDashOffset = total * (secs % 1);
+                return true;
+            });
+        }
+    }
+}

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapesGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapesGallery.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
                         GalleryBuilder.NavButton("Path LayoutOptions Gallery", () => new PathLayoutOptionsGallery(), Navigation),
                         GalleryBuilder.NavButton("Transform Playground", () => new TransformPlaygroundGallery(), Navigation),
                         GalleryBuilder.NavButton("Path Transform using string (TypeConverter) Gallery", () => new PathTransformStringGallery(), Navigation),
+                        GalleryBuilder.NavButton("Animate Shape Gallery", () => new AnimateShapeGallery(), Navigation),
                         GalleryBuilder.NavButton("Clip Gallery", () => new ClipGallery(), Navigation),
                         GalleryBuilder.NavButton("Clip Views Gallery", () => new ClipViewsGallery(), Navigation),
                         GalleryBuilder.NavButton("Add/Remove Clip Gallery", () => new AddRemoveClipGallery(), Navigation),

--- a/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms.Platform.Android
                 UpdateStroke();
                 UpdateStrokeThickness();
                 UpdateStrokeDashArray();
+                UpdateStrokeDashOffset();
                 UpdateStrokeLineCap();
                 UpdateStrokeLineJoin();
             }
@@ -65,6 +66,8 @@ namespace Xamarin.Forms.Platform.Android
                 UpdateStrokeThickness();
             else if (args.PropertyName == Shape.StrokeDashArrayProperty.PropertyName)
                 UpdateStrokeDashArray();
+            else if (args.PropertyName == Shape.StrokeDashOffsetProperty.PropertyName)
+                UpdateStrokeDashOffset();
             else if (args.PropertyName == Shape.StrokeLineCapProperty.PropertyName)
                 UpdateStrokeLineCap();
             else if (args.PropertyName == Shape.StrokeLineJoinProperty.PropertyName)
@@ -109,6 +112,11 @@ namespace Xamarin.Forms.Platform.Android
         void UpdateStrokeDashArray()
         {
             Control.UpdateStrokeDashArray(Element.StrokeDashArray.ToArray());
+        }
+
+        void UpdateStrokeDashOffset()
+        {
+            Control.UpdateStrokeDashOffset((float)Element.StrokeDashOffset);
         }
 
         void UpdateStrokeLineCap()
@@ -168,6 +176,7 @@ namespace Xamarin.Forms.Platform.Android
 
         float _strokeWidth;
         float[] _strokeDash;
+        float _strokeDashOffset;
 
         Stretch _aspect;
 
@@ -268,13 +277,23 @@ namespace Xamarin.Forms.Platform.Android
         {
             _strokeWidth = _density * strokeWidth;
             _drawable.Paint.StrokeWidth = _strokeWidth;
-            UpdatePathStrokeBounds();
+            UpdateStrokeDash();
         }
 
         public void UpdateStrokeDashArray(float[] dash)
         {
             _strokeDash = dash;
+            UpdateStrokeDash();
+        }
 
+        public void UpdateStrokeDashOffset(float strokeDashOffset)
+		{
+            _strokeDashOffset = strokeDashOffset;
+            UpdateStrokeDash();
+        }
+
+        public void UpdateStrokeDash()
+        {
             if (_strokeDash != null && _strokeDash.Length > 1)
             {
                 float[] strokeDash = new float[_strokeDash.Length];
@@ -282,7 +301,7 @@ namespace Xamarin.Forms.Platform.Android
                 for (int i = 0; i < _strokeDash.Length; i++)
                     strokeDash[i] = _strokeDash[i] * _strokeWidth;
 
-                _drawable.Paint.SetPathEffect(new DashPathEffect(strokeDash, 0));
+                _drawable.Paint.SetPathEffect(new DashPathEffect(strokeDash, _strokeDashOffset * _strokeWidth));
             }
             else
                 _drawable.Paint.SetPathEffect(null);


### PR DESCRIPTION
### Description of Change ###

Fix issue animating StrokeDashOffset.

### Issues Resolved ### 

- fixes #11052

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

#### Before
Animation did not work on Android.

#### After
![animate-shape](https://user-images.githubusercontent.com/6755973/84635786-ff326480-aef3-11ea-995f-aa1095d80c9b.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the Shapes Gallery. Select the "Animate Shape Gallery" and verify that the shape is animating.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
