### PR TITLE
Update the tab bar visibility before the layout of the subviews

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
@@ -1,0 +1,110 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11107, "[Bug][iOS] Shell Navigation implicitly adds Tabbar",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11107 : TestShell
+	{
+		protected async override void Init()
+		{
+			Shell.SetTabBarIsVisible(this, false);
+			Shell.SetNavBarHasShadow(this, false);
+
+			ContentPage firstPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "If this page has a tab bar the test has failed",
+							AutomationId = "Page1Loaded"
+						}
+					}
+				}
+			};
+
+			ContentPage secondPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Hold Please!! Or fail the test if nothing happens."
+						}
+					}
+				}
+			};
+
+			var item1 = AddFlyoutItem(firstPage, "Page1");
+			item1.Items[0].Title = "Tab 1";
+			item1.Items[0].AutomationId = "Tab1AutomationId";
+			var item2 = AddFlyoutItem(secondPage, "Page2");
+
+			item1.Route = "FirstPage";
+			Routing.RegisterRoute("Issue11107HeaderPage", typeof(Issue11107HeaderPage));
+
+			CurrentItem = item2;
+			await Task.Delay(2000);
+			await GoToAsync("//FirstPage/Issue11107HeaderPage");
+		}
+
+		[Preserve(AllMembers = true)]
+		public class Issue11107HeaderPage : ContentPage
+		{
+			public Issue11107HeaderPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "If this page has a tab bar the test has failed",
+							AutomationId = "SecondPageLoaded"
+						},
+						new Label()
+						{
+							Text = "Click the Back Button"
+						}
+					}
+				};
+			}
+		}
+
+
+#if UITEST
+		[Test]
+		public void TabShouldntBeVisibleWhenThereIsOnlyOnePage()
+		{
+			RunningApp.WaitForElement("SecondPageLoaded");
+			RunningApp.WaitForNoElement("Tab1AutomationId");
+			TapBackArrow();
+			RunningApp.WaitForElement("Page1Loaded");
+			RunningApp.WaitForNoElement("Tab1AutomationId");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
@@ -33,9 +33,11 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue11107(bool tabBarIsVisible)
 		{
 			_tabBarIsVisible = tabBarIsVisible;
+#if !UITEST
 			Shell.SetTabBarIsVisible(this, _tabBarIsVisible);
 			Shell.SetNavBarHasShadow(this, false);
 			_tabBarLabel.Text = $"TabBarIsVisible: {_tabBarIsVisible}";
+#endif
 		}
 
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 			_tabBarLabel.Text = $"TabBarIsVisible: {_tabBarIsVisible}";
 		}
 
-		protected async override void Init()
+		protected override void Init()
 		{
 			_tabBarLabel = new Label();
 			ContentPage firstPage = new ContentPage()
@@ -101,9 +101,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 			CurrentItem = item2;
 
-
-			await Task.Delay(2000);
-			await GoToAsync("//FirstPage/Issue11107HeaderPage");
+			Device.BeginInvokeOnMainThread(async () =>
+			{
+				await Task.Delay(1000);
+				await GoToAsync("//FirstPage/Issue11107HeaderPage");
+			});
 		}
 
 		[Preserve(AllMembers = true)]
@@ -139,15 +141,15 @@ namespace Xamarin.Forms.Controls.Issues
 			RunTests();
 			RunningApp.Tap("RunTestTwoTabs");
 			RunTests();
-		}
 
-		void RunTests()
-		{
-			RunningApp.WaitForElement("SecondPageLoaded");
-			RunningApp.WaitForNoElement("Tab1AutomationId");
-			TapBackArrow();
-			RunningApp.WaitForElement("Page1Loaded");
-			RunningApp.WaitForNoElement("Tab1AutomationId");
+			void RunTests()
+			{
+				RunningApp.WaitForElement("SecondPageLoaded");
+				RunningApp.WaitForNoElement("Tab1AutomationId");
+				TapBackArrow();
+				RunningApp.WaitForElement("Page1Loaded");
+				RunningApp.WaitForNoElement("Tab1AutomationId");
+			}
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11107.cs
@@ -24,21 +24,54 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class Issue11107 : TestShell
 	{
+		bool _tabBarIsVisible = false;
+		Label _tabBarLabel;
+		public Issue11107() : this(false)
+		{
+		}
+
+		public Issue11107(bool tabBarIsVisible)
+		{
+			_tabBarIsVisible = tabBarIsVisible;
+			Shell.SetTabBarIsVisible(this, _tabBarIsVisible);
+			Shell.SetNavBarHasShadow(this, false);
+			_tabBarLabel.Text = $"TabBarIsVisible: {_tabBarIsVisible}";
+		}
+
 		protected async override void Init()
 		{
-			Shell.SetTabBarIsVisible(this, false);
-			Shell.SetNavBarHasShadow(this, false);
-
+			_tabBarLabel = new Label();
 			ContentPage firstPage = new ContentPage()
 			{
 				Content = new StackLayout()
 				{
 					Children =
 					{
+						_tabBarLabel,
 						new Label()
 						{
 							Text = "If this page has a tab bar the test has failed",
 							AutomationId = "Page1Loaded"
+						},
+						new Button()
+						{
+							Text = "Run test again with TabBarIsVisible Toggled",
+							Command = new Command(() =>
+							{
+								Application.Current.MainPage = new Issue11107(!Shell.GetTabBarIsVisible(this));
+							}),
+							AutomationId = "RunTestTabBarIsVisible"
+						},
+						new Button()
+						{
+							Text = "Run with Two Tabs and TabBarIsVisible False",
+							Command = new Command(() =>
+							{
+								var shell = new Issue11107(false);
+								shell.AddBottomTab("Second Tab");
+								Application.Current.MainPage = shell;
+							}),
+							AutomationId = "RunTestTwoTabs"
 						}
 					}
 				}
@@ -67,6 +100,8 @@ namespace Xamarin.Forms.Controls.Issues
 			Routing.RegisterRoute("Issue11107HeaderPage", typeof(Issue11107HeaderPage));
 
 			CurrentItem = item2;
+
+
 			await Task.Delay(2000);
 			await GoToAsync("//FirstPage/Issue11107HeaderPage");
 		}
@@ -98,6 +133,15 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 		[Test]
 		public void TabShouldntBeVisibleWhenThereIsOnlyOnePage()
+		{
+			RunTests();
+			RunningApp.Tap("RunTestTabBarIsVisible");
+			RunTests();
+			RunningApp.Tap("RunTestTwoTabs");
+			RunTests();
+		}
+
+		void RunTests()
 		{
 			RunningApp.WaitForElement("SecondPageLoaded");
 			RunningApp.WaitForNoElement("Tab1AutomationId");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1399,6 +1399,7 @@
       <DependentUpon>Issue9555.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11031.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11107.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -370,8 +370,17 @@ namespace Xamarin.Forms.Platform.iOS
 			return null;
 		}
 
+		public override void ViewWillLayoutSubviews()
+		{
+			UpdateTabBarHidden();
+			base.ViewWillLayoutSubviews();
+		}
+
 		void SetTabBarHidden(bool hidden)
 		{
+			if (TabBar.Hidden == hidden)
+				return;
+
 			TabBar.Hidden = hidden;
 
 			if (CurrentRenderer == null)
@@ -393,11 +402,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_displayedPage == null || ShellItem == null)
 				return;
 
-			var hidden = !Shell.GetTabBarIsVisible(_displayedPage);
-			if (ShellItemController.GetItems().Count > 1)
-			{
-				SetTabBarHidden(hidden);
-			}
+			var hidden = ShellItemController.GetItems().Count < 1 ||
+				!Shell.GetTabBarIsVisible(_displayedPage);
+
+			SetTabBarHidden(hidden);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -402,8 +402,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_displayedPage == null || ShellItem == null)
 				return;
 
-			var hidden = ShellItemController.GetItems().Count < 1 ||
-				!Shell.GetTabBarIsVisible(_displayedPage);
+			var hidden = !(ShellItemController.GetItems().Count > 1 &&
+				Shell.GetTabBarIsVisible(_displayedPage));
 
 			SetTabBarHidden(hidden);
 		}


### PR DESCRIPTION
### Description of Change ###
Update the tab bar visibility before the layout of the subviews

### Issues Resolved ### 

- fixes #11107
- fixes #10126


### Platforms Affected ### 
- iOS

### Testing Procedure ###
- ui tests included
- test tab bar visibility in CG

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
