### PR TITLE
Call Setting Page if SetPage has been delayed

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -92,6 +92,8 @@ namespace Xamarin.Forms.ControlGallery.Android
 				return null;
 			});
 
+			DependencyService.Register<IMultiWindowService, MultiWindowService>();
+			
 			LoadApplication(_app);
 
 #if !TEST_EXPERIMENTAL_RENDERERS
@@ -101,6 +103,11 @@ namespace Xamarin.Forms.ControlGallery.Android
 				Window.SetStatusBarColor(Color.MediumPurple.ToAndroid());
 			}
 #endif
+		}
+
+		public void ReloadApplication()
+		{
+			LoadApplication(_app);
 		}
 
 		protected override void OnResume()
@@ -113,6 +120,25 @@ namespace Xamarin.Forms.ControlGallery.Android
 		public bool IsPreAppCompat()
 		{
 			return false;
+		}
+
+		[Java.Interop.Export("BackgroundApp")]
+		public void BackgroundApp()
+		{
+			Intent intent = new Intent();
+			intent.SetAction(Intent.ActionMain);
+			intent.AddCategory(Intent.CategoryHome);
+			this.StartActivity(intent);
+		}
+
+		[Java.Interop.Export("ForegroundApp")]
+		public void ForegroundApp()
+		{
+			// this only works pre API 29
+			Intent intent = new Intent(ApplicationContext, typeof(Activity1));
+			intent.SetAction(Intent.ActionMain);
+			intent.AddCategory(Intent.CategoryLauncher);
+			this.ApplicationContext.StartActivity(intent);
 		}
 	}
 }

--- a/Xamarin.Forms.ControlGallery.Android/Issue10182Activity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Issue10182Activity.cs
@@ -1,0 +1,106 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Android.App;
+using Android.Content;
+using Android.Content.PM;
+using Android.OS;
+using Android.Renderscripts;
+using Android.Runtime;
+using Android.Views;
+using Android.Widget;
+using Xamarin.Forms.Controls.Issues;
+
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	[Activity(Label = "Issue10182Activity", Icon = "@drawable/icon", Theme = "@style/MyTheme",
+		MainLauncher = false, HardwareAccelerated = true,
+		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.UiMode)]
+	public class Issue10182Activity : global::Xamarin.Forms.Platform.Android.FormsAppCompatActivity
+	{
+		Activity1 _activity1;
+		protected override void OnCreate(Bundle savedInstanceState)
+		{
+			var currentApplication = Xamarin.Forms.Application.Current;
+			TabLayoutResource = Resource.Layout.Tabbar;
+			ToolbarResource = Resource.Layout.Toolbar;
+
+			base.OnCreate(savedInstanceState);
+
+			global::Xamarin.Forms.Forms.Init(this, savedInstanceState);
+			LoadApplication(new Issue10182Application());
+
+			_activity1 = (Activity1)DependencyService.Resolve<Context>();
+
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				try
+				{
+
+					await Task.Delay(1000);
+					{
+						Intent intent = new Intent(_activity1, typeof(Activity1));
+						intent.AddFlags(ActivityFlags.ReorderToFront);
+						_activity1.StartActivity(intent);
+					}
+
+					await Task.Delay(1000);
+					{
+						Intent intent = new Intent(this, typeof(Issue10182Activity));
+						intent.AddFlags(ActivityFlags.ReorderToFront);
+						StartActivity(intent);
+					}
+
+					await Task.Delay(1000);
+					{
+						Intent intent = new Intent(_activity1, typeof(Activity1));
+						intent.AddFlags(ActivityFlags.ReorderToFront);
+						_activity1.StartActivity(intent);
+					}
+				}
+				finally
+				{
+					this.Finish();
+					_activity1.ReloadApplication();
+					currentApplication.MainPage = new Issue10182.Issue10182SuccessPage();
+				}
+			});
+		}
+
+		public class Issue10182Test : ContentPage
+		{
+			public Issue10182Test()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Hold Please. Activity should vanish soon and you'll see a success label",
+							AutomationId = "Loaded"
+						}
+					}
+				};
+			}
+		}
+
+		public class Issue10182Application : Application
+		{
+			protected override void OnStart()
+			{
+				var contentPage = new Issue10182Test();
+				base.OnStart();
+				MainPage = contentPage;
+			}
+
+			protected override void OnSleep()
+			{
+				base.OnSleep();
+				MainPage = new NavigationPage(new ContentPage());
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.Android/MultiWindowService.cs
+++ b/Xamarin.Forms.ControlGallery.Android/MultiWindowService.cs
@@ -1,0 +1,23 @@
+﻿#if !FORMS_APPLICATION_ACTIVITY && !PRE_APPLICATION_CLASS
+
+using Android.Content;
+using Xamarin.Forms.Controls.Issues;
+using System;
+
+namespace Xamarin.Forms.ControlGallery.Android
+{
+	public class MultiWindowService : IMultiWindowService
+	{
+		public void OpenWindow(Type type)
+		{
+			if (type == typeof(Issue10182))
+			{
+				var context = DependencyService.Resolve<Context>();
+				Intent intent = new Intent(context, typeof(Issue10182Activity));
+				context.StartActivity(intent);
+			}
+		}
+	}
+}
+
+#endif

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -102,7 +102,9 @@
     <Compile Include="DisposeLabelRenderer.cs" />
     <Compile Include="DisposePageRenderer.cs" />
     <Compile Include="FormsAppCompatActivity.cs" />
+    <Compile Include="Issue10182Activity.cs" />
     <Compile Include="MainApplication.cs" />
+    <Compile Include="MultiWindowService.cs" />
     <Compile Include="PerformanceTrackerRenderer.cs" />
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
     <Compile Include="Resources\Resource.Designer.cs" />
@@ -407,7 +409,7 @@
       <SubType>Designer</SubType>
     </AndroidResource>
   </ItemGroup>
-  <ItemGroup Condition="Exists('Properties\MapsKey.cs')">  
+  <ItemGroup Condition="Exists('Properties\MapsKey.cs')">
     <Compile Include="Properties\MapsKey.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10182.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10182.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 10182, "[Bug] Exception Ancestor must be provided for all pushes except first", PlatformAffected.Android, NavigationBehavior.SetApplicationRoot)]
 #if UITEST
-	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
 	[NUnit.Framework.Category(UITestCategories.LifeCycle)]
 #endif
 	public class Issue10182 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10182.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10182.cs
@@ -68,11 +68,11 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-#if UITEST
+#if UITEST && __ANDROID__
 		[Test]
 		public void AppDoesntCrashWhenResettingPage()
 		{
-			RunningApp.WaitForElement("Loaded");
+			RunningApp.WaitForElement("Success");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10182.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10182.cs
@@ -1,0 +1,79 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+using System.Threading;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10182, "[Bug] Exception Ancestor must be provided for all pushes except first", PlatformAffected.Android, NavigationBehavior.SetApplicationRoot)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+	[NUnit.Framework.Category(UITestCategories.LifeCycle)]
+#endif
+	public class Issue10182 : TestContentPage
+	{
+		public Issue10182()
+		{
+			
+		}
+
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "Starting Activity to Test Changing Page on Resume. If success label shows up test has passed."
+					}
+				}
+			};
+
+#if !UITEST
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				DependencyService.Get<IMultiWindowService>().OpenWindow(this.GetType());
+			});
+#endif
+
+		}
+
+		public class Issue10182SuccessPage : ContentPage
+		{ 
+			public Issue10182SuccessPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Success.",
+							AutomationId = "Success"
+						}
+					}
+				};
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void AppDoesntCrashWhenResettingPage()
+		{
+			RunningApp.WaitForElement("Loaded");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1399,6 +1399,7 @@
       <DependentUpon>Issue9555.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11031.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10182.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls/IMultiWindowService.cs
+++ b/Xamarin.Forms.Controls/IMultiWindowService.cs
@@ -1,0 +1,11 @@
+﻿using System;
+
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	public interface IMultiWindowService
+	{
+		void OpenWindow(Type type);
+	}
+}

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -400,7 +400,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (_needMainPageAssign)
 			{
 				_needMainPageAssign = false;
-
+				SettingMainPage();
 				SetMainPage();
 			}
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/Platform.cs
@@ -254,8 +254,11 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		internal void SettingNewPage()
 		{
-			_previousNavModel = _navModel;
-			_navModel = new NavigationModel();
+			if (Page != null)
+			{
+				_previousNavModel = _navModel;
+				_navModel = new NavigationModel();
+			}
 		}
 
 		internal void SetPage(Page newRoot)


### PR DESCRIPTION
### Description of Change ###

If the MainPage is set while the app is paused, then Android delays setting the actual page at the platform level and just delays it until the app is actually resumed

https://github.com/xamarin/Xamarin.Forms/blob/b5b6f85a46b738f2682cfa1d5ce4dadddc8e00a8/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs#L400

If this combination of events happens
- new main page set
- app paused
- new main page set
- app resumed

Then the previous app model wasn't being cleaned up properly

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10182

### Platforms Affected ### 
- Android

### Testing Procedure ###
- still need to figure this out. Creating PR so I can give people a nuget to test

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
