### PR TITLE
Bug/9106 - Adding cascading fallbacks for visual state management in CheckBox

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
@@ -24,7 +24,6 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 
-
 			Button button = null;
 			button = new Button()
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3150.cs
@@ -24,6 +24,7 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 
+
 			Button button = null;
 			button = new Button()
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+                       xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                       xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+                       x:Class="Xamarin.Forms.Controls.Issues.Issue9106">
+    <StackLayout Orientation="Vertical">
+        <Button Text="Toggle IsEnabled" Command="{Binding ToggleCheckboxIsEnabledCommand}"/>
+        <CheckBox x:Name="CheckBoxUnderTest"
+                  IsChecked="{Binding CheckboxIsChecked}"
+                  IsEnabled="{Binding CheckboxIsEnabled}">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup x:Name="CommonStates">
+                    <VisualState x:Name="Normal">
+                        <VisualState.Setters>
+                            <Setter Property="Color" Value="Green" />
+                        </VisualState.Setters>
+                    </VisualState>
+
+                    <VisualState x:Name="Focused" />
+
+                    <VisualState x:Name="Disabled">
+                        <VisualState.Setters>
+                            <Setter Property="Color" Value="Red" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+        </CheckBox>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml
@@ -4,6 +4,7 @@
                        xmlns:local="clr-namespace:Xamarin.Forms.Controls"
                        x:Class="Xamarin.Forms.Controls.Issues.Issue9106">
     <StackLayout Orientation="Vertical">
+        <Label Text="Although we did not define a visual state for IsChecked, we return to Normal state when IsChecked is true and we toggle IsEnabled from false to true."/>
         <Button Text="Toggle IsEnabled" Command="{Binding ToggleCheckboxIsEnabledCommand}"/>
         <CheckBox x:Name="CheckBoxUnderTest"
                   IsChecked="{Binding CheckboxIsChecked}"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml
@@ -4,11 +4,13 @@
                        xmlns:local="clr-namespace:Xamarin.Forms.Controls"
                        x:Class="Xamarin.Forms.Controls.Issues.Issue9106">
     <StackLayout Orientation="Vertical">
-        <Label Text="Although we did not define a visual state for IsChecked, we return to Normal state when IsChecked is true and we toggle IsEnabled from false to true."/>
+        <Label Text="If the user forgets to assign IsChecked or Normal for a visual state group but did define Disabled, the Visual State Manager should remove the Disabled Setters when trying to return to a Normal State."/>
         <Button Text="Toggle IsEnabled" Command="{Binding ToggleCheckboxIsEnabledCommand}"/>
         <CheckBox x:Name="CheckBoxUnderTest"
                   IsChecked="{Binding CheckboxIsChecked}"
                   IsEnabled="{Binding CheckboxIsEnabled}">
+
+            <!--Try different combinations of setting visual states-->
             <VisualStateManager.VisualStateGroups>
                 <VisualStateGroup x:Name="CommonStates">
                     <VisualState x:Name="Normal">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using System.Threading.Tasks;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Windows.Input;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9106, "[Bug] Checked CheckBox does not update VisualState properly")]
+	public partial class Issue9106 : TestContentPage
+	{
+#if UITEST
+		[Test]
+		[NUnit.Framework.Category(UITestCategories.ManualReview)]
+		public void Issue3798Test()
+		{
+			RunningApp.WaitForElement("listViewSeparatorColor");
+			RunningApp.Screenshot("Green ListView Separator");
+			RunningApp.Tap(q => q.Marked("item1"));
+			RunningApp.Screenshot("Red ListView Separator");
+		}
+#endif
+		public Issue9106()
+		{
+			InitializeComponent();
+		}
+
+
+		protected override void Init()
+		{
+			BindingContext = new Issue9106ViewModel();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue9106ViewModel : BindableObject
+	{
+		public bool CheckboxIsEnabled { get; set; } 
+		public bool CheckboxIsChecked { get; set; } 
+
+		public Issue9106ViewModel()
+		{
+			CheckboxIsEnabled = false;
+			CheckboxIsChecked = false;
+		}
+
+		public ICommand ToggleCheckboxIsEnabledCommand => new Command(ToggleCheckboxIsEnabled);
+
+		void ToggleCheckboxIsEnabled()
+		{
+			CheckboxIsEnabled = !CheckboxIsEnabled;
+			OnPropertyChanged("CheckboxIsEnabled");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9106.xaml.cs
@@ -19,17 +19,6 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 9106, "[Bug] Checked CheckBox does not update VisualState properly")]
 	public partial class Issue9106 : TestContentPage
 	{
-#if UITEST
-		[Test]
-		[NUnit.Framework.Category(UITestCategories.ManualReview)]
-		public void Issue3798Test()
-		{
-			RunningApp.WaitForElement("listViewSeparatorColor");
-			RunningApp.Screenshot("Green ListView Separator");
-			RunningApp.Tap(q => q.Marked("item1"));
-			RunningApp.Screenshot("Red ListView Separator");
-		}
-#endif
 		public Issue9106()
 		{
 			InitializeComponent();
@@ -51,7 +40,7 @@ namespace Xamarin.Forms.Controls.Issues
 		public Issue9106ViewModel()
 		{
 			CheckboxIsEnabled = false;
-			CheckboxIsChecked = false;
+			CheckboxIsChecked = true;
 		}
 
 		public ICommand ToggleCheckboxIsEnabledCommand => new Command(ToggleCheckboxIsEnabled);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1444,6 +1444,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11374.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9106.xaml.cs">
+      <DependentUpon>Issue9106.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1696,6 +1700,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11262.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9106.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Core/CheckBox.cs
+++ b/Xamarin.Forms.Core/CheckBox.cs
@@ -34,10 +34,15 @@ namespace Xamarin.Forms
 
 		protected internal override void ChangeVisualState()
 		{
-			base.ChangeVisualState();
-
 			if (IsEnabled && IsChecked)
-				VisualStateManager.GoToState(this, IsCheckedVisualState);
+			{
+				if (!VisualStateManager.GoToState(this, IsCheckedVisualState))
+					VisualStateManager.GoToState(this, "Normal");
+			}
+			else
+			{ 
+				base.ChangeVisualState();
+			}
 		}
 
 		public event EventHandler<CheckedChangedEventArgs> CheckedChanged;

--- a/Xamarin.Forms.Core/CheckBox.cs
+++ b/Xamarin.Forms.Core/CheckBox.cs
@@ -34,10 +34,10 @@ namespace Xamarin.Forms
 
 		protected internal override void ChangeVisualState()
 		{
+			base.ChangeVisualState();
+
 			if (IsEnabled && IsChecked)
 				VisualStateManager.GoToState(this, IsCheckedVisualState);
-			else
-				base.ChangeVisualState();
 		}
 
 		public event EventHandler<CheckedChangedEventArgs> CheckedChanged;

--- a/Xamarin.Forms.Core/CheckBox.cs
+++ b/Xamarin.Forms.Core/CheckBox.cs
@@ -37,10 +37,11 @@ namespace Xamarin.Forms
 			if (IsEnabled && IsChecked)
 			{
 				if (!VisualStateManager.GoToState(this, IsCheckedVisualState))
-					VisualStateManager.GoToState(this, "Normal");
+					if(!VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal))
+						VisualStateManager.ResetCommonStatesGroupSetters(this);
 			}
 			else
-			{ 
+			{
 				base.ChangeVisualState();
 			}
 		}

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -966,7 +966,8 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal);
+				if(!VisualStateManager.GoToState(this, VisualStateManager.CommonStates.Normal))
+					VisualStateManager.ResetCommonStatesGroupSetters(this);
 			}
 		}
 

--- a/Xamarin.Forms.Core/VisualStateManager.cs
+++ b/Xamarin.Forms.Core/VisualStateManager.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Forms
 			public const string Selected = "Selected";
 		}
 
+		public const string CommonStatesGroupName = "CommonStates";
+
 		public static readonly BindableProperty VisualStateGroupsProperty =
 			BindableProperty.CreateAttached("VisualStateGroups", typeof(VisualStateGroupList), typeof(VisualElement),
 				defaultValue: null, propertyChanged: VisualStateGroupsPropertyChanged,
@@ -46,6 +48,35 @@ namespace Xamarin.Forms
 		public static void SetVisualStateGroups(VisualElement visualElement, VisualStateGroupList value)
 		{
 			visualElement.SetValue(VisualStateGroupsProperty, value);
+		}
+
+		// Use this as a fallback if the user did not define all the common states and got into an undesireable state
+		public static bool ResetCommonStatesGroupSetters(VisualElement visualElement)
+		{
+			if (!visualElement.HasVisualStateGroups())
+			{
+				return false;
+			}
+
+			var groups = (IList<VisualStateGroup>)visualElement.GetValue(VisualStateGroupsProperty);
+
+			foreach (VisualStateGroup group in groups)
+			{
+				if (group.Name == CommonStatesGroupName)
+				{
+					if (group.CurrentState != null)
+					{
+						foreach (Setter setter in group.CurrentState.Setters)
+						{
+							setter.UnApply(visualElement);
+						}
+						group.CurrentState = null;
+						return true;
+					}
+				}
+			}
+
+			return false;
 		}
 
 		public static bool GoToState(VisualElement visualElement, string name)


### PR DESCRIPTION
### Description of Change ###

Add fallbacks in Checkbox and VisualElements that are trying to get to a "Normal" state, but may not have defined that state. Ideally this should really be up to the user to define all the states correctly, but it might be nice to have fallbacks.

### Issues Resolved ###

- fixes #9106 

### API Changes ###

Added CommonStatesGroupName const.
Added ResetCommonStatesGroupSetters method in the Visual State Manager to revert value setters when the user is trying to return to a Normal State.
Added cascading fallbacks in the Checkbox ChangeVisualState method.

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###


### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Go to Issue9106.xaml and test different variations of defining all/some common states(Normal,Disabled,IsChecked).
The elements should always return to a state that makes sense to the user.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
