### PR TITLE
Add BoostrapHelper

### DIFF
--- a/Xamarin.Forms.Platform.UAP/BootstrapHelper.cs
+++ b/Xamarin.Forms.Platform.UAP/BootstrapHelper.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using System.Reflection;
+using System.Runtime.InteropServices;
+
+namespace Xamarin.Forms.Platform.UAP
+{
+	/// <summary>
+	/// Enables C++ code to simulate ICLRRuntimeHost2::ExecuteAssembly on top of ICLRRuntimeHost2::CreateDelegate in .net core 2.
+	/// </summary>
+	static class BootstrapHelper
+	{
+
+		// Do not overload this method. ICLRRuntimeHost2::CreateDelegate can not resolve overloaded methods.
+		[PreserveSig]
+		private static int Bootstrap(
+			[MarshalAs(UnmanagedType.LPWStr)] string assemblyPath,
+			[MarshalAs(UnmanagedType.LPWStr)] string typeName,
+			[MarshalAs(UnmanagedType.LPWStr)] string methodName,
+			[MarshalAs(UnmanagedType.LPWStr)] string argument)
+		{
+			try
+			{
+				MethodInfo loadFrom = typeof(Assembly).GetMethod("LoadFrom", new Type[] { typeof(string) });
+				if (loadFrom == null)
+				{
+					// LoadFrom is only available in .net core 2.0 and later. Since the target
+					// assembly isn't in the normal load path there isn't anything we can do.
+					throw new PlatformNotSupportedException();
+				}
+
+				Assembly assembly = (Assembly)loadFrom.Invoke(null, new object[] { assemblyPath });
+				Type type = assembly.GetType(typeName);
+				MethodInfo method = type.GetMethod(methodName);
+				method.Invoke(null, new object[] { argument });
+				return 0;
+			}
+			catch (Exception ex)
+			{
+				return ex.HResult;
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Enable C++ code to simulate ICLRRuntimeHost2::ExecuteAssembly on top of ICLRRuntimeHost2::CreateDelegate in .net core 2.

### Issues Resolved ### 
None

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Validated locally that C++ code can use BoostrapHelper.Bootstrap to load a managed dll.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)

> VS bug [#1156448](https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1156448)