### PR TITLE
Check UICollectionView visibility before asking it for content height

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11311.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11311.cs
@@ -1,9 +1,7 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
-using System.Text;
 using System.Windows.Input;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Markup;
@@ -25,10 +23,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 		ContentPage FirstPage() 
 		{
-			var firstPage = new ContentPage();
-			firstPage.Title = "The first page";
-
-			firstPage.Content = new Label { Text = Success };
+			var firstPage = new ContentPage
+			{
+				Title = "The first page",
+				Content = new Label { Text = Success }
+			};
 
 			firstPage.Appearing += (sender, args) => {
 				if (firstPage.Parent is TabbedPage tabbedPage
@@ -44,18 +43,17 @@ namespace Xamarin.Forms.Controls.Issues
 
 		ContentPage CollectionViewPage()
 		{
-			BindingContext = new CollectionViewModel();
+			BindingContext = new _11311ViewModel();
 
 			var refreshView = new RefreshView
 			{
 				Content = new CollectionView
 				{
-					ItemTemplate = new GreenBoxDataTemplate(),
 					Footer = new BoxView { BackgroundColor = Color.Red, HeightRequest = 53 }
-				}.Bind(CollectionView.ItemsSourceProperty, nameof(CollectionViewModel.ScoreCollectionList))
+				}.Bind(ItemsView.ItemsSourceProperty, nameof(_11311ViewModel.ScoreCollectionList))
 
-			}.Bind(RefreshView.CommandProperty, nameof(CollectionViewModel.PopulateCollectionCommand))
-			 .Bind(RefreshView.IsRefreshingProperty, nameof(CollectionViewModel.IsRefreshing));
+			}.Bind(RefreshView.CommandProperty, nameof(_11311ViewModel.PopulateCollectionCommand))
+			 .Bind(RefreshView.IsRefreshingProperty, nameof(_11311ViewModel.IsRefreshing));
 
 			var page = new ContentPage
 			{
@@ -66,12 +64,12 @@ namespace Xamarin.Forms.Controls.Issues
 			return page;
 		}
 
-		class CollectionViewModel : INotifyPropertyChanged
+		class _11311ViewModel : INotifyPropertyChanged
 		{
 			bool _isRefreshing;
 			IEnumerable<int> _scoreCollectionList;
 
-			public CollectionViewModel()
+			public _11311ViewModel()
 			{
 				PopulateCollectionCommand = new Command(ExecuteRefreshCommand);
 				_scoreCollectionList = Enumerable.Empty<int>();
@@ -110,37 +108,8 @@ namespace Xamarin.Forms.Controls.Issues
 				IsRefreshing = false;
 			}
 
-			void OnPropertyChanged([CallerMemberName] string propertyName = "") => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
-		}
-
-		class GreenBoxDataTemplate : DataTemplate
-		{
-			public GreenBoxDataTemplate() : base(CreateTemplate)
-			{
-
-			}
-
-			static View CreateTemplate() => new StackLayout
-			{
-				Children =
-				{
-					new BoxView
-					{
-						BackgroundColor = Color.Black,
-						HeightRequest = 5
-					},
-					new BoxView
-					{
-						BackgroundColor = Color.Green,
-						HeightRequest = 50
-					},
-					new BoxView
-					{
-						BackgroundColor = Color.Black,
-						HeightRequest = 5
-					}
-				}
-			};
+			void OnPropertyChanged([CallerMemberName] string propertyName = "") => 
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
 		}
 
 #if UITEST

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11311.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11311.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
+using NUnit.Framework;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Markup;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11311.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11311.cs
@@ -1,0 +1,155 @@
+﻿using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using System.Text;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Markup;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.None, 11311, "[Regression] CollectionView NSRangeException", PlatformAffected.iOS)]
+	public class Issue11311 : TestTabbedPage
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			Device.SetFlags(new[] { "Markup_Experimental" });
+
+			Children.Add(FirstPage());
+			Children.Add(CollectionViewPage());
+		}
+
+		ContentPage FirstPage() 
+		{
+			var firstPage = new ContentPage();
+			firstPage.Title = "The first page";
+
+			firstPage.Content = new Label { Text = Success };
+
+			firstPage.Appearing += (sender, args) => {
+				if (firstPage.Parent is TabbedPage tabbedPage
+				&& tabbedPage.Children[1] is ContentPage collectionViewPage
+				&& collectionViewPage.Content is RefreshView refreshView)
+				{
+					refreshView.IsRefreshing = true;
+				}
+			};
+
+			return firstPage;
+		}
+
+		ContentPage CollectionViewPage()
+		{
+			BindingContext = new CollectionViewModel();
+
+			var refreshView = new RefreshView
+			{
+				Content = new CollectionView
+				{
+					ItemTemplate = new GreenBoxDataTemplate(),
+					Footer = new BoxView { BackgroundColor = Color.Red, HeightRequest = 53 }
+				}.Bind(CollectionView.ItemsSourceProperty, nameof(CollectionViewModel.ScoreCollectionList))
+
+			}.Bind(RefreshView.CommandProperty, nameof(CollectionViewModel.PopulateCollectionCommand))
+			 .Bind(RefreshView.IsRefreshingProperty, nameof(CollectionViewModel.IsRefreshing));
+
+			var page = new ContentPage
+			{
+				Title = "CollectionView Page",
+				Content = refreshView
+			};
+
+			return page;
+		}
+
+		class CollectionViewModel : INotifyPropertyChanged
+		{
+			bool _isRefreshing;
+			IEnumerable<int> _scoreCollectionList;
+
+			public CollectionViewModel()
+			{
+				PopulateCollectionCommand = new Command(ExecuteRefreshCommand);
+				_scoreCollectionList = Enumerable.Empty<int>();
+			}
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			public ICommand PopulateCollectionCommand { get; }
+
+			public IEnumerable<int> ScoreCollectionList
+			{
+				get => _scoreCollectionList;
+				set
+				{
+					_scoreCollectionList = value;
+					OnPropertyChanged();
+				}
+			}
+
+			public bool IsRefreshing
+			{
+				get => _isRefreshing;
+				set
+				{
+					if (IsRefreshing != value)
+					{
+						_isRefreshing = value;
+						OnPropertyChanged();
+					}
+				}
+			}
+
+			void ExecuteRefreshCommand()
+			{
+				ScoreCollectionList = Enumerable.Range(0, 100);
+				IsRefreshing = false;
+			}
+
+			void OnPropertyChanged([CallerMemberName] string propertyName = "") => PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+		}
+
+		class GreenBoxDataTemplate : DataTemplate
+		{
+			public GreenBoxDataTemplate() : base(CreateTemplate)
+			{
+
+			}
+
+			static View CreateTemplate() => new StackLayout
+			{
+				Children =
+				{
+					new BoxView
+					{
+						BackgroundColor = Color.Black,
+						HeightRequest = 5
+					},
+					new BoxView
+					{
+						BackgroundColor = Color.Green,
+						HeightRequest = 50
+					},
+					new BoxView
+					{
+						BackgroundColor = Color.Black,
+						HeightRequest = 5
+					}
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionViewWithFooterShouldNotCrashOnDisplay()
+		{
+			// If this hasn't already crashed, the test is passing
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -34,8 +34,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11106.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11251.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11259.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11523.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11259.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11311.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -205,9 +205,16 @@ namespace Xamarin.Forms.Platform.iOS
 					_headerUIView.Frame = new CoreGraphics.CGRect(0, -headerHeight, CollectionView.Frame.Width, headerHeight);
 				}
 
-				if (_footerUIView != null && (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height || emptyHeight > 0))
+				nfloat height = 0;
+
+				if (IsViewLoaded && View.Window != null)
 				{
-					_footerUIView.Frame = new CoreGraphics.CGRect(0, ItemsViewLayout.CollectionViewContentSize.Height + emptyHeight, CollectionView.Frame.Width, footerHeight);
+					height = ItemsViewLayout.CollectionViewContentSize.Height;
+				}
+
+				if (_footerUIView != null && (_footerUIView.Frame.Y != height || emptyHeight > 0))
+				{
+					_footerUIView.Frame = new CoreGraphics.CGRect(0, height + emptyHeight, CollectionView.Frame.Width, footerHeight);
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

If the UICollectionView hasn't actually been loaded yet (e.g., if it's on a not-yet-visible tab), when the footer attempts to determine its vertical position (and asks the UICollectionView for the height of its content), the UICollectionView will throw an exception. 

This change adds a check to see if the UICollectionView has been loaded and attached to a window yet; if not, it reports a height of zero for the purposes of positioning the footer.

### Issues Resolved ### 

- fixes #11311

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test (Issue11311)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
