### PR TITLE
[Android] Changes in the logic to detect Device.Idiom

### DIFF
--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Forms
 
 			var currentIdiom = TargetIdiom.Unsupported;
 
-			// first try UIModeManager
+			// First try UIModeManager
 			using (var uiModeManager = UiModeManager.FromContext(ApplicationContext))
 			{
 				try
@@ -380,11 +380,29 @@ namespace Xamarin.Forms
 				}
 			}
 
+			// Then try Configuration
 			if (TargetIdiom.Unsupported == currentIdiom)
 			{
-				// This could change as a result of a config change, so we need to check it every time
-				int minWidthDp = activity.Resources.Configuration.SmallestScreenWidthDp;
-				Device.SetIdiom(minWidthDp >= TabletCrossover ? TargetIdiom.Tablet : TargetIdiom.Phone);
+				var configuration = activity.Resources.Configuration;
+
+				if (configuration != null)
+				{
+					var minWidth = configuration.SmallestScreenWidthDp;
+					var isWide = minWidth >= TabletCrossover;
+					currentIdiom = isWide ? TargetIdiom.Tablet : TargetIdiom.Phone;
+				}
+				else
+				{
+					// Start clutching at straws
+					var metrics = activity.Resources?.DisplayMetrics;
+
+					if (metrics != null)
+					{
+						var minSize = Math.Min(metrics.WidthPixels, metrics.HeightPixels);
+						var isWide = minSize * metrics.Density >= TabletCrossover;
+						currentIdiom = isWide ? TargetIdiom.Tablet : TargetIdiom.Phone;
+					}
+				}
 			}
 
 			if (SdkInt >= BuildVersionCodes.JellyBeanMr1)
@@ -400,13 +418,13 @@ namespace Xamarin.Forms
 		static TargetIdiom DetectIdiom(UiMode uiMode)
 		{
 			var returnValue = TargetIdiom.Unsupported;
-			if (uiMode.HasFlag(UiMode.TypeNormal))
+			if (uiMode == UiMode.TypeNormal)
 				returnValue = TargetIdiom.Unsupported;
-			else if (uiMode.HasFlag(UiMode.TypeTelevision))
+			else if (uiMode == UiMode.TypeTelevision)
 				returnValue = TargetIdiom.TV;
-			else if (uiMode.HasFlag(UiMode.TypeDesk))
+			else if (uiMode == UiMode.TypeDesk)
 				returnValue = TargetIdiom.Desktop;
-			else if (SdkInt >= BuildVersionCodes.KitkatWatch && uiMode.HasFlag(UiMode.TypeWatch))
+			else if (SdkInt >= BuildVersionCodes.KitkatWatch && uiMode == UiMode.TypeWatch)
 				returnValue = TargetIdiom.Watch;
 
 			Device.SetIdiom(returnValue);

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -405,6 +405,8 @@ namespace Xamarin.Forms
 				}
 			}
 
+			Device.SetIdiom(currentIdiom);
+
 			if (SdkInt >= BuildVersionCodes.JellyBeanMr1)
 				Device.SetFlowDirection(activity.Resources.Configuration.LayoutDirection.ToFlowDirection());
 


### PR DESCRIPTION
### Description of Change ###

Changed checking the `UiMode` enum using HasFlag  to use  ==. Based on this changes https://github.com/xamarin/Essentials/commit/b937b1292840d8267969d6fe6f34a312aa6f9a36 from Xamarin Essentials.

### Issues Resolved ### 

- fixes #11166
- fixes #11177

### API Changes ###

 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
