### PR TITLE
Export animationControllerForOperation to fix hot restart

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -538,6 +538,16 @@ namespace Xamarin.Forms.Platform.iOS
 				_self = renderer;
 			}
 
+			// This is currently working around a Mono Interpreter bug
+			// if you remove this code please verify that hot restart still works
+			// https://github.com/xamarin/Xamarin.Forms/issues/10519
+			[Export("navigationController:animationControllerForOperation:fromViewController:toViewController:")]
+			[Foundation.Preserve(Conditional = true)]
+			public new IUIViewControllerAnimatedTransitioning GetAnimationControllerForOperation(UINavigationController navigationController, UINavigationControllerOperation operation, UIViewController fromViewController, UIViewController toViewController)
+			{
+				return null;
+			}
+
 			public override void DidShowViewController(UINavigationController navigationController, [Transient] UIViewController viewController, bool animated)
 			{
 				var tasks = _self._completionTasks;


### PR DESCRIPTION
### Description of Change ###

The addition of the following override
https://github.com/xamarin/Xamarin.Forms/pull/9237/files#diff-8222d0783ad0aa5666a6d9d008a474b6R109

Is triggering a mono interpreter bug that causes hot restart to crash when navigating on shell

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #10519

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- download the nuget, create a xamarin forms shell template, install this nuget, verify hot restart works

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
