### PR TITLE
[iOS] Pop when on second page and BackButton is replaced

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -353,11 +353,6 @@ namespace Xamarin.Forms.Platform.iOS
 			return img;
 		}
 
-		void OnMenuButtonPressed(object sender, EventArgs e)
-		{
-			_context.Shell.SetValueFromRenderer(Shell.FlyoutIsPresentedProperty, true);
-		}
-
 		async void OnToolbarItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
 			await UpdateToolbarItems().ConfigureAwait(false);


### PR DESCRIPTION
### Description of Change ###

When the back button is being replaced it was always opening the flyout instead of navigating back when not on the root page

### Issues Resolved ### 

- fixes #7856 

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- ui tests included
- open the Back Button page and play around make sure it all acts as you'd expect

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
