### PR TITLE
[iOS] Change Button state if the touch-up event occurs outside

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11430.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11430.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11430,
+		"[Bug] [iOS] Button stays in Pressed state if the touch-up event occurs outside",
+		PlatformAffected.iOS)]
+	public class Issue11430 : TestContentPage
+	{
+		public Issue11430()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 11430";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Tap a Button, drag your finger outside the Button and lift up your finger."
+			};
+
+			var button = new Button
+			{
+				Text = "Click Me"
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(button);
+
+			Content = layout;
+
+			button.Clicked += (sender, args) =>
+			{
+				DisplayAlert("Issue 11430", "If you can read this message, the test has passed.", "Ok");
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11430.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11430.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Padding = 12,
 				BackgroundColor = Color.Black,
 				TextColor = Color.White,
-				Text = "Tap a Button, drag your finger outside the Button and lift up your finger."
+				Text = "Tap a Button, drag your finger outside the Button and lift up your finger. If the Button state is Normal, the test has passed."
 			};
 
 			var button = new Button
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			button.Clicked += (sender, args) =>
 			{
-				DisplayAlert("Issue 11430", "If you can read this message, the test has passed.", "Ok");
+				DisplayAlert("Issue 11430", "Button Clicked.", "Ok");
 			};
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1436,6 +1436,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11120.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11272.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonElementManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonElementManager.cs
@@ -85,5 +85,10 @@ namespace Xamarin.Forms.Platform.iOS
 			element?.SendReleased();
 			element?.SendClicked();
 		}
+
+		internal static void OnButtonTouchUpOutside(IButtonController element)
+		{
+			element?.SendReleased();
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -62,6 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (Control != null)
 				{
 					Control.TouchUpInside -= OnButtonTouchUpInside;
+					Control.TouchUpOutside -= OnButtonTouchUpOutside;
 					Control.TouchDown -= OnButtonTouchDown;
 					BorderElementManager.Dispose(this);
 					_buttonLayoutManager?.Dispose();
@@ -93,6 +94,7 @@ namespace Xamarin.Forms.Platform.iOS
 					_buttonTextColorDefaultDisabled = Control.TitleColor(UIControlState.Disabled);
 
 					Control.TouchUpInside += OnButtonTouchUpInside;
+					Control.TouchUpOutside += OnButtonTouchUpOutside;
 					Control.TouchDown += OnButtonTouchDown;
 				}
 
@@ -145,6 +147,11 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnButtonTouchUpInside(object sender, EventArgs eventArgs)
 		{
 			ButtonElementManager.OnButtonTouchUpInside(this.Element);
+		}
+
+		void OnButtonTouchUpOutside(object sender, EventArgs eventArgs)
+		{
+			ButtonElementManager.OnButtonTouchUpOutside(this.Element);
 		}
 
 		void OnButtonTouchDown(object sender, EventArgs eventArgs)


### PR DESCRIPTION
### Description of Change ###

Change Button state (to Normal state) if the touch-up event occurs outside on iOS.

### Issues Resolved ### 

- fixes #11430 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
