### PR TITLE
Update Left Tool Bar Item even if flyout is disabled

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11244.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11244.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11244, "[Bug] BackButtonBehavior no longer displays on the first routed page in 4.7",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11244 : TestShell
+	{
+		protected async override void Init()
+		{
+			var page1 = AddContentPage<TabBar, Tab>();
+			ContentPage page = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "The app bar should have text instead of a hamburger"
+						},
+						new Button()
+						{
+							Text = "Run test again",
+							Command = new Command(async () =>
+							{
+								CurrentItem = page1;
+								await Task.Delay(1000);
+								GoToAsync("//MainPage");
+							})
+						}
+					}
+				}
+			};
+
+			Shell.SetBackButtonBehavior(page,
+				new BackButtonBehavior()
+				{
+					TextOverride = "Logout",
+					Command = new Command(() => { })
+				});
+
+			var page2 = AddContentPage<TabBar, Tab>(page);
+			page2.Route = "MainPage";
+			await Task.Delay(1000);
+			GoToAsync("//MainPage");
+		}
+
+
+#if UITEST
+		[Test]
+		public void LeftToolbarItemTextDisplaysWhenFlyoutIsDisabled()
+		{
+			RunningApp.WaitForElement("Logout");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11244.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11244.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Controls.Issues
 							{
 								CurrentItem = page1;
 								await Task.Delay(1000);
-								GoToAsync("//MainPage");
+								await GoToAsync("//MainPage");
 							})
 						}
 					}
@@ -61,7 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var page2 = AddContentPage<TabBar, Tab>(page);
 			page2.Route = "MainPage";
 			await Task.Delay(1000);
-			GoToAsync("//MainPage");
+			await GoToAsync("//MainPage");
 		}
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8529.cs
@@ -49,11 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST && __SHELL__
 		public void NavigateBack()
 		{
-#if __IOS__
-			RunningApp.Tap(c => c.Marked("BackButtonImage"));
-#else
-			RunningApp.Tap(FlyoutIconAutomationId);
-#endif
+			RunningApp.Tap("BackButtonImage");
 		}
 
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -36,10 +36,12 @@ namespace Xamarin.Forms.Controls.Issues
 		const string ToggleTextId = "ToggleTextId";
 		const string CommandResultId = "CommandResult";
 		const string PushPageId = "PushPageId";
+		const string FlyoutOpen = "Flyout Open";
 
 		protected override void Init()
 		{
 			AddContentPage(new BackButtonPage());
+			Items.Add(new MenuItem() { Text = "Flyout Open", AutomationId = "Flyout Open" });
 		}
 
 		public class BackButtonPage : ContentPage
@@ -50,6 +52,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			public BackButtonPage()
 			{
+				Title = $"Page {Shell.Current?.Navigation?.NavigationStack?.Count ?? 0}";
 				_commandParameter = new Entry()
 				{
 					Placeholder = "Command Parameter",
@@ -65,6 +68,17 @@ namespace Xamarin.Forms.Controls.Issues
 				};
 
 				StackLayout layout = new StackLayout();
+
+				Button toggleFlyoutBehaviorButton = null;
+
+				toggleFlyoutBehaviorButton = new Button()
+				{
+					Text = "Flyout Behavior: Flyout",
+					Command = new Command((o) => ToggleFlyoutBehavior(o, toggleFlyoutBehaviorButton)),
+					AutomationId = "ToggleFlyoutBehavior"
+				};
+
+				layout.Children.Add(toggleFlyoutBehaviorButton);
 
 				layout.Children.Add(new Label()
 				{
@@ -120,18 +134,12 @@ namespace Xamarin.Forms.Controls.Issues
 					AutomationId = PushPageId
 				});
 
-				layout.Children.Add(new Button()
-				{
-					Text = "Toggle Flyout Behavior",
-					Command = new Command(ToggleFlyoutBehavior)
-				});
-
 
 				Content = new ScrollView() { Content = layout };
 				ToggleBehavior();
 			}
 
-			void ToggleFlyoutBehavior(object obj)
+			void ToggleFlyoutBehavior(object obj, Button btn)
 			{
 				var behavior = (int)(Shell.Current.FlyoutBehavior);
 				behavior++;
@@ -140,6 +148,7 @@ namespace Xamarin.Forms.Controls.Issues
 					behavior = 0;
 
 				Shell.Current.FlyoutBehavior = (FlyoutBehavior)behavior;
+				btn.Text = $"Flyout Behavior: {(FlyoutBehavior)behavior}";
 
 			}
 
@@ -180,15 +189,23 @@ namespace Xamarin.Forms.Controls.Issues
 				if (!String.IsNullOrWhiteSpace(behavior.TextOverride))
 					behavior.ClearValue(BackButtonBehavior.TextOverrideProperty);
 				else
-					behavior.TextOverride = "Text";
+					behavior.TextOverride = "T3xt";
 			}
 
 			public void ToggleIcon()
 			{
 				if (behavior.IsSet(BackButtonBehavior.IconOverrideProperty))
+				{
 					behavior.ClearValue(BackButtonBehavior.IconOverrideProperty);
+				}
 				else
-					behavior.IconOverride = "coffee.png";
+				{
+					behavior.IconOverride = new FileImageSource()
+					{
+						File = "coffee.png",
+						AutomationId = "CoffeeAutomation"
+					};
+				}
 
 			}
 
@@ -209,12 +226,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
 
-			Assert.AreEqual(commandResult, "parameter");
+			Assert.AreEqual("parameter", commandResult);
 			RunningApp.EnterText(EntryCommandParameter, "canexecutetest");
 			RunningApp.Tap(ToggleCommandCanExecuteId);
 
 			commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
-			Assert.AreEqual(commandResult, "parameter");
+			Assert.AreEqual("parameter", commandResult);
 		}
 
 		[Test]
@@ -223,11 +240,79 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(PushPageId);
 			RunningApp.Tap(ToggleCommandId);
 			RunningApp.EnterText(EntryCommandParameter, "parameter");
-			TapBackArrow();
+
+#if __ANDROID__
+			base.TapBackArrow();
+#else
+			RunningApp.Tap("Page 0");
+#endif
 
 			var commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
 			Assert.AreEqual(commandResult, "parameter");
 		}
+
+		[Test]
+		public void BackButtonSetToTextStillNavigatesBack()
+		{
+			RunningApp.Tap(PushPageId);
+			RunningApp.Tap(ToggleTextId);
+			RunningApp.Tap("T3xt");
+			RunningApp.WaitForNoElement(FlyoutOpen);
+			RunningApp.WaitForElement("Page 0");
+		}
+
+		[Test]
+		public void BackButtonSetToTextStillOpensFlyout()
+		{
+			RunningApp.Tap(ToggleTextId);
+
+			RunningApp.Tap("T3xt");
+			RunningApp.WaitForElement(FlyoutOpen);
+		}
+
+#if __ANDROID__
+		[Test]
+		public void FlyoutDisabledDoesntOpenFlyoutWhenSetToText()
+		{
+			RunningApp.WaitForElement("ToggleFlyoutBehavior");
+			RunningApp.Tap("ToggleFlyoutBehavior");
+			RunningApp.Tap("ToggleFlyoutBehavior");
+			RunningApp.WaitForElement("Flyout Behavior: Disabled");
+			RunningApp.Tap(ToggleTextId);
+			RunningApp.Tap("T3xt");
+			RunningApp.WaitForNoElement(FlyoutOpen);
+		}
+#else
+		[Test]
+		public void FlyoutDisabledDoesntOpenFlyoutWhenSetToText()
+		{
+			RunningApp.WaitForElement("ToggleFlyoutBehavior");
+			RunningApp.Tap(ToggleTextId);
+			RunningApp.WaitForElement("T3xt");
+			RunningApp.Tap("ToggleFlyoutBehavior");
+			RunningApp.WaitForElement("T3xt");
+			RunningApp.Tap("ToggleFlyoutBehavior");
+			RunningApp.WaitForElement("Flyout Behavior: Disabled");
+			RunningApp.Tap("T3xt");
+			RunningApp.WaitForNoElement(FlyoutOpen);
+		}
+
+		[Test]
+		public void AutomationIdOnIconOverride()
+		{
+			RunningApp.WaitForElement("ToggleFlyoutBehavior");
+			RunningApp.Tap(ToggleIconId);
+			RunningApp.WaitForElement("CoffeeAutomation");
+			RunningApp.Tap("ToggleFlyoutBehavior");
+			RunningApp.WaitForElement("CoffeeAutomation");
+			RunningApp.Tap("ToggleFlyoutBehavior");
+			RunningApp.WaitForElement("Flyout Behavior: Disabled");
+			RunningApp.Tap("CoffeeAutomation");
+			RunningApp.WaitForNoElement(FlyoutOpen);
+		}
+
+#endif
+
 #endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -656,32 +656,6 @@ namespace Xamarin.Forms.Controls
 			return item;
 		}
 
-		public TabBar CreateTabBar(string shellItemTitle)
-		{
-			shellItemTitle = shellItemTitle ?? $"Item: {Items.Count}";
-			ContentPage page = new ContentPage();
-			TabBar item = new TabBar()
-			{
-				Title = shellItemTitle,
-				Items =
-				{
-					new ShellSection()
-					{
-						Items =
-						{
-							new ShellContent()
-							{
-								ContentTemplate = new DataTemplate(() => page),
-							}
-						}
-					}
-				}
-			};
-
-			Items.Add(item);
-			return item;
-		}
-
 		public ContentPage CreateContentPage(string shellItemTitle = null)
 			=> CreateContentPage<ShellItem, ShellSection>(shellItemTitle);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1434,6 +1434,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11107.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11120.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11291.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11244.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11272.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -276,7 +276,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnBackButtonBehaviorChanged(object sender, PropertyChangedEventArgs e)
 		{
-			UpdateLeftBarButtonItem();
+			if(!e.Is(BackButtonBehavior.CommandParameterProperty))
+				UpdateLeftBarButtonItem();
 		}
 
 
@@ -415,10 +416,11 @@ namespace Xamarin.Forms.Platform.Android
 				if (drawerEnabled)
 				{
 					_drawerToggle.DrawerArrowDrawable = icon;
-					toolbar.NavigationIcon = null;
 				}
 				else
+				{
 					toolbar.NavigationIcon = icon;
+				}
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -393,14 +393,16 @@ namespace Xamarin.Forms.Platform.Android
 				icon = new FlyoutIconDrawerDrawable(context, tintColor, null, text);
 			}
 
-			if (icon == null)
+			if (icon == null && _flyoutBehavior == FlyoutBehavior.Flyout)
 			{
 				icon = new DrawerArrowDrawable(context.GetThemedContext());
 				icon.SetColorFilter(tintColor, FilterMode.SrcAtop);
 				defaultDrawerArrowDrawable = true;
 			}
 
-			icon.Progress = (CanNavigateBack) ? 1 : 0;
+			if(icon != null)
+				icon.Progress = (CanNavigateBack) ? 1 : 0;
+
 			if (command != null || CanNavigateBack)
 			{
 				_drawerToggle.DrawerIndicatorEnabled = false;
@@ -408,8 +410,9 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else if(_flyoutBehavior == FlyoutBehavior.Flyout || !defaultDrawerArrowDrawable)
 			{
-				_drawerToggle.DrawerIndicatorEnabled = isEnabled;
-				if (isEnabled)
+				bool drawerEnabled = isEnabled && icon != null;
+				_drawerToggle.DrawerIndicatorEnabled = drawerEnabled;
+				if (drawerEnabled)
 				{
 					_drawerToggle.DrawerArrowDrawable = icon;
 					toolbar.NavigationIcon = null;
@@ -422,7 +425,6 @@ namespace Xamarin.Forms.Platform.Android
 				_drawerToggle.DrawerIndicatorEnabled = false;
 			}
 
-			toolbar.NavigationIcon = icon;
 			_drawerToggle.SyncState();
 
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -312,6 +312,26 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		ImageSource GetFlyoutIcon(BackButtonBehavior backButtonHandler, Page page)
+		{
+			var image = backButtonHandler.GetPropertyIfSet<ImageSource>(BackButtonBehavior.IconOverrideProperty, null);
+			if (image == null)
+			{
+				Element item = page;
+				while (!Application.IsApplicationOrNull(item))
+				{
+					if (item is IShellController shell)
+					{
+						image = shell.FlyoutIcon;
+						break;
+					}
+					item = item?.Parent;
+				}
+			}
+
+			return image;
+		}
+
 		protected virtual async void UpdateLeftBarButtonItem(Context context, Toolbar toolbar, DrawerLayout drawerLayout, Page page)
 		{
 			if (_drawerToggle == null && !context.IsDesignerContext())
@@ -328,27 +348,13 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			var backButtonHandler = Shell.GetBackButtonBehavior(page);
-
-			var image = backButtonHandler.GetPropertyIfSet<ImageSource>(BackButtonBehavior.IconOverrideProperty, null);
 			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
 			var command = backButtonHandler.GetPropertyIfSet<ICommand>(BackButtonBehavior.CommandProperty, null);
 			bool isEnabled = _backButtonBehavior.GetPropertyIfSet(BackButtonBehavior.IsEnabledProperty, true);
-
-			if (image == null)
-			{
-				Element item = page;
-				while (!Application.IsApplicationOrNull(item))
-				{
-					if (item is IShellController shell)
-					{
-						image = shell.FlyoutIcon;
-						break;
-					}
-					item = item?.Parent;
-				}
-			}
+			var image = GetFlyoutIcon(backButtonHandler, page);
 
 			DrawerArrowDrawable icon = null;
+			bool defaultDrawerArrowDrawable = false;
 
 			var tintColor = Color.White;
 			if (TintColor != Color.Default)
@@ -356,29 +362,51 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (image != null)
 			{
-				var customIcon = await context.GetFormsDrawableAsync(image);
+				FlyoutIconDrawerDrawable fid = toolbar.NavigationIcon as FlyoutIconDrawerDrawable;
+				Drawable customIcon;
+
+				if (fid?.IconBitmapSource == image)
+					customIcon = fid.IconBitmap;
+				else
+					customIcon = await context.GetFormsDrawableAsync(image);
 
 				if (customIcon != null)
-					icon = new FlyoutIconDrawerDrawable(context, tintColor, customIcon, text);
+				{
+					if (fid == null)
+					{
+						fid = new FlyoutIconDrawerDrawable(context, tintColor, customIcon, text);
+					}
+					else
+					{
+						fid.TintColor = tintColor;
+						fid.IconBitmap = customIcon;
+						fid.Text = text;
+					}
+
+					fid.IconBitmapSource = image;
+					icon = fid;
+				}
 			}
 
 			if (!string.IsNullOrWhiteSpace(text) && icon == null)
-				icon = new FlyoutIconDrawerDrawable(context, tintColor, icon, text);
+			{
+				icon = new FlyoutIconDrawerDrawable(context, tintColor, null, text);
+			}
 
 			if (icon == null)
 			{
 				icon = new DrawerArrowDrawable(context.GetThemedContext());
 				icon.SetColorFilter(tintColor, FilterMode.SrcAtop);
+				defaultDrawerArrowDrawable = true;
 			}
 
 			icon.Progress = (CanNavigateBack) ? 1 : 0;
-
 			if (command != null || CanNavigateBack)
 			{
 				_drawerToggle.DrawerIndicatorEnabled = false;
 				toolbar.NavigationIcon = icon;
 			}
-			else if (_flyoutBehavior == FlyoutBehavior.Flyout)
+			else if(_flyoutBehavior == FlyoutBehavior.Flyout || !defaultDrawerArrowDrawable)
 			{
 				_drawerToggle.DrawerIndicatorEnabled = isEnabled;
 				if (isEnabled)
@@ -394,7 +422,9 @@ namespace Xamarin.Forms.Platform.Android
 				_drawerToggle.DrawerIndicatorEnabled = false;
 			}
 
+			toolbar.NavigationIcon = icon;
 			_drawerToggle.SyncState();
+
 
 			//this needs to be set after SyncState
 			UpdateToolbarIconAccessibilityText(toolbar, _shellContext.Shell);
@@ -408,12 +438,18 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void UpdateToolbarIconAccessibilityText(Toolbar toolbar, Shell shell)
 		{
+			var backButtonHandler = Shell.GetBackButtonBehavior(Page);
+			var image = GetFlyoutIcon(backButtonHandler, Page);
+			var text = backButtonHandler.GetPropertyIfSet(BackButtonBehavior.TextOverrideProperty, String.Empty);
+			var automationId = image?.AutomationId ?? text;
+
 			//if AutomationId was specified the user wants to use UITests and interact with FlyoutIcon
-			if (!string.IsNullOrEmpty(shell.FlyoutIcon?.AutomationId))
+			if (!string.IsNullOrEmpty(automationId))
 			{
-				toolbar.NavigationContentDescription = shell.FlyoutIcon.AutomationId;
+				toolbar.NavigationContentDescription = automationId;
 			}
-			else if (toolbar.SetNavigationContentDescription(_shellContext.Shell.FlyoutIcon) == null)
+			else if (image == null ||
+				toolbar.SetNavigationContentDescription(image) == null)
 			{
 				toolbar.SetNavigationContentDescription(R.String.Ok);
 			}
@@ -615,49 +651,50 @@ namespace Xamarin.Forms.Platform.Android
 
 		class FlyoutIconDrawerDrawable : DrawerArrowDrawable
 		{
-			Drawable _iconBitmap;
-			string _text;
-			Color _defaultColor;
+			public Drawable IconBitmap { get; set; }
+			public string Text { get; set; }
+			public Color TintColor { get; set; }
+			public ImageSource IconBitmapSource { get; set; }
 			float _defaultSize;
 
-			Color _pressedBackgroundColor => _defaultColor.AddLuminosity(-.12);//<item name="highlight_alpha_material_light" format="float" type="dimen">0.12</item>
+			Color _pressedBackgroundColor => TintColor.AddLuminosity(-.12);//<item name="highlight_alpha_material_light" format="float" type="dimen">0.12</item>
 
 			protected override void Dispose(bool disposing)
 			{
 				base.Dispose(disposing);
-				if (disposing && _iconBitmap != null)
+				if (disposing && IconBitmap != null)
 				{
-					_iconBitmap.Dispose();
+					IconBitmap.Dispose();
 				}
 			}
 
 			public FlyoutIconDrawerDrawable(Context context, Color defaultColor, Drawable icon, string text) : base(context)
 			{
-				_defaultColor = defaultColor;
+				TintColor = defaultColor;
 				_defaultSize = Forms.GetFontSizeNormal(context);
-				_iconBitmap = icon;
-				_text = text;
+				IconBitmap = icon;
+				Text = text;		
 			}
 
 			public override void Draw(Canvas canvas)
 			{
 				bool pressed = false;
-				if (_iconBitmap != null)
+				if (IconBitmap != null)
 				{
-					ADrawableCompat.SetTint(_iconBitmap, _defaultColor.ToAndroid());
-					ADrawableCompat.SetTintMode(_iconBitmap, PorterDuff.Mode.SrcAtop);
+					ADrawableCompat.SetTint(IconBitmap, TintColor.ToAndroid());
+					ADrawableCompat.SetTintMode(IconBitmap, PorterDuff.Mode.SrcAtop);
 
-					_iconBitmap.SetBounds(Bounds.Left, Bounds.Top, Bounds.Right, Bounds.Bottom);
-					_iconBitmap.Draw(canvas);
+					IconBitmap.SetBounds(Bounds.Left, Bounds.Top, Bounds.Right, Bounds.Bottom);
+					IconBitmap.Draw(canvas);
 				}
-				else if (!string.IsNullOrEmpty(_text))
+				else if (!string.IsNullOrEmpty(Text))
 				{
 					var paint = new Paint { AntiAlias = true };
 					paint.TextSize = _defaultSize;
-					paint.Color = pressed ? _pressedBackgroundColor.ToAndroid() : _defaultColor.ToAndroid();
+					paint.Color = pressed ? _pressedBackgroundColor.ToAndroid() : TintColor.ToAndroid();
 					paint.SetStyle(Paint.Style.Fill);
 					var y = (Bounds.Height() + paint.TextSize) / 2;
-					canvas.DrawText(_text, 0, y, paint);
+					canvas.DrawText(Text, 0, y, paint);
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

Changes in 4.7 incorrectly ignored BackButtonBehavior if the flyoutbehavior was set to disabled.
This combination was also causing android to incorrectly toggle the flyout menu when it's disabled but the text is set. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11244
- fixes #11102


### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
