### PR TITLE
[iOS] Fix exception checking Element.IsLooping 

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
@@ -211,6 +211,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void PlayedToEnd(NSNotification notification)
 		{
+			if (Element == null)
+			{
+				return;
+			}
+
 			if (Element.IsLooping)
 			{
 				_avPlayerViewController.Player.Seek(CMTime.Zero);
@@ -226,7 +231,10 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Device.BeginInvokeOnMainThread(Controller.OnMediaEnded);
 				}
-				catch { }
+				catch (Exception e)
+				{
+					Log.Warning("MediaElement", $"Failed to play media to end: {e}");
+				}
 			}
 		}
 		


### PR DESCRIPTION
### Description of Change ###

When video playing to end. It will check IsLooping to play again or not.
But if we pop page or something else that release MediaElement when video almost play to end.
MediaElementRender will still receive IOS event to call `PlayedToEnd`, and there is no null check.
Then a null reference exception will throw when access `Element.IsLooping`.

### Issues Resolved ### 

- fixes #11071 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the MediaElement Gallery. Reproduce the video and move the position almost at the end. Then, navigate back. Without any exception the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
