### PR TITLE
[X] Wrap FormatException with lineInfo

### DIFF
--- a/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
+++ b/Xamarin.Forms.Build.Tasks/NodeILExtensions.cs
@@ -131,6 +131,14 @@ namespace Xamarin.Forms.Build.Tasks
 				unboxValueTypes);
 		}
 
+		static T TryFormat<T>(Func<string, T> func, IXmlLineInfo lineInfo, string str)
+		{
+			try {
+				return func(str);
+			} catch (FormatException fex) {
+				throw new BuildException(BuildExceptionCode.Conversion, lineInfo, fex, str, typeof(T));
+			}
+		}
 		public static IEnumerable<Instruction> PushConvertedValue(this ValueNode node, ILContext context,
 			TypeReference targetTypeRef, TypeReference typeConverter, IEnumerable<Instruction> pushServiceProvider,
 			bool boxValueTypes, bool unboxValueTypes)
@@ -208,39 +216,39 @@ namespace Xamarin.Forms.Build.Tasks
 			if (targetTypeRef.ResolveCached().BaseType != null && targetTypeRef.ResolveCached().BaseType.FullName == "System.Enum")
 				yield return PushParsedEnum(targetTypeRef, str, node);
 			else if (targetTypeRef.FullName == "System.Char")
-				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)Char.Parse(str)));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)TryFormat(Char.Parse, node, str)));
 			else if (targetTypeRef.FullName == "System.SByte")
-				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)SByte.Parse(str, CultureInfo.InvariantCulture)));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)TryFormat(s => SByte.Parse(s,CultureInfo.InvariantCulture), node, str)));
 			else if (targetTypeRef.FullName == "System.Int16")
-				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)Int16.Parse(str, CultureInfo.InvariantCulture)));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)TryFormat(s => Int16.Parse(s, CultureInfo.InvariantCulture), node, str)));
 			else if (targetTypeRef.FullName == "System.Int32")
-				yield return Instruction.Create(OpCodes.Ldc_I4, Int32.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I4, TryFormat(s => Int32.Parse(s, CultureInfo.InvariantCulture), node, str));
 			else if (targetTypeRef.FullName == "System.Int64")
-				yield return Instruction.Create(OpCodes.Ldc_I8, Int64.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_I8, TryFormat(s => Int64.Parse(s, CultureInfo.InvariantCulture), node, str));
 			else if (targetTypeRef.FullName == "System.Byte")
-				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)Byte.Parse(str, CultureInfo.InvariantCulture)));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)TryFormat(s => Byte.Parse(s, CultureInfo.InvariantCulture), node, str)));
 			else if (targetTypeRef.FullName == "System.UInt16")
-				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)UInt16.Parse(str, CultureInfo.InvariantCulture)));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)TryFormat(s => UInt16.Parse(s, CultureInfo.InvariantCulture), node, str)));
 			else if (targetTypeRef.FullName == "System.UInt32")
-				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)UInt32.Parse(str, CultureInfo.InvariantCulture)));
+				yield return Instruction.Create(OpCodes.Ldc_I4, unchecked((int)TryFormat(s => UInt32.Parse(s, CultureInfo.InvariantCulture), node, str)));
 			else if (targetTypeRef.FullName == "System.UInt64")
-				yield return Instruction.Create(OpCodes.Ldc_I8, unchecked((long)UInt64.Parse(str, CultureInfo.InvariantCulture)));
+				yield return Instruction.Create(OpCodes.Ldc_I8, unchecked((long)TryFormat(s => UInt64.Parse(s, CultureInfo.InvariantCulture), node, str)));
 			else if (targetTypeRef.FullName == "System.Single")
-				yield return Instruction.Create(OpCodes.Ldc_R4, Single.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_R4, TryFormat(s => Single.Parse(str, CultureInfo.InvariantCulture), node, str));
 			else if (targetTypeRef.FullName == "System.Double")
-				yield return Instruction.Create(OpCodes.Ldc_R8, Double.Parse(str, CultureInfo.InvariantCulture));
+				yield return Instruction.Create(OpCodes.Ldc_R8, TryFormat(s => Double.Parse(str, CultureInfo.InvariantCulture), node, str));
 			else if (targetTypeRef.FullName == "System.Boolean") {
-				if (Boolean.Parse(str))
+				if (TryFormat(Boolean.Parse, node, str))
 					yield return Instruction.Create(OpCodes.Ldc_I4_1);
 				else
 					yield return Instruction.Create(OpCodes.Ldc_I4_0);
 			} else if (targetTypeRef.FullName == "System.TimeSpan") {
-				var ts = TimeSpan.Parse(str, CultureInfo.InvariantCulture);
+				var ts = TryFormat(s => TimeSpan.Parse(s, CultureInfo.InvariantCulture), node, str);
 				var ticks = ts.Ticks;
 				yield return Instruction.Create(OpCodes.Ldc_I8, ticks);
 				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("mscorlib", "System", "TimeSpan"), parameterTypes: new[] { ("mscorlib", "System", "Int64") }));
 			} else if (targetTypeRef.FullName == "System.DateTime") {
-				var dt = DateTime.Parse(str, CultureInfo.InvariantCulture);
+				var dt = TryFormat(s => DateTime.Parse(s, CultureInfo.InvariantCulture), node, str);
 				var ticks = dt.Ticks;
 				yield return Instruction.Create(OpCodes.Ldc_I8, ticks);
 				yield return Instruction.Create(OpCodes.Newobj, module.ImportCtorReference(("mscorlib", "System", "DateTime"), parameterTypes: new[] { ("mscorlib", "System", "Int64") }));

--- a/Xamarin.Forms.Core/Xaml/ValueConverterProvider.cs
+++ b/Xamarin.Forms.Core/Xaml/ValueConverterProvider.cs
@@ -12,8 +12,10 @@ namespace Xamarin.Forms.Xaml
 		public object Convert(object value, Type toType, Func<MemberInfo> minfoRetriever, IServiceProvider serviceProvider)
 		{
 			var ret = value.ConvertTo(toType, minfoRetriever, serviceProvider, out Exception exception);
-			if (exception != null)
-				throw exception;
+			if (exception != null) {
+				var lineInfo = (serviceProvider.GetService(typeof(IXmlLineInfoProvider)) is IXmlLineInfoProvider lineInfoProvider) ? lineInfoProvider.XmlLineInfo : new XmlLineInfo();
+				throw new XamlParseException(exception.Message, serviceProvider, exception);
+			}
 			return ret;
 		}
 	}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11711.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11711.xaml
@@ -1,0 +1,9 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms" xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" x:Class="Xamarin.Forms.Xaml.UnitTests.Gh11711">
+    <ContentPage.Resources>
+        <Style TargetType="Frame">
+            <Setter Property="HasShadow" Value="#False"/>
+        </Style>
+    </ContentPage.Resources>
+    <Frame x:Name="frame" />
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11711.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh11711.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Build.Tasks;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	[XamlCompilation(XamlCompilationOptions.Skip)]
+	public partial class Gh11711 : ContentPage
+	{
+		public Gh11711() => InitializeComponent();
+		public Gh11711(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void FormatExceptionAreCaught([Values(false, true)] bool useCompiledXaml)
+			{
+				if (useCompiledXaml)
+					Assert.Throws<BuildException>(() => MockCompiler.Compile(typeof(Gh11711)));
+				else
+					Assert.Throws<XamlParseException>(() => new Gh11711(useCompiledXaml));
+			}
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

Wrap FormatException while Parsing built-in types, and wrap the exception into a XamlParseException, or BuildException, with additional information about line info

### Issues Resolved ### 

- fixes #11711

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
