### PR TITLE
Null check Element in VisualElementRenderer.LayoutSubviews

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Items[1].FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems;
 		}
 
-#if UITEST
+#if UITEST && __SHELL__
 		[Test]
 		[Category(UITestCategories.Shell)]
 		public void ShellWithTopTabsFreezesWhenNavigatingFlyoutItems()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
@@ -21,16 +21,45 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 		}
 
+		void AddPage(string title)
+		{
+			var page = AddFlyoutItem(title);
+
+			page.Content = new Grid()
+			{
+				Children =
+				{
+					new ScrollView()
+					{
+						Content =
+							new StackLayout()
+							{
+								Children =
+								{
+									new Button()
+									{
+										Text = "Learn More",
+										Margin = new Thickness(0,10,0,0),
+										BackgroundColor = Color.Purple,
+										TextColor = Color.White
+									}
+								}
+							}
+					}
+				}
+			};
+		}
+
 		protected override void Init()
 		{
 			FlyoutBehavior = FlyoutBehavior.Locked;
 
-			AddFlyoutItem("Click");
-			AddFlyoutItem("Between");
-			AddFlyoutItem("These Flyouts");
-			AddFlyoutItem("Really Fast");
-			AddFlyoutItem("If it doesn't");
-			AddFlyoutItem("Lock test has passed");
+			AddPage("Click");
+			AddPage("Between");
+			AddPage("These Flyouts");
+			AddPage("Really Fast");
+			AddPage("If it doesn't");
+			AddPage("Lock test has passed");
 
 			int i = 0;
 			foreach(var item in Items)

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -328,7 +328,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					Superview.Add(_blur);
 			}
 
-			bool hasBackground = Element.Background != null && !Element.Background.IsEmpty;
+			bool hasBackground = Element?.Background != null && !Element.Background.IsEmpty;
 
 			if (hasBackground)
 				NativeView.UpdateBackgroundLayer();


### PR DESCRIPTION
### Description of Change ###

`VisualElementRenderer.LayoutSubviews` is sometimes called after the `VisualElementRenderer` has been disposed of so we should null check Element inside LayoutSubviews 

### Issues Resolved ### 
- fixes #11664 


### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
- run the UI tests and just click really fast between flyout items

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
