### PR TITLE
Don't update safe area offset on non visible page

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
@@ -1,0 +1,97 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shell)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10608, "[Bug] [Shell] [iOS] Locked flyout causes application to freezes when quickly switching between tabs", PlatformAffected.iOS)]
+	public class Issue10608 : TestShell
+	{
+		public Issue10608()
+		{
+		}
+
+		protected override void Init()
+		{
+			FlyoutBehavior = FlyoutBehavior.Locked;
+
+			AddFlyoutItem("Click");
+			AddFlyoutItem("Between");
+			AddFlyoutItem("These Flyouts");
+			AddFlyoutItem("Really Fast");
+			AddFlyoutItem("If it doesn't");
+			AddFlyoutItem("Lock test has passed");
+
+			int i = 0;
+			foreach(var item in Items)
+			{
+				item.Items[0].AutomationId = $"FlyoutItem{i}";
+				item.Items[0].Items.Add(new ContentPage()
+				{
+					Title = "Page"
+				});
+
+				i++;
+			}
+
+			Items.Add(new MenuItem()
+			{
+				Text = "Let me click for you",
+				AutomationId = $"FlyoutItem{i}",
+				Command = new Command(async () =>
+				{
+					for (int j = 0; j < 5; j++)
+					{
+						CurrentItem = Items[0].Items[0];
+						await Task.Delay(10);
+						CurrentItem = Items[1].Items[0];
+						await Task.Delay(10);
+					}
+
+					CurrentItem = Items[0].Items[0];
+				})
+			});
+
+			Items[0].Items[0].Items[0].Title = "Tab 1";
+			Items[0].Items[0].Items[0].AutomationId = "Tab1AutomationId";
+			Items[1].Items[0].Items[0].Title = "Tab 2";
+			Items[1].Items[0].Items[0].AutomationId = "Tab2AutomationId";
+
+			Items[0].FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems;
+			Items[1].FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems;
+		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.Shell)]
+		public void ShellWithTopTabsFreezesWhenNavigatingFlyoutItems()
+		{
+			RunningApp.Tap("FlyoutItem6");
+			RunningApp.Tap("FlyoutItem0");
+			for (int i = 0; i < 5; i++)
+			{
+				RunningApp.WaitForElement("Tab1AutomationId");
+				RunningApp.Tap("FlyoutItem0");
+				RunningApp.Tap("FlyoutItem1");
+				RunningApp.Tap("FlyoutItem0");
+			}
+
+			RunningApp.WaitForElement("Tab1AutomationId");
+			RunningApp.Tap("FlyoutItem1");
+			RunningApp.WaitForElement("Tab2AutomationId");
+			RunningApp.Tap("FlyoutItem0");
+			RunningApp.WaitForElement("Tab1AutomationId");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1442,6 +1442,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11272.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10608.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -396,6 +396,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!IsPartOfShell && !Forms.IsiOS11OrNewer)
 				return;
 
+			if (IsPartOfShell && !_appeared)
+				return;
+
 			var tabThickness = _tabThickness;
 			if (!_isInItems)
 				tabThickness = 0;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootHeader.cs
@@ -104,6 +104,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 				headerCell.Selected = false;
 
+			headerCell.SetAccessibilityProperties(shellContent);
 			return headerCell;
 		}
 


### PR DESCRIPTION
### Description of Change ###

- the ios page renderer when disappearing was still propagating its inset information to shell which was causing a ping pong effect
- Automation properties weren't being set on top tabs

### Issues Resolved ### 
- fixes #10608

### Platforms Affected ### 
- iOS
- Android


### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
