### PR TITLE
Hide tabbar if only one tab is present

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -105,8 +105,10 @@ namespace Xamarin.Forms
 				if (shell == null)
 					return true;
 
-				bool defaultShow = ShellItemController.GetItems().Count > 1;
-				return shell.GetEffectiveValue<bool>(Shell.TabBarIsVisibleProperty, () => defaultShow, null, displayedPage);
+				if (ShellItemController.GetItems().Count <= 1)
+					return false;
+
+				return shell.GetEffectiveValue<bool>(Shell.TabBarIsVisibleProperty, () => true, null, displayedPage);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -419,14 +419,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (DisplayedPage == null)
 				return;
 
-			bool visible = ShellItemController.ShowTabs;
-			using (var menu = _bottomView.Menu)
-			{
-				if (menu.Size() == 1)
-					visible = false;
-			}
-
-			_bottomView.Visibility = visible ? ViewStates.Visible : ViewStates.Gone;
+			_bottomView.Visibility = ShellItemController.ShowTabs ? ViewStates.Visible : ViewStates.Gone;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

When the logic for determining tab visibility was moved into the xplat code it wasn't correctly returning false if there was only one tab present

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- ui test Issue11107 passes

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
