### PR TITLE
[Shapes] Fix RectTypeConverter

### DIFF
--- a/Xamarin.Forms.Core/RectTypeConverter.cs
+++ b/Xamarin.Forms.Core/RectTypeConverter.cs
@@ -1,14 +1,25 @@
-﻿namespace Xamarin.Forms
+﻿using System;
+using System.Globalization;
+
+namespace Xamarin.Forms
 {
 	[Xaml.TypeConversion(typeof(Rect))]
-	public class RectTypeConverter : RectangleTypeConverter
+	public class RectTypeConverter : TypeConverter
 	{
 		public override object ConvertFromInvariantString(string value)
 		{
-			var rectangle = base.ConvertFromInvariantString(value);
-			Rect rect = (Rectangle)rectangle;
+			if (value != null)
+			{
+				string[] xywh = value.Split(',');
+				if (xywh.Length == 4
+					&& double.TryParse(xywh[0], NumberStyles.Number, CultureInfo.InvariantCulture, out double x)
+					&& double.TryParse(xywh[1], NumberStyles.Number, CultureInfo.InvariantCulture, out double y)
+					&& double.TryParse(xywh[2], NumberStyles.Number, CultureInfo.InvariantCulture, out double w)
+					&& double.TryParse(xywh[3], NumberStyles.Number, CultureInfo.InvariantCulture, out double h))
+					return new Rect(x, y, w, h);
+			}
 
-			return rect;
+			throw new InvalidOperationException(string.Format("Cannot convert \"{0}\" into {1}", value, typeof(Rect)));
 		}
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml
@@ -1,0 +1,11 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+        xmlns="http://xamarin.com/schemas/2014/forms"
+        xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+        x:Class="Xamarin.Forms.Xaml.UnitTests.Gh11541">
+    <Image Source="monkeyface.png">
+	<Image.Clip>
+	    <RectangleGeometry Rect="40,100,300,150" />
+        </Image.Clip>
+    </Image>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Collections.Generic;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh11541 : ContentPage
+	{
+		public Gh11541() => InitializeComponent();
+		public Gh11541(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void RectangleGeometryDoesntThrow([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new Gh11541(useCompiledXaml);
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Fix inheritance of RectTypeConverter from RectangleTypeConverter, as the
child isn't precompiled, even if the parent has the attribute...

### Issues Resolved ### 

- fixes #11541

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
