### PR TITLE
Null check for LightDismissLayer on UWP Shell

### DIFF
--- a/Xamarin.Forms.Platform.UAP.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Platform.UAP.UnitTests/ShellTests.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.UAP.UnitTests;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ExportRenderer(typeof(TestShell), typeof(TestShellRenderer))]
+namespace Xamarin.Forms.Platform.UAP.UnitTests
+{
+	public class ShellTests : PlatformTestFixture
+	{
+		[Test, Category("Shell")]
+		[Description("Shell doesn't crash when Flyout Behavior Initialized to Locked")]
+		public async Task FlyoutHeaderReactsToChanges()
+		{
+			var shell = CreateShell();
+			shell.FlyoutBehavior = FlyoutBehavior.Locked;
+
+			try
+			{
+				await Device.InvokeOnMainThreadAsync(() =>
+				{
+					var r = GetRenderer(shell);
+				});
+			}
+			catch (Exception exc)			
+			{
+				Assert.Fail(exc.ToString());
+			}
+
+			Assert.Pass();
+		}
+
+		Shell CreateShell()
+		{
+			return new Shell()
+			{
+				Items =
+				{
+					new FlyoutItem()
+					{
+						Items =
+						{
+							new Tab()
+							{
+								Items =
+								{
+									new ShellContent()
+									{
+										Content = new ContentPage()
+									}
+								}
+							}
+						}
+					}
+				}
+			};
+		}
+	}
+
+	public class TestShell : Shell { }	
+	
+	public class TestShellRenderer : ShellRenderer
+	{
+	}
+}

--- a/Xamarin.Forms.Platform.UAP.UnitTests/Xamarin.Forms.Platform.UAP.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.UAP.UnitTests/Xamarin.Forms.Platform.UAP.UnitTests.csproj
@@ -131,6 +131,7 @@
     <Compile Include="RotationTests.cs" />
     <Compile Include="ScaleTests.cs" />
     <Compile Include="ScrollBarVisibilityTests.cs" />
+    <Compile Include="ShellTests.cs" />
     <EmbeddedResource Include="Properties\Xamarin.Forms.Platform.UAP.UnitTests.rd.xml" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Platform.UWP
 		const string NavigationViewBackButton = "NavigationViewBackButton";
 		internal const string ShellStyle = "ShellNavigationView";
 		Shell _shell;
-
+		FlyoutBehavior _flyoutBehavior;
 		ShellItemRenderer ItemRenderer { get; }
 
 		public ShellRenderer()
@@ -65,7 +65,9 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
 			UpdateFlyoutBackdropColor();
-			ShellSplitView.UpdateFlyoutBackdropColor();
+
+			if(_flyoutBehavior == FlyoutBehavior.Flyout)
+				ShellSplitView.UpdateFlyoutBackdropColor();
 		}
 
 		void OnPaneClosed()
@@ -179,6 +181,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected virtual void UpdateFlyoutBackdropColor()
 		{
+			if (_flyoutBehavior != FlyoutBehavior.Flyout)
+				return;
+
 			var splitView = ShellSplitView;
 			if (splitView != null)
 			{
@@ -295,9 +300,10 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 		#endregion IAppearanceObserver
-
+		
 		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)
 		{
+			_flyoutBehavior = behavior;
 			switch (behavior)
 			{
 				case FlyoutBehavior.Disabled:

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -24,6 +24,9 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			var dismissLayer = ((WRectangle)GetTemplateChild("LightDismissLayer"));
 
+			if (dismissLayer == null)
+				return;
+
 			if (_defaultBrush == null)
 				_defaultBrush = dismissLayer.Fill;
 


### PR DESCRIPTION
### Description of Change ###

When initializing shell with the flyoutbehavior set to locked the `LightDismissLayer` doesn't exist

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11096 

### Platforms Affected ### 

- UWP

### Testing Procedure ###
- added unit test
- click around in the store shell

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
