### PR TITLE
Android Entry/Editor disable automatic keyboard dismiss

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10703.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10703.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 10703, "Android keyboard disappears on losing focus", PlatformAffected.Android)]
+	public class Issue10703 : TestContentPage
+	{
+		protected override void Init()
+		{
+			//This same issue is also reported in #4298
+			//https://github.com/xamarin/Xamarin.Forms/issues/4298
+			var editor = new Editor() { Text = "This is an editor" };
+			var entry = new Entry { Text = "This is an entry" };
+			var secondEntry = new Entry { Text = "This Entry will lose focus in Android." };
+			var button = new Button { Text = "Tap this button, editor and entry shouldn't lose focus" };
+
+			//This issue was reported in Issue#2136 and got fixed for iOS with PR #8740.
+			//https://github.com/xamarin/Xamarin.Forms/issues/2136
+			button.On<PlatformConfiguration.iOS>().SetCanBecomeFirstResponder(true);
+
+			//Commenting below two lines will show existing behavior. 
+			entry.On<PlatformConfiguration.Android>().SetDismissKeyboardOnOutsideTap(false);
+			editor.On<PlatformConfiguration.Android>().SetDismissKeyboardOnOutsideTap(false);
+
+			//With above feature, developer is getting a chance to disable automatic dismissing of Keyboard
+			//when Editor/Entry loses focus. Helpful in developing chat application. Keyboard will not
+			//dismiss on tapping Send Button. Developer can then maybe dismiss keyboard with a TapGestureRecognizer
+			//on ContentPage.
+			Content = new StackLayout()
+			{
+				Children = { editor, entry, secondEntry, button }
+			};
+
+			TapGestureRecognizer gestureRecognizer = new TapGestureRecognizer
+			{
+				Command = new Command(() =>
+				{
+					editor.Unfocus();
+
+				})
+			};
+			Content.GestureRecognizers.Add(gestureRecognizer);
+		}
+	}
+}

--- a/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/InputView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/AndroidSpecific/InputView.cs
@@ -1,0 +1,30 @@
+﻿namespace Xamarin.Forms.PlatformConfiguration.AndroidSpecific
+{
+	using FormsElement = Forms.InputView;
+
+	public static class InputView
+	{
+		public static readonly BindableProperty DismissKeyboardOnOutsideTapProperty = BindableProperty.Create(nameof(DismissKeyboardOnOutsideTap), typeof(bool), typeof(InputView), true);
+
+		public static bool GetDismissKeyboardOnOutsideTap(BindableObject element)
+		{
+			return (bool)element.GetValue(DismissKeyboardOnOutsideTapProperty);
+		}
+
+		public static void SetDismissKeyboardOnOutsideTap(BindableObject element, bool value)
+		{
+			element.SetValue(DismissKeyboardOnOutsideTapProperty, value);
+		}
+
+		public static bool DismissKeyboardOnOutsideTap(this IPlatformElementConfiguration<Android, FormsElement> config)
+		{
+			return GetDismissKeyboardOnOutsideTap(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Android, FormsElement> SetDismissKeyboardOnOutsideTap(this IPlatformElementConfiguration<Xamarin.Forms.PlatformConfiguration.Android, FormsElement> config, bool value)
+		{
+			SetDismissKeyboardOnOutsideTap(config.Element, value);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
@@ -40,6 +40,9 @@ namespace Xamarin.Forms.Platform.Android
 				if (!(currentView is EditText))
 					break;
 
+				if (currentView is FormsEditText formsEditText && !formsEditText.ShouldDismissKeyboardOnOutsideTap)
+					break;
+
 				global::Android.Views.View newCurrentView = Context.GetActivity().CurrentFocus;
 
 				if (currentView != newCurrentView)

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -11,6 +11,7 @@ using Android.Views;
 using Java.Lang;
 using Android.Widget;
 using Android.Views.InputMethods;
+using Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -50,6 +51,35 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_textColorSwitcher = _textColorSwitcher ?? new TextColorSwitcher(EditText.TextColors, Element.UseLegacyColorManagement());
 			_textColorSwitcher.UpdateTextColor(EditText, Element.TextColor);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Editor> e)
+		{
+			base.OnElementChanged(e);
+
+			UpdateDismissKeyboardOnOutsideTap();
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (this.IsDisposed())
+			{
+				return;
+			}
+
+			if (e.PropertyName == PlatformConfiguration.AndroidSpecific.InputView.DismissKeyboardOnOutsideTapProperty.PropertyName)
+				UpdateDismissKeyboardOnOutsideTap();
+
+			base.OnElementPropertyChanged(sender, e);
+		}
+
+		protected virtual void UpdateDismissKeyboardOnOutsideTap()
+		{
+			if (Element == null || Control == null)
+				return;
+			var dismissKeyboardOnOutsideTap = Element.OnThisPlatform().DismissKeyboardOnOutsideTap();
+
+			Control.ShouldDismissKeyboardOnOutsideTap = dismissKeyboardOnOutsideTap;
 		}
 
 		protected override void OnAttachedToWindow()

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -65,6 +65,35 @@ namespace Xamarin.Forms.Platform.Android
 			_textColorSwitcher = _textColorSwitcher ?? new TextColorSwitcher(EditText.TextColors, Element.UseLegacyColorManagement());
 			_textColorSwitcher.UpdateTextColor(EditText, color);
 		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
+		{
+			base.OnElementChanged(e);
+
+			UpdateDismissKeyboardOnOutsideTap();
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (this.IsDisposed())
+			{
+				return;
+			}
+
+			if (e.PropertyName == PlatformConfiguration.AndroidSpecific.InputView.DismissKeyboardOnOutsideTapProperty.PropertyName)
+				UpdateDismissKeyboardOnOutsideTap();
+
+			base.OnElementPropertyChanged(sender, e);
+		}
+
+		protected virtual void UpdateDismissKeyboardOnOutsideTap()
+		{
+			if (Element == null || Control == null)
+				return;
+			var dismissKeyboardOnOutsideTap = Element.OnThisPlatform().DismissKeyboardOnOutsideTap();
+
+			Control.ShouldDismissKeyboardOnOutsideTap = dismissKeyboardOnOutsideTap;
+		}
 	}
 
 	public abstract partial class EntryRendererBase<TControl> : ViewRenderer<Entry, TControl>, ITextWatcher, TextView.IOnEditorActionListener

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsEditText.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 		}
 
+		public bool ShouldDismissKeyboardOnOutsideTap { get; set; } = true;
 
 		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
 		{


### PR DESCRIPTION
### Description of Change ###

Currently, there is no provision to avoid automatic dismissal of Keyboard attached to an Entry/Editor in the Android platform, when a user taps anywhere else. This is a required feature in many applications, especially chat applications where the user would expect the Input Keyboard to stay after tapping the "Send" button. This issue was raised earlier in [#2136](https://github.com/xamarin/Xamarin.Forms/issues/2136) and was fixed for iOS alone with PR [#8740](https://github.com/xamarin/Xamarin.Forms/pull/8740). Similar to fix done for iOS, here a new Platform-specific property is added to Entry & Editor which can disable automatic dismissal of Keyboard.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10703
- fixes #4298

### API Changes ###

Added:
 - bool InputValue.DismissKeyboardOnOutsideTapProperty { get; set; } //Bindable Property, Android.PlatformSpecific, Default => True


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###

If an Editor's /Entry's DismissKeyboardOnOutsideTapProperty (AndroidSpecific Property) is set to false, Keyboard will not dismiss on tapping elsewhere.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
1. Please deploy the Xamarin.Forms.ControlGallery.Android app and open Test Case 10703
2. You will find UI Controls in this order
 a) Editor
 b) Entry
 c) Entry
 d) Button
3. On tapping any of the Entry/Editor controls, the keyboard comes up. 
4. The newly created Android Platform-specific API (which defaults to True) has been set to false for first Editor and Entry.
5. On tapping the button when the focus is on the first Editor or Entry, the keyboard is not dismissed. 
6. But the keyboard dismissed for the last Entry when we tap anywhere (which has been the default behaviour till now).
7. When the focus is on the first Editor, and user taps on Page (not button), Keyboard dismissed. Because a TapGesture has been configured to dismiss the Editor on tapping on the page.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
