### PR TITLE
[UWP] Remove Focus call when setting FormsTextBox Vertical Alignment

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 4915, "Unify the image handling", NavigationBehavior.SetApplicationRoot)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -51,12 +51,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		}
 
-		protected override void OnAppearing()
-		{
-			base.OnAppearing();
-			throw new Exception("asdf cat cat");
-		}
-
 #if UITEST
 		[Test]
 		public void LegacyImageSourceProperties()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 4915, "Unify the image handling", NavigationBehavior.SetApplicationRoot)]
+	[Issue(IssueTracker.Github, 4915, "Unify the image handling")]
 	public class Issue4915 : TestTabbedPage
 	{
 		protected override void Init()
@@ -49,6 +49,12 @@ namespace Xamarin.Forms.Controls.Issues
 			Children.Add(new Issue4915ContentPage() { Title = "page 2" });
 
 
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			throw new Exception("asdf cat cat");
 		}
 
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4915.xaml.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 4915, "Unify the image handling")]
+	[Issue(IssueTracker.Github, 4915, "Unify the image handling", NavigationBehavior.SetApplicationRoot)]
 	public class Issue4915 : TestTabbedPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -1,5 +1,6 @@
 #if UITEST
 using System;
+using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using NUnit.Framework;
@@ -499,7 +500,14 @@ namespace Xamarin.Forms.Controls
 
 			if (file != null)
 			{
-				TestContext.AddTestAttachment(file.FullName, TestContext.CurrentContext.Test.FullName);
+				try
+				{
+					TestContext.AddTestAttachment(file.FullName, TestContext.CurrentContext.Test.FullName);
+				}
+				catch(Exception exc)
+				{
+					Debug.WriteLine($"Failed to write {file?.FullName} {exc}");
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -462,6 +462,10 @@ namespace Xamarin.Forms.Controls
 
 		public void TestSetup(Type testType, bool isolate)
 		{
+#if __WINDOWS__
+
+			(_app as WinDriverApp).RestartIfAppIsClosed();
+#endif
 			if (isolate)
 			{
 				AppSetup.BeginIsolate();

--- a/Xamarin.Forms.Controls/TestCases.cs
+++ b/Xamarin.Forms.Controls/TestCases.cs
@@ -193,6 +193,16 @@ namespace Xamarin.Forms.Controls
 				FilterIssues(_filter);
 			}
 
+			public bool TryToNavigateTo(string name)
+			{
+				var issue = _issues.SingleOrDefault(x => String.Equals(x.Name, name, StringComparison.OrdinalIgnoreCase));
+				if (issue == null)
+					return false;
+
+				issue.Action();
+				return true;
+			}
+
 			public async void FilterIssues(string filter = null)
 			{
 				filter = filter?.Trim();
@@ -271,6 +281,7 @@ namespace Xamarin.Forms.Controls
 
 		public static NavigationPage GetTestCases ()
 		{
+			TestCaseScreen testCaseScreen = null;
 			var rootLayout = new StackLayout ();
 			
 			var testCasesRoot = new ContentPage {
@@ -288,9 +299,17 @@ namespace Xamarin.Forms.Controls
 				AutomationId = "SearchButton",
 				Command = new Command (() => {
 					try {
-						TestCaseScreen.PageToAction[searchBar.Text?.Trim()] ();
+						if (TestCaseScreen.PageToAction.ContainsKey(searchBar.Text?.Trim()))
+						{
+							TestCaseScreen.PageToAction[searchBar.Text?.Trim()]();
+						}
+						else if(!testCaseScreen.TryToNavigateTo(searchBar.Text?.Trim()))
+						{
+							throw new Exception($"Unable to Navigate to {searchBar.Text}");
+						}
 					} catch (Exception e) {
-						System.Diagnostics.Debug.WriteLine (e.Message);
+						System.Diagnostics.Debug.WriteLine(e.Message);
+						Console.WriteLine(e.Message);
 					}
 					 
 				})
@@ -306,7 +325,7 @@ namespace Xamarin.Forms.Controls
 			rootLayout.Children.Add (searchBar);
 			rootLayout.Children.Add (searchButton);
 
-			var testCaseScreen = new TestCaseScreen();
+			testCaseScreen = new TestCaseScreen();
 
 			rootLayout.Children.Add(CreateTrackerFilter(testCaseScreen));
 

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -56,6 +56,18 @@ namespace Xamarin.Forms.Core.UITests
 			TestServer = new WindowsTestServer(_session, this);
 		}
 
+		public void RestartIfAppIsClosed()
+		{
+			try
+			{
+				var handle = _session.CurrentWindowHandle;
+			}
+			catch
+			{
+				RestartFromCrash();
+			}
+		}
+
 		public void RestartFromCrash()
 		{
 			Init(WindowsTestBase.CreateWindowsDriver());

--- a/Xamarin.Forms.Platform.UAP.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Platform.UAP.UnitTests/ShellTests.cs
@@ -13,6 +13,12 @@ namespace Xamarin.Forms.Platform.UAP.UnitTests
 {
 	public class ShellTests : PlatformTestFixture
 	{
+		[OneTimeSetUp]
+		public void ShellTestSetup()
+		{
+			Device.SetFlags(new[] { "Shell_UWP_Experimental" });
+		}
+
 		[Test, Category("Shell")]
 		[Description("Shell doesn't crash when Flyout Behavior Initialized to Locked")]
 		public async Task FlyoutHeaderReactsToChanges()

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -194,7 +194,6 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_scrollViewer != null && UpdateVerticalAlignmentOnLoad)
 			{
 				_scrollViewer.VerticalAlignment = VerticalContentAlignment;
-				Focus(FocusState.Programmatic);
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Removes call to Focus added in #11140 that caused regression #11348

#8787 should be reopened as it is no longer resolved with this change.

### Issues Resolved ### 

- fixes #11348
- fixes #11352

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###

Entry was getting focus when a page loaded and it should not be.  This restores the original behavior.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Check issue pages 2172, 8503, 8222, and then Entry Gallery Focus page

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
