### PR TITLE
Apply uniform contractions to starred rows/columns

### DIFF
--- a/.Xamarin.Forms.Android.slnf
+++ b/.Xamarin.Forms.Android.slnf
@@ -2,9 +2,6 @@
   "solution": {
     "path": "Xamarin.Forms.sln",
     "projects": [
-      "EmbeddingTestBeds\\Embedding.Droid\\Embedding.Droid.csproj",
-      "PagesGallery\\PagesGallery.Droid\\PagesGallery.Droid.csproj",
-      "PagesGallery\\PagesGallery\\PagesGallery.csproj",
       "Stubs\\Xamarin.Forms.Platform.Android\\Xamarin.Forms.Platform.Android (Forwarders).csproj",
       "XFCorePostProcessor.Tasks\\XFCorePostProcessor.Tasks.csproj",
       "Xamarin.Flex\\Xamarin.Flex.shproj",
@@ -22,14 +19,12 @@
       "Xamarin.Forms.Maps\\Xamarin.Forms.Maps.csproj",
       "Xamarin.Forms.Material.Android\\Xamarin.Forms.Material.Android.csproj",
       "Xamarin.Forms.Pages.Azure\\Xamarin.Forms.Pages.Azure.csproj",
-      "Xamarin.Forms.Pages.UnitTests\\Xamarin.Forms.Pages.UnitTests.csproj",
       "Xamarin.Forms.Pages\\Xamarin.Forms.Pages.csproj",
       "Xamarin.Forms.Platform.Android.AppLinks\\Xamarin.Forms.Platform.Android.AppLinks.csproj",
       "Xamarin.Forms.Platform.Android.FormsViewGroup\\Xamarin.Forms.Platform.Android.FormsViewGroup.csproj",
+      "Xamarin.Forms.Platform.Android.UnitTests\\Xamarin.Forms.Platform.Android.UnitTests.csproj",
       "Xamarin.Forms.Platform.Android\\Xamarin.Forms.Platform.Android.csproj",
       "Xamarin.Forms.Platform\\Xamarin.Forms.Platform.csproj",
-      "Xamarin.Forms.Sandbox.Android\\Xamarin.Forms.Sandbox.Android.csproj",
-      "Xamarin.Forms.Sandbox\\Xamarin.Forms.Sandbox.csproj",
       "Xamarin.Forms.Xaml.Design\\Xamarin.Forms.Xaml.Design.csproj",
       "Xamarin.Forms.Xaml.UnitTests\\Xamarin.Forms.Xaml.UnitTests.csproj",
       "Xamarin.Forms.Xaml\\Xamarin.Forms.Xaml.csproj"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8797.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8797.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			var scrollView = new ScrollView();
 			var layout = new StackLayout { Margin = new Thickness(5, 80, 5, 0) };
 
 			var instructions = new Label { Text = "The text visible in the Grid should end with 'finding a good way to spend it'. If that text is cut off, this test has failed." };
@@ -19,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.Start,
 				BackgroundColor = Color.Bisque,
 				Margin = new Thickness(0, 40, 0, 0),
-				ColumnSpacing = 12
+				ColumnSpacing = 6
 			};
 
 			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
@@ -33,6 +34,7 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.Start,
 				LineBreakMode = LineBreakMode.WordWrap,
 				BackgroundColor = Color.CornflowerBlue,
+				FontSize = 10,
 				Text = "There's a 104 days of summer vacation 'til school comes along just to end it. So the annual problem for our generation is finding a good way to spend it."
 			};
 
@@ -41,7 +43,9 @@ namespace Xamarin.Forms.Controls.Issues
 			layout.Children.Add(instructions);
 			layout.Children.Add(grid);
 
-			Content = layout;
+			scrollView.Content = layout;
+
+			Content = scrollView;
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8797.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8797.cs
@@ -1,0 +1,47 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 8797, "[Bug] Word wrapped Label not measured correctly",
+		PlatformAffected.Android | PlatformAffected.iOS)]
+	public class Issue8797 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var layout = new StackLayout { Margin = new Thickness(5, 80, 5, 0) };
+
+			var instructions = new Label { Text = "The text visible in the Grid should end with 'finding a good way to spend it'. If that text is cut off, this test has failed." };
+
+			BackgroundColor = Color.BlanchedAlmond;
+
+			var grid = new Grid
+			{
+				VerticalOptions = LayoutOptions.Start,
+				BackgroundColor = Color.Bisque,
+				Margin = new Thickness(0, 40, 0, 0),
+				ColumnSpacing = 12
+			};
+
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(5, GridUnitType.Star)});
+			
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			var label = new Label
+			{
+				VerticalOptions = LayoutOptions.Start,
+				LineBreakMode = LineBreakMode.WordWrap,
+				BackgroundColor = Color.CornflowerBlue,
+				Text = "There's a 104 days of summer vacation 'til school comes along just to end it. So the annual problem for our generation is finding a good way to spend it."
+			};
+
+			grid.Children.Add(label, 1, 0);
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(grid);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -46,6 +46,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8766.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8797.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8801.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9279.xaml.cs">
       <DependentUpon>Issue9279.xaml</DependentUpon>

--- a/Xamarin.Forms.Core.UnitTests/GridTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GridTests.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void ThrowsOnNullAdd ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			Assert.Throws<ArgumentNullException> (() => layout.Children.Add (null));
 		}
@@ -34,9 +34,112 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void ThrowsOnNullRemove ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			Assert.Throws<ArgumentNullException> (() => layout.Children.Remove (null));
+		}
+
+		[Test]
+		public void StarColumnsHaveEqualWidths()
+		{
+			var grid = new Grid
+			{
+				VerticalOptions = LayoutOptions.Start,
+				ColumnSpacing = 12
+			};
+
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(5, GridUnitType.Star) });
+
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			var label = new ColumnTestLabel
+			{
+				VerticalOptions = LayoutOptions.Start,
+				LineBreakMode = LineBreakMode.WordWrap,
+				Text = "There's a 104 days of summer vacation 'til school comes along just to end it. So the annual problem for our generation is finding a good way to spend it."
+			};
+
+			grid.Children.Add(label, 1, 0);
+
+			var gridWidth = 411;
+			grid.Measure(gridWidth, 1000);
+			var column0Width = grid.ColumnDefinitions[0].ActualWidth;
+			var column1Width = grid.ColumnDefinitions[1].ActualWidth;
+
+			Assert.That(column0Width, Is.EqualTo(column1Width));
+			Assert.That(column0Width, Is.LessThan(gridWidth));
+		}
+
+		[Test]
+		public void StarRowsHaveEqualHeights()
+		{
+			var grid = new Grid
+			{
+				VerticalOptions = LayoutOptions.Start,
+				RowSpacing = 12
+			};
+
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+			grid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+			grid.RowDefinitions.Add(new RowDefinition() { Height = new GridLength(5, GridUnitType.Star) });
+
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+
+			var label = new RowTestLabel
+			{
+				VerticalOptions = LayoutOptions.Start,
+				LineBreakMode = LineBreakMode.WordWrap,
+				Text = "There's a 104 days of summer vacation 'til school comes along just to end it. So the annual problem for our generation is finding a good way to spend it."
+			};
+
+			grid.Children.Add(label, 1, 0);
+
+			var gridHeight = 411;
+
+			grid.Measure(1000, gridHeight);
+			var column0Height = grid.RowDefinitions[0].ActualHeight;
+			var column1Height = grid.RowDefinitions[1].ActualHeight;
+
+			Assert.That(column0Height, Is.EqualTo(column1Height));
+			Assert.That(column0Height, Is.LessThan(gridHeight));
+		}
+
+		class ColumnTestLabel : Label
+		{
+			public ColumnTestLabel() 
+			{
+				IsPlatformEnabled = true;
+			}
+			
+			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+			{
+				var minimumSize = new Size(20, 20);
+				var height = 10000 / widthConstraint;
+				return new SizeRequest(new Size(widthConstraint, height), minimumSize);
+			}
+		}
+
+		class RowTestLabel : Label
+		{
+			public RowTestLabel()
+			{
+				IsPlatformEnabled = true;
+			}
+
+			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+			{
+				var minimumSize = new Size(20, 20);
+
+				if (double.IsInfinity(heightConstraint))
+				{
+					heightConstraint = 1000;
+				}
+
+				var width = 10000 / heightConstraint;
+				return new SizeRequest(new Size(width, heightConstraint), minimumSize);
+			}
 		}
 
 		[TestFixture]
@@ -199,11 +302,11 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestBasicVerticalLayout ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.Children.AddVertical (new View[] {
 				label1,
@@ -211,24 +314,24 @@ namespace Xamarin.Forms.Core.UnitTests
 				label3
 			});
 
-			layout.Layout (new Rectangle (0, 0, 912, 912));
+			layout.Layout (new Rectangle(0, 0, 912, 912));
 
 			Assert.AreEqual (912, layout.Width);
 			Assert.AreEqual (912, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 912, 300), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 306, 912, 300), label2.Bounds);
-			Assert.AreEqual (new Rectangle (0, 612, 912, 300), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 912, 300), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 306, 912, 300), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 612, 912, 300), label3.Bounds);
 		}
 
 		[Test]
 		public void TestBasicHorizontalLayout ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.Children.AddHorizontal (new View[] {
 				label1,
@@ -236,23 +339,23 @@ namespace Xamarin.Forms.Core.UnitTests
 				label3
 			});
 
-			layout.Layout (new Rectangle (0, 0, 912, 912));
+			layout.Layout (new Rectangle(0, 0, 912, 912));
 
 			Assert.AreEqual (912, layout.Width);
 			Assert.AreEqual (912, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 300, 912), label1.Bounds);
-			Assert.AreEqual (new Rectangle (306, 0, 300, 912), label2.Bounds);
-			Assert.AreEqual (new Rectangle (612, 0, 300, 912), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 300, 912), label1.Bounds);
+			Assert.AreEqual (new Rectangle(306, 0, 300, 912), label2.Bounds);
+			Assert.AreEqual (new Rectangle(612, 0, 300, 912), label3.Bounds);
 		}
 
 		[Test]
 		public void TestVerticalExpandStart ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
 
 			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = new GridLength (1, GridUnitType.Star) },
@@ -261,19 +364,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label1, 0, 0);
 			layout.Children.Add (label2, 0, 1);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 1000, 1000 - 20 - layout.RowSpacing), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 1000 - 20, 1000, 20), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 1000, 1000 - 20 - layout.RowSpacing), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 1000 - 20, 1000, 20), label2.Bounds);
 		}
 
 		[Test]
 		public void TestHorizontalExpandStart ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true };
 			var label2 = new Label { IsPlatformEnabled = true };
@@ -285,22 +388,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label1, 0, 0);
 			layout.Children.Add (label2, 1, 0);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 1000 - 106, 1000), label1.Bounds);
-			Assert.AreEqual (new Rectangle (1000 - 100, 0, 100, 1000), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 1000 - 106, 1000), label1.Bounds);
+			Assert.AreEqual (new Rectangle(1000 - 100, 0, 100, 1000), label2.Bounds);
 		}
 
 		[Test]
 		public void TestVerticalExpandEnd ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
 
 			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = GridLength.Auto},
@@ -309,22 +412,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label1, 0, 0);
 			layout.Children.Add (label2, 0, 1);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 1000, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 26, 1000, 1000 - 26), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 1000, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 26, 1000, 1000 - 26), label2.Bounds);
 		}
 
 		[Test]
 		public void TestHorizontalExpandEnd ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -334,23 +437,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label1, 0, 0);
 			layout.Children.Add (label2, 1, 0);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 1000), label1.Bounds);
-			Assert.AreEqual (new Rectangle (106, 0, 1000 - 106, 1000), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 1000), label1.Bounds);
+			Assert.AreEqual (new Rectangle(106, 0, 1000 - 106, 1000), label2.Bounds);
 		}
 
 		[Test]
 		public void TestVerticalExpandMiddle ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = GridLength.Auto},
@@ -361,24 +464,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label2, 0, 1);
 			layout.Children.Add (label3, 0, 2);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 1000, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 26, 1000, 1000 - 52), label2.Bounds);
-			Assert.AreEqual (new Rectangle (0, 980, 1000, 20), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 1000, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 26, 1000, 1000 - 52), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 980, 1000, 20), label3.Bounds);
 		}
 
 		[Test]
 		public void TestHorizontalExpandMiddle ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -390,25 +493,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label2, 1, 0);
 			layout.Children.Add (label3, 2, 0);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 1000), label1.Bounds);
-			Assert.AreEqual (new Rectangle (106, 0, 1000 - 212, 1000), label2.Bounds);
-			Assert.AreEqual (new Rectangle (900, 0, 100, 1000), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 1000), label1.Bounds);
+			Assert.AreEqual (new Rectangle(106, 0, 1000 - 212, 1000), label2.Bounds);
+			Assert.AreEqual (new Rectangle(900, 0, 100, 1000), label3.Bounds);
 		}
 
 		[Test]
 		public void TestTableNoExpand ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
-			var label4 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
+			var label4 = new Label { IsPlatformEnabled = true};
 
 			layout.Children.Add (label1, 0, 0);
 			layout.Children.Add (label2, 1, 0);
@@ -424,26 +527,26 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto}
 			};
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (106, 0, 100, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle (0, 26, 100, 20), label3.Bounds);
-			Assert.AreEqual (new Rectangle (106, 26, 100, 20), label4.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(106, 0, 100, 20), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 26, 100, 20), label3.Bounds);
+			Assert.AreEqual (new Rectangle(106, 26, 100, 20), label4.Bounds);
 		}
 
 		[Test]
 		public void TestTableExpand ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
-			var label4 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
+			var label4 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -455,25 +558,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label3, 0, 1);
 			layout.Children.Add (label4, 1, 1);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 497), label1.Bounds);
-			Assert.AreEqual (new Rectangle (106, 0, 894, 497), label2.Bounds);
-			Assert.AreEqual (new Rectangle (0, 503, 100, 497), label3.Bounds);
-			Assert.AreEqual (new Rectangle (106, 503, 894, 497), label4.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 497), label1.Bounds);
+			Assert.AreEqual (new Rectangle(106, 0, 894, 497), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 503, 100, 497), label3.Bounds);
+			Assert.AreEqual (new Rectangle(106, 503, 894, 497), label4.Bounds);
 		}
 
 		[Test]
 		public void TestTableSpan ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.Children.Add (label1, 0, 2, 0, 1);
 			layout.Children.Add (label2, 0, 1, 1, 2);
@@ -488,24 +591,24 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto}
 			};
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 206, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 26, 100, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle (106, 26, 100, 20), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 206, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 26, 100, 20), label2.Bounds);
+			Assert.AreEqual (new Rectangle(106, 26, 100, 20), label3.Bounds);
 		}
 
 		[Test]
 		public void TestTableExpandedSpan ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
@@ -520,22 +623,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label2, 0, 1, 1, 2);
 			layout.Children.Add (label3, 1, 2, 1, 2);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 1000, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 26, 497, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle (503, 26, 497, 20), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 1000, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 26, 497, 20), label2.Bounds);
+			Assert.AreEqual (new Rectangle(503, 26, 497, 20), label3.Bounds);
 		}
 
 		[Test]
 		public void TestInvalidSet ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
 
 			bool thrown = false;
 
@@ -551,9 +654,9 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestCentering ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
+			var label1 = new Label { IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition () {Width = new GridLength (1, GridUnitType.Star)},
 			};
@@ -563,15 +666,15 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			layout.Children.Add (label1);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (new Rectangle (450, 490, 100, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(450, 490, 100, 20), label1.Bounds);
 		}
 
 		[Test]
 		public void TestStart ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.Start, VerticalOptions = LayoutOptions.StartAndExpand };
 
@@ -583,15 +686,15 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition () {Height = new GridLength (1,GridUnitType.Star)},
 			};
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 20), label1.Bounds);
 		}
 
 		[Test]
 		public void TestEnd ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.End, VerticalOptions = LayoutOptions.EndAndExpand };
 
@@ -603,15 +706,15 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition () {Height = new GridLength (1,GridUnitType.Star)},
 			};
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (new Rectangle (900, 980, 100, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(900, 980, 100, 20), label1.Bounds);
 		}
 
 		[Test]
 		public void TestDefaultRowSpacing ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			bool preferredSizeChanged = false;
 			layout.MeasureInvalidated += (sender, args) => {
@@ -630,7 +733,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestDefaultColumnSpacing ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			bool preferredSizeChanged = false;
 			layout.MeasureInvalidated += (sender, args) => {
@@ -649,13 +752,13 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestAddCell ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 			bool preferredSizeChanged = false;
 			layout.MeasureInvalidated += (sender, args) => preferredSizeChanged = true;
 
 			Assert.False (preferredSizeChanged);
 
-			layout.Children.Add (new Label (), 0, 0);
+			layout.Children.Add (new Label(), 0, 0);
 
 			Assert.True (preferredSizeChanged);
 		}
@@ -663,8 +766,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestMoveCell ()
 		{
-			var layout = new Grid ();
-			var label = new Label ();
+			var layout = new Grid();
+			var label = new Label();
 			layout.Children.Add (label, 0, 0);
 
 			bool preferredSizeChanged = false;
@@ -695,9 +798,9 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestInvalidBottomAdd ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			Assert.Throws<ArgumentOutOfRangeException> (() => layout.Children.Add (new View (), 0, 1, 1, 0));
+			Assert.Throws<ArgumentOutOfRangeException> (() => layout.Children.Add (new View(), 0, 1, 1, 0));
 		}
 
 		[Test]
@@ -705,15 +808,15 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			var layout = new Grid();
 
-			Assert.AreEqual (new Size (0, 0), layout.GetSizeRequest (0, 0).Request);
-			Assert.AreEqual (new Size (0, 0), layout.GetSizeRequest (0, 10).Request);
-			Assert.AreEqual (new Size (0, 0), layout.GetSizeRequest (10, 0).Request);
+			Assert.AreEqual (new Size(0, 0), layout.GetSizeRequest (0, 0).Request);
+			Assert.AreEqual (new Size(0, 0), layout.GetSizeRequest (0, 10).Request);
+			Assert.AreEqual (new Size(0, 0), layout.GetSizeRequest (10, 0).Request);
 		}
 
 		[Test]
 		public void TestSizeRequest ()
 		{
-			var layout = new Grid {IsPlatformEnabled = true};
+			var layout = new Grid { IsPlatformEnabled = true};
 			layout.Children.AddVertical (new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
@@ -721,13 +824,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			});
 
 			var result = layout.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity).Request;
-			Assert.AreEqual (new Size (100, 72), result);
+			Assert.AreEqual (new Size(100, 72), result);
 		}
 
 		[Test]
 		public void TestLimitedSizeRequest ()
 		{
-			var layout = new Grid {IsPlatformEnabled = true};
+			var layout = new Grid { IsPlatformEnabled = true};
 			layout.Children.AddVertical (new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
@@ -735,13 +838,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			});
 
 			var result = layout.GetSizeRequest (10, 10).Request;
-			Assert.AreEqual (new Size (100, 72), result);
+			Assert.AreEqual (new Size(100, 72), result);
 		}
 
 		[Test]
 		public void TestLimitedWidthSizeRequest ()
 		{
-			var layout = new Grid {IsPlatformEnabled = true};
+			var layout = new Grid { IsPlatformEnabled = true};
 			layout.Children.AddVertical (new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
@@ -749,14 +852,14 @@ namespace Xamarin.Forms.Core.UnitTests
 			});
 
 			var result = layout.GetSizeRequest (10, double.PositiveInfinity).Request;
-			Assert.AreEqual (new Size (100, 72), result);
+			Assert.AreEqual (new Size(100, 72), result);
 		}
 
 		[Test]
 		public void TestLimitedHeightSizeRequest ()
 		{
 
-			var layout = new Grid {IsPlatformEnabled = true};
+			var layout = new Grid { IsPlatformEnabled = true};
 			layout.Children.AddVertical (new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
@@ -764,7 +867,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			});
 
 			var result = layout.GetSizeRequest (double.PositiveInfinity, 10).Request;
-			Assert.AreEqual (new Size (100, 72), result);
+			Assert.AreEqual (new Size(100, 72), result);
 		}
 
 		[Test]
@@ -786,19 +889,19 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto},
 			};
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, -1, -1), label1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 6, 100, 20), label2.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, -1, -1), label1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 6, 100, 20), label2.Bounds);
 		}
 
 		[Test]
 		public void TestSizeRequestWithPadding ()
 		{
-			var layout = new Grid {IsPlatformEnabled = true, Padding = new Thickness(20, 10, 15, 5)};
+			var layout = new Grid { IsPlatformEnabled = true, Padding = new Thickness(20, 10, 15, 5)};
 			layout.Children.AddVertical (new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
@@ -806,32 +909,33 @@ namespace Xamarin.Forms.Core.UnitTests
 			});
 
 			var result = layout.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity).Request;
-			Assert.AreEqual (new Size (135, 87), result);
+			Assert.AreEqual (new Size(135, 87), result);
 		}
 
 		[Test]
 		public void InvalidCallsToStaticMethods ()
 		{
-			Assert.Throws<ArgumentException> (() => Grid.SetRow (new Label (), -1));
-			Assert.Throws<ArgumentException> (() => Grid.SetColumn (new Label (), -1));
-			Assert.Throws<ArgumentException> (() => Grid.SetRowSpan (new Label (), 0));
-			Assert.Throws<ArgumentException> (() => Grid.SetColumnSpan (new Label (), 0));
+			Assert.Throws<ArgumentException> (() => Grid.SetRow (new Label(), -1));
+			Assert.Throws<ArgumentException> (() => Grid.SetColumn (new Label(), -1));
+			Assert.Throws<ArgumentException> (() => Grid.SetRowSpan (new Label(), 0));
+			Assert.Throws<ArgumentException> (() => Grid.SetColumnSpan (new Label(), 0));
 		}
 
 		[Test]
 		public void TestAddedBP ()
 		{
-			var labela0 = new Label {IsPlatformEnabled = true};
-			var labela1 = new Label {IsPlatformEnabled = true };
+			var labela0 = new Label { IsPlatformEnabled = true};
+			var labela1 = new Label { IsPlatformEnabled = true };
 			Grid.SetColumn (labela1, 1);
-			var labelb1 = new Label {IsPlatformEnabled = true};
+			var labelb1 = new Label { IsPlatformEnabled = true};
 			Grid.SetRow (labelb1, 1);
 			Grid.SetColumn (labelb1, 1);
-			var labelc = new Label {IsPlatformEnabled = true};
+			var labelc = new Label { IsPlatformEnabled = true};
 			Grid.SetRow (labelc, 2);
 			Grid.SetColumnSpan (labelc, 2);
 
-			var layout = new Grid {
+			var layout = new Grid
+			{
 				Children = {
 					labela0,
 					labela1,
@@ -850,15 +954,15 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto},
 			};
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 20), labela0.Bounds);
-			Assert.AreEqual (new Rectangle (106, 0, 100, 20), labela1.Bounds);
-			Assert.AreEqual (new Rectangle (106, 26, 100, 20), labelb1.Bounds);
-			Assert.AreEqual (new Rectangle (0, 52, 206, 20), labelc.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 20), labela0.Bounds);
+			Assert.AreEqual (new Rectangle(106, 0, 100, 20), labela1.Bounds);
+			Assert.AreEqual (new Rectangle(106, 26, 100, 20), labelb1.Bounds);
+			Assert.AreEqual (new Rectangle(0, 52, 206, 20), labelc.Bounds);
 		}
 
 		[Test]
@@ -874,7 +978,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			Grid.SetRow(labelc, 2);
 			Grid.SetColumnSpan(labelc, 2);
 
-			var layout = new Grid {
+			var layout = new Grid
+			{
 				Children = {
 					labela0,
 					labela1,
@@ -890,11 +995,11 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void TestAbsoluteLayout ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition {Width = new GridLength (150)},
@@ -911,24 +1016,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label3, 2, 2);
 
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 150, 30), label1.Bounds);
-			Assert.AreEqual (new Rectangle (156, 36, 150, 30), label2.Bounds);
-			Assert.AreEqual (new Rectangle (312, 72, 150, 30), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 150, 30), label1.Bounds);
+			Assert.AreEqual (new Rectangle(156, 36, 150, 30), label2.Bounds);
+			Assert.AreEqual (new Rectangle(312, 72, 150, 30), label3.Bounds);
 		}
 
 		[Test]
 		public void TestAbsoluteLayoutWithSpans ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition {Width = new GridLength (150)},
@@ -945,24 +1050,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label3, 1, 2);
 
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 306, 30), label1.Bounds);
-			Assert.AreEqual (new Rectangle (312, 0, 150, 66), label2.Bounds);
-			Assert.AreEqual (new Rectangle (156, 72, 150, 30), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 306, 30), label1.Bounds);
+			Assert.AreEqual (new Rectangle(312, 0, 150, 66), label2.Bounds);
+			Assert.AreEqual (new Rectangle(156, 72, 150, 30), label3.Bounds);
 		}
 
 		[Test]
 		public void TestStarLayout ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
@@ -982,23 +1087,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual (312, request.Request.Width);
 			Assert.AreEqual (72, request.Request.Height);
 
-			layout.Layout (new Rectangle (0, 0, 1002, 462));
+			layout.Layout (new Rectangle(0, 0, 1002, 462));
 			Assert.AreEqual (1002, layout.Width);
 			Assert.AreEqual (462, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 330, 150), label1.Bounds);
-			Assert.AreEqual (new Rectangle (336, 156, 330, 150), label2.Bounds);
-			Assert.AreEqual (new Rectangle (672, 312, 330, 150), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 330, 150), label1.Bounds);
+			Assert.AreEqual (new Rectangle(336, 156, 330, 150), label2.Bounds);
+			Assert.AreEqual (new Rectangle(672, 312, 330, 150), label3.Bounds);
 		}
 
 		[Test]
 		public void TestStarLayoutWithSpans ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
@@ -1014,24 +1119,24 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label2, 2, 3, 0, 2);
 			layout.Children.Add (label3, 1, 2);
 
-			layout.Layout (new Rectangle (0, 0, 1002, 462));
+			layout.Layout (new Rectangle(0, 0, 1002, 462));
 
 			Assert.AreEqual (1002, layout.Width);
 			Assert.AreEqual (462, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 666, 150), label1.Bounds);
-			Assert.AreEqual (new Rectangle (672, 0, 330, 306), label2.Bounds);
-			Assert.AreEqual (new Rectangle (336, 312, 330, 150), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 666, 150), label1.Bounds);
+			Assert.AreEqual (new Rectangle(672, 0, 330, 306), label2.Bounds);
+			Assert.AreEqual (new Rectangle(336, 312, 330, 150), label3.Bounds);
 		}
 
 		[Test]
 		public void TestAutoLayout ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition {Width = GridLength.Auto},
@@ -1048,20 +1153,20 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label3, 2, 2);
 
 
-			layout.Layout (new Rectangle (0, 0, 1000, 1000));
+			layout.Layout (new Rectangle(0, 0, 1000, 1000));
 
 			Assert.AreEqual (1000, layout.Width);
 			Assert.AreEqual (1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 100, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (106, 26, 100, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle (212, 52, 100, 20), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 100, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(106, 26, 100, 20), label2.Bounds);
+			Assert.AreEqual (new Rectangle(212, 52, 100, 20), label3.Bounds);
 		}
 
 		[Test]
 		public void TestAutoLayoutWithSpans ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true, WidthRequest = 150, Text = "label1" };
 			var label2 = new Label { IsPlatformEnabled = true, HeightRequest = 50, Text = "label2" };
@@ -1081,27 +1186,27 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label2, 2, 3, 0, 2);
 			layout.Children.Add (label3, 1, 2);
 
-			layout.Layout (new Rectangle (0, 0, 1002, 462));
+			layout.Layout (new Rectangle(0, 0, 1002, 462));
 
 			Assert.AreEqual (1002, layout.Width);
 			Assert.AreEqual (462, layout.Height);
 
-			Assert.AreEqual (new Rectangle (0, 0, 150, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle (156, 0, 100, 50), label2.Bounds);
-			Assert.AreEqual (new Rectangle (50, 56, 100, 20), label3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 150, 20), label1.Bounds);
+			Assert.AreEqual (new Rectangle(156, 0, 100, 50), label2.Bounds);
+			Assert.AreEqual (new Rectangle(50, 56, 100, 20), label3.Bounds);
 		}
 
 		[Test]
 		public void AutoLayoutWithComplexSpans ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true};
-			var label4 = new Label {IsPlatformEnabled = true, WidthRequest = 206};
-			var label5 = new Label {IsPlatformEnabled = true, WidthRequest = 312};
-			var label6 = new Label {IsPlatformEnabled = true, WidthRequest = 312};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true};
+			var label4 = new Label { IsPlatformEnabled = true, WidthRequest = 206};
+			var label5 = new Label { IsPlatformEnabled = true, WidthRequest = 312};
+			var label6 = new Label { IsPlatformEnabled = true, WidthRequest = 312};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition {Width = GridLength.Auto},
@@ -1118,7 +1223,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label5, 0, 3, 0, 1);
 			layout.Children.Add (label6, 2, 6, 0, 1);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 500));
+			layout.Layout (new Rectangle(0, 0, 1000, 500));
 
 			Assert.AreEqual (100, layout.ColumnDefinitions [0].ActualWidth);
 			Assert.AreEqual (100, layout.ColumnDefinitions [1].ActualWidth);
@@ -1130,11 +1235,11 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void AutoLayoutExpandColumns ()
 		{
-			var layout = new Grid ();
+			var layout = new Grid();
 
-			var label1 = new Label {IsPlatformEnabled = true};
-			var label2 = new Label {IsPlatformEnabled = true};
-			var label3 = new Label {IsPlatformEnabled = true, WidthRequest = 300};
+			var label1 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true};
+			var label3 = new Label { IsPlatformEnabled = true, WidthRequest = 300};
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -1145,7 +1250,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			layout.Children.Add (label2, 1, 0);
 			layout.Children.Add (label3, 0, 2, 0, 1);
 
-			layout.Layout (new Rectangle (0, 0, 1000, 500));
+			layout.Layout (new Rectangle(0, 0, 1000, 500));
 
 			Assert.AreEqual (100, layout.ColumnDefinitions [0].ActualWidth);
 			Assert.AreEqual (194, layout.ColumnDefinitions [1].ActualWidth);
@@ -1154,7 +1259,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void GridHasDefaultDefinitions ()
 		{
-			var grid = new Grid ();
+			var grid = new Grid();
 			Assert.NotNull (grid.ColumnDefinitions);
 			Assert.NotNull (grid.RowDefinitions);
 		}
@@ -1162,11 +1267,11 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void DefaultDefinitionsArentSharedAccrossInstances ()
 		{
-			var grid0 = new Grid ();
+			var grid0 = new Grid();
 			var coldefs = grid0.ColumnDefinitions;
 			var rowdefs = grid0.RowDefinitions;
 
-			var grid1 = new Grid ();
+			var grid1 = new Grid();
 			Assert.AreNotSame (grid0, grid1);
 			Assert.AreNotSame (coldefs, grid1.ColumnDefinitions);
 			Assert.AreNotSame (rowdefs, grid1.RowDefinitions);
@@ -1175,27 +1280,29 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void ChildrenLayoutRespectAlignment ()
 		{
-			var grid = new Grid { 
-				ColumnDefinitions = { new ColumnDefinition { Width = new GridLength (300) } },
-				RowDefinitions = { new RowDefinition { Height = new GridLength (100) } },
+			var grid = new Grid
+			{ 
+				ColumnDefinitions = { new ColumnDefinition { Width = new GridLength(300) } },
+				RowDefinitions = { new RowDefinition { Height = new GridLength(100) } },
 			};
-			var label = new Label { 
+			var label = new Label
+			{ 
 				IsPlatformEnabled = true,
 				VerticalOptions = LayoutOptions.Center,
 				HorizontalOptions = LayoutOptions.End,
 			};
 
 			grid.Children.Add (label);
-			grid.Layout (new Rectangle (0, 0, 500, 500));
+			grid.Layout (new Rectangle(0, 0, 500, 500));
 
-			Assert.AreEqual (new Rectangle (200, 40, 100, 20), label.Bounds);
+			Assert.AreEqual (new Rectangle(200, 40, 100, 20), label.Bounds);
 		}
 
 		[Test]
 		public void BothChildrenPropertiesUseTheSameBackendStore ()
 		{
-			var view = new View ();
-			var grid = new Grid ();
+			var view = new View();
+			var grid = new Grid();
 			Assert.AreEqual (0, grid.Children.Count);
 			(grid as Layout<View>).Children.Add (view);
 			Assert.AreEqual (1, grid.Children.Count);
@@ -1208,29 +1315,32 @@ namespace Xamarin.Forms.Core.UnitTests
 		//Issue 1384
 		public void ImageInAutoCellIsProperlyConstrained ()
 		{
-			var content = new Image { 
+			var content = new Image
+			{ 
 				Aspect= Aspect.AspectFit,
 				IsPlatformEnabled = true 
 			};
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				IsPlatformEnabled = true,
 				BackgroundColor = Color.Red, 
-				VerticalOptions=LayoutOptions.Start,
+				VerticalOptions= LayoutOptions.Start,
 				Children = {
 					content
 				},
 				RowDefinitions = { new RowDefinition { Height = GridLength.Auto} },
 				ColumnDefinitions = { new ColumnDefinition { Width = GridLength.Auto } }
 			};
-			var view = new ContentView {
+			var view = new ContentView
+			{
 				IsPlatformEnabled = true,
 				Content = grid,
 			};
-			view.Layout (new Rectangle (0, 0, 100, 100));
+			view.Layout (new Rectangle(0, 0, 100, 100));
 			Assert.AreEqual (100, grid.Width);
 			Assert.AreEqual (20, grid.Height);
 
-			view.Layout (new Rectangle (0, 0, 50, 50));
+			view.Layout (new Rectangle(0, 0, 50, 50));
 			Assert.AreEqual (50, grid.Width);
 			Assert.AreEqual (10, grid.Height);
 		}
@@ -1239,29 +1349,32 @@ namespace Xamarin.Forms.Core.UnitTests
 		//Issue 1384
 		public void ImageInStarCellIsProperlyConstrained ()
 		{
-			var content = new Image { 
+			var content = new Image
+			{ 
 				Aspect= Aspect.AspectFit,
 				MinimumHeightRequest = 10,
 				MinimumWidthRequest = 50,
 				IsPlatformEnabled = true 
 			};
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				IsPlatformEnabled = true,
 				BackgroundColor = Color.Red, 
-				VerticalOptions=LayoutOptions.Start,
+				VerticalOptions= LayoutOptions.Start,
 				Children = {
 					content
 				}
 			};
-			var view = new ContentView {
+			var view = new ContentView
+			{
 				IsPlatformEnabled = true,
 				Content = grid,
 			};
-			view.Layout (new Rectangle (0, 0, 100, 100));
+			view.Layout (new Rectangle(0, 0, 100, 100));
 			Assert.AreEqual (100, grid.Width);
 			Assert.AreEqual (20, grid.Height);
 
-			view.Layout (new Rectangle (0, 0, 50, 50));
+			view.Layout (new Rectangle(0, 0, 50, 50));
 			Assert.AreEqual (50, grid.Width);
 			Assert.AreEqual (10, grid.Height);
 		}
@@ -1269,7 +1382,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void SizeRequestForStar ()
 		{
-			var grid = new Grid{ 
+			var grid = new Grid
+			{ 
 				RowDefinitions = new RowDefinitionCollection {
 					new RowDefinition {Height = new GridLength (1, GridUnitType.Star)},
 					new RowDefinition {Height = GridLength.Auto},
@@ -1279,10 +1393,10 @@ namespace Xamarin.Forms.Core.UnitTests
 					new ColumnDefinition {Width = GridLength.Auto},
 				}
 			};
-			grid.Children.Add (new Label {BackgroundColor = Color.Lime, Text="Foo", IsPlatformEnabled = true});
-			grid.Children.Add (new Label {Text = "Bar", IsPlatformEnabled = true},0,1);
-			grid.Children.Add (new Label {Text="Baz",XAlign = TextAlignment.End, IsPlatformEnabled = true},1,0);
-			grid.Children.Add (new Label {Text="Qux", XAlign = TextAlignment.End, IsPlatformEnabled = true},1,1);
+			grid.Children.Add (new Label { BackgroundColor = Color.Lime, Text="Foo", IsPlatformEnabled = true});
+			grid.Children.Add (new Label { Text = "Bar", IsPlatformEnabled = true},0,1);
+			grid.Children.Add (new Label { Text = "Baz", XAlign = TextAlignment.End, IsPlatformEnabled = true},1,0);
+			grid.Children.Add (new Label { Text = "Qux", XAlign = TextAlignment.End, IsPlatformEnabled = true},1,1);
 
 			var request = grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);
 			Assert.AreEqual (206, request.Request.Width);
@@ -1297,15 +1411,18 @@ namespace Xamarin.Forms.Core.UnitTests
 		//Issue 1497
 		public void StarRowsShouldOccupyTheSpace ()
 		{
-			var label = new Label { 
+			var label = new Label
+			{ 
 				IsPlatformEnabled = true,
 			};
-			var Button = new Button {
+			var Button = new Button
+			{
 				HorizontalOptions = LayoutOptions.FillAndExpand,
 				VerticalOptions = LayoutOptions.EndAndExpand,
 				IsPlatformEnabled = true,
 			};
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				RowDefinitions = new RowDefinitionCollection {
 					new RowDefinition { Height = GridLength.Auto },
 					new RowDefinition { Height = new GridLength (1, GridUnitType.Star) },
@@ -1319,14 +1436,15 @@ namespace Xamarin.Forms.Core.UnitTests
 			grid.Children.Add (label);
 			grid.Children.Add (Button, 0, 1);
 
-			grid.Layout (new Rectangle (0, 0, 300, 300));
-			Assert.AreEqual (new Rectangle (0, 280, 300, 20), Button.Bounds);
+			grid.Layout (new Rectangle(0, 0, 300, 300));
+			Assert.AreEqual (new Rectangle(0, 280, 300, 20), Button.Bounds);
 		}
 
 		[Test]
 		public void StarColumnsWithSpansDoNotExpandAutos ()
 		{
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				RowDefinitions = {
 					new RowDefinition {Height = GridLength.Auto},
 					new RowDefinition {Height = GridLength.Auto},
@@ -1339,10 +1457,10 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true
 			};
 
-			var spanBox = new BoxView {WidthRequest = 70, HeightRequest = 20, IsPlatformEnabled = true};
-			var box1 = new BoxView {WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
-			var box2 = new BoxView {WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
-			var box3 = new BoxView {WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
+			var spanBox = new BoxView { WidthRequest = 70, HeightRequest = 20, IsPlatformEnabled = true};
+			var box1 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
+			var box2 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
+			var box3 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
 
 			grid.Children.Add (spanBox, 0, 3, 0, 1);
 			grid.Children.Add (box1, 0, 1);
@@ -1351,21 +1469,21 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			grid.Layout (new Rectangle(0, 0, 300, 46));
 
-			Assert.AreEqual (new Rectangle (0, 0, 300, 20), spanBox.Bounds);
-			Assert.AreEqual (new Rectangle (0, 26, 20, 20), box1.Bounds);
-			Assert.AreEqual (new Rectangle (26, 26, 20, 20), box2.Bounds);
-			Assert.AreEqual (new Rectangle (52, 26, 248, 20), box3.Bounds);
+			Assert.AreEqual (new Rectangle(0, 0, 300, 20), spanBox.Bounds);
+			Assert.AreEqual (new Rectangle(0, 26, 20, 20), box1.Bounds);
+			Assert.AreEqual (new Rectangle(26, 26, 20, 20), box2.Bounds);
+			Assert.AreEqual (new Rectangle(52, 26, 248, 20), box3.Bounds);
 		}
 
 		static SizeRequest GetResizableSize (VisualElement view, double widthconstraint, double heightconstraint)
 		{
 			if (!(view is Editor))
-				return new SizeRequest(new Size (100, 20));
+				return new SizeRequest(new Size(100, 20));
 			if (widthconstraint < 100)
-				return new SizeRequest(new Size (widthconstraint, 2000/widthconstraint));
+				return new SizeRequest(new Size(widthconstraint, 2000/widthconstraint));
 			if (heightconstraint < 20)
-				return new SizeRequest(new Size (2000/heightconstraint, heightconstraint));
-			return new SizeRequest(new Size (100, 20));
+				return new SizeRequest(new Size(2000/heightconstraint, heightconstraint));
+			return new SizeRequest(new Size(100, 20));
 		}
 			
 		[Test]
@@ -1374,7 +1492,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			Device.PlatformServices = new MockPlatformServices(getNativeSizeFunc:GetResizableSize);
 
-			var grid0 = new Grid {
+			var grid0 = new Grid
+			{
 				ColumnDefinitions = {
 					new ColumnDefinition { Width = GridLength.Auto },
 					new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
@@ -1391,10 +1510,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			grid0.Children.Add (label0, 0, 0);
 			grid0.Children.Add (editor0, 1, 2, 0, 2);
 
-			grid0.Layout (new Rectangle (0, 0, 156, 200));
-			Assert.AreEqual (new Rectangle (106, 0, 50, 40), editor0.Bounds);
+			grid0.Layout (new Rectangle(0, 0, 156, 200));
+			Assert.AreEqual (new Rectangle(106, 0, 50, 40), editor0.Bounds);
 
-			var grid1 = new Grid {
+			var grid1 = new Grid
+			{
 				ColumnDefinitions = {
 					new ColumnDefinition { Width = GridLength.Auto },
 					new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
@@ -1410,8 +1530,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			grid1.Children.Add (label1, 0, 0);
 			grid1.Children.Add (editor1, 1, 0);
 
-			grid1.Layout (new Rectangle (0, 0, 156, 200));
-			Assert.AreEqual (new Rectangle (106, 0, 50, 40), editor1.Bounds);
+			grid1.Layout (new Rectangle(0, 0, 156, 200));
+			Assert.AreEqual (new Rectangle(106, 0, 50, 40), editor1.Bounds);
 		}
 
 		[Test]
@@ -1419,7 +1539,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			Device.PlatformServices = new MockPlatformServices(getNativeSizeFunc:GetResizableSize);
 
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				ColumnDefinitions = {
 					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) },
 					new ColumnDefinition { Width = new GridLength(1, GridUnitType.Star) }
@@ -1433,9 +1554,9 @@ namespace Xamarin.Forms.Core.UnitTests
 				ColumnSpacing = 0,
 			};
 
-			var topLabel = new Editor {IsPlatformEnabled = true};
-			var leftLabel = new Label {IsPlatformEnabled = true, WidthRequest = 10};
-			var rightLabel = new Label {IsPlatformEnabled = true, WidthRequest = 10};
+			var topLabel = new Editor { IsPlatformEnabled = true};
+			var leftLabel = new Label { IsPlatformEnabled = true, WidthRequest = 10};
+			var rightLabel = new Label { IsPlatformEnabled = true, WidthRequest = 10};
 
 			grid.Children.Add (topLabel, 0, 2, 0, 1);
 			grid.Children.Add (leftLabel, 0, 1);
@@ -1444,17 +1565,18 @@ namespace Xamarin.Forms.Core.UnitTests
 			var unboundRequest = grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);
 			var widthBoundRequest = grid.GetSizeRequest (50, double.PositiveInfinity);
 
-			Assert.AreEqual (new SizeRequest (new Size (20, 120), new Size (0, 120)), unboundRequest);
-			Assert.AreEqual (new SizeRequest (new Size (50, 60), new Size (0, 60)), widthBoundRequest);
+			Assert.AreEqual (new SizeRequest(new Size(20, 120), new Size(0, 120)), unboundRequest);
+			Assert.AreEqual (new SizeRequest(new Size(50, 60), new Size(0, 60)), widthBoundRequest);
 		}
 
 		[Test]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=31608
 		public void ColAndRowDefinitionsAreActuallyBindable ()
 		{
-			var rowdef = new RowDefinition ();
+			var rowdef = new RowDefinition();
 			rowdef.SetBinding (RowDefinition.HeightProperty, "Height");
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				RowDefinitions = new RowDefinitionCollection { rowdef },
 			};
 			Assert.AreEqual (RowDefinition.HeightProperty.DefaultValue, rowdef.Height);
@@ -1466,9 +1588,10 @@ namespace Xamarin.Forms.Core.UnitTests
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=31967
 		public void ChangingRowHeightViaBindingTriggersRedraw ()
 		{
-			var rowdef = new RowDefinition ();
+			var rowdef = new RowDefinition();
 			rowdef.SetBinding (RowDefinition.HeightProperty, "Height");
-			var grid = new Grid {
+			var grid = new Grid
+			{
 //				RowDefinitions = new RowDefinitionCollection {
 //					new RowDefinition { Height = GridLength.Auto },
 //					rowdef
@@ -1488,15 +1611,15 @@ namespace Xamarin.Forms.Core.UnitTests
 			grid.Children.Add (label0);
 			grid.Children.Add (label1);
 
-			Assert.AreEqual (new SizeRequest (new Size (100, 20), new Size (0, 20)), grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity));
+			Assert.AreEqual (new SizeRequest(new Size(100, 20), new Size(0, 20)), grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity));
 			grid.BindingContext = new {Height = 42};
-			Assert.AreEqual (new SizeRequest (new Size (100, 62), new Size (0, 62)), grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity));
+			Assert.AreEqual (new SizeRequest(new Size(100, 62), new Size(0, 62)), grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity));
 		}
 
 		[Test]
 		public void InvalidationBlockedForAbsoluteCell ()
 		{
-			var grid = new Grid () {
+			var grid = new Grid() {
 				IsPlatformEnabled = true,
 				RowDefinitions = {
 					new RowDefinition { Height = new GridLength (100, GridUnitType.Absolute) }
@@ -1697,7 +1820,8 @@ namespace Xamarin.Forms.Core.UnitTests
 		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
 		public bool InvalidationPropogationTests (HackLayoutConstraint gridConstraint, GridUnitType horizontalType, GridUnitType verticalType)
 		{
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				ComputedConstraint = (LayoutConstraint) gridConstraint,
 				IsPlatformEnabled = true,
 				RowDefinitions = {
@@ -1744,16 +1868,19 @@ namespace Xamarin.Forms.Core.UnitTests
 		[Test]
 		public void NestedInvalidateMeasureDoesNotCrash ()
 		{
-			var grid = new Grid {
+			var grid = new Grid
+			{
 				IsPlatformEnabled = true
 			};
 
-			var child = new Label {
+			var child = new Label
+			{
 				IsPlatformEnabled = true
 			};
 			grid.Children.Add (child);
 
-			var child2 = new Label {
+			var child2 = new Label
+			{
 				IsPlatformEnabled = true
 			};
 			grid.Children.Add (child2);
@@ -1765,7 +1892,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				fire = false;
 			};
 
-			grid.Layout (new Rectangle (0, 0, 100, 100));
+			grid.Layout (new Rectangle(0, 0, 100, 100));
 
 			foreach (var delayAction in delayActions) {
 				delayAction ();

--- a/Xamarin.Forms.Core/GridCalc.cs
+++ b/Xamarin.Forms.Core/GridCalc.cs
@@ -196,90 +196,220 @@ namespace Xamarin.Forms
 			}
 		}
 
-		void ContractColumnsIfNeeded(double width, Func<ColumnDefinition, bool> predicate)
+		double ComputeColumnWidthSum()
 		{
-			double columnWidthSum = 0;
+			double columnwWidthSum = 0;
 			for (var index = 0; index < _columns.Count; index++)
 			{
 				ColumnDefinition c = _columns[index];
-				columnWidthSum += c.ActualWidth;
+				columnwWidthSum += Math.Max(0, c.ActualWidth);
 			}
 
+			return columnwWidthSum;
+		}
+
+		double ComputeRowHeightSum()
+		{
 			double rowHeightSum = 0;
 			for (var index = 0; index < _rows.Count; index++)
 			{
 				RowDefinition r = _rows[index];
-				rowHeightSum += r.ActualHeight;
+				rowHeightSum += Math.Max(0, r.ActualHeight);
 			}
 
-			var request = new Size(columnWidthSum + (_columns.Count - 1) * ColumnSpacing, rowHeightSum + (_rows.Count - 1) * RowSpacing);
-			if (request.Width > width)
+			return rowHeightSum;
+		}
+
+		Size ComputeCurrentSize() 
+		{
+			var columnWidthSum = ComputeColumnWidthSum();
+			var rowHeightSum = ComputeRowHeightSum();
+
+			return new Size(columnWidthSum + (_columns.Count - 1) * ColumnSpacing, rowHeightSum + (_rows.Count - 1) * RowSpacing);
+		}
+
+		void ContractAutoColumnsIfNeeded(double targetWidth)
+		{
+			var currentSize = ComputeCurrentSize();
+
+			if (currentSize.Width <= targetWidth)
 			{
-				double contractionSpace = 0;
+				return;
+			}
+
+			double contractionSpace = 0;
+			for (var index = 0; index < _columns.Count; index++)
+			{
+				ColumnDefinition c = _columns[index];
+				if (c.Width.IsAuto)
+					contractionSpace += c.ActualWidth - c.MinimumWidth;
+			}
+			if (contractionSpace > 0)
+			{
+				// contract as much as we can but no more
+				double contractionNeeded = Math.Min(contractionSpace, Math.Max(currentSize.Width - targetWidth, 0));
+				double contractFactor = contractionNeeded / contractionSpace;
+
 				for (var index = 0; index < _columns.Count; index++)
 				{
-					ColumnDefinition c = _columns[index];
-					if (predicate(c))
-						contractionSpace += c.ActualWidth - c.MinimumWidth;
-				}
-				if (contractionSpace > 0)
-				{
-					// contract as much as we can but no more
-					double contractionNeeded = Math.Min(contractionSpace, Math.Max(request.Width - width, 0));
-					double contractFactor = contractionNeeded / contractionSpace;
-					for (var index = 0; index < _columns.Count; index++)
-					{
-						ColumnDefinition col = _columns[index];
-						if (!predicate(col))
-							continue;
-						double availableSpace = col.ActualWidth - col.MinimumWidth;
-						double contraction = availableSpace * contractFactor;
-						col.ActualWidth -= contraction;
-						contractionNeeded -= contraction;
-					}
+					ColumnDefinition col = _columns[index];
+					if (!col.Width.IsAuto)
+						continue;
+					double availableSpace = col.ActualWidth - Math.Max(col.MinimumWidth, 0);
+					double contraction = availableSpace * contractFactor;
+					col.ActualWidth -= contraction;
+					contractionNeeded -= contraction;
 				}
 			}
 		}
 
-		void ContractRowsIfNeeded(double height, Func<RowDefinition, bool> predicate)
+		void ContractAutoRowsIfNeeded(double targetHeight)
 		{
-			double columnSum = 0;
-			for (var index = 0; index < _columns.Count; index++)
+			var currentSize = ComputeCurrentSize();
+
+			if (currentSize.Height <= targetHeight)
 			{
-				ColumnDefinition c = _columns[index];
-				columnSum += Math.Max(0, c.ActualWidth);
-			}
-			double rowSum = 0;
-			for (var index = 0; index < _rows.Count; index++)
-			{
-				RowDefinition r = _rows[index];
-				rowSum += Math.Max(0, r.ActualHeight);
+				return;
 			}
 
-			var request = new Size(columnSum + (_columns.Count - 1) * ColumnSpacing, rowSum + (_rows.Count - 1) * RowSpacing);
-			if (request.Height <= height)
-				return;
 			double contractionSpace = 0;
 			for (var index = 0; index < _rows.Count; index++)
 			{
 				RowDefinition r = _rows[index];
-				if (predicate(r))
+				if (r.Height.IsAuto)
 					contractionSpace += r.ActualHeight - r.MinimumHeight;
 			}
 			if (!(contractionSpace > 0))
 				return;
 			// contract as much as we can but no more
-			double contractionNeeded = Math.Min(contractionSpace, Math.Max(request.Height - height, 0));
+			double contractionNeeded = Math.Min(contractionSpace, Math.Max(currentSize.Height - targetHeight, 0));
 			double contractFactor = contractionNeeded / contractionSpace;
 			for (var index = 0; index < _rows.Count; index++)
 			{
 				RowDefinition row = _rows[index];
-				if (!predicate(row))
+				if (!row.Height.IsAuto)
 					continue;
 				double availableSpace = row.ActualHeight - row.MinimumHeight;
 				double contraction = availableSpace * contractFactor;
 				row.ActualHeight -= contraction;
 				contractionNeeded -= contraction;
+			}
+		}
+
+		void ContractStarColumnsIfNeeded(double targetWidth)
+		{
+			var request = ComputeCurrentSize();
+
+			if (request.Width <= targetWidth)
+			{
+				return;
+			}
+
+			double starColumnWidth = 0;
+			double starColumnMinWidth = 0;
+			double contractionSpace = 0;
+
+			for (int n = 0; n < _columns.Count; n++)
+			{
+				var column = _columns[n];
+
+				if (!column.Width.IsStar)
+				{
+					continue;
+				}
+
+				starColumnWidth = column.ActualWidth;
+
+				if (column.MinimumWidth > starColumnMinWidth)
+				{
+					starColumnMinWidth = column.MinimumWidth;
+				}
+
+				contractionSpace += column.ActualWidth - column.MinimumWidth;
+			}
+
+			if (contractionSpace <= 0)
+			{
+				return;
+			}
+
+			// contract as much as we can but no more
+			double contractionNeeded = Math.Min(contractionSpace, Math.Max(request.Width - targetWidth, 0));
+			double contractFactor = contractionNeeded / contractionSpace;
+			var delta = contractFactor * starColumnWidth;
+
+			if (starColumnWidth - delta <= starColumnMinWidth)
+			{
+				delta = starColumnWidth - starColumnMinWidth;
+			}
+
+			for (var index = 0; index < _columns.Count; index++)
+			{
+				ColumnDefinition column = _columns[index];
+				if (!column.Width.IsStar)
+				{
+					continue;
+				}
+
+				column.ActualWidth -= delta;
+			}
+		}
+
+		void ContractStarRowsIfNeeded(double targetHeight)
+		{
+			var request = ComputeCurrentSize();
+
+			if (request.Height <= targetHeight)
+			{
+				return;
+			}
+
+			double starRowHeight = 0;
+			double starRowMinHeight = 0;
+			double contractionSpace = 0;
+
+			for (int n = 0; n < _rows.Count; n++)
+			{
+				var row = _rows[n];
+
+				if (!row.Height.IsStar)
+				{
+					continue;
+				}
+
+				starRowHeight = row.ActualHeight;
+
+				if (row.MinimumHeight > starRowMinHeight)
+				{
+					starRowMinHeight = row.MinimumHeight;
+				}
+
+				contractionSpace += row.ActualHeight - row.MinimumHeight;
+			}
+
+			if (contractionSpace <= 0)
+			{
+				return;
+			}
+
+			double contractionNeeded = Math.Min(contractionSpace, Math.Max(request.Height - targetHeight, 0));
+			double contractionFactor = contractionNeeded / contractionSpace;
+			var delta = contractionFactor * starRowHeight;
+
+			if (starRowHeight - delta <= starRowMinHeight)
+			{
+				delta = starRowHeight - starRowMinHeight;
+			}
+
+			for (var index = 0; index < _rows.Count; index++)
+			{
+				RowDefinition row = _rows[index];
+				if (!row.Height.IsStar)
+				{
+					continue;
+				}
+
+				row.ActualHeight -= delta;
 			}
 		}
 
@@ -361,7 +491,10 @@ namespace Xamarin.Forms
 
 				double assignedHeight = GetAssignedRowHeight(child);
 				double h = double.IsPositiveInfinity(height) ? double.PositiveInfinity : assignedHeight + GetUnassignedHeight(height);
-				SizeRequest sizeRequest = child.Measure(GetAssignedColumnWidth(child), h, MeasureFlags.IncludeMargins);
+
+				var acw = GetAssignedColumnWidth(child);
+
+				SizeRequest sizeRequest = child.Measure(acw, h, MeasureFlags.IncludeMargins);
 				double requiredHeight = expandToRequest ? sizeRequest.Request.Height : sizeRequest.Minimum.Height;
 				double deltaHeight = requiredHeight - assignedHeight - (GetRowSpan(child) - 1) * RowSpacing;
 				if (deltaHeight > 0)
@@ -396,7 +529,7 @@ namespace Xamarin.Forms
 					col.ActualWidth = col.Width.Value * starColWidth;
 			}
 
-			ContractColumnsIfNeeded(width, c => c.Width.IsStar);
+			ContractStarColumnsIfNeeded(width);
 		}
 
 		void MeasureAndContractStarredRows(double width, double height, double totalStarsHeight)
@@ -423,7 +556,7 @@ namespace Xamarin.Forms
 					row.ActualHeight = row.Height.Value * starRowHeight;
 			}
 
-			ContractRowsIfNeeded(height, r => r.Height.IsStar);
+			ContractStarRowsIfNeeded(height);
 		}
 
 		double MeasuredStarredColumns(double widthConstraint, double heightConstraint)
@@ -449,6 +582,8 @@ namespace Xamarin.Forms
 							if (!child.IsVisible || GetColumnSpan(child) != colspan || !IsInColumn(child, i) || NumberOfUnsetColumnWidth(child) > 1)
 								continue;
 							double assignedWidth = GetAssignedColumnWidth(child);
+
+							// Can we start with a more reasonable constraint here? if our starred column count is greater than 1, widthConstraint _has_ to be too big
 
 							SizeRequest sizeRequest = child.Measure(widthConstraint, heightConstraint, MeasureFlags.IncludeMargins);
 							actualWidth = Math.Max(actualWidth, sizeRequest.Request.Width - assignedWidth - (GetColumnSpan(child) - 1) * ColumnSpacing);
@@ -486,8 +621,8 @@ namespace Xamarin.Forms
 
 			if (!requestSize)
 			{
-				ContractColumnsIfNeeded(width, c => c.Width.IsAuto);
-				ContractRowsIfNeeded(height, r => r.Height.IsAuto);
+				ContractAutoColumnsIfNeeded(width);
+				ContractAutoRowsIfNeeded(height);
 			}
 
 			double totalStarsHeight = 0;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -125,6 +125,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (!string.IsNullOrEmpty(hint) && setHint)
 				Control.Hint = string.Empty;
 
+			var hc = MeasureSpec.GetSize(heightConstraint);
+
 			Measure(widthConstraint, heightConstraint);
 			var result = new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), new Size());
 


### PR DESCRIPTION
### Description of Change ###

The Grid attempts to contract columns/rows to fit into the targeted layout. When doing this, it uses the same logic for contracting Star columns/rows as it does for Auto columns/rows. However, Star columns/rows are supposed to equally divide the remaining space; i.e., all 1* columns/rows should be the same size. 

The algorithm for contracting Auto columns/rows does so proportionally based on the difference between the current size and the minimum size of the contents. This is fine for Auto columns/rows, but for Stars this causes a problem. If the minimum sizes of the contents of the columns/rows vary, then the amount of contraction applied also varies; this means that the Star columns/rows can end up with different sizes.

In addition to violating the definition of Star columns/rows, this can also cause a nasty problem with multi-line text with wrapping turned on; a Label can be measured multiple times with contracting widths. If the Label is also defining the height of a containing Grid, the second measurement pass and subsequent layout will use the narrower width from the second pass and the height from the first pass. This forces the bottom of the text to be cut off. 

Anyway, these changes fix the problem. The contraction of Starred columns/rows is now done in a separate method than the Auto columns/rows; the new method respects the requirements for equal size.

### Issues Resolved ### 

- fixes #8797

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Unit tests, plus a manual test (Issue 8797 in Control Gallery)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
