### PR TITLE
Fix Null reference exception on UpdateIsRefreshing when the window is resized

### DIFF
--- a/Xamarin.Forms.Platform.UAP/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/RefreshViewRenderer.cs
@@ -143,13 +143,13 @@ namespace Xamarin.Forms.Platform.UWP
 			if (!_isLoaded)
 				return;
 
-			if (!Element.IsRefreshing)
+			if (!Element?.IsRefreshing??false)
 			{
 				CompleteRefresh();
 			}
 			else if (_refreshCompletionDeferral == null)
 			{
-				Control.RequestRefresh();
+				Control?.RequestRefresh();
 			}
 		}
 


### PR DESCRIPTION



### Description of Change ###

Check if Element or control is null before attemping to change their status

### Issues Resolved ### 
Null reference exception on UpdateIsRefreshing when the window is resized

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
