### PR TITLE
[iOS] Call page appearing when restoring app from background

### DIFF
--- a/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
+++ b/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using CoreTelephony;
+using Foundation;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal class PageLifecycleManager : IDisposable
+	{
+		NSObject _activateObserver;
+		NSObject _resignObserver;
+		bool _disposed;
+		bool _appeared;
+		IPageController _pageController;
+
+		public PageLifecycleManager(IPageController pageController)
+		{
+			if (pageController == null)
+				throw new ArgumentNullException("You need to provide a Page Element ");
+
+			_pageController = pageController;
+
+			_activateObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.DidBecomeActiveNotification, n => HandlePageAppearing());
+
+			_resignObserver = NSNotificationCenter.DefaultCenter.AddObserver(UIApplication.WillResignActiveNotification, n => HandlePageDisappearing());
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if (disposing)
+			{
+				if (_activateObserver != null)
+				{
+					NSNotificationCenter.DefaultCenter.RemoveObserver(_activateObserver);
+					_activateObserver = null;
+				}
+
+				if (_resignObserver != null)
+				{
+					NSNotificationCenter.DefaultCenter.RemoveObserver(_resignObserver);
+					_resignObserver = null;
+				}
+
+				HandlePageDisappearing();
+
+				_pageController = null;
+			}
+
+			_disposed = true;
+		}
+
+		public void Dispose()
+		{
+			Dispose(disposing: true);
+			GC.SuppressFinalize(this);
+		}
+
+		public void HandlePageAppearing()
+		{
+			if (!_appeared)
+			{
+				_appeared = true;
+				_pageController?.SendAppearing();
+			}
+		}
+
+		public void HandlePageDisappearing()
+		{
+			if (!_appeared || _pageController == null)
+				return;
+
+			_appeared = false;
+			_pageController.SendDisappearing();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool? _defaultBarTranslucent;
 		bool _loaded;
 		Size _queuedSize;
+		PageLifecycleManager _pageLifecycleManager;
 
 		Page Page => Element as Page;
 
@@ -72,6 +73,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
+			_pageLifecycleManager = new PageLifecycleManager(Element as IPageController);
+
 			OnPagesChanged(null, new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
 
 			if (element != null)
@@ -110,14 +113,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void ViewDidAppear(bool animated)
 		{
-			Page.SendAppearing();
+			_pageLifecycleManager?.HandlePageAppearing();
 			base.ViewDidAppear(animated);
 		}
 
 		public override void ViewDidDisappear(bool animated)
 		{
 			base.ViewDidDisappear(animated);
-			Page.SendDisappearing();
+			_pageLifecycleManager?.HandlePageDisappearing();
+
 		}
 
 		public override void ViewDidLayoutSubviews()
@@ -152,7 +156,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (disposing)
 			{
-				Page.SendDisappearing();
+				_pageLifecycleManager?.Dispose();
+				_pageLifecycleManager = null;
 				Tabbed.PropertyChanged -= OnPropertyChanged;
 				Tabbed.PagesChanged -= OnPagesChanged;
 				FinishedCustomizingViewControllers -= HandleFinishedCustomizingViewControllers;

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -182,6 +182,7 @@
     <Compile Include="IOSDeviceInfo.cs" />
     <Compile Include="LinkerSafeAttribute.cs" />
     <Compile Include="ModalWrapper.cs" />
+    <Compile Include="PageLifecycleManager.cs" />
     <Compile Include="Renderers\FormsCAKeyFrameAnimation.cs" />
     <Compile Include="Renderers\FormsCheckBox.cs" />
     <Compile Include="Renderers\FormsUIImageView.cs" />
@@ -336,7 +337,5 @@
   <ItemGroup>
     <PackageReference Condition="'$(CI)' == 'true'" Include="Xamarin.Build.TypeRedirector" Version="0.1.2-preview" PrivateAssets="all" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Shapes\" />
-  </ItemGroup>
+  <ItemGroup />
 </Project>


### PR DESCRIPTION
### Description of Change ###

Handle calling appearing and disappearing of pages when the Application is going to background and restored.


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #4986 

### API Changes ###

```
internal class PageLifecycleManager : IDisposable
{
        public PageLifecycleManager(IPageController pageController)
	protected virtual void Dispose(bool disposing)

	public void Dispose()

	public void HandlePageAppearing()

	public void HandlePageDisappearing()
}
```
### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

When the app is restored the current page should have the Appearing event being called, like on Android.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

use `new NavigationPage(new ContentPage52318())`in the MainPage

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
