### PR TITLE
Easing type converter

### DIFF
--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/EasingTypeConverter.cs
@@ -17,10 +17,15 @@ namespace Xamarin.Forms.Core.XamlC
 				yield break;
 			}
 
+			value = value?.Trim() ?? "";
+			var parts = value.Split('.');
+			if (parts.Length == 2 && parts[0] == nameof(Easing))
+				value = parts[parts.Length - 1];
+
 			var assemblyTypeInfo = ("Xamarin.Forms.Core", "Xamarin.Forms", nameof(Easing));
-			var easing = value?.Trim();
+			
 			var module = context.Body.Method.Module;
-			var fieldReference = module.ImportFieldReference(assemblyTypeInfo, easing, isStatic: true, caseSensitive: false);
+			var fieldReference = module.ImportFieldReference(assemblyTypeInfo, value, isStatic: true, caseSensitive: false);
 
 			if (fieldReference != null)
 			{

--- a/Xamarin.Forms.Build.Tasks/CompiledConverters/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Build.Tasks/CompiledConverters/EasingTypeConverter.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Mono.Cecil.Cil;
+using Xamarin.Forms.Xaml;
+using Xamarin.Forms.Build.Tasks;
+using static Mono.Cecil.Cil.Instruction;
+using static Mono.Cecil.Cil.OpCodes;
+
+namespace Xamarin.Forms.Core.XamlC
+{
+	class EasingTypeConverter : ICompiledTypeConverter
+	{
+		public IEnumerable<Instruction> ConvertFromString(string value, ILContext context, BaseNode node)
+		{
+			if (string.IsNullOrWhiteSpace(value))
+			{
+				yield return Create(Ldnull);
+				yield break;
+			}
+
+			var assemblyTypeInfo = ("Xamarin.Forms.Core", "Xamarin.Forms", nameof(Easing));
+			var easing = value?.Trim();
+			var module = context.Body.Method.Module;
+			var fieldReference = module.ImportFieldReference(assemblyTypeInfo, easing, isStatic: true, caseSensitive: false);
+
+			if (fieldReference != null)
+			{
+				yield return Create(Ldsfld, fieldReference);
+				yield break;
+			}
+
+			throw new BuildException(BuildExceptionCode.Conversion, node, null, value, typeof(Easing));
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/EasingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/EasingTests.cs
@@ -28,5 +28,49 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True (Math.Abs (val - Easing.SpringIn.Ease (val)) < epsilon);
 			Assert.True (Math.Abs (val - Easing.SpringOut.Ease (val)) < epsilon);
 		}
+
+		[Test]
+		public void TestEasingTypeConverter()
+		{
+			var converter = new EasingTypeConverter();
+			Assert.True(converter.CanConvertFrom(typeof(string)));
+			Assert.Null(converter.ConvertFromInvariantString(null));
+			Assert.Null(converter.ConvertFromInvariantString(string.Empty));
+			Assert.AreEqual(Easing.Linear, converter.ConvertFromInvariantString("Linear"));
+			Assert.AreEqual(Easing.Linear, converter.ConvertFromInvariantString("linear"));
+			Assert.AreEqual(Easing.Linear, converter.ConvertFromInvariantString("Easing.Linear"));
+			Assert.AreEqual(Easing.SinOut, converter.ConvertFromInvariantString("SinOut"));
+			Assert.AreEqual(Easing.SinOut, converter.ConvertFromInvariantString("sinout"));
+			Assert.AreEqual(Easing.SinOut, converter.ConvertFromInvariantString("Easing.SinOut"));
+			Assert.AreEqual(Easing.SinIn, converter.ConvertFromInvariantString("SinIn"));
+			Assert.AreEqual(Easing.SinIn, converter.ConvertFromInvariantString("sinin"));
+			Assert.AreEqual(Easing.SinIn, converter.ConvertFromInvariantString("Easing.SinIn"));
+			Assert.AreEqual(Easing.SinInOut, converter.ConvertFromInvariantString("SinInOut"));
+			Assert.AreEqual(Easing.SinInOut, converter.ConvertFromInvariantString("sininout"));
+			Assert.AreEqual(Easing.SinInOut, converter.ConvertFromInvariantString("Easing.SinInOut"));
+			Assert.AreEqual(Easing.CubicOut, converter.ConvertFromInvariantString("CubicOut"));
+			Assert.AreEqual(Easing.CubicOut, converter.ConvertFromInvariantString("cubicout"));
+			Assert.AreEqual(Easing.CubicOut, converter.ConvertFromInvariantString("Easing.CubicOut"));
+			Assert.AreEqual(Easing.CubicIn, converter.ConvertFromInvariantString("CubicIn"));
+			Assert.AreEqual(Easing.CubicIn, converter.ConvertFromInvariantString("cubicin"));
+			Assert.AreEqual(Easing.CubicIn, converter.ConvertFromInvariantString("Easing.CubicIn"));
+			Assert.AreEqual(Easing.CubicInOut, converter.ConvertFromInvariantString("CubicInOut"));
+			Assert.AreEqual(Easing.CubicInOut, converter.ConvertFromInvariantString("cubicinout"));
+			Assert.AreEqual(Easing.CubicInOut, converter.ConvertFromInvariantString("Easing.CubicInOut"));
+			Assert.AreEqual(Easing.BounceOut, converter.ConvertFromInvariantString("BounceOut"));
+			Assert.AreEqual(Easing.BounceOut, converter.ConvertFromInvariantString("bounceout"));
+			Assert.AreEqual(Easing.BounceOut, converter.ConvertFromInvariantString("Easing.BounceOut"));
+			Assert.AreEqual(Easing.BounceIn, converter.ConvertFromInvariantString("BounceIn"));
+			Assert.AreEqual(Easing.BounceIn, converter.ConvertFromInvariantString("bouncein"));
+			Assert.AreEqual(Easing.BounceIn, converter.ConvertFromInvariantString("Easing.BounceIn"));
+			Assert.AreEqual(Easing.SpringOut, converter.ConvertFromInvariantString("SpringOut"));
+			Assert.AreEqual(Easing.SpringOut, converter.ConvertFromInvariantString("springout"));
+			Assert.AreEqual(Easing.SpringOut, converter.ConvertFromInvariantString("Easing.SpringOut"));
+			Assert.AreEqual(Easing.SpringIn, converter.ConvertFromInvariantString("SpringIn"));
+			Assert.AreEqual(Easing.SpringIn, converter.ConvertFromInvariantString("springin"));
+			Assert.AreEqual(Easing.SpringIn, converter.ConvertFromInvariantString("Easing.SpringIn"));
+			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("WrongEasingName"));
+			Assert.Throws<InvalidOperationException>(() => converter.ConvertFromInvariantString("Easing.Linear.SinInOut"));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/BindableProperty.cs
+++ b/Xamarin.Forms.Core/BindableProperty.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms
 		{
 			{ typeof(Uri), new UriTypeConverter() },
 			{ typeof(Color), new ColorTypeConverter() },
+			{ typeof(Easing), new EasingTypeConverter() },
 		};
 
 		static readonly Dictionary<Type, IValueConverter> KnownIValueConverters = new Dictionary<Type, IValueConverter>

--- a/Xamarin.Forms.Core/Easing.cs
+++ b/Xamarin.Forms.Core/Easing.cs
@@ -28,6 +28,7 @@ using System;
 
 namespace Xamarin.Forms
 {
+	[TypeConverter(typeof(EasingTypeConverter))]
 	public class Easing
 	{
 		public static readonly Easing Linear = new Easing(x => x);

--- a/Xamarin.Forms.Core/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Core/EasingTypeConverter.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using System.Reflection;
 using static Xamarin.Forms.Easing;
 
 namespace Xamarin.Forms
@@ -39,6 +41,15 @@ namespace Xamarin.Forms
 				return SpringIn;
 			if (value.Equals(nameof(SpringOut), StringComparison.OrdinalIgnoreCase))
 				return SpringOut;
+
+			var fallbackValue = typeof(Easing)
+				.GetTypeInfo()
+				.DeclaredFields
+				.FirstOrDefault(f => f.Name.Equals(value, StringComparison.OrdinalIgnoreCase))
+				?.GetValue(null);
+
+			if (fallbackValue is Easing fallbackEasing)
+				return fallbackEasing;
 
 			throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Easing)}");
 		}

--- a/Xamarin.Forms.Core/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Core/EasingTypeConverter.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms
 
 			value = value?.Trim() ?? "";
 			var parts = value.Split('.');
-			if (parts.Length == 2 && parts[0].Equals(nameof(Easing), StringComparison.OrdinalIgnoreCase))
+			if (parts.Length == 2 && parts[0] == nameof(Easing))
 				value = parts[parts.Length - 1];
 
 			if (value.Equals(nameof(Linear), StringComparison.OrdinalIgnoreCase))

--- a/Xamarin.Forms.Core/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Core/EasingTypeConverter.cs
@@ -17,21 +17,24 @@ namespace Xamarin.Forms
 			if (parts.Length == 2 && parts[0] == nameof(Easing))
 				value = parts[parts.Length - 1];
 
-			switch (value.ToLowerInvariant().Trim())
+			switch (value)
 			{
-				case "linear": return Linear;
-				case "sinin": return SinIn;
-				case "sinout": return SinOut;
-				case "sininout": return SinInOut;
-				case "cubicin": return CubicIn;
-				case "cubicout": return CubicOut;
-				case "cubicinout": return CubicInOut;
-				case "bouncein": return BounceIn;
-				case "bounceout": return BounceOut;
-				case "springin": return SpringIn;
-				case "springout": return SpringOut;
+				case string easing when AreEqual(easing, nameof(Linear)): return Linear;
+				case string easing when AreEqual(easing, nameof(SinIn)): return SinIn;
+				case string easing when AreEqual(easing, nameof(SinOut)): return SinOut;
+				case string easing when AreEqual(easing, nameof(SinInOut)): return SinInOut;
+				case string easing when AreEqual(easing, nameof(CubicIn)): return CubicIn;
+				case string easing when AreEqual(easing, nameof(CubicOut)): return CubicOut;
+				case string easing when AreEqual(easing, nameof(CubicInOut)): return CubicInOut;
+				case string easing when AreEqual(easing, nameof(BounceIn)): return BounceIn;
+				case string easing when AreEqual(easing, nameof(BounceOut)): return BounceOut;
+				case string easing when AreEqual(easing, nameof(SpringIn)): return SpringIn;
+				case string easing when AreEqual(easing, nameof(SpringOut)): return SpringOut;
 				default: throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Easing)}");
 			}
 		}
+
+		bool AreEqual(string first, string second)
+			=> first.Equals(second, StringComparison.OrdinalIgnoreCase);
 	}
 }

--- a/Xamarin.Forms.Core/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Core/EasingTypeConverter.cs
@@ -9,9 +9,16 @@ namespace Xamarin.Forms
 	{
 		public override object ConvertFromInvariantString(string value)
 		{
-			switch (value?.ToLowerInvariant()?.Trim() ?? "")
+			if (string.IsNullOrWhiteSpace(value))
+				return null;
+
+			value = value?.Trim() ?? "";
+			var parts = value.Split('.');
+			if (parts.Length == 2 && parts[0] == nameof(Easing))
+				value = parts[parts.Length - 1];
+
+			switch (value.ToLowerInvariant().Trim())
 			{
-				case "": return null;
 				case "linear": return Linear;
 				case "sinin": return SinIn;
 				case "sinout": return SinOut;

--- a/Xamarin.Forms.Core/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Core/EasingTypeConverter.cs
@@ -14,27 +14,33 @@ namespace Xamarin.Forms
 
 			value = value?.Trim() ?? "";
 			var parts = value.Split('.');
-			if (parts.Length == 2 && parts[0] == nameof(Easing))
+			if (parts.Length == 2 && parts[0].Equals(nameof(Easing), StringComparison.OrdinalIgnoreCase))
 				value = parts[parts.Length - 1];
 
-			switch (value)
-			{
-				case string easing when AreEqual(easing, nameof(Linear)): return Linear;
-				case string easing when AreEqual(easing, nameof(SinIn)): return SinIn;
-				case string easing when AreEqual(easing, nameof(SinOut)): return SinOut;
-				case string easing when AreEqual(easing, nameof(SinInOut)): return SinInOut;
-				case string easing when AreEqual(easing, nameof(CubicIn)): return CubicIn;
-				case string easing when AreEqual(easing, nameof(CubicOut)): return CubicOut;
-				case string easing when AreEqual(easing, nameof(CubicInOut)): return CubicInOut;
-				case string easing when AreEqual(easing, nameof(BounceIn)): return BounceIn;
-				case string easing when AreEqual(easing, nameof(BounceOut)): return BounceOut;
-				case string easing when AreEqual(easing, nameof(SpringIn)): return SpringIn;
-				case string easing when AreEqual(easing, nameof(SpringOut)): return SpringOut;
-				default: throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Easing)}");
-			}
-		}
+			if (value.Equals(nameof(Linear), StringComparison.OrdinalIgnoreCase))
+				return Linear;
+			if (value.Equals(nameof(SinIn), StringComparison.OrdinalIgnoreCase))
+				return SinIn;
+			if (value.Equals(nameof(SinOut), StringComparison.OrdinalIgnoreCase))
+				return SinOut;
+			if (value.Equals(nameof(SinInOut), StringComparison.OrdinalIgnoreCase))
+				return SinInOut;
+			if (value.Equals(nameof(CubicIn), StringComparison.OrdinalIgnoreCase))
+				return CubicIn;
+			if (value.Equals(nameof(CubicOut), StringComparison.OrdinalIgnoreCase))
+				return CubicOut;
+			if (value.Equals(nameof(CubicInOut), StringComparison.OrdinalIgnoreCase))
+				return CubicInOut;
+			if (value.Equals(nameof(BounceIn), StringComparison.OrdinalIgnoreCase))
+				return BounceIn;
+			if (value.Equals(nameof(BounceOut), StringComparison.OrdinalIgnoreCase))
+				return BounceOut;
+			if (value.Equals(nameof(SpringIn), StringComparison.OrdinalIgnoreCase))
+				return SpringIn;
+			if (value.Equals(nameof(SpringOut), StringComparison.OrdinalIgnoreCase))
+				return SpringOut;
 
-		bool AreEqual(string first, string second)
-			=> first.Equals(second, StringComparison.OrdinalIgnoreCase);
+			throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Easing)}");
+		}
 	}
 }

--- a/Xamarin.Forms.Core/EasingTypeConverter.cs
+++ b/Xamarin.Forms.Core/EasingTypeConverter.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using static Xamarin.Forms.Easing;
+
+namespace Xamarin.Forms
+{
+	[Xaml.ProvideCompiled("Xamarin.Forms.Core.XamlC.EasingTypeConverter")]
+	[Xaml.TypeConversion(typeof(Easing))]
+	public class EasingTypeConverter : TypeConverter
+	{
+		public override object ConvertFromInvariantString(string value)
+		{
+			switch (value?.ToLowerInvariant()?.Trim() ?? "")
+			{
+				case "": return null;
+				case "linear": return Linear;
+				case "sinin": return SinIn;
+				case "sinout": return SinOut;
+				case "sininout": return SinInOut;
+				case "cubicin": return CubicIn;
+				case "cubicout": return CubicOut;
+				case "cubicinout": return CubicInOut;
+				case "bouncein": return BounceIn;
+				case "bounceout": return BounceOut;
+				case "springin": return SpringIn;
+				case "springout": return SpringOut;
+				default: throw new InvalidOperationException($"Cannot convert \"{value}\" into {typeof(Easing)}");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/TypeConverterTests.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeConverterTests.xaml
@@ -8,5 +8,9 @@
 				<UriImageSource Uri="https://xamarin.com/content/images/pages/branding/assets/xamagon.png" x:Name="imageSource"/>
 			</Image.Source>
 		</Image>
+		<Expander x:Name="expander"
+				  ExpandAnimationEasing="CubicInOut"
+				  CollapseAnimationEasing="Easing.sininout">
+		</Expander>
 	</StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/TypeConverterTests.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/TypeConverterTests.xaml.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 	{
 		public TypeConverterTests ()
 		{
+			Device.SetFlags(new[] { ExperimentalFlags.ExpanderExperimental });
 			InitializeComponent ();
 		}
 
@@ -33,6 +34,17 @@ namespace Xamarin.Forms.Xaml.UnitTests
 				var layout = new TypeConverterTests (useCompiledXaml);
 				Assert.That (layout.imageSource.Uri, Is.TypeOf<Uri> ());
 				Assert.AreEqual ("https://xamarin.com/content/images/pages/branding/assets/xamagon.png", layout.imageSource.Uri.ToString ());
+			}
+
+			[TestCase(false)]
+			[TestCase(true)]
+			public void EasingsAreConverted(bool useCompiledXaml)
+			{
+				var layout = new TypeConverterTests(useCompiledXaml);
+				Assert.That(layout.expander.ExpandAnimationEasing, Is.TypeOf<Easing>());
+				Assert.That(layout.expander.CollapseAnimationEasing, Is.TypeOf<Easing>());
+				Assert.AreEqual(Easing.CubicInOut, layout.expander.ExpandAnimationEasing);
+				Assert.AreEqual(Easing.SinInOut, layout.expander.CollapseAnimationEasing);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###
Added EasingTypeConverter for convenient use Easings with xaml.

### API Changes ###
Added:
 - EasingTypeConverter

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
**BEFORE**
```xaml
<Expander ExpandAnimationEasing="{x:Static Easing.CubicIn}"
          CollapseAnimationEasing="{x:Static Easing.CubicOut}">
<!-- Content -->
</Expander>
```

**AFTER**
```xaml
<Expander ExpandAnimationEasing="CubicIn"
          CollapseAnimationEasing="Easing.CubicOut">
<!-- Content -->
</Expander>
```

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Run unit test **TestEasingTypeConverter** test case.

### PR Checklist ###
- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
