### PR TITLE
[iOS] Fix Entry PlaceholderColor issue using a global Span TextColor Style

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormattedStringExtensions.cs
@@ -101,13 +101,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 				targetFont = span.ToNSFont();
 #endif
-
 			var fgcolor = span.TextColor;
+
 			if (fgcolor.IsDefault)
 				fgcolor = defaultForegroundColor;
+
+			if (owner is Entry && !fgcolor.IsDefault)
+				fgcolor = defaultForegroundColor;
+
 			if (fgcolor.IsDefault)
 				fgcolor = ColorExtensions.LabelColor.ToColor();
-
 #if __MOBILE__
 			UIColor spanFgColor;
 			UIColor spanBgColor;
@@ -146,6 +149,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (formattedString == null)
 				return null;
+
 			var attributed = new NSMutableAttributedString();
 
 			for (int i = 0; i < formattedString.Spans.Count; i++)


### PR DESCRIPTION
### Description of Change ###

Fix Entry PlaceholderColor issue using a global Span TextColor Style on iOS. Internally, in iOS the placeholder is a `FormattedString` with one `Span`. By applying the global Span style, we were overwriting the placeholder color. Added validation to fix the issue.

### Issues Resolved ### 

- fixes #11425 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="395" alt="Captura de pantalla 2020-07-14 a las 16 39 10" src="https://user-images.githubusercontent.com/6755973/87439040-93294600-c5f0-11ea-9e18-a92031524f7d.png">

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
