### PR TITLE
Shell FlyoutBackdrop now with Brushes!!

### DIFF
--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Controls.XamStore
 		{
 			InitializeComponent();
 
-			Device.SetFlags(new List<string> { ExperimentalFlags.BrushExperimental });
+			Device.SetFlags(new List<string> { ExperimentalFlags.BrushExperimental, ExperimentalFlags.ShellUWPExperimental });
 
 			CurrentItem = _storeItem;
 		}

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -316,15 +316,34 @@ namespace Xamarin.Forms.Controls.XamStore
 			Content = new ScrollView { Content = grid };
 
 
-			//grid.Children.Add(MakeButton("FlyoutBackdrop Color",
-			//		() =>
-			//		{
-			//			if (Shell.GetFlyoutBackdropColor(Shell.Current) == Color.Default)
-			//				Shell.SetFlyoutBackdropColor(Shell.Current, Color.Purple);
-			//			else
-			//				Shell.SetFlyoutBackdropColor(Shell.Current, Color.Default);
-			//		}),
-			//	0, 21);
+			Brush nextBrush = SolidColorBrush.Purple;
+			grid.Children.Add(MakeButton("FlyoutBackdrop Brush",
+					() =>
+					{
+						if(nextBrush == SolidColorBrush.Purple)
+						{
+							LinearGradientBrush linearGradientBrush = new LinearGradientBrush();
+							linearGradientBrush.StartPoint = new Point(0, 0);
+							linearGradientBrush.EndPoint = new Point(1, 1);
+
+							linearGradientBrush.GradientStops.Add(new GradientStop(Color.FromHex("#8A2387"), 0.1f));
+							linearGradientBrush.GradientStops.Add(new GradientStop(Color.FromHex("#E94057"), 0.6f));
+							linearGradientBrush.GradientStops.Add(new GradientStop(Color.FromHex("#F27121"), 1.0f));
+
+							nextBrush = linearGradientBrush;
+						}
+						else if(nextBrush is LinearGradientBrush)
+						{
+							nextBrush = Brush.Default;
+						}
+						else
+						{
+							nextBrush = SolidColorBrush.Purple;
+						}
+
+						Shell.SetFlyoutBackdrop(Shell.Current, nextBrush);
+					}),
+				0, 21);
 
 			grid.Children.Add(MakeButton("Hide Nav Shadow",
                     () => Shell.SetNavBarHasShadow(this, false)),

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -903,6 +903,12 @@ namespace Xamarin.Forms
 			set => SetValue(FlyoutBackgroundProperty, value);
 		}
 
+		public Brush FlyoutBackdrop
+		{
+			get => (Brush)GetValue(FlyoutBackdropProperty);
+			set => SetValue(FlyoutBackdropProperty, value);
+		}
+
 		public FlyoutBehavior FlyoutBehavior
 		{
 			get => (FlyoutBehavior)GetValue(FlyoutBehaviorProperty);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -146,9 +146,9 @@ namespace Xamarin.Forms
 			BindableProperty.CreateAttached("UnselectedColor", typeof(Color), typeof(Shell), Color.Default,
 				propertyChanged: OnColorValueChanged);
 
-		//public static readonly BindableProperty FlyoutBackdropColorProperty =
-		//	BindableProperty.CreateAttached("FlyoutBackdropColor", typeof(Color), typeof(Shell), Color.Default,
-		//		propertyChanged: OnColorValueChanged);
+		public static readonly BindableProperty FlyoutBackdropProperty =
+			BindableProperty.CreateAttached("FlyoutBackdrop", typeof(Brush), typeof(Shell), Brush.Default,
+				propertyChanged: OnColorValueChanged);
 
 		public static Color GetBackgroundColor(BindableObject obj) => (Color)obj.GetValue(BackgroundColorProperty);
 		public static void SetBackgroundColor(BindableObject obj, Color value) => obj.SetValue(BackgroundColorProperty, value);
@@ -180,8 +180,8 @@ namespace Xamarin.Forms
 		public static Color GetUnselectedColor(BindableObject obj) => (Color)obj.GetValue(UnselectedColorProperty);
 		public static void SetUnselectedColor(BindableObject obj, Color value) => obj.SetValue(UnselectedColorProperty, value);
 
-		//public static Color GetFlyoutBackdropColor(BindableObject obj) => (Color)obj.GetValue(FlyoutBackdropColorProperty);
-		//public static void SetFlyoutBackdropColor(BindableObject obj, Color value) => obj.SetValue(FlyoutBackdropColorProperty, value);
+		public static Brush GetFlyoutBackdrop(BindableObject obj) => (Brush)obj.GetValue(FlyoutBackdropProperty);
+		public static void SetFlyoutBackdrop(BindableObject obj, Brush value) => obj.SetValue(FlyoutBackdropProperty, value);
 
 		static void OnColorValueChanged(BindableObject bindable, object oldValue, object newValue)
 		{

--- a/Xamarin.Forms.Core/Shell/ShellAppearance.cs
+++ b/Xamarin.Forms.Core/Shell/ShellAppearance.cs
@@ -17,11 +17,16 @@ namespace Xamarin.Forms
 			Shell.TabBarTitleColorProperty,
 			Shell.TabBarUnselectedColorProperty,
 			Shell.TitleColorProperty,
-			Shell.UnselectedColorProperty,
-			//Shell.FlyoutBackdropColorProperty
+			Shell.UnselectedColorProperty
+		};
+
+		static readonly BindableProperty[] s_ingestBrushArray = new[]
+		{
+			Shell.FlyoutBackdropProperty
 		};
 
 		Color?[] _colorArray = new Color?[s_ingestArray.Length];
+		Brush[] _brushArray = new Brush[s_ingestBrushArray.Length];
 
 		public Color BackgroundColor => _colorArray[0].Value;
 
@@ -43,7 +48,7 @@ namespace Xamarin.Forms
 
 		public Color UnselectedColor => _colorArray[9].Value;
 
-		//public Color FlyoutBackdropColor => _colorArray[10].Value;
+		public Brush FlyoutBackdrop => _brushArray[0];
 
 		Color IShellAppearanceElement.EffectiveTabBarBackgroundColor =>
 			!TabBarBackgroundColor.IsDefault ? TabBarBackgroundColor : BackgroundColor;
@@ -62,7 +67,8 @@ namespace Xamarin.Forms
 
 		internal ShellAppearance()
 		{
-
+			for (int i = 0; i < _brushArray.Length; i++)
+				_brushArray[0] = Brush.Default;
 		}
 
 		public override bool Equals(object obj)
@@ -76,6 +82,12 @@ namespace Xamarin.Forms
 					return false;
 			}
 
+			for (int i = 0; i < _brushArray.Length; i++)
+			{
+				if (!EqualityComparer<Brush>.Default.Equals(_brushArray[i], appearance._brushArray[i]))
+					return false;
+			}
+
 			return true;
 		}
 
@@ -84,6 +96,9 @@ namespace Xamarin.Forms
 			var hashCode = -1988429770;
 			for (int i = 0; i < _colorArray.Length; i++)
 				hashCode = hashCode * -1521134295 + EqualityComparer<Color>.Default.GetHashCode(_colorArray[i].Value);
+
+			for (int i = 0; i < _brushArray.Length; i++)
+				hashCode = hashCode * -1521134295 + EqualityComparer<Brush>.Default.GetHashCode(_brushArray[i]);
 
 			return hashCode;
 		}
@@ -99,6 +114,16 @@ namespace Xamarin.Forms
 				{
 					anySet = true;
 					_colorArray[i] = dataSet[i].Value;
+				}
+			}
+
+			var brushDataSet = pivot.GetValues<Brush>(s_ingestBrushArray);
+			for (int i = 0; i < s_ingestBrushArray.Length; i++)
+			{
+				if (_brushArray[i] != Brush.Default && brushDataSet[i].IsSet)
+				{
+					anySet = true;
+					_brushArray[i] = brushDataSet[i].Value;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -57,8 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IDrawerListener.OnDrawerSlide(AView drawerView, float slideOffset)
 		{
-			if(_scrimPaint != null)
-				_scrimPaint.Alpha = (int)(slideOffset * 255);
+			_scrimOpacity = (int)(slideOffset * 255);
 		}
 
 		void IDrawerListener.OnDrawerStateChanged(int newState)
@@ -92,6 +91,7 @@ namespace Xamarin.Forms.Platform.Android
 		Paint _scrimPaint;
 		int _previousHeight;
 		int _previousWidth;
+		int _scrimOpacity;
 
 		FlyoutBehavior _behavior;
 
@@ -131,6 +131,7 @@ namespace Xamarin.Forms.Platform.Android
 					_previousWidth = Width;
 				}
 
+				_scrimPaint.Alpha = _scrimOpacity;
 				canvas.DrawRect(0, 0, Width, Height, _scrimPaint);
 			}
 

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -77,10 +77,10 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(TogglePaneButton, false);
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
-			UpdateFlyoutBackdropColor();
+			UpdateFlyoutBackdrop();
 
 			if(_flyoutBehavior == FlyoutBehavior.Flyout)
-				ShellSplitView.UpdateFlyoutBackdropColor();
+				ShellSplitView.UpdateFlyoutBackdrop();
 		}
 
 		void OnPaneClosed()
@@ -186,13 +186,13 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateFlyoutBackgroundColor();
 			}
-			//else if (e.PropertyName == Shell.FlyoutBackdropColorProperty.PropertyName)
+			//else if (e.PropertyName == Shell.FlyoutBackdropProperty.PropertyName)
 			//{
-			//	UpdateFlyoutBackdropColor();
+			//	UpdateFlyoutBackdrop();
 			//}
 		}
 
-		protected virtual void UpdateFlyoutBackdropColor()
+		protected virtual void UpdateFlyoutBackdrop()
 		{
 			if (_flyoutBehavior != FlyoutBehavior.Flyout)
 				return;
@@ -200,9 +200,9 @@ namespace Xamarin.Forms.Platform.UWP
 			var splitView = ShellSplitView;
 			if (splitView != null)
 			{
-				//splitView.FlyoutBackdropColor = _shell.FlyoutBackdropColor;
+				splitView.FlyoutBackdrop = _shell.FlyoutBackdrop;
 				if (IsPaneOpen)
-					ShellSplitView.UpdateFlyoutBackdropColor();
+					ShellSplitView.UpdateFlyoutBackdrop();
 			}
 		}
 
@@ -249,7 +249,7 @@ namespace Xamarin.Forms.Platform.UWP
 			ShellController.ItemsCollectionChanged += OnItemsCollectionChanged;
 			ShellController.StructureChanged += OnStructureChanged;
 			UpdateFlyoutBackgroundColor();
-			UpdateFlyoutBackdropColor();
+			UpdateFlyoutBackdrop();
 
 			_shell.Navigated += OnShellNavigated;
 			UpdateToolBar();

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Platform.UWP
 		const string NavigationViewBackButton = "NavigationViewBackButton";
 		internal const string ShellStyle = "ShellNavigationView";
 		Shell _shell;
+		Brush _flyoutBackdrop;
 		FlyoutBehavior _flyoutBehavior;
 		ShellItemRenderer ItemRenderer { get; }
 		IShellController ShellController => (IShellController)_shell;
@@ -31,6 +32,7 @@ namespace Xamarin.Forms.Platform.UWP
 		public ShellRenderer()
 		{
 			Xamarin.Forms.Shell.VerifyShellUWPFlagEnabled(nameof(ShellRenderer));
+			_flyoutBackdrop = Brush.Default;
 			IsSettingsVisible = false;
 			PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
 			IsPaneOpen = false;
@@ -186,13 +188,9 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateFlyoutBackgroundColor();
 			}
-			//else if (e.PropertyName == Shell.FlyoutBackdropProperty.PropertyName)
-			//{
-			//	UpdateFlyoutBackdrop();
-			//}
 		}
 
-		protected virtual void UpdateFlyoutBackdrop()
+		void UpdateFlyoutBackdrop()
 		{
 			if (_flyoutBehavior != FlyoutBehavior.Flyout)
 				return;
@@ -200,7 +198,7 @@ namespace Xamarin.Forms.Platform.UWP
 			var splitView = ShellSplitView;
 			if (splitView != null)
 			{
-				splitView.FlyoutBackdrop = _shell.FlyoutBackdrop;
+				splitView.FlyoutBackdrop = _flyoutBackdrop;
 				if (IsPaneOpen)
 					ShellSplitView.UpdateFlyoutBackdrop();
 			}
@@ -249,7 +247,6 @@ namespace Xamarin.Forms.Platform.UWP
 			ShellController.ItemsCollectionChanged += OnItemsCollectionChanged;
 			ShellController.StructureChanged += OnStructureChanged;
 			UpdateFlyoutBackgroundColor();
-			UpdateFlyoutBackdrop();
 
 			_shell.Navigated += OnShellNavigated;
 			UpdateToolBar();
@@ -362,6 +359,9 @@ namespace Xamarin.Forms.Platform.UWP
 			titleBar.ForegroundColor = titleBar.ButtonForegroundColor = titleColor;
 			UpdatePaneButtonColor(TogglePaneButton, !IsPaneOpen);
 			UpdatePaneButtonColor(NavigationViewBackButton, !IsPaneOpen);
+
+			_flyoutBackdrop = appearance.FlyoutBackdrop;
+			UpdateFlyoutBackdrop();
 		}
 
 		#endregion IAppearanceObserver

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -7,6 +7,7 @@ namespace Xamarin.Forms.Platform.UWP
 	public class ShellSplitView : SplitView
 	{
 		Brush _flyoutBackdrop;
+		WBrush _flyoutPlatformBrush;
 		WBrush _defaultBrush;
 		LightDismissOverlayMode? _defaultLightDismissOverlayMode;
 		public ShellSplitView()
@@ -24,13 +25,13 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_defaultBrush == null)
 				_defaultBrush = dismissLayer.Fill;
 
-			if (_flyoutBackdrop == Brush.Default)
+			if (Brush.IsNullOrEmpty(_flyoutBackdrop))
 			{
 				dismissLayer.Fill = _defaultBrush;
 			}
 			else
 			{
-				dismissLayer.Fill = _flyoutBackdrop.ToBrush();
+				dismissLayer.Fill = _flyoutPlatformBrush;				
 			}
 		}
 
@@ -54,6 +55,8 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					LightDismissOverlayMode = LightDismissOverlayMode.On;
 				}
+
+				_flyoutPlatformBrush = _flyoutBackdrop.ToBrush();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class ShellSplitView : SplitView
 	{
-		Color _flyoutBackdropColor;
+		Brush _flyoutBackdrop;
 		WBrush _defaultBrush;
 		LightDismissOverlayMode? _defaultLightDismissOverlayMode;
 		public ShellSplitView()
@@ -14,7 +14,7 @@ namespace Xamarin.Forms.Platform.UWP
 		}
 
 
-		internal void UpdateFlyoutBackdropColor()
+		internal void UpdateFlyoutBackdrop()
 		{
 			var dismissLayer = ((WRectangle)GetTemplateChild("LightDismissLayer"));
 
@@ -24,29 +24,29 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_defaultBrush == null)
 				_defaultBrush = dismissLayer.Fill;
 
-			if (_flyoutBackdropColor == Color.Default)
+			if (_flyoutBackdrop == Brush.Default)
 			{
 				dismissLayer.Fill = _defaultBrush;
 			}
 			else
 			{
-				dismissLayer.Fill = _flyoutBackdropColor.ToBrush();
+				dismissLayer.Fill = _flyoutBackdrop.ToBrush();
 			}
 		}
 
-		internal Color FlyoutBackdropColor
+		internal Brush FlyoutBackdrop
 		{
 			set
 			{
-				if (_flyoutBackdropColor == value)
+				if (_flyoutBackdrop == value)
 					return;
 
-				_flyoutBackdropColor = value;
+				_flyoutBackdrop = value;
 
 				if (_defaultLightDismissOverlayMode == null)
 					_defaultLightDismissOverlayMode = LightDismissOverlayMode;
 
-				if (value == Color.Default)
+				if (value == Brush.Default)
 				{
 					LightDismissOverlayMode = _defaultLightDismissOverlayMode ?? LightDismissOverlayMode.Auto;
 				}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -56,7 +56,8 @@ namespace Xamarin.Forms.Platform.UWP
 					LightDismissOverlayMode = LightDismissOverlayMode.On;
 				}
 
-				_flyoutPlatformBrush = _flyoutBackdrop.ToBrush();
+				if (_flyoutBackdrop != null)
+					_flyoutPlatformBrush = _flyoutBackdrop.ToBrush();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -58,6 +58,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 				if (_flyoutBackdrop != null)
 					_flyoutPlatformBrush = _flyoutBackdrop.ToBrush();
+				else
+					_flyoutPlatformBrush = Brush.Default.ToBrush();
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else
 			{
-				dismissLayer.Fill = _flyoutPlatformBrush;				
+				dismissLayer.Fill = _flyoutPlatformBrush ?? _defaultBrush;
 			}
 		}
 
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.UWP
 				if (_flyoutBackdrop != null)
 					_flyoutPlatformBrush = _flyoutBackdrop.ToBrush();
 				else
-					_flyoutPlatformBrush = Brush.Default.ToBrush();
+					_flyoutPlatformBrush = _defaultBrush;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -14,10 +14,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
-			//if (appearance == null)
-				_backdropColor = Color.Default;
-			//else
-			//	_backdropColor = appearance.FlyoutBackdropColor;
+			if (appearance == null)
+				_backdropBrush = Brush.Default;
+			else
+				_backdropBrush = appearance.FlyoutBackdrop;
 
 			UpdateTapoffViewBackgroundColor();
 		}
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _gestureActive;
 		bool _isOpen;
 		UIViewPropertyAnimator _flyoutAnimation;
-		Color _backdropColor;
+		Brush _backdropBrush;
 
 		public UIViewAnimationCurve AnimationCurve { get; set; } = UIViewAnimationCurve.EaseOut;
 
@@ -236,11 +236,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (TapoffView == null)
 				return;
 
-			
-			if (_backdropColor != Color.Default)
-				TapoffView.BackgroundColor = _backdropColor.ToUIColor();
-			else
-				TapoffView.BackgroundColor = ColorExtensions.BackgroundColor.ColorWithAlpha(0.5f);
+			TapoffView.UpdateBackground(_backdropBrush);
 		}
 
 		void AddTapoffView()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -237,6 +237,8 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			TapoffView.UpdateBackground(_backdropBrush);
+			if (Brush.IsNullOrEmpty(_backdropBrush))
+				TapoffView.BackgroundColor = ColorExtensions.BackgroundColor.ColorWithAlpha(0.5f);
 		}
 
 		void AddTapoffView()


### PR DESCRIPTION
### Description of Change ###

Add FlyoutBackdrop back into Shell but now based on Brushes

https://github.com/xamarin/Xamarin.Forms/pull/10511

### API Changes ###
Added:
 - Brush ShellAppearance.FlyoutBackdrop


### Platforms Affected ### 
- iOS
- Android
- UWP

### Before/After Screenshots ### 

#### Android
![6F1D65D4-DD8E-4C3B-A7FD-116E42C857C9](https://user-images.githubusercontent.com/5375137/80635878-c3157400-8a19-11ea-8344-ff2a5217323f.GIF)


### Testing Procedure ###
- play with store shell

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
