### PR TITLE
[C] Round Stepper.Value

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StepperUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StepperUnitTests.cs
@@ -183,15 +183,67 @@ namespace Xamarin.Forms.Core.UnitTests
 			var stepper = new Stepper(0, 10, 0, 0.5);
 
 			for (int i = steps; i < steps; i++)
-			{
 				stepper.Value += stepper.Increment;
-			}
+			
 			for (int i = steps; i < steps; i--)
-			{
 				stepper.Value += stepper.Increment;
-			}
 
 			Assert.AreEqual(0.0, stepper.Value);
+		}
+
+		[TestCase(100, .5, 0, 100)]
+		[TestCase(100, .3, 0, 100)]
+		[TestCase(100, .03, 0, 100)]
+		[TestCase(100, .003, 0, 100)]
+		[TestCase(100, .0003, 0, 100)]
+		[TestCase(100, .0000003, 0, 100)]
+		[TestCase(100, .0000000003, 0, 100)]
+		[TestCase(100, .0000000000003, 0, 100)]
+		[TestCase(100, .5, -10000, 10000)]
+		[TestCase(100, .3, -10000, 10000)]
+		[TestCase(100, .03, -10000, 10000)]
+		[TestCase(100, .003, -10000, 10000)]
+		[TestCase(100, .0003, -10000, 10000)]
+		[TestCase(100, .0000003, -10000, 10000)]
+		[TestCase(100, .0000000003, -10000, 10000)]
+		[TestCase(100, .0000000000003, -10000, 10000)]
+		[TestCase(100, .00003456, -10000, 10000)] //we support 4 significant digits for the increment. no less, no more
+		//https://github.com/xamarin/Xamarin.Forms/issues/5168
+		public void SmallIncrements(int steps, double increment, double min, double max)
+		{
+			var stepper = new Stepper(min, max, 0, increment);
+			int digits = Math.Max(1, Math.Min(15, (int)(-Math.Log10((double)increment) + 4))); //logic copied from the Stepper code
+
+			Assert.AreEqual(0.0, stepper.Value);
+
+			for (var i = 0; i < steps; i++)
+				stepper.Value += stepper.Increment;
+
+			Assert.AreEqual(Math.Round(stepper.Increment * steps, digits), stepper.Value);
+
+			for (var i = 0; i < steps; i++)
+				stepper.Value -= stepper.Increment;
+
+			Assert.AreEqual(0.0, stepper.Value);
+		}
+
+		[Test]
+		//https://github.com/xamarin/Xamarin.Forms/issues/10032
+		public void InitialValue()
+		{
+			var increment = .1;
+			var stepper = new Stepper(0, 10, 4.99, increment);
+
+			Assert.AreEqual(4.99, stepper.Value);
+
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(5.09, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(5.19, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(5.29, stepper.Value);
+			stepper.Value += stepper.Increment;
+			Assert.AreEqual(5.39, stepper.Value);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -27,14 +27,18 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay,
 			coerceValue: (bindable, value) => {
 				var stepper = (Stepper)bindable;
-				return ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
+				return Math.Round(((double)value), stepper.digits).Clamp(stepper.Minimum, stepper.Maximum);
 			},
 			propertyChanged: (bindable, oldValue, newValue) => {
 				var stepper = (Stepper)bindable;
 				stepper.ValueChanged?.Invoke(stepper, new ValueChangedEventArgs((double)oldValue, (double)newValue));
 			});
 
-		public static readonly BindableProperty IncrementProperty = BindableProperty.Create(nameof(Increment), typeof(double), typeof(Stepper), 1.0);
+		int digits = 4;
+		//'-log10(increment) + 4' as rounding digits gives us 4 significant decimal digits after the most significant one.
+		//If your increment uses more than 4 significant digits, you're holding it wrong.
+		public static readonly BindableProperty IncrementProperty = BindableProperty.Create(nameof(Increment), typeof(double), typeof(Stepper), 1.0,
+			propertyChanged: (b, o, n) => { ((Stepper)b).digits = (int)(-Math.Log10((double)n) + 4).Clamp(1, 15); });
 
 		readonly Lazy<PlatformConfigurationRegistry<Stepper>> _platformConfigurationRegistry;
 
@@ -94,6 +98,5 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		[Obsolete("deprecated without replacement in 4.8.0")]
 		public static readonly BindableProperty StepperPositionProperty = BindableProperty.Create(nameof(StepperPosition), typeof(int), typeof(Stepper), 0);
-
 	}
 }

--- a/Xamarin.Forms.Core/Stepper.cs
+++ b/Xamarin.Forms.Core/Stepper.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
 
@@ -7,57 +8,42 @@ namespace Xamarin.Forms
 	[RenderWith(typeof(_StepperRenderer))]
 	public class Stepper : View, IElementConfiguration<Stepper>
 	{
-		public static readonly BindableProperty MaximumProperty = BindableProperty.Create("Maximum", typeof(double), typeof(Stepper), 100.0, validateValue: (bindable, value) =>
-		{
-			var stepper = (Stepper)bindable;
-			return (double)value > stepper.Minimum;
-		}, coerceValue: (bindable, value) =>
-		{
-			var stepper = (Stepper)bindable;
-			stepper.Value = stepper.Value.Clamp(stepper.Minimum, (double)value);
-			return value;
-		});
+		public static readonly BindableProperty MaximumProperty = BindableProperty.Create(nameof(Maximum), typeof(double), typeof(Stepper), 100.0,
+			validateValue: (bindable, value) => (double)value > ((Stepper)bindable).Minimum,
+			coerceValue: (bindable, value) => {
+				var stepper = (Stepper)bindable;
+				stepper.Value = stepper.Value.Clamp(stepper.Minimum, (double)value);
+				return value;
+			});
 
-		public static readonly BindableProperty MinimumProperty = BindableProperty.Create("Minimum", typeof(double), typeof(Stepper), 0.0, validateValue: (bindable, value) =>
-		{
-			var stepper = (Stepper)bindable;
-			return (double)value < stepper.Maximum;
-		}, coerceValue: (bindable, value) =>
-		{
-			var stepper = (Stepper)bindable;
-			stepper.Value = stepper.Value.Clamp((double)value, stepper.Maximum);
-			return value;
-		});
+		public static readonly BindableProperty MinimumProperty = BindableProperty.Create(nameof(Minimum), typeof(double), typeof(Stepper), 0.0,
+			validateValue: (bindable, value) => (double)value < ((Stepper)bindable).Maximum,
+			coerceValue: (bindable, value) => {
+				var stepper = (Stepper)bindable;
+				stepper.Value = stepper.Value.Clamp((double)value, stepper.Maximum);
+				return value;
+			});
 
-		public static readonly BindableProperty ValueProperty = BindableProperty.Create("Value", typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay, coerceValue: (bindable, value) =>
-		{
-			var stepper = (Stepper)bindable;
-			stepper.StepperPosition = Convert.ToInt32(((double)value - stepper.Minimum) / stepper.Increment);
-			var stepVal = stepper.Minimum + (stepper.StepperPosition * stepper.Increment);
-			return stepVal.Clamp(stepper.Minimum, stepper.Maximum);
-		}, propertyChanged: (bindable, oldValue, newValue) =>
-		{
-			var stepper = (Stepper)bindable;
-			EventHandler<ValueChangedEventArgs> eh = stepper.ValueChanged;
-			if (eh != null)
-				eh(stepper, new ValueChangedEventArgs((double)oldValue, (double)newValue));
-		});
+		public static readonly BindableProperty ValueProperty = BindableProperty.Create(nameof(Value), typeof(double), typeof(Stepper), 0.0, BindingMode.TwoWay,
+			coerceValue: (bindable, value) => {
+				var stepper = (Stepper)bindable;
+				return ((double)value).Clamp(stepper.Minimum, stepper.Maximum);
+			},
+			propertyChanged: (bindable, oldValue, newValue) => {
+				var stepper = (Stepper)bindable;
+				stepper.ValueChanged?.Invoke(stepper, new ValueChangedEventArgs((double)oldValue, (double)newValue));
+			});
 
 		public static readonly BindableProperty IncrementProperty = BindableProperty.Create(nameof(Increment), typeof(double), typeof(Stepper), 1.0);
 
-		public static readonly BindableProperty StepperPositionProperty = BindableProperty.Create(nameof(StepperPosition), typeof(int), typeof(Stepper), 0);
-
 		readonly Lazy<PlatformConfigurationRegistry<Stepper>> _platformConfigurationRegistry;
 
-		public Stepper()
-		{
-			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Stepper>>(() => new PlatformConfigurationRegistry<Stepper>(this));
-		}
+		public Stepper() => _platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<Stepper>>(() => new PlatformConfigurationRegistry<Stepper>(this));
 
 		public Stepper(double min, double max, double val, double increment) : this()
 		{
 			if (min >= max)
-				throw new ArgumentOutOfRangeException("min");
+				throw new ArgumentOutOfRangeException(nameof(min));
 			if (max > Minimum)
 			{
 				Maximum = max;
@@ -69,46 +55,45 @@ namespace Xamarin.Forms
 				Maximum = max;
 			}
 
-			StepperPosition = (int)((val - min) / increment);
 			Increment = increment;
 			Value = val.Clamp(min, max);
 		}
 
 		public double Increment
 		{
-			get { return (double)GetValue(IncrementProperty); }
-			set { SetValue(IncrementProperty, value); }
+			get => (double)GetValue(IncrementProperty);
+			set => SetValue(IncrementProperty, value);
 		}
 
 		public double Maximum
 		{
-			get { return (double)GetValue(MaximumProperty); }
-			set { SetValue(MaximumProperty, value); }
+			get => (double)GetValue(MaximumProperty);
+			set => SetValue(MaximumProperty, value);
 		}
 
 		public double Minimum
 		{
-			get { return (double)GetValue(MinimumProperty); }
-			set { SetValue(MinimumProperty, value); }
+			get => (double)GetValue(MinimumProperty);
+			set => SetValue(MinimumProperty, value);
 		}
 
 		public double Value
 		{
-			get { return (double)GetValue(ValueProperty); }
-			set { SetValue(ValueProperty, value); }
-		}
-
-		public int StepperPosition
-		{
-			get { return (int)GetValue(StepperPositionProperty); }
-			set { SetValue(StepperPositionProperty, value); }
+			get => (double)GetValue(ValueProperty);
+			set => SetValue(ValueProperty, value);
 		}
 
 		public event EventHandler<ValueChangedEventArgs> ValueChanged;
 
-		public IPlatformElementConfiguration<T, Stepper> On<T>() where T : IConfigPlatform
-		{
-			return _platformConfigurationRegistry.Value.On<T>();
-		}
+		public IPlatformElementConfiguration<T, Stepper> On<T>() where T : IConfigPlatform => _platformConfigurationRegistry.Value.On<T>();
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("deprecated without replacement in 4.8.0")]
+		public int StepperPosition { get; set; }
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		[Obsolete("deprecated without replacement in 4.8.0")]
+		public static readonly BindableProperty StepperPositionProperty = BindableProperty.Create(nameof(StepperPosition), typeof(int), typeof(Stepper), 0);
+
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Round stepper values so we can pretend they're not FP numbers but obey
the decimal logic. Rounding happen at n+4 position, n being the position
of the most significant digit of the increment. That gives up to 4
significant digit to the increment.

- reverts #7383
- reverts #10941

### Issues Resolved ### 

- fixes #5168 (for good)
- fixes #10032
- fixes #11169

### API Changes ###
Obsoleted:
 - `double Stepper.StepperPosition {get; set;}`
 - `BindableProperty Stepper.StepperPositionProperty;`

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

StepperPosition is no-op

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
