### PR TITLE
[iOS] Fix Frame IsClippedToBounds issue 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11120.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11120.xaml
@@ -1,0 +1,101 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11120"
+    Title="Issue 11120">
+    <Grid
+        BackgroundColor="Wheat"
+        RowSpacing="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Label
+            Grid.Row="0"
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the corners of the buttons clip to bounds, the test has passed."/>
+        <Grid
+            Grid.Row="1">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Frame
+                Padding="0"
+                CornerRadius="{Binding Source={x:Reference CornerRadiusSlider},Path=Value}"
+                IsClippedToBounds="{Binding Source={x:Reference IsClippedToBoundsCheckBox},Path=IsChecked}">
+                <Frame.Resources>
+                    <ResourceDictionary>
+
+                        <Style
+                            TargetType="Frame">
+                            <Setter Property="BackgroundColor" Value="WhiteSmoke"/>
+                            <Setter Property="HasShadow" Value="True"/>
+                            <Setter Property="HorizontalOptions" Value="FillAndExpand"/>
+                            <Setter Property="Margin" Value="40"/>
+                            <Setter Property="Padding" Value="20"/>
+                            <Setter Property="VerticalOptions" Value="Center"/>
+                        </Style>
+
+                    </ResourceDictionary>
+                </Frame.Resources>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="50" />
+                        <RowDefinition Height="Auto" />
+                    </Grid.RowDefinitions>
+                    <Label
+                        FontSize="Subtitle"
+                        HorizontalOptions="Center"
+                        HorizontalTextAlignment="Center"
+                        Text="..."
+                        VerticalOptions="Center"/>
+                    <Grid
+                        Grid.Row="1"
+                        ColumnSpacing="0">     
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="50"/>
+                        </Grid.RowDefinitions>
+                        <Button
+                            BackgroundColor="Blue"
+                            TextColor="White"
+                            CornerRadius="0"
+                            Grid.Column="1"
+                            Text="YES"/>
+                        <Button                   
+                            BackgroundColor="Gray"
+                            TextColor="White"
+                            CornerRadius="0"
+                            Text="NO"/>
+                    </Grid>
+                </Grid>
+            </Frame>
+            <StackLayout
+                Grid.Row="1">
+                <StackLayout
+                    Orientation="Horizontal"
+                    VerticalOptions="Start"
+                    Padding="12 , 0">
+                    <CheckBox
+                        x:Name="IsClippedToBoundsCheckBox"
+                        VerticalOptions="Center"
+                        IsChecked="True"/>
+                    <Label
+                        VerticalOptions="Center"
+                        Text="IsClippedToBounds"/>
+                </StackLayout>
+                <Label
+                    Text="CornerRadius"
+                    Margin="12, 0"/>
+                <Slider
+                    x:Name="CornerRadiusSlider"
+                    Minimum="0"
+                    Maximum="48"
+                    Value="12"/>
+            </StackLayout>
+        </Grid>
+    </Grid>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11120.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11120.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11120, "[iOS] Opacity on Frame behavior change in 4.5", PlatformAffected.iOS)]
+	public partial class Issue11120 : ContentPage
+	{
+		public Issue11120()
+		{
+#if APP
+			InitializeComponent();
+#endif
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11120.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11120.xaml.cs
@@ -1,10 +1,19 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 11120, "[iOS] Opacity on Frame behavior change in 4.5", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Github, 11120, "[Bug] IsClippedToBounds iOS not work", PlatformAffected.iOS)]
 	public partial class Issue11120 : ContentPage
 	{
 		public Issue11120()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11291.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11291.cs
@@ -1,0 +1,63 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11291,
+		"[Bug] IsClippedToBounds not clipping Image when inside a Frame",
+		PlatformAffected.iOS)]
+	public class Issue11291 : TestContentPage
+	{
+		public Issue11291()
+		{
+
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 11291";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If the image clips with the border of the Frame, the test has passed."
+			};
+
+			var frame = new Frame
+			{
+				IsClippedToBounds=true,
+				BorderColor = Color.Black,
+				Padding = 0,
+				CornerRadius = 24,
+				Margin = 12
+			};
+
+			var image = new Image
+			{
+				Aspect = Aspect.AspectFill,
+				Source = "oasis.jpg"
+			};
+
+			frame.Content = image;
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(frame);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1428,6 +1428,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11113.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10182.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11107.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11120.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1667,6 +1668,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11113.xaml">
+     <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11120.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1429,6 +1429,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10182.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11107.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11120.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11291.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -109,6 +109,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			Layer.RasterizationScale = UIScreen.MainScreen.Scale;
 			Layer.ShouldRasterize = true;
+			Layer.MasksToBounds = false;
 
 			_actualView.Layer.RasterizationScale = UIScreen.MainScreen.Scale;
 			_actualView.Layer.ShouldRasterize = true;

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Forms.Platform.iOS
 			    e.PropertyName == Xamarin.Forms.Frame.BorderColorProperty.PropertyName ||
 				e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
 				e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName ||
+				e.PropertyName == Xamarin.Forms.Frame.IsClippedToBoundsProperty.PropertyName ||
 				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName)
 				SetupLayer();
 		}
@@ -111,6 +112,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_actualView.Layer.RasterizationScale = UIScreen.MainScreen.Scale;
 			_actualView.Layer.ShouldRasterize = true;
+			_actualView.Layer.MasksToBounds = Element.IsClippedToBounds;
 		}
 
 		public override void LayoutSubviews()


### PR DESCRIPTION
### Description of Change ###

Fix Frame IsClippedToBounds issue on iOS.

### Issues Resolved ### 

- fixes #11120
- fixes #11091
- fixes #11278
- fixes #11291

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix11120](https://user-images.githubusercontent.com/6755973/85119735-7e8ca480-b222-11ea-9bfd-3a3023939112.gif)

_(The gif quality is low to keep a small size)_

### Testing Procedure ###
Launch Core Gallery and navigate to issue 11120. Toggle the CheckBox to use or not `IsClippedToBounds` in the Frame. If using `IsClippedToBounds` clip the buttons, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
