### PR TITLE
[UWP] Fix interaction issue with ScrollView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11106.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11106.cs
@@ -1,0 +1,39 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ScrollView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 1101110631,
+		"[Bug] ScrollView UWP bug in 4.7.0.968!",
+		PlatformAffected.UWP)]
+	public class Issue11106 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 11106";
+
+			var scroll = new ScrollView();
+
+			var layout = new StackLayout();
+
+			for (int i = 0; i < 30; i++)
+			{
+				layout.Children.Add(new Entry());
+			}
+
+			scroll.Content = layout;
+
+			Content = scroll;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11106.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11106.cs
@@ -22,6 +22,19 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Title = "Issue 11106";
 
+			var grid = new Grid();
+
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Star });
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Scroll to the end and try to set focus to the last Entry. If you can tap the Entry and set the focus, the test has passed."
+			};
+
 			var scroll = new ScrollView();
 
 			var layout = new StackLayout();
@@ -33,7 +46,13 @@ namespace Xamarin.Forms.Controls.Issues
 
 			scroll.Content = layout;
 
-			Content = scroll;
+			grid.Children.Add(instructions);
+			Grid.SetRow(instructions, 0);
+
+			grid.Children.Add(scroll);
+			Grid.SetRow(scroll, 1);
+
+			Content = grid;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11106.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11106.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[Category(UITestCategories.ScrollView)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 1101110631,
+	[Issue(IssueTracker.Github, 11106,
 		"[Bug] ScrollView UWP bug in 4.7.0.968!",
 		PlatformAffected.UWP)]
 	public class Issue11106 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -21,6 +21,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11106.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -5,6 +5,7 @@ using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
 using Windows.UI.Xaml;
+using Windows.UI.Xaml.Hosting;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media;
 using Xamarin.Forms.Internals;
@@ -29,6 +30,8 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _isPinching;
 		bool _wasPanGestureStartedSent;
 		bool _wasPinchGestureStartedSent;
+
+		static bool HasClip;
 
 		public VisualElementTracker()
 		{
@@ -522,14 +525,35 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static void UpdateClip(VisualElement view, FrameworkElement frameworkElement)
 		{
+			if (!ShouldUpdateClip(view, frameworkElement))
+				return;
+
 			var geometry = view.Clip;
+
+			HasClip = geometry != null;
 
 			if (CompositionHelper.IsCompositionGeometryTypePresent)
 				frameworkElement.ClipVisual(geometry);
 			else
 				frameworkElement.Clip(geometry);
 		}
-	
+
+		static bool ShouldUpdateClip(VisualElement view, FrameworkElement frameworkElement)
+		{
+			if (view == null || frameworkElement == null)
+				return false;
+
+			var formsGeometry = view.Clip;
+
+			if (formsGeometry != null)
+				return true;
+
+			if (formsGeometry == null && HasClip)
+				return true;
+
+			return false;
+		}
+
 		static void UpdateOpacity(VisualElement view, FrameworkElement frameworkElement)
 		{
 			frameworkElement.Opacity = view.Opacity;


### PR DESCRIPTION
### Description of Change ###

Fix interaction issue with ScrollView on UWP.

### Issues Resolved ### 

- fixes #11106 
- fixes #11174 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix11106](https://user-images.githubusercontent.com/6755973/85760429-1d793b00-b712-11ea-859c-ed9517e460fc.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11106. Scroll to the end and try to set focus to the last Entry. If you can tap the Entry and set the focus, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
