### PR TITLE
[UWP] Fixes for font when using MultiWindow

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/SecondaryWindowService.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/SecondaryWindowService.cs
@@ -26,10 +26,6 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 				ContentPage instance = (ContentPage)Activator.CreateInstance(pageType);
 				frame.Navigate(instance);
 				Window.Current.Content = frame;
-				Window.Current.SizeChanged += (sender, args) =>
-				{
-					instance.Layout(new Rectangle(0, 0, args.Size.Width, args.Size.Height));
-				};
 				Window.Current.Activate();
 
 				newViewId = ApplicationView.GetForCurrentView().Id;

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/SecondaryWindowService.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/SecondaryWindowService.cs
@@ -26,6 +26,10 @@ namespace Xamarin.Forms.ControlGallery.WindowsUniversal
 				ContentPage instance = (ContentPage)Activator.CreateInstance(pageType);
 				frame.Navigate(instance);
 				Window.Current.Content = frame;
+				Window.Current.SizeChanged += (sender, args) =>
+				{
+					instance.Layout(new Rectangle(0, 0, args.Size.Width, args.Size.Height));
+				};
 				Window.Current.Activate();
 
 				newViewId = ApplicationView.GetForCurrentView().Id;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
@@ -87,6 +87,9 @@ namespace Xamarin.Forms.Controls.Issues
 			layout.Children.Add(_result);
 			layout.Children.Add(button);
 
+			if (Device.RuntimePlatform == Device.UWP)
+				layout.Children.Add(new Label { Text = "\xE76E", FontFamily = "Segoe MDL2 Assets", FontSize = 32 });
+
 			Content = layout;
 		}
 

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public static class FontExtensions
 	{
+		[ThreadStatic]
 		static Dictionary<string, FontFamily> FontFamilies = new Dictionary<string, FontFamily>();
 		static double DefaultFontSize = double.NegativeInfinity;
 
@@ -92,6 +93,8 @@ namespace Xamarin.Forms.Platform.UWP
 			if (string.IsNullOrWhiteSpace(fontFamily))
 				return (FontFamily)WApplication.Current.Resources["ContentControlThemeFontFamily"];
 
+			if (FontFamilies == null)
+				FontFamilies = new Dictionary<string, FontFamily>();
 			//Return from Cache!
 			if (FontFamilies.TryGetValue(fontFamily, out var f))
 			{


### PR DESCRIPTION

### Description of Change ###

When using multiple windows we need to take in account that each CoreApplicationView has it's own thread so caching items doesn't work if they are shared. Like FontFamilies for example

We also need to relayout our contents when the window is resized.

### Issues Resolved ### 

- fixes #11705

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###

Try open 2 our 3 windows from the control gallery 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
