### PR TITLE
 Remove EditorBrowsableState.Never from Matrix struct

### DIFF
--- a/Xamarin.Forms.Core/Shapes/Matrix.cs
+++ b/Xamarin.Forms.Core/Shapes/Matrix.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.ComponentModel;
 
 namespace Xamarin.Forms.Shapes
 {
@@ -12,7 +11,6 @@ namespace Xamarin.Forms.Shapes
     }
 
     [TypeConverter(typeof(MatrixTypeConverter))]
-    [EditorBrowsable(EditorBrowsableState.Never)]
     public struct Matrix
     {
         internal double _m11;


### PR DESCRIPTION
### Description of Change ###
```

Facilitate the use of Matrix (Intellisense). Example:

<Path>
     <Path.RenderTransform>
          <MatrixTransform>
               <MatrixTransform.Matrix>
                    <Matrix OffsetX="10"
                                  OffsetY="100"
                                  M11="3"
                                  M12="2" />
               </MatrixTransform.Matrix>
          </MatrixTransform>
     </Path.RenderTransform>
</Path>
```

### Issues Resolved ### 

- fixes #11088

### API Changes ###
 
 Remove _EditorBrowsableState.Never_ from `Matrix` struct.

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Can use Intellisense creating something like:

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
