### PR TITLE
[Bug] [UWP] Modify ItemsViewRenderer to handle ItemsSource being set during Layout

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10977.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10977.cs
@@ -1,0 +1,82 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Issue(IssueTracker.Github, 10977, "[Bug] UWP: Page with CollectionView is not displayed until the window is resized.", PlatformAffected.UWP)]
+	public partial class Issue10977 : ContentPage
+	{
+		private MainViewModel viewModel;
+
+		public Issue10977()
+		{
+			viewModel = new MainViewModel();
+			BindingContext = viewModel;
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			viewModel.Items = new List<MainModel>
+			{
+				new MainModel { Text = "a"},
+				new MainModel { Text = "b"},
+				new MainModel { Text = "c"}
+			};
+		}
+
+		public class MainViewModel : INotifyPropertyChanged
+		{
+			private IEnumerable<MainModel> items;
+			public IEnumerable<MainModel> Items
+			{
+				get => items;
+				set
+				{
+					items = value;
+					OnPropertyChanged(nameof(Items));
+				}
+			}
+
+
+			public event PropertyChangedEventHandler PropertyChanged;
+			private void OnPropertyChanged(string propertyName)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+			}
+		}
+
+		public class MainModel
+		{
+			public string Text { get; set; }
+		}
+
+#if APP
+		void Button_OnClicked_NewSource(object sender, EventArgs e)
+		{
+			viewModel.Items = new List<MainModel>
+			{
+				new MainModel { Text = $"{DateTime.Now.Second} d"},
+				new MainModel { Text = $"{DateTime.Now.Second} e"},
+				new MainModel { Text = $"{DateTime.Now.Second} f"}
+			};
+		}
+
+		void Button_OnClicked_NewLayout(object sender, EventArgs e)
+		{
+			var gridLayout = new GridItemsLayout(ItemsLayoutOrientation.Horizontal);
+			CV.ItemsLayout = gridLayout;
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10977.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10977.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues"
+             x:Class=" Xamarin.Forms.Controls.Issues.Issue10977"
+             x:DataType="issues:MainViewModel"
+             Title="All element should be visible on load">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="ItemsDataTemplate">
+                <Label Text="{Binding Text}" />
+            </DataTemplate>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <StackLayout>
+        <SearchBar Placeholder="Search text..." />
+        <Button Text="Click to test loading new items source after initial load" Clicked="Button_OnClicked_NewSource"/>
+        <Button Text="Click to test creating a new items layout" Clicked="Button_OnClicked_NewLayout"/>
+
+        <CollectionView x:Name="CV"
+            ItemsSource="{Binding Items}"
+            ItemTemplate="{StaticResource ItemsDataTemplate}">
+        </CollectionView>
+
+        <Button Text="OK" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -37,6 +37,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7606.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10977.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11106.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11251.cs" />
@@ -2389,6 +2390,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11259.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10977.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

This PR prevents the ItemsViewRenderer from setting the ItemSource on ListViewBase before it has been through the layout process.  Waiting for the ListViewBase SizeChanged event to be called and for it to have a width is used as the check for layout completed.  UpdateItemSource was split into two methods with setting the ListViewBase.ItemSource and Empty view only occurring after SizeChanged has been called.

**Original Description**
Forces a Layout of the ItemList in the ItemsViewRenderer (CollectionView and CarouselView) when the ItemsSource is updated.

As shown in #10977 if the ItemsSource of the CollectionView is changed during a page OnAppearing event, it causes an issue with the UWP layout cycle.  It's some type of timing issues as adding a delay of even 1ms resolves the issue in testing, but relying on a simple delay could be inconsistent depending on the machine, etc.

Ideally, I would want to detect if we were in OnAppearing event and only force the UploadLayout in that case.  But I've been unable to find a way to detect that.  This PR could be improved if there is a way to do that.

Since UWP is a desktop platform, it's likely that forcing a Layout cycle of just the ListViewBase and it's sub tree won't be very noticeable.

I did test the same example in 10977 with a ListView and it worked fine to set ItemSource in OnAppearing, so it's likely that existing apps my use this method to set ItemsSource and should be expected to work.

### Issues Resolved ### 

- fixes #10977
- fixes #8814 
- likely fixes #12009 - Don't have a repro to test

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
Forces the collection view to layout and be displayed when the itemsSource is updated during page appearance.

### Before/After Screenshots ### 

10977
Before

![Before](https://user-images.githubusercontent.com/15127788/88077732-33c3bc80-cb41-11ea-8548-28092c442c66.gif)

After

![After](https://user-images.githubusercontent.com/15127788/88077742-37574380-cb41-11ea-941d-38e147400679.gif)

8814
Before

![Before](https://user-images.githubusercontent.com/15127788/88822974-2b473380-d18a-11ea-8601-4c315bf4203d.gif)


After

![After](https://user-images.githubusercontent.com/15127788/88822999-326e4180-d18a-11ea-8ed2-03c6ef0bb587.gif)

### Testing Procedure ###
Open Issue 10977 page and ensure all controls are visible and click both test buttons

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
