### PR TITLE
[UWP] Fix Shapes issue using big margins

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11137.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11137.cs
@@ -1,0 +1,71 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Shapes;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11137,
+		"[Bug] UWP - Path object resized to zero height or width crashes ShapeRenderer",
+		PlatformAffected.UWP)]
+	public class Issue11137 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Device.SetFlags(new List<string> { ExperimentalFlags.ShapesExperimental });
+
+			Title = "Issue 11137";
+
+			var grid = new Grid();
+
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Reduce the Window size to a minimum, without exceptions the test has passed."
+			};
+
+			var path = new Path
+			{
+				BackgroundColor = Color.LightGray,
+				Stroke = Color.Black,
+				Fill = Color.Blue,
+				StrokeThickness = 4,
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Margin = new Thickness(300)
+			};
+
+			EllipseGeometry ellipseGeometry = new EllipseGeometry
+			{
+				Center = new Point(50, 50),
+				RadiusX = 50,
+				RadiusY = 50
+			};
+
+			path.Data = ellipseGeometry;
+
+			grid.Children.Add(instructions);
+			Grid.SetRow(instructions, 0);
+
+			grid.Children.Add(path);
+			Grid.SetRow(path, 1);
+
+			Content = grid;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -20,6 +20,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.WPF
 #endif	
 		void UpdateHeight()
 		{
-			Control.Height = Element.Height;
+			Control.Height = Element.Height > 0 ? Element.Height : 0;
 		}
 
 #if !WINDOWS_UWP
@@ -82,7 +82,7 @@ namespace Xamarin.Forms.Platform.WPF
 #endif
 		void UpdateWidth()
 		{
-			Control.Width = Element.Width;
+			Control.Width = Element.Width > 0 ? Element.Width : 0;
 		}
 
 		void UpdateAspect()

--- a/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shapes/ShapeRenderer.cs
@@ -1,4 +1,5 @@
-﻿using System.ComponentModel;
+﻿using System;
+using System.ComponentModel;
 using Xamarin.Forms.Shapes;
 using Shape = Xamarin.Forms.Shapes.Shape;
 
@@ -74,7 +75,7 @@ namespace Xamarin.Forms.Platform.WPF
 #endif	
 		void UpdateHeight()
 		{
-			Control.Height = Element.Height > 0 ? Element.Height : 0;
+			Control.Height = Math.Max(Element.Height, 0);
 		}
 
 #if !WINDOWS_UWP
@@ -82,7 +83,7 @@ namespace Xamarin.Forms.Platform.WPF
 #endif
 		void UpdateWidth()
 		{
-			Control.Width = Element.Width > 0 ? Element.Width : 0;
+			Control.Width = Math.Max(Element.Width, 0);
 		}
 
 		void UpdateAspect()


### PR DESCRIPTION
### Description of Change ###

Fixed issue in UWP Shapes getting a negative value for the height or width.

### Issues Resolved ### 

- fixes #11137 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11137. Reduce the Window size to a minimum, without exceptions the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
