### PR TITLE
[UWP] Fix crash PopAsync in CollectionView SelectionChanged

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11090.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11090.cs
@@ -1,0 +1,74 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11090,
+		"[Bug] UWP: PopAsync causes a crash when called from a CollectionView.SelectionChanged event",
+		PlatformAffected.UWP)]
+	public class Issue11090 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 11090";
+
+			var layout = new StackLayout();
+
+			var navButton = new Button
+			{
+				Text = "Navigate"
+			};
+
+			layout.Children.Add(navButton);
+
+			Content = layout;
+
+			navButton.Clicked += (sender, args) =>
+			{
+				Navigation.PushAsync(new Issue111090Page2());
+			};
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue111090Page2 : ContentPage
+	{
+		public Issue111090Page2()
+		{
+			Title = "Issue 11090";
+
+			var layout = new StackLayout();
+
+			var collectionView = new CollectionView
+			{
+				SelectionMode = SelectionMode.Single,
+				ItemsSource = new List<string>()
+				{
+					"Item 1",
+					"Item 2",
+					"Item 3"
+				}
+			};
+
+			layout.Children.Add(collectionView);
+
+			Content = layout;
+
+			collectionView.SelectionChanged += async (sender, args) =>
+			{
+				await Navigation.PopAsync();
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -25,6 +25,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11090.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11794.xaml.cs">
       <DependentUpon>Issue11794.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
@@ -171,13 +171,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateFormsSingleSelection()
 		{
-			var selectedItem = ListViewBase.SelectedItem is ItemTemplateContext itemPair 
-				? itemPair.Item 
+			var selectedItem = ListViewBase.SelectedItem is ItemTemplateContext itemPair
+				? itemPair.Item
 				: ListViewBase.SelectedItem;
-			
+
 			ItemsView.SelectionChanged -= FormsSelectionChanged;
 			ItemsView.SelectedItem = selectedItem;
-			ItemsView.SelectionChanged += FormsSelectionChanged;
+
+			if (ItemsView != null)
+				ItemsView.SelectionChanged += FormsSelectionChanged;
 		}
 
 		void UpdateFormsMultipleSelection()

--- a/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
@@ -175,11 +175,13 @@ namespace Xamarin.Forms.Platform.UWP
 				? itemPair.Item
 				: ListViewBase.SelectedItem;
 
-			ItemsView.SelectionChanged -= FormsSelectionChanged;
-			ItemsView.SelectedItem = selectedItem;
-
 			if (ItemsView != null)
+			{
+				ItemsView.SelectionChanged -= FormsSelectionChanged;
+				ItemsView.SelectedItem = selectedItem;
+
 				ItemsView.SelectionChanged += FormsSelectionChanged;
+			}
 		}
 
 		void UpdateFormsMultipleSelection()


### PR DESCRIPTION
### Description of Change ###

Fix crash PopAsync in ColllectionView SelectionChanged on UWP.

### Issues Resolved ### 

- fixes #11090 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
Crash

#### After
![fix11090](https://user-images.githubusercontent.com/6755973/85268348-af651780-b476-11ea-84cc-d947364d292b.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11090. Press the button to navigate to a new page, and after navigate, select an item from the CollectionView. If navigate back without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
