### PR TITLE
[Bug] [UWP] Fix GitHub 11513 - UWP Frame default Background color not consistent with other platforms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
@@ -13,9 +13,11 @@
 			    <Label Text="This one changes colour and loses the corner radius" />
 		    </Frame>
 
-        <Frame  CornerRadius="10">
-          <Label TextColor="Black" Text="Default Background should be white" />
-        </Frame>
+            <StackLayout BackgroundColor="Gray" Padding="10">
+                <Frame CornerRadius="10">
+                    <Label Text="Default Background should be white in light mode, black in dark mode" />
+                </Frame>
+            </StackLayout>
 
       <Button x:Name="btnChangeColour" Text="Change colour" />
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla60787.xaml
@@ -13,7 +13,11 @@
 			    <Label Text="This one changes colour and loses the corner radius" />
 		    </Frame>
 
-		    <Button x:Name="btnChangeColour" Text="Change colour" />
+        <Frame  CornerRadius="10">
+          <Label TextColor="Black" Text="Default Background should be white" />
+        </Frame>
+
+      <Button x:Name="btnChangeColour" Text="Change colour" />
 
 	    </StackLayout>
 	</ContentPage.Content>

--- a/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (Control != null)
 			{
-				Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
+				Control.Background = backgroundColor.IsDefault ? Color.White.ToBrush() : backgroundColor.ToBrush();
 			}
 		}
 
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (Control != null)
 			{
 				if (Brush.IsNullOrEmpty(background))
-					Control.Background = backgroundColor.IsDefault ? null : backgroundColor.ToBrush();
+					Control.Background = backgroundColor.IsDefault ? Color.White.ToBrush() : backgroundColor.ToBrush();
 				else
 					Control.Background = background.ToBrush();
 			}

--- a/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/FrameRenderer.cs
@@ -65,7 +65,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (Control != null)
 			{
-				Control.Background = backgroundColor.IsDefault ? Color.White.ToBrush() : backgroundColor.ToBrush();
+				Control.Background = backgroundColor.IsDefault ? 
+					new Windows.UI.Xaml.Media.SolidColorBrush((Windows.UI.Color)Resources["SystemAltHighColor"]) : backgroundColor.ToBrush();
 			}
 		}
 
@@ -77,7 +78,8 @@ namespace Xamarin.Forms.Platform.UWP
 			if (Control != null)
 			{
 				if (Brush.IsNullOrEmpty(background))
-					Control.Background = backgroundColor.IsDefault ? Color.White.ToBrush() : backgroundColor.ToBrush();
+					Control.Background = backgroundColor.IsDefault ?
+						new Windows.UI.Xaml.Media.SolidColorBrush((Windows.UI.Color)Resources["SystemAltHighColor"]) : backgroundColor.ToBrush();
 				else
 					Control.Background = background.ToBrush();
 			}


### PR DESCRIPTION
### Description of Change ###

Changes behavior of UWP FrameRenderer default background color to match iOS and Android.

I would consider this a breaking change and suggest 5.0 as the target for it.

### Issues Resolved ### 

- fixes #11513 

### API Changes ### 
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
The default background color of a Frame on UWP will now be white.

### Before/After Screenshots ### 
Before
![image](https://user-images.githubusercontent.com/15127788/88442578-aac7b200-cdda-11ea-9147-8bcb02088f84.png)
![image](https://user-images.githubusercontent.com/15127788/88442556-91266a80-cdda-11ea-9cd5-b57d12bed01d.png)


After
![image](https://user-images.githubusercontent.com/15127788/88442439-1f4e2100-cdda-11ea-8f8c-b5b3fd56962e.png)
![image](https://user-images.githubusercontent.com/15127788/88442485-53294680-cdda-11ea-80e5-6de404979eb5.png)



### Testing Procedure ###
Open Issue B60787 and ensure the last Frame has a white background.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
