### PR TITLE
[macOS] Fix Button issues with BackgroundColor, BorderColor, etc

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -8,6 +8,8 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public class ButtonRenderer : ViewRenderer<Button, NSButton>
 	{
+		const float DefaultCornerRadius = 6;
+
 		class FormsNSButton : NSButton
 		{
 			class FormsNSButtonCell : NSButtonCell
@@ -94,7 +96,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					var btn = new FormsNSButton();
 					btn.SetButtonType(NSButtonType.MomentaryPushIn);
-					btn.BezelStyle = NSBezelStyle.Rounded;
+					btn.BezelStyle = NSBezelStyle.RoundRect;
 					btn.Pressed += HandleButtonPressed;
 					btn.Released += HandleButtonReleased;
 					SetNativeControl(btn);
@@ -155,7 +157,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				uiButton.Layer.BorderColor = button.BorderColor.ToCGColor();
 
 			uiButton.Layer.BorderWidth = (float)button.BorderWidth;
-			uiButton.Layer.CornerRadius = button.CornerRadius;
+			uiButton.Layer.CornerRadius = button.CornerRadius > 0 ? button.CornerRadius : DefaultCornerRadius;
 
 			UpdateBackgroundVisibility();
 		}
@@ -214,6 +216,5 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			Element?.SendReleased();
 		}
-
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Fix Button issues with BackgroundColor, BorderColor, etc on macOS.
In this change https://github.com/xamarin/Xamarin.Forms/commit/bfe7b7450a8f63e8e6bf3cb147976b5548991f5f#diff-ba4df52c80dd304b5fc99f852c2a04d7 we changed the `BezelStyle` affecting some properties like the background or border color.

### Issues Resolved ### 

- fixes #11431

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="1022" alt="button-before01" src="https://user-images.githubusercontent.com/6755973/87523983-e6020c80-c687-11ea-9aa4-a4151484da21.png">
<img width="1022" alt="button-before02" src="https://user-images.githubusercontent.com/6755973/87523973-e1d5ef00-c687-11ea-8757-4b3de5c1b93f.png">

#### After
<img width="1020" alt="button-after01" src="https://user-images.githubusercontent.com/6755973/87523981-e5697600-c687-11ea-9081-6e6abd080bf6.png">
<img width="1021" alt="button-after02" src="https://user-images.githubusercontent.com/6755973/87523979-e4d0df80-c687-11ea-956e-8222466fb15d.png">

### Testing Procedure ###
Launch Core Gallery on macOS and navigate to the Button Gallery. Select the Button Gallery and test properties like the BackgroundColor and the BorderColor.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
