### PR TITLE
Mark Transform.ValueProperty as public

### DIFF
--- a/Xamarin.Forms.Core/Shapes/Transform.cs
+++ b/Xamarin.Forms.Core/Shapes/Transform.cs
@@ -3,7 +3,7 @@
     [TypeConverter(typeof(TransformTypeConverter))]
     public class Transform : BindableObject
     {
-        internal static readonly BindableProperty ValueProperty =
+        public static readonly BindableProperty ValueProperty =
            BindableProperty.Create(nameof(Value), typeof(Matrix), typeof(Transform), new Matrix());
 
         public Matrix Value


### PR DESCRIPTION
### Description of Change ###

The `ValueProperty` bindable field of the new `Xamarin.Forms.Shapes.Transform` is marked `internal` which prevents accessing the BindableProperty from the code and use things like `ClearValue` to reset the property to its default value.

Since all other BindableProperty fields are marked public, I don't see any reason not to for this one as well.
I changed it to public too.

### Issues Resolved ### 

- Didn't created a linked issue. Let me know if you want me to.

### API Changes ###

Changed:
 - internal static readonly BindableProperty ValueProperty => public static readonly BindableProperty ValueProperty
 
### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

None

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
