### PR TITLE
Fix FlyoutIsPresented when set from Navigating

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11247.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 
-#if UITEST
+#if UITEST && __SHELL__
 		[Test]
 		public void SettingFlyoutIsPresentedInNavigatingKeepsFlyoutOpen()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11247.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11247.cs
@@ -1,0 +1,82 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Shapes;
+using System.Collections.Generic;
+using System;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shell)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11247,
+		"[Bug] Shell FlyoutIsPresented not working if set in \"navigating\" handler",
+		PlatformAffected.iOS)]
+	public class Issue11247 : TestShell
+	{
+		protected override void Init()
+		{
+			var page = AddFlyoutItem("FlyoutItem 1");
+			AddFlyoutItem("FlyoutItem 2");
+
+			Items.Add(new MenuItem()
+			{
+				Text = "Click Me To Close Flyout",
+				AutomationId = "CloseFlyout",
+				Command = new Command(() =>
+				{
+					FlyoutIsPresented = false;
+				})
+			});
+
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "If the flyout wasn't open when this test started the test has failed"
+					},
+					new Label()
+					{
+						Text = "Now, Open the Flyout and Click on FlyoutItem 2. Nothing should happen and flyout should remain open"
+					}
+				}
+			};
+		}
+
+		protected override void OnNavigating(ShellNavigatingEventArgs args)
+		{
+			base.OnNavigating(args);
+
+			if (args.CanCancel)
+			{
+				args.Cancel();
+			}
+
+			FlyoutIsPresented = true;
+		}
+
+
+#if UITEST
+		[Test]
+		public void SettingFlyoutIsPresentedInNavigatingKeepsFlyoutOpen()
+		{
+			RunningApp.Tap("CloseFlyout");
+			ShowFlyout();
+			RunningApp.Tap("FlyoutItem 1");
+			RunningApp.Tap("FlyoutItem 2");
+			RunningApp.WaitForElement("FlyoutItem 1");
+			RunningApp.WaitForElement("FlyoutItem 2");
+
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -661,6 +661,13 @@ namespace Xamarin.Forms.Controls
 			return page;
 		}
 
+		public ContentPage AddFlyoutItem(string title)
+		{
+			ContentPage page = new ContentPage() { Title = title };
+			AddFlyoutItem(page, title);
+			return page;
+		}
+
 		public FlyoutItem AddFlyoutItem(ContentPage page, string title)
 		{
 			var item = new FlyoutItem

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1440,6 +1440,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11291.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11244.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11272.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2161,7 +2162,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11259.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -10,9 +10,11 @@ namespace Xamarin.Forms
 		{
 			MenuItem = menuItem;
 			MenuItem.Parent = this;
+
 			SetBinding(TitleProperty, new Binding(nameof(MenuItem.Text), BindingMode.OneWay, source: menuItem));
 			SetBinding(IconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
 			SetBinding(FlyoutIconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
+			SetBinding(AutomationIdProperty, new Binding(nameof(MenuItem.AutomationId), BindingMode.OneWay, source: menuItem));
 
 			MenuItem.PropertyChanged += OnMenuItemPropertyChanged;
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -273,7 +273,7 @@ namespace Xamarin.Forms.Platform.Android
 
 					if (_element != null)
 					{
-						FastRenderers.AutomationPropertiesProvider.SetAutomationId(_itemView, value);
+						FastRenderers.AutomationPropertiesProvider.AccessibilitySettingsChanged(_itemView, value);
 						_element.SetValue(Platform.RendererProperty, _itemView);
 						_element.PropertyChanged += OnElementPropertyChanged;
 						UpdateVisualState();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -273,6 +273,7 @@ namespace Xamarin.Forms.Platform.Android
 
 					if (_element != null)
 					{
+						FastRenderers.AutomationPropertiesProvider.SetAutomationId(_itemView, value);
 						_element.SetValue(Platform.RendererProperty, _itemView);
 						_element.PropertyChanged += OnElementPropertyChanged;
 						UpdateVisualState();

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -168,6 +168,9 @@ namespace Xamarin.Forms.Platform.Android
 			((IShellController)context.Shell).AddFlyoutBehaviorObserver(this);
 
 			Profile.FrameEnd();
+
+			if (Shell.FlyoutIsPresented)
+				OpenDrawer(_flyoutContent.AndroidView, false);
 		}
 
 		protected virtual void OnShellPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Extensions/AccessibilityExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/AccessibilityExtensions.cs
@@ -11,6 +11,17 @@ namespace Xamarin.Forms.Platform.MacOS
 {
 	public static class AccessibilityExtensions
 	{
+		public static void SetAccessibilityProperties(this NativeView nativeViewElement, Element element)
+		{
+			if (element == null)
+				return;
+
+			nativeViewElement.AccessibilityIdentifier = element?.AutomationId;
+			SetAccessibilityLabel(nativeViewElement, element);
+			SetAccessibilityHint(nativeViewElement, element);
+			SetIsAccessibilityElement(nativeViewElement, element);
+		}
+
 		public static string SetAccessibilityHint(this NativeView Control, Element Element, string _defaultAccessibilityHint = null)
 		{
 			if (Element == null || Control == null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -68,6 +68,7 @@ namespace Xamarin.Forms.Platform.iOS
 			};
 						
 			ShellController.AddAppearanceObserver(this, Shell);
+			IsOpen = Shell.FlyoutIsPresented;
 		}
 
 		bool IsSwipeView(UIView view)
@@ -88,10 +89,13 @@ namespace Xamarin.Forms.Platform.iOS
 		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)
 		{
 			_flyoutBehavior = behavior;
+			var currentState = IsOpen;
+
 			if (behavior == FlyoutBehavior.Locked)
 				IsOpen = true;
 			else if (behavior == FlyoutBehavior.Disabled)
 				IsOpen = false;
+
 			LayoutSidebar(false);
 		}
 
@@ -200,7 +204,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (IsOpen != isPresented)
 				{
 					IsOpen = isPresented;
-					LayoutSidebar(true);
+					LayoutSidebar(true, true);
 				}
 			}
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
@@ -352,10 +356,16 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		void LayoutSidebar(bool animate)
+		void LayoutSidebar(bool animate, bool cancelExisting = false)
 		{
 			if (_gestureActive)
 				return;
+
+			if(cancelExisting && _flyoutAnimation != null)
+			{
+				_flyoutAnimation.StopAnimation(true);
+				_flyoutAnimation = null;
+			}
 
 			if (animate && _flyoutAnimation != null)
 				return;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -89,13 +89,10 @@ namespace Xamarin.Forms.Platform.iOS
 		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)
 		{
 			_flyoutBehavior = behavior;
-			var currentState = IsOpen;
-
 			if (behavior == FlyoutBehavior.Locked)
 				IsOpen = true;
 			else if (behavior == FlyoutBehavior.Disabled)
 				IsOpen = false;
-
 			LayoutSidebar(false);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -113,7 +113,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			cell.AccessibilityIdentifier = context?.AutomationId;
 
-
 			_views[context] = cell.View;
 			return cell;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Forms.Platform.iOS
 				cell.BindingContext = context;
 			}
 
-			cell.AccessibilityIdentifier = context?.AutomationId;
+			cell.SetAccessibilityProperties(context);
 
 			_views[context] = cell.View;
 			return cell;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -111,6 +111,9 @@ namespace Xamarin.Forms.Platform.iOS
 				cell.BindingContext = context;
 			}
 
+			cell.AccessibilityIdentifier = context?.AutomationId;
+
+
 			_views[context] = cell.View;
 			return cell;
 		}


### PR DESCRIPTION
### Description of Change ###

- If the FlyoutIsPresented toggles while animation is active just cancel the animation
- Set AutomationIds for flyout menu
- Fix issue when setting FlyoutIsPresented to true during load

### Issues Resolved ### 
- fixes #11247


### Platforms Affected ### 
- iOS
- Android


### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
