### PR TITLE
#11552 - made Color property bindable in FontImageExtension

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11552.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11552.xaml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns:controls="clr-namespace:Xamarin.Forms.Controls" xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues"
+	x:Class="Xamarin.Forms.Controls.Issues.Issue11552" >
+	 <ContentPage.Resources>
+        <ResourceDictionary>
+            <Color x:Key="DarkColor">#000000</Color>
+            <Color x:Key="LightColor">#FFFFFF</Color>
+
+            <Color x:Key="DarkTextColor">#FF0000</Color>
+            <Color x:Key="LightTextColor">#0000FF</Color>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+	<StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+      <Image Source="{FontImage FontFamily={x:Static issues:Issue11552.FontFamily}, Color={AppThemeBinding Dark={StaticResource DarkTextColor}, Light={StaticResource LightTextColor}}, Size=22, Glyph='&#xf30c;'}" AutomationId="{x:Static issues:Issue11552.IconId}" />
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11552.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11552.xaml.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11552, "Make FontImageExtension Color property bindable", PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	public partial class Issue11552 : TestContentPage
+	{
+		private const string IconId = "icon";
+
+		public static string FontFamily
+		{
+			get
+			{
+				var fontFamily = "";
+				switch (Device.RuntimePlatform)
+				{
+					case Device.iOS:
+						fontFamily = "Ionicons";
+						break;
+					case Device.UWP:
+						fontFamily = "Assets/Fonts/ionicons.ttf#ionicons";
+						break;
+					case Device.Android:
+					default:
+						fontFamily = "fonts/ionicons.ttf#";
+						break;
+				}
+
+				return fontFamily;
+			}
+
+		}
+		
+
+		protected override void Init()
+		{
+		}
+
+#if APP
+		public Issue11552()
+		{
+			InitializeComponent();
+			
+		}
+#endif
+#if UITEST
+		[Test]
+		public void AppThemeBindingFontImage()
+		{
+			RunningApp.WaitForElement(IconId);
+			RunningApp.Screenshot("Icon color");
+		}
+
+		
+#endif
+	}
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1462,6 +1462,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11244.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11272.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11552.xaml.cs">
+      <DependentUpon>Issue11552.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1723,6 +1726,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11262.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11552.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
@@ -2205,7 +2212,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11259.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Xaml/MarkupExtensions/FontImageExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/FontImageExtension.cs
@@ -4,11 +4,17 @@ namespace Xamarin.Forms.Xaml
 {
 	[AcceptEmptyServiceProvider]
 	[ContentProperty(nameof(Glyph))]
-	public class FontImageExtension : IMarkupExtension<ImageSource>
+	public class FontImageExtension : BindableObject, IMarkupExtension<ImageSource>
 	{
+		public static BindableProperty ColorProperty = BindableProperty.Create(nameof(Color), typeof(Color), typeof(FontImageExtension), Color.Default);
+
 		public string FontFamily { get; set; }
 		public string Glyph { get; set; }
-		public Color Color { get; set; }
+		public Color Color
+		{
+			get => (Color)GetValue(ColorProperty);
+			set => SetValue(ColorProperty, value);
+		}
 
 		[TypeConverter(typeof(FontSizeConverter))]
 		public double Size { get; set; } = (double)FontImageSource.SizeProperty.DefaultValue;


### PR DESCRIPTION

### Description of Change ###
Made Color property bindable in FontImageExtension so it is possible to use with AppThemeBinding.

### Issues Resolved ### 
Fixes #11552

### API Changes ###
Added BindableObject as the base class.

Added:
- BindableProperty ColorProperty

Changed:
 - Color Color - Changed so it is backed by ColorProperty


 None

### Platforms Affected ### 
- Core/XAML (all platforms)


### Behavioral/Visual Changes ###
None


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
