### PR TITLE
[macOS] Fix crash setting the default Label color using Span

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11272.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11272.cs
@@ -1,0 +1,78 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Label)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11272,
+		"[Bug] Crash XF for Mac 4.7.0.1080",
+		PlatformAffected.macOS)]
+	public class Issue11272 : TestContentPage
+	{
+		public Issue11272()
+		{
+
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 11272";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Without exception, this test has passed."
+			};
+
+			var errorLabel1 = new Label()
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span()
+						{
+							Text = "🔔🌀 Issue 11272",
+						}
+					}
+				}
+			};
+
+			var errorLabel2 = new Label()
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				FormattedText = new FormattedString
+				{
+					Spans =
+					{
+						new Span()
+						{
+							TextColor = Color.Red,
+							Text = "🔔🌀 Issue 11272 (Using TextColor)",
+						}
+					}
+				}
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(errorLabel1);
+			layout.Children.Add(errorLabel2);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1429,6 +1429,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11113.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10182.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11107.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11272.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Platform.MacOS
 #else
 		internal static readonly NSColor Black = NSColor.Black;
 		internal static readonly NSColor SeventyPercentGrey = NSColor.FromRgba(0.7f, 0.7f, 0.7f, 1);
-		internal static readonly NSColor LabelColor = NSColor.Black;
+		internal static readonly NSColor LabelColor = NSColor.Black.UsingColorSpace("NSCalibratedRGBColorSpace");
 		internal static readonly NSColor AccentColor = Color.FromRgba(50, 79, 133, 255).ToNSColor();
 #endif
 
@@ -190,8 +190,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (color.Type == NSColorType.Catalog)
 				throw new InvalidOperationException("Cannot convert a NSColorType.Catalog color without specifying the color space, use the overload to specify an NSColorSpace");
 
-			var newColor = color.UsingColorSpace("NSCalibratedRGBColorSpace");
-			newColor.GetRgba(out red, out green, out blue, out alpha);
+			color.GetRgba(out red, out green, out blue, out alpha);
 #endif
 			return new Color(red, green, blue, alpha);
 		}

--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -190,7 +190,8 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (color.Type == NSColorType.Catalog)
 				throw new InvalidOperationException("Cannot convert a NSColorType.Catalog color without specifying the color space, use the overload to specify an NSColorSpace");
 
-			color.GetRgba(out red, out green, out blue, out alpha);
+			var newColor = color.UsingColorSpace("NSCalibratedRGBColorSpace");
+			newColor.GetRgba(out red, out green, out blue, out alpha);
 #endif
 			return new Color(red, green, blue, alpha);
 		}


### PR DESCRIPTION
### Description of Change ###

Fix crash setting the default Label color using Span.

### Issues Resolved ### 
- fixes #11272 
- fixes #11248

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
Crash

#### After
<img width="1023" alt="fix11272" src="https://user-images.githubusercontent.com/6755973/86460662-11e8ce00-bd29-11ea-97f4-6f3556d7f133.png">

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
