### PR TITLE
[UWP] FormsTextBox clean up OnApplyTemplate

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -47,7 +47,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 		InputScope _passwordInputScope;
 		InputScope _numericPasswordInputScope;
-		Border _borderElement;
 		Windows.UI.Xaml.Controls.ScrollViewer _scrollViewer;
 		Windows.UI.Xaml.Controls.Grid _rootGrid;
 		Windows.UI.Xaml.VisualState _DeleteButtonVisibleState;
@@ -157,14 +156,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnApplyTemplate();
 
-			if (Device.Idiom == TargetIdiom.Phone)
-			{
-				// If we're on the phone, we need to grab this from the template
-				// so we can manually handle its background when focused
-				_borderElement = (Border)GetTemplateChild("BorderElement");
-			}
-			
-			_rootGrid = (Windows.UI.Xaml.Controls.Grid)GetTemplateChild("RootGrid");
+			_rootGrid = GetTemplateChild("RootGrid") as Windows.UI.Xaml.Controls.Grid;
 			if (_rootGrid != null)
 			{
 				var stateGroups = WVisualStateManager.GetVisualStateGroups(_rootGrid).ToList();
@@ -173,7 +165,7 @@ namespace Xamarin.Forms.Platform.UWP
 					_DeleteButtonVisibleState = _DeleteButtonVisibleStateGroups.States.SingleOrDefault(s => s.Name == "ButtonVisible");
 			}
 
-			_scrollViewer= (Windows.UI.Xaml.Controls.ScrollViewer)GetTemplateChild("ContentElement");
+			_scrollViewer= GetTemplateChild("ContentElement") as ScrollViewer;
 		}
 
 		void OnSizeChanged(object sender, SizeChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		InputScope _passwordInputScope;
 		InputScope _numericPasswordInputScope;
-		Windows.UI.Xaml.Controls.ScrollViewer _scrollViewer;
+		ScrollViewer _scrollViewer;
 		Windows.UI.Xaml.Controls.Grid _rootGrid;
 		Windows.UI.Xaml.VisualState _DeleteButtonVisibleState;
 		Windows.UI.Xaml.VisualStateGroup _DeleteButtonVisibleStateGroups;

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Forms.Platform.UWP
 			RegisterPropertyChangedCallback(VerticalContentAlignmentProperty, OnVerticalContentAlignmentChanged);
 		}
 
+
 		void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
 			UpdateEnabled();

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -68,7 +68,6 @@ namespace Xamarin.Forms.Platform.UWP
 			RegisterPropertyChangedCallback(VerticalContentAlignmentProperty, OnVerticalContentAlignmentChanged);
 		}
 
-
 		void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
 			UpdateEnabled();

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -144,6 +144,7 @@ namespace Xamarin.Forms.Platform.UWP
 					Tracker = new VisualElementTracker<TElement, TNativeElement>();
 				}
 
+				// Old Comment
 				// Disabled until reason for crashes with unhandled exceptions is discovered
 				// Without this some layouts may end up with improper sizes, however their children
 				// will position correctly

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -144,7 +144,6 @@ namespace Xamarin.Forms.Platform.UWP
 					Tracker = new VisualElementTracker<TElement, TNativeElement>();
 				}
 
-				// Old Comment
 				// Disabled until reason for crashes with unhandled exceptions is discovered
 				// Without this some layouts may end up with improper sizes, however their children
 				// will position correctly


### PR DESCRIPTION
 ### Description of Change ###

Changing to safe casting when pulling elements out of the control template incase the template changes.  Per a suggestion in this comment on PR https://github.com/xamarin/Xamarin.Forms/pull/11140#discussion_r448810684

I also removed the code pulling out the BorderElement from the template.  The variable was not referenced, other than to be set and windows phone is no longer supported.


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

None, housekeeping only

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I retest all issues from PR 11140 and all tested good.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
