### PR TITLE
[iOS] Fix controls added to Frame multiple times when container is recycled on ListView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36802.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36802.cs
@@ -37,7 +37,7 @@ namespace Xamarin.Forms.Controls.Issues
 
         protected override void Init()
         {
-            var label = new Label { Text = Instructions };
+            var label = new Label { Text = Instructions, AutomationId = "TestReady" };
             grouped = new ObservableCollection<GroupedItem>();
             lstView = new ListView(ListViewCachingStrategy.RecycleElement) {
                 IsGroupingEnabled = true,
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
         public void Bugzilla36802Test()
         {
+			RunningApp.WaitForElement("TestReady");
             RunningApp.Screenshot("AccessoryView partially hidden test");
         }
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var label = new Label { Text = Instructions };
+			var label = new Label { Text = Instructions, AutomationId = "TestReady" };
 			grouped = new ObservableCollection<GroupedItem>();
 			lstView = new ListView()
 			{
@@ -87,6 +87,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Bugzilla53834Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("incorrect row heights test");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var label = new Label { Text = Instructions, AutomationId = "TestReady" };
+			var label = new Label { Text = Instructions, };
 			grouped = new ObservableCollection<GroupedItem>();
 			lstView = new ListView()
 			{
@@ -57,6 +57,7 @@ namespace Xamarin.Forms.Controls.Issues
 				ItemTemplate = new DataTemplate(typeof(MyViewCell)),
 				GroupHeaderTemplate = new DataTemplate(typeof(MyHeaderViewCell)),
 				ItemsSource = grouped,
+				AutomationId = "TestReady"
 			};
 
 			var grp1 = new GroupedItem() { LongName = "Group 1", ShortName = "1" };

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
@@ -29,7 +29,8 @@ namespace Xamarin.Forms.Controls.Issues
 				Text = "Button",
 				HorizontalOptions = LayoutOptions.End,
 				BorderColor = Color.AliceBlue,
-				BorderWidth = 5
+				BorderWidth = 5,
+				AutomationId = "TestReady"
 			}, 0, 0);
 
 			grid.Children.Add(new Button
@@ -102,6 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue1436Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 1436");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
@@ -28,7 +28,8 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.Center,
 				TextColor = Color.White,
 				VerticalOptions = LayoutOptions.Center,
-				WidthRequest = 64
+				WidthRequest = 64,
+				AutomationId = "TestReady"
 			};
 
 			button.On<Android>().SetUseDefaultPadding(true).SetUseDefaultShadow(true);
@@ -60,6 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue1909Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 1909");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = new StackLayout
 			{
+				AutomationId = "TestReady",
 				Children = {
 					list,
 					listTransparent,
@@ -121,6 +122,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue2775Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 2775");
 			RunningApp.Screenshot("I see the Label");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
@@ -233,16 +233,34 @@ namespace Xamarin.Forms.Controls.Issues
 			for (int i = 1; i < 5; i++)
 			{
 				RunningApp.Tap($"TestSpan{i}");
-				RunningApp.TapCoordinates(target.X + 5, target.Y + 5);
+
+				// These tap retries work around a Tap Coordinate bug
+				// with Xamarin.UITest >= 3.0.7
+				int tapAttempts = 0;
+				do
+				{
+					RunningApp.TapCoordinates(target.X + 5, target.Y + 5);
+					if (tapAttempts == 4)
+						RunningApp.WaitForElement($"{kGesture1}{i}");
+
+					tapAttempts++;
+				} while (RunningApp.Query($"{kGesture1}{i}").Length == 0);
+
+				tapAttempts = 0;
+
+				do
+				{
 #if __WINDOWS__
-				RunningApp.TapCoordinates(target.X + target.Width - 10, target.Y + 2);
+					RunningApp.TapCoordinates(target.X + target.Width - 10, target.Y + 2);
 #else
-				RunningApp.TapCoordinates(target.X + target.CenterX, target.Y + 2);
+					RunningApp.TapCoordinates(target.X + target.CenterX, target.Y + 2);
 #endif
+					if (tapAttempts == 4)
+						RunningApp.WaitForElement($"{kGesture1}{i}");
 
+					tapAttempts++;
 
-				RunningApp.WaitForElement($"{kGesture1}{i}");
-				RunningApp.WaitForElement($"{kGesture2}{i}");
+				} while (RunningApp.Query($"{kGesture2}{i}").Length == 0);
 			}
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue342.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue342.cs
@@ -53,6 +53,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = new StackLayout
 			{
+				AutomationId = "TestReady",
 				Children = {
 					new Label {
 						Text = "Delayed image"
@@ -81,6 +82,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue342DelayedLoadTestsImageLoads()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("Should not crash");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label { Text = "You should see a blue circle" };
 			var box = new BoxView
 			{
+				AutomationId = "TestReady",
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center,
 				BackgroundColor = Color.Blue,
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue3884Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I see a blue circle");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4879.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4879.cs
@@ -31,7 +31,8 @@ namespace Xamarin.Forms.Controls.Issues
 					VerticalOptions = LayoutOptions.End,
 					ImageSource = "coffee.png",
 					Padding = new Thickness(10),
-					BackgroundColor = Color.Green
+					BackgroundColor = Color.Green,
+					AutomationId = "TestReady"
 				};
 				// Add BorderWidth to ImageButtons to match border of Button and allow for easier size comparisons
 				ImageButton ib1 = new ImageButton
@@ -79,6 +80,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue4879Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 4879 - All buttons/images should be the same size.");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5830.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var label = new Label { Text = Instructions };
+			var label = new Label { Text = Instructions, AutomationId = "TestReady" };
 			lstView = new ListView(ListViewCachingStrategy.RecycleElement)
 			{
 				ItemTemplate = new DataTemplate(typeof(ExtendedEntryCell)),
@@ -49,6 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
         public void Issue5830Test()
         {
+			RunningApp.WaitForElement("TestReady");
             RunningApp.Screenshot("EntryTableViewCell Test with custom Text and TextColor");
         }
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5831.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5831.cs
@@ -69,10 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 		}
 
-#if UITEST
-#if !(__ANDROID__ || __IOS__)
-		[Ignore("Shell test is only supported on Android and iOS")]
-#endif
+#if UITEST && __SHELL__
 		[Test]
 		public void CollectionViewRenderingWhenLeavingAndReturningViaFlyout()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
@@ -28,7 +28,8 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label
 			{
 				Text = "Click the button below to animate the BoxView using individual ScaleXTo and ScaleYTo extension methods.",
-				TextColor = Color.Black
+				TextColor = Color.Black,
+				AutomationId = "TestReady"
 			};
 
 			var button = new Button
@@ -74,6 +75,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public async Task AnimateScaleOfBoxView()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("Small blue box");
 
 			// Check the box and button elements.

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8766.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8766.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			Visual = VisualMarker.Material;
 
-			var layout = new StackLayout();
+			var layout = new StackLayout() { AutomationId = "TestReady" };
 
 			var instructions = new Label { Text = "If the Entry and Button above the CollectionView and the Entry and Button inside the CollectionView, should both be using the Material Visual. If so, this test has passed."};
 			layout.Children.Add(instructions);
@@ -47,6 +47,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void VisualPropagatesToEmptyView()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("CollectionViewWithEmptyView");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue968.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue968.cs
@@ -23,7 +23,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var layout = new StackLayout {
 				Padding = new Thickness (20),
-				BackgroundColor = Color.Gray
+				BackgroundColor = Color.Gray,
+				AutomationId = "TestReady"
 			};
 
 			layout.Children.Add (new BoxView {
@@ -45,6 +46,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[UiTest (typeof(StackLayout))]
 		public void Issue968TestsRotationRelayoutIssue ()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.SetOrientationLandscape ();
 			RunningApp.Screenshot ("Rotated to Landscape");
 			RunningApp.WaitForElement (q => q.Marked ("You should see me after rotating"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
@@ -158,7 +158,8 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(TableViewTitle);
 			RunningApp.WaitForElement(TableViewId);
-			RunningApp.ScrollDownTo("entry30", TableViewId, ScrollStrategy.Gesture);
+
+			RunningApp.ScrollDownTo("entry30", TableViewId, ScrollStrategy.Gesture, swipePercentage: 0.20, timeout: TimeSpan.FromMinutes(1));
 		}
 
 		[NUnit.Framework.Category(UITestCategories.ListView)]
@@ -167,7 +168,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(ListViewTitle);
 			RunningApp.WaitForElement(ListViewId);
-			RunningApp.ScrollDownTo("30 Entry", ListViewId, ScrollStrategy.Gesture);
+			RunningApp.ScrollDownTo("30 Entry", ListViewId, ScrollStrategy.Gesture, swipePercentage: 0.20, timeout: TimeSpan.FromMinutes(1));
 		}
 
 #if __ANDROID__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Controls.Issues
 		
 		const string EntrySuccess = "EntrySuccess";
 		const string ResetKeyboard = "Hide Keyboard";
+		const string ResetKeyboard2 = "Hide Keyboard 2";
 		const string Reset = "Reset";
 
 		const string ToggleSafeArea = "ToggleSafeArea";
@@ -286,7 +287,8 @@ namespace Xamarin.Forms.Controls.Issues
 							},
 							new Button()
 							{
-								Text = ResetKeyboard
+								Text = ResetKeyboard,
+								AutomationId = ResetKeyboard2
 
 							},
 							new Button()
@@ -346,7 +348,7 @@ namespace Xamarin.Forms.Controls.Issues
 					Assert.LessOrEqual(entry[0].Rect.Y, originalPosition.Y);
 			}
 
-			RunningApp.Tap(ResetKeyboard);
+			RunningApp.Tap(ResetKeyboard2);
 			var finalPosition = RunningApp.WaitForElement(EntrySuccess)[0].Rect;
 
 			// verify that label has returned to about the same spot

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -8,7 +8,6 @@ using NUnit.Framework.Interfaces;
 using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
-using System.Diagnostics;
 
 #if __IOS__
 using Xamarin.UITest.iOS;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -8,6 +8,7 @@ using NUnit.Framework.Interfaces;
 using Xamarin.Forms.Core.UITests;
 using Xamarin.UITest;
 using Xamarin.UITest.Queries;
+using System.Diagnostics;
 
 #if __IOS__
 using Xamarin.UITest.iOS;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
@@ -30,8 +30,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1Test() 
+		public void Issue1Test()
 		{
+			RunningApp.WaitForElement("Issue1Label");
 			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
 			RunningApp.Screenshot("I am at Issue1");
 			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_TemplateMarkup.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_TemplateMarkup.xaml.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue2Test()
 		{
+			RunningApp.WaitForElement("Issue2Label");
 			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
 			RunningApp.Screenshot("I am at Issue2");
 			RunningApp.WaitForElement(q => q.Marked("Issue2Label"));

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
@@ -34,7 +34,14 @@ namespace Xamarin.Forms.Core.UITests
 				new Drag(ScreenBounds, Drag.Direction.BottomToTop, Drag.DragLength.Medium));
 #endif
 			App.WaitForElement(q => q.Marked(testName));
-			App.Tap(q => q.Marked(testName));
+
+			// This code was added to work around an issue
+			// UI Test was having clicking the first two items in the List
+			for(int i = 0; i < 5 && App.Query(q => q.Marked(testName)).Length > 0; i++)
+			{
+				App.Tap(q => q.Marked(testName));
+				Thread.Sleep(500);
+			}
 		}
 
 		[Test]

--- a/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
@@ -1,0 +1,39 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+using Foundation;
+using UIKit;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture]
+	public class FrameTests : PlatformTestFixture
+	{
+		[Test, Category("Frame")]
+		public void ReusingFrameRendererDoesCauseOverlapWithPreviousContent()
+		{
+			Frame frame1 = new Frame()
+			{
+				Content = new Label()
+				{
+					Text = "I am frame 1"
+				}
+			};
+
+			var frameRenderer = GetRenderer(frame1);
+
+			Frame frame2 = new Frame()
+			{
+				Content = new Label()
+				{
+					Text = "I am frame 2"
+				}
+			};
+
+			frameRenderer.SetElement(frame2);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
@@ -73,7 +73,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 
 					frameRenderer.SetElement(frameWithButton);
 
-					var uiButton = (UIButton)frameRenderer.NativeView.Subviews[0].Subviews[0];
+					var uiButton = (UIButton)frameRenderer.NativeView.Subviews[0].Subviews[0].Subviews[0];
 					Assert.AreEqual("I am a Button", uiButton.Title(UIControlState.Normal));
 				}
 			});

--- a/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
@@ -49,9 +49,18 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 					Assert.AreEqual(1, frameRenderer.NativeView.Subviews.Length);
 					Assert.AreEqual(1, frameRenderer.NativeView.Subviews[0].Subviews.Length);
 
-					var labelRenderer = (LabelRenderer)frameRenderer.NativeView.Subviews[0];
-					var uILabel = (UILabel)labelRenderer.NativeView.Subviews[0];
+					LabelRenderer labelRenderer = null;
+					var view = frameRenderer.NativeView;
+					Assert.AreEqual(1, view.Subviews.Length);
 
+					while (labelRenderer == null)
+					{
+						view = view.Subviews[0];
+						Assert.AreEqual(1, view.Subviews.Length);
+						labelRenderer = view as LabelRenderer;
+					}
+
+					var uILabel = (UILabel)labelRenderer.NativeView.Subviews[0];
 					Assert.AreEqual("I am frame 2", uILabel.Text);
 
 					Frame frameWithButton = new Frame()

--- a/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/FrameTests.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			await Device.InvokeOnMainThreadAsync(() => {
 
 
+				ContentPage page = new ContentPage();
 				Frame frame1 = new Frame()
 				{
 					Content = new Label()
@@ -27,6 +28,10 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 					}
 				};
 
+				page.Content = frame1;
+
+
+				using (var pageRenderer = GetRenderer(page))
 				using (var renderer = GetRenderer(frame1))
 				{
 					var frameRenderer = GetRenderer(frame1);

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="CornerRadiusTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
+    <Compile Include="FrameTests.cs" />
     <Compile Include="ImageButtonTests.cs" />
     <Compile Include="IsEnabledTests.cs" />
     <Compile Include="IsVisibleTests.cs" />

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -128,7 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void Draw(CGRect rect)
 		{
-			if (_actualView == null)
+			if (_actualView != null)
 				_actualView.Frame = Bounds;
 
 			base.Draw(rect);

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -17,7 +17,6 @@ namespace Xamarin.Forms.Platform.iOS
 		public FrameRenderer()
 		{
 			_actualView = new FrameView();
-			_actualView.UserInteractionEnabled = false;
 			AddSubview(_actualView);
 		}
 
@@ -164,6 +163,17 @@ namespace Xamarin.Forms.Platform.iOS
 					var item = Subviews[i];
 					item.RemoveFromSuperview();
 				}
+			}
+
+			public override bool PointInside(CGPoint point, UIEvent uievent)
+			{
+				foreach(var view in Subviews)
+				{
+					if (view.HitTest(ConvertPointToView(point, view), uievent) != null)
+						return true;
+				}
+
+				return false;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public FrameRenderer()
 		{
 			_actualView = new FrameView();
+			_actualView.UserInteractionEnabled = false;
 			AddSubview(_actualView);
 		}
 
@@ -33,18 +34,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.OnElementChanged(e);
 
 			if (e.NewElement != null)
-			{				
-				// Make sure the gestures still work on our subview
-				if (NativeView.GestureRecognizers != null)
-				{
-					foreach (var gesture in NativeView.GestureRecognizers)
-						_actualView.AddGestureRecognizer(gesture);
-				}
-				else if (_actualView.Subviews.Length == 0)
-				{
-					_actualView.UserInteractionEnabled = false;
-				}
-
+			{
 				SetupLayer();
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -15,12 +15,6 @@ namespace Xamarin.Forms.Platform.iOS
 		[Internals.Preserve(Conditional = true)]
 		public FrameRenderer()
 		{
-
-		}
-
-		public override void AddSubview(UIView view)
-		{
-			base.AddSubview(view);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
@@ -29,28 +23,25 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.NewElement != null)
 			{
-				if (_actualView == null)
+				_actualView = new UIView();
+				// Add the subviews to the actual view.
+				foreach (var item in NativeView.Subviews)
 				{
-					_actualView = new UIView();
-					// Add the subviews to the actual view.
-					foreach (var item in NativeView.Subviews)
-					{
-						_actualView.AddSubview(item);
-					}
-
-					// Make sure the gestures still work on our subview
-					if (NativeView.GestureRecognizers != null)
-					{
-						foreach (var gesture in NativeView.GestureRecognizers)
-							_actualView.AddGestureRecognizer(gesture);
-					}
-					else if (_actualView.Subviews.Length == 0)
-					{
-						_actualView.UserInteractionEnabled = false;
-					}
-
-					AddSubview(_actualView);
+					_actualView.AddSubview(item);
 				}
+
+				// Make sure the gestures still work on our subview
+				if (NativeView.GestureRecognizers != null)
+				{
+					foreach (var gesture in NativeView.GestureRecognizers)
+						_actualView.AddGestureRecognizer(gesture);
+				}
+				else if (_actualView.Subviews.Length == 0)
+				{
+					_actualView.UserInteractionEnabled = false;
+				}
+
+				AddSubview(_actualView);
 
 				SetupLayer();
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -15,8 +15,14 @@ namespace Xamarin.Forms.Platform.iOS
 		[Internals.Preserve(Conditional = true)]
 		public FrameRenderer()
 		{
+
 		}
-		
+
+		public override void AddSubview(UIView view)
+		{
+			base.AddSubview(view);
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
 		{
 			base.OnElementChanged(e);

--- a/build.cake
+++ b/build.cake
@@ -66,7 +66,7 @@ bool isHostedAgent = agentName.StartsWith("Azure Pipelines") || agentName.Starts
 
 string defaultUnitTestWhere = "";
 
-if(target.Contains("uwp", StringComparison.OrdinalIgnoreCase))
+if(target.ToLower().Contains("uwp"))
     defaultUnitTestWhere = "cat != Shell && cat != CollectionView && cat != UwpIgnore && cat != CarouselView";
 
 var NUNIT_TEST_WHERE = Argument("NUNIT_TEST_WHERE", defaultUnitTestWhere);
@@ -477,7 +477,12 @@ Task ("cg-uwp-deploy")
 });
 
 Task("cg-uwp-run-tests")
+    .IsDependentOn("cg-uwp-build-tests")
+    .IsDependentOn("cg-uwp-deploy")
     .IsDependentOn("provision-uitests-uwp")
+    .IsDependentOn("_cg-uwp-run-tests");
+
+Task("_cg-uwp-run-tests")
     .Does(() =>
     {
         System.Diagnostics.Process process = null;
@@ -526,7 +531,7 @@ Task("cg-uwp-run-tests")
 Task("cg-uwp-run-tests-ci")
     .IsDependentOn("provision-windowssdk")
     .IsDependentOn("cg-uwp-deploy")
-    .IsDependentOn("cg-uwp-run-tests")
+    .IsDependentOn("_cg-uwp-run-tests")
     .Does(() =>
     {
     });

--- a/build.cake
+++ b/build.cake
@@ -41,8 +41,8 @@ string workingDirectory = EnvironmentVariable("SYSTEM_DEFAULTWORKINGDIRECTORY", 
 var configuration = Argument("BUILD_CONFIGURATION", "Debug");
 
 var target = Argument("target", "Default");
-var IOS_SIM_NAME = Argument("IOS_SIM_NAME", "iPhone 8");
-var IOS_SIM_RUNTIME = Argument("IOS_SIM_RUNTIME", "com.apple.CoreSimulator.SimRuntime.iOS-13-5");
+var IOS_SIM_NAME = Argument("IOS_SIM_NAME", "iPhone 7");
+var IOS_SIM_RUNTIME = Argument("IOS_SIM_RUNTIME", "com.apple.CoreSimulator.SimRuntime.iOS-12-4");
 var IOS_TEST_PROJ = "./Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj";
 var IOS_TEST_LIBRARY = Argument("IOS_TEST_LIBRARY", $"./Xamarin.Forms.Core.iOS.UITests/bin/{configuration}/Xamarin.Forms.Core.iOS.UITests.dll");
 var IOS_IPA_PATH = Argument("IOS_IPA_PATH", $"./Xamarin.Forms.ControlGallery.iOS/bin/iPhoneSimulator/{configuration}/XamarinFormsControlGalleryiOS.app");
@@ -923,6 +923,11 @@ Task("cg-ios-build-tests")
     });
 
 Task("cg-ios-run-tests")
+    .IsDependentOn("cg-ios-build-tests")
+    .IsDependentOn("cg-ios-deploy")
+    .IsDependentOn("_cg-ios-run-tests");
+
+Task("_cg-ios-run-tests")
     .Does(() =>
     {
         var sim = GetIosSimulator();
@@ -945,7 +950,7 @@ Task("cg-ios-run-tests")
 
 Task("cg-ios-run-tests-ci")
     .IsDependentOn("cg-ios-deploy")
-    .IsDependentOn("cg-ios-run-tests")
+    .IsDependentOn("_cg-ios-run-tests")
     .Does(() =>
     {
     });


### PR DESCRIPTION
### Description of Change ###

These changes let us keep the same actualview without instantiating it everytime

- When calling AddSubView on the framerenderer just forward those calls to ActualView
- When calling removefromparentview on ActualView just forward those to the views added to ActualView

Instead of forwarding the Gesture Recognizers just set UserInteractionEnabled to false on the inserted middle view. 
I ran tests with this to make sure content inside the frame still worked and APIs like InputTranparent still function correctly. Issue10422.xaml.cs has a PanGestureRecognizer you can test with

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11266


### Platforms Affected ### 
- iOS

### Testing Procedure ###
- Test all the issues here https://github.com/xamarin/Xamarin.Forms/pull/10469 make sure nothing regressed. One of the tests in there doesn't clip quite right but that's fixed by a PR @jsuarezruiz did on 4.7 

- test nuget against following sample https://github.com/xamarin/Xamarin.Forms/files/4893291/Archive.zip and make sure the frames update correctly with updated bindings

- Verify tapping things inside a frame and using gesture recognizers with a frame still all works

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
