### PR TITLE
Update LinearGradientBrush based on FlowDirection 

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/AnimateBrushGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/AnimateBrushGallery.xaml.cs
@@ -29,8 +29,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.GradientGalleries
 				EndPoint = new Point(GetRandomInt(), GetRandomInt()),
 				GradientStops = new GradientStopCollection
 					{
-						new GradientStop { Color = GetRandomColor() },
-						new GradientStop { Color = GetRandomColor() }
+						new GradientStop { Color = GetRandomColor(), Offset = (float)GetRandomInt() },
+						new GradientStop { Color = GetRandomColor(), Offset = (float)GetRandomInt() }
 					}
 			};
 

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientsGallery.cs
@@ -44,6 +44,8 @@
 						new SolidColorBrushConverterGallery(), Navigation),
 					GalleryBuilder.NavButton("LinearGradientBrush Points Gallery", () =>
 						new LinearGradientPointsGallery(), Navigation),
+					GalleryBuilder.NavButton("LinearGradientBrush FlowDirection Gallery", () =>
+						new LinearGradientBrushFlowDirectionGallery(), Navigation),
 					GalleryBuilder.NavButton("LinearGradientBrush Explorer", () =>
 						new LinearGradientExplorerGallery(), Navigation),
 					GalleryBuilder.NavButton("RadialGradient Explorer", () =>

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml
@@ -1,0 +1,207 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.GradientGalleries.LinearGradientBrushFlowDirectionGallery"
+    Title="LinearGradientBrush FlowDirection Gallery">
+       <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <LinearGradientBrush 
+                x:Key="LinearGradient"
+                StartPoint="0, 0"
+                EndPoint="1, 0">
+                <LinearGradientBrush.GradientStops>
+                    <GradientStop Color="Yellow" Offset="0.1" />
+                    <GradientStop Color="YellowGreen" Offset="0.6" />
+                    <GradientStop Color="Green" Offset="1.0" />
+                </LinearGradientBrush.GradientStops>
+            </LinearGradientBrush>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Grid
+                Grid.Row="0">
+                <Picker
+                    x:Name="BackgroundPicker"
+                    Title="Choose an option for the FlowDirection:"
+                    SelectedIndexChanged="OnFlowDirectionSelectedIndexChanged">
+                    <Picker.ItemsSource>
+                        <x:Array Type="{x:Type x:String}">
+                            <x:String>MatchParent</x:String>
+                            <x:String>LeftToRight</x:String>
+                            <x:String>RightToLeft</x:String>
+                        </x:Array>
+                    </Picker.ItemsSource>
+                </Picker>
+            </Grid>
+            <ScrollView
+                Grid.Row="1">
+                <StackLayout
+                    Padding="12">
+                    <Button
+                        x:Name="Button"
+                        Background="{StaticResource LinearGradient}"
+                        CornerRadius="12"
+                        Text="Button"/>
+                    <BoxView
+                        x:Name="BoxView"
+                        Background="{StaticResource LinearGradient}"
+                        HeightRequest="100"/>
+                    <BoxView
+                        x:Name="CornerRadiusBoxView"
+                        Background="{StaticResource LinearGradient}"
+                        CornerRadius="12"
+                        HeightRequest="100"/>
+                    <CheckBox 
+                         x:Name="CheckBox"
+                        Background="{StaticResource LinearGradient}"/>
+                    <CarouselView 
+                        x:Name="CarouselView"
+                        Background="{StaticResource LinearGradient}"
+                        HeightRequest="120">
+                        <CarouselView.ItemTemplate>
+                            <DataTemplate>
+                                <Grid>
+                                    <Label
+                                        HorizontalOptions="Center"
+                                        VerticalOptions="Center"
+                                        Text="{Binding .}"/>
+                                </Grid>
+                            </DataTemplate>
+                        </CarouselView.ItemTemplate>
+                        <CarouselView.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>This</x:String>
+                                <x:String>is</x:String>
+                                <x:String>a</x:String>
+                                <x:String>CarouselView</x:String>
+                            </x:Array>
+                        </CarouselView.ItemsSource>
+                    </CarouselView>
+                    <CollectionView 
+                        x:Name="CollectionView"
+                        Background="{StaticResource LinearGradient}"
+                        HeightRequest="120">
+                        <CollectionView.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>This</x:String>
+                                <x:String>is</x:String>
+                                <x:String>a</x:String>
+                                <x:String>CollectionView</x:String>
+                            </x:Array>
+                        </CollectionView.ItemsSource>
+                    </CollectionView>
+                    <DatePicker
+                        x:Name="DatePicker"
+                        Background="{StaticResource LinearGradient}"/>
+                    <Editor
+                        x:Name="Editor"
+                        Background="{StaticResource LinearGradient}"
+                        Text="Editor"/>
+                    <Entry
+                        x:Name="Entry"
+                        Background="{StaticResource LinearGradient}"
+                        Text="Entry"/>
+                    <Expander
+                        x:Name="Expander"
+                        Background="{StaticResource LinearGradient}">
+                        <Expander.Header>
+                            <Label
+                                Text="Expander Header" />
+                        </Expander.Header>
+                        <Grid>
+                            <Label
+                                Text="Expander Content" />
+                        </Grid>
+                    </Expander>
+                    <Frame
+                        x:Name="Frame"
+                        Background="{StaticResource LinearGradient}"
+                        CornerRadius="12"
+                        HeightRequest="100">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Frame"/>
+                    </Frame>
+                    <Grid
+                        x:Name="Grid"
+                        Background="{StaticResource LinearGradient}"
+                        HeightRequest="100">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Grid"/>
+                    </Grid>
+                    <Label
+                        x:Name="Label"
+                        Background="{StaticResource LinearGradient}"
+                        Text="Label"/>
+                    <ListView 
+                        x:Name="ListView"
+                        Background="{StaticResource LinearGradient}"
+                        HeightRequest="100">
+                        <ListView.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>This</x:String>
+                                <x:String>is</x:String>
+                                <x:String>a</x:String>
+                                <x:String>ListView</x:String>
+                            </x:Array>
+                        </ListView.ItemsSource>
+                    </ListView>
+                    <Picker 
+                        x:Name="Picker"
+                        Background="{StaticResource LinearGradient}"
+                        Title="Gradients"
+                        SelectedIndex="0">
+                        <Picker.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>Picker</x:String>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
+                    <ScrollView
+                         x:Name="ScrollView"
+                        Background="{StaticResource LinearGradient}"
+                         HeightRequest="150">
+                        <StackLayout>
+                            <Label 
+                                 Text="This"/>
+                            <Label 
+                                 Text="is"/>
+                            <Label 
+                                 Text="a"/>
+                            <Label 
+                                 Text="ScrollView"/>
+                        </StackLayout>
+                    </ScrollView>
+                    <SearchBar
+                        x:Name="SearchBar"
+                        Background="{StaticResource LinearGradient}"
+                        Text="SearchBar"/>
+                    <Slider
+                        x:Name="Slider"
+                        Background="{StaticResource LinearGradient}"/>
+                    <Stepper
+                        x:Name="Stepper"
+                        Background="{StaticResource LinearGradient}"/>
+                    <TableView
+                        x:Name="TableView"
+                        Background="{StaticResource LinearGradient}"
+                        HeightRequest="100" />
+                    <TimePicker
+                        x:Name="TimePicker"
+                        Background="{StaticResource LinearGradient}"/>
+                </StackLayout>
+            </ScrollView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml
@@ -3,7 +3,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Controls.GalleryPages.GradientGalleries.LinearGradientBrushFlowDirectionGallery"
-    Title="LinearGradientBrush FlowDirection Gallery">
+    Title="Brush FlowDirection Gallery">
        <ContentPage.Resources>
         <ResourceDictionary>
 

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml
@@ -109,18 +109,6 @@
                         x:Name="Entry"
                         Background="{StaticResource LinearGradient}"
                         Text="Entry"/>
-                    <Expander
-                        x:Name="Expander"
-                        Background="{StaticResource LinearGradient}">
-                        <Expander.Header>
-                            <Label
-                                Text="Expander Header" />
-                        </Expander.Header>
-                        <Grid>
-                            <Label
-                                Text="Expander Content" />
-                        </Grid>
-                    </Expander>
                     <Frame
                         x:Name="Frame"
                         Background="{StaticResource LinearGradient}"

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml.cs
@@ -1,0 +1,63 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.GradientGalleries
+{
+	public partial class LinearGradientBrushFlowDirectionGallery : ContentPage
+	{
+		public LinearGradientBrushFlowDirectionGallery()
+		{
+			InitializeComponent();
+			BackgroundPicker.SelectedIndex = 1;
+
+			Button.Clicked += (sender, args) =>
+			{
+				DisplayAlert("Events", "Button Clicked", "Ok");
+			};
+		}
+
+		void OnFlowDirectionSelectedIndexChanged(object sender, System.EventArgs e)
+		{
+			FlowDirection flowDirection = FlowDirection.MatchParent;
+
+			var selectedIndex = ((Picker)sender).SelectedIndex;
+
+			switch (selectedIndex)
+			{
+				case 0:
+					flowDirection = FlowDirection.MatchParent;
+					break;
+				case 1:
+					flowDirection = FlowDirection.LeftToRight;
+					break;
+				case 2:
+					flowDirection = FlowDirection.RightToLeft;
+					break;
+			}
+
+			UpdateFlowDirection(flowDirection);
+		}
+
+		void UpdateFlowDirection(FlowDirection flowDirection)
+		{
+			Button.FlowDirection = flowDirection;
+			BoxView.FlowDirection = flowDirection;
+			CornerRadiusBoxView.FlowDirection = flowDirection;
+			CheckBox.FlowDirection = flowDirection;
+			CarouselView.FlowDirection = flowDirection;
+			CollectionView.FlowDirection = flowDirection;
+			DatePicker.FlowDirection = flowDirection;
+			Editor.FlowDirection = flowDirection;
+			Entry.FlowDirection = flowDirection;
+			Expander.FlowDirection = flowDirection;
+			Frame.FlowDirection = flowDirection;
+			Grid.FlowDirection = flowDirection;
+			Label.FlowDirection = flowDirection;
+			ListView.FlowDirection = flowDirection;
+			Picker.FlowDirection = flowDirection;
+			ScrollView.FlowDirection = flowDirection;
+			SearchBar.FlowDirection = flowDirection;
+			Slider.FlowDirection = flowDirection;
+			Stepper.FlowDirection = flowDirection;
+			TableView.FlowDirection = flowDirection;
+			TimePicker.FlowDirection = flowDirection;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/LinearGradientBrushFlowDirectionGallery.xaml.cs
@@ -46,7 +46,6 @@
 			DatePicker.FlowDirection = flowDirection;
 			Editor.FlowDirection = flowDirection;
 			Entry.FlowDirection = flowDirection;
-			Expander.FlowDirection = flowDirection;
 			Frame.FlowDirection = flowDirection;
 			Grid.FlowDirection = flowDirection;
 			Label.FlowDirection = flowDirection;

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/VisualGradientViewsGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/VisualGradientViewsGallery.xaml
@@ -83,18 +83,25 @@
                         x:Name="Button"
                         CornerRadius="12"
                         Text="Button"
+                        TextColor="White"
                         Margin="{StaticResource ViewMargin}"/>
                     <CheckBox
                         x:Name="CheckBox"
+                        Color="White"
                         Margin="{StaticResource ViewMargin}"/>
                     <DatePicker
                         x:Name="DatePicker"
+                        TextColor="White"
                         Margin="{StaticResource ViewMargin}"/>
                     <Editor
                         x:Name="Editor"
+                        Placeholder="Editor"
+                        PlaceholderColor="White"
                         Margin="{StaticResource ViewMargin}"/>
                     <Entry
                         x:Name="Entry"
+                        Placeholder="Entry"
+                        PlaceholderColor="White"
                         Margin="{StaticResource ViewMargin}"/>
                     <Frame
                         x:Name="Frame"
@@ -105,6 +112,7 @@
                         <Label
                             HorizontalOptions="Center"
                             VerticalOptions="Center"
+                            TextColor="White"
                             Text="Frame"/>
                     </Frame>
                     <Picker
@@ -121,6 +129,7 @@
                         Margin="{StaticResource ViewMargin}"/>
                     <TimePicker
                         x:Name="TimePicker"
+                        TextColor="White"
                         Margin="{StaticResource ViewMargin}"/>
                 </StackLayout>
             </ScrollView>

--- a/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
@@ -132,7 +132,7 @@ namespace Xamarin.Forms.Material.Android
 				UpdateIsRunning();
 			else if (e.Is(ActivityIndicator.ColorProperty))
 				UpdateColor();
-			else if (e.IsOneOf(VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty))
+			else if (e.IsOneOf(VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground();
 		}
 

--- a/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialActivityIndicatorRenderer.cs
@@ -151,7 +151,7 @@ namespace Xamarin.Forms.Material.Android
 		void UpdateBackground()
 		{
 			if (Element != null && _control != null)
-				_control.SetBackground(Element.BackgroundColor, Element.Background);
+				_control.SetBackground(Element.BackgroundColor, Element.Background, Element.FlowDirection);
 		}
 
 		// IVisualElementRenderer

--- a/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialButtonRenderer.cs
@@ -206,7 +206,7 @@ namespace Xamarin.Forms.Material.Android
 				UpdateBorder();
 			else if (e.PropertyName == Button.FontProperty.PropertyName)
 				UpdateFont();
-			else if (e.IsOneOf(Button.TextColorProperty, VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty))
+			else if (e.IsOneOf(Button.TextColorProperty, VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdatePrimaryColors();
 			else if (e.PropertyName == VisualElement.InputTransparentProperty.PropertyName)
 				UpdateInputTransparent();

--- a/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
@@ -269,7 +269,9 @@ namespace Xamarin.Forms.Material.Android
 				_backgroundGradientDrawable.SetShape(ShapeType.Rectangle);
 
 				_backgroundGradientDrawable.SetCornerRadius(Radius);
-				_backgroundGradientDrawable.UpdateBackground(bgBrush, Height, Width);
+
+				BrushData brushData = new BrushData(bgBrush, Element.FlowDirection, Height, Width);
+				_backgroundGradientDrawable.UpdateBackground(brushData);
 
 				Background = _backgroundGradientDrawable;
 			}

--- a/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialActivityIndicatorRenderer.cs
@@ -134,7 +134,8 @@ namespace Xamarin.Forms.Material.iOS
 			if (_backgroundLayer == null)
 				return;
 
-			var backgroundImage = this.GetBackgroundImage(brush);
+			BrushData brushData = new BrushData(brush, Element.FlowDirection);
+			var backgroundImage = this.GetBackgroundImage(brushData);
 
 			_backgroundLayer.Hidden = brush == null || brush.IsEmpty;
 			_backgroundLayer.StrokeColor = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage).CGColor : UIColor.Clear.CGColor;

--- a/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
@@ -120,7 +120,8 @@ namespace Xamarin.Forms.Material.iOS
 			if (Brush.IsNullOrEmpty(bgBrush))
 				return;
 
-			var backgroundImage = this.GetBackgroundImage(bgBrush);
+			BrushData brushData = new BrushData(bgBrush, Element.FlowDirection);
+			var backgroundImage = this.GetBackgroundImage(brushData);
 
 			if (_backgroundSize != null && _backgroundSize != backgroundImage?.Size)
 				UpdateBackground();
@@ -214,7 +215,8 @@ namespace Xamarin.Forms.Material.iOS
 				}
 				else
 				{
-					var backgroundImage = Control.GetBackgroundImage(brush);
+					BrushData brushData = new BrushData(brush, Element.FlowDirection);
+					var backgroundImage = Control.GetBackgroundImage(brushData);
 					_backgroundSize = backgroundImage?.Size;
 					UIColor uiColor = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage) : UIColor.Clear;
 

--- a/Xamarin.Forms.Material.iOS/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialFrameRenderer.cs
@@ -201,7 +201,7 @@ namespace Xamarin.Forms.Material.iOS
 			{
 				updatedTheme = true;
 			}
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 			{
 				updatedTheme = true;
 			}
@@ -262,6 +262,7 @@ namespace Xamarin.Forms.Material.iOS
 				if (Brush.IsNullOrEmpty(bgBrush))
 				{
 					var bgColor = Element.BackgroundColor;
+
 					if (bgColor.IsDefault)
 						colorScheme.SurfaceColor = _defaultCardScheme.ColorScheme.SurfaceColor;
 					else
@@ -269,7 +270,8 @@ namespace Xamarin.Forms.Material.iOS
 				}
 				else
 				{
-					var backgroundLayer = this.GetBackgroundLayer(bgBrush);
+					BrushData brushData = new BrushData(bgBrush, Element.FlowDirection);
+					var backgroundLayer = this.GetBackgroundLayer(brushData);
 
 					if (backgroundLayer != null)
 					{

--- a/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
@@ -70,7 +70,13 @@ namespace Xamarin.Forms.Material.iOS
 				// Background
 				if (textField is UITextField || textField is MultilineTextField)
 				{
-					var backgroundImage = ((UIView)textField).GetBackgroundImage(brush);
+					FlowDirection flowDirection = FlowDirection.MatchParent;
+
+					if (element is View view)
+						flowDirection = view.FlowDirection;
+
+					BrushData brushData = new BrushData(brush, flowDirection);
+					var backgroundImage = ((UIView)textField).GetBackgroundImage(brushData);
 					textField.BackgroundSize = backgroundImage?.Size;
 					var color = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage) : UIColor.Clear;
 					textField.ActiveTextInputController.BorderFillColor = color;
@@ -90,7 +96,15 @@ namespace Xamarin.Forms.Material.iOS
 			UIImage backgroundImage = null;
 
 			if (textField is UITextField || textField is MultilineTextField)
-				backgroundImage = ((UIView)textField).GetBackgroundImage(bgBrush);
+			{
+				FlowDirection flowDirection = FlowDirection.MatchParent;
+
+				if (element is View view)
+					flowDirection = view.FlowDirection;
+
+				BrushData brushData = new BrushData(bgBrush, flowDirection);
+				backgroundImage = ((UIView)textField).GetBackgroundImage(brushData);
+			}
 
 			if (textField.BackgroundSize != null && textField.BackgroundSize != backgroundImage?.Size)
 				ApplyTheme(textField, element);

--- a/Xamarin.Forms.Platform.Android/AppCompat/CheckBoxDesignerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CheckBoxDesignerRenderer.cs
@@ -166,7 +166,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateBackgroundColor();
 			}
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 			{
 				UpdateBackground();
 			}
@@ -215,9 +215,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateBackground()
 		{
-			Brush background = Element.Background;
-
-			this.UpdateBackground(background);
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			this.UpdateBackground(brushData);
 		}
 
 		void UpdateOnColor()

--- a/Xamarin.Forms.Platform.Android/AppCompat/CheckBoxRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/CheckBoxRendererBase.cs
@@ -172,7 +172,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateBackgroundColor();
 			}
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 			{
 				UpdateBackground();
 			}
@@ -220,9 +220,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateBackground()
 		{
-			Brush background = Element.Background;
-
-			this.UpdateBackground(background);
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			this.UpdateBackground(brushData);
 		}
 
 		void UpdateOnColor()

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -383,7 +383,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateToolbar();
-			else if (e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName)
+			else if (e.IsOneOf(NavigationPage.BarBackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateToolbar();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName)
 				UpdateToolbar();
@@ -1007,8 +1007,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 			}
 
-			Brush barBackground = Element.BarBackground;
-			bar.UpdateBackground(barBackground);
+			BrushData brushData = new BrushData(Element.BarBackground, Element.FlowDirection);
+			bar.UpdateBackground(brushData);
 
 			Color textColor = Element.BarTextColor;
 			if (!textColor.IsDefault)

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -345,7 +345,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			}
 			else if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
-			else if (e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName)
+			else if (e.IsOneOf(NavigationPage.BarBackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBarBackground();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName ||
 				e.PropertyName == TabbedPage.UnselectedTabColorProperty.PropertyName ||
@@ -773,12 +773,12 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			if (IsDisposed)
 				return;
 
-			var barBackground = Element.BarBackground;
+			BrushData brushData = new BrushData(Element.BarBackground, Element.FlowDirection);
 
 			if (IsBottomTabPlacement)
-				_bottomNavigationView.UpdateBackground(barBackground);
+				_bottomNavigationView.UpdateBackground(brushData);
 			else
-				_tabLayout.UpdateBackground(barBackground);
+				_tabLayout.UpdateBackground(brushData);
 		}
 
 		protected virtual ColorStateList GetItemTextColorStates()

--- a/Xamarin.Forms.Platform.Android/BackgroundManager.cs
+++ b/Xamarin.Forms.Platform.Android/BackgroundManager.cs
@@ -45,9 +45,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (Element == null || Control == null)
 				return;
 
-			Brush background = Element.Background;
-
-			Control.UpdateBackground(background);
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			Control.UpdateBackground(brushData);
 		}
 
 		static void OnElementChanged(object sender, VisualElementChangedEventArgs e)
@@ -69,7 +68,6 @@ namespace Xamarin.Forms.Platform.Android
 			Performance.Stop(reference);
 		}
 
-
 		static void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
@@ -77,7 +75,7 @@ namespace Xamarin.Forms.Platform.Android
 				var renderer = (sender as IVisualElementRenderer);
 				UpdateBackgroundColor(renderer?.View, renderer?.Element);
 			}
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 			{
 				var renderer = (sender as IVisualElementRenderer);
 				UpdateBackground(renderer?.View, renderer?.Element);

--- a/Xamarin.Forms.Platform.Android/BorderBackgroundManager.cs
+++ b/Xamarin.Forms.Platform.Android/BorderBackgroundManager.cs
@@ -1,10 +1,10 @@
 using System;
 using System.ComponentModel;
 using Android.Content.Res;
-using AView = Android.Views.View;
 using Android.Graphics.Drawables;
 using Specifics = Xamarin.Forms.PlatformConfiguration.AndroidSpecific;
 using AColor = Android.Graphics.Color;
+using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
@@ -117,6 +117,7 @@ namespace Xamarin.Forms.Platform.Android
 				float shadowDy = 0;
 				float shadowDx = 0;
 				AColor shadowColor = Color.Transparent.ToAndroid();
+
 				// Add Android's default material shadow if we want it
 				if (useDefaultShadow)
 				{
@@ -135,6 +136,7 @@ namespace Xamarin.Forms.Platform.Android
 				}
 
 				_backgroundDrawable.SetPadding(paddingTop, paddingLeft);
+
 				if (_renderer.IsShadowEnabled())
 				{
 					_backgroundDrawable
@@ -229,6 +231,7 @@ namespace Xamarin.Forms.Platform.Android
 				e.PropertyName.Equals(Button.CornerRadiusProperty.PropertyName) ||
 				e.PropertyName.Equals(VisualElement.BackgroundColorProperty.PropertyName) ||
 				e.PropertyName.Equals(VisualElement.BackgroundProperty.PropertyName) ||
+				e.PropertyName.Equals(VisualElement.FlowDirectionProperty.PropertyName) ||
 				e.PropertyName.Equals(Specifics.Button.UseDefaultPaddingProperty.PropertyName) ||
 				e.PropertyName.Equals(Specifics.Button.UseDefaultShadowProperty.PropertyName) ||
 				e.PropertyName.Equals(Specifics.ImageButton.IsShadowEnabledProperty.PropertyName) ||

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewRenderer.cs
@@ -220,7 +220,7 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				UpdateBackgroundColor();
 			}
-			else if (changedProperty.Is(VisualElement.BackgroundProperty))
+			else if (changedProperty.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 			{
 				UpdateBackground();
 			}
@@ -473,9 +473,8 @@ namespace Xamarin.Forms.Platform.Android
 			if (!(this is RecyclerView recyclerView))
 				return;
 
-			Brush background = Element.Background;
-
-			recyclerView.UpdateBackground(background);
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			recyclerView.UpdateBackground(brushData);
 		}
 
 		protected virtual void UpdateFlowDirection()

--- a/Xamarin.Forms.Platform.Android/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/BrushExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Graphics.Drawables.Shapes;
@@ -7,9 +8,37 @@ using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
 {
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class BrushData
+	{
+		public BrushData()
+		{
+
+		}
+
+		public BrushData(Brush brush, FlowDirection flowDirection)
+		{
+			Brush = brush;
+			FlowDirection = flowDirection;
+		}
+
+		public BrushData(Brush brush, FlowDirection flowDirection, int height, int width)
+		{
+			Brush = brush;
+			FlowDirection = flowDirection;
+			Height = height;
+			Width = width;
+		}
+
+		public Brush Brush { get; internal set; }
+		public FlowDirection FlowDirection { get; internal set; }
+		public int Height { get; internal set; }
+		public int Width { get; internal set; }
+	}
+
 	public static class BrushExtensions
 	{
-		public static void UpdateBackground(this AView view, Brush brush)
+		public static void UpdateBackground(this AView view, BrushData brushData)
 		{
 			if (view == null)
 				return;
@@ -20,10 +49,10 @@ namespace Xamarin.Forms.Platform.Android
 				view.SetBackground(null);
 			}
 
-			if (Brush.IsNullOrEmpty(brush))
+			if (brushData == null || Brush.IsNullOrEmpty(brushData.Brush))
 				return;
 
-			if (brush is LinearGradientBrush linearGradientBrush)
+			if (brushData.Brush is LinearGradientBrush linearGradientBrush)
 			{
 				GradientStopCollection gradients = linearGradientBrush.GradientStops;
 
@@ -31,7 +60,7 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 			}
 
-			if (brush is RadialGradientBrush radialGradientBrush)
+			if (brushData.Brush is RadialGradientBrush radialGradientBrush)
 			{
 				GradientStopCollection gradients = radialGradientBrush.GradientStops;
 
@@ -39,29 +68,43 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 			}
 
-			view.SetPaintGradient(brush);
+			view.SetPaintGradient(brushData.Brush, brushData.FlowDirection);
 		}
 
-		public static void UpdateBackground(this Paint paint, Brush brush, int height, int width)
+		public static void UpdateBackground(this Paint paint, BrushData brushData)
 		{
-			if (paint == null || brush == null || brush.IsEmpty)
+			if (paint == null || brushData == null || brushData.Brush == null || brushData.Brush.IsEmpty)
 				return;
 
-			if (brush is SolidColorBrush solidColorBrush)
+			if (brushData.Brush is SolidColorBrush solidColorBrush)
 			{
 				var backgroundColor = solidColorBrush.Color;
 				paint.Color = backgroundColor.ToAndroid();
 			}
 
-			if (brush is LinearGradientBrush linearGradientBrush)
+			if (brushData.Brush is LinearGradientBrush linearGradientBrush)
 			{
 				var p1 = linearGradientBrush.StartPoint;
-				var x1 = (float)p1.X;
-				var y1 = (float)p1.Y;
-
 				var p2 = linearGradientBrush.EndPoint;
-				var x2 = (float)p2.X;
-				var y2 = (float)p2.Y;
+
+				float x1, y1, x2, y2;
+
+				if (brushData.FlowDirection == FlowDirection.RightToLeft)
+				{
+					x1 = (float)p2.X;
+					y1 = (float)p2.Y;
+
+					x2 = (float)p1.X;
+					y2 = (float)p1.Y;
+				}
+				else
+				{
+					x1 = (float)p1.X;
+					y1 = (float)p1.Y;
+
+					x2 = (float)p2.X;
+					y2 = (float)p2.Y;
+				}
 
 				var gradientBrushData = linearGradientBrush.GetGradientBrushData();
 				var colors = gradientBrushData.Item1;
@@ -71,10 +114,10 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 
 				var linearGradientShader = new LinearGradient(
-					width * x1,
-					height * y1,
-					width * x2,
-					height * y2,
+					brushData.Width * x1,
+					brushData.Height * y1,
+					brushData.Width * x2,
+					brushData.Height * y2,
 					colors,
 					offsets,
 					Shader.TileMode.Clamp);
@@ -82,7 +125,7 @@ namespace Xamarin.Forms.Platform.Android
 				paint.SetShader(linearGradientShader);
 			}
 
-			if (brush is RadialGradientBrush radialGradientBrush)
+			if (brushData.Brush is RadialGradientBrush radialGradientBrush)
 			{
 				var center = radialGradientBrush.Center;
 				float centerX = (float)center.X;
@@ -97,9 +140,9 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 
 				var radialGradientShader = new RadialGradient(
-					width * centerX,
-					height * centerY,
-					Math.Max(height, width) * radius,
+					brushData.Width * centerX,
+					brushData.Height * centerY,
+					Math.Max(brushData.Height, brushData.Width) * radius,
 					colors,
 					offsets,
 					Shader.TileMode.Clamp);
@@ -108,26 +151,40 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		public static void UpdateBackground(this GradientDrawable gradientDrawable, Brush brush, int height, int width)
+		public static void UpdateBackground(this GradientDrawable gradientDrawable, BrushData brushData)
 		{
-			if (gradientDrawable == null || brush == null || brush.IsEmpty)
+			if (gradientDrawable == null || brushData == null || brushData.Brush == null || brushData.Brush.IsEmpty)
 				return;
 
-			if (brush is SolidColorBrush solidColorBrush)
+			if (brushData.Brush is SolidColorBrush solidColorBrush)
 			{
 				Color bgColor = solidColorBrush.Color;
 				gradientDrawable.SetColor(bgColor.IsDefault ? Color.Default.ToAndroid() : bgColor.ToAndroid());
 			}
 
-			if (brush is LinearGradientBrush linearGradientBrush)
+			if (brushData.Brush is LinearGradientBrush linearGradientBrush)
 			{
 				var p1 = linearGradientBrush.StartPoint;
-				var x1 = (float)p1.X;
-				var y1 = (float)p1.Y;
-
 				var p2 = linearGradientBrush.EndPoint;
-				var x2 = (float)p2.X;
-				var y2 = (float)p2.Y;
+
+				float x1, y1, x2, y2;
+
+				if (brushData.FlowDirection == FlowDirection.RightToLeft)
+				{
+					x1 = (float)p2.X;
+					y1 = (float)p2.Y;
+
+					x2 = (float)p1.X;
+					y2 = (float)p1.Y;
+				}
+				else
+				{
+					x1 = (float)p1.X;
+					y1 = (float)p1.Y;
+
+					x2 = (float)p2.X;
+					y2 = (float)p2.Y;
+				}
 
 				const double Rad2Deg = 180.0 / Math.PI;
 				var angle = Math.Atan2(y2 - y1, x2 - x1) * Rad2Deg;
@@ -143,7 +200,7 @@ namespace Xamarin.Forms.Platform.Android
 				gradientDrawable.SetGradientOrientation(angle);
 			}
 
-			if (brush is RadialGradientBrush radialGradientBrush)
+			if (brushData.Brush is RadialGradientBrush radialGradientBrush)
 			{
 				var center = radialGradientBrush.Center;
 				float centerX = (float)center.X;
@@ -158,7 +215,7 @@ namespace Xamarin.Forms.Platform.Android
 
 				gradientDrawable.SetGradientType(GradientType.RadialGradient);
 				gradientDrawable.SetGradientCenter(centerX, centerY);
-				gradientDrawable.SetGradientRadius(Math.Max(height, width) * radius);
+				gradientDrawable.SetGradientRadius(Math.Max(brushData.Height, brushData.Width) * radius);
 				gradientDrawable.SetColors(colors);
 			}
 		}
@@ -180,7 +237,7 @@ namespace Xamarin.Forms.Platform.Android
 			return true;
 		}
 
-		internal static void SetPaintGradient(this AView view, Brush brush)
+		internal static void SetPaintGradient(this AView view, Brush brush, FlowDirection flowDirection)
 		{
 			var gradientStrokeDrawable = new GradientStrokeDrawable
 			{
@@ -195,7 +252,10 @@ namespace Xamarin.Forms.Platform.Android
 				gradientStrokeDrawable.SetColor(color);
 			}
 			else
-				gradientStrokeDrawable.SetGradient(brush);
+			{
+				gradientStrokeDrawable.SetStroke(0, Color.Default.ToAndroid());
+				gradientStrokeDrawable.SetGradient(brush, flowDirection);
+			}
 
 			view.Background?.Dispose();
 			view.Background = gradientStrokeDrawable;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -250,7 +250,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateShadow();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground();
 			else if (e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
 				UpdateCornerRadius();
@@ -300,7 +300,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				UpdateBackgroundColor();
 			}
 			else
-				_backgroundDrawable.UpdateBackground(background, Control.Height, Control.Width);
+			{
+				BrushData brushData = new BrushData(background, Element.FlowDirection, Control.Height, Control.Width);
+				_backgroundDrawable.UpdateBackground(brushData);
+			}
 		}
 
 		void UpdateBorderColor()

--- a/Xamarin.Forms.Platform.Android/GradientStrokeDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/GradientStrokeDrawable.cs
@@ -34,17 +34,31 @@ namespace Xamarin.Forms.Platform.Android
 			InvalidateSelf();
 		}
 
-		public void SetGradient(Brush brush)
+		public void SetGradient(Brush brush, FlowDirection flowDirection)
 		{
 			if (brush is LinearGradientBrush linearGradientBrush)
 			{
 				var p1 = linearGradientBrush.StartPoint;
-				var x1 = (float)p1.X;
-				var y1 = (float)p1.Y;
-
 				var p2 = linearGradientBrush.EndPoint;
-				var x2 = (float)p2.X;
-				var y2 = (float)p2.Y;
+
+				float x1, y1, x2, y2;
+
+				if (flowDirection == FlowDirection.RightToLeft)
+				{
+					x1 = (float)p2.X;
+					y1 = (float)p2.Y;
+
+					x2 = (float)p1.X;
+					y2 = (float)p1.Y;
+				}
+				else
+				{
+					x1 = (float)p1.X;
+					y1 = (float)p1.Y;
+
+					x2 = (float)p2.X;
+					y2 = (float)p2.Y;
+				}
 
 				var gradientBrushData = linearGradientBrush.GetGradientBrushData();
 				var colors = gradientBrushData.Item1;

--- a/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BorderDrawable.cs
@@ -202,8 +202,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (BorderElement.IsBackgroundSet())
 			{
-				Brush background = BorderElement.Background;
-				paint.UpdateBackground(background, height, width);
+				FlowDirection flowDirection = FlowDirection.MatchParent;
+
+				if (BorderElement is View view)
+					flowDirection = view.FlowDirection;
+
+				BrushData brushData = new BrushData(BorderElement.Background, flowDirection, height, width);
+
+				paint.UpdateBackground(brushData);
 			}
 
 			canvas.DrawPath(path, paint);

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.IsOneOf(VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty, BoxView.ColorProperty))
+			if (e.IsOneOf(VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty, BoxView.ColorProperty))
 				UpdateBoxView();
 			else if (e.PropertyName == BoxView.CornerRadiusProperty.PropertyName)
 				UpdateCornerRadius();
@@ -79,12 +79,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (!Brush.IsNullOrEmpty(brushToSet))
 			{
+				BrushData brushData = new BrushData(brushToSet, Element.FlowDirection, Height, Width);
+
 				if (_backgroundDrawable != null)
-					_backgroundDrawable.UpdateBackground(brushToSet, Height, Width);
+					_backgroundDrawable.UpdateBackground(brushData);
 				else
 				{
 					_backgroundDrawable = new GradientDrawable();
-					_backgroundDrawable.UpdateBackground(brushToSet, Height, Width);
+					_backgroundDrawable.UpdateBackground(brushData);
 					this.SetBackground(_backgroundDrawable);
 				}
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -175,6 +175,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateCharacterSpacing();
 			UpdateEnabled();
 			UpdateBackgroundColor();
+			UpdateBackground();
 			UpdatePadding();
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CircularProgress.cs
@@ -53,14 +53,17 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		public void SetBackground(Color color, Brush brush)
+		public void SetBackground(Color color, Brush brush, FlowDirection flowDirection)
 		{
 			if (Background is GradientDrawable gradientDrawable)
 			{
 				GradientDrawable backgroundDrawable = gradientDrawable.GetConstantState().NewDrawable() as GradientDrawable;
 
 				if (!Brush.IsNullOrEmpty(brush))
-					backgroundDrawable.UpdateBackground(brush, Height, Width);
+				{
+					BrushData brushData = new BrushData(brush, flowDirection, Height, Width);
+					backgroundDrawable.UpdateBackground(brushData);
+				}
 				else
 				{
 					_backgroudColor = color.IsDefault ? AColor.Transparent : color.ToAndroid();

--- a/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FrameRenderer.cs
@@ -59,7 +59,8 @@ namespace Xamarin.Forms.Platform.Android
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			base.OnElementPropertyChanged(sender, e);
-			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == Frame.CornerRadiusProperty.PropertyName)
+
+			if (e.IsOneOf(VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty, Frame.CornerRadiusProperty))
 			{
 				UpdateFrameBackground();
 			}
@@ -187,8 +188,8 @@ namespace Xamarin.Forms.Platform.Android
 
 					if (!Brush.IsNullOrEmpty(_frame.Background))
 					{
-						Brush background = _frame.Background;
-						paint.UpdateBackground(background, height, width);
+						BrushData brushData = new BrushData(_frame.Background, _frame.FlowDirection, height, width);
+						paint.UpdateBackground(brushData);
 					}
 					else
 					{

--- a/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/LabelRenderer.cs
@@ -7,7 +7,6 @@ using Android.Views;
 using Android.Widget;
 using System;
 using System.ComponentModel;
-using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
 
 namespace Xamarin.Forms.Platform.Android
 {

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -303,7 +303,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateBackgroundImage(_page);
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor(_page);
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground(_page);
 		}
 
@@ -355,9 +355,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateBackground(Page view)
 		{
-			Brush background = view.Background;
-
-			this.UpdateBackground(background);
+			BrushData brushData = new BrushData(view.Background, view.FlowDirection);
+			this.UpdateBackground(brushData);
 		}
 
 		void UpdateBackgroundImage(Page view)

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateBackground(true);
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackground(false);
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground(false);
 			else if (e.PropertyName == VisualElement.HeightProperty.PropertyName)
 				UpdateHeight();
@@ -138,7 +138,10 @@ namespace Xamarin.Forms.Platform.Android
 					Brush background = Element.Background;
 
 					if (!Brush.IsNullOrEmpty(background))
-						this.UpdateBackground(background);
+					{
+						BrushData brushData = new BrushData(background, Element.FlowDirection);
+						this.UpdateBackground(brushData);
+					}
 					else
 					{
 						Color backgroundColor = page.BackgroundColor;

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateIsEnabled();
 			else if (e.PropertyName == RefreshView.IsRefreshingProperty.PropertyName)
 				UpdateIsRefreshing();
-			else if (e.IsOneOf(RefreshView.RefreshColorProperty, VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty))
+			else if (e.IsOneOf(RefreshView.RefreshColorProperty, VisualElement.BackgroundColorProperty, VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateColors();
 
 			ElementPropertyChanged?.Invoke(sender, e);

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -338,7 +338,7 @@ namespace Xamarin.Forms.Platform.Android
 				LoadContent();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground();
 			else if (e.PropertyName == ScrollView.OrientationProperty.PropertyName)
 				UpdateOrientation();
@@ -477,9 +477,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateBackground()
 		{
-			Brush background = Element.Background;
-
-			this.UpdateBackground(background);
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			this.UpdateBackground(brushData);
 		}
 
 		void UpdateOrientation()

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -20,10 +20,9 @@ namespace Xamarin.Forms.Platform.Android
 			if (appearance == null)
 				UpdateScrim(Brush.Transparent);
 			else
-			{
 				UpdateScrim(appearance.FlyoutBackdrop);
-			}
 		}
+
 		#endregion IAppearanceObserver
 
 		#region IShellFlyoutRenderer
@@ -120,7 +119,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (_previousHeight != Height || _previousWidth != Width)
 				{
-					_scrimPaint.UpdateBackground(_scrimBrush, Height, Width);
+					BrushData brushData = new BrushData(_scrimBrush, Shell.FlowDirection, Height, Width);
+					_scrimPaint.UpdateBackground(brushData);
 					_previousHeight = Height;
 					_previousWidth = Width;
 				}
@@ -263,7 +263,8 @@ namespace Xamarin.Forms.Platform.Android
 				else
 				{
 					_scrimPaint = _scrimPaint ?? new Paint();
-					_scrimPaint.UpdateBackground(_scrimBrush, Height, Width);
+					BrushData brushData = new BrushData(_scrimBrush, Shell.FlowDirection, Height, Width);
+					_scrimPaint.UpdateBackground(brushData);
 					SetScrimColor(Color.Transparent.ToAndroid());
 				}
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -132,7 +132,8 @@ namespace Xamarin.Forms.Platform.Android
 				Shell.FlyoutBackgroundColorProperty,
 				Shell.FlyoutBackgroundProperty,
 				Shell.FlyoutBackgroundImageProperty,
-				Shell.FlyoutBackgroundImageAspectProperty))
+				Shell.FlyoutBackgroundImageAspectProperty,
+				VisualElement.FlowDirectionProperty))
 				UpdateFlyoutBackground();
 			else if (e.Is(Shell.FlyoutVerticalScrollModeProperty))
 				UpdateVerticalScrollMode();
@@ -193,8 +194,11 @@ namespace Xamarin.Forms.Platform.Android
 				_rootView.Background = color.IsDefault ? _defaultBackgroundColor : new ColorDrawable(color.ToAndroid());
 			}
 			else
-				_rootView.UpdateBackground(brush);
-			
+			{
+				BrushData brushData = new BrushData(brush, _shellContext.Shell.FlowDirection);
+				_rootView.UpdateBackground(brushData);
+			}
+
 			UpdateFlyoutBgImageAsync();
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateContent();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsSwipeEnabled();
@@ -154,12 +154,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void UpdateBackground()
 		{
-			Brush background = Element.Background;
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
 
-			this.UpdateBackground(background);
+			this.UpdateBackground(brushData);
 
 			if (Element.Content == null)
-				_contentView?.UpdateBackground(background);
+				_contentView?.UpdateBackground(brushData);
 		}
 
 		protected override void OnAttachedToWindow()

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -366,7 +366,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.IsOneOf(VisualElement.BackgroundProperty, VisualElement.FlowDirectionProperty))
 				UpdateBackground();
 			else if (e.PropertyName == AutomationProperties.HelpTextProperty.PropertyName)
 				SetContentDescription();
@@ -478,9 +478,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected virtual void UpdateBackground()
 		{
-			Brush background = Element.Background;
-
-			this.UpdateBackground(background);
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			this.UpdateBackground(brushData);
 		}
 
 		internal virtual void SendVisualElementInitialized(VisualElement element, AView nativeView)

--- a/Xamarin.Forms.Platform.MacOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/BrushExtensions.cs
@@ -122,6 +122,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (backgroundLayer == null)
 				return null;
 
+			if (backgroundLayer.Bounds.IsEmpty)
+				return null;
+
 			NSImage backgroundImage = new NSImage(new CGSize(backgroundLayer.Bounds.Width, backgroundLayer.Bounds.Height));
 			backgroundImage.LockFocus();
 			var context = NSGraphicsContext.CurrentContext.GraphicsPort;
@@ -133,6 +136,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public static void InsertBackgroundLayer(this NSView view, CAGradientLayer backgroundLayer, int index)
 		{
+			if (view == null)
+				return;
+
 			InsertBackgroundLayer(view.Layer, backgroundLayer, index);
 		}
 
@@ -170,7 +176,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		static bool ShouldUseParentView(NSView view)
 		{
-			if (view is NSButton || view is NSTextField || view is NSDatePicker || view is NSSlider || view is NSStepper)
+			if ((view is NSButton || view is NSTextField || view is NSDatePicker || view is NSSlider || view is NSStepper) && view.Superview != null)
 				return true;
 
 			return false;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/BoxViewRenderer.cs
@@ -71,7 +71,8 @@ namespace Xamarin.Forms.Platform.MacOS
 					(Control as FormsBoxView)?.SetColor(solidColorBrush.Color.ToNSColor());
 				else
 				{
-					var backgroundImage = this.GetBackgroundImage(brush);
+					BrushData brushData = new BrushData(brush, Element.FlowDirection);
+					var backgroundImage = this.GetBackgroundImage(brushData);
 					(Control as FormsBoxView)?.SetBrush(backgroundImage != null ? NSColor.FromPatternImage(backgroundImage) : NSColor.Clear);
 				}
 			}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/CarouselPageRenderer.cs
@@ -190,7 +190,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (e.PropertyName == nameof(TabbedPage.CurrentPage))
 				UpdateCurrentPage();
-			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == Page.BackgroundImageSourceProperty.PropertyName)
 				UpdateBackground();
@@ -212,8 +212,8 @@ namespace Xamarin.Forms.Platform.MacOS
 					Color bgColor = Element.BackgroundColor;
 					View.Layer.BackgroundColor = bgColor.IsDefault ? NSColor.White.CGColor : bgColor.ToCGColor();
 
-					Brush background = Element.Background;
-					View.UpdateBackground(background);
+					BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+					View.UpdateBackground(brushData);
 				}
 			});
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/CheckBoxRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/CheckBoxRenderer.cs
@@ -1,13 +1,25 @@
 ﻿using System;
 using AppKit;
+using CoreGraphics;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
 	public class CheckBoxRenderer : ViewRenderer<CheckBox, NSButton>
 	{
 		bool _disposed;
+		CGSize _previousSize;
 
 		IElementController ElementController => Element;
+
+		public override void Layout()
+		{
+			base.Layout();
+
+			if (_previousSize != Bounds.Size)
+				SetBackground(Element.Background);
+
+			_previousSize = Bounds.Size;
+		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<CheckBox> e)
 		{

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EditorRenderer.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Platform.MacOS
 	public class EditorRenderer : ViewRenderer<Editor, NSTextField>
 	{
 		const string NewLineSelector = "insertNewline";
+
 		bool _disposed;
 		CGSize _previousSize;
 
@@ -106,8 +107,17 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null)
 				return;
 
-			var backgroundImage = this.GetBackgroundImage(brush);
-			Control.BackgroundColor = backgroundImage != null ? NSColor.FromPatternImage(backgroundImage) : NSColor.Clear;
+			if (brush is SolidColorBrush solidColorBrush)
+			{
+				Color color = solidColorBrush.Color;
+				Control.BackgroundColor = color.ToNSColor(NSColor.White);
+			}
+			else
+			{
+				BrushData brushData = new BrushData(brush, Element.FlowDirection);
+				var backgroundImage = this.GetBackgroundImage(brushData);
+				Control.BackgroundColor = backgroundImage != null ? NSColor.FromPatternImage(backgroundImage) : NSColor.Clear;
+			}
 
 			base.SetBackground(brush);
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/EntryRenderer.cs
@@ -170,8 +170,17 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (Control == null)
 				return;
 
-			var backgroundImage = this.GetBackgroundImage(brush);
-			Control.BackgroundColor = backgroundImage != null ? NSColor.FromPatternImage(backgroundImage) : NSColor.Clear;
+			if (brush is SolidColorBrush solidColorBrush)
+			{
+				Color color = solidColorBrush.Color;
+				Control.BackgroundColor = color.ToNSColor(NSColor.White);
+			}
+			else
+			{
+				BrushData brushData = new BrushData(brush, Element.FlowDirection);
+				var backgroundImage = this.GetBackgroundImage(brushData);
+				Control.BackgroundColor = backgroundImage != null ? NSColor.FromPatternImage(backgroundImage) : NSColor.Clear;
+			}
 
 			base.SetBackground(brush);
 		}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/NavigationPageRenderer.cs
@@ -449,7 +449,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
-			else if (e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName)
+			else if (e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBarBackground();
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName)
 				UpdateBarTextColor();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -33,7 +33,10 @@ namespace Xamarin.Forms.Platform.MacOS
 					Brush background = _renderer.Element.Background;
 
 					if (!Brush.IsNullOrEmpty(background))
-						_renderer.NativeView.UpdateBackground(_renderer.Element.Background);
+					{
+						FlowDirection flowDirection = _renderer.Element.FlowDirection;
+						_renderer.NativeView.UpdateBackground(new BrushData(background, flowDirection));
+					}
 					else
 					{
 						Color bgColor = _renderer.Element.BackgroundColor;

--- a/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/PageRenderer.cs
@@ -203,7 +203,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == Page.BackgroundImageSourceProperty.PropertyName)
 				UpdateBackground();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateContentSize();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == ScrollView.VerticalScrollBarVisibilityProperty.PropertyName)
 				UpdateVerticalScrollBarVisibility();
@@ -237,9 +237,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (NativeView == null)
 				return;
 
-			Brush background = Element.Background;
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
 
-			NativeView.UpdateBackground(background);
+			NativeView.UpdateBackground(brushData);
 		}
 
 		void UpdateContentSize()

--- a/Xamarin.Forms.Platform.MacOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/TableViewRenderer.cs
@@ -87,7 +87,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void SetBackground(Brush brush)
 		{
-			TableView.UpdateBackground(brush);
+			BrushData brushData = new BrushData(brush, Element.FlowDirection);
+			TableView.UpdateBackground(brushData);
 			base.SetBackground(brush);
 		}
 

--- a/Xamarin.Forms.Platform.UAP/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ViewRenderer.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml;
+﻿using System.ComponentModel;
+using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
 
 namespace Xamarin.Forms.Platform.UWP
@@ -20,6 +21,14 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateBackground();
 				UpdateFlowDirection();
 			}
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
+				UpdateFlowDirection();
 		}
 
 		protected override void SetAutomationId(string id)

--- a/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/BoxRenderer.cs
@@ -104,7 +104,8 @@ namespace Xamarin.Forms.Platform.iOS
 					_colorToRenderer = solidColorBrush.Color.ToUIColor();
 				else
 				{
-					var backgroundImage = this.GetBackgroundImage(brush);
+					BrushData brushData = new BrushData(brush, Element.FlowDirection);
+					var backgroundImage = this.GetBackgroundImage(brushData);
 					_colorToRenderer = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage) : UIColor.Clear;
 				}
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonRenderer.cs
@@ -167,7 +167,8 @@ namespace Xamarin.Forms.Platform.iOS
 					backgroundColor = solidColorBrush.Color.ToUIColor();
 				else
 				{
-					var backgroundImage = this.GetBackgroundImage(brush);
+					BrushData brushData = new BrushData(brush, Element.FlowDirection);
+					var backgroundImage = this.GetBackgroundImage(brushData);
 					backgroundColor = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage) : UIColor.Clear;
 				}
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/CarouselPageRenderer.cs
@@ -303,7 +303,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (e.PropertyName == "CurrentPage")
 				UpdateCurrentPage();
-			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == Page.BackgroundImageSourceProperty.PropertyName)
 				UpdateBackground();
@@ -375,8 +375,8 @@ namespace Xamarin.Forms.Platform.iOS
 					else
 						View.BackgroundColor = Element.BackgroundColor.ToUIColor();
 
-					Brush background = Element.Background;
-					View.UpdateBackground(background);
+					BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+					View.UpdateBackground(brushData);
 				}
 			});
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -48,7 +48,8 @@ namespace Xamarin.Forms.Platform.iOS
 				e.PropertyName == Xamarin.Forms.Frame.HasShadowProperty.PropertyName ||
 				e.PropertyName == Xamarin.Forms.Frame.CornerRadiusProperty.PropertyName ||
 				e.PropertyName == Xamarin.Forms.Frame.IsClippedToBoundsProperty.PropertyName ||
-				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName)
+				e.PropertyName == VisualElement.IsVisibleProperty.PropertyName ||
+				e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				SetupLayer();
 		}
 
@@ -87,7 +88,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!Brush.IsNullOrEmpty(Element.Background))
 			{
-				var backgroundLayer = this.GetBackgroundLayer(Element.Background);
+				BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+				var backgroundLayer = this.GetBackgroundLayer(brushData);
 
 				if (backgroundLayer != null)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -326,7 +326,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void SetBackground(Brush brush)
 		{
-			var backgroundLayer = this.GetBackgroundLayer(brush);
+			BrushData brushData = new BrushData(brush, Element.FlowDirection);
+			var backgroundLayer = this.GetBackgroundLayer(brushData);
 
 			if (backgroundLayer != null)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ListViewRenderer.cs
@@ -140,7 +140,8 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 				else
 				{
-					var backgroundLayer = _backgroundUIView.GetBackgroundLayer(Element.Background);
+					BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+					var backgroundLayer = _backgroundUIView.GetBackgroundLayer(brushData);
 
 					if (backgroundLayer != null)
 					{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -434,7 +434,8 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateTint();
 			}
 			else if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName ||
-				e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName)
+				e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName ||
+				e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 			{
 				UpdateBarBackground();
 			}
@@ -672,8 +673,8 @@ namespace Xamarin.Forms.Platform.iOS
 					navigationBarAppearance.BackgroundColor = barBackgroundColor.ToUIColor();
 				}
 
-				var barBackgroundBrush = NavPage.BarBackground;
-				var backgroundImage = NavigationBar.GetBackgroundImage(barBackgroundBrush);
+				BrushData brushData = new BrushData(NavPage.BarBackground, NavPage.FlowDirection);
+				var backgroundImage = NavigationBar.GetBackgroundImage(brushData);
 				navigationBarAppearance.BackgroundImage = backgroundImage;
 
 				NavigationBar.CompactAppearance = navigationBarAppearance;
@@ -687,8 +688,8 @@ namespace Xamarin.Forms.Platform.iOS
 					? UINavigationBar.Appearance.BarTintColor
 					: barBackgroundColor.ToUIColor();
 
-				var barBackgroundBrush = NavPage.BarBackground;
-				var backgroundImage = NavigationBar.GetBackgroundImage(barBackgroundBrush);
+				BrushData brushData = new BrushData(NavPage.BarBackground, NavPage.FlowDirection);
+				var backgroundImage = NavigationBar.GetBackgroundImage(brushData);
 				NavigationBar.SetBackgroundImage(backgroundImage, UIBarMetrics.Default);
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -314,7 +314,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnHandlePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
-			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == Page.BackgroundImageSourceProperty.PropertyName)
 				UpdateBackground();
@@ -511,7 +511,10 @@ namespace Xamarin.Forms.Platform.iOS
 					Brush background = Element.Background;
 
 					if (!Brush.IsNullOrEmpty(background))
-						NativeView.UpdateBackground(Element.Background);
+					{
+						BrushData brushData = new BrushData(background, Element.FlowDirection);
+						NativeView.UpdateBackground(brushData);
+					}
 					else
 					{
 						Color backgroundColor = Element.BackgroundColor;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PhoneMasterDetailRenderer.cs
@@ -238,7 +238,7 @@ namespace Xamarin.Forms.Platform.iOS
 				Presented = ((MasterDetailPage)Element).IsPresented;
 			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsGestureEnabledProperty.PropertyName)
 				UpdatePanGesture();
-			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == Page.BackgroundImageSourceProperty.PropertyName)
 				UpdateBackground();
@@ -332,7 +332,10 @@ namespace Xamarin.Forms.Platform.iOS
 					Brush background = Element.Background;
 
 					if (!Brush.IsNullOrEmpty(background))
-						View.UpdateBackground(Element.Background);
+					{
+						BrushData brushData = new BrushData(background, Element.FlowDirection);
+						View.UpdateBackground(brushData);
+					}
 					else
 					{
 						if (Element.BackgroundColor == Color.Default)

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -100,7 +100,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_refreshControl == null)
 				return;
 
-			_refreshControl.UpdateBackground(brush);
+			BrushData brushData = new BrushData(brush, Element.FlowDirection);
+
+			_refreshControl.UpdateBackground(brushData);
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ScrollViewRenderer.cs
@@ -204,7 +204,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateContentSize();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				UpdateBackgroundColor();
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled();
@@ -308,9 +308,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (NativeView == null)
 				return;
 
-			Brush background = Element.Background;
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
 
-			NativeView.UpdateBackground(background);
+			NativeView.UpdateBackground(brushData);
 		}
 
 		void UpdateContentSize()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -43,7 +43,8 @@ namespace Xamarin.Forms.Platform.iOS
 				Shell.FlyoutBackgroundColorProperty,
 				Shell.FlyoutBackgroundProperty,
 				Shell.FlyoutBackgroundImageProperty,
-				Shell.FlyoutBackgroundImageAspectProperty))
+				Shell.FlyoutBackgroundImageAspectProperty,
+				VisualElement.FlowDirectionProperty))
 				UpdateBackground();
 			else if (e.Is(VisualElement.FlowDirectionProperty))
 				UpdateFlowDirection();
@@ -70,8 +71,8 @@ namespace Xamarin.Forms.Platform.iOS
 					_blurView.RemoveFromSuperview();
 			}
 
-			var brush = _shellContext.Shell.FlyoutBackground;
-			View.UpdateBackground(brush);
+			BrushData brushData = new BrushData(_shellContext.Shell.FlyoutBackground, _shellContext.Shell.FlowDirection);
+			View.UpdateBackground(brushData);
 
 			UpdateFlyoutBgImageAsync();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -237,8 +237,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (TapoffView == null)
 				return;
 
-			TapoffView.UpdateBackground(_backdropBrush);
-			if (Brush.IsNullOrEmpty(_backdropBrush))
+			BrushData brushData = new BrushData(_backdropBrush, Shell.FlowDirection);
+
+			TapoffView.UpdateBackground(brushData);
+			if (Brush.IsNullOrEmpty(brushData.Brush))
 				TapoffView.BackgroundColor = ColorExtensions.BackgroundColor.ColorWithAlpha(0.5f);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateContent();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				SetBackgroundColor(Element.BackgroundColor);
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				SetBackground(Element.Background);
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsSwipeEnabled();
@@ -182,13 +182,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void SetBackground(Brush brush)
 		{
-			Brush background = Element.Background;
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
 
 			if (Control != null)
-				Control.UpdateBackground(background);
+				Control.UpdateBackground(brushData);
 
 			if (_contentView != null && Element.Content == null && HasSwipeItems())
-				_contentView.UpdateBackground(background);
+				_contentView.UpdateBackground(brushData);
 		}
 
 		public override void TouchesEnded(NSSet touches, UIEvent evt)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -249,7 +249,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else if (e.PropertyName == TabbedPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
-			else if (e.PropertyName == TabbedPage.BarBackgroundProperty.PropertyName)
+			else if (e.PropertyName == TabbedPage.BarBackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBarBackground();
 			else if (e.PropertyName == TabbedPage.BarTextColorProperty.PropertyName)
 				UpdateBarTextColor();
@@ -382,9 +382,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Tabbed == null || TabBar == null)
 				return;
 
-			var barBackground = Tabbed.BarBackground;
-
-			TabBar.UpdateBackground(barBackground);
+			BrushData brushData = new BrushData(Tabbed.BarBackground, Tabbed.FlowDirection);
+			TabBar.UpdateBackground(brushData);
 		}
 
 		void UpdateBarTextColor()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateRowHeight();
 			else if (e.PropertyName == TableView.HasUnevenRowsProperty.PropertyName)
 				SetSource();
-			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackgroundView();
 		}
 
@@ -144,7 +144,9 @@ namespace Xamarin.Forms.Platform.iOS
 		void UpdateBackgroundView()
 		{
 			Control.BackgroundView = Element.BackgroundColor == Color.Default ? _originalBackgroundView : null;
-			Control.BackgroundView.UpdateBackground(Element.Background);
+
+			BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+			Control.BackgroundView.UpdateBackground(brushData);
 		}
 
 		void UpdateRowHeight()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletMasterDetailRenderer.cs
@@ -460,7 +460,7 @@ namespace Xamarin.Forms.Platform.iOS
 				ToggleMaster();
 			else if (e.PropertyName == Xamarin.Forms.MasterDetailPage.IsGestureEnabledProperty.PropertyName)
 				base.PresentsWithGesture = this.MasterDetailPage.IsGestureEnabled;
-			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateBackground();
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
@@ -517,7 +517,10 @@ namespace Xamarin.Forms.Platform.iOS
 					Brush background = Element.Background;
 
 					if (!Brush.IsNullOrEmpty(background))
-						View.UpdateBackground(Element.Background);
+					{
+						BrushData brushData = new BrushData(Element.Background, Element.FlowDirection);
+						View.UpdateBackground(brushData);
+					}
 					else
 					{
 						if (Element.BackgroundColor == Color.Default)

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -154,7 +154,7 @@ namespace Xamarin.Forms.Platform.MacOS
 					UpdateIsEnabled();
 				else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 					SetBackgroundColor(Element.BackgroundColor);
-				else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+				else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 					SetBackground(Element.Background);
 				else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 					UpdateFlowDirection();
@@ -215,7 +215,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (IsElementOrControlEmpty)
 				return;
 
-			Control.UpdateBackground(brush);
+			BrushData brushData = new BrushData(brush, Element.FlowDirection);
+
+			Control.UpdateBackground(brushData);
 		}
 
 		protected void SetNativeControl(TNativeView uiview)

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -405,7 +405,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 				SetBackgroundColor(Element.BackgroundColor);
-			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName || e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				SetBackground(Element.Background);
 			else if (e.PropertyName == Xamarin.Forms.Layout.IsClippedToBoundsProperty.PropertyName)
 				UpdateClipToBounds();
@@ -470,7 +470,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected virtual void SetBackground(Brush brush)
 		{
-			NativeView.UpdateBackground(brush);
+			BrushData brushData = new BrushData(brush, Element.FlowDirection);
+			NativeView.UpdateBackground(brushData);
 		}
 
 #if __MOBILE__


### PR DESCRIPTION
### Description of Change ###

Update LinearGradientBrush based on FlowDirection .

_Work in progress_

### Issues Resolved ### 

- fixes #11603 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- macOS
- Android
- UWP

### Behavioral/Visual Changes ###

FlowDirection defines not only how text flows in a textual element but also the flow direction of almost every other UI element. With this changes, changing the FlowDirection also affects to a LinearGradientBrush.

### Before/After Screenshots ### 

![brush-flowdirection-ios](https://user-images.githubusercontent.com/6755973/90035861-9d5b6480-dcc2-11ea-9ac8-7df97d2c63c1.gif)

![flow-brush-macos](https://user-images.githubusercontent.com/6755973/90122680-f1675700-dd5d-11ea-872f-a3f6c75fec63.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the brushes gallery. Select the "" and apply FlowDirection changes to see the behavior.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
