### PR TITLE
[iOS] Fixed NRE checking if ShouldUpdateClip

### DIFF
--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -452,19 +452,19 @@ namespace Xamarin.Forms.Platform.MacOS
 				hasClipShapeLayer =
 					uiview.Layer != null &&
 					uiview.Layer.Mask != null &&
-					uiview.Layer.Mask.Name.Equals(ClipShapeLayer);
+					uiview.Layer.Mask.Name == ClipShapeLayer;
 			else
 			{
 				hasClipShapeLayer =
 					uiview.MaskView != null &&
 					uiview.MaskView.Layer.Mask != null &&
-					uiview.MaskView.Layer.Mask.Name.Equals(ClipShapeLayer);
+					uiview.MaskView.Layer.Mask.Name == ClipShapeLayer;
 			}
 #else
 			hasClipShapeLayer =
 				uiview.Layer != null &&
 				uiview.Layer.Mask != null &&
-				uiview.Layer.Mask.Name.Equals(ClipShapeLayer);
+				uiview.Layer.Mask.Name == ClipShapeLayer;
 #endif
 
 			var formsGeometry = element.Clip;


### PR DESCRIPTION
### Description of Change ###

Fixed NRE checking if `ShouldUpdateClip` on iOS. The Mask Name could be null and raise an exception when comparing using Equals.

### Issues Resolved ### 
- fixes #11274 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Launch Core Gallery, navigate to the Shapes gallery, rotate the device and touch the Shape.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
