### PR TITLE
Fix for issue #10307, embedded fonts not working on UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10307.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10307.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10307, "Embedded Fonts not working", PlatformAffected.UWP)]
+	public class Issue10307 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label() { Text = "Four bell icons should be visible below", Margin = new Thickness(10)},
+					
+					new Label { FontFamily = "FontAwesome", FontSize = 50, TextColor = Color.Black, Text = "\xf0f3" },
+					new Label { FontFamily = "fa-regular-400.ttf", FontSize = 50, TextColor = Color.Black, Text = "\xf0f3" },
+					new Image() { Source = new FontImageSource() { FontFamily = "FontAwesome", Glyph = "\xf0f3", Color = Color.Black, Size = 50}, HorizontalOptions = LayoutOptions.Start},
+					new Image() { Source = new FontImageSource() { FontFamily = "fa-regular-400.ttf", Glyph = "\xf0f3", Color = Color.Black, Size = 50}, HorizontalOptions = LayoutOptions.Start},
+				}
+			};
+
+
+			BindingContext = new ViewModelIssue1();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -835,6 +835,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10699.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11185.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10307.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Controls/GalleryPages/EmbeddedFonts.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/EmbeddedFonts.xaml.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms;
 [assembly: ExportFont("CuteFont-Regular.ttf", Alias = "Foo")]
 [assembly: ExportFont("PTM55FT.ttf")]
 [assembly: ExportFont("Dokdo-Regular.ttf")]
-[assembly: ExportFont("fa-regular-400.ttf", Alias="FontAwesome", FontName = "Font Awesome 5 Free")]
+[assembly: ExportFont("fa-regular-400.ttf", Alias="FontAwesome")]
 
 namespace Xamarin.Forms.Controls.GalleryPages
 {

--- a/Xamarin.Forms.Controls/GalleryPages/EmbeddedFonts.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/EmbeddedFonts.xaml.cs
@@ -5,7 +5,7 @@ using Xamarin.Forms;
 [assembly: ExportFont("CuteFont-Regular.ttf", Alias = "Foo")]
 [assembly: ExportFont("PTM55FT.ttf")]
 [assembly: ExportFont("Dokdo-Regular.ttf")]
-[assembly: ExportFont("fa-regular-400.ttf")]
+[assembly: ExportFont("fa-regular-400.ttf", Alias="FontAwesome", FontName = "Font Awesome 5 Free")]
 
 namespace Xamarin.Forms.Controls.GalleryPages
 {

--- a/Xamarin.Forms.Core/ExportFontAttribute.cs
+++ b/Xamarin.Forms.Core/ExportFontAttribute.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Forms
 	public class ExportFontAttribute : Attribute
 	{
 		public string Alias { get; set; }
+		public string FontName { get; set; } // Required for some UWP fonts
+
 		public ExportFontAttribute(string fontFileName)
 		{
 			FontFileName = fontFileName;

--- a/Xamarin.Forms.Core/ExportFontAttribute.cs
+++ b/Xamarin.Forms.Core/ExportFontAttribute.cs
@@ -6,7 +6,6 @@ namespace Xamarin.Forms
 	public class ExportFontAttribute : Attribute
 	{
 		public string Alias { get; set; }
-		public string FontName { get; set; } // Required for some UWP fonts
 
 		public ExportFontAttribute(string fontFileName)
 		{

--- a/Xamarin.Forms.Core/FontRegistrar.cs
+++ b/Xamarin.Forms.Core/FontRegistrar.cs
@@ -48,16 +48,6 @@ namespace Xamarin.Forms.Internals
 			return fontLookupCache[font] = (false, null);
 		}
 
-		public static string GetFontName(string font)
-		{
-			if (EmbeddedFonts.TryGetValue(font, out var foundFont))
-			{
-				return foundFont.attribute.FontName;
-			}
-
-			return null;
-		}
-
 		static Stream GetEmbeddedResourceStream(Assembly assembly, string resourceFileName)
 		{
 			var resourceNames = assembly.GetManifestResourceNames();

--- a/Xamarin.Forms.Core/FontRegistrar.cs
+++ b/Xamarin.Forms.Core/FontRegistrar.cs
@@ -48,6 +48,16 @@ namespace Xamarin.Forms.Internals
 			return fontLookupCache[font] = (false, null);
 		}
 
+		public static string GetFontName(string font)
+		{
+			if (EmbeddedFonts.TryGetValue(font, out var foundFont))
+			{
+				return foundFont.attribute.FontName;
+			}
+
+			return null;
+		}
+
 		static Stream GetEmbeddedResourceStream(Assembly assembly, string resourceFileName)
 		{
 			var resourceNames = assembly.GetManifestResourceNames();

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -111,10 +111,10 @@ namespace Xamarin.Forms.Platform.UWP
 			var (hasFontAlias, fontPostScriptName) = FontRegistrar.HasFont(fontFamily);
 			if (hasFontAlias)
 			{
+				var fontName = FontRegistrar.GetFontName(fontFamily);
 				var file = FontFile.FromString(IOPath.GetFileName(fontPostScriptName));
-				var formated = $"{fontPostScriptName}#{file.GetPostScriptNameWithSpaces()}";
-				yield return formated;
-				yield return fontFamily;
+				var formatted = $"{fontPostScriptName}#{fontName ?? file.GetPostScriptNameWithSpaces()}";
+				yield return formatted;
 				yield break;
 			}
 
@@ -133,8 +133,8 @@ namespace Xamarin.Forms.Platform.UWP
 				var (hasFont, filePath) = FontRegistrar.HasFont(fontFile.FileNameWithExtension());
 				if (hasFont)
 				{
-					var formated = $"{filePath}#{fontFile.GetPostScriptNameWithSpaces()}";
-					yield return formated;
+					var formatted = $"{filePath}#{fontFile.GetPostScriptNameWithSpaces()}";
+					yield return formatted;
 					yield break;
 				}
 				else

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -1,5 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Graphics.Canvas.Text;
 using Windows.UI.Text;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media;
@@ -105,15 +107,26 @@ namespace Xamarin.Forms.Platform.UWP
 			return font;
 		}
 
+		static string FindFontFamilyName(string fontFile)
+		{
+			using (var fontSet = new CanvasFontSet(new Uri(fontFile)))
+			{
+				if (fontSet.Fonts.Count == 0)
+					return null;
+
+				return fontSet.GetPropertyValues(CanvasFontPropertyIdentifier.FamilyName).FirstOrDefault().Value;
+			}
+		}
+
 		static IEnumerable<string> GetAllFontPossibilities(string fontFamily)
 		{
 			//First check Alias
 			var (hasFontAlias, fontPostScriptName) = FontRegistrar.HasFont(fontFamily);
 			if (hasFontAlias)
 			{
-				var fontName = FontRegistrar.GetFontName(fontFamily);
+				var familyName = FindFontFamilyName(fontPostScriptName);
 				var file = FontFile.FromString(IOPath.GetFileName(fontPostScriptName));
-				var formatted = $"{fontPostScriptName}#{fontName ?? file.GetPostScriptNameWithSpaces()}";
+				var formatted = $"{fontPostScriptName}#{familyName ?? file.GetPostScriptNameWithSpaces()}";
 				yield return formatted;
 				yield break;
 			}
@@ -133,7 +146,8 @@ namespace Xamarin.Forms.Platform.UWP
 				var (hasFont, filePath) = FontRegistrar.HasFont(fontFile.FileNameWithExtension());
 				if (hasFont)
 				{
-					var formatted = $"{filePath}#{fontFile.GetPostScriptNameWithSpaces()}";
+					var familyName = FindFontFamilyName(filePath);
+					var formatted = $"{filePath}#{familyName ?? fontFile.GetPostScriptNameWithSpaces()}";
 					yield return formatted;
 					yield break;
 				}
@@ -147,7 +161,8 @@ namespace Xamarin.Forms.Platform.UWP
 				var (hasFont, filePath) = FontRegistrar.HasFont(fontFile.FileNameWithExtension(ext));
 				if (hasFont)
 				{
-					var formatted = $"{filePath}#{fontFile.GetPostScriptNameWithSpaces()}";
+					var familyName = FindFontFamilyName(filePath);
+					var formatted = $"{filePath}#{familyName ?? fontFile.GetPostScriptNameWithSpaces()}";
 					yield return formatted;
 					yield break;
 				}
@@ -158,7 +173,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 			foreach (var ext in extensions)
 			{
-				var formatted = $"{path}{fontFile.FileNameWithExtension(ext)}#{fontFile.GetPostScriptNameWithSpaces()}";
+				var fileName = $"{path}{fontFile.FileNameWithExtension(ext)}";
+				var familyName = FindFontFamilyName(fileName);
+				var formatted = $"{fileName}#{familyName ?? fontFile.GetPostScriptNameWithSpaces()}";
 				yield return formatted;
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var textFormat = new CanvasTextFormat
 			{
-				FontFamily = fontsource.FontFamily,
+				FontFamily = fontsource.FontFamily.ToFontFamily().Source,
 				FontSize = (float)fontsource.Size,
 				HorizontalAlignment = CanvasHorizontalAlignment.Center,
 				VerticalAlignment = CanvasVerticalAlignment.Center,
@@ -65,8 +65,10 @@ namespace Xamarin.Forms.Platform.UWP
 					Foreground = fontImageSource.Color.ToBrush()
 				};
 
-				if (!string.IsNullOrEmpty(fontImageSource.FontFamily))
-					((WFontIconSource)image).FontFamily = new FontFamily(fontImageSource.FontFamily);
+				var uwpFontFamily = fontImageSource.FontFamily.ToFontFamily().Source;
+
+				if (!string.IsNullOrEmpty(uwpFontFamily))
+					((WFontIconSource)image).FontFamily = new FontFamily(uwpFontFamily);
 			}
 
 			return Task.FromResult(image);
@@ -85,8 +87,10 @@ namespace Xamarin.Forms.Platform.UWP
 					Foreground = fontImageSource.Color.ToBrush()
 				};
 
-				if (!string.IsNullOrEmpty(fontImageSource.FontFamily))
-					((FontIcon)image).FontFamily = new FontFamily(fontImageSource.FontFamily);
+				var uwpFontFamily = fontImageSource.FontFamily.ToFontFamily().Source;
+
+				if (!string.IsNullOrEmpty(uwpFontFamily))
+					((FontIcon)image).FontFamily = new FontFamily(uwpFontFamily);
 			}
 
 			return Task.FromResult(image);


### PR DESCRIPTION
Embedded fonts on UWP don't work when the font name does not match the file name of the font, which is the case with many Google fonts (and FontAwesome icons)

To fix this, the font family name has to be extracted from the font file and appended to the font name when the font is created from the font file.

### Issues Resolved ### 

- fixes #10307 

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None (fixes bug #10307)

### Before/After Screenshots ### 

Before:
![ApplicationFrameHost_2020-08-10_19-42-17](https://user-images.githubusercontent.com/650710/89844591-a244da80-db41-11ea-8c70-efaf0a871946.png)

After:
![ApplicationFrameHost_2020-08-10_19-38-44](https://user-images.githubusercontent.com/650710/89844452-35c9db80-db41-11ea-980e-975ab6efddbc.png)

Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
