### PR TITLE
Added a Flow Direction Property to action sheets and alert dialogs

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml.cs
@@ -14,11 +14,11 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 #endif
-	[Preserve (AllMembers = true)]
-	[Issue (IssueTracker.Github, 2447, "Force label text direction", PlatformAffected.Android)]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2447, "Force label text direction", PlatformAffected.Android)]
 	public partial class Issue2447 : ContentPage
 	{
-		public Issue2447 ()
+		public Issue2447()
 		{
 			InitializeComponent();
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2447.xaml.cs
@@ -10,7 +10,6 @@ using Xamarin.Forms.Internals;
 namespace Xamarin.Forms.Controls.Issues
 {
 
-#if APP
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 #endif
@@ -18,10 +17,11 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 2447, "Force label text direction", PlatformAffected.Android)]
 	public partial class Issue2447 : ContentPage
 	{
+#if APP
 		public Issue2447()
 		{
 			InitializeComponent();
 		}
-	}
 #endif
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
@@ -1,0 +1,12 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+			 x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
+             FlowDirection="RightToLeft">
+	<StackLayout>
+        <Label Text="English Text" FontSize="Large" />
+        <Label Text="نووسینی کوردی" FontSize="Large" />
+        <Button Text="Press this button to get a display alert" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" Clicked="Button_Clicked" FlowDirection="RightToLeft"/>
+        <Button Text="Press this button to get a display actionsheet" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" Clicked="Button2_Clicked" FlowDirection="RightToLeft"/>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
@@ -1,9 +1,8 @@
-﻿<?xml version="1.0" encoding="UTF-8" ?>
-<ContentPage
-    x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    FlowDirection="MatchParent">
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
+             FlowDirection="MatchParent">
     <StackLayout>
         <Button
             Clicked="AlertNoFlow_Clicked"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
@@ -2,8 +2,7 @@
 <ContentPage
     x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    FlowDirection="RightToLeft">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
     <StackLayout>
         <Button
             Clicked="Button1_Clicked"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
@@ -2,45 +2,46 @@
 <ContentPage
     x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
     xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml">
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    FlowDirection="MatchParent">
     <StackLayout>
         <Button
-            Clicked="Button1_Clicked"
+            Clicked="AlertNoFlow_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display Alert No Flow Direction"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button2_Clicked"
+            Clicked="AlertMatchParent_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display Alert Flow Direction Match Parent"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button3_Clicked"
+            Clicked="AlertRTL_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display Alert Flow Direction RTL"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button4_Clicked"
+            Clicked="AlertLTR_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display Alert Flow Direction LTR"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button5_Clicked"
+            Clicked="ActionsheetNoFlow_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display ActionSheet No Flow Direction"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button6_Clicked"
+            Clicked="ActionsheetMatchParent_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display ActionSheet Flow Direction Match Parent"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button7_Clicked"
+            Clicked="ActionsheetRTL_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display ActionSheet Flow Direction RTL"
             VerticalOptions="CenterAndExpand" />
         <Button
-            Clicked="Button8_Clicked"
+            Clicked="ActionsheetLTR_Clicked"
             HorizontalOptions="CenterAndExpand"
             Text="Display ActionSheet Flow Direction LTR"
             VerticalOptions="CenterAndExpand" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml
@@ -1,12 +1,49 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-			 xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-			 x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
-             FlowDirection="RightToLeft">
-	<StackLayout>
-        <Label Text="English Text" FontSize="Large" />
-        <Label Text="نووسینی کوردی" FontSize="Large" />
-        <Button Text="Press this button to get a display alert" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" Clicked="Button_Clicked" FlowDirection="RightToLeft"/>
-        <Button Text="Press this button to get a display actionsheet" HorizontalOptions="CenterAndExpand" VerticalOptions="CenterAndExpand" Clicked="Button2_Clicked" FlowDirection="RightToLeft"/>
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    x:Class="Xamarin.Forms.Controls.Issues.Issue2448"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    FlowDirection="RightToLeft">
+    <StackLayout>
+        <Button
+            Clicked="Button1_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display Alert No Flow Direction"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button2_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display Alert Flow Direction Match Parent"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button3_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display Alert Flow Direction RTL"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button4_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display Alert Flow Direction LTR"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button5_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display ActionSheet No Flow Direction"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button6_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display ActionSheet Flow Direction Match Parent"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button7_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display ActionSheet Flow Direction RTL"
+            VerticalOptions="CenterAndExpand" />
+        <Button
+            Clicked="Button8_Clicked"
+            HorizontalOptions="CenterAndExpand"
+            Text="Display ActionSheet Flow Direction LTR"
+            VerticalOptions="CenterAndExpand" />
     </StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
@@ -16,60 +16,46 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 		}
 
-		void Button1_Clicked(object sender, EventArgs args)
-		{
 #if APP
+		void AlertNoFlow_Clicked(object sender, EventArgs args)
+		{
 			var alert = DisplayAlert("Alert", "You have been alerted", "OK");
-#endif
 		}
 
-		void Button2_Clicked(object sender, EventArgs args)
+		void AlertMatchParent_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayAlert("Alert", "You have been alerted", "OK", FlowDirection.MatchParent);
-#endif
 		}
 
-		void Button3_Clicked(object sender, EventArgs args)
+		void AlertRTL_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayAlert("Alert", "You have been alerted", "OK", FlowDirection.RightToLeft);
-#endif
 		}
 
-		void Button4_Clicked(object sender, EventArgs args)
+		void AlertLTR_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayAlert("Alert", "You have been alerted", "OK", FlowDirection.LeftToRight);
-#endif
 		}
 
-		void Button5_Clicked(object sender, EventArgs args)
+		void ActionsheetNoFlow_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", "Photo Roll", "Email");
-#endif
 		}
 
-		void Button6_Clicked(object sender, EventArgs args)
+		void ActionsheetMatchParent_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.MatchParent, "Photo Roll", "Email");
-#endif
 		}
 
-		void Button7_Clicked(object sender, EventArgs args)
+		void ActionsheetRTL_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.RightToLeft, "Photo Roll", "Email");
-#endif
 		}
 
-		void Button8_Clicked(object sender, EventArgs args)
+		void ActionsheetLTR_Clicked(object sender, EventArgs args)
 		{
-#if APP
 			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.LeftToRight, "Photo Roll", "Email");
-#endif
 		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
@@ -16,7 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 		}
 
-		void Button_Clicked(object sender, EventArgs args)
+		void Button1_Clicked(object sender, EventArgs args)
 		{
 #if APP
 			var alert = DisplayAlert("Alert", "You have been alerted", "OK");
@@ -26,7 +26,49 @@ namespace Xamarin.Forms.Controls.Issues
 		void Button2_Clicked(object sender, EventArgs args)
 		{
 #if APP
+			var alert = DisplayAlert("Alert", "You have been alerted", "OK", FlowDirection.MatchParent);
+#endif
+		}
+
+		void Button3_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayAlert("Alert", "You have been alerted", "OK", FlowDirection.RightToLeft);
+#endif
+		}
+
+		void Button4_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayAlert("Alert", "You have been alerted", "OK", FlowDirection.LeftToRight);
+#endif
+		}
+
+		void Button5_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", "Photo Roll", "Email");
+#endif
+		}
+
+		void Button6_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.MatchParent, "Photo Roll", "Email");
+#endif
+		}
+
+		void Button7_Clicked(object sender, EventArgs args)
+		{
+#if APP
 			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.RightToLeft, "Photo Roll", "Email");
+#endif
+		}
+
+		void Button8_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.LeftToRight, "Photo Roll", "Email");
 #endif
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 2448, "Setting FlowDirection of Alerts and ActionSheets", PlatformAffected.iOS | PlatformAffected.Android)]
+
+	public partial class Issue2448 : ContentPage
+	{
+		public Issue2448()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		void Button_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayAlert("Alert", "You have been alerted", "OK");
+#endif
+		}
+
+		void Button2_Clicked(object sender, EventArgs args)
+		{
+#if APP
+			var alert = DisplayActionSheet("ActionSheet: SavePhoto?", "Cancel", "Delete", FlowDirection.RightToLeft, "Photo Roll", "Email");
+#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2448.xaml.cs
@@ -1,12 +1,21 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
 
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2448, "Setting FlowDirection of Alerts and ActionSheets", PlatformAffected.iOS | PlatformAffected.Android)]
-
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
 	public partial class Issue2448 : ContentPage
 	{
 		public Issue2448()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -51,6 +51,12 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12246.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12652.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12714.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2447.xaml.cs">
+      <DependentUpon>Issue2447.xaml</DependentUpon>
+    </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue2448.xaml.cs">
+      <DependentUpon>Issue2448.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />
@@ -2492,6 +2498,16 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12344.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2447.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2448.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/ActionSheetArguments.cs
+++ b/Xamarin.Forms.Core/ActionSheetArguments.cs
@@ -5,44 +5,47 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
-	[EditorBrowsable(EditorBrowsableState.Never)]
-	public class ActionSheetArguments
-	{
-		public ActionSheetArguments(string title, string cancel, string destruction, IEnumerable<string> buttons)
-		{
-			Title = title;
-			Cancel = cancel;
-			Destruction = destruction;
-			Buttons = buttons?.Where(c => c != null);
-			Result = new TaskCompletionSource<string>();
-		}
+    [EditorBrowsable(EditorBrowsableState.Never)]
+    public class ActionSheetArguments
+    {
+        public ActionSheetArguments(string title, string cancel, string destruction, IEnumerable<string> buttons)
+        {
+            Title = title;
+            Cancel = cancel;
+            Destruction = destruction;
+            Buttons = buttons?.Where(c => c != null);
+            Result = new TaskCompletionSource<string>();
+            FlowDirection = FlowDirection.MatchParent;
+        }
 
-		/// <summary>
-		///     Gets titles of any buttons on the action sheet that aren't <see cref="Cancel" /> or <see cref="Destruction" />. Can
-		///     be <c>null</c>.
-		/// </summary>
-		public IEnumerable<string> Buttons { get; private set; }
+        /// <summary>
+        ///     Gets titles of any buttons on the action sheet that aren't <see cref="Cancel" /> or <see cref="Destruction" />. Can
+        ///     be <c>null</c>.
+        /// </summary>
+        public IEnumerable<string> Buttons { get; private set; }
 
-		/// <summary>
-		///     Gets the text for a cancel button. Can be null.
-		/// </summary>
-		public string Cancel { get; private set; }
+        /// <summary>
+        ///     Gets the text for a cancel button. Can be null.
+        /// </summary>
+        public string Cancel { get; private set; }
 
-		/// <summary>
-		///     Gets the text for a destructive button. Can be null.
-		/// </summary>
-		public string Destruction { get; private set; }
+        /// <summary>
+        ///     Gets the text for a destructive button. Can be null.
+        /// </summary>
+        public string Destruction { get; private set; }
 
-		public TaskCompletionSource<string> Result { get; }
+        public TaskCompletionSource<string> Result { get; }
 
-		/// <summary>
-		///     Gets the title for the action sheet. Can be null.
-		/// </summary>
-		public string Title { get; private set; }
+        /// <summary>
+        ///     Gets the title for the action sheet. Can be null.
+        /// </summary>
+        public string Title { get; private set; }
 
-		public void SetResult(string result)
-		{
-			Result.TrySetResult(result);
-		}
-	}
+        public FlowDirection FlowDirection { get; set; }
+
+        public void SetResult(string result)
+        {
+            Result.TrySetResult(result);
+        }
+    }
 }

--- a/Xamarin.Forms.Core/ActionSheetArguments.cs
+++ b/Xamarin.Forms.Core/ActionSheetArguments.cs
@@ -5,47 +5,47 @@ using System.Threading.Tasks;
 
 namespace Xamarin.Forms.Internals
 {
-    [EditorBrowsable(EditorBrowsableState.Never)]
-    public class ActionSheetArguments
-    {
-        public ActionSheetArguments(string title, string cancel, string destruction, IEnumerable<string> buttons)
-        {
-            Title = title;
-            Cancel = cancel;
-            Destruction = destruction;
-            Buttons = buttons?.Where(c => c != null);
-            Result = new TaskCompletionSource<string>();
-            FlowDirection = FlowDirection.MatchParent;
-        }
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class ActionSheetArguments
+	{
+		public ActionSheetArguments(string title, string cancel, string destruction, IEnumerable<string> buttons)
+		{
+			Title = title;
+			Cancel = cancel;
+			Destruction = destruction;
+			Buttons = buttons?.Where(c => c != null);
+			Result = new TaskCompletionSource<string>();
+			FlowDirection = FlowDirection.MatchParent;
+		}
 
-        /// <summary>
-        ///     Gets titles of any buttons on the action sheet that aren't <see cref="Cancel" /> or <see cref="Destruction" />. Can
-        ///     be <c>null</c>.
-        /// </summary>
-        public IEnumerable<string> Buttons { get; private set; }
+		/// <summary>
+		///     Gets titles of any buttons on the action sheet that aren't <see cref="Cancel" /> or <see cref="Destruction" />. Can
+		///     be <c>null</c>.
+		/// </summary>
+		public IEnumerable<string> Buttons { get; private set; }
 
-        /// <summary>
-        ///     Gets the text for a cancel button. Can be null.
-        /// </summary>
-        public string Cancel { get; private set; }
+		/// <summary>
+		///     Gets the text for a cancel button. Can be null.
+		/// </summary>
+		public string Cancel { get; private set; }
 
-        /// <summary>
-        ///     Gets the text for a destructive button. Can be null.
-        /// </summary>
-        public string Destruction { get; private set; }
+		/// <summary>
+		///     Gets the text for a destructive button. Can be null.
+		/// </summary>
+		public string Destruction { get; private set; }
 
-        public TaskCompletionSource<string> Result { get; }
+		public TaskCompletionSource<string> Result { get; }
 
-        /// <summary>
-        ///     Gets the title for the action sheet. Can be null.
-        /// </summary>
-        public string Title { get; private set; }
+		/// <summary>
+		///     Gets the title for the action sheet. Can be null.
+		/// </summary>
+		public string Title { get; private set; }
 
-        public FlowDirection FlowDirection { get; set; }
+		public FlowDirection FlowDirection { get; set; }
 
-        public void SetResult(string result)
-        {
-            Result.TrySetResult(result);
-        }
-    }
+		public void SetResult(string result)
+		{
+			Result.TrySetResult(result);
+		}
+	}
 }

--- a/Xamarin.Forms.Core/AlertArguments.cs
+++ b/Xamarin.Forms.Core/AlertArguments.cs
@@ -13,6 +13,7 @@ namespace Xamarin.Forms.Internals
 			Accept = accept;
 			Cancel = cancel;
 			Result = new TaskCompletionSource<bool>();
+			FlowDirection = FlowDirection.MatchParent;
 		}
 
 		/// <summary>
@@ -31,6 +32,8 @@ namespace Xamarin.Forms.Internals
 		public string Message { get; private set; }
 
 		public TaskCompletionSource<bool> Result { get; }
+
+		public FlowDirection FlowDirection { get; set; }
 
 		/// <summary>
 		///     Gets the title for the alert. Can be null.

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -190,6 +190,19 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
+		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, FlowDirection flowDirection, params string[] buttons)
+		{
+			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
+			args.FlowDirection = flowDirection;
+
+			if (IsPlatformEnabled)
+				MessagingCenter.Send(this, ActionSheetSignalName, args);
+			else
+				_pendingActions.Add(() => MessagingCenter.Send(this, ActionSheetSignalName, args));
+
+			return args.Result.Task;
+		}
+
 		public Task DisplayAlert(string title, string message, string cancel)
 		{
 			return DisplayAlert(title, message, null, cancel);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -180,14 +180,7 @@ namespace Xamarin.Forms
 
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, params string[] buttons)
 		{
-			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
-
-			if (IsPlatformEnabled)
-				MessagingCenter.Send(this, ActionSheetSignalName, args);
-			else
-				_pendingActions.Add(() => MessagingCenter.Send(this, ActionSheetSignalName, args));
-
-			return args.Result.Task;
+			return DisplayActionSheet(title, cancel, destruction, FlowDirection.MatchParent, buttons);
 		}
 
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, FlowDirection flowDirection, params string[] buttons)
@@ -204,7 +197,17 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection = FlowDirection.MatchParent)
+		public Task DisplayAlert(string title, string message, string cancel)
+		{
+			return DisplayAlert(title, message, null, cancel, FlowDirection.MatchParent);
+		}
+
+		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
+		{
+			return DisplayAlert(title, message, accept, cancel, FlowDirection.MatchParent);
+		}
+
+		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection)
 		{
 			return DisplayAlert(title, message, null, cancel, flowDirection);
 		}

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -212,7 +212,7 @@ namespace Xamarin.Forms
 			return DisplayAlert(title, message, null, cancel, flowDirection);
 		}
 
-		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection = FlowDirection.MatchParent)
+		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection)
 		{
 			if (string.IsNullOrEmpty(cancel))
 				throw new ArgumentNullException("cancel");

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -193,6 +193,7 @@ namespace Xamarin.Forms
 		public Task<string> DisplayActionSheet(string title, string cancel, string destruction, FlowDirection flowDirection, params string[] buttons)
 		{
 			var args = new ActionSheetArguments(title, cancel, destruction, buttons);
+
 			args.FlowDirection = flowDirection;
 
 			if (IsPlatformEnabled)
@@ -203,17 +204,19 @@ namespace Xamarin.Forms
 			return args.Result.Task;
 		}
 
-		public Task DisplayAlert(string title, string message, string cancel)
+		public Task DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection = FlowDirection.MatchParent)
 		{
-			return DisplayAlert(title, message, null, cancel);
+			return DisplayAlert(title, message, null, cancel, flowDirection);
 		}
 
-		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel)
+		public Task<bool> DisplayAlert(string title, string message, string accept, string cancel, FlowDirection flowDirection = FlowDirection.MatchParent)
 		{
 			if (string.IsNullOrEmpty(cancel))
 				throw new ArgumentNullException("cancel");
 
 			var args = new AlertArguments(title, message, accept, cancel);
+			args.FlowDirection = flowDirection;
+
 			if (IsPlatformEnabled)
 				MessagingCenter.Send(this, AlertSignalName, args);
 			else

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -132,6 +132,7 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 				}
 
+				int messageID = 16908299;
 				var alert = new DialogBuilder(Activity).Create();
 				alert.SetTitleFlowDirection(arguments.FlowDirection);
 				alert.SetTitle(arguments.Title);
@@ -144,12 +145,13 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (arguments.FlowDirection == FlowDirection.LeftToRight)
 				{
-					TextView textView = (TextView)alert.findViewByID(Resource.Id.message);
+					
+					TextView textView = (TextView)alert.findViewByID(messageID);
 					textView.TextDirection = TextDirection.Ltr;
 				}
 				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
 				{
-					TextView textView = (TextView)alert.findViewByID(Resource.Id.message);
+					TextView textView = (TextView)alert.findViewByID(messageID);
 					textView.TextDirection = TextDirection.Rtl;
 				}
 			}
@@ -388,15 +390,11 @@ namespace Xamarin.Forms.Platform.Android
 					if (_useAppCompat)
 					{
 						_appcompatAlertDialog.SetMessage(message);
-						TextView msgtext = (TextView)_appcompatAlertDialog.FindViewById(Resource.Id.message);
-						msgtext.SetForegroundGravity(GravityFlags.CenterHorizontal);
 
 					}
 					else
 					{
 						_legacyAlertDialog.SetMessage(message);
-						TextView msgtext = (TextView)_legacyAlertDialog.FindViewById(Resource.Id.message);
-						msgtext.SetForegroundGravity(GravityFlags.CenterHorizontal);
 					}
 				}
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -109,10 +109,18 @@ namespace Xamarin.Forms.Platform.Android
 				//and return null
 				if (arguments.FlowDirection == FlowDirection.MatchParent)
 				{
-					if (sender.FlowDirection == FlowDirection.MatchParent)
-						dialog.SetTitleFlowDirection(Device.FlowDirection);
-					else
-						dialog.SetTitleFlowDirection(sender.FlowDirection);
+					//if (sender.FlowDirection == FlowDirection.MatchParent)
+					//	dialog.SetTitleFlowDirection(Device.FlowDirection);
+					//else
+					//	dialog.SetTitleFlowDirection(sender.FlowDirection);
+					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
+					{
+						dialog.SetTitleFlowDirection(FlowDirection.RightToLeft);
+					}
+					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
+					{
+						dialog.SetTitleFlowDirection(FlowDirection.LeftToRight);
+					}
 				}
 				else
 				{
@@ -137,28 +145,15 @@ namespace Xamarin.Forms.Platform.Android
 				}
 				else
 				{
-					if (sender.FlowDirection == FlowDirection.LeftToRight)
-					{
-						layoutDirection = LayoutDirection.Ltr;
-						textDirection = TextDirection.Ltr;
-					}
-					else if (sender.FlowDirection == FlowDirection.RightToLeft)
+					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 					{
 						layoutDirection = LayoutDirection.Rtl;
 						textDirection = TextDirection.Rtl;
 					}
-					else
+					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
 					{
-						if (Device.FlowDirection == FlowDirection.LeftToRight)
-						{
-							layoutDirection = LayoutDirection.Ltr;
-							textDirection = TextDirection.Ltr;
-						}
-						else if (Device.FlowDirection == FlowDirection.RightToLeft)
-						{
-							layoutDirection = LayoutDirection.Rtl;
-							textDirection = TextDirection.Rtl;
-						}
+						layoutDirection = LayoutDirection.Ltr;
+						textDirection = TextDirection.Ltr;
 					}
 				}
 
@@ -182,10 +177,18 @@ namespace Xamarin.Forms.Platform.Android
 				var alert = new DialogBuilder(Activity).Create();
 				if (arguments.FlowDirection == FlowDirection.MatchParent)
 				{
-					if (sender.FlowDirection == FlowDirection.MatchParent)
-						alert.SetTitleFlowDirection(Device.FlowDirection);
-					else
-						alert.SetTitleFlowDirection(sender.FlowDirection);
+					//if (sender.FlowDirection == FlowDirection.MatchParent)
+					//	alert.SetTitleFlowDirection(Device.FlowDirection);
+					//else
+					//	alert.SetTitleFlowDirection(sender.FlowDirection);
+					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
+					{
+						alert.SetTitleFlowDirection(FlowDirection.RightToLeft);
+					}
+					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
+					{
+						alert.SetTitleFlowDirection(FlowDirection.LeftToRight);
+					}
 				}
 				else
 				{
@@ -214,28 +217,15 @@ namespace Xamarin.Forms.Platform.Android
 				}
 				else
 				{
-					if (sender.FlowDirection == FlowDirection.LeftToRight)
-					{
-						layoutDirection = LayoutDirection.Ltr;
-						textDirection = TextDirection.Ltr;
-					}
-					else if (sender.FlowDirection == FlowDirection.RightToLeft)
+					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 					{
 						layoutDirection = LayoutDirection.Rtl;
 						textDirection = TextDirection.Rtl;
 					}
-					else
+					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
 					{
-						if (Device.FlowDirection == FlowDirection.LeftToRight)
-						{
-							layoutDirection = LayoutDirection.Ltr;
-							textDirection = TextDirection.Ltr;
-						}
-						else if (Device.FlowDirection == FlowDirection.RightToLeft)
-						{
-							layoutDirection = LayoutDirection.Rtl;
-							textDirection = TextDirection.Rtl;
-						}
+						layoutDirection = LayoutDirection.Ltr;
+						textDirection = TextDirection.Ltr;
 					}
 				}
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -93,8 +93,6 @@ namespace Xamarin.Forms.Platform.Android
 
 				var builder = new DialogBuilder(Activity);
 
-				arguments.FlowDirection = FlowDirection.LeftToRight;
-
 				builder.SetTitle(arguments.Title);
 				string[] items = arguments.Buttons.ToArray();
 				builder.SetItems(items, (o, args) => arguments.Result.TrySetResult(items[args.Which]));
@@ -109,9 +107,21 @@ namespace Xamarin.Forms.Platform.Android
 				builder.Dispose();
 				//to match current functionality of renderer we set cancelable on outside
 				//and return null
+				dialog.SetTitleFlowDirection(arguments.FlowDirection);
 				dialog.SetCanceledOnTouchOutside(true);
 				dialog.SetCancelEvent((o, e) => arguments.SetResult(null));
 				dialog.Show();
+
+				if (arguments.FlowDirection == FlowDirection.LeftToRight)
+				{
+					var listview = dialog.GetListView();
+					listview.TextDirection = TextDirection.Ltr;
+				}
+				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
+				{
+					var listview = dialog.GetListView();
+					listview.TextDirection = TextDirection.Rtl;
+				}
 			}
 
 			void OnAlertRequested(Page sender, AlertArguments arguments)
@@ -123,6 +133,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				var alert = new DialogBuilder(Activity).Create();
+				alert.SetTitleFlowDirection(arguments.FlowDirection);
 				alert.SetTitle(arguments.Title);
 				alert.SetMessage(arguments.Message);
 				if (arguments.Accept != null)
@@ -130,6 +141,17 @@ namespace Xamarin.Forms.Platform.Android
 				alert.SetButton((int)DialogButtonType.Negative, arguments.Cancel, (o, args) => arguments.SetResult(false));
 				alert.SetCancelEvent((o, args) => { arguments.SetResult(false); });
 				alert.Show();
+
+				if (arguments.FlowDirection == FlowDirection.LeftToRight)
+				{
+					TextView textView = (TextView)alert.findViewByID(Resource.Id.message);
+					textView.TextDirection = TextDirection.Ltr;
+				}
+				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
+				{
+					TextView textView = (TextView)alert.findViewByID(Resource.Id.message);
+					textView.TextDirection = TextDirection.Rtl;
+				}
 			}
 
 			void OnPromptRequested(Page sender, PromptArguments arguments)
@@ -306,14 +328,6 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 
-			//public class RightJustifyAlertDialog : AlertDialog
-			//{
-			//	public RightJustifyAlertDialog(Context ctx)
-			//	{
-			//		base(ctx, )
-			//	}
-			//}
-
 			internal sealed class FlexibleAlertDialog
 			{
 				readonly AppCompatAlertDialog _appcompatAlertDialog;
@@ -323,16 +337,12 @@ namespace Xamarin.Forms.Platform.Android
 				public FlexibleAlertDialog(AlertDialog alertDialog)
 				{
 					_legacyAlertDialog = alertDialog;
-					_legacyAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
-					
 				}
 
 				public FlexibleAlertDialog(AppCompatAlertDialog alertDialog)
 				{
 					_appcompatAlertDialog = alertDialog;
 					_useAppCompat = true;
-					_appcompatAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
-					
 				}
 
 				public void SetTitle(string title)
@@ -344,6 +354,32 @@ namespace Xamarin.Forms.Platform.Android
 					else
 					{
 						_legacyAlertDialog.SetTitle(title);
+					}
+				}
+
+				public void SetTitleFlowDirection(FlowDirection flowDirection)
+				{
+					if (flowDirection == FlowDirection.LeftToRight)
+					{
+						if (_useAppCompat)
+						{
+							_appcompatAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Ltr;
+						}
+						else
+						{
+							_legacyAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Ltr;
+						}
+					}
+					else if (flowDirection == FlowDirection.RightToLeft)
+					{
+						if (_useAppCompat)
+						{
+							_appcompatAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
+						}
+						else
+						{
+							_legacyAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
+						}
 					}
 				}
 
@@ -373,6 +409,18 @@ namespace Xamarin.Forms.Platform.Android
 					else
 					{
 						_legacyAlertDialog.SetButton(whichButton, text, handler);
+					}
+				}
+
+				public global::Android.Views.View GetListView()
+				{
+					if (_useAppCompat)
+					{
+						return _appcompatAlertDialog.ListView;
+					}
+					else
+					{
+						return _legacyAlertDialog.ListView;
 					}
 				}
 
@@ -409,6 +457,18 @@ namespace Xamarin.Forms.Platform.Android
 					else
 					{
 						_legacyAlertDialog.SetView(view);
+					}
+				}
+
+				public global::Android.Views.View findViewByID(int id)
+				{
+					if (_useAppCompat)
+					{
+						return _appcompatAlertDialog.FindViewById(id);
+					}
+					else
+					{
+						return _legacyAlertDialog.FindViewById(id);
 					}
 				}
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -93,10 +93,12 @@ namespace Xamarin.Forms.Platform.Android
 
 				var builder = new DialogBuilder(Activity);
 
+				arguments.FlowDirection = FlowDirection.LeftToRight;
+
 				builder.SetTitle(arguments.Title);
 				string[] items = arguments.Buttons.ToArray();
 				builder.SetItems(items, (o, args) => arguments.Result.TrySetResult(items[args.Which]));
-
+				
 				if (arguments.Cancel != null)
 					builder.SetPositiveButton(arguments.Cancel, (o, args) => arguments.Result.TrySetResult(arguments.Cancel));
 
@@ -304,6 +306,14 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 
+			//public class RightJustifyAlertDialog : AlertDialog
+			//{
+			//	public RightJustifyAlertDialog(Context ctx)
+			//	{
+			//		base(ctx, )
+			//	}
+			//}
+
 			internal sealed class FlexibleAlertDialog
 			{
 				readonly AppCompatAlertDialog _appcompatAlertDialog;
@@ -313,12 +323,16 @@ namespace Xamarin.Forms.Platform.Android
 				public FlexibleAlertDialog(AlertDialog alertDialog)
 				{
 					_legacyAlertDialog = alertDialog;
+					_legacyAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
+					
 				}
 
 				public FlexibleAlertDialog(AppCompatAlertDialog alertDialog)
 				{
 					_appcompatAlertDialog = alertDialog;
 					_useAppCompat = true;
+					_appcompatAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
+					
 				}
 
 				public void SetTitle(string title)
@@ -338,10 +352,15 @@ namespace Xamarin.Forms.Platform.Android
 					if (_useAppCompat)
 					{
 						_appcompatAlertDialog.SetMessage(message);
+						TextView msgtext = (TextView)_appcompatAlertDialog.FindViewById(Resource.Id.message);
+						msgtext.SetForegroundGravity(GravityFlags.CenterHorizontal);
+
 					}
 					else
 					{
 						_legacyAlertDialog.SetMessage(message);
+						TextView msgtext = (TextView)_legacyAlertDialog.FindViewById(Resource.Id.message);
+						msgtext.SetForegroundGravity(GravityFlags.CenterHorizontal);
 					}
 				}
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -109,10 +109,6 @@ namespace Xamarin.Forms.Platform.Android
 				//and return null
 				if (arguments.FlowDirection == FlowDirection.MatchParent)
 				{
-					//if (sender.FlowDirection == FlowDirection.MatchParent)
-					//	dialog.SetTitleFlowDirection(Device.FlowDirection);
-					//else
-					//	dialog.SetTitleFlowDirection(sender.FlowDirection);
 					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 					{
 						dialog.SetTitleFlowDirection(FlowDirection.RightToLeft);
@@ -177,10 +173,6 @@ namespace Xamarin.Forms.Platform.Android
 				var alert = new DialogBuilder(Activity).Create();
 				if (arguments.FlowDirection == FlowDirection.MatchParent)
 				{
-					//if (sender.FlowDirection == FlowDirection.MatchParent)
-					//	alert.SetTitleFlowDirection(Device.FlowDirection);
-					//else
-					//	alert.SetTitleFlowDirection(sender.FlowDirection);
 					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 					{
 						alert.SetTitleFlowDirection(FlowDirection.RightToLeft);

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -107,29 +107,67 @@ namespace Xamarin.Forms.Platform.Android
 				builder.Dispose();
 				//to match current functionality of renderer we set cancelable on outside
 				//and return null
-				dialog.SetTitleFlowDirection(arguments.FlowDirection);
+				if (arguments.FlowDirection == FlowDirection.MatchParent)
+				{
+					if (sender.FlowDirection == FlowDirection.MatchParent)
+						dialog.SetTitleFlowDirection(Device.FlowDirection);
+					else
+						dialog.SetTitleFlowDirection(sender.FlowDirection);
+				}
+				else
+				{
+					dialog.SetTitleFlowDirection(arguments.FlowDirection);
+				}
 				dialog.SetCanceledOnTouchOutside(true);
 				dialog.SetCancelEvent((o, e) => arguments.SetResult(null));
 				dialog.Show();
 
+				LayoutDirection layoutDirection = LayoutDirection.Ltr;
+				TextDirection textDirection = TextDirection.Ltr;
+
 				if (arguments.FlowDirection == FlowDirection.LeftToRight)
 				{
-					var listview = dialog.GetListView();
-					listview.TextDirection = TextDirection.Ltr;
-					if (arguments.Cancel != null)
-						((dialog.GetButton((int)DialogButtonType.Positive).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Ltr;
-					if (arguments.Destruction != null)
-						((dialog.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Ltr;
+					layoutDirection = LayoutDirection.Ltr;
+					textDirection = TextDirection.Ltr;
 				}
 				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
 				{
-					var listview = dialog.GetListView();
-					listview.TextDirection = TextDirection.Rtl;
-					if (arguments.Cancel != null)
-						((dialog.GetButton((int)DialogButtonType.Positive).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Rtl;
-					if (arguments.Destruction != null)
-						((dialog.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Rtl;
+					layoutDirection = LayoutDirection.Rtl;
+					textDirection = TextDirection.Rtl;
 				}
+				else
+				{
+					if (sender.FlowDirection == FlowDirection.LeftToRight)
+					{
+						layoutDirection = LayoutDirection.Ltr;
+						textDirection = TextDirection.Ltr;
+					}
+					else if (sender.FlowDirection == FlowDirection.RightToLeft)
+					{
+						layoutDirection = LayoutDirection.Rtl;
+						textDirection = TextDirection.Rtl;
+					}
+					else
+					{
+						if (Device.FlowDirection == FlowDirection.LeftToRight)
+						{
+							layoutDirection = LayoutDirection.Ltr;
+							textDirection = TextDirection.Ltr;
+						}
+						else if (Device.FlowDirection == FlowDirection.RightToLeft)
+						{
+							layoutDirection = LayoutDirection.Rtl;
+							textDirection = TextDirection.Rtl;
+						}
+					}
+				}
+
+				var listview = dialog.GetListView();
+				listview.TextDirection = textDirection;
+				if (arguments.Cancel != null)
+					((dialog.GetButton((int)DialogButtonType.Positive).Parent) as global::Android.Views.View).LayoutDirection = layoutDirection;
+				if (arguments.Destruction != null)
+					((dialog.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = layoutDirection;
 			}
 
 			void OnAlertRequested(Page sender, AlertArguments arguments)
@@ -142,7 +180,17 @@ namespace Xamarin.Forms.Platform.Android
 
 				int messageID = 16908299;
 				var alert = new DialogBuilder(Activity).Create();
-				alert.SetTitleFlowDirection(arguments.FlowDirection);
+				if (arguments.FlowDirection == FlowDirection.MatchParent)
+				{
+					if (sender.FlowDirection == FlowDirection.MatchParent)
+						alert.SetTitleFlowDirection(Device.FlowDirection);
+					else
+						alert.SetTitleFlowDirection(sender.FlowDirection);
+				}
+				else
+				{
+					alert.SetTitleFlowDirection(arguments.FlowDirection);
+				}
 				alert.SetTitle(arguments.Title);
 				alert.SetMessage(arguments.Message);
 				if (arguments.Accept != null)
@@ -151,19 +199,51 @@ namespace Xamarin.Forms.Platform.Android
 				alert.SetCancelEvent((o, args) => { arguments.SetResult(false); });
 				alert.Show();
 
+				Console.WriteLine("SENDER!!!" + sender.FlowDirection.ToString());
+
+				LayoutDirection layoutDirection = LayoutDirection.Ltr;
+				TextDirection textDirection = TextDirection.Ltr;
+
 				if (arguments.FlowDirection == FlowDirection.LeftToRight)
 				{
-					TextView textView = (TextView)alert.findViewByID(messageID);
-					textView.TextDirection = TextDirection.Ltr;
-					((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Ltr;
+					layoutDirection = LayoutDirection.Ltr;
+					textDirection = TextDirection.Ltr;
 				}
 				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
 				{
-					TextView textView = (TextView)alert.findViewByID(messageID);
-					textView.TextDirection = TextDirection.Rtl;
-					((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Rtl;
+					layoutDirection = LayoutDirection.Rtl;
+					textDirection = TextDirection.Rtl;
+				}
+				else
+				{
+					if (sender.FlowDirection == FlowDirection.LeftToRight)
+					{
+						layoutDirection = LayoutDirection.Ltr;
+						textDirection = TextDirection.Ltr;
+					}
+					else if (sender.FlowDirection == FlowDirection.RightToLeft)
+					{
+						layoutDirection = LayoutDirection.Rtl;
+						textDirection = TextDirection.Rtl;
+					}
+					else
+					{
+						if (Device.FlowDirection == FlowDirection.LeftToRight)
+						{
+							layoutDirection = LayoutDirection.Ltr;
+							textDirection = TextDirection.Ltr;
+						}
+						else if (Device.FlowDirection == FlowDirection.RightToLeft)
+						{
+							layoutDirection = LayoutDirection.Rtl;
+							textDirection = TextDirection.Rtl;
+						}
+					}
 				}
 
+				TextView textView = (TextView)alert.findViewByID(messageID);
+				textView.TextDirection = textDirection;
+				((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = layoutDirection;
 			}
 
 			void OnPromptRequested(Page sender, PromptArguments arguments)

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -107,54 +107,19 @@ namespace Xamarin.Forms.Platform.Android
 				builder.Dispose();
 				//to match current functionality of renderer we set cancelable on outside
 				//and return null
-				if (arguments.FlowDirection == FlowDirection.MatchParent)
-				{
-					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
-					{
-						dialog.SetTitleFlowDirection(FlowDirection.RightToLeft);
-					}
-					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
-					{
-						dialog.SetTitleFlowDirection(FlowDirection.LeftToRight);
-					}
-				}
-				else
-				{
-					dialog.SetTitleFlowDirection(arguments.FlowDirection);
-				}
+				if (arguments.FlowDirection == FlowDirection.MatchParent && sender is IVisualElementController ve)
+					dialog.Window.DecorView.UpdateFlowDirection(ve);
+				else if (arguments.FlowDirection == FlowDirection.LeftToRight)
+					dialog.Window.DecorView.LayoutDirection = LayoutDirection.Ltr;
+				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
+					dialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
+
 				dialog.SetCanceledOnTouchOutside(true);
 				dialog.SetCancelEvent((o, e) => arguments.SetResult(null));
 				dialog.Show();
 
-				LayoutDirection layoutDirection = LayoutDirection.Ltr;
-				TextDirection textDirection = TextDirection.Ltr;
-
-				if (arguments.FlowDirection == FlowDirection.LeftToRight)
-				{
-					layoutDirection = LayoutDirection.Ltr;
-					textDirection = TextDirection.Ltr;
-				}
-				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
-				{
-					layoutDirection = LayoutDirection.Rtl;
-					textDirection = TextDirection.Rtl;
-				}
-				else
-				{
-					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
-					{
-						layoutDirection = LayoutDirection.Rtl;
-						textDirection = TextDirection.Rtl;
-					}
-					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
-					{
-						layoutDirection = LayoutDirection.Ltr;
-						textDirection = TextDirection.Ltr;
-					}
-				}
-
-				var listview = dialog.GetListView();
-				listview.TextDirection = textDirection;
+				dialog.GetListView().TextDirection = GetTextDirection(sender, arguments.FlowDirection);
+				LayoutDirection layoutDirection = GetLayoutDirection(sender, arguments.FlowDirection);
 				if (arguments.Cancel != null)
 					((dialog.GetButton((int)DialogButtonType.Positive).Parent) as global::Android.Views.View).LayoutDirection = layoutDirection;
 				if (arguments.Destruction != null)
@@ -171,21 +136,13 @@ namespace Xamarin.Forms.Platform.Android
 
 				int messageID = 16908299;
 				var alert = new DialogBuilder(Activity).Create();
-				if (arguments.FlowDirection == FlowDirection.MatchParent)
-				{
-					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
-					{
-						alert.SetTitleFlowDirection(FlowDirection.RightToLeft);
-					}
-					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
-					{
-						alert.SetTitleFlowDirection(FlowDirection.LeftToRight);
-					}
-				}
-				else
-				{
-					alert.SetTitleFlowDirection(arguments.FlowDirection);
-				}
+				if (arguments.FlowDirection == FlowDirection.MatchParent && sender is IVisualElementController ve)
+					alert.Window.DecorView.UpdateFlowDirection(ve);
+				else if (arguments.FlowDirection == FlowDirection.LeftToRight)
+					alert.Window.DecorView.LayoutDirection = LayoutDirection.Ltr;
+				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
+					alert.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
+
 				alert.SetTitle(arguments.Title);
 				alert.SetMessage(arguments.Message);
 				if (arguments.Accept != null)
@@ -194,36 +151,41 @@ namespace Xamarin.Forms.Platform.Android
 				alert.SetCancelEvent((o, args) => { arguments.SetResult(false); });
 				alert.Show();
 
-				LayoutDirection layoutDirection = LayoutDirection.Ltr;
-				TextDirection textDirection = TextDirection.Ltr;
+				TextView textView = (TextView)alert.findViewByID(messageID);
+				textView.TextDirection = GetTextDirection(sender, arguments.FlowDirection);
+				((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = GetLayoutDirection(sender, arguments.FlowDirection);
+			}
 
-				if (arguments.FlowDirection == FlowDirection.LeftToRight)
-				{
-					layoutDirection = LayoutDirection.Ltr;
-					textDirection = TextDirection.Ltr;
-				}
-				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
-				{
-					layoutDirection = LayoutDirection.Rtl;
-					textDirection = TextDirection.Rtl;
-				}
+			private LayoutDirection GetLayoutDirection(Page sender, FlowDirection flowDirection)
+			{
+				if (flowDirection == FlowDirection.LeftToRight)
+					return LayoutDirection.Ltr;
+				else if (flowDirection == FlowDirection.RightToLeft)
+					return LayoutDirection.Rtl;
 				else
 				{
 					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
-					{
-						layoutDirection = LayoutDirection.Rtl;
-						textDirection = TextDirection.Rtl;
-					}
+						return LayoutDirection.Rtl;
 					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
-					{
-						layoutDirection = LayoutDirection.Ltr;
-						textDirection = TextDirection.Ltr;
-					}
+						return LayoutDirection.Ltr;
 				}
+				return LayoutDirection.Ltr;
+			}
 
-				TextView textView = (TextView)alert.findViewByID(messageID);
-				textView.TextDirection = textDirection;
-				((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = layoutDirection;
+			private TextDirection GetTextDirection(Page sender, FlowDirection flowDirection)
+			{
+				if (flowDirection == FlowDirection.LeftToRight)
+					return TextDirection.Ltr;
+				else if (flowDirection == FlowDirection.RightToLeft)
+					return TextDirection.Rtl;
+				else
+				{
+					if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
+						return TextDirection.Rtl;
+					else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
+						return TextDirection.Ltr;
+				}
+				return TextDirection.Ltr;
 			}
 
 			void OnPromptRequested(Page sender, PromptArguments arguments)
@@ -426,32 +388,6 @@ namespace Xamarin.Forms.Platform.Android
 					else
 					{
 						_legacyAlertDialog.SetTitle(title);
-					}
-				}
-
-				public void SetTitleFlowDirection(FlowDirection flowDirection)
-				{
-					if (flowDirection == FlowDirection.LeftToRight)
-					{
-						if (_useAppCompat)
-						{
-							_appcompatAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Ltr;
-						}
-						else
-						{
-							_legacyAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Ltr;
-						}
-					}
-					else if (flowDirection == FlowDirection.RightToLeft)
-					{
-						if (_useAppCompat)
-						{
-							_appcompatAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
-						}
-						else
-						{
-							_legacyAlertDialog.Window.DecorView.LayoutDirection = LayoutDirection.Rtl;
-						}
 					}
 				}
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -199,8 +199,6 @@ namespace Xamarin.Forms.Platform.Android
 				alert.SetCancelEvent((o, args) => { arguments.SetResult(false); });
 				alert.Show();
 
-				Console.WriteLine("SENDER!!!" + sender.FlowDirection.ToString());
-
 				LayoutDirection layoutDirection = LayoutDirection.Ltr;
 				TextDirection textDirection = TextDirection.Ltr;
 

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -478,7 +478,6 @@ namespace Xamarin.Forms.Platform.Android
 					if (_useAppCompat)
 					{
 						_appcompatAlertDialog.SetMessage(message);
-
 					}
 					else
 					{

--- a/Xamarin.Forms.Platform.Android/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Android/PopupManager.cs
@@ -116,11 +116,19 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					var listview = dialog.GetListView();
 					listview.TextDirection = TextDirection.Ltr;
+					if (arguments.Cancel != null)
+						((dialog.GetButton((int)DialogButtonType.Positive).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Ltr;
+					if (arguments.Destruction != null)
+						((dialog.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Ltr;
 				}
 				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
 				{
 					var listview = dialog.GetListView();
 					listview.TextDirection = TextDirection.Rtl;
+					if (arguments.Cancel != null)
+						((dialog.GetButton((int)DialogButtonType.Positive).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Rtl;
+					if (arguments.Destruction != null)
+						((dialog.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Rtl;
 				}
 			}
 
@@ -145,15 +153,17 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (arguments.FlowDirection == FlowDirection.LeftToRight)
 				{
-					
 					TextView textView = (TextView)alert.findViewByID(messageID);
 					textView.TextDirection = TextDirection.Ltr;
+					((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Ltr;
 				}
 				else if (arguments.FlowDirection == FlowDirection.RightToLeft)
 				{
 					TextView textView = (TextView)alert.findViewByID(messageID);
 					textView.TextDirection = TextDirection.Rtl;
+					((alert.GetButton((int)DialogButtonType.Negative).Parent) as global::Android.Views.View).LayoutDirection = LayoutDirection.Rtl;
 				}
+
 			}
 
 			void OnPromptRequested(Page sender, PromptArguments arguments)
@@ -407,6 +417,18 @@ namespace Xamarin.Forms.Platform.Android
 					else
 					{
 						_legacyAlertDialog.SetButton(whichButton, text, handler);
+					}
+				}
+
+				public global::Android.Widget.Button GetButton(int whichButton)
+				{
+					if (_useAppCompat)
+					{
+						return _appcompatAlertDialog.GetButton(whichButton);
+					}
+					else
+					{
+						return _legacyAlertDialog.GetButton(whichButton);
 					}
 				}
 

--- a/Xamarin.Forms.Platform.UAP/FormsFlyout.xaml.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsFlyout.xaml.cs
@@ -20,15 +20,39 @@ namespace Xamarin.Forms.Platform.UWP
 			TitleBlock.Text = options.Title ?? string.Empty;
 			OptionsList.ItemsSource = options.Buttons.ToList();
 
-			if (options.Cancel != null)
+			if (options.FlowDirection == Xamarin.Forms.FlowDirection.RightToLeft)
 			{
-				RightBtn.Content = options.Cancel;
+				TitleBlock.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
+				OptionsList.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
+			}
+			else if (options.FlowDirection == Xamarin.Forms.FlowDirection.LeftToRight)
+			{
+				TitleBlock.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+				OptionsList.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+			}
 
-				if (options.Destruction != null)
+			if (options.FlowDirection == Xamarin.Forms.FlowDirection.RightToLeft)
+			{
+				if (options.Cancel != null)
+				{
+					LeftBtn.Content = options.Cancel;
+					if (options.Destruction != null)
+						RightBtn.Content = options.Destruction;
+				}
+				else if (options.Destruction != null)
 					LeftBtn.Content = options.Destruction;
 			}
-			else if (options.Destruction != null)
-				RightBtn.Content = options.Destruction;
+			else
+			{
+				if (options.Cancel != null)
+				{
+					RightBtn.Content = options.Cancel;
+					if (options.Destruction != null)
+						LeftBtn.Content = options.Destruction;
+				}
+				else if (options.Destruction != null)
+					RightBtn.Content = options.Destruction;
+			}
 
 			LeftBtn.Visibility = LeftBtn.Content == null ? Visibility.Collapsed : Visibility.Visible;
 			RightBtn.Visibility = RightBtn.Content == null ? Visibility.Collapsed : Visibility.Visible;

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -658,6 +658,15 @@ namespace Xamarin.Forms.Platform.UWP
 				VerticalScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility.Auto
 			};
 
+			if (options.FlowDirection == FlowDirection.RightToLeft)
+			{
+				alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
+			}
+			else if (options.FlowDirection == FlowDirection.LeftToRight)
+			{
+				alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+			}
+
 			if (options.Cancel != null)
 				alertDialog.SecondaryButtonText = options.Cancel;
 

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -12,6 +12,7 @@ using Windows.UI.Xaml.Controls;
 using Xamarin.Forms.Internals;
 using NativeAutomationProperties = Windows.UI.Xaml.Automation.AutomationProperties;
 using WImage = Windows.UI.Xaml.Controls.Image;
+using WFlowDirection = Windows.UI.Xaml.FlowDirection;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -683,11 +684,11 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 				{
-					alertDialog.FlowDirection = FlowDirection.RightToLeft;
+					alertDialog.FlowDirection = WFlowDirection.RightToLeft;
 				}
 				else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
 				{
-					alertDialog.FlowDirection = FlowDirection.LeftToRight;
+					alertDialog.FlowDirection = WFlowDirection.LeftToRight;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -578,16 +578,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (options.FlowDirection == FlowDirection.MatchParent)
 			{
-				if (sender.FlowDirection == FlowDirection.RightToLeft)
-					options.FlowDirection = FlowDirection.RightToLeft;
-				else if (sender.FlowDirection == FlowDirection.LeftToRight)
-					options.FlowDirection = FlowDirection.LeftToRight;
-				else
+				if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 				{
-					if (Device.FlowDirection == FlowDirection.RightToLeft)
-						options.FlowDirection = FlowDirection.RightToLeft;
-					else if (Device.FlowDirection == FlowDirection.LeftToRight)
-						options.FlowDirection = FlowDirection.LeftToRight;
+					options.FlowDirection = FlowDirection.RightToLeft;
+				}
+				else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
+				{
+					options.FlowDirection = FlowDirection.LeftToRight;
 				}
 			}
 
@@ -684,16 +681,13 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 			else
 			{
-				if (sender.FlowDirection == FlowDirection.RightToLeft)
-					alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
-				else if (sender.FlowDirection == FlowDirection.LeftToRight)
-					alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
-				else
+				if ((sender as IVisualElementController).EffectiveFlowDirection.IsRightToLeft())
 				{
-					if (Device.FlowDirection == FlowDirection.RightToLeft)
-						alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
-					else if (Device.FlowDirection == FlowDirection.LeftToRight)
-						alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+					alertDialog.FlowDirection = FlowDirection.RightToLeft;
+				}
+				else if ((sender as IVisualElementController).EffectiveFlowDirection.IsLeftToRight())
+				{
+					alertDialog.FlowDirection = FlowDirection.LeftToRight;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -572,9 +572,25 @@ namespace Xamarin.Forms.Platform.UWP
 			MessagingCenter.Subscribe<Page, PromptArguments>(Window.Current, Page.PromptSignalName, OnPagePrompt);
 		}
 
-		static void OnPageActionSheet(object sender, ActionSheetArguments options)
+		static void OnPageActionSheet(Page sender, ActionSheetArguments options)
 		{
 			bool userDidSelect = false;
+
+			if (options.FlowDirection == FlowDirection.MatchParent)
+			{
+				if (sender.FlowDirection == FlowDirection.RightToLeft)
+					options.FlowDirection = FlowDirection.RightToLeft;
+				else if (sender.FlowDirection == FlowDirection.LeftToRight)
+					options.FlowDirection = FlowDirection.LeftToRight;
+				else
+				{
+					if (Device.FlowDirection == FlowDirection.RightToLeft)
+						options.FlowDirection = FlowDirection.RightToLeft;
+					else if (Device.FlowDirection == FlowDirection.LeftToRight)
+						options.FlowDirection = FlowDirection.LeftToRight;
+				}
+			}
+
 			var flyoutContent = new FormsFlyout(options);
 
 			var actionSheet = new Flyout
@@ -665,6 +681,20 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (options.FlowDirection == FlowDirection.LeftToRight)
 			{
 				alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+			}
+			else
+			{
+				if (sender.FlowDirection == FlowDirection.RightToLeft)
+					alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
+				else if (sender.FlowDirection == FlowDirection.LeftToRight)
+					alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+				else
+				{
+					if (Device.FlowDirection == FlowDirection.RightToLeft)
+						alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.RightToLeft;
+					else if (Device.FlowDirection == FlowDirection.LeftToRight)
+						alertDialog.FlowDirection = Windows.UI.Xaml.FlowDirection.LeftToRight;
+				}
 			}
 
 			if (options.Cancel != null)


### PR DESCRIPTION
### Description of Change ###

Added a Flow Direction Property to action sheets and alert dialogs. Also, changed the default flow direction of action sheets and alert dialogs to follow the page's effective flow direction.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #2448
- fixes #7065 

### API Changes ###

Added:
 - FlowDirection AlertSheetArguments.FlowDirection { get; set; }
 - DisplayActionSheet(string title, string cancel, string destruction, FlowDirection flowDirection, params string[] buttons)
 - DisplayAlert(string title, string message, string cancel, FlowDirection flowDirection)

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

The action sheets and alert dialogs may change depending on the flow direction of the parent page.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before (no flow direction):

![Screenshot 2020-08-06 at 1 13 15 PM](https://user-images.githubusercontent.com/66331238/89581654-f4fa5b80-d7fc-11ea-976a-3ca414155ba6.png)
![Screenshot 2020-08-06 at 1 13 48 PM](https://user-images.githubusercontent.com/66331238/89581669-fa57a600-d7fc-11ea-875f-53792cccb42d.png)

After (RTL flow direction):

![Screenshot 2020-08-06 at 1 13 33 PM](https://user-images.githubusercontent.com/66331238/89581636-ef9d1100-d7fc-11ea-8ba9-6eac5fbdfd95.png)
![Screenshot 2020-08-06 at 1 14 08 PM](https://user-images.githubusercontent.com/66331238/89581683-fe83c380-d7fc-11ea-8309-6f50fe3205ad.png)

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Create an alert dialog and action sheet on Android and UWP and set the FlowDirection property to right-to-left and left-to-right to see if the alert dialog and actions sheet follows the flow direction properly. Also, can play around with changing the phone culture to right-to-left and left-to-right languages and see if the default flow direction of the alerts and action sheets follow the phone setting properly.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
