### PR TITLE
[Core] Unify LinearGradientBrush default values with WPF

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/LinearGradientBrushTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/LinearGradientBrushTests.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			LinearGradientBrush linearGradientBrush = new LinearGradientBrush();
 
 			Assert.AreEqual(1.0d, linearGradientBrush.EndPoint.X, "EndPoint.X");
-			Assert.AreEqual(0.0d, linearGradientBrush.EndPoint.Y, "EndPoint.Y");
+			Assert.AreEqual(1.0d, linearGradientBrush.EndPoint.Y, "EndPoint.Y");
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/LinearGradientBrush.cs
+++ b/Xamarin.Forms.Core/LinearGradientBrush.cs
@@ -38,7 +38,7 @@
 		}
 
 		public static readonly BindableProperty EndPointProperty = BindableProperty.Create(
-			nameof(EndPoint), typeof(Point), typeof(LinearGradientBrush), new Point(1, 0));
+			nameof(EndPoint), typeof(Point), typeof(LinearGradientBrush), new Point(1, 1));
 
 		public Point EndPoint
 		{


### PR DESCRIPTION
### Description of Change ###

Unify LinearGradientBrush default **EndPoint** value with WPF.

### Issues Resolved ### 

- fixes #11569 

### API Changes ###

Changed the LinearGradientBrush EndPoint default value.

### Platforms Affected ### 
- Core/XAML (all platforms)


### Behavioral/Visual Changes ###

The default LinearGradientBrush will be a diagonal gradient.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the brushes samples. The default LinearGradientBrush should be a a diagonal gradient.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
