### PR TITLE
[UWP] Cleanup _modalBackgroundPage

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -319,6 +319,14 @@ namespace Xamarin.Forms.Platform.UWP
 					else
 					{
 						RemovePage(previousPage);
+
+						if(!modal && _modalBackgroundPage != null)
+						{
+							RemovePage(_modalBackgroundPage);
+							_modalBackgroundPage.Cleanup();
+							_modalBackgroundPage.Parent = null;
+						}
+						
 						_modalBackgroundPage = null;
 					}
 


### PR DESCRIPTION
### Description of Change ###

When there's a Modal Page on UWP and you swap out the main page the background page needs to be removed and cleaned up otherwise it still exists and is still visible

Regressed as part of this PR
https://github.com/xamarin/Xamarin.Forms/pull/8551

Because with that PR the page is kept around when there's a modal page opposed to just being removed.

This is causing the UI Tests on UWP to break

![image](https://user-images.githubusercontent.com/5375137/85823913-26830000-b744-11ea-972c-28c25ac48ba3.png)

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- Run Bugzilla B44476 and then hit ESC to reset Main Page. You should see no artifacts from the previously loaded page

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
