### PR TITLE
[iOS] Prevent CollectionView exception when item spacing is too large 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9929.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9929.cs
@@ -1,0 +1,46 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SpacingGalleries;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9929, "[Bug] NSInternalInconsistencyException when trying to run XamarinTV on iOS",
+		PlatformAffected.iOS)]
+	public class Issue9929 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			PushAsync(new SpacingGallery (new GridItemsLayout(3, ItemsLayoutOrientation.Vertical)));
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void InsanelyWideHorizontalSpacingShouldNotCrash()
+		{
+			RunningApp.WaitForElement("entryUpdate_Spacing");
+			RunningApp.Tap("entryUpdate_Spacing");	
+			RunningApp.ClearText();
+			RunningApp.EnterText("500,0");
+			RunningApp.Tap("btnUpdate_Spacing");	
+
+			// If it hasn't crashed, we should still be able to find this
+			RunningApp.WaitForElement("entryUpdate Spacing");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9929.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9929.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SpacingGalleries;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
@@ -24,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 #if APP
-			PushAsync(new SpacingGallery (new GridItemsLayout(3, ItemsLayoutOrientation.Vertical)));
+			PushAsync(new Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SpacingGalleries.SpacingGallery(new GridItemsLayout(3, ItemsLayoutOrientation.Vertical)));
 #endif
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9929.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9929.cs
@@ -34,11 +34,11 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("entryUpdate_Spacing");
 			RunningApp.Tap("entryUpdate_Spacing");	
 			RunningApp.ClearText();
-			RunningApp.EnterText("500,0");
+			RunningApp.EnterText("0,500");
 			RunningApp.Tap("btnUpdate_Spacing");	
 
 			// If it hasn't crashed, we should still be able to find this
-			RunningApp.WaitForElement("entryUpdate Spacing");
+			RunningApp.WaitForElement("entryUpdate_Spacing");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -254,6 +254,7 @@
       <DependentUpon>Issue9771.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue9833.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9929.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SpacingGalleries/SpacingGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SpacingGalleries/SpacingGallery.cs
@@ -36,7 +36,7 @@
 			};
 
 			var generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
-			var spacingModifier = new SpacingModifier(collectionView.ItemsLayout, "Update Spacing");
+			var spacingModifier = new SpacingModifier(collectionView.ItemsLayout, "Update_Spacing");
 
 			layout.Children.Add(generator);
 			layout.Children.Add(instructions);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -39,7 +39,9 @@ namespace Xamarin.Forms.Platform.iOS
 					? _itemsLayout.HorizontalItemSpacing
 					: _itemsLayout.VerticalItemSpacing);
 
-			spacing = spacing * (_itemsLayout.Span - 1);
+			spacing = ReduceSpacingToFitIfNeeded(availableSpace, spacing, _itemsLayout.Span);
+
+			spacing *= (_itemsLayout.Span - 1);
 
 			ConstrainedDimension = (availableSpace - spacing) / _itemsLayout.Span;
 
@@ -171,6 +173,19 @@ namespace Xamarin.Forms.Platform.iOS
 			return invalidationContext;
 		}
 
+		public override nfloat GetMinimumInteritemSpacingForSection(UICollectionView collectionView, UICollectionViewLayout layout, nint section)
+		{
+			var requestedSpacing = ScrollDirection == UICollectionViewScrollDirection.Horizontal
+				? (nfloat)_itemsLayout.VerticalItemSpacing
+				: (nfloat)_itemsLayout.HorizontalItemSpacing;
+
+			var availableSpace = ScrollDirection == UICollectionViewScrollDirection.Horizontal
+				? collectionView.Frame.Height
+				: collectionView.Frame.Width;
+
+			return ReduceSpacingToFitIfNeeded(availableSpace, requestedSpacing, _itemsLayout.Span);
+		}
+
 		void CenterAlignCellsInColumn(UICollectionViewLayoutAttributes preferredAttributes) 
 		{
 			// Determine the set of cells above this one
@@ -263,6 +278,17 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return true;
+		}
+
+		static nfloat ReduceSpacingToFitIfNeeded(nfloat available, nfloat requestedSpacing, int span) 
+		{
+			if (span == 1)
+			{
+				return requestedSpacing;
+			}
+
+			var maxSpacing = (available - span) / (span - 1);
+			return (nfloat)Math.Min(requestedSpacing, maxSpacing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -125,16 +125,6 @@ namespace Xamarin.Forms.Platform.iOS
 		public virtual nfloat GetMinimumInteritemSpacingForSection(UICollectionView collectionView,
 			UICollectionViewLayout layout, nint section)
 		{
-			if (_itemsLayout is GridItemsLayout gridItemsLayout)
-			{
-				if (ScrollDirection == UICollectionViewScrollDirection.Horizontal)
-				{
-					return (nfloat)gridItemsLayout.VerticalItemSpacing;
-				}
-
-				return (nfloat)gridItemsLayout.HorizontalItemSpacing;
-			}
-
 			return (nfloat)0.0;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Setting the item spacing in a GridItemsLayout on iOS can cause the CollectionView to throw an internal consistency exception because the spacing forces the individual item size below zero.

These changes prevent the actual layout size of the items from going below zero, even if the item spacing is set to a very large value.

### Issues Resolved ### 

- fixes #9929

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
