### PR TITLE
[iOS] ActivityIndicator starting animation only when attached to superview

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -4,6 +4,33 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
+	public sealed class UIActivityIndicatorViewDelegate : UIActivityIndicatorView
+    {
+        ActivityIndicator _element;
+        public UIActivityIndicatorViewDelegate(RectangleF point, ActivityIndicator element) : base(point)
+            => _element = element;
+
+        public override void Draw(CGRect rect)
+        {
+            base.Draw(rect);
+            if (_element?.IsRunning == true)
+                StartAnimating();
+        }
+
+        public override void LayoutSubviews()
+        {
+            base.LayoutSubviews();
+            if (_element?.IsRunning == true)
+                StartAnimating();
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            base.Dispose(disposing);
+            _element = null;
+        }
+    }
+	
 	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, UIActivityIndicatorView>
 	{
 		[Internals.Preserve(Conditional = true)]
@@ -20,10 +47,10 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 #if __XCODE11__
 					if(Forms.IsiOS13OrNewer)
-						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium });
+						SetNativeControl(new UIActivityIndicatorViewDelegate(RectangleF.Empty, e.NewElement) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium });
 					else
 #endif
-						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
+						SetNativeControl(new UIActivityIndicatorViewDelegate(RectangleF.Empty, e.NewElement) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
 				}
 
 				UpdateColor();
@@ -50,6 +77,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateIsRunning()
 		{
+			if (Control?.Superview == null)
+                return;
+				
 			if (Element.IsRunning)
 				Control.StartAnimating();
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -1,3 +1,4 @@
+using CoreGraphics;
 using System.ComponentModel;
 using System.Drawing;
 using UIKit;


### PR DESCRIPTION
### Description of Change ###

I'm not even sure this is the best way at the moment, but it's a conversation point to move towards a resolution.

The issue comes from having an ActivityIndicator in a CarouselView or UICollectionViewFlowLayout in this case.

You can't call StartAnimating until it has been added to the top UIView (its Superview), otherwise it doesn't do anything. It seems to affect any cell based view, where the cell might not be visible, when the Activity starts its animation.

### Issues Resolved ### 

I found this issue locally, in scanning open issues, these could be related

fixes #10377
fixes #1989

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Issue:
Put an ActivityIndicator in a CarouselView (not the first one), and when you move to it, it won't be visible, even if running.

With Fix:
It now will keep showing, even if you go away and come back again.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
