### PR TITLE
[iOS] Added preserve default constructor in Shapes renderers

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Shapes/EllipseRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/EllipseRenderer.cs
@@ -9,6 +9,12 @@ namespace Xamarin.Forms.Platform.MacOS
 {
     public class EllipseRenderer : ShapeRenderer<Ellipse, EllipseView>
     {
+        [Internals.Preserve(Conditional = true)]
+        public EllipseRenderer()
+        {
+
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Ellipse> args)
         {
             if (Control == null)

--- a/Xamarin.Forms.Platform.iOS/Shapes/LineRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/LineRenderer.cs
@@ -11,6 +11,12 @@ namespace Xamarin.Forms.Platform.MacOS
 {
     public class LineRenderer : ShapeRenderer<Line, LineView>
     {
+        [Internals.Preserve(Conditional = true)]
+        public LineRenderer()
+        {
+
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Line> args)
         {
             if (Control == null)

--- a/Xamarin.Forms.Platform.iOS/Shapes/PathRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/PathRenderer.cs
@@ -10,6 +10,12 @@ namespace Xamarin.Forms.Platform.MacOS
 {
     public class PathRenderer : ShapeRenderer<Path, PathView>
     {
+        [Internals.Preserve(Conditional = true)]
+        public PathRenderer()
+        {
+
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Path> args)
         {
             if (Control == null)

--- a/Xamarin.Forms.Platform.iOS/Shapes/PolygonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/PolygonRenderer.cs
@@ -10,6 +10,12 @@ namespace Xamarin.Forms.Platform.MacOS
 {
     public class PolygonRenderer : ShapeRenderer<Polygon, PolygonView>
     {
+        [Internals.Preserve(Conditional = true)]
+        public PolygonRenderer()
+        {
+
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Polygon> args)
         {
             if (Control == null)

--- a/Xamarin.Forms.Platform.iOS/Shapes/PolylineRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/PolylineRenderer.cs
@@ -10,6 +10,12 @@ namespace Xamarin.Forms.Platform.MacOS
 {
     public class PolylineRenderer : ShapeRenderer<Polyline, PolylineView>
     {
+        [Internals.Preserve(Conditional = true)]
+        public PolylineRenderer()
+        {
+
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Polyline> args)
         {
             if (Control == null)

--- a/Xamarin.Forms.Platform.iOS/Shapes/RectangleRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/RectangleRenderer.cs
@@ -11,6 +11,12 @@ namespace Xamarin.Forms.Platform.MacOS
 {
     public class RectangleRenderer : ShapeRenderer<Rect, RectView>
     {
+        [Internals.Preserve(Conditional = true)]
+        public RectangleRenderer()
+        {
+
+        }
+
         protected override void OnElementChanged(ElementChangedEventArgs<Rect> args)
         {
             if (Control == null)


### PR DESCRIPTION
### Description of Change ###

Recently we set the  experimental linker flag: https://github.com/xamarin/Xamarin.Forms/blob/master/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj#L18

This PR add a default constructor in the Shapes renderer with a preserve attribute to avoid any issue.

Example: 

`System.MissingMethodException: Default constructor not found for type Xamarin.Forms.Platform.iOS.PathRenderer`

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to any of the Shapes Gallery samples. If you can navigate and see the Shapes, the test has passed.

### PR Checklist ###
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
