### PR TITLE
[X] throw on mismatching param type for Add()

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11061.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11061.xaml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh11061"
+        MyDateTime="{Binding Date}">
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11061.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11061.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Build.Tasks;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh11061 : ContentPage
+	{
+		public DateTime MyDateTime { get; set; }
+
+		public Gh11061() => InitializeComponent();
+		public Gh11061(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void XamlCBindingOnNonBP([Values(false, true)] bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<BuildException>(() => MockCompiler.Compile(typeof(Gh11061)));
+				else
+					Assert.Throws<XamlParseException>(()=> new Gh11061(useCompiledXaml) { BindingContext = new { Date = DateTime.Today} });
+			}
+		}
+	}
+}
+ 


### PR DESCRIPTION
### Description of Change ###

There was a `TODO: check parameter type` in this code, like if past me
knew that, at some point in time, what was only a potential edge case
bug, would explode in my face and ruin my faith in humanity.

Those FIXMEs... they are bottled 'I TOLD YOU SO' little time capsules


### Issues Resolved ### 

- fixes #11061

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
