### PR TITLE
[C] convert value on multibindings before apply

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/MultiBindingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MultiBindingTests.cs
@@ -150,7 +150,7 @@ namespace Xamarin.Forms.Core.UnitTests
 							source: new RelativeBindingSource(RelativeBindingSourceMode.FindAncestor, typeof(StackLayout))),
 					},
 					Converter = new AnyTrueMultiConverter(),
-					FallbackValue = false,
+					FallbackValue = "false", //use a string literal here to test xaml conversion
 				});
 
 			// ^^

--- a/Xamarin.Forms.Core/MultiBinding.cs
+++ b/Xamarin.Forms.Core/MultiBinding.cs
@@ -85,6 +85,11 @@ namespace Xamarin.Forms
 				var value = GetSourceValue(GetValueArray(), _targetProperty.ReturnType);
 				if (value != Binding.DoNothing) {
 					_applying = true;
+					if (!BindingExpression.TryConvert(ref value, _targetProperty, _targetProperty.ReturnType, true))
+					{
+						Log.Warning("MultiBinding", "'{0}' can not be converted to type '{1}'.", value, _targetProperty.ReturnType);
+						return;
+					}
 					_targetObject.SetValueCore(_targetProperty, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
 					_applying = false;
 				}
@@ -147,6 +152,11 @@ namespace Xamarin.Forms
 			var value = GetSourceValue(GetValueArray(), _targetProperty.ReturnType);
 			if (value != Binding.DoNothing) {
 				_applying = true;
+				if (!BindingExpression.TryConvert(ref value, _targetProperty, _targetProperty.ReturnType, true))
+				{
+					Log.Warning("MultiBinding", "'{0}' can not be converted to type '{1}'.", value, _targetProperty.ReturnType);
+					return;
+				}
 				_targetObject.SetValueCore(_targetProperty, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
 				_applying = false;
 			}


### PR DESCRIPTION
### Description of Change ###

Convert values (and fallback) to target type to avoid cast exception (like BindingExpression is doing)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11058

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
