### PR TITLE
EasingDesignTypeConverter

### DIFF
--- a/Xamarin.Forms.Core.Design/EasingDesignTypeConverter.cs
+++ b/Xamarin.Forms.Core.Design/EasingDesignTypeConverter.cs
@@ -1,0 +1,35 @@
+﻿namespace Xamarin.Forms.Core.Design
+{
+	using System.Linq;
+	using System;
+	using System.Reflection;
+
+	public class EasingDesignTypeConverter : TypeConverter
+	{
+		readonly Lazy<StandardValuesCollection> _lazyValues = new Lazy<StandardValuesCollection>(() =>
+		{
+			var props = typeof(Easing)
+				.GetFields(BindingFlags.Static | BindingFlags.Public)
+				.Select(p => p.Name)
+				.ToArray();
+			return new StandardValuesCollection(props);
+		});
+
+		protected StandardValuesCollection Values
+			=> _lazyValues.Value;
+
+		// This tells XAML this converter can be used to process strings
+		// Without this the values won't show up as hints
+		public override bool CanConvertFrom(ITypeDescriptorContext context, Type sourceType)
+			=> sourceType == typeof(string) || base.CanConvertFrom(context, sourceType);
+
+		public override StandardValuesCollection GetStandardValues(ITypeDescriptorContext context)
+			=> Values;
+
+		public override bool GetStandardValuesExclusive(ITypeDescriptorContext context)
+			=> false;
+
+		public override bool GetStandardValuesSupported(ITypeDescriptorContext context)
+			=> true;
+	}
+}

--- a/Xamarin.Forms.Core.Design/EasingDesignTypeConverter.cs
+++ b/Xamarin.Forms.Core.Design/EasingDesignTypeConverter.cs
@@ -3,6 +3,7 @@
 	using System.Linq;
 	using System;
 	using System.Reflection;
+	using System.ComponentModel;
 
 	public class EasingDesignTypeConverter : TypeConverter
 	{

--- a/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
+++ b/Xamarin.Forms.Core.Design/Xamarin.Forms.Core.Design.csproj
@@ -74,6 +74,7 @@
   <ItemGroup>
     <Compile Include="ItemsLayoutDesignTypeConverter.cs" />
     <Compile Include="KeyboardDesignTypeConverter.cs" />
+    <Compile Include="EasingDesignTypeConverter.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- Ensure that all images in the 'mac' and 'win' subdirectories are included as embedded resources -->


### PR DESCRIPTION
### Description of Change ###
@StephaneDelcroix  Here is my attempt to create Easing Xaml "hints".
Since that's impossible to build Design.dll on Mac, I can't verify that the project builds, but I hope it should.

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Not sure about the flow, but the end goad to provide "hints" when using Easing in xaml.

### PR Checklist ###
- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
