### PR TITLE
[Android] Fixed incorrect border applying a SolidColorBrush in some cases

### DIFF
--- a/Xamarin.Forms.Platform.Android/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/BrushExtensions.cs
@@ -187,16 +187,16 @@ namespace Xamarin.Forms.Platform.Android
 				Shape = new RectShape()
 			};
 
+			gradientStrokeDrawable.SetStroke(0, Color.Default.ToAndroid());
+
 			if (brush is SolidColorBrush solidColorBrush)
 			{
 				var color = solidColorBrush.Color.IsDefault ? Color.Default.ToAndroid() : solidColorBrush.Color.ToAndroid();
 				gradientStrokeDrawable.SetColor(color);
 			}
 			else
-			{
-				gradientStrokeDrawable.SetStroke(0, Color.Default.ToAndroid());
 				gradientStrokeDrawable.SetGradient(brush);
-			}
+
 			view.Background?.Dispose();
 			view.Background = gradientStrokeDrawable;
 		}


### PR DESCRIPTION
### Description of Change ###

Fixed incorrect border applying a SolidColorBrush in some cases on Android.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
<img width="455" alt="border-before" src="https://user-images.githubusercontent.com/6755973/90032808-122c9f80-dcbf-11ea-8022-f7e5cf695b06.png">
#### After
<img width="458" alt="border-after" src="https://user-images.githubusercontent.com/6755973/90032797-0fca4580-dcbf-11ea-9b41-4e03c0a96619.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the brushes gallery. Select the SolidColorBrushConverterGallery and verify that applying a `Color` or a `SolidColorBrush` has exactly the same result in Layouts. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
