### PR TITLE
[iOS] Fix issue with duplicated played to end observer in MediaElement

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/MediaElementRenderer.cs
@@ -24,9 +24,7 @@ namespace Xamarin.Forms.Platform.iOS
 		[Internals.Preserve(Conditional = true)]
 		public MediaElementRenderer()
 		{
-			Xamarin.Forms.MediaElement.VerifyMediaElementFlagEnabled(nameof(MediaElementRenderer));
-
-			_playedToEndObserver = NSNotificationCenter.DefaultCenter.AddObserver(AVPlayerItem.DidPlayToEndTimeNotification, PlayedToEnd);
+			MediaElement.VerifyMediaElementFlagEnabled(nameof(MediaElementRenderer));
 		}
 
 		void SetKeepScreenOn(bool value)


### PR DESCRIPTION
# Description of Change ###
Fix issue with duplicated played to end observer in `MediaElement` on **iOS**.

### Issues Resolved ### 

- fixes #11315 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the MediaElement Gallery. Reproduce the video and move the time to the end. MediaEnded must be invoked only one time.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
