### PR TITLE
Create a specific XAML page for the ShellPageWrapper used for Shell Navigation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellStoreTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellStoreTests.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Linq;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using System.Threading;
+using System.ComponentModel;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellStoreTests
+	{
+#if UITEST
+
+		IApp RunningApp;
+		[SetUp]
+		public void ShellStoreSetup()
+		{
+			RunningApp = AppSetup.Setup();
+			if (RunningApp.Query("SwapRoot - Store Shell").Length > 0)
+				RunningApp.Tap("SwapRoot - Store Shell");
+			else
+				RunningApp.NavigateTo("SwapRoot - Store Shell");
+
+			RunningApp.WaitForElement("Welcome to the HomePage");
+		}
+
+		[Test]
+		public void LoadsWithoutCrashing()
+		{
+			RunningApp.WaitForElement("Welcome to the HomePage");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -825,6 +825,7 @@
       <DependentUpon>Issue6698View2.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)ShellStoreTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ViewModel.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8145.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10222.cs" />

--- a/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Utilities/AppExtensions.cs
@@ -148,6 +148,8 @@ namespace Xamarin.Forms.Core.UITests
 {
 	internal static class AppExtensions
 	{
+		const string goToTestButtonQuery = "* marked:'GoToTestButton'";
+
 		public static AppRect ScreenBounds(this IApp app)
 		{
 			return app.Query(Queries.Root()).First().Rect;
@@ -163,14 +165,13 @@ namespace Xamarin.Forms.Core.UITests
 			NavigateToGallery(app, page, null);
 		}
 
-		public static void NavigateToGallery(this IApp app, string page, string visual)
+		public static void NavigateTo(this IApp app, string text)
 		{
-			const string goToTestButtonQuery = "* marked:'GoToTestButton'";
+			NavigateTo(app, text, null);
+		}
 
-			app.WaitForElement(q => q.Raw(goToTestButtonQuery), "Timed out waiting for Go To Test button to appear", TimeSpan.FromMinutes(2));
-
-			var text = Regex.Match(page, "'(?<text>[^']*)'").Groups["text"].Value;
-
+		public static void NavigateTo(this IApp app, string text, string visual)
+		{
 			app.WaitForElement("SearchBar");
 			app.ClearText(q => q.Raw("* marked:'SearchBar'"));
 			app.EnterText(q => q.Raw("* marked:'SearchBar'"), text);
@@ -187,7 +188,14 @@ namespace Xamarin.Forms.Core.UITests
 				app.Tap(q => q.Raw(goToTestButtonQuery));
 			}
 
-			app.WaitForNoElement(o => o.Raw(goToTestButtonQuery), "Timed out waiting for Go To Test button to disappear", TimeSpan.FromMinutes(2));
+			app.WaitForNoElement(o => o.Raw(goToTestButtonQuery), "Timed out waiting for Go To Test button to disappear", TimeSpan.FromMinutes(1));
+		}
+
+		public static void NavigateToGallery(this IApp app, string page, string visual)
+		{
+			app.WaitForElement(q => q.Raw(goToTestButtonQuery), "Timed out waiting for Go To Test button to appear", TimeSpan.FromMinutes(2));
+			var text = Regex.Match(page, "'(?<text>[^']*)'").Groups["text"].Value;
+			NavigateTo(app, text, visual);
 		}
 
 

--- a/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WindowsTestBase.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			if (Session == null)
 				Session = CreateWindowsDriver();
+			else
+				Reset();
 
 			return new WinDriverApp(Session);
 		}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellPageWrapper.xaml
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellPageWrapper.xaml
@@ -1,0 +1,13 @@
+﻿<Page
+    x:Class="Xamarin.Forms.Platform.UWP.ShellPageWrapper"
+    xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+    xmlns:local="using:Xamarin.Forms.Platform.UAP"
+    xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d">
+
+    <ContentPresenter Name="Root" HorizontalAlignment="Stretch" VerticalAlignment="Stretch">
+
+    </ContentPresenter>
+</Page>

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellPageWrapper.xaml.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellPageWrapper.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.UI.Xaml;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	partial class ShellPageWrapper
+	{
+		public ShellPageWrapper()
+		{
+			InitializeComponent();
+		}
+
+		public Page Page { get; set; }
+		protected override void OnNavigatedTo(Windows.UI.Xaml.Navigation.NavigationEventArgs e)
+		{
+			base.OnNavigatedTo(e);
+			LoadPage();
+		}
+
+		protected override void OnNavigatedFrom(Windows.UI.Xaml.Navigation.NavigationEventArgs e)
+		{
+			base.OnNavigatedFrom(e);
+			Root.Content = null;
+		}
+
+		public void LoadPage()
+		{
+			if (Page != null)
+			{
+				var container = Page.GetOrCreateRenderer().ContainerElement;
+				Root.Content = container;
+				container.Loaded -= OnPageLoaded;
+				container.Loaded += OnPageLoaded;
+			}
+		}
+
+		private void OnPageLoaded(object sender, RoutedEventArgs e)
+		{
+			var frameworkElement = sender as FrameworkElement;
+			Page.Layout(new Rectangle(0, 0, frameworkElement.ActualWidth, frameworkElement.ActualHeight));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -162,43 +162,6 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		internal class ShellPageWrapper : Windows.UI.Xaml.Controls.Page
-		{
-			public ShellPageWrapper()
-			{
-			}
-
-			public Page Page { get; set; }
-			protected override void OnNavigatedTo(Windows.UI.Xaml.Navigation.NavigationEventArgs e)
-			{
-				base.OnNavigatedTo(e);
-				LoadPage();
-			}
-
-			protected override void OnNavigatedFrom(Windows.UI.Xaml.Navigation.NavigationEventArgs e)
-			{
-				base.OnNavigatedFrom(e);
-				Content = null;
-			}
-
-			public void LoadPage()
-			{
-				if (Page != null)
-				{
-					var container = Page.GetOrCreateRenderer().ContainerElement;
-					Content = container;
-					container.Loaded -= OnPageLoaded;
-					container.Loaded += OnPageLoaded;
-				}
-			}
-
-			private void OnPageLoaded(object sender, RoutedEventArgs e)
-			{
-				var frameworkElement = sender as FrameworkElement;
-				Page.Layout(new Rectangle(0, 0, frameworkElement.ActualWidth, frameworkElement.ActualHeight));
-			}
-		}
-
 		NavigationTransitionInfo GetTransitionInfo(ShellNavigationSource navSource)
 		{
 			switch (navSource)

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -31,6 +31,10 @@
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </Page>
+    <Page Include="Shell\ShellPageWrapper.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </Page>
     <Page Include="CollectionView\ItemsViewStyles.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>

--- a/build.cake
+++ b/build.cake
@@ -474,7 +474,7 @@ Task ("cg-uwp-build-tests")
     );
 
     MSBuild("Xamarin.Forms.Core.Windows.UITests\\Xamarin.Forms.Core.Windows.UITests.csproj", 
-        GetMSBuildSettings().WithRestore());
+        GetMSBuildSettings(buildConfiguration:"Debug").WithRestore());
 });
 
 Task ("cg-uwp-deploy")

--- a/build.cake
+++ b/build.cake
@@ -470,6 +470,8 @@ Task ("cg-uwp-build-tests")
             .WithProperty("PackageCertificateThumbprint", "a59087cc92a9a8117ffdb5255eaa155748f9f852")
             .WithProperty("PackageCertificateKeyFile", "Xamarin.Forms.ControlGallery.WindowsUniversal_TemporaryKey.pfx")
             .WithProperty("PackageCertificatePassword", "")
+            // The platform unit tests can't run when UseDotNetNativeToolchain is set to true so we force it off here
+            .WithProperty("UseDotNetNativeToolchain", "false")
             .WithRestore()
     );
 

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -193,12 +193,12 @@ steps:
       TargetFolder: ${{ parameters.artifactsTargetFolder }}
   
   - script: build.cmd -Target cg-uwp-build-tests  -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"'
-    condition: eq(variables['BuildConfiguration'], 'Release')
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.includePages }}', true))
     displayName: 'Build Tests and APPX'
 
   - task: CopyFiles@2
     displayName: 'Copy Appx Packages'
-    condition: eq(variables['BuildConfiguration'], 'Release')
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.includePages }}', true))
     inputs:
       Contents: |
         Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/*
@@ -220,9 +220,9 @@ steps:
 
   - task: CopyFiles@2
     displayName: 'Copy UITest Files'
-    condition: eq(variables['BuildConfiguration'], 'Debug')
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.includePages }}', true))
     inputs:
-      SourceFolder: Xamarin.Forms.Core.Windows.UITests/bin/$(BuildConfiguration)/
+      SourceFolder: Xamarin.Forms.Core.Windows.UITests/bin/Debug/
       TargetFolder: '$(build.artifactstagingdirectory)/UITests'
 
   - task: CopyFiles@2

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -193,12 +193,12 @@ steps:
       TargetFolder: ${{ parameters.artifactsTargetFolder }}
   
   - script: build.cmd -Target cg-uwp-build-tests  -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"'
-    condition: and(eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.includePages }}', true))
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
     displayName: 'Build Tests and APPX'
 
   - task: CopyFiles@2
     displayName: 'Copy Appx Packages'
-    condition: and(eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.includePages }}', true))
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
     inputs:
       Contents: |
         Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/*
@@ -220,7 +220,7 @@ steps:
 
   - task: CopyFiles@2
     displayName: 'Copy UITest Files'
-    condition: and(eq(variables['BuildConfiguration'], 'Release'), eq('${{ parameters.includePages }}', true))
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
     inputs:
       SourceFolder: Xamarin.Forms.Core.Windows.UITests/bin/Debug/
       TargetFolder: '$(build.artifactstagingdirectory)/UITests'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -193,12 +193,12 @@ steps:
       TargetFolder: ${{ parameters.artifactsTargetFolder }}
   
   - script: build.cmd -Target cg-uwp-build-tests  -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"'
-    condition: eq(variables['BuildConfiguration'], 'Debug')
+    condition: eq(variables['BuildConfiguration'], 'Release')
     displayName: 'Build Tests and APPX'
 
   - task: CopyFiles@2
     displayName: 'Copy Appx Packages'
-    condition: eq(variables['BuildConfiguration'], 'Debug')
+    condition: eq(variables['BuildConfiguration'], 'Release')
     inputs:
       Contents: |
         Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/*


### PR DESCRIPTION
### Description of Change ###
- Convert the Shell holder page for frame navigation to a XAML page because it appears that when in release mode that's required
- Change the Windows UI Tests to build and deploy using a release build with native tool chain bits

### Issues Resolved ### 
- fixes #11736

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- UI Tests pass
- Control GAllery deploys in release mode and works

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
