### PR TITLE
[iOS] Fix RadialGradientBrush position issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11573.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11573.xaml
@@ -1,0 +1,90 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11573"
+    Title="Issue 11573">
+    <ScrollView>
+        <StackLayout>
+            <Label
+                Padding="12"
+                BackgroundColor="Black"
+                TextColor="White"
+                Text="If the RadialGradientBrush Radius is the same in all cases, the test has passed."/>
+            <StackLayout
+                Padding="12">
+                <Label
+                    Text="RadialGradientBrush (Upper left)"
+                    FontAttributes="Bold" />
+                <Frame 
+                    Margin="0,12,0,0"
+                    BorderColor="LightGray"
+                    HasShadow="True"
+                    CornerRadius="12"
+                    HeightRequest="60"
+                    WidthRequest="120">
+                    <Frame.Background>
+                        <RadialGradientBrush Center="0.1,0.1"
+                                             Radius="0.5">
+                            <RadialGradientBrush.GradientStops>
+                                <GradientStop Color="Red"
+                                            Offset="0.1" />
+                                <GradientStop Color="DarkBlue"
+                                            Offset="1.0" />                                                         
+                            </RadialGradientBrush.GradientStops>
+                        </RadialGradientBrush>
+                    </Frame.Background>
+                </Frame>    
+                <Label
+                    Margin="0,12,0,0"
+                    Text="RadialGradientBrush (Center)"
+                    FontAttributes="Bold" />        
+                <Frame 
+                    Margin="0,12,0,0"
+                    BorderColor="LightGray"
+                    HasShadow="True"
+                    CornerRadius="12"
+                    HeightRequest="60"
+                    WidthRequest="120">
+                    <Frame.Background>
+                        <RadialGradientBrush Center="0.5,0.5"
+                                             Radius="0.5">
+                            <RadialGradientBrush.GradientStops>
+                                <GradientStop Color="Red"
+                                            Offset="0.1" />
+                                <GradientStop Color="DarkBlue"
+                                            Offset="1.0" />                                                         
+                            </RadialGradientBrush.GradientStops>
+                        </RadialGradientBrush>
+                    </Frame.Background>
+                </Frame>                    
+                <Label Margin="0,12,0,0"
+                       Text="RadialGradientBrush (Lower right)"
+                       FontAttributes="Bold" />
+                <Frame
+                    Margin="0,12,0,0"
+                    BorderColor="LightGray"
+                    HasShadow="True"
+                    CornerRadius="12"
+                    HeightRequest="60"
+                    WidthRequest="120">
+                    <Frame.Background>
+                        <RadialGradientBrush Center="0.9,0.9"
+                                             Radius="0.5">
+                            <RadialGradientBrush.GradientStops>
+                                <GradientStop Color="Red"
+                                            Offset="0.1" />
+                                <GradientStop Color="DarkBlue"
+                                            Offset="1.0" />                                                         
+                            </RadialGradientBrush.GradientStops>
+                        </RadialGradientBrush>
+                    </Frame.Background>
+                </Frame>                           
+            </StackLayout>
+        </StackLayout>
+    </ScrollView>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11573.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11573.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11573, "[Bug][Brushes] RadialGradient size on iOS",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Brush)]
+#endif
+	public partial class Issue11573 : TestContentPage
+	{
+		public Issue11573()
+		{
+#if APP
+			Device.SetFlags(new List<string> { ExperimentalFlags.BrushExperimental });
+
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1472,6 +1472,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10608.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11573.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1739,6 +1740,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11547.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11573.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
@@ -203,20 +203,7 @@ namespace Xamarin.Forms.Platform.iOS
 		static CGPoint GetRadialGradientBrushEndPoint(Point startPoint, double radius)
 		{
 			double x = startPoint.X == 1 ? (startPoint.X - radius) : (startPoint.X + radius);
-
-			if (x < 0)
-				x = 0;
-
-			if (x > 1)
-				x = 1;
-
 			double y = startPoint.Y == 1 ? (startPoint.Y - radius) : (startPoint.Y + radius);
-
-			if (y < 0)
-				y = 0;
-
-			if (y > 1)
-				y = 1;
 
 			return new CGPoint(x, y);
 		}


### PR DESCRIPTION
### Description of Change ###

Fix `RadialGradientBrush` position issue on iOS. We were limiting the maximum value for the `EndPoint`.

### Issues Resolved ### 

- fixes #11573 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="320" alt="Captura de pantalla 2020-08-10 a las 17 16 22" src="https://user-images.githubusercontent.com/6755973/89801253-33ab5100-db30-11ea-926c-a2adbec8c96d.png">

#### After
<img width="326" alt="Captura de pantalla 2020-08-10 a las 17 13 12" src="https://user-images.githubusercontent.com/6755973/89801271-37d76e80-db30-11ea-8bc3-e524a262be45.png">

### Testing Procedure ###
Launch Core Gallery on iOS simulator or device and navigate to the issue 11573. If the RadialGradientBrush Radius is the same in all cases, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
