### PR TITLE
Show backarrow if FlyoutBehavior is set to disabled

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11523.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11523.cs
@@ -1,0 +1,85 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11523, "[Bug] FlyoutBehavior.Disabled removes back-button from navbar",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11523 : TestShell
+	{
+		protected override async void Init()
+		{
+			ContentPage contentPage = new ContentPage()
+			{
+				Content =
+					new StackLayout()
+					{
+						Children = 
+						{
+							new Label()
+							{
+								Text = "This Page Should Have a Back Button that you should click",
+								AutomationId = "PageLoaded"
+							}
+						}
+					}
+			};
+
+			var firstPage = AddBottomTab("First Page");
+			firstPage.Content =
+					new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "This Page Should Have a Hamburger Menu Icon when you return to it",
+								
+							}
+						}
+					};
+
+			await Task.Delay(1000);
+
+			contentPage.Appearing += (_, __) =>
+			{
+				this.FlyoutBehavior = FlyoutBehavior.Disabled;
+			};
+
+			contentPage.Disappearing += (_, __) =>
+			{
+				this.FlyoutBehavior = FlyoutBehavior.Flyout;
+			};
+
+			await Navigation.PushAsync(contentPage);
+		}
+
+#if UITEST
+		[Test]
+		public void BackButtonStillVisibleWhenFlyoutBehaviorDisabled()
+		{
+			RunningApp.WaitForElement("PageLoaded");
+			RunningApp.WaitForElement(BackButtonAutomationId);
+			RunningApp.Tap(BackButtonAutomationId);
+			RunningApp.WaitForElement(FlyoutIconAutomationId);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -24,6 +24,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11106.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11259.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11523.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue2674.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6484.cs" />

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -394,7 +394,7 @@ namespace Xamarin.Forms.Platform.Android
 				icon = new FlyoutIconDrawerDrawable(context, tintColor, null, text);
 			}
 
-			if (icon == null && _flyoutBehavior == FlyoutBehavior.Flyout)
+			if (icon == null && (_flyoutBehavior == FlyoutBehavior.Flyout || CanNavigateBack))
 			{
 				icon = new DrawerArrowDrawable(context.GetThemedContext());
 				icon.SetColorFilter(tintColor, FilterMode.SrcAtop);


### PR DESCRIPTION
### Description of Change ###

If the user has disabled the flyout but they are on the second page then we still need to render the back button

### Issues Resolved ### 
- fixes #11523

### Platforms Affected ### 
- Android

### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
