### PR TITLE
Baseline UWP Tests when running them on CI

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla31330.cs
@@ -150,6 +150,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[Category(UITestCategories.UwpIgnore)]
 		public void Bugzilla31330Test()
 		{
 			RunningApp.WaitForElement(c => c.Marked("Something 2"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla34561.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 34561, "[A] Navigation.PushAsync crashes when used in Context Actions (legacy)", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42620.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla42620.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 42620, " Grid.Children.AddHorizontal does not span all rows", PlatformAffected.Default)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51825.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla51825.cs
@@ -53,10 +53,16 @@ namespace Xamarin.Forms.Controls.Issues
 		public void Bugzilla51825Test()
 		{
 			RunningApp.WaitForElement(q => q.Marked("Bugzilla51825SearchBar"));
-			RunningApp.EnterText(q => q.Marked("Bugzilla51825SearchBar"), "Hello");
-			RunningApp.WaitForElement(q => q.Text("Hello"));
+			RunningApp.EnterText("Bugzilla51825SearchBar", "Hello");
+			var label = RunningApp.WaitForFirstElement("Bugzilla51825Label");
+
+			Assert.IsNotEmpty(label.ReadText());
+			Assert.AreEqual("Hello", label.ReadText());
+
 			RunningApp.Tap("Bugzilla51825Button");
-			RunningApp.WaitForElement(q => q.Text("Test"));
+
+			var labelChange2 = RunningApp.WaitForFirstElement("Bugzilla51825Label");
+			Assert.AreEqual("Test", labelChange2.ReadText());
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57317.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla57317.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 57317, "Modifying Cell.ContextActions can crash on Android", PlatformAffected.Android)]
@@ -26,7 +27,8 @@ namespace Xamarin.Forms.Controls.Issues
 			var tableSection = new TableSection();
 			var switchCell = new TextCell
 			{
-				Text = "Cell"
+				Text = "Cell",
+				AutomationId = "Cell"
 			};
 
 			var menuItem = new MenuItem
@@ -45,11 +47,11 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Bugzilla57317Test()
 		{
-			RunningApp.WaitForElement(c => c.Marked("Cell"));
+			RunningApp.WaitForFirstElement("Cell");
 
 			RunningApp.ActivateContextMenu("Cell");
 
-			RunningApp.WaitForElement(c => c.Marked("Self-Deleting item"));
+			RunningApp.WaitForFirstElement("Self-Deleting item");
 			RunningApp.Tap(c => c.Marked("Self-Deleting item"));
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59580.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla59580.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Bugzilla, 59580, "Raising Command.CanExecutChanged causes crash on Android",

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/GestureBubblingTests.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test, TestCaseSource(nameof(TestCases))]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void VerifyTapBubbling(string menuItem, bool frameShouldRegisterTap)
 		{
 			var results = RunningApp.WaitForElement(q => q.Marked(menuItem));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Helpers/UITestHelper.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Helpers/UITestHelper.cs
@@ -13,6 +13,19 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public static string ReadText(this AppResult result) =>
 			result.Text ?? result.Description;
+
+
+		public static void AssertHasText(this AppResult result, string text)
+		{
+			if(String.Equals(result.Description, text, StringComparison.OrdinalIgnoreCase) ||
+				String.Equals(result.Text, text, StringComparison.OrdinalIgnoreCase) ||
+				String.Equals(result.Label, text, StringComparison.OrdinalIgnoreCase))
+			{
+				return;
+			}
+
+			Assert.Fail();
+		}
 	}
 }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10744.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10744.cs
@@ -65,6 +65,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void WebViewEvalCrashesOnAndroidWithLongString()
 		{
 			RunningApp.WaitForElement("navigatedLabel");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1583_1.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public async Task Issue1583_1_WebviewTest()
 		{
 			RunningApp.WaitForElement(q => q.Marked("label"), "Could not find label", TimeSpan.FromSeconds(10), null, null);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2338.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Forms.Controls.Issues
 		// Various tests are commented out on certain platforms because
 		// https://github.com/xamarin/Xamarin.Forms/issues/3188
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public async Task SwapMainPageOut()
 		{
 			await TestForSuccess(RunningApp, typeof(Issue2338_SwapMainPageDuringAppearing));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2414.cs
@@ -61,6 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void TestDoesntCrashShowingContextMenu()
 		{
 			RunningApp.ActivateContextMenu("Swipe ME");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2597.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void Issue2597Test()
 		{
 #if __IOS__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2680ScrollView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2680ScrollView.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void Issue2680Test_ScrollEnabled()
 		{
 			RunningApp.Tap(q => q.Button(ToggleButtonMark));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 	[NUnit.Framework.Category(UITestCategories.Gestures)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	public class Issue2894 : TestContentPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3475.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3475.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Layout)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 3475, "[iOS] LayoutCompression Performance Issues", PlatformAffected.iOS)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3809.cs
@@ -84,12 +84,23 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 #if UITEST
+
+		void AssertSafeAreaText(string text)
+		{
+			var element =
+				RunningApp
+					.WaitForFirstElement(_safeAreaAutomationId);
+
+			element.AssertHasText(text);
+		}
+
 		[Test]
+		[Category(UITestCategories.UwpIgnore)]
 		public void SafeAreaInsetsBreaksAndroidPadding()
 		{
 			// ensure initial paddings are honored
-			RunningApp.WaitForElement($"{_safeAreaText}{true}");
-			var element = RunningApp.WaitForElement(_paddingLabel).First();
+			AssertSafeAreaText($"{_safeAreaText}{true}");
+			var element = RunningApp.WaitForFirstElement(_paddingLabel);
 
 			bool usesSafeAreaInsets = false;
 			if (element.ReadText() != "25, 25, 25, 25")
@@ -101,15 +112,15 @@ namespace Xamarin.Forms.Controls.Issues
 
 			// disable Safe Area Insets
 			RunningApp.Tap(_safeAreaAutomationId);
-			RunningApp.WaitForElement($"{_safeAreaText}{false}");
-			element = RunningApp.WaitForElement(_paddingLabel).First();
+			AssertSafeAreaText($"{_safeAreaText}{false}");
+			element = RunningApp.WaitForFirstElement(_paddingLabel);
 
 			Assert.AreEqual(element.ReadText(), "25, 25, 25, 25");
 
 			// enable Safe Area insets
 			RunningApp.Tap(_safeAreaAutomationId);
-			RunningApp.WaitForElement($"{_safeAreaText}{true}");
-			element = RunningApp.WaitForElement(_paddingLabel).First();
+			AssertSafeAreaText($"{_safeAreaText}{true}");
+			element = RunningApp.WaitForFirstElement(_paddingLabel);
 			Assert.AreNotEqual(element.ReadText(), "0, 0, 0, 0");
 
 			if (!usesSafeAreaInsets)
@@ -119,8 +130,8 @@ namespace Xamarin.Forms.Controls.Issues
 			// Set Padding and then disable safe area insets
 			RunningApp.Tap(_setPagePadding);
 			RunningApp.Tap(_safeAreaAutomationId);
-			RunningApp.WaitForElement($"{_safeAreaText}{false}");
-			element = RunningApp.WaitForElement(_paddingLabel).First();
+			AssertSafeAreaText($"{_safeAreaText}{false}");
+			element = RunningApp.WaitForFirstElement(_paddingLabel);
 			Assert.AreEqual(element.ReadText(), "25, 25, 25, 25");
 
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5376.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5376.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue5376Test() 
 		{
-			RunningApp.WaitForElement ("Success");
+			RunningApp.WaitForFirstElement ("Success");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5518.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5518.cs
@@ -13,6 +13,9 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 5518, "Frame Tap Gesture not working when using Visual=\"Material\" in iOS", PlatformAffected.iOS)]
 	public class Issue5518 : TestContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6260.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6260.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Controls.Issues
 		PlatformAffected.Android)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Button)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	public class Issue6260 : TestContentPage
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6286.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.WebView)]
+	[Category(UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 6286, "ObjectDisposedException in Android WebView.EvaluateJavascriptAsync ", PlatformAffected.Android)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6994.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.ListView)]
 	[NUnit.Framework.Category(UITestCategories.Label)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7167.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7167.xaml.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 		const string AddRangeWithCleanCommandId = "AddRangeWithCleanCommandId";
 
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public  void Issue7167Test()
 		{
 			// arrange

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7890.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7890.cs
@@ -61,6 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void TestCorrectListItemsRemoved()
 		{
 			RunningApp.WaitForElement(q => q.Button("RemoveBtn"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9306.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9306.cs
@@ -69,6 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void Issue9306SwipeViewCloseSwiping()
 		{
 			RunningApp.WaitForElement(x => x.Marked(SwipeViewId));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LabelTextType.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LabelTextType.cs
@@ -71,6 +71,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void LabelToggleHtmlAndPlainTextTest() 
 		{
 			RunningApp.WaitForElement ("TextTypeLabel");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RefreshViewTests.cs
@@ -140,6 +140,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void IsRefreshingAndCommandTest_SwipeDown()
 		{
 			RunningApp.WaitForElement(q => q.Marked("IsRefreshing: False"));
@@ -152,6 +153,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void RefreshDisablesWithCommand()
 		{
 			RunningApp.WaitForElement("IsRefreshing: False");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -1,6 +1,10 @@
 #if UITEST
 using System;
 using System.IO;
+using System.Linq;
+using NUnit.Framework;
+using NUnit.Framework.Interfaces;
+using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 
@@ -209,6 +213,16 @@ namespace Xamarin.Forms.Controls
 			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
 		{
 			return _app.WaitForElement(query, timeoutMessage, timeout, retryFrequency, postTimeout);
+		}
+
+		public AppResult WaitForFirstElement(string marked, string timeoutMessage = "Timed out waiting for element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null)
+		{
+#if __WINDOWS__
+			return (_app as WinDriverApp).WaitForFirstElement(marked, timeoutMessage, timeout, retryFrequency);
+#else
+			return _app.WaitForElement(marked, timeoutMessage, timeout, retryFrequency).FirstOrDefault();
+#endif
 		}
 
 		public void WaitForNoElement(Func<AppQuery, AppQuery> query, string timeoutMessage = "Timed out waiting for no element...",
@@ -468,17 +482,28 @@ namespace Xamarin.Forms.Controls
 				AppSetup.EndIsolate();
 			}
 
-#if __WINDOWS__
-			ScreenshotFailure();
-#endif
+			AttachScreenshotIfOutcomeFailed();
 		}
 
-#if __WINDOWS__
-		public void ScreenshotFailure()
+		public void AttachScreenshotToTestContext(string title = null)
 		{
-			(_app as Core.UITests.WinDriverApp).ScreenshotFailure();
+			title = title ?? TestContext.CurrentContext.Test.FullName
+				.Replace(".", "_")
+				.Replace(" ", "_");
+
+			FileInfo file = _app.Screenshot(title);
+
+			if (file != null)
+			{
+				TestContext.AddTestAttachment(file.FullName, TestContext.CurrentContext.Test.FullName);
+			}
 		}
-#endif
+
+		public void AttachScreenshotIfOutcomeFailed()
+		{
+			if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+				AttachScreenshotToTestContext();
+		}
 
 #if __IOS__
 

--- a/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
@@ -51,6 +51,7 @@ namespace Xamarin.Forms.Core.UITests
 		[TearDown]
 		protected virtual void TestTearDown()
 		{
+			App.AttachScreenshotIfOutcomeFailed();
 		}
 
 		protected abstract void NavigateToGallery();
@@ -87,6 +88,7 @@ namespace Xamarin.Forms.Core.UITests
 					}
 					else
 					{
+						App.AttachScreenshotToTestContext("NavigateToGallery Failed");
 						// But if it's still not working after [maxAttempts], we've got assume this is a legit
 						// problem that restarting won't fix
 						throw;

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ActivityIndicatorUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ActivityIndicatorUITests.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Core.UITests
 		// ActivityIndicator tests
 		[Test]
 		[UiTest(typeof(ActivityIndicator), "IsRunning")]
+		[Category(UITestCategories.UwpIgnore)]
 		public void IsRunning()
 		{
 			var remote = new ViewContainerRemote(App, Test.ActivityIndicator.IsRunning, PlatformViewType);

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ExpanderViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ExpanderViewUITests.cs
@@ -3,6 +3,7 @@
 namespace Xamarin.Forms.Core.UITests
 {
 	[Category(UITestCategories.ExpanderView)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 	internal class ExpanderViewUITests : BaseTestFixture
 	{
 		protected override void NavigateToGallery()

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ImageButtonUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ImageButtonUITests.cs
@@ -84,6 +84,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(ImageButton), "Clicked")]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void Clicked()
 		{
 			var remote = new EventViewContainerRemote(App, Test.ImageButton.Clicked, PlatformViewType);
@@ -101,6 +102,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(ImageButton), "Pressed")]
+		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 		public void Pressed()
 		{
 			var remote = new EventViewContainerRemote(App, Test.ImageButton.Pressed, PlatformViewType);

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/ViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/ViewUITests.cs
@@ -120,6 +120,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(VisualElement), "Opacity")]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _Opacity()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.Opacity, PlatformViewType);
@@ -138,6 +139,7 @@ namespace Xamarin.Forms.Core.UITests
 		[Test]
 		[UiTest(typeof(VisualElement), "Rotation")]
 		[UiTestBroken(BrokenReason.CalabashBug, "Calabash bug")]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _Rotation()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.Rotation, PlatformViewType);
@@ -159,6 +161,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(VisualElement), "RotationX")]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _RotationX()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.RotationX, PlatformViewType);
@@ -180,6 +183,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(VisualElement), "RotationY")]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _RotationY()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.RotationY, PlatformViewType);
@@ -201,6 +205,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		[Test]
 		[UiTest(typeof(VisualElement), "Scale")]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _Scale()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.Scale, PlatformViewType);
@@ -220,6 +225,7 @@ namespace Xamarin.Forms.Core.UITests
 		[Test]
 		[UiTest(typeof(VisualElement), "TranslationX")]
 		[Category(UITestCategories.ManualReview)]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _TranslationX()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.TranslationX, PlatformViewType);
@@ -232,6 +238,7 @@ namespace Xamarin.Forms.Core.UITests
 		[Test]
 		[UiTest(typeof(VisualElement), "TranslationY")]
 		[Category(UITestCategories.ManualReview)]
+		[Category(UITestCategories.UwpIgnore)]
 		public virtual void _TranslationY()
 		{
 			var remote = new ViewContainerRemote(App, Test.VisualElement.TranslationY, PlatformViewType);

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -6,6 +6,7 @@ using Xamarin.UITest.Queries;
 using System.Text.RegularExpressions;
 using System.Threading;
 using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Controls;
 #if __IOS__
 using Xamarin.UITest.iOS;
 #endif
@@ -14,6 +15,24 @@ namespace Xamarin.UITest
 {
 	internal static class AppExtensions
 	{
+		public static void AttachScreenshotToTestContext(this IApp app, string title)
+		{
+			((ScreenshotConditionalApp)app).AttachScreenshotToTestContext(title);
+		}
+
+		public static void AttachScreenshotIfOutcomeFailed(this IApp app)
+		{
+			((ScreenshotConditionalApp)app).AttachScreenshotIfOutcomeFailed();
+		}
+
+		public static AppResult WaitForFirstElement(this IApp app, string marked, string timeoutMessage = "Timed out waiting for element...")
+		{
+			if (app is ScreenshotConditionalApp scp)
+				return scp.WaitForFirstElement(marked, timeoutMessage);
+
+			return app.WaitForElement(marked, timeoutMessage).FirstOrDefault();
+		}
+
 		public static T[] QueryUntilPresent<T>(
 			this IApp app,
 			Func<T[]> func,
@@ -138,6 +157,7 @@ namespace Xamarin.Forms.Core.UITests
 			var text = Regex.Match(page, "'(?<text>[^']*)'").Groups["text"].Value;
 
 			app.WaitForElement("SearchBar");
+			app.ClearText(q => q.Raw("* marked:'SearchBar'"));
 			app.EnterText(q => q.Raw("* marked:'SearchBar'"), text);
 			app.DismissKeyboard();
 

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -310,7 +310,6 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			try
 			{
-				// TODO hartez 2017/07/18 10:16:56 Verify that this is working; seems a bit too simple	
 				string filename = $"{title}.png";
 
 				Screenshot screenshot = _session.GetScreenshot();

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -69,12 +69,12 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void Back()
 		{
-			QueryWindows("Back").First().Click();
+			QueryWindows("Back", true).First().Click();
 		}
 
 		public void ClearText(Func<AppQuery, AppQuery> query)
 		{
-			SwapInUsefulElement(QueryWindows(query).First()).Clear();
+			SwapInUsefulElement(QueryWindows(query, true).First()).Clear();
 		}
 
 		public void ClearText(Func<AppQuery, AppWebQuery> query)
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void ClearText(string marked)
 		{
-			SwapInUsefulElement(QueryWindows(marked).First()).Clear();
+			SwapInUsefulElement(QueryWindows(marked, true).First()).Clear();
 		}
 
 		public void ClearText()
@@ -147,13 +147,13 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void EnterText(Func<AppQuery, AppQuery> query, string text)
 		{
-			var result = QueryWindows(query).First();
+			var result = QueryWindows(query, true).First();
 			SwapInUsefulElement(result).SendKeys(text);
 		}
 
 		public void EnterText(string marked, string text)
 		{
-			var result = QueryWindows(marked).First();
+			var result = QueryWindows(marked, true).First();
 			SwapInUsefulElement(result).SendKeys(text);
 		}
 
@@ -306,31 +306,29 @@ namespace Xamarin.Forms.Core.UITests
 			throw new NotImplementedException();
 		}
 
-
-		public void ScreenshotFailure()
+		public FileInfo Screenshot(string title)
 		{
-			if (TestContext.CurrentContext.Result.Outcome.Status == TestStatus.Failed)
+			try
 			{
-				string filename = $"{TestContext.CurrentContext.Test.FullName}.png";
+				// TODO hartez 2017/07/18 10:16:56 Verify that this is working; seems a bit too simple	
+				string filename = $"{title}.png";
+
 				Screenshot screenshot = _session.GetScreenshot();
 				screenshot.SaveAsFile(filename, ScreenshotImageFormat.Png);
 				var file = new FileInfo(filename);
 
-				TestContext.AddTestAttachment(file.FullName, TestContext.CurrentContext.Test.FullName);
+				TestContext.AddTestAttachment(file.FullName, title);
+				return file;
 			}
-		}
-
-		public FileInfo Screenshot(string title)
-		{
-			// TODO hartez 2017/07/18 10:16:56 Verify that this is working; seems a bit too simple	
-			string filename = $"{title}.png";
-
-			Screenshot screenshot = _session.GetScreenshot();
-			screenshot.SaveAsFile(filename, ScreenshotImageFormat.Png);
-			var file = new FileInfo(filename);
-
-			TestContext.AddTestAttachment(file.FullName, title);
-			return file;
+			catch (OpenQA.Selenium.WebDriverException we)
+			when (we.Message.Contains("Currently selected window has been closed"))
+			{
+				return null;
+			}
+			catch (Exception exception)
+			{
+				throw;
+			}
 		}
 
 		public void ScrollDown(Func<AppQuery, AppQuery> withinQuery = null, ScrollStrategy strategy = ScrollStrategy.Auto,
@@ -602,6 +600,15 @@ namespace Xamarin.Forms.Core.UITests
 			throw new NotImplementedException();
 		}
 
+		public AppResult WaitForFirstElement(string marked, string timeoutMessage = "Timed out waiting for element...",
+			TimeSpan? timeout = null, TimeSpan? retryFrequency = null)
+		{
+			Func<ReadOnlyCollection<WindowsElement>> result = () => QueryWindows(marked, true);
+			return WaitForAtLeastOne(result, timeoutMessage, timeout, retryFrequency)
+				.Select(ToAppResult)
+				.FirstOrDefault();
+		}
+
 		public void WaitForNoElement(Func<AppQuery, AppQuery> query,
 			string timeoutMessage = "Timed out waiting for no element...",
 			TimeSpan? timeout = null, TimeSpan? retryFrequency = null, TimeSpan? postTimeout = null)
@@ -626,7 +633,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		public void ContextClick(string marked)
 		{
-			WindowsElement element = QueryWindows(marked).First();
+			WindowsElement element = QueryWindows(marked, true).First();
 			PointF point = ElementToClickablePoint(element);
 
 			MouseClickAt(point.X, point.Y, ClickType.ContextClick);
@@ -746,11 +753,13 @@ namespace Xamarin.Forms.Core.UITests
 
 		WindowsElement FindFirstElement(WinQuery query)
 		{
-			Func<ReadOnlyCollection<WindowsElement>> fquery = () => QueryWindows(query);
+			Func<ReadOnlyCollection<WindowsElement>> fquery = 
+				() => QueryWindows(query, true);
 
 			string timeoutMessage = $"Timed out waiting for element: {query.Raw}";
 
-			ReadOnlyCollection<WindowsElement> results = WaitForAtLeastOne(fquery, timeoutMessage);
+			ReadOnlyCollection<WindowsElement> results = 
+				WaitForAtLeastOne(fquery, timeoutMessage);
 
 			WindowsElement element = results.FirstOrDefault();
 
@@ -859,12 +868,18 @@ namespace Xamarin.Forms.Core.UITests
 			new Actions(_session).MoveToElement(viewPort, xOffset, yOffset);
 		}
 
-		ReadOnlyCollection<WindowsElement> QueryWindows(WinQuery query)
+		ReadOnlyCollection<WindowsElement> QueryWindows(WinQuery query, bool findFirst = false)
 		{
 			ReadOnlyCollection<WindowsElement> resultByAccessibilityId = _session.FindElementsByAccessibilityId(query.Marked);
-			ReadOnlyCollection<WindowsElement> resultByName = _session.FindElementsByName(query.Marked);
+			ReadOnlyCollection<WindowsElement> resultByName = null;
 
-			IEnumerable<WindowsElement> result = resultByAccessibilityId.Concat(resultByName);
+			if(!findFirst || resultByAccessibilityId.Count == 0)
+				resultByName = _session.FindElementsByName(query.Marked);
+
+			IEnumerable<WindowsElement> result = resultByAccessibilityId;
+
+			if (resultByName != null)
+				result = result.Concat(resultByName);
 
 			// TODO hartez 2017/10/30 09:47:44 Should this be == "*" || == "TextBox"?	
 			// what about other controls where we might be looking by content? TextBlock?
@@ -878,16 +893,16 @@ namespace Xamarin.Forms.Core.UITests
 			return FilterControlType(result, query.ControlType);
 		}
 
-		ReadOnlyCollection<WindowsElement> QueryWindows(string marked)
+		ReadOnlyCollection<WindowsElement> QueryWindows(string marked, bool findFirst = false)
 		{
 			WinQuery winQuery = WinQuery.FromMarked(marked);
-			return QueryWindows(winQuery);
+			return QueryWindows(winQuery, findFirst);
 		}
 
-		ReadOnlyCollection<WindowsElement> QueryWindows(Func<AppQuery, AppQuery> query)
+		ReadOnlyCollection<WindowsElement> QueryWindows(Func<AppQuery, AppQuery> query, bool findFirst = false)
 		{
 			WinQuery winQuery = WinQuery.FromQuery(query);
-			return QueryWindows(winQuery);
+			return QueryWindows(winQuery, findFirst);
 		}
 
 		void Scroll(WinQuery query, bool down)
@@ -1048,7 +1063,8 @@ namespace Xamarin.Forms.Core.UITests
 
 		static ReadOnlyCollection<WindowsElement> WaitForAtLeastOne(Func<ReadOnlyCollection<WindowsElement>> query,
 			string timeoutMessage = null,
-			TimeSpan? timeout = null, TimeSpan? retryFrequency = null)
+			TimeSpan? timeout = null, 
+			TimeSpan? retryFrequency = null)
 		{
 			return Wait(query, i => i > 0, timeoutMessage, timeout, retryFrequency);
 		}

--- a/build.cake
+++ b/build.cake
@@ -528,7 +528,13 @@ Task("provision-uitests-uwp")
         string driverPath = System.IO.Path.Combine(installPath, "Windows Application Driver");
         if(!DirectoryExists(driverPath))
         {
-            InstallMsi(UWP_APP_DRIVER_INSTALL_PATH, installPath);
+            try{
+                InstallMsi(UWP_APP_DRIVER_INSTALL_PATH, installPath);
+            }
+            catch(Exception e)
+            {
+                Information("Failed to Install Win App Driver: {0}", e);
+            }
         }
     });
 


### PR DESCRIPTION
### Description of Change ###

- Baseline current UWP tests to green so we can be aware of new ones that pop up during the CI process
- Modified a few tests to work better with UWP
- reworked searching on UWP so it can exit early if it finds a field matching accessibility id. UWP goes really slow when it has to search without accessibility ID so might as well exit early
- The UWP tests still fail occasionally :-/ with window closed exceptions but I'll work on that in another PR
- Next week I'll go through all the ignores in here and create issues for anything that looks like a UWP regression but for now I'd like to just get UWP close to green so we can catch anything new

### Platforms Affected ### 
- UWP

### Testing Procedure ###
- make sure UWP is green

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
