### PR TITLE
[msbuild] skip XamlC target if no xaml files

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -106,7 +106,12 @@
 		</CompileDependsOn>
 	</PropertyGroup>
 
-	<Target Name="XamlC" AfterTargets="AfterCompile" Inputs="$(IntermediateOutputPath)$(TargetFileName)" Outputs="$(IntermediateOutputPath)XamlC.stamp" Condition=" '$(DesignTimeBuild)' != 'True'">
+	<Target Name="XamlC"
+		AfterTargets="AfterCompile"
+		DependsOnTargets="_FindXamlGFiles"
+		Inputs="$(IntermediateOutputPath)$(TargetFileName)"
+		Outputs="$(IntermediateOutputPath)XamlC.stamp"
+		Condition=" '$(DesignTimeBuild)' != 'True' AND '@(_XamlGInputs->Count())' != '0' ">
 	    <PropertyGroup>
 		<_XFXamlCValidateOnly>$(XFXamlCValidateOnly)</_XFXamlCValidateOnly>
 		<_XFXamlCValidateOnly Condition="'$(BuildingForLiveUnitTesting)' == 'True' ">True</_XFXamlCValidateOnly>


### PR DESCRIPTION
### Description of Change ###

I was reviewing a customer's build logs, and saw the following:

    32953 ms  XamlC                                     34 calls

This was a build log where they changed one line of C# code in a
project that is referenced by many other projects. This is a fairly
large solution with ~63 projects.

Digging deeper, there were 5 instances of:

    No compiled resources. Skipping writing assembly.

Looking at the `XamlG` target, these had no `.xaml` files at all:

    Target Name=XamlG
        Target Name=_FindXamlGFiles
        Skipping target "XamlG" because it has no outputs.
        Though the target has declared its outputs, the output specification only references empty properties and/or empty item lists.

Yet `XamlC` still ran and took ~667ms in one instance.

If we *skipped* `XamlC` when there no `.xaml` files, it would have
saved approximately 5.5 seconds of time in the original customer's
build.

Changes:

* `XamlC` skips if `@(_XamlGInputs)` has no items. I used `->Count()`
  here for better performance, because MSBuild will expand into a
  semicolon-delimited string if using: `'@(_XamlGInputs)' != ''`.
* I explicitly listed `_FindXamlGFiles` as a dependency of the `XamlC`
  target.
* Added a test checking `XamlC` properly skips.
* I made `MSBuildTests` leave the temporary directory intact if a test
  fails. This was useful when working on this.
* One test needed a proper `.xaml` file in order to pass now.

### Issues Resolved ### 

n/a

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

CI should be sufficient.

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
