### PR TITLE
[Core] Remove capture the CarouselView Experimental flag exception

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10234.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10234.cs
@@ -20,6 +20,13 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class Issue10234 : TestShell
 	{
+		public Issue10234()
+		{
+#if APP
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
+#endif
+		}
+
 		protected override void Init()
 		{
 			TabBar tabBar = new TabBar

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
@@ -2,6 +2,7 @@
 using Xamarin.Forms.Internals;
 using System;
 using System.Collections.ObjectModel;
+using System.Collections.Generic;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -18,12 +19,15 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 10300, "ObservableCollection.RemoveAt(index) with a valid index raises ArgementOutOfRangeException", PlatformAffected.iOS)]
 	public class Issue10300 : TestContentPage // or TestMasterDetailPage, etc ...
 	{
-		CarouselView carousel;
+		CarouselView _carousel;
 
 		public class ModalPage : ContentPage
 		{
 			public ModalPage()
 			{
+#if APP
+				Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
+#endif
 				var btn = new Button
 				{
 					Text = "Close",
@@ -56,8 +60,8 @@ namespace Xamarin.Forms.Controls.Issues
 																new ModelIssue10300("8", Color.IndianRed),
 																new ModelIssue10300("9", Color.Khaki),
 															});
-			carousel = new CarouselView();
-			carousel.ItemTemplate = new DataTemplate(() =>
+			_carousel = new CarouselView();
+			_carousel.ItemTemplate = new DataTemplate(() =>
 			{
 				var l = new Grid();
 				l.SetBinding(Grid.BackgroundColorProperty, new Binding("Color"));
@@ -70,14 +74,14 @@ namespace Xamarin.Forms.Controls.Issues
 				l.Children.Add(label);
 				return l;
 			});
-			carousel.CurrentItemChanged += Carousel_CurrentItemChanged;
-			carousel.PositionChanged += Carousel_PositionChanged;
+			_carousel.CurrentItemChanged += Carousel_CurrentItemChanged;
+			_carousel.PositionChanged += Carousel_PositionChanged;
 
-			Grid.SetColumnSpan(carousel, 2);
+			Grid.SetColumnSpan(_carousel, 2);
 
 
-			carousel.SetBinding(CarouselView.ItemsSourceProperty, new Binding("Items"));
-			carousel.BindingContext = this;
+			_carousel.SetBinding(CarouselView.ItemsSourceProperty, new Binding("Items"));
+			_carousel.BindingContext = this;
 
 			var grd = new Grid
 			{
@@ -106,7 +110,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Grid.SetRow(btnAdd, 1);
 			Grid.SetColumn(btnAdd, 1);
 
-			grd.Children.Add(carousel);
+			grd.Children.Add(_carousel);
 			grd.Children.Add(btn);
 			grd.Children.Add(btnAdd);
 			Content = grd;
@@ -125,7 +129,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		void Callback(Page page)
 		{
-			var index = Items.IndexOf(carousel.CurrentItem as ModelIssue10300);
+			var index = Items.IndexOf(_carousel.CurrentItem as ModelIssue10300);
 			System.Diagnostics.Debug.WriteLine($"Delete {index}");
 			Items.RemoveAt(index);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8964.cs
@@ -23,6 +23,13 @@ namespace Xamarin.Forms.Controls.Issues
 		int _counter;
 		Label _lbl;
 
+		public Issue8964()
+		{
+#if APP
+			Device.SetFlags(new List<string> { ExperimentalFlags.CarouselViewExperimental });
+#endif
+		}
+
 		protected override void Init()
 		{
 			ItemSourceUnderTest = new ObservableCollection<ModelIssue8964>(GetCarouselItems());

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -14,8 +14,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var button = new Button
 			{
-				Text = "Enable IndicatorView",
-				AutomationId = "EnableIndicatorView"
+				Text = "Enable CarouselView",
+				AutomationId = "EnableCarouselView"
 			};
 			button.Clicked += ButtonClicked;
 
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		{
 			var button = sender as Button;
 
-			button.Text = "IndicatorView Enabled!";
+			button.Text = "CarouselView Enabled!";
 			button.TextColor = Color.Black;
 			button.IsEnabled = false;
 

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Core.UITests
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewRemoveAndUpdateCurrentItem(string subgallery)
 		{
-			VisitSubGallery(subgallery);
+			VisitSubGallery(subgallery, true);
 
 			CheckPositionValue("lblPosition", "0");
 			CheckPositionValue("lblCurrentItem", "0");
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Core.UITests
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewRemoveFirstCurrentItem(string subgallery)
 		{
-			VisitSubGallery(subgallery);
+			VisitSubGallery(subgallery, true);
 
 			CheckPositionValue("lblPosition", "0");
 			CheckPositionValue("lblCurrentItem", "0");
@@ -64,7 +64,7 @@ namespace Xamarin.Forms.Core.UITests
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewGoToNextCurrentItem(string subgallery)
 		{
-			VisitSubGallery(subgallery);
+			VisitSubGallery(subgallery, true);
 
 			CheckPositionValue("lblPosition", "0");
 			CheckPositionValue("lblCurrentItem", "0");
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Core.UITests
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewRemoveLastCurrentItem(string subgallery)
 		{
-			VisitSubGallery(subgallery);
+			VisitSubGallery(subgallery, true);
 
 			CheckPositionValue("lblPosition", "0");
 			CheckPositionValue("lblCurrentItem", "0");
@@ -143,8 +143,7 @@ namespace Xamarin.Forms.Core.UITests
 		//[TestCase("CarouselView (XAML, Horizontal)")]
 		public void CarouselViewHorizontal(string subgallery)
 		{
-			VisitSubGallery(subgallery);
-
+			VisitSubGallery(subgallery, true);
 
 			App.WaitForElement("pos:1", "Did start on the correct position");
 			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
@@ -177,7 +176,7 @@ namespace Xamarin.Forms.Core.UITests
 #endif
 		public void CarouselViewVertical(string subgallery)
 		{
-			VisitSubGallery(subgallery);
+			VisitSubGallery(subgallery, true);
 			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
 
 			var centerX = rect.CenterX;
@@ -214,7 +213,7 @@ namespace Xamarin.Forms.Core.UITests
 			App.ScrollUp();
 
 			if (enableIndicator)
-				App.Tap(t => t.Marked("EnableIndicatorView"));
+				App.Tap(t => t.Marked("EnableCarouselView"));
 
 			App.QueryUntilPresent(() =>
 			{

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -201,7 +201,7 @@ namespace Xamarin.Forms
 			string constructorHint = null,
 			[CallerMemberName] string memberName = "")
 		{
-			ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CarouselViewExperimental,
+			ExperimentalFlags.VerifyFlagEnabled(nameof(CarouselView), ExperimentalFlags.CarouselViewExperimental,
 				constructorHint, memberName);
 		}
 

--- a/Xamarin.Forms.Core/Items/CarouselView.cs
+++ b/Xamarin.Forms.Core/Items/CarouselView.cs
@@ -201,15 +201,8 @@ namespace Xamarin.Forms
 			string constructorHint = null,
 			[CallerMemberName] string memberName = "")
 		{
-			try
-			{
-				ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CarouselViewExperimental,
-					constructorHint, memberName);
-			}
-			catch (InvalidOperationException)
-			{
-
-			}
+			ExperimentalFlags.VerifyFlagEnabled(nameof(CollectionView), ExperimentalFlags.CarouselViewExperimental,
+				constructorHint, memberName);
 		}
 
 		protected virtual void OnPositionChanged(PositionChangedEventArgs args)


### PR DESCRIPTION
### Description of Change ###

Remove capture the CarouselView Experimental flag exception.

### Issues Resolved ###

- fixes #11236

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the CarouselView Gallery. Try to navigate to any sample without setting the "CarouselView_Experimental" flag. An exception must be thrown.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
