### PR TITLE
Check for null appearance before setting backdrop

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -352,6 +352,8 @@ namespace Xamarin.Forms.Platform.UWP
 					backgroundColor = appearance.BackgroundColor.ToWindowsColor();
 				if (!appearance.TitleColor.IsDefault)
 					titleColor = appearance.TitleColor.ToWindowsColor();
+
+				_flyoutBackdrop = appearance.FlyoutBackdrop;
 			}
 
 			var titleBar = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TitleBar;
@@ -360,7 +362,6 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(TogglePaneButton, !IsPaneOpen);
 			UpdatePaneButtonColor(NavigationViewBackButton, !IsPaneOpen);
 
-			_flyoutBackdrop = appearance.FlyoutBackdrop;
 			UpdateFlyoutBackdrop();
 		}
 


### PR DESCRIPTION
### Description of Change ###

If appearance is null than don't set the backdrop


### Platforms Affected ### 
- UWP


### Testing Procedure ###
- ui tests pass
- backdrop still works on uwp

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
