### PR TITLE
[iOS] Fix controls added to Frame multiple times when container is recycled on ListView (#11375)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36802.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla36802.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms.Controls.Issues
 
         protected override void Init()
         {
-            var label = new Label { Text = Instructions };
+            var label = new Label { Text = Instructions, AutomationId = "TestReady" };
             grouped = new ObservableCollection<GroupedItem>();
             lstView = new ListView(ListViewCachingStrategy.RecycleElement) {
                 IsGroupingEnabled = true,
@@ -74,6 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
         public void Bugzilla36802Test()
         {
+			RunningApp.WaitForElement("TestReady");
             RunningApp.Screenshot("AccessoryView partially hidden test");
         }
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla53834.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var label = new Label { Text = Instructions };
+			var label = new Label { Text = Instructions, };
 			grouped = new ObservableCollection<GroupedItem>();
 			lstView = new ListView()
 			{
@@ -57,6 +57,7 @@ namespace Xamarin.Forms.Controls.Issues
 				ItemTemplate = new DataTemplate(typeof(MyViewCell)),
 				GroupHeaderTemplate = new DataTemplate(typeof(MyHeaderViewCell)),
 				ItemsSource = grouped,
+				AutomationId = "TestReady"
 			};
 
 			var grp1 = new GroupedItem() { LongName = "Group 1", ShortName = "1" };
@@ -87,6 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Bugzilla53834Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("incorrect row heights test");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1436.cs
@@ -29,7 +29,8 @@ namespace Xamarin.Forms.Controls.Issues
 				Text = "Button",
 				HorizontalOptions = LayoutOptions.End,
 				BorderColor = Color.AliceBlue,
-				BorderWidth = 5
+				BorderWidth = 5,
+				AutomationId = "TestReady"
 			}, 0, 0);
 
 			grid.Children.Add(new Button
@@ -102,6 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue1436Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 1436");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue1909.cs
@@ -28,7 +28,8 @@ namespace Xamarin.Forms.Controls.Issues
 				HorizontalOptions = LayoutOptions.Center,
 				TextColor = Color.White,
 				VerticalOptions = LayoutOptions.Center,
-				WidthRequest = 64
+				WidthRequest = 64,
+				AutomationId = "TestReady"
 			};
 
 			button.On<Android>().SetUseDefaultPadding(true).SetUseDefaultShadow(true);
@@ -60,6 +61,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue1909Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 1909");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2775.cs
@@ -58,7 +58,9 @@ namespace Xamarin.Forms.Controls.Issues
 				ItemTemplate = new DataTemplate (typeof(ContextActionsCell))
 			};
 
-			Content = new StackLayout {
+			Content = new StackLayout
+			{
+				AutomationId = "TestReady",
 				Children = {
 					list,
 					listTransparent,
@@ -113,8 +115,9 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue2775Test ()
 		{
-			RunningApp.Screenshot ("I am at Issue 2775");
-			RunningApp.Screenshot ("I see the Label");
+			RunningApp.WaitForElement("TestReady");
+			RunningApp.Screenshot("I am at Issue 2775");
+			RunningApp.Screenshot("I see the Label");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2894.cs
@@ -231,16 +231,34 @@ namespace Xamarin.Forms.Controls.Issues
 			for (int i = 1; i < 5; i++)
 			{
 				RunningApp.Tap($"TestSpan{i}");
-				RunningApp.TapCoordinates(target.X + 5, target.Y + 5);
+
+				// These tap retries work around a Tap Coordinate bug
+				// with Xamarin.UITest >= 3.0.7
+				int tapAttempts = 0;
+				do
+				{
+					RunningApp.TapCoordinates(target.X + 5, target.Y + 5);
+					if (tapAttempts == 4)
+						RunningApp.WaitForElement($"{kGesture1}{i}");
+
+					tapAttempts++;
+				} while (RunningApp.Query($"{kGesture1}{i}").Length == 0);
+
+				tapAttempts = 0;
+
+				do
+				{
 #if __WINDOWS__
-				RunningApp.TapCoordinates(target.X + target.Width - 10, target.Y + 2);
+					RunningApp.TapCoordinates(target.X + target.Width - 10, target.Y + 2);
 #else
-				RunningApp.TapCoordinates(target.X + target.CenterX, target.Y + 2);
+					RunningApp.TapCoordinates(target.X + target.CenterX, target.Y + 2);
 #endif
+					if (tapAttempts == 4)
+						RunningApp.WaitForElement($"{kGesture1}{i}");
 
+					tapAttempts++;
 
-				RunningApp.WaitForElement($"{kGesture1}{i}");
-				RunningApp.WaitForElement($"{kGesture2}{i}");
+				} while (RunningApp.Query($"{kGesture2}{i}").Length == 0);
 			}
 
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue342.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue342.cs
@@ -50,8 +50,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 			_image = new Image ();
 
-			Content = new StackLayout {
-				Children = { 
+			Content = new StackLayout
+			{
+				AutomationId = "TestReady",
+				Children = {
 					new Label {
 						Text = "Delayed image"
 					},
@@ -78,7 +80,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue342DelayedLoadTestsImageLoads ()
 		{
-			RunningApp.Screenshot ("Should not crash");
+			RunningApp.WaitForElement("TestReady");
+			RunningApp.Screenshot("Should not crash");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3884.cs
@@ -21,6 +21,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label { Text = "You should see a blue circle" };
 			var box = new BoxView
 			{
+				AutomationId = "TestReady",
 				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center,
 				BackgroundColor = Color.Blue,
@@ -40,7 +41,8 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue3884Test() 
 		{
-			RunningApp.Screenshot ("I see a blue circle");
+			RunningApp.WaitForElement("TestReady");
+			RunningApp.Screenshot("I see a blue circle");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4879.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4879.cs
@@ -31,7 +31,8 @@ namespace Xamarin.Forms.Controls.Issues
 					VerticalOptions = LayoutOptions.End,
 					ImageSource = "coffee.png",
 					Padding = new Thickness(10),
-					BackgroundColor = Color.Green
+					BackgroundColor = Color.Green,
+					AutomationId = "TestReady"
 				};
 				// Add BorderWidth to ImageButtons to match border of Button and allow for easier size comparisons
 				ImageButton ib1 = new ImageButton
@@ -79,6 +80,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
 		public void Issue4879Test()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("I am at Issue 4879 - All buttons/images should be the same size.");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5830.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5830.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var label = new Label { Text = Instructions };
+			var label = new Label { Text = Instructions, AutomationId = "TestReady" };
 			lstView = new ListView(ListViewCachingStrategy.RecycleElement)
 			{
 				ItemTemplate = new DataTemplate(typeof(ExtendedEntryCell)),
@@ -49,6 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Category(UITestCategories.ManualReview)]
         public void Issue5830Test()
         {
+			RunningApp.WaitForElement("TestReady");
             RunningApp.Screenshot("EntryTableViewCell Test with custom Text and TextColor");
         }
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5831.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5831.cs
@@ -69,10 +69,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 		}
 
-#if UITEST
-#if !(__ANDROID__ || __IOS__)
-		[Ignore("Shell test is only supported on Android and iOS")]
-#endif
+#if UITEST && __SHELL__
 		[Test]
 		public void CollectionViewRenderingWhenLeavingAndReturningViaFlyout()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8004.cs
@@ -27,7 +27,8 @@ namespace Xamarin.Forms.Controls.Issues
 			var label = new Label
 			{
 				Text = "Click the button below to animate the BoxView using individual ScaleXTo and ScaleYTo extension methods.",
-				TextColor = Color.Black
+				TextColor = Color.Black,
+				AutomationId = "TestReady"
 			};
 
 			var button = new Button
@@ -73,6 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public async Task AnimateScaleOfBoxView()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.Screenshot("Small blue box");
 
 			// Check the box and button elements.

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue968.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue968.cs
@@ -19,7 +19,8 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var layout = new StackLayout {
 				Padding = new Thickness (20),
-				BackgroundColor = Color.Gray
+				BackgroundColor = Color.Gray,
+				AutomationId = "TestReady"
 			};
 
 			layout.Children.Add (new BoxView {
@@ -41,6 +42,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[UiTest (typeof(StackLayout))]
 		public void Issue968TestsRotationRelayoutIssue ()
 		{
+			RunningApp.WaitForElement("TestReady");
 			RunningApp.SetOrientationLandscape ();
 			RunningApp.Screenshot ("Rotated to Landscape");
 			RunningApp.WaitForElement (q => q.Marked ("You should see me after rotating"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellGestures.cs
@@ -157,7 +157,8 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(TableViewTitle);
 			RunningApp.WaitForElement(TableViewId);
-			RunningApp.ScrollDownTo("entry30", TableViewId, ScrollStrategy.Gesture);
+
+			RunningApp.ScrollDownTo("entry30", TableViewId, ScrollStrategy.Gesture, swipePercentage: 0.20, timeout: TimeSpan.FromMinutes(1));
 		}
 
 		[NUnit.Framework.Category(UITestCategories.ListView)]
@@ -166,7 +167,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			TapInFlyout(ListViewTitle);
 			RunningApp.WaitForElement(ListViewId);
-			RunningApp.ScrollDownTo("30 Entry", ListViewId, ScrollStrategy.Gesture);
+			RunningApp.ScrollDownTo("30 Entry", ListViewId, ScrollStrategy.Gesture, swipePercentage: 0.20, timeout: TimeSpan.FromMinutes(1));
 		}
 
 #if __ANDROID__

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellInsets.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Controls.Issues
 		
 		const string EntrySuccess = "EntrySuccess";
 		const string ResetKeyboard = "Hide Keyboard";
+		const string ResetKeyboard2 = "Hide Keyboard 2";
 		const string Reset = "Reset";
 
 		const string ToggleSafeArea = "ToggleSafeArea";
@@ -286,7 +287,8 @@ namespace Xamarin.Forms.Controls.Issues
 							},
 							new Button()
 							{
-								Text = ResetKeyboard
+								Text = ResetKeyboard,
+								AutomationId = ResetKeyboard2
 
 							},
 							new Button()
@@ -346,7 +348,7 @@ namespace Xamarin.Forms.Controls.Issues
 					Assert.LessOrEqual(entry[0].Rect.Y, originalPosition.Y);
 			}
 
-			RunningApp.Tap(ResetKeyboard);
+			RunningApp.Tap(ResetKeyboard2);
 			var finalPosition = RunningApp.WaitForElement(EntrySuccess)[0].Rect;
 
 			// verify that label has returned to about the same spot

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_Template.cs
@@ -30,8 +30,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue1Test() 
+		public void Issue1Test()
 		{
+			RunningApp.WaitForElement("Issue1Label");
 			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
 			RunningApp.Screenshot("I am at Issue1");
 			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_TemplateMarkup.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/_TemplateMarkup.xaml.cs
@@ -36,6 +36,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void Issue2Test()
 		{
+			RunningApp.WaitForElement("Issue2Label");
 			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
 			RunningApp.Screenshot("I am at Issue2");
 			RunningApp.WaitForElement(q => q.Marked("Issue2Label"));

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
@@ -34,7 +34,14 @@ namespace Xamarin.Forms.Core.UITests
 				new Drag(ScreenBounds, Drag.Direction.BottomToTop, Drag.DragLength.Medium));
 #endif
 			App.WaitForElement(q => q.Marked(testName));
-			App.Tap(q => q.Marked(testName));
+
+			// This code was added to work around an issue
+			// UI Test was having clicking the first two items in the List
+			for(int i = 0; i < 5 && App.Query(q => q.Marked(testName)).Length > 0; i++)
+			{
+				App.Tap(q => q.Marked(testName));
+				Thread.Sleep(500);
+			}
 		}
 
 		[Test]

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -7,14 +7,25 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class FrameRenderer : VisualElementRenderer<Frame>, ITabStop
 	{
-		UIView _actualView = new UIView();
+		UIView _actualView;
 		CGSize _previousSize;
+		bool _isDisposed;
 
 		UIView ITabStop.TabStop => this;
 
 		[Internals.Preserve(Conditional = true)]
 		public FrameRenderer()
 		{
+			_actualView = new FrameView();
+			AddSubview(_actualView);
+		}
+
+		public override void AddSubview(UIView view)
+		{
+			if (view != _actualView)
+				_actualView.AddSubview(view);
+			else
+				base.AddSubview(view);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Frame> e)
@@ -23,24 +34,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.NewElement != null)
 			{
-				// Add the subviews to the actual view.
-				foreach (var item in NativeView.Subviews)
-				{
-					_actualView.AddSubview(item);
-				}
-
-				// Make sure the gestures still work on our subview
-				if (NativeView.GestureRecognizers != null)
-				{
-					foreach (var gesture in NativeView.GestureRecognizers)
-						_actualView.AddGestureRecognizer(gesture);
-				}
-				else if (_actualView.Subviews.Length == 0)
-				{
-					_actualView.UserInteractionEnabled = false;
-				}
-
-				AddSubview(_actualView);
 				SetupLayer();
 			}
 		}
@@ -58,7 +51,10 @@ namespace Xamarin.Forms.Platform.iOS
 		}
 
 		public virtual void SetupLayer()
-		{
+		{			
+			if (_actualView == null)
+				return;
+
 			float cornerRadius = Element.CornerRadius;
 
 			if (cornerRadius == -1f)
@@ -113,7 +109,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void Draw(CGRect rect)
 		{
-			_actualView.Frame = Bounds;
+			if (_actualView != null)
+				_actualView.Frame = Bounds;
 
 			base.Draw(rect);
 
@@ -122,13 +119,17 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_isDisposed)
+				return;
+
+			_isDisposed = true;
+
 			base.Dispose(disposing);
 
 			if (disposing)
 			{
 				if (_actualView != null)
 				{
-					
 					for (var i = 0; i < _actualView.GestureRecognizers?.Length; i++)
 						_actualView.GestureRecognizers.Remove(_actualView.GestureRecognizers[i]);
 
@@ -139,6 +140,30 @@ namespace Xamarin.Forms.Platform.iOS
 					_actualView.Dispose();
 					_actualView = null;
 				}
+			}
+		}
+
+		[Internals.Preserve(Conditional = true)]
+		class FrameView : UIView
+		{
+			public override void RemoveFromSuperview()
+			{
+				for (var i = Subviews.Length - 1; i >= 0; i--)
+				{
+					var item = Subviews[i];
+					item.RemoveFromSuperview();
+				}
+			}
+
+			public override bool PointInside(CGPoint point, UIEvent uievent)
+			{
+				foreach(var view in Subviews)
+				{
+					if (view.HitTest(ConvertPointToView(point, view), uievent) != null)
+						return true;
+				}
+
+				return false;
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

The frame code that regressed frame on iOS was cherry picked down to 4.5
This cherry picks the fix down to 4.5

fixes #11266

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- make sure ui tests run 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
