### PR TITLE
[UWP] Fixes 8787 Entry text not visible until focus or window resize

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Helpers/UITestHelper.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Helpers/UITestHelper.cs
@@ -11,6 +11,15 @@ namespace Xamarin.Forms.Controls.Issues
 {
 	public static class UITestHelper
 	{
+		public static bool IsWindowClosedException(this Exception exc)
+		{
+#if __WINDOWS__
+			return exc.Message?.Contains("Currently selected window has been closed") ?? false;
+#else
+			return false;
+#endif
+		}
+
 		public static string ReadText(this AppResult result) =>
 			result.Text ?? result.Description;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11259.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11259.cs
@@ -1,0 +1,17 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11259, "[Bug] UWP ScrollView Entry's text is blank until a tap on it", PlatformAffected.UWP)]
+	public partial class Issue11259
+	{
+		public Issue11259()
+		{
+#if APP
+			InitializeComponent();			
+#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11259.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11259.xaml
@@ -1,0 +1,510 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11259"
+    mc:Ignorable="d">
+
+    <Grid
+        HorizontalOptions="FillAndExpand"
+        VerticalOptions="FillAndExpand">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <ContentView
+            Grid.Row="0"
+            HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <Label
+                Text="Text should be visible in all entries on load.  If missing test fails."
+                FontSize="Header"
+                Margin="0,50,0,0"
+                HorizontalTextAlignment="Center" />
+        </ContentView>
+
+        <ScrollView
+            Grid.Row="1"
+            HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <StackLayout
+                Spacing="10"
+                Padding="10,0,10,0">
+                <Entry
+                    Text="Test 1"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 2"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 3"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 5"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 6"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 7"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 8"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 9"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 10"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 11"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 12"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 13"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 14"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 15"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 16"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 17"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 18"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 19"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 20"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 21"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 22"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 23"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 24"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 25"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 26"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 27"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 28"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 29"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 30"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 31"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 32"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 33"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 34"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 35"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 36"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 37"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 38"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 39"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 40"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 41"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 42"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 43"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 44"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 45"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 46"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 47"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 48"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 49"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 50"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 51"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 52"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 53"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 54"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 55"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 56"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 57"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 58"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 59"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+                <Entry
+                    Text="Test 60"
+                    HeightRequest="50" />
+                <BoxView
+                    BackgroundColor="Red"
+                    HeightRequest="25"
+                    HorizontalOptions="FillAndExpand"
+                    VerticalOptions="End" />
+            </StackLayout>
+        </ScrollView>
+    </Grid>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -461,12 +461,20 @@ namespace Xamarin.Forms.Controls
 			get { return _app.TestServer; }
 		}
 
+#if __WINDOWS__
+		public void RestartIfAppIsClosed()
+		{
+			(_app as WinDriverApp).RestartIfAppIsClosed();
+		}
+#endif
+
 		public void TestSetup(Type testType, bool isolate)
 		{
-#if __WINDOWS__
 
-			(_app as WinDriverApp).RestartIfAppIsClosed();
+#if __WINDOWS__
+			RestartIfAppIsClosed();
 #endif
+
 			if (isolate)
 			{
 				AppSetup.BeginIsolate();

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -170,7 +170,9 @@ namespace Xamarin.Forms.Controls
 
 			int maxAttempts = 2;
 			int attempts = 0;
+#if __WINDOWS__
 			bool attemptOneRestart = false;
+#endif
 			while (attempts < maxAttempts)
 			{
 				attempts += 1;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -3,6 +3,7 @@ using System.Reflection;
 using Xamarin.Forms.CustomAttributes;
 using IOPath = System.IO.Path;
 using NUnit.Framework.Interfaces;
+using Xamarin.Forms.Controls.Issues;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -169,7 +170,7 @@ namespace Xamarin.Forms.Controls
 
 			int maxAttempts = 2;
 			int attempts = 0;
-
+			bool attemptOneRestart = false;
 			while (attempts < maxAttempts)
 			{
 				attempts += 1;
@@ -197,6 +198,7 @@ namespace Xamarin.Forms.Controls
 					// So we're just going to use the 'Reset' method to bounce the app to the opening screen
 					// and then fall back to the old manual navigation
 					WindowsTestBase.Reset();
+					app.RestartIfAppIsClosed();
 #endif
 				}
 				catch (Exception ex)
@@ -220,6 +222,15 @@ namespace Xamarin.Forms.Controls
 
 					return;
 				}
+#if __WINDOWS__
+				catch (Exception we)
+				when (we.IsWindowClosedException() && !attemptOneRestart)
+				{
+					attemptOneRestart = true;
+					attempts--;
+					app.RestartIfAppIsClosed();
+				}
+#endif
 				catch (Exception ex)
 				{
 					var debugMessage = $"Both navigation methods failed. {ex}";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11106.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11259.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />
@@ -1680,7 +1681,7 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11113.xaml">
-     <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11120.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
@@ -2150,6 +2151,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9279.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11259.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
@@ -78,7 +78,7 @@ namespace Xamarin.Forms.Core.UITests
 
 					Debug.WriteLine(debugMessage);
 					Console.WriteLine(debugMessage);
-					App.AttachScreenshotToTestContext("NavigateToGallery Failed");
+					App.AttachScreenshotToTestContext(TestContext.CurrentContext?.Test?.FullName ?? "NavigateToGalleryFailed");
 
 					if (attempts < maxAttempts)
 					{

--- a/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/BaseTestFixture.cs
@@ -78,6 +78,7 @@ namespace Xamarin.Forms.Core.UITests
 
 					Debug.WriteLine(debugMessage);
 					Console.WriteLine(debugMessage);
+					App.AttachScreenshotToTestContext("NavigateToGallery Failed");
 
 					if (attempts < maxAttempts)
 					{
@@ -88,7 +89,6 @@ namespace Xamarin.Forms.Core.UITests
 					}
 					else
 					{
-						App.AttachScreenshotToTestContext("NavigateToGallery Failed");
 						// But if it's still not working after [maxAttempts], we've got assume this is a legit
 						// problem that restarting won't fix
 						throw;

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -15,6 +15,13 @@ namespace Xamarin.UITest
 {
 	internal static class AppExtensions
 	{
+#if __WINDOWS__
+		public static void RestartIfAppIsClosed(this IApp app)
+		{
+			((ScreenshotConditionalApp)app).RestartIfAppIsClosed();
+		}
+#endif
+
 		public static void AttachScreenshotToTestContext(this IApp app, string title)
 		{
 			((ScreenshotConditionalApp)app).AttachScreenshotToTestContext(title);

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -15,6 +15,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
 using OpenQA.Selenium.Remote;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
 using Xamarin.UITest.Queries.Tokens;
@@ -329,7 +330,7 @@ namespace Xamarin.Forms.Core.UITests
 				return file;
 			}
 			catch (OpenQA.Selenium.WebDriverException we)
-			when (we.Message.Contains("Currently selected window has been closed"))
+			when (we.IsWindowClosedException())
 			{
 				return null;
 			}

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -5,6 +5,7 @@ using OpenQA.Selenium;
 using OpenQA.Selenium.Appium;
 using OpenQA.Selenium.Appium.Windows;
 using OpenQA.Selenium.Interactions;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.UITest;
 
 namespace Xamarin.Forms.Core.UITests
@@ -37,7 +38,7 @@ namespace Xamarin.Forms.Core.UITests
 
 		internal static void HandleAppClosed(Exception ex)
 		{
-			if (ex is InvalidOperationException && ex.Message == "Currently selected window has been closed")
+			if (ex.IsWindowClosedException())
 			{
 				Session = null;
 			}

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestServer.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestServer.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using OpenQA.Selenium.Appium.Windows;
+using Xamarin.Forms.Controls.Issues;
 using Xamarin.UITest;
 
 namespace Xamarin.Forms.Core.UITests
@@ -34,7 +35,7 @@ namespace Xamarin.Forms.Core.UITests
 					return _session.CurrentWindowHandle;
 				}
 				catch (OpenQA.Selenium.WebDriverException we)
-				when (we.Message.Contains("Currently selected window has been closed"))
+				when (we.IsWindowClosedException())
 				{
 					_winDriverApp.RestartFromCrash();
 				}

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -65,15 +65,17 @@ namespace Xamarin.Forms.Platform.UWP
 			SelectionChanged += OnSelectionChanged;
 			IsEnabledChanged += OnIsEnabledChanged;
 			Loaded += OnLoaded;
+			SizeChanged += OnSizeChanged;
 			RegisterPropertyChangedCallback(VerticalContentAlignmentProperty, OnVerticalContentAlignmentChanged);
 		}
+
 
 		void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
 			UpdateEnabled();
 		}
 
-		public bool UpdateVerticalAlignmentOnLoad { get; set; } = true;
+		internal bool UpdateVerticalAlignmentOnLoad { get; set; } = true;
 
 		public bool ClearButtonVisible
 		{
@@ -176,12 +178,16 @@ namespace Xamarin.Forms.Platform.UWP
 			_scrollViewer= (Windows.UI.Xaml.Controls.ScrollViewer)GetTemplateChild("ContentElement");
 		}
 
+		void OnSizeChanged(object sender, SizeChangedEventArgs e)
+		{
+			UpdateTemplateScrollViewerVerticalAlignment();
+		}
+
 		void OnLoaded(object sender, RoutedEventArgs e)
 		{
 			// Set the vertical alignment on load, because setting it in the FormsTextBoxStyle causes text display issues
 			// But the editor has display issues if you do set the vertical alignment here, so the flag allows renderer using
 			// the text box to control this
-			UpdateTemplateScrollViewerVerticalAlignment();
 		}
 
 		void OnVerticalContentAlignmentChanged(DependencyObject sender, DependencyProperty dp)

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -64,11 +64,9 @@ namespace Xamarin.Forms.Platform.UWP
 			TextChanged += OnTextChanged;
 			SelectionChanged += OnSelectionChanged;
 			IsEnabledChanged += OnIsEnabledChanged;
-			Loaded += OnLoaded;
 			SizeChanged += OnSizeChanged;
 			RegisterPropertyChangedCallback(VerticalContentAlignmentProperty, OnVerticalContentAlignmentChanged);
 		}
-
 
 		void OnIsEnabledChanged(object sender, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
 		{
@@ -183,13 +181,6 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateTemplateScrollViewerVerticalAlignment();
 		}
 
-		void OnLoaded(object sender, RoutedEventArgs e)
-		{
-			// Set the vertical alignment on load, because setting it in the FormsTextBoxStyle causes text display issues
-			// But the editor has display issues if you do set the vertical alignment here, so the flag allows renderer using
-			// the text box to control this
-		}
-
 		void OnVerticalContentAlignmentChanged(DependencyObject sender, DependencyProperty dp)
 		{
 			UpdateTemplateScrollViewerVerticalAlignment();
@@ -197,6 +188,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateTemplateScrollViewerVerticalAlignment()
 		{
+			// This is used to set the vertical alignment after the text box has a size, setting it before causes rendering issues.
+			// But the editor has display issues if you do set the vertical alignment here, so the flag allows renderer using
+			// the text box to control this
 			if (_scrollViewer != null && UpdateVerticalAlignmentOnLoad)
 			{
 				_scrollViewer.VerticalAlignment = VerticalContentAlignment;

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -149,7 +149,7 @@ namespace Xamarin.Forms.Platform.UWP
 				// Without this some layouts may end up with improper sizes, however their children
 				// will position correctly
 
-				// Put the packager load call back in the Loaded event to resolve text visabilty issues
+				// Put the packager load call back in the Loaded event to resolve text visibility issues
 				// with FormsTextBox
 				Loaded += (sender, args) =>
 				{

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -144,18 +144,16 @@ namespace Xamarin.Forms.Platform.UWP
 					Tracker = new VisualElementTracker<TElement, TNativeElement>();
 				}
 
-				// Old Comment
 				// Disabled until reason for crashes with unhandled exceptions is discovered
 				// Without this some layouts may end up with improper sizes, however their children
 				// will position correctly
-
-				// Put the packager load call back in the Loaded event to resolve text visibility issues
-				// with FormsTextBox
+				// Consider using Loading vs Loaded if this is added back, calling in Loaded appears to be to late in the layout cycle
+				// and may cause issues
 				//Loaded += (sender, args) =>
-				{
-					if (Packager != null)
-						Packager.Load();
-				};
+				//{
+				if (Packager != null)
+					Packager.Load();
+				//};
 			}
 
 			OnElementChanged(new ElementChangedEventArgs<TElement>(oldElement, Element));

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -144,13 +144,18 @@ namespace Xamarin.Forms.Platform.UWP
 					Tracker = new VisualElementTracker<TElement, TNativeElement>();
 				}
 
+				// Old Comment
 				// Disabled until reason for crashes with unhandled exceptions is discovered
 				// Without this some layouts may end up with improper sizes, however their children
 				// will position correctly
-				//Loaded += (sender, args) => {
-				if (Packager != null)
-					Packager.Load();
-				//};
+
+				// Put the packager load call back in the Loaded event to resolve text visabilty issues
+				// with FormsTextBox
+				Loaded += (sender, args) =>
+				{
+					if (Packager != null)
+						Packager.Load();
+				};
 			}
 
 			OnElementChanged(new ElementChangedEventArgs<TElement>(oldElement, Element));

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -151,7 +151,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				// Put the packager load call back in the Loaded event to resolve text visibility issues
 				// with FormsTextBox
-				Loaded += (sender, args) =>
+				//Loaded += (sender, args) =>
 				{
 					if (Packager != null)
 						Packager.Load();


### PR DESCRIPTION
### Description of Change ###

Updates VisualElementRenderer to delay calling Packager.Load until the Loaded event fires.

PR #11350 should be merged first

I'm not sure I completely understand the layout pipeline of the UWP backend, so I'm not 100% sure of all the possible effects of this change could have.  It should be noted that the code to call Packager.Load in the Loaded event was previously commented out for causing an unhandled exception.  I have not experienced any exceptions during testing, but I can find no other reference to the issue other than the comment left in the code.  That comment pre-dates the import into GitHub, so it's rather old at this point.

My working theory is that the text not showing initially sometimes in the FormsTextBox is a timing issue of when the element is added to the visual tree when there are many layouts nested.  What I believe happens with this change is the elements are added later in the process when Packager.Load is executed in the Loaded event vs just called in SetElement method of VisualElementRenderer.

Fair warning, my theory could be totally wrong too!

Other similar issues where the FormsTextBox is not as deeply nested in layouts seem to work file with the changes in #11140 (minus the Focus() call) #8503 as an example

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8787 
- fixes #11259

### API Changes ###
 
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###

Ensures Entry text is visible immediately 

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Issue page 8787 and full UI tests

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
