### PR TITLE
Fix SwipeView crash with NullReferenceException [BUG #10679]

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -1378,6 +1378,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateIsOpen(bool isOpen)
 		{
+			if (Element == null)
+				return;
+
 			((ISwipeViewController)Element).IsOpen = isOpen;
 		}
 


### PR DESCRIPTION
### Fix SwipeView crash with NullReferenceException ###



### Issues Resolved ### 

- fixes #10679 

### API Changes ###
None

Added:
None

Changed:
Added an if statement to the SwipeViewRenderer on iOS to prevent a crash described on bug #10679 
 
 Removed:
None
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Run this code on the sample provided on the bug #10679 and you'll see the bug is solved on iOS. 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
