### PR TITLE
[UWP] Fixed validation to check if can use Composition Clip 

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CompositionHelper.cs
+++ b/Xamarin.Forms.Platform.UAP/CompositionHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Reflection;
+﻿using System;
+using System.Linq;
+using System.Reflection;
 using Windows.UI.Composition;
 
 namespace Xamarin.Forms.Platform.UWP
@@ -14,8 +16,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (!SetTypePresent)
 				{
-					MethodInfo methodInfo = typeof(Compositor).GetMethod("CreateEllipseGeometry");
-					IsTypePresent = methodInfo != null;
+					var compositorMethods = typeof(Compositor).GetMethods();
+					var createGeometricClipExists = compositorMethods.Any(m => m.Name == "CreateGeometricClip");
+					var createEllipseGeometryExists = compositorMethods.Any(m => m.Name == "CreateEllipseGeometry");
+
+					IsTypePresent = createGeometricClipExists && createEllipseGeometryExists;
 					SetTypePresent = true;
 				}
 


### PR DESCRIPTION
### Description of Change ###

Fixed validation to check if can use Composition Clip on UWP.

### Issues Resolved ### 

- fixes #11265 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use the generated NuGet package with a Xamarin.Forms App. Use 1734 as target in UWP App and launch it. Without error, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
