### PR TITLE
Remove rendundant calls to UpdateCharacterSpacing

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PickerRenderer.cs
@@ -115,7 +115,6 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateFont();
 				UpdatePicker();
 				UpdateTextColor();
-				UpdateCharacterSpacing();
 				UpdateHorizontalTextAlignment();
 				UpdateVerticalTextAlignment();
 
@@ -135,12 +134,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (e.PropertyName == Picker.TitleProperty.PropertyName || e.PropertyName == Picker.TitleColorProperty.PropertyName)
 			{
 				UpdatePicker();
-				UpdateCharacterSpacing();
 			}
 			else if (e.PropertyName == Picker.SelectedIndexProperty.PropertyName)
 			{
 				UpdatePicker();
-				UpdateCharacterSpacing();
 			}
 			else if (e.PropertyName == Picker.CharacterSpacingProperty.PropertyName)
 				UpdateCharacterSpacing();
@@ -183,7 +180,6 @@ namespace Xamarin.Forms.Platform.iOS
 		void RowsCollectionChanged(object sender, EventArgs e)
 		{
 			UpdatePicker();
-			UpdateCharacterSpacing();
 		}
 
         protected void UpdateCharacterSpacing()


### PR DESCRIPTION
### Description of Change ###

Several parts of the iOS `PickerRendererBase` call `UpdateCharacterSpacing` after calling `UpdatePicker`. But `UpdatePicker` already calls `UpdateCharacterSpacing`.

### Issues Resolved ### 

- None, just saving some cycles

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Whatever tests we already have for the Picker.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
