### PR TITLE
[C] Some Rect API changes

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/RectUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RectUnitTests.cs
@@ -27,12 +27,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(4, rect.Width);
 			Assert.AreEqual(5, rect.Height);
 
-			var rectangle = new Rectangle(2, 3, 4, 5);
-			rect = new Rect(rectangle);
-			Assert.AreEqual(2, rect.X);
-			Assert.AreEqual(3, rect.Y);
-			Assert.AreEqual(4, rect.Width);
-			Assert.AreEqual(5, rect.Height);
 		}
 
 		[Test]
@@ -56,18 +50,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(new Point(2, 3), rect.Location);
 
 			Assert.AreEqual(new Point(4, 5.5), rect.Center);
-
-			rect.Left = 1;
-			Assert.AreEqual(1, rect.X);
-
-			rect.Right = 3;
-			Assert.AreEqual(2, rect.Width);
-
-			rect.Top = 1;
-			Assert.AreEqual(1, rect.Y);
-
-			rect.Bottom = 2;
-			Assert.AreEqual(1, rect.Height);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Rect.cs
+++ b/Xamarin.Forms.Core/Rect.cs
@@ -20,14 +20,6 @@ namespace Xamarin.Forms
 		{
 		}
 
-		public Rect(Rectangle rectangle) 
-		{
-			X = rectangle.X;
-			Y = rectangle.Y;
-			Width = rectangle.Width;
-			Height = rectangle.Height;
-		}
-
 		public double X { get; set; }
 
 		public double Y { get; set; }
@@ -38,41 +30,20 @@ namespace Xamarin.Forms
 
 		public static Rect Zero = new Rect();
 
-		// Position/Size
-		public double Top
-		{
-			get { return Y; }
-			set { Y = value; }
-		}
+		public double Top => Y;
 
-		public double Bottom
-		{
-			get { return Y + Height; }
-			set { Height = value - Y; }
-		}
+		public double Bottom => Y + Height;
 
-		public double Right
-		{
-			get { return X + Width; }
-			set { Width = value - X; }
-		}
+		public double Right => X + Width;
 
-		public double Left
-		{
-			get { return X; }
-			set { X = value; }
-		}
+		public double Left => X;
 
-		public bool IsEmpty
-		{
-			get { return (Width <= 0) || (Height <= 0); }
-		}
+		public bool IsEmpty => (Width <= 0) || (Height <= 0);
 
 		public Size Size
 		{
-			get { return new Size(Width, Height); }
-			set
-			{
+			get => new Size(Width, Height);
+			set {
 				Width = value.Width;
 				Height = value.Height;
 			}
@@ -80,28 +51,18 @@ namespace Xamarin.Forms
 
 		public Point Location
 		{
-			get { return new Point(X, Y); }
-			set
-			{
+			get => new Point(X, Y);
+			set {
 				X = value.X;
 				Y = value.Y;
 			}
 		}
 
-		public Point Center
-		{
-			get { return new Point(X + Width / 2, Y + Height / 2); }
-		}
+		public Point Center => new Point(X + Width / 2, Y + Height / 2);
 
-		public static Rect FromLTRB(double left, double top, double right, double bottom)
-		{
-			return new Rect(left, top, right - left, bottom - top);
-		}
+		public static Rect FromLTRB(double left, double top, double right, double bottom) => new Rect(left, top, right - left, bottom - top);
 
-		public bool Equals(Rect other)
-		{
-			return X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);
-		}
+		public bool Equals(Rect other) => X.Equals(other.X) && Y.Equals(other.Y) && Width.Equals(other.Width) && Height.Equals(other.Height);
 
 		public override bool Equals(object obj)
 		{
@@ -123,51 +84,24 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public static bool operator ==(Rect r1, Rect r2)
-		{
-			return (r1.Location == r2.Location) && (r1.Size == r2.Size);
-		}
+		public static bool operator ==(Rect r1, Rect r2) => (r1.Location == r2.Location) && (r1.Size == r2.Size);
 
-		public static bool operator !=(Rect r1, Rect r2)
-		{
-			return !(r1 == r2);
-		}
+		public static bool operator !=(Rect r1, Rect r2) => !(r1 == r2);
 
 		// Hit Testing / Intersection / Union
-		public bool Contains(Rect rect)
-		{
-			return X <= rect.X && Right >= rect.Right && Y <= rect.Y && Bottom >= rect.Bottom;
-		}
+		public bool Contains(Rect rect) => X <= rect.X && Right >= rect.Right && Y <= rect.Y && Bottom >= rect.Bottom;
 
-		public bool Contains(Point pt)
-		{
-			return Contains(pt.X, pt.Y);
-		}
+		public bool Contains(Point pt) => Contains(pt.X, pt.Y);
 
-		public bool Contains(double x, double y)
-		{
-			return (x >= Left) && (x < Right) && (y >= Top) && (y < Bottom);
-		}
+		public bool Contains(double x, double y) => (x >= Left) && (x < Right) && (y >= Top) && (y < Bottom);
 
-		public bool IntersectsWith(Rect r)
-		{
-			return !((Left >= r.Right) || (Right <= r.Left) || (Top >= r.Bottom) || (Bottom <= r.Top));
-		}
+		public bool IntersectsWith(Rect r) => !((Left >= r.Right) || (Right <= r.Left) || (Top >= r.Bottom) || (Bottom <= r.Top));
 
-		public Rect Union(Rect r)
-		{
-			return Union(this, r);
-		}
+		public Rect Union(Rect r) => Union(this, r);
 
-		public static Rect Union(Rect r1, Rect r2)
-		{
-			return FromLTRB(Math.Min(r1.Left, r2.Left), Math.Min(r1.Top, r2.Top), Math.Max(r1.Right, r2.Right), Math.Max(r1.Bottom, r2.Bottom));
-		}
+		public static Rect Union(Rect r1, Rect r2) => FromLTRB(Math.Min(r1.Left, r2.Left), Math.Min(r1.Top, r2.Top), Math.Max(r1.Right, r2.Right), Math.Max(r1.Bottom, r2.Bottom));
 
-		public Rect Intersect(Rect r)
-		{
-			return Intersect(this, r);
-		}
+		public Rect Intersect(Rect r) => Intersect(this, r);
 
 		public static Rect Intersect(Rect r1, Rect r2)
 		{
@@ -177,17 +111,13 @@ namespace Xamarin.Forms
 			double height = Math.Min(r1.Bottom, r2.Bottom) - y;
 
 			if (width < 0 || height < 0)
-			{
 				return Zero;
-			}
+
 			return new Rect(x, y, width, height);
 		}
 
 		// Inflate and Offset
-		public Rect Inflate(Size sz)
-		{
-			return Inflate(sz.Width, sz.Height);
-		}
+		public Rect Inflate(Size sz) => Inflate(sz.Width, sz.Height);
 
 		public Rect Inflate(double width, double height)
 		{
@@ -207,15 +137,9 @@ namespace Xamarin.Forms
 			return r;
 		}
 
-		public Rect Offset(Point dr)
-		{
-			return Offset(dr.X, dr.Y);
-		}
+		public Rect Offset(Point dr) => Offset(dr.X, dr.Y);
 
-		public Rect Round()
-		{
-			return new Rect(Math.Round(X), Math.Round(Y), Math.Round(Width), Math.Round(Height));
-		}
+		public Rect Round() => new Rect(Math.Round(X), Math.Round(Y), Math.Round(Width), Math.Round(Height));
 
 		public void Deconstruct(out double x, out double y, out double width, out double height)
 		{
@@ -225,15 +149,6 @@ namespace Xamarin.Forms
 			height = Height;
 		}
 
-		public static implicit operator Rect(Rectangle rectangle)
-		{
-			return new Rect(rectangle);
-		}
-
-		public override string ToString()
-		{
-			return string.Format("{{X={0} Y={1} Width={2} Height={3}}}", X.ToString(CultureInfo.InvariantCulture), Y.ToString(CultureInfo.InvariantCulture), Width.ToString(CultureInfo.InvariantCulture),
-				Height.ToString(CultureInfo.InvariantCulture));
-		}
+		public override string ToString() => $"{{X={X.ToString(CultureInfo.InvariantCulture)} Y={Y.ToString(CultureInfo.InvariantCulture)} Width={Width.ToString(CultureInfo.InvariantCulture)} Height={Height.ToString(CultureInfo.InvariantCulture)}}}";
 	}
 }

--- a/Xamarin.Forms.Core/Rectangle.cs
+++ b/Xamarin.Forms.Core/Rectangle.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms
 {
 	[DebuggerDisplay("X={X}, Y={Y}, Width={Width}, Height={Height}")]
 	[TypeConverter(typeof(RectangleTypeConverter))]
+	//[Obsolete("Xamarin.Forms.Rectangle is obsolete in 4.8. use Xamarin.Forms.Rect instead")]
 	public struct Rectangle
 	{
 		public double X { get; set; }
@@ -250,9 +251,8 @@ namespace Xamarin.Forms
 			height = Height;
 		}
 
-		public static implicit operator Rectangle(Rect rect)
-		{
-			return new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
-		}
+		public static implicit operator Rect(Rectangle rectangle) => new Rect(rectangle.X, rectangle.Y, rectangle.Width, rectangle.Height);
+
+		public static implicit operator Rectangle(Rect rect) => new Rectangle(rect.X, rect.Y, rect.Width, rect.Height);
 	}
 }

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml
@@ -4,8 +4,8 @@
         xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
         x:Class="Xamarin.Forms.Xaml.UnitTests.Gh11541">
     <Image Source="monkeyface.png">
-	<Image.Clip>
-	    <RectangleGeometry Rect="40,100,300,150" />
+	    <Image.Clip>
+	        <RectangleGeometry Rect="40,100,300,150" />
         </Image.Clip>
     </Image>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11541.xaml.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 			[Test]
 			public void RectangleGeometryDoesntThrow([Values(false, true)] bool useCompiledXaml)
 			{
-				var layout = new Gh11541(useCompiledXaml);
+				Assert.DoesNotThrow(()=> new Gh11541(useCompiledXaml));
 			}
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11551.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11551.xaml
@@ -4,13 +4,13 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	x:Class="Xamarin.Forms.Xaml.UnitTests.Gh11551">
     <ContentPage.Resources>
-	<Rect x:Key="rect" Height="22" Width="{x:Static AbsoluteLayout.AutoSize}" X="1" Y="0.5"/>
+		<Rect x:Key="rect" Height="22" Width="{x:Static AbsoluteLayout.AutoSize}" X="1" Y="0.5"/>
     </ContentPage.Resources>
     <Label x:Name="label">
-	<Label.Style>
-	    <Style TargetType="Label">
-		<Setter Property="AbsoluteLayout.LayoutBounds" Value="{DynamicResource rect}"/>
-	    </Style>
-	</Label.Style>
+		<Label.Style>
+			<Style TargetType="Label">
+				<Setter Property="AbsoluteLayout.LayoutBounds" Value="{DynamicResource rect}"/>
+			</Style>
+		</Label.Style>
     </Label>
 </ContentPage>


### PR DESCRIPTION
### Description of Change ###

- move both implicit operator to the same type (Rectangle)
- remove setters on convenience properties

### Issues Resolved ### 

- fixes #11557
- fixes #11555
- fixes maybe #11542 (to be confirmed)

### API Changes ###
 
 Removed:
 - `Rect.ctor(Rectangle)`
 - `double Rect.Top {set;}`
 - `double Rect.Bottom {set;}`
 - `double Rect.Right {set;}`
 - `double Rect.Left {set;}`
-  `static implicit operator Rect.Rect(Rectangle rectangle)`

Added:
-  `static implicit operator Rectangle.Rect(Rectangle rectangle)`

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
