### PR TITLE
[Android] FlowDirection property now has an effect on label controls

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Controls.Issues.Issue2447" FlowDirection="RightToLeft">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label Text="English Text" FontSize="Large" FlowDirection="RightToLeft"/>
+            <Label Text="نووسینی کوردی" FontSize="Large" FlowDirection="RightToLeft" />
+            <Label Text="English Text" FontSize="Large" FlowDirection="LeftToRight"/>
+            <Label Text="نووسینی کوردی" FontSize="Large" FlowDirection="LeftToRight"/>
+            <Label Text="English Text" FontSize="Large"/>
+            <Label Text="نووسینی کوردی" FontSize="Large"/>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using System.Windows.Input;
+using System.Diagnostics;
+
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+#if APP
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+#endif
+	[Preserve (AllMembers = true)]
+	[Issue (IssueTracker.Github, 2447, "Force label text direction", PlatformAffected.Android)]
+	public partial class Issue2447 : ContentPage
+	{
+		public Issue2447 ()
+		{
+			InitializeComponent();
+		}
+	}
+#endif
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -169,6 +169,13 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateMaxLines();
 			else if (e.PropertyName == Label.PaddingProperty.PropertyName)
 				UpdatePadding();
+			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				UpdateFlowDirection();
+		}
+
+		void UpdateFlowDirection()
+		{
+			Control.UpdateFlowDirection(Element);
 		}
 
 		void UpdateColor()

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -122,6 +122,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateLineHeight();
 				UpdateGravity();
 				UpdateMaxLines();
+				UpdateFlowDirection();
 			}
 			else
 			{	
@@ -134,6 +135,8 @@ namespace Xamarin.Forms.Platform.Android
 					UpdateMaxLines();
 				if (e.OldElement.CharacterSpacing != e.NewElement.CharacterSpacing)
 					UpdateCharacterSpacing();
+				if (e.OldElement.FlowDirection != e.NewElement.FlowDirection)
+					UpdateFlowDirection();
 			}
 			UpdateTextDecorations();
 			UpdatePadding();


### PR DESCRIPTION
### Description of Change ###

The FlowDirection property now has an effect on label controls. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2447

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before:
![image](https://user-images.githubusercontent.com/66331238/88825646-731b8a00-d18d-11ea-951f-2cd2c9b5adbd.png)

After:
![image](https://user-images.githubusercontent.com/66331238/88828352-be836780-d190-11ea-9157-de78db98c235.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

1. Create new project
2. Add Two labels to a page
3. Write English text in the first label and Kurdish/Arabic (نووسینی کوردی) text in the other
4. Set Page FlowDirection to RightToLeft

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
