### PR TITLE
[Shell] Don't remove default routes if that's all there is

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -368,6 +368,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			*/
 		}
 
+		[Test]
+		public async Task DefaultRoutesMaintainedIfThatsAllThereIs()
+		{
+			Routing.RegisterRoute(nameof(DefaultRoutesMaintainedIfThatsAllThereIs), typeof(ContentPage));
+			var shell = new Shell();
+			var shellContent = new ShellContent();
+			FlyoutItem flyoutItem = new FlyoutItem()
+			{
+				Items =
+				{
+					shellContent
+				}
+			};
+			shell.Items.Add(flyoutItem);
+
+			await shell.GoToAsync(nameof(DefaultRoutesMaintainedIfThatsAllThereIs));
+			Assume.That(shell.CurrentState.Location.ToString(), Is.EqualTo($"//{Routing.GetRoute(shellContent)}/{nameof(DefaultRoutesMaintainedIfThatsAllThereIs)}"));
+			await shell.GoToAsync("..");
+		}
 
 		[Test]
 		public async Task DotDotNavigationPassesParameters()

--- a/Xamarin.Forms.Core/Routing.cs
+++ b/Xamarin.Forms.Core/Routing.cs
@@ -32,6 +32,19 @@ namespace Xamarin.Forms
 			return source.StartsWith(DefaultPrefix, StringComparison.Ordinal);
 		}
 
+		internal static bool IsDefault(BindableObject source)
+		{
+			return IsDefault(GetRoute(source));
+		}
+
+		internal static bool IsUserDefined(BindableObject source)
+		{
+			if (source == null)
+				return false;
+
+			return !(IsDefault(source) || IsImplicit(source));
+		}
+
 		internal static void Clear()
 		{
 			s_routes.Clear();

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -634,6 +634,10 @@ namespace Xamarin.Forms
 			List<string> routeStack = new List<string>();
 
 			bool stackAtRoot = sectionStack == null || sectionStack.Count <= 1;
+			bool hasUserDefinedRoute =
+				(Routing.IsUserDefined(shellItem)) ||
+				(Routing.IsUserDefined(shellSection)) ||
+				(Routing.IsUserDefined(shellContent));
 
 			if (shellItem != null)
 			{
@@ -656,7 +660,7 @@ namespace Xamarin.Forms
 						for (int i = 1; i < sectionStack.Count; i++)
 						{
 							var page = sectionStack[i];
-							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack));
+							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack, hasUserDefinedRoute));
 						}
 					}
 
@@ -666,11 +670,11 @@ namespace Xamarin.Forms
 						{
 							var topPage = modalStack[i];
 
-							routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage), routeStack));
+							routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage), routeStack, hasUserDefinedRoute));
 
 							for (int j = 1; j < topPage.Navigation.NavigationStack.Count; j++)
 							{
-								routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack));
+								routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack, hasUserDefinedRoute));
 							}
 						}
 					}
@@ -683,12 +687,16 @@ namespace Xamarin.Forms
 			return String.Join("/", routeStack);
 
 
-			List<string> CollapsePath(string myRoute, List<string> currentRouteStack)
+			List<string> CollapsePath(
+				string myRoute, 
+				List<string> currentRouteStack,
+				bool userDefinedRoute)
 			{
 				for (var i = currentRouteStack.Count - 1; i >= 0; i--)
 				{
 					var route = currentRouteStack[i];
-					if (Routing.IsImplicit(route) || Routing.IsDefault(route))
+					if (Routing.IsImplicit(route) || 
+						(Routing.IsDefault(route) && userDefinedRoute))
 						currentRouteStack.RemoveAt(i);
 				}
 


### PR DESCRIPTION
### Description of Change ###

When the code was added to collapse down routes when navigating to nested registration it was removing default routes for the current state when navigating to a page. If the user hasn't specified any routes themselves we have to keep the default around on the URL so shell can know where it is.

### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
