### PR TITLE
[iOS] Null check Mask.Name

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/_11132CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/_11132CustomRenderer.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 					Path = clipPath
 				};
 				layer.Mask = clipShapeLayer;
-                layer.Mask.Name = "test";
+                layer.Mask.Name = null;
 
                 Debug.WriteLine($"_11132CustomRenderer Layer Name { layer.Mask.Name}");
             }

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -452,19 +452,19 @@ namespace Xamarin.Forms.Platform.MacOS
 				hasClipShapeLayer =
 					uiview.Layer != null &&
 					uiview.Layer.Mask != null &&
-					uiview.Layer.Mask.Name == ClipShapeLayer;
+					uiview.Layer.Mask?.Name == ClipShapeLayer;
 			else
 			{
 				hasClipShapeLayer =
 					uiview.MaskView != null &&
 					uiview.MaskView.Layer.Mask != null &&
-					uiview.MaskView.Layer.Mask.Name == ClipShapeLayer;
+					uiview.MaskView.Layer.Mask?.Name == ClipShapeLayer;
 			}
 #else
 			hasClipShapeLayer =
 				uiview.Layer != null &&
 				uiview.Layer.Mask != null &&
-				uiview.Layer.Mask.Name == ClipShapeLayer;
+				uiview.Layer.Mask?.Name == ClipShapeLayer;
 #endif
 
 			var formsGeometry = element.Clip;


### PR DESCRIPTION
### Description of Change ###

Not sure why the gallery doesn't crash when the mask name is null, but this should be the last of the required null checks 🤞 

### Issues Resolved ### 


- fixes #11132

### API Changes ###

 
 None

### Platforms Affected ### 

- iOS


### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###
Test with the project included in #11132 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
