### PR TITLE
Null check WeakReference in UnapplyStyle

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StyleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleTests.cs
@@ -909,6 +909,34 @@ namespace Xamarin.Forms.Core.UnitTests
 			}
 
 			await Task.WhenAll(tasks);
-		} 
+		}
+
+		[Test]
+		public async Task ApplyUnapplyStyledElementsOffMainThreadShouldNotCrash()
+		{
+			List<Task> tasks = new List<Task>();
+
+			var style = new Style(typeof(VisualElement))
+			{
+				Setters = {
+					new Setter { Property = Label.TextProperty, Value = "foo" },
+					new Setter { Property = VisualElement.BackgroundColorProperty, Value = Color.Pink },
+				}
+			};
+
+			for (int n = 0; n < 10000; n++)
+			{
+				tasks.Add(Task.Run(() => {
+					var label = new Label
+					{
+						Style = style
+					};
+
+					label.Style = null;
+				}));
+			}
+
+			await Task.WhenAll(tasks);
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/StyleTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleTests.cs
@@ -912,7 +912,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task ApplyUnapplyStyledElementsOffMainThreadShouldNotCrash()
+		public async Task ApplyAndRemoveStyleOffMainThreadShouldNotCrash()
 		{
 			List<Task> tasks = new List<Task>();
 

--- a/Xamarin.Forms.Core/Style.cs
+++ b/Xamarin.Forms.Core/Style.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms
 				_targets.RemoveAll(wr =>
 				{
 					BindableObject target;
-					return wr.TryGetTarget(out target) && target == bindable;
+					return wr != null && wr.TryGetTarget(out target) && target == bindable;
 				});
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

If a Style is removed off of the UI thread, it's possible to create a situation where the Style.Unapply method throws a NullReferenceException when accessing a WeakReference.

This change adds a null check to avoid the exception.

### Issues Resolved ### 

- fixes #10697

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Unit test `ApplyAndRemoveStyleOffMainThreadShouldNotCrash()`.

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
