### PR TITLE
Fix [iOS] Button, ImageButton and RadioButton have minimum height of 44px

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageButtonRenderer.cs
@@ -14,32 +14,12 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		bool _isDisposed;
 
-		// This looks like it should be a const under iOS Classic,
-		// but that doesn't work under iOS 
-		// ReSharper disable once BuiltInTypeReferenceStyle
-		// Under iOS Classic Resharper wants to suggest this use the built-in type ref
-		// but under iOS that suggestion won't work
-		readonly nfloat _minimumButtonHeight = 44; // Apple docs
-
-
 		[Preserve(Conditional = true)]
 		public ImageButtonRenderer() : base()
 		{
 			ButtonElementManager.Init(this);
 			BorderElementManager.Init(this);
 			ImageElementManager.Init(this);
-		}
-
-		public override SizeF SizeThatFits(SizeF size)
-		{
-			var result = base.SizeThatFits(size);
-
-			if (result.Height < _minimumButtonHeight)
-			{
-				result.Height = _minimumButtonHeight;
-			}
-
-			return result;
 		}
 
 		protected override void Dispose(bool disposing)


### PR DESCRIPTION
Remove minimum height of 44px enforced on `Button`, `ImageButton` and `RadioButton`.
Apple guidelines recommend a minimum touch target of 44px or greater, but this value should not be forced upon the user nor is is mandated by Apple.

_"Provide ample touch targets for interactive elements. Try to maintain a minimum tappable area of 44pt x 44pt for all controls."_ ([Source](https://developer.apple.com/design/human-interface-guidelines/ios/visual-design/adaptivity-and-layout/))

### Issues Resolved ### 
- Fixes #11130

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Minimum height of 44px no longer enforced on these controls.
Brings behavior on iOS to be consistent with other platforms (i.e. Android, UWP).

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)