### PR TITLE
[Android] Pass fading properties to HorizontalScrollViewContainer

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -58,6 +58,7 @@ using IOPath = System.IO.Path;
 [assembly: ExportRenderer(typeof(Issue9360.Issue9360NavigationPage), typeof(Issue9360NavigationPageRenderer))]
 [assembly: ExportRenderer(typeof(Issue8801.PopupStackLayout), typeof(Issue8801StackLayoutRenderer))]
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Tests.TestClasses.CustomButton), typeof(CustomButtonRenderer))]
+[assembly: ExportRenderer(typeof(ScrolView11185), typeof(ScrollViewFadeRenderer))]
 
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
@@ -66,6 +67,15 @@ using IOPath = System.IO.Path;
 #endif
 namespace Xamarin.Forms.ControlGallery.Android
 {
+	public sealed class ScrollViewFadeRenderer : ScrollViewRenderer
+	{
+		public ScrollViewFadeRenderer(Context context) : base(context)
+		{
+			HorizontalFadingEdgeEnabled = true;
+			SetFadingEdgeLength(200);
+		}
+	}
+
 	public class Issue8801StackLayoutRenderer : VisualElementRenderer<StackLayout>
 	{
 		public Issue8801StackLayoutRenderer(Context context) : base(context)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11185.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11185.cs
@@ -1,0 +1,43 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11185, "ScrollViewRenderer HorizontalFadingEdgeEnabled ignored on horizontal ScrollView orientation", PlatformAffected.Android)]
+	public class Issue11185 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			var layout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			for (int i = 0; i < 20; i++)
+			{
+				layout.Children.Add(new BoxView { WidthRequest = 100, HeightRequest = 100, BackgroundColor = Color.LightCoral });
+			}
+
+			Content = new ScrolView11185
+			{
+				Orientation = ScrollOrientation.Horizontal,
+				Content = layout
+			};
+		}
+	}
+
+	public class ScrolView11185 : ScrollView
+	{
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -812,6 +812,7 @@
       <DependentUpon>Issue9827.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10699.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11185.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -483,6 +483,8 @@ namespace Xamarin.Forms.Platform.Android
 				if (_hScrollView == null)
 				{
 					_hScrollView = new AHorizontalScrollView(Context, this);
+					_hScrollView.HorizontalFadingEdgeEnabled = HorizontalFadingEdgeEnabled;
+					_hScrollView.SetFadingEdgeLength(HorizontalFadingEdgeLength);
 					UpdateFlowDirection();
 				}
 


### PR DESCRIPTION
### Description of Change ###

We create a custom horizontal and need to pass it properties users set on custom renderers , properties like `HorizontalFadingEdgeEnabled`  and `HorizontalFadingEdgeLength`

### Issues Resolved ### 

- fixes #11185

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Should be able to see fading edge  on scrollviewer

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###

Manual visit issue 11185 and see if it shows the fading edges

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
