### PR TITLE
[iOS] Fix NRE clearing ListView ContextActions 

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -472,9 +472,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (e.PropertyName == "HasContextActions")
 			{
-				var parentListView = _cell.RealParent as ListView;
-				var recycling = parentListView != null && 
+				if (_cell != null)
+					return;
+
+				var recycling = _cell.RealParent is ListView parentListView &&
 					((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
+
 				if (!recycling)
 					ReloadRow();
 			}

--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -472,7 +472,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (e.PropertyName == "HasContextActions")
 			{
-				if (_cell != null)
+				if (_cell == null)
 					return;
 
 				var recycling = _cell.RealParent is ListView parentListView &&


### PR DESCRIPTION
### Description of Change ###

Fix NRE clearing ListView ContextActions on iOS.

### Issues Resolved ### 

- fixes #10934 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
