### PR TITLE
Enable macOS slider rotation

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SliderRenderer.cs
@@ -113,6 +113,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateMinimumTrackColor();
 				UpdateMaximumTrackColor();
 				UpdateThumbColor();
+				UpdateRotation();
 			}
 
 			base.OnElementChanged(e);
@@ -136,6 +137,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				UpdateThumbColor();
 			}
+			else if (e.PropertyName == VisualElement.RotationProperty.PropertyName)
+				UpdateRotation();
 		}
 
 		void UpdateMaximumTrackColor()
@@ -211,6 +214,11 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Math.Abs(Element.Value - Control.DoubleValue) > 0)
 				Control.DoubleValue = (float)Element.Value;
+		}
+
+		void UpdateRotation()
+		{
+			Control.BoundsRotation = (float)Element.Rotation;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->
Allow rotating a slider control in macOS to match other platforms' behavior.

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

Setting the `Rotation` property on a `Slider` element effectively rotates the element visually on macOS.

### Before/After Screenshots ### 

(Setting Rotation to 270)

Before:
![image](https://user-images.githubusercontent.com/4507319/85856510-fe5bc700-b76c-11ea-82a4-aa0c9bf8f48b.png)

After:
![image](https://user-images.githubusercontent.com/4507319/85856738-5f839a80-b76d-11ea-85a9-310ab3da754e.png)

### Testing Procedure ###

Manual testing through the ControlGallery app.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
