### PR TITLE
Invert logic for SendBackButtonPressed on Shell

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -272,10 +272,17 @@ namespace Xamarin.Forms.Core.UnitTests
 				OnNavigatingCount++;
 			}
 
+			public Func<bool> OnBackButtonPressedFunc;
 			protected override bool OnBackButtonPressed()
 			{
+				var result = OnBackButtonPressedFunc?.Invoke() ?? false;
+
 				OnBackButtonPressedCount++;
-				return base.OnBackButtonPressed();
+
+				if(!result)
+					result = base.OnBackButtonPressed();
+
+				return result;
 			}
 
 			public void Reset()

--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -36,6 +36,15 @@ namespace Xamarin.Forms.Core.UnitTests
 			return navPage;
 		}
 
+		protected T GetVisiblePage<T>(Shell shell)
+			where T : Page
+		{
+			if (shell?.CurrentItem?.CurrentItem is IShellSectionController scc)
+				return (T)scc.PresentedPage;
+
+			return default(T);
+		}
+
 		protected IEnumerable<Element> GetParentsPath(Element self)
 		{
 			Element current = self;
@@ -96,6 +105,9 @@ namespace Xamarin.Forms.Core.UnitTests
 			protected override bool OnBackButtonPressed()
 			{
 				if (CancelNavigationOnBackButtonPressed == "true")
+					return true;
+
+				if (CancelNavigationOnBackButtonPressed == "false")
 					return false;
 
 				return base.OnBackButtonPressed();

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -592,13 +592,29 @@ namespace Xamarin.Forms.Core.UnitTests
 
 
 		[Test]
-		public async Task OnBackbuttonPressedFiresOnPage()
-		{
-			Shell shell = new Shell();
+		public async Task OnBackbuttonPressedPageReturnsTrue()
+		{			
+			TestShell shell = new TestShell();
+
 			Routing.RegisterRoute("OnBackbuttonPressedFiresOnPage", typeof(ShellTestPage));
 			shell.Items.Add(CreateShellItem());
 			await shell.GoToAsync($"OnBackbuttonPressedFiresOnPage?CancelNavigationOnBackButtonPressed=true");
-			Assert.AreEqual(false, shell.SendBackButtonPressed());
+
+			shell.SendBackButtonPressed();
+			Assert.AreEqual(2, shell.Navigation.NavigationStack.Count);
+		}
+
+		[Test]
+		public async Task OnBackbuttonPressedPageReturnsFalse()
+		{
+			TestShell shell = new TestShell();
+
+			Routing.RegisterRoute("OnBackbuttonPressedFiresOnPage", typeof(ShellTestPage));
+			shell.Items.Add(CreateShellItem());
+			await shell.GoToAsync($"OnBackbuttonPressedFiresOnPage?CancelNavigationOnBackButtonPressed=false");
+
+			shell.SendBackButtonPressed();
+			Assert.AreEqual(1, shell.Navigation.NavigationStack.Count);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -590,7 +590,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assume.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//one/tabone/content"));
 		}
 
-
 		[Test]
 		public async Task OnBackbuttonPressedPageReturnsTrue()
 		{			
@@ -615,6 +614,19 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			shell.SendBackButtonPressed();
 			Assert.AreEqual(1, shell.Navigation.NavigationStack.Count);
+		}
+
+		[Test]
+		public async Task OnBackbuttonPressedShellReturnsTrue()
+		{
+			TestShell shell = new TestShell();
+
+			Routing.RegisterRoute("OnBackbuttonPressedShellReturnsTrue", typeof(ShellTestPage));
+			shell.Items.Add(CreateShellItem());
+			await shell.GoToAsync($"OnBackbuttonPressedShellReturnsTrue");
+			shell.OnBackButtonPressedFunc = () => true;
+			shell.SendBackButtonPressed();
+			Assert.AreEqual(2, shell.Navigation.NavigationStack.Count);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -286,7 +286,7 @@ namespace Xamarin.Forms
 		protected virtual bool OnBackButtonPressed()
 		{
 			if (RealParent is BaseShellItem || RealParent is Shell)
-				return true;
+				return false;
 
 			var application = RealParent as Application;
 			if (application == null || this == application.MainPage)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -992,24 +992,31 @@ namespace Xamarin.Forms
 
 		protected override bool OnBackButtonPressed()
 		{
-			if(GetVisiblePage() is Page page)
-			{
-				if(!page.SendBackButtonPressed())
-				{
-					return false;
-				}
-			}
+			if (GetVisiblePage() is Page page && page.SendBackButtonPressed())
+				return true;
 
 			var currentContent = CurrentItem?.CurrentItem;
 			if (currentContent != null && currentContent.Stack.Count > 1)
 			{
-				currentContent.Navigation.PopAsync();
+				NavigationPop();
 				return true;
 			}
 
 			var args = new ShellNavigatingEventArgs(this.CurrentState, "", ShellNavigationSource.Pop, true);
 			OnNavigating(args);
 			return args.Cancelled;
+
+			async void NavigationPop()
+			{
+				try
+				{
+					await currentContent.Navigation.PopAsync();
+				}
+				catch(Exception exc)
+				{
+					Internals.Log.Warning(nameof(Shell), $"Failed to Navigate Back: {exc}");
+				}
+			}
 		}
 
 		bool ValidDefaultShellItem(Element child) => !(child is MenuShellItem);


### PR DESCRIPTION
### Description of Change ###

The logic for interpreting SendBackButtonPressed needs to be inverted. Currently it's treating false as handled.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7072

### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
