### PR TITLE
[Tizen] Adds the Unified Theme Manager

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Cells/EntryCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/EntryCellRenderer.cs
@@ -2,15 +2,11 @@ using System;
 using System.Collections.Generic;
 using System.Globalization;
 using ElmSharp;
-using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
 	public class EntryCellRenderer : ViewCellRenderer
 	{
-		static readonly double s_defaultHeight = 65;
-		static readonly EColor s_defaultLabelColor = EColor.Black;
-
 		readonly Dictionary<EvasObject, VisualElement> _cacheCandidate = new Dictionary<EvasObject, VisualElement>();
 
 		public EntryCellRenderer()
@@ -23,7 +19,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				var entryCell = cell as EntryCell;
 				int pixelHeight = Forms.ConvertToScaledPixel(entryCell.RenderHeight);
-				pixelHeight = pixelHeight > 0 ? pixelHeight : Forms.ConvertToPixel(s_defaultHeight);
+				pixelHeight = pixelHeight > 0 ? pixelHeight : this.GetDefaultHeightPixel();
 
 				var label = new Label()
 				{
@@ -90,7 +86,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			var layout = _cacheCandidate[old];
 			layout.BindingContext = cell;
 			int height = Forms.ConvertToScaledPixel(cell.RenderHeight);
-			height = height > 0 ? height : Forms.ConvertToPixel(s_defaultHeight);
+			height = height > 0 ? height : this.GetDefaultHeightPixel();
 			old.MinimumHeight = height;
 			return old;
 		}
@@ -99,7 +95,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
 			{
-				return ((Color)value).IsDefault ? s_defaultLabelColor : value;
+				return ((Color)value).IsDefault ? ThemeConstants.EntryCell.ColorClass.DefaultLabelColor : value;
 			}
 
 			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)

--- a/Xamarin.Forms.Platform.Tizen/Cells/ImageCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/ImageCellRenderer.cs
@@ -5,11 +5,9 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class ImageCellRenderer : TextCellRenderer
 	{
-		const int _defaultHeight = 55;
-
-		public ImageCellRenderer() : this(Device.Idiom == TargetIdiom.Watch ? "1icon_2text" : (Device.Idiom == TargetIdiom.Phone ? "double_label" : "default"))
+		public ImageCellRenderer() : this(ThemeManager.GetImageCellRendererStyle())
 		{
-			ImagePart = "elm.swallow.icon";
+			ImagePart = this.GetImagePart();
 		}
 
 		protected ImageCellRenderer(string style) : base(style)
@@ -26,7 +24,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				int pixelSize = Forms.ConvertToScaledPixel(imgCell.RenderHeight);
 				if (pixelSize <= 0)
 				{
-					pixelSize = Forms.ConvertToPixel(_defaultHeight);
+					pixelSize = this.GetDefaultHeightPixel();
 				}
 
 				var image = new Native.Image(Forms.NativeParent)

--- a/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/SwitchCellRenderer.cs
@@ -11,10 +11,10 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 		}
 
-		public SwitchCellRenderer() : this(Device.Idiom == TargetIdiom.Watch ? "1text.1icon.1" : "default")
+		public SwitchCellRenderer() : this(ThemeManager.GetSwitchCellRendererStyle())
 		{
-			MainPart = "elm.text";
-			SwitchPart = Device.Idiom == TargetIdiom.Watch ? "elm.icon" : "elm.swallow.end";
+			MainPart = this.GetMainPart();
+			SwitchPart = this.GetSwitchPart();
 		}
 
 		protected string MainPart { get; set; }

--- a/Xamarin.Forms.Platform.Tizen/Cells/TextCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/TextCellRenderer.cs
@@ -7,12 +7,12 @@ namespace Xamarin.Forms.Platform.Tizen
 	{
 		bool _groupMode = false;
 		// TextCell.Detail property is not supported on TV profile due to UX limitation.
-		public TextCellRenderer() : this(Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.Watch ? "double_label" : "default") { }
+		public TextCellRenderer() : this(ThemeManager.GetTextCellRendererStyle()) { }
 
 		protected TextCellRenderer(string style) : base(style)
 		{
-			MainPart = "elm.text";
-			DetailPart = "elm.text.sub";
+			MainPart = this.GetMainPart();
+			DetailPart = this.GetDetailPart();
 		}
 
 		protected string MainPart { get; set; }
@@ -24,18 +24,9 @@ namespace Xamarin.Forms.Platform.Tizen
 				return;
 
 			_groupMode = enable;
-			if (enable)
-			{
-				Class = null;
-				Style = "group_index";
-				DetailPart = "elm.text.end";
-			}
-			else
-			{
-				Class = null;
-				Style = Device.Idiom == TargetIdiom.Phone ? "double_label" : "default";
-				DetailPart = "elm.text.sub";
-			}
+			Class = null;
+			Style = ThemeManager.GetTextCellGroupModeStyle(enable);
+			DetailPart = this.GetDetailPart();
 		}
 
 		protected override Span OnGetText(Cell cell, string part)

--- a/Xamarin.Forms.Platform.Tizen/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Cells/ViewCellRenderer.cs
@@ -6,9 +6,9 @@ namespace Xamarin.Forms.Platform.Tizen
 	public class ViewCellRenderer : CellRenderer
 	{
 		readonly Dictionary<EvasObject, ViewCell> _cacheCandidate = new Dictionary<EvasObject, ViewCell>();
-		public ViewCellRenderer() : base("full")
+		public ViewCellRenderer() : base(ThemeManager.GetViewCellRendererStyle())
 		{
-			MainContentPart = "elm.swallow.content";
+			MainContentPart = this.GetMainContentPart();
 		}
 
 		protected string MainContentPart { get; set; }

--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -10,6 +10,7 @@ using ELayout = ElmSharp.Layout;
 using DeviceOrientation = Xamarin.Forms.Internals.DeviceOrientation;
 using ElmSharp.Wearable;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Application;
+using Xamarin.Forms.Platform.Tizen.Native;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -181,7 +182,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				(renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
 				nativeView = renderer?.NativeView;
 			}
-			Forms.BaseLayout.SetPartContent("elm.swallow.overlay", nativeView);
+			Forms.BaseLayout.SetOverlayPart(nativeView);
 		}
 
 		void SetPage(Page page)
@@ -217,8 +218,8 @@ namespace Xamarin.Forms.Platform.Tizen
 				var conformant = new Conformant(MainWindow);
 				conformant.Show();
 
-				var layout = new ELayout(conformant);
-				layout.SetTheme("layout", "application", "default");
+				var layout = new ApplicationLayout(conformant);
+
 				layout.Show();
 
 				BaseLayout = layout;

--- a/Xamarin.Forms.Platform.Tizen/Native/Button.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Button.cs
@@ -202,7 +202,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				if (Image != null)
 					MinimumWidth += Image.Geometry.Width;
 
-				var rawSize = TextHelper.GetRawTextBlockSize(this);
+				var rawSize = this.GetTextBlockNativeSize();
 				return new ESize(rawSize.Width + MinimumWidth , Math.Max(MinimumHeight, rawSize.Height));
 			}
 		}
@@ -230,25 +230,16 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <param name="textStyle">Style applied to the formattedText.</param>
 		void SetInternalTextAndStyle(string formattedText, string textStyle)
 		{
-			string emission = "elm,state,text,visible";
-
+			bool isVisible = true;
 			if (string.IsNullOrEmpty(formattedText))
 			{
 				formattedText = null;
 				textStyle = null;
-				emission = "elm,state,text,hidden";
+				isVisible = false;
 			}
-
 			base.Text = formattedText;
-
-			var textblock = EdjeObject["elm.text"];
-
-			if (textblock != null)
-			{
-				textblock.TextStyle = textStyle;
-			}
-
-			EdjeObject.EmitSignal(emission, "elm");
+			this.SetTextBlockStyle(textStyle);
+			this.SendTextVisibleSignal(isVisible);
 		}
 
 		/// <summary>
@@ -268,14 +259,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// </summary>
 		void SetInternalImage()
 		{
-			if (_image == null)
-			{
-				SetPartContent("icon", null);
-			}
-			else
-			{
-				SetPartContent("icon", _image);
-			}
+			this.SetIconPart(_image);
 		}
 
 		/// <summary>

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CarouselView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CarouselView.cs
@@ -19,8 +19,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			return new ViewHolder(this)
 			{
-				FocusedColor = ElmSharp.Color.Transparent,
-				SelectedColor = ElmSharp.Color.Transparent,
+				FocusedColor = ThemeConstants.CarouselView.ColorClass.DefaultFocusedColor,
+				SelectedColor = ThemeConstants.CarouselView.ColorClass.DefaultSelectedColor,
 			};
 		}
 		ESize ICollectionViewController.GetItemSize(int widthConstraint, int heightConstraint)

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/IndicatorView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/IndicatorView.cs
@@ -14,9 +14,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			AutoHide = false;
 			IsHorizontal = true;
-			Style = "pagecontrol";
-			if (Device.Idiom == TargetIdiom.Watch)
-				Style = "circle";
+			this.SetStyledIndex();
 		}
 
 		public event EventHandler<SelectedPositionChangedEventArgs> SelectedPosition;
@@ -55,18 +53,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			foreach (var item in _list)
 			{
-				if (_list.Count % 2 == 0)
-				{
-					int position = EvenMiddleItem - (_list.Count / 2) + _list.IndexOf(item);
-					string itemStyle = "item/even_" + position;
-					item.Style = itemStyle;
-				}
-				else
-				{
-					int position = OddMiddleItem - (_list.Count / 2) + _list.IndexOf(item);
-					string itemStyle = "item/odd_" + position;
-					item.Style = itemStyle;
-				}
+				item.SetIndexItemStyle(_list.Count, _list.IndexOf(item), EvenMiddleItem, OddMiddleItem);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ViewHolder.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ViewHolder.cs
@@ -15,9 +15,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 	public class ViewHolder : Box
 	{
-		static readonly EColor s_defaultFocusEffectColor = EColor.FromRgba(244, 244, 244, 200);
-		static readonly EColor s_defaultSelectedColor = EColor.FromRgba(227, 242, 253, 200);
-
 		ERectangle _background;
 		Button _focusArea;
 		EvasObject _content;
@@ -32,8 +29,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		public EColor FocusedColor { get; set; }
 		public EColor SelectedColor { get; set; }
 
-		EColor EffectiveFocusedColor => FocusedColor == EColor.Default ? s_defaultFocusEffectColor : FocusedColor;
-		EColor EffectiveSelectedColor => SelectedColor == EColor.Default ? s_defaultSelectedColor : FocusedColor;
+		EColor EffectiveFocusedColor => FocusedColor == EColor.Default ? ThemeConstants.CollectionView.ColorClass.DefaultFocusedColor : FocusedColor;
+		EColor EffectiveSelectedColor => SelectedColor == EColor.Default ? ThemeConstants.CollectionView.ColorClass.DefaultSelectedColor : SelectedColor;
 
 		EColor FocusSelectedColor
 		{
@@ -107,7 +104,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			_focusArea = new Button(parent);
 			_focusArea.Color = EColor.Transparent;
 			_focusArea.BackgroundColor = EColor.Transparent;
-			_focusArea.SetPartColor("effect", EColor.Transparent);
+			_focusArea.SetEffectColor(EColor.Transparent);
 			_focusArea.Clicked += OnClicked;
 			_focusArea.Focused += OnFocused;
 			_focusArea.Unfocused += OnFocused;

--- a/Xamarin.Forms.Platform.Tizen/Native/Dialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Dialog.cs
@@ -236,12 +236,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <param name="title">New dialog title.</param>
 		protected virtual void ApplyTitle(string title)
 		{
-			SetPartText("title,text", title);
+			this.SetTitleTextPart(title);
 		}
 
 		protected virtual void ApplyTitleColor(EColor color)
 		{
-			SetPartColor(Device.Idiom == TargetIdiom.TV ? "text_title" : "text_maintitle", color);
+			this.SetTitleColor(color);
 		}
 
 		/// <summary>
@@ -253,26 +253,23 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			if (button != null)
 			{
-				button.Style = "popup";
+				button.SetPopupStyle();
 			}
 
-			string part;
 			switch (position)
 			{
 				case ButtonPosition.Positive:
-					part = "button3";
+					this.SetButton3Part(button, true);
 					break;
 
 				case ButtonPosition.Neutral:
-					part = "button2";
+					this.SetButton2Part(button, true);
 					break;
 
 				default:
-					part = "button1";
+					this.SetButton1Part(button, true);
 					break;
 			}
-
-			SetPartContent(part, button, true);
 		}
 
 		/// <summary>
@@ -281,7 +278,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <param name="content">New dialog content.</param>
 		protected virtual void ApplyContent(EvasObject content)
 		{
-			SetPartContent("default", content, true);
+			this.SetContentPart(content, true);
 		}
 
 		protected virtual void ApplyMessage(string message)

--- a/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
@@ -18,8 +18,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		public EditfieldEntry(EvasObject parent, string style) : base(parent)
 		{
-			if (!string.IsNullOrEmpty(style))
-				_editfieldLayout.SetTheme("layout", "editfield", style);
+			if (!string.IsNullOrEmpty(style) && _editfieldLayout is FormsLayout formsLayout)
+				formsLayout.SetTheme(formsLayout.ThemeClass, formsLayout.ThemeGroup, style);
 		}
 
 		public bool IsTextBlockFocused { get; private set; }
@@ -48,15 +48,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		public EColor ClearButtonColor
 		{
-			get => _clearButton?.GetPartColor("icon") ?? EColor.Default;
-			set
-			{
-				if (_clearButton != null)
-				{
-					_clearButton.SetPartColor("icon", value);
-					_clearButton.SetPartColor("icon_pressed", value);
-				}
-			}
+			get => _clearButton.GetIconColor();
+			set => _clearButton.SetIconColor(value);
 		}
 
 		public void SetFocusOnTextBlock(bool isFocused)
@@ -100,41 +93,33 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 			Handle = handle;
 
-			if (!_editfieldLayout.SetPartContent("elm.swallow.content", this))
-			{
-				// Restore theme to default if editfield style is not available
-				_editfieldLayout.SetTheme("layout", "application", "default");
-				_editfieldLayout.SetPartContent("elm.swallow.content", this);
-			}
-
-			_heightPadding = _editfieldLayout.EdjeObject["elm.swallow.content"].Geometry.Height;
+			_editfieldLayout.SetContentPart(this);
+			_heightPadding = _editfieldLayout.GetContentPartEdjeObject().Geometry.Height;
 			return _editfieldLayout;
 		}
 
 		protected override void OnTextChanged(string oldValue, string newValue)
 		{
 			base.OnTextChanged(oldValue, newValue);
-			if (EnableClearButton)
+			if (EnableClearButton && _editfieldLayout is EditFieldEntryLayout layout)
 			{
-				var emission = string.IsNullOrEmpty(newValue) ? "elm,action,hide,button" : "elm,action,show,button";
-				_editfieldLayout.SignalEmit(emission, "");
+				layout.SendButtonActionSignal(!string.IsNullOrEmpty(newValue));
 			}
 		}
 
 		protected virtual ELayout CreateEditFieldLayout(EvasObject parent)
 		{
-			var layout = new ELayout(parent);
-			layout.SetTheme("layout", "editfield", "singleline");
+			var layout = new EditFieldEntryLayout(parent, EditFieldEntryLayout.Styles.SingleLine);
 			layout.AllowFocus(true);
 			layout.Unfocused += (s, e) =>
 			{
 				SetFocusOnTextBlock(false);
-				layout.SignalEmit("elm,state,unfocused", "");
+				layout.SendFocusStateSignal(false);
 				OnEntryLayoutUnfocused();
 			};
 			layout.Focused += (s, e) =>
 			{
-				layout.SignalEmit("elm,state,focused", "");
+				layout.SendFocusStateSignal(true);
 				OnEntryLayoutFocused();
 			};
 
@@ -154,12 +139,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			Focused += (s, e) =>
 			{
 				layout.RaiseTop();
-				layout.SignalEmit("elm,state,focused", "");
+				layout.SendFocusStateSignal(true);
 			};
 
 			Unfocused += (s, e) =>
 			{
-				layout.SignalEmit("elm,state,unfocused", "");
+				layout.SendFocusStateSignal(false);
 			};
 
 			return layout;
@@ -167,22 +152,22 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		protected virtual void UpdateEnableClearButton()
 		{
-			if (EnableClearButton)
+			if (_editfieldLayout is EditFieldEntryLayout layout)
 			{
-				_clearButton = new Button(_editfieldLayout)
+				if (EnableClearButton)
 				{
-					Style = "editfield_clear"
-				};
-				_clearButton.AllowFocus(false);
-				_clearButton.Clicked += OnClearButtonClicked;
+					_clearButton = (Button)new Button(_editfieldLayout).SetEditFieldClearStyle();
+					_clearButton.AllowFocus(false);
+					_clearButton.Clicked += OnClearButtonClicked;
 
-				_editfieldLayout.SetPartContent("elm.swallow.button", _clearButton);
-				_editfieldLayout.SignalEmit("elm,action,show,button", "");
-			}
-			else
-			{
-				_editfieldLayout.SetPartContent("elm.swallow.button", null);
-				_clearButton = null;
+					layout.SetButtonPart(_clearButton);
+					layout.SendFocusStateSignal(true);
+				}
+				else
+				{
+					layout.SetButtonPart(null);
+					_clearButton = null;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Native/EmbeddingControls.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EmbeddingControls.cs
@@ -10,9 +10,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 {
 	public class EmbeddingControls : ContentView
 	{
-		static readonly string PlayImagePath = "Xamarin.Forms.Platform.Tizen.Resource.img_button_play.png";
-		static readonly string PauseImagePath = "Xamarin.Forms.Platform.Tizen.Resource.img_button_pause.png";
-
 		public ImageButton PlayImage { get; private set; }
 		public ImageButton PauseImage { get; private set; }
 
@@ -20,7 +17,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			PlayImage = new ImageButton
 			{
-				Source = ImageSource.FromResource(PlayImagePath, typeof(EmbeddingControls).Assembly),
+				Source = ImageSource.FromResource(ThemeConstants.MediaPlayer.Resources.PlayImagePath, typeof(EmbeddingControls).Assembly),
 				IsVisible = false
 			};
 			PlayImage.Clicked += OnImageButtonClicked;
@@ -29,7 +26,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 			PauseImage = new ImageButton
 			{
-				Source = ImageSource.FromResource(PauseImagePath, typeof(EmbeddingControls).Assembly),
+				Source = ImageSource.FromResource(ThemeConstants.MediaPlayer.Resources.PauseImagePath, typeof(EmbeddingControls).Assembly),
 				IsVisible = false
 			};
 			PauseImage.Clicked += OnImageButtonClicked;
@@ -40,7 +37,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label), false),
 				HorizontalTextAlignment = XTextAlignment.Center,
-				TextColor = Color.FromHex("#eeeeeeee")
+				TextColor = ThemeConstants.MediaPlayer.ColorClass.DefaultProgressLabelColor
 			};
 			bufferingLabel.SetBinding(XLabel.TextProperty, new Binding
 			{
@@ -56,7 +53,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 			var progressBoxView = new BoxView
 			{
-				Color = Color.FromHex($"#4286f4")
+				Color = ThemeConstants.MediaPlayer.ColorClass.DefaultProgressBarColor
 			};
 			progressBoxView.SetBinding(AbsoluteLayout.LayoutBoundsProperty, new Binding
 			{
@@ -97,7 +94,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				HorizontalOptions = LayoutOptions.FillAndExpand,
 				HeightRequest = 23,
-				BackgroundColor = Color.FromHex("#80000000"),
+				BackgroundColor = ThemeConstants.MediaPlayer.ColorClass.DefaultProgressAreaColor,
 				Children =
 				{
 					progressBoxView,
@@ -116,7 +113,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 						Margin =  Device.Idiom == TargetIdiom.Watch ? new Thickness(80, 0, 80, 0) : 20,
 						VerticalOptions = LayoutOptions.End,
 						HorizontalOptions = LayoutOptions.FillAndExpand,
-						BackgroundColor = Color.FromHex("#50000000"),
+						BackgroundColor = ThemeConstants.MediaPlayer.ColorClass.DefaultProgressAreaBackgroundColor,
 						Children = { progressInnerLayout }
 					}
 				}

--- a/Xamarin.Forms.Platform.Tizen/Native/Entry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Entry.cs
@@ -333,19 +333,18 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 			ESize rawSize;
 			ESize formattedSize;
-			var edjeTextBlock = EdjeObject["elm.guide"];
 
 			// if there's no text, but there's a placeholder, use it for measurements
-			if (string.IsNullOrEmpty(Text) && !string.IsNullOrEmpty(Placeholder) && edjeTextBlock != null)
+			if (string.IsNullOrEmpty(Text) && !string.IsNullOrEmpty(Placeholder))
 			{
-				rawSize = edjeTextBlock.TextBlockNativeSize;
-				formattedSize = edjeTextBlock.TextBlockFormattedSize;
+				rawSize = this.GetPlaceHolderTextBlockNativeSize();
+				formattedSize = this.GetPlaceHolderTextBlockFormattedSize();
 			}
 			else
 			{
 				// there's text in the entry, use it instead
-				rawSize = TextHelper.GetRawTextBlockSize(this);
-				formattedSize = TextHelper.GetFormattedTextBlockSize(this);
+				rawSize = this.GetTextBlockNativeSize();
+				formattedSize = this.GetTextBlockFormattedSize();
 			}
 
 			// restore the original size
@@ -518,7 +517,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 #if __MATERIAL__
 			base.Label = markupText;
 #else
-			SetPartText("elm.guide", markupText ?? "");
+			this.SetPlaceHolderTextPart(markupText ?? "");
 #endif
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Native/FormsLayout.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/FormsLayout.cs
@@ -1,0 +1,128 @@
+﻿using ElmSharp;
+
+using ELayout = ElmSharp.Layout;
+
+namespace Xamarin.Forms.Platform.Tizen.Native
+{
+	public class FormsLayout : ELayout
+	{
+		public string ThemeClass { get; private set; }
+		public string ThemeGroup { get; private set; }
+		public string ThemeStyle { get; private set; }
+
+		public FormsLayout(EvasObject parent) : base(parent)
+		{
+		}
+
+		public new void SetTheme(string klass, string group, string style)
+		{
+			base.SetTheme(klass, group, style);
+			ThemeClass = klass;
+			ThemeGroup = group;
+			ThemeStyle = style;
+		}
+	}
+
+	public class ApplicationLayout : FormsLayout
+	{
+		public class Styles
+		{
+			public const string Default = "default";
+		}
+
+		public class Parts
+		{
+			public const string Content = "elm.swallow.content";
+			public const string Background = "elm.swallow.bg";
+		}
+
+		public ApplicationLayout(EvasObject parent, string style = Styles.Default) : base(parent)
+		{
+			SetTheme("layout", "application", style);
+		}
+
+		public bool SetContentPart(EvasObject content, bool preserveOldContent = false)
+		{
+			return SetPartContent(Parts.Content, content, preserveOldContent);
+		}
+
+		public bool SetBackgroundPart(EvasObject content, bool preserveOldContent = false)
+		{
+			return SetPartContent(Parts.Background, content, preserveOldContent);
+		}
+	}
+
+	public class WidgetLayout : FormsLayout
+	{
+		public class Styles
+		{
+			public const string Default = "default";
+		}
+
+		public WidgetLayout(EvasObject parent, string style = Styles.Default) : base(parent)
+		{
+			SetTheme("layout", "elm_widget", style);
+		}
+	}
+
+	public class EntryLayout : FormsLayout
+	{
+		public class Styles
+		{
+			public const string Default = "default";
+		}
+
+		public class Parts
+		{
+			public const string Content = "elm.swallow.content";
+		}
+
+		public EntryLayout(EvasObject parent, string style = Styles.Default) : base(parent)
+		{
+			SetTheme("layout", "entry", style);
+		}
+	}
+
+	public class EditFieldEntryLayout : FormsLayout
+	{
+		public class Styles
+		{
+			public const string SingleLine = "singleline";
+			public const string MulitLine = "multiline";
+		}
+
+		public class Parts
+		{
+			public const string Button = "elm.swallow.button";
+		}
+
+		public class Signals
+		{
+			public const string FocusedState = "elm,state,focused";
+			public const string UnFocusedState = "elm,state,unfocused";
+			public const string ShowButtonAction = "elm,action,show,button";
+			public const string HideButtonAction = "elm,action,hide,button";
+		}
+
+		public EditFieldEntryLayout(EvasObject parent, string style) : base(parent)
+		{
+			SetTheme("layout", "editfield", style);
+		}
+
+		public bool SetButtonPart(EvasObject content, bool preserveOldContent = false)
+		{
+			return SetPartContent(Parts.Button, content, preserveOldContent);
+		}
+
+		public void SendButtonActionSignal(bool isVisible)
+		{
+			SignalEmit(isVisible ? Signals.ShowButtonAction : Signals.HideButtonAction, "");
+		}
+
+		public void SendFocusStateSignal(bool isFocus)
+		{
+			SignalEmit(isFocus ? Signals.FocusedState : Signals.UnFocusedState, "");
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/Label.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Label.cs
@@ -288,7 +288,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			// README: It only work on Tizen 4.0
 			get
 			{
-				double valign = GetVerticalTextAlignment("elm.text");
+				double valign = this.GetVerticalTextAlignment();
 				if (valign == 0.0)
 				{
 					return TextAlignment.Start;
@@ -325,7 +325,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 						valign = 1.0;
 						break;
 				}
-				SetVerticalTextAlignment("elm.text", valign);
+				this.SetVerticalTextAlignment(valign);
 			}
 		}
 
@@ -383,7 +383,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 			Resize(availableWidth, size.Height);
 
-			var formattedSize = Native.TextHelper.GetFormattedTextBlockSize(this);
+			var formattedSize = this.GetTextBlockFormattedSize();
 			Resize(size.Width, size.Height);
 
 			// Set bottom padding for lower case letters that have segments below the bottom line of text (g, j, p, q, y).

--- a/Xamarin.Forms.Platform.Tizen/Native/LayoutCanvas.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/LayoutCanvas.cs
@@ -3,18 +3,15 @@ using ElmSharp;
 using System.Collections.Generic;
 using System.Collections.Specialized;
 
-using ELayout = ElmSharp.Layout;
-
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
-	public class LayoutCanvas : ELayout, IContainable<EvasObject>
+	public class LayoutCanvas : WidgetLayout, IContainable<EvasObject>
 	{
 		readonly ObservableCollection<EvasObject> _children = new ObservableCollection<EvasObject>();
 		Box _box;
 
 		public LayoutCanvas(EvasObject parent) : base(parent)
 		{
-			SetTheme("layout", "elm_widget", "default");
 			_box = new Box(parent);
 			SetContent(_box);
 

--- a/Xamarin.Forms.Platform.Tizen/Native/ListView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/ListView.cs
@@ -658,7 +658,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			if (_headerFooterItemClass == null)
 			{
-				_headerFooterItemClass = new GenItemClass("full")
+				_headerFooterItemClass = new GenItemClass(ThemeConstants.GenItemClass.Styles.Full)
 				{
 					GetContentHandler = (data, part) =>
 					{

--- a/Xamarin.Forms.Platform.Tizen/Native/MasterDetailPage.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/MasterDetailPage.cs
@@ -381,8 +381,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			_drawer.SetContent(null, true);
 			_drawer.Hide();
 
-			_splitPane.SetPartContent("left", null, true);
-			_splitPane.SetPartContent("right", null, true);
+			_splitPane.SetLeftPart(null, true);
+			_splitPane.SetRightPart(null, true);
 			_splitPane.Hide();
 
 			UnPackAll();
@@ -390,8 +390,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			// the structure for split mode and for popover mode looks differently
 			if (IsSplit)
 			{
-				_splitPane.SetPartContent("left", _masterCanvas, true);
-				_splitPane.SetPartContent("right", _detailCanvas, true);
+				_splitPane.SetLeftPart(_masterCanvas, true);
+				_splitPane.SetRightPart(_detailCanvas, true);
 				_splitPane.Show();
 				_mainWidget = _splitPane;
 				PackEnd(_splitPane);

--- a/Xamarin.Forms.Platform.Tizen/Native/Page.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Page.cs
@@ -12,7 +12,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <summary>
 		/// The name of the part to be used when setting content.
 		/// </summary>
-		public const string ContentPartName = "overlay";
+		[Obsolete("ContentPartName is obsolete. Please use the ThemeConstants.Background.Parts.Overlay instead.")]
+		public const string ContentPartName = ThemeConstants.Background.Parts.Overlay;
 
 		/// <summary>
 		/// Exposes the Children property, mapping it to the _canvas' Children property.
@@ -33,7 +34,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		public Page(EvasObject parent) : base(parent)
 		{
 			_canvas = new Canvas(this);
-			SetPartContent(ContentPartName, _canvas);
+			this.SetOverlayPart(_canvas);
 		}
 
 		/// <summary>

--- a/Xamarin.Forms.Platform.Tizen/Native/Scroller.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Scroller.cs
@@ -21,8 +21,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		protected override void OnRealized()
 		{
 			base.OnRealized();
-			new SmartEvent(this, RealHandle, "scroll,anim,start").On += (s, e) => _isAnimation = true;
-			new SmartEvent(this, RealHandle, "scroll,anim,stop").On += (s, e) =>
+			new SmartEvent(this, RealHandle, ThemeConstants.Scroller.Signals.StartScrollAnimation).On += (s, e) => _isAnimation = true;
+			new SmartEvent(this, RealHandle, ThemeConstants.Scroller.Signals.StopScrollAnimation).On += (s, e) =>
 			{
 				if (_animationTaskComplateSource != null)
 				{

--- a/Xamarin.Forms.Platform.Tizen/Native/Span.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Span.cs
@@ -10,7 +10,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 	/// </summary>
 	public class Span
 	{
-		static EColor s_defaultLineColor = EColor.Black;
 		string _text;
 
 		/// <summary>
@@ -200,13 +199,13 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			if (Underline)
 			{
 				_formattingString.AppendFormat("underline=on underline_color={0} ",
-					ForegroundColor.IsDefault ? s_defaultLineColor.ToHex() : ForegroundColor.ToHex());
+					ForegroundColor.IsDefault ? ThemeConstants.Span.ColorClass.DefaultUnderLineColor.ToHex() : ForegroundColor.ToHex());
 			}
 
 			if (Strikethrough)
 			{
 				_formattingString.AppendFormat("strikethrough=on strikethrough_color={0} ",
-					ForegroundColor.IsDefault ? s_defaultLineColor.ToHex() : ForegroundColor.ToHex());
+					ForegroundColor.IsDefault ? ThemeConstants.Span.ColorClass.DefaultUnderLineColor.ToHex() : ForegroundColor.ToHex());
 			}
 
 			switch (HorizontalTextAlignment)

--- a/Xamarin.Forms.Platform.Tizen/Native/TableView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/TableView.cs
@@ -56,10 +56,10 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		internal class SectionCellRenderer : TextCellRenderer
 		{
-			public SectionCellRenderer() : this("group_index")
+			public SectionCellRenderer() : this(ThemeConstants.GenItemClass.Styles.GroupIndex)
 			{
-				DetailPart = "null";
 			}
+
 			protected SectionCellRenderer(string style) : base(style) { }
 		}
 		class SectionCell : TextCell

--- a/Xamarin.Forms.Platform.Tizen/Native/TextHelper.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/TextHelper.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				Log.Error("textable should be ElmSharp.Layout");
 			}
-			EdjeTextPartObject textPart = widget?.EdjeObject["elm.text"];
+			EdjeTextPartObject textPart = widget?.EdjeObject[ThemeConstants.Common.Parts.Text];
 			if (textPart == null)
 			{
 				Log.Error("There is no elm.text part");

--- a/Xamarin.Forms.Platform.Tizen/Native/ToolbarItemButton.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/ToolbarItemButton.cs
@@ -7,11 +7,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 {
 	public class ToolbarItemButton : Button
 	{
-		const string StyleDefault = "default";
-		const string StyleDefaultToolbarIcon = "naviframe/drawers";
-		const string StyleLeftToolBarButton = "naviframe/title_left";
-		const string StyleRightToolbarButton = "naviframe/title_right";
-
 		ToolbarItem _item;
 		string _defaultAccessibilityName;
 		string _defaultAccessibilityDescription;
@@ -115,19 +110,19 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				if (string.IsNullOrEmpty(_item.Text))
 				{
 					// We assumed the default toolbar icon is "naviframe/drawer" if there are no icon and text.
-					Style = StyleDefaultToolbarIcon;
+					this.SetNavigationDrawerStyle();
 				}
 				else
 				{
 					if (_item.Order == ToolbarItemOrder.Primary)
-						Style = StyleRightToolbarButton;
+						this.SetNavigationTitleRightStyle();
 					else
-						Style = StyleLeftToolBarButton;
+						this.SetNavigationTitleLeftStyle();
 				}
 			}
 			else
 			{
-				Style = StyleDefault;
+				this.SetDefaultStyle();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/FormsWatchLayout.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/FormsWatchLayout.cs
@@ -1,0 +1,112 @@
+﻿using ElmSharp;
+using EColor = ElmSharp.Color;
+
+namespace Xamarin.Forms.Platform.Tizen.Native.Watch
+{
+	public class FormsWatchLayout : FormsLayout
+	{
+		public FormsWatchLayout(EvasObject parent) : base(parent)
+		{
+			if (Device.Idiom != TargetIdiom.Watch)
+				Log.Error($"{0} is only supported on TargetIdiom.Watch : {1}", this, Device.Idiom);
+		}
+	}
+
+	public class DateTimeLayout : FormsWatchLayout
+	{
+		public class Styles
+		{
+			public const string Default = "datetime";
+		}
+
+		public class Parts
+		{
+			public const string ButtomButton = "elm.swallow.btn";
+		}
+
+		public DateTimeLayout(EvasObject parent, string style = Styles.Default) : base(parent)
+		{
+			SetTheme("layout", "circle", style);
+		}
+
+		public bool SetBottomButtonPart(EvasObject content, bool preserveOldContent = false)
+		{
+			return SetPartContent(Parts.ButtomButton, content, preserveOldContent);
+		}
+	}
+
+	public class PopupLayout : FormsWatchLayout
+	{
+		public class Parts
+		{
+			public const string Button1 = "button1";
+			public const string Button2 = "button2";
+			public const string Title = "elm.text.title";
+			public const string Content = "elm.swallow.content";
+
+			public class Colors
+			{
+				public const string Title = "text_title";
+			}
+		}
+
+		public class Styles
+		{
+			public const string Circle = "content/circle";
+			public const string Buttons2 = "content/circle/buttons2";
+		}
+
+		
+		public PopupLayout(EvasObject parent, string style) : base(parent)
+		{
+			SetTheme("layout", "popup", style);
+		}
+
+		public bool SetTitleText(string title)
+		{
+			return SetPartText(Parts.Title, title);
+		}
+
+		public void SetTitleColor(EColor color)
+		{
+			SetPartColor(Parts.Colors.Title, color);
+		}
+	}
+
+	public class PopupClassBaseGroupLayout : FormsWatchLayout
+	{
+		public class Styles
+		{
+			public const string Circle = "circle";
+		}
+		
+		public class Parts
+		{
+			public const string ActionArea = "elm.swallow.action_area";
+		}
+
+		public PopupClassBaseGroupLayout(EvasObject parent) : base(parent)
+		{
+			SetTheme("popup", "base", Styles.Circle);
+		}
+	}
+
+	public class PopupClass2ButtonGroupLayout : FormsWatchLayout
+	{
+		public class Styles
+		{
+			public const string Circle = "popup/circle";
+		}
+
+		public class Parts
+		{
+			public const string Content = "elm.swallow.content";
+		}
+
+		public PopupClass2ButtonGroupLayout(EvasObject parent) : base(parent)
+		{
+			SetTheme("popup", "buttons2", Styles.Circle);
+		}
+	}
+
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchButton.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchButton.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 				MinimumWidth = MinimumWidth < 40 ? 40 : MinimumWidth;
 				if (Image != null)
 					MinimumWidth += Image.Geometry.Width;
-				var rawSize = TextHelper.GetRawTextBlockSize(this);
+				var rawSize = this.GetTextBlockNativeSize();
 				return new ESize(rawSize.Width + MinimumWidth, Math.Max(MinimumHeight, rawSize.Height));
 			}
 			else

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDateTimePicker.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDateTimePicker.cs
@@ -35,12 +35,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 		{
 			if (_mode == DateTimePickerMode.Date)
 			{
-				Style = "datepicker/circle";
+				Style = ThemeConstants.CircleDateTimeSelector.Styles.CircleDatePicker;
 				Format = "%d/%b/%Y";
 			}
 			else
 			{
-				Style = "timepicker/circle";
+				Style = ThemeConstants.CircleDateTimeSelector.Styles.CircleTimePicker;
 				Format = "%d/%b/%Y %I:%M %p";
 			}
 		}

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDateTimePickerDialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDateTimePickerDialog.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 	public class WatchDateTimePickerDialog : Popup, IDateTimeDialog
 	{
 		ELayout _surfaceLayout;
-		ELayout _datetimeLayout;
+		DateTimeLayout _datetimeLayout;
 		CircleSurface _surface;
 		EButton _doneButton;
 		Box _container;
@@ -19,23 +19,22 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		public WatchDateTimePickerDialog(EvasObject parent) : base(parent)
 		{
+			this.SetWatchCircleStyle();
 			AlignmentX = -1;
 			AlignmentY = -1;
 			WeightX = 1.0;
 			WeightY = 1.0;
-			Style = "circle";
 
 			_container = new Box(parent) { AlignmentX = -1, AlignmentY = -1, WeightX = 1, WeightY = 1 };
 			_container.BackgroundColor = ElmSharp.Color.Blue;
 			_container.SetLayoutCallback(OnContainerLayout);
 
-			_datetimeLayout = new ELayout(parent);
+			_datetimeLayout = new DateTimeLayout(parent);
 			_surfaceLayout = new ELayout(parent);
 
 			_container.PackEnd(_datetimeLayout);
 			_container.PackEnd(_surfaceLayout);
 
-			_datetimeLayout.SetTheme("layout", "circle", "datetime");
 			_surface = new CircleSurface(_surfaceLayout);
 
 			_picker = new WatchDateTimePicker(parent, _surface);
@@ -45,9 +44,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 			_doneButton = new Button(parent)
 			{
 				Text = "Set",
-				Style = "bottom",
 			};
-			_datetimeLayout.SetPartContent("elm.swallow.btn", _doneButton);
+			_doneButton.SetBottomStyle();
+			_datetimeLayout.SetBottomButtonPart(_doneButton);
 			_doneButton.Clicked += OnDoneClicked;
 
 			ActivateRotaryInteraction();
@@ -67,7 +66,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 			set
 			{
 				_title = value;
-				_datetimeLayout.SetPartText("elm.text", _title);
+				_datetimeLayout.SetTextPart(_title);
 			}
 		}
 
@@ -118,8 +117,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		void OnDoneClicked(object sender, EventArgs e)
 		{
-			System.Console.WriteLine("Done clicked");
-			System.Console.WriteLine("Picker.DateTime - {0} ", _picker.DateTime);
 			DateTimeChanged?.Invoke(this, new DateChangedEventArgs(_picker.DateTime));
 			Hide();
 			PickerClosed?.Invoke(this, EventArgs.Empty);

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDialog.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchDialog.cs
@@ -15,43 +15,39 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 		/// </summary>
 		public WatchDialog(EvasObject parent, bool hasAcceptButton) : base(parent)
 		{
-			Style = "circle";
-
-			_popupLayout = new ELayout(this)
+			this.SetWatchCircleStyle();
+			_hasAcceptButton = hasAcceptButton;
+			_popupLayout = new PopupLayout(this, hasAcceptButton ? PopupLayout.Styles.Buttons2 : PopupLayout.Styles.Circle)
 			{
 				AlignmentX = -1,
 				AlignmentY = -1,
 				WeightX = 1,
 				WeightY = 1
 			};
-
-			_hasAcceptButton = hasAcceptButton;
-
-			var style = hasAcceptButton ? "content/circle/buttons2" : "content/circle";
-
-			_popupLayout.SetTheme("layout", "popup", style);
 			_popupLayout.Show();
-
 			SetContent(_popupLayout);
 		}
 
 		protected override void ApplyButton(ButtonPosition position, EButton button)
 		{
-			string style = "";
-			string part = "";
-			EColor color = EColor.Default;
 
 			switch (position)
 			{
 				case ButtonPosition.Neutral:
-					style = "popup/circle/right_check";
-					part = "button2";
+					this.SetButton2Part(button.SetWatchPopupRightStyle());
 					break;
 
 				case ButtonPosition.Negative:
-					style = _hasAcceptButton ? "popup/circle/left_delete" : "bottom";
-					color = _hasAcceptButton ? EColor.Default : new EColor(0, 47, 66, 255);
-					part = "button1";
+					if (_hasAcceptButton)
+					{
+						button.BackgroundColor = EColor.Default;
+						this.SetButton1Part(button.SetWatchPopupLeftStyle());
+					}
+					else
+					{
+						button.BackgroundColor = new EColor(0, 47, 66, 255);
+						this.SetButton1Part(button.SetBottomStyle());
+					}
 					break;
 
 				case ButtonPosition.Positive:
@@ -59,13 +55,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 					// Due to ux limiation, nothing to do
 					break;
 			}
-
-			if (button != null)
-			{
-				button.Style = style;
-				button.BackgroundColor = color;
-			}
-			SetPartContent(part, button);
 		}
 
 		protected override void ApplyContent(EvasObject content)
@@ -75,17 +64,23 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		protected override void ApplyTitle(string title)
 		{
-			_popupLayout.SetPartText("elm.text.title", title);
+			if (_popupLayout is PopupLayout layout)
+			{
+				layout.SetTitleText(title);
+			}
 		}
 
 		protected override void ApplyTitleColor(EColor color)
 		{
-			_popupLayout.SetPartColor("text_title", color);
+			if (_popupLayout is PopupLayout layout)
+			{
+				layout.SetTitleColor(color);
+			}
 		}
 
 		protected override void ApplyMessage(string message)
 		{
-			_popupLayout.SetPartText("elm.text", message);
+			_popupLayout.SetTextPart(message);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchListView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchListView.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		class PaddingItemClass : GenItemClass
 		{
-			public PaddingItemClass() : base("padding")
+			public PaddingItemClass() : base(ThemeConstants.GenItemClass.Styles.Watch.Padding)
 			{
 			}
 		}

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchSpinner.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchSpinner.cs
@@ -1,7 +1,6 @@
 using System;
 using ElmSharp;
 using ElmSharp.Wearable;
-using TizenDotnetUtil = Tizen.Common.DotnetUtil;
 
 namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 {
@@ -17,18 +16,9 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		public WatchSpinner(EvasObject parent, CircleSurface surface) : base(parent, surface)
 		{
-			Style = "circle";
-
-			if (TizenDotnetUtil.TizenAPIVersion == 4)
-			{
-				_wheelAppeared = new ElmSharp.SmartEvent(this, "genlist,show");
-				_wheelDisappeared = new ElmSharp.SmartEvent(this, "genlist,hide");
-			}
-			else
-			{
-				_wheelAppeared = new ElmSharp.SmartEvent(this, "list,show");
-				_wheelDisappeared = new ElmSharp.SmartEvent(this, "list,hide");
-			}
+			Style = ThemeConstants.CircleSpinner.Styles.Circle;
+			_wheelAppeared = new SmartEvent(this, ThemeConstants.CircleSpinner.Signals.ShowList);
+			_wheelDisappeared = new SmartEvent(this, ThemeConstants.CircleSpinner.Signals.HideList);
 
 			_wheelAppeared.On += (s, e) => WheelAppeared?.Invoke(this, EventArgs.Empty);
 			_wheelDisappeared.On += (s, e) => WheelDisappeared?.Invoke(this, EventArgs.Empty);

--- a/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchTableView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Watch/WatchTableView.cs
@@ -46,9 +46,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		internal class SectionCellRenderer : TextCellRenderer
 		{
-			public SectionCellRenderer() : this("group_index")
+			public SectionCellRenderer() : this(ThemeConstants.GenItemClass.Styles.GroupIndex)
 			{
-				DetailPart = "null";
 			}
 			protected SectionCellRenderer(string style) : base(style) { }
 		}
@@ -58,7 +57,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native.Watch
 
 		class PaddingItemClass : GenItemClass
 		{
-			public PaddingItemClass() : base("padding")
+			public PaddingItemClass() : base(ThemeConstants.GenItemClass.Styles.Watch.Padding)
 			{
 			}
 		}

--- a/Xamarin.Forms.Platform.Tizen/Native/WebViewContainer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/WebViewContainer.cs
@@ -4,13 +4,12 @@ using TWebView = Tizen.WebView.WebView;
 
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
-	public class WebViewContainer : ElmSharp.Layout
+	public class WebViewContainer : WidgetLayout
 	{
 		public TWebView WebView { get; }
 
 		public WebViewContainer(EvasObject parent) : base(parent)
 		{
-			SetTheme("layout", "elm_widget", "default");
 			WebView = new TWebView(parent);
 			SetContent(WebView);
 			AllowFocus(true);

--- a/Xamarin.Forms.Platform.Tizen/PreloadedWindow.cs
+++ b/Xamarin.Forms.Platform.Tizen/PreloadedWindow.cs
@@ -1,4 +1,5 @@
 ﻿using ElmSharp;
+using Xamarin.Forms.Platform.Tizen.Native;
 using ELayout = ElmSharp.Layout;
 
 namespace Xamarin.Forms.Platform.Tizen
@@ -24,8 +25,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			var conformant = new Conformant(this);
 			conformant.Show();
 
-			var layout = new ELayout(conformant);
-			layout.SetTheme("layout", "application", "default");
+			var layout = new ApplicationLayout(conformant);
 			layout.Show();
 
 			BaseLayout = layout;

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ActivityIndicatorRenderer.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, EProgressBar>
 	{
-		static readonly EColor s_defaultColor = new EColor(129, 198, 255);
+		static readonly EColor s_defaultColor = ThemeConstants.ProgressBar.ColorClass.Default;
 
 		public ActivityIndicatorRenderer()
 		{
@@ -19,9 +19,9 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				SetNativeControl(new EProgressBar(Forms.NativeParent)
 				{
-					Style = "process_small",
 					IsPulseMode = true,
-				});
+				}
+				.SetSmallStyle());
 			}
 			base.OnElementChanged(e);
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ButtonRenderer.cs
@@ -103,7 +103,6 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateFontSize()
 		{
-			//(Control as IButton).FontSize = Element.FontSize;
 			if (Control is IButton ib)
 			{
 				ib.FontSize = Element.FontSize;

--- a/Xamarin.Forms.Platform.Tizen/Renderers/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/CarouselViewRenderer.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using ElmSharp;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -33,9 +34,9 @@ namespace Xamarin.Forms.Platform.Tizen
 				Control.Scrolled += OnScrolled;
 				Control.Scroll.DragStart += OnDragStart;
 				Control.Scroll.DragStop += OnDragStop;
-				_animationStart = new ElmSharp.SmartEvent(Control.Scroll, Control.Scroll.RealHandle, "scroll,anim,start");
+				_animationStart = new SmartEvent(Control.Scroll, Control.Scroll.RealHandle, ThemeConstants.Scroller.Signals.StartScrollAnimation);
 				_animationStart.On += OnScrollStart;
-				_animationStop = new ElmSharp.SmartEvent(Control.Scroll, Control.Scroll.RealHandle, "scroll,anim,stop");
+				_animationStop = new SmartEvent(Control.Scroll, Control.Scroll.RealHandle, ThemeConstants.Scroller.Signals.StopScrollAnimation);
 				_animationStop.On += OnScrollStop;
 			}
 			UpdatePositionFromElement(false);
@@ -166,17 +167,17 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Element.IsSwipeEnabled)
 			{
-				Control.Scroll.ScrollBlock = ElmSharp.ScrollBlock.None;
+				Control.Scroll.ScrollBlock = ScrollBlock.None;
 			}
 			else
 			{
 				if (Control.LayoutManager.IsHorizontal)
 				{
-					Control.Scroll.ScrollBlock = ElmSharp.ScrollBlock.Horizontal;
+					Control.Scroll.ScrollBlock = ScrollBlock.Horizontal;
 				}
 				else
 				{
-					Control.Scroll.ScrollBlock = ElmSharp.ScrollBlock.Vertical;
+					Control.Scroll.ScrollBlock = ScrollBlock.Vertical;
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/CheckBoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/CheckBoxRenderer.cs
@@ -6,13 +6,8 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class CheckBoxRenderer : ViewRenderer<CheckBox, Check>
 	{
-		readonly string[] _onColorParts;
-		readonly string[] _onColorEdjeParts;
-
 		public CheckBoxRenderer()
 		{
-			_onColorParts = Device.Idiom == TargetIdiom.Watch ? new string[] {"outer_bg_on", "outer_bg_on_pressed", "check_on", "check_on_pressed"} : new string[] {"bg_on", "stroke"};
-			_onColorEdjeParts = new string[_onColorParts.Length];
 			RegisterPropertyHandler(CheckBox.IsCheckedProperty, UpdateIsChecked);
 			RegisterPropertyHandler(CheckBox.ColorProperty, UpdateOnColor);
 		}
@@ -23,10 +18,6 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				SetNativeControl(new Check(Forms.NativeParent));
 				Control.StateChanged += OnStateChanged;
-				for (int i=0; i<_onColorParts.Length; i++)
-				{
-					_onColorEdjeParts[i] = Control.ClassName.ToLower().Replace("elm_", "") + "/" + _onColorParts[i];
-				}
 			}
 			base.OnElementChanged(e);
 		}
@@ -60,18 +51,11 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			if (Element.Color.IsDefault)
 			{
-				foreach(string s in _onColorEdjeParts)
-				{
-					Control.EdjeObject.DeleteColorClass(s);
-				}
+				Control.DeleteOnColors();
 			}
 			else
 			{
-				EColor color = Element.Color.ToNative();
-				foreach (string s in _onColorParts)
-				{
-					Control.SetPartColor(s, color);
-				}
+				Control.SetOnColors(Element.Color.ToNative());
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/DatePickerRenderer.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control == null)
 			{
 				var entry = CreateNativeControl();
-				entry.SetVerticalTextAlignment("elm.text", 0.5);
+				entry.SetVerticalTextAlignment(0.5);
 				SetNativeControl(entry);
 
 				if (entry is IEntry ie)
@@ -97,8 +97,8 @@ namespace Xamarin.Forms.Platform.Tizen
 				if (_lazyDialog.IsValueCreated)
 				{
 					_lazyDialog.Value.DateTimeChanged -= OnDateTimeChanged;
-					_lazyDialog.Value.PickerOpened += OnPickerOpened;
-					_lazyDialog.Value.PickerClosed += OnPickerClosed;
+					_lazyDialog.Value.PickerOpened -= OnPickerOpened;
+					_lazyDialog.Value.PickerClosed -= OnPickerClosed;
 					_lazyDialog.Value.Unrealize();
 				}
 			}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		protected virtual EEntry CreateNativeControl()
 		{
 			// Multiline EditField style is only available on Mobile and TV profile
-			var entry = Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.TV ? new Native.EditfieldEntry(Forms.NativeParent, "multiline") : new Native.Entry(Forms.NativeParent)
+			var entry = Device.Idiom == TargetIdiom.Phone || Device.Idiom == TargetIdiom.TV ? new EditfieldEntry(Forms.NativeParent, EditFieldEntryLayout.Styles.MulitLine) : new Native.Entry(Forms.NativeParent)
 			{
 				IsSingleLine = false,
 			};

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -34,8 +34,8 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control == null)
 			{
 				var entry = CreateNativeControl();
-				entry.SetVerticalTextAlignment("elm.text", 0.5);
-				entry.SetVerticalTextAlignment("elm.guide", 0.5);
+				entry.SetVerticalTextAlignment(0.5);
+				entry.SetVerticalPlaceHolderTextAlignment(0.5);
 				entry.Activated += OnCompleted;
 				entry.CursorChanged += OnCursorChanged;
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/FrameRenderer.cs
@@ -9,9 +9,8 @@ namespace Xamarin.Forms.Platform.Tizen
 		const int _shadow_shift = 2;
 		const int _shadow_thickness = _thickness + 2;
 
-		static readonly EColor s_DefaultColor = Device.Idiom == TargetIdiom.TV || Device.Idiom == TargetIdiom.Watch ? EColor.Gray : EColor.Black;
-		static readonly EColor s_ShadowColor = EColor.FromRgba(80, 80, 80, 50);
-
+		static readonly EColor s_DefaultColor = ThemeConstants.Frame.ColorClass.DefaultBorderColor;
+		static readonly EColor s_ShadowColor = ThemeConstants.Frame.ColorClass.DefaultShadowColor;
 		EPolygon _shadow = null;
 		EPolygon _frame = null;
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ImageButtonRenderer.cs
@@ -33,10 +33,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				_border.Show();
 				_image = new Native.Image(Forms.NativeParent);
 				_image.Show();
-				_button = new EButton(Forms.NativeParent)
-				{
-					Style = "transparent"
-				};
+				_button = new EButton(Forms.NativeParent).SetTransparentStyle();
 				_button.Clicked += OnClicked;
 				_button.Pressed += OnPressed;
 				_button.Released += OnReleased;

--- a/Xamarin.Forms.Platform.Tizen/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/NavigationPageRenderer.cs
@@ -21,14 +21,6 @@ namespace Xamarin.Forms.Platform.Tizen
 			Right
 		};
 
-		const string PartTitle = "default";
-		const string PartBackButton = "elm.swallow.prev_btn";
-		const string PartLeftToolbar = "title_left_btn";
-		const string PartRightToolbar = "title_right_btn";
-		const string PartNavigationBar = "navigationbar";
-		const string StyleBackButton = "naviframe/back_btn/default";
-		const string StyleNavigationBar = "navigationbar";
-
 		readonly List<Widget> _naviItemContentPartList = new List<Widget>();
 		Naviframe _naviFrame = null;
 		Page _previousPage = null;
@@ -184,11 +176,8 @@ namespace Xamarin.Forms.Platform.Tizen
 				}
 				return;
 			}
-			//According to TV UX Guideline, item style should be set to "tabbar" in case of TabbedPage only for TV profile.
-			if (Device.Idiom == TargetIdiom.TV)
-			{
-				item.Style = page is TabbedPage ? "tabbar" : "default";
-			}
+
+			item.SetTabBarStyle();
 			item.TitleBarVisible = (bool)page.GetValue(NavigationPage.HasNavigationBarProperty);
 			UpdateToolbarItem(page, item);
 			UpdateBarBackgroundColor(item);
@@ -204,10 +193,10 @@ namespace Xamarin.Forms.Platform.Tizen
 				return;
 
 			Native.Button rightButton = GetToolbarButton(ToolbarButtonPosition.Right);
-			item.SetPartContent(PartRightToolbar, rightButton);
+			item.SetRightToolbarButton(rightButton);
 
 			Native.Button leftButton = GetToolbarButton(ToolbarButtonPosition.Left);
-			item.SetPartContent(PartLeftToolbar, leftButton);
+			item.SetLeftToolbarButton(leftButton);
 			UpdateHasBackButton(page, item);
 		}
 
@@ -222,7 +211,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				button = CreateNavigationButton((string)page.GetValue(NavigationPage.BackButtonTitleProperty));
 			}
-			item.SetPartContent(PartBackButton, button);
+			item.SetBackButton(button);
 		}
 
 		void UpdateTitle(Page page, NaviItem item = null)
@@ -230,7 +219,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (item == null)
 				item = GetNaviItemForPage(page);
 
-			item.SetPartText(PartTitle, SpanTitle(page.Title));
+			item.SetTitle(SpanTitle(page.Title));
 		}
 
 		string SpanTitle(string Title)
@@ -262,30 +251,29 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (Element.OnThisPlatform().HasBreadCrumbsBar())
 			{
-				item.Style = StyleNavigationBar;
-				item.SetPartContent(PartNavigationBar, GetBreadCrumbsBar());
+				item.SetNavigationBarStyle();
+				item.SetNavigationBar(GetBreadCrumbsBar());
 			}
 			else
 			{
-				item.SetPartContent(PartNavigationBar, null, false);
+				item.SetNavigationBar(null, false);
 			}
 		}
 
 		EButton CreateNavigationButton(string text)
 		{
-			EButton button = new EButton(Forms.NativeParent);
+			EButton button = new EButton(Forms.NativeParent)
+			{
+				Text = text
+			};
+			button.SetNavigationBackStyle();
 			button.Clicked += (sender, e) =>
 			{
 				if (!Element.SendBackButtonPressed())
 					Forms.Context.Exit();
 			};
-
-			button.Style = StyleBackButton;
-			button.Text = text;
-
 			_naviItemContentPartList.Add(button);
 			button.Deleted += NaviItemPartContentDeletedHandler;
-
 			return button;
 		}
 
@@ -322,11 +310,11 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			EToolbar toolbar = new EToolbar(Forms.NativeParent)
 			{
-				Style = StyleNavigationBar,
 				ItemAlignment = 0,
 				Homogeneous = false,
 				ShrinkMode = ToolbarShrinkMode.Scroll
 			};
+			toolbar.SetNavigationBarStyle();
 
 			foreach (var p in Element.Navigation.NavigationStack)
 			{

--- a/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/PickerRenderer.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control == null)
 			{
 				var entry = CreateNativeControl();
-				entry.SetVerticalTextAlignment("elm.text", 0.5);
+				entry.SetVerticalTextAlignment(0.5);
 				if (entry is IEntry ie)
 				{
 					ie.TextBlockFocused += OnTextBlockFocused;

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ProgressBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ProgressBarRenderer.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class ProgressBarRenderer : ViewRenderer<ProgressBar, EProgressBar>
 	{
-		static readonly EColor s_defaultColor = new EColor(129, 198, 255);
+		static readonly EColor s_defaultColor = ThemeConstants.ProgressBar.ColorClass.Default;
 
 		public ProgressBarRenderer()
 		{

--- a/Xamarin.Forms.Platform.Tizen/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/RadioButtonRenderer.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			var size = Control.Geometry;
 			Control.Resize(availableWidth, size.Height);
-			var formattedSize = Control.EdjeObject["elm.text"].TextBlockFormattedSize;
+			var formattedSize = Control.GetTextBlockFormattedSize();
 			Control.Resize(size.Width, size.Height);
 			return new ESize()
 			{
@@ -97,21 +97,16 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void SetInternalTextAndStyle(string formattedText, string textStyle)
 		{
-			string emission = "elm,state,text,visible";
+			bool isVisible = true;
 			if (string.IsNullOrEmpty(formattedText))
 			{
 				formattedText = null;
 				textStyle = null;
-				emission = "elm,state,text,hidden";
+				isVisible = false;
 			}
 			Control.Text = formattedText;
-
-			var textblock = Control.EdjeObject["elm.text"];
-			if (textblock != null)
-			{
-				textblock.TextStyle = textStyle;
-			}
-			Control.EdjeObject.EmitSignal(emission, "elm");
+			Control.SetTextBlockStyle(textStyle);
+			Control.SendTextVisibleSignal(isVisible);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/RefreshViewRenderer.cs
@@ -9,9 +9,9 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	class RefreshIcon : ContentView
 	{
-		public static readonly int IconSize = 48;
-		static readonly Color DefaultColor = Color.FromHex("#6200EE");
-		static readonly string IconPath = "Xamarin.Forms.Platform.Tizen.Resource.refresh_48dp.png";
+		public const int IconSize = ThemeConstants.RefreshView.Resources.IconSize;
+		static readonly Color DefaultColor = ThemeConstants.RefreshView.ColorClass.DefaultColor;
+		const string IconPath = ThemeConstants.RefreshView.Resources.IconPath;
 
 		bool _isPlaying;
 		Image _icon;

--- a/Xamarin.Forms.Platform.Tizen/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/SliderRenderer.cs
@@ -20,9 +20,9 @@ namespace Xamarin.Forms.Platform.Tizen
 				Control.ValueChanged += OnValueChanged;
 				Control.DragStarted += OnDragStarted;
 				Control.DragStopped += OnDragStopped;
-				_defaultMinColor = Control.GetPartColor("bar");
-				_defaultMaxColor = Control.GetPartColor("bg");
-				_defaultThumbColor = Control.GetPartColor("handler");
+				_defaultMinColor = Control.GetBarColor();
+				_defaultMaxColor = Control.GetBackgroundColor();
+				_defaultThumbColor = Control.GetHandlerColor();
 			}
 			UpdateMinimum();
 			UpdateMaximum();
@@ -112,20 +112,18 @@ namespace Xamarin.Forms.Platform.Tizen
 		protected void UpdateMinimumTrackColor()
 		{
 			var color = Element.MinimumTrackColor.IsDefault ? _defaultMinColor : Element.MinimumTrackColor.ToNative();
-			Control.SetPartColor("bar", color);
-			Control.SetPartColor("bar_pressed", color);
+			Control.SetBarColor(color);
 		}
 
 		protected void UpdateMaximumTrackColor()
 		{
-			Control.SetPartColor("bg", Element.MaximumTrackColor.IsDefault ? _defaultMaxColor : Element.MaximumTrackColor.ToNative());
+			Control.SetBackgroundColor(Element.MaximumTrackColor.IsDefault ? _defaultMaxColor : Element.MaximumTrackColor.ToNative());
 		}
 
 		protected virtual void UpdateThumbColor()
 		{
 			var color = Element.ThumbColor.IsDefault ? _defaultThumbColor : Element.ThumbColor.ToNative();
-			Control.SetPartColor("handler", color);
-			Control.SetPartColor("handler_pressed", color);
+			Control.SetHandlerColor(color);
 		}
 
 		protected void UpdateSliderColors()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/SwitchRenderer.cs
@@ -9,14 +9,8 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class SwitchRenderer : ViewRenderer<Switch, Check>
 	{
-		readonly string _onColorPart;
-		readonly bool _isTV;
-		string _onColorEdjePart;
-
 		public SwitchRenderer()
 		{
-			_isTV = Device.Idiom == TargetIdiom.TV;
-			_onColorPart = _isTV ? "slider_on" : Device.Idiom == TargetIdiom.Watch ? "outer_bg_on" : "bg_on";
 			RegisterPropertyHandler(Switch.IsToggledProperty, HandleToggled);
 			RegisterPropertyHandler(Switch.OnColorProperty, UpdateOnColor);
 			RegisterPropertyHandler(SpecificSwitch.ColorProperty, UpdateColor);
@@ -31,7 +25,6 @@ namespace Xamarin.Forms.Platform.Tizen
 					Style = SwitchStyle.Toggle
 				});
 				Control.StateChanged += OnStateChanged;
-				_onColorEdjePart = Control.ClassName.ToLower().Replace("elm_", "") + "/" + _onColorPart;
 			}
 			base.OnElementChanged(e);
 		}
@@ -90,16 +83,11 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			if (Element.OnColor.IsDefault)
 			{
-				Control.EdjeObject.DeleteColorClass(_onColorEdjePart);
-				if (_isTV)
-					Control.EdjeObject.DeleteColorClass(_onColorEdjePart.Replace(_onColorPart, "slider_focused_on"));
+				Control.DeleteOnColors();
 			}
 			else
 			{
-				EColor color = Element.OnColor.ToNative();
-				Control.SetPartColor(_onColorPart, color);
-				if (_isTV)
-					Control.SetPartColor("slider_focused_on", color);
+				Control.SetOnColors(Element.OnColor.ToNative());
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/TabbedPageRenderer.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				else if (Device.Idiom == TargetIdiom.TV)
 				{
 					//According to TV UX Guideline, toolbar style should be set to "tabbar_with_title" in case of TabbedPage only for TV profile.
-					_toolbar.Style = "tabbar_with_title";
+					_toolbar.SetTVTabBarWithTitleStyle();
 				}
 
 				_toolbar.Show();
@@ -449,48 +449,16 @@ namespace Xamarin.Forms.Platform.Tizen
 				switch (type)
 				{
 					case BarItemColorType.Background:
-						item.SetPartColor("bg", color);
+						item.SetBackgroundColor(color);
 						break;
 					case BarItemColorType.Text:
-						if (string.IsNullOrEmpty(item.Icon))
-						{
-							item.SetPartColor("text", color);
-							item.SetPartColor("text_pressed", color);
-							item.SetPartColor("text_selected", color);
-						}
-						else
-						{
-							item.SetPartColor("text_under_icon", color);
-							item.SetPartColor("text_under_icon_pressed", color);
-							item.SetPartColor("text_under_icon_selected", color);
-						}
-						item.SetPartColor("underline", color);
+						item.SetTextColor(color);
 						break;
 					case BarItemColorType.SelectedTab:
-						if (string.IsNullOrEmpty(item.Icon))
-						{
-							item.SetPartColor("text_selected", color);
-						}
-						else
-						{
-							item.SetPartColor("text_under_icon_selected", color);
-							item.SetPartColor("icon_selected", color);
-						}
-						item.SetPartColor("underline", color);
+						item.SetSelectedTabColor(color);
 						break;
 					case BarItemColorType.UnselectedTab:
-						if (string.IsNullOrEmpty(item.Icon))
-						{
-							item.SetPartColor("text", color);
-							item.SetPartColor("text_pressed", color);
-						}
-						else
-						{
-							item.SetPartColor("text_under_icon", color);
-							item.SetPartColor("text_under_icon_pressed", color);
-							item.SetPartColor("icon", color);
-							item.SetPartColor("icon_pressed", color);
-						}
+						item.SetUnselectedTabColor(color);
 						break;
 					default:
 						break;
@@ -503,48 +471,16 @@ namespace Xamarin.Forms.Platform.Tizen
 			switch (type)
 			{
 				case BarItemColorType.Background:
-					item.DeletePartColor("bg");
+					item.DeleteBackgroundColor();
 					break;
 				case BarItemColorType.Text:
-					if (string.IsNullOrEmpty(item.Icon))
-					{
-						item.DeletePartColor("text");
-						item.DeletePartColor("text_pressed");
-						item.DeletePartColor("text_selected");
-					}
-					else
-					{
-						item.DeletePartColor("text_under_icon");
-						item.DeletePartColor("text_under_icon_pressed");
-						item.DeletePartColor("text_under_icon_selected");
-					}
-					item.DeletePartColor("underline");
+					item.DeleteTextColor();
 					break;
 				case BarItemColorType.SelectedTab:
-					if (string.IsNullOrEmpty(item.Icon))
-					{
-						item.DeletePartColor("text_selected");
-					}
-					else
-					{
-						item.DeletePartColor("text_under_icon_selected");
-						item.DeletePartColor("icon_selected");
-					}
-					item.DeletePartColor("underline");
+					item.DeleteSelectedTabColor();
 					break;
 				case BarItemColorType.UnselectedTab:
-					if (string.IsNullOrEmpty(item.Icon))
-					{
-						item.DeletePartColor("text");
-						item.DeletePartColor("text_pressed");
-					}
-					else
-					{
-						item.DeletePartColor("text_under_icon");
-						item.DeletePartColor("text_under_icon_pressed");
-						item.DeletePartColor("icon");
-						item.DeletePartColor("icon_pressed");
-					}
+					item.DeleteUnselectedTabColor();
 					break;
 				default:
 					break;

--- a/Xamarin.Forms.Platform.Tizen/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/TimePickerRenderer.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control == null)
 			{
 				var entry = CreateNativeControl();
-				entry.SetVerticalTextAlignment("elm.text", 0.5);
+				entry.SetVerticalTextAlignment(0.5);
 				SetNativeControl(entry);
 
 				if (entry is IEntry ie)

--- a/Xamarin.Forms.Platform.Tizen/Shell/NavigationDrawer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/NavigationDrawer.cs
@@ -87,7 +87,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				AlignmentY = -1,
 				WeightX = 1,
 				WeightY = 1,
-				BackgroundColor = new ElmSharp.Color(0, 0, 0, 82)
+				BackgroundColor = ThemeConstants.Shell.ColorClass.DefaultDrawerDimBackgroundColor
 			};
 
 			PackEnd(_dimArea);

--- a/Xamarin.Forms.Platform.Tizen/Shell/NavigationView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/NavigationView.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		GenList _menu;
 		GenItemClass _defaultClass;
 		EColor _backgroundColor;
-		EColor _defaultBackgroundColor = EColor.White;
+		EColor _defaultBackgroundColor = ThemeConstants.Shell.ColorClass.DefaultNavigationViewBackgroundColor;
 		List<Group> _groups;
 		IDictionary<Item, Element> _flyoutMenu = new Dictionary<Item, Element>();
 
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.Tizen
 						_bg = new EImage(this);
 					}
 					_menu.BackgroundColor = EColor.Transparent;
-					SetPartContent("elm.swallow.background", _bg);
+					this.SetBackgroundPart(_bg);
 					_bg.ApplyAspect(_bgImageAspect);
 					_ = _bg.LoadFromImageSourceAsync(_bgImageSource);
 				}
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				{
 					EColor effectiveColor = _backgroundColor.IsDefault ? _defaultBackgroundColor : _backgroundColor;
 					_menu.BackgroundColor = effectiveColor;
-					SetPartContent("elm.swallow.background", null);
+					this.SetBackgroundPart(null);
 				}
 			}
 		}
@@ -183,8 +183,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			_menu = new GenList(parent)
 			{
 				BackgroundColor = EColor.Transparent,
-				Style = "solid/default",
-			};
+			}.SetSolidStyle();
 
 			_menu.ItemSelected += (s, e) =>
 			{
@@ -196,11 +195,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			_menu.Show();
 			_box.PackEnd(_menu);
 
-			_defaultClass = new GenItemClass("double_label")
+			_defaultClass = new GenItemClass(ThemeConstants.GenItemClass.Styles.DoubleLabel)
 			{
 				GetTextHandler = (obj, part) =>
 				{
-					if (part == "elm.text")
+					if (part == ThemeConstants.GenItemClass.Parts.Text)
 					{
 						return ((Item)obj).Title;
 					}
@@ -211,7 +210,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				},
 				GetContentHandler = (obj, part) =>
 				{
-					if (part == "elm.swallow.icon")
+					if (part == ThemeConstants.GenItemClass.Parts.Icon)
 					{
 						var icon = ((Item)obj).Icon;
 						if (icon != null)
@@ -250,10 +249,11 @@ namespace Xamarin.Forms.Platform.Tizen
 						var item = _menu.Append(_defaultClass, _groups[i].Items[j]);
 						if (j != 0)
 						{
-							item.SetPartColor("bottomline", EColor.Transparent);
+
+							item.SetBottomlineColor(EColor.Transparent);
 						}
 
-						item.SetPartColor("bg", EColor.Transparent);
+						item.SetBackgroundColor(EColor.Transparent);
 					}
 				}
 			}

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellItemRenderer.cs
@@ -30,8 +30,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		bool _disposed = false;
 		EColor _backgroudColor = ShellRenderer.DefaultBackgroundColor.ToNative();
-		// The source of icon resources is https://materialdesignicons.com/
-		const string _dotsIcon = "Xamarin.Forms.Platform.Tizen.Resource.dots_horizontal.png";
+		const string _dotsIcon = ThemeConstants.Shell.Resources.DotsIcon;
 
 		public ShellItemRenderer(IFlyoutController flyoutController, ShellItem item)
 		{
@@ -190,11 +189,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			UpdateToolbarBackgroudColor(appearance.BackgroundColor.ToNative());
 		}
 
-		void UpdateToolbarBackgroudColor(ElmSharp.Color color)
+		void UpdateToolbarBackgroudColor(EColor color)
 		{
 			foreach (EToolbarItem item in _toolbarItemList)
 			{
-				item.SetPartColor("bg", color);
+				item.SetBackgroundColor(color);
 			}
 		}
 
@@ -323,8 +322,8 @@ namespace Xamarin.Forms.Platform.Tizen
 
 				if (item != null)
 				{
-					item.SetPartColor("bg", _backgroudColor);
-					item.SetPartColor("underline", EColor.Transparent);
+					item.SetBackgroundColor(_backgroudColor);
+					item.DeleteUnderlineColor();
 
 					_toolbarItemList.AddLast(item);
 					_itemToSection.Add(item, section);
@@ -361,9 +360,9 @@ namespace Xamarin.Forms.Platform.Tizen
 			Native.Image icon = new Native.Image(Forms.NativeParent);
 			var task = icon.LoadFromImageSourceAsync(src);
 
-			item.SetPartContent("elm.swallow.icon", icon);
-			item.SetPartColor("bg", _backgroudColor);
-			item.SetPartColor("underline", EColor.Transparent);
+			item.SetIconPart(icon);
+			item.SetBackgroundColor(_backgroudColor);
+			item.DeleteUnderlineColor();
 		}
 
 		EToolbarItem CreateTabsItem(string text)

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellMoreToolbar.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellMoreToolbar.cs
@@ -28,7 +28,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			WeightY = 1;
 			BackgroundColor = ShellRenderer.DefaultBackgroundColor.ToNative();
 			ItemSelected += OnItemSelected;
-			_defaultClass = new GenItemClass("full")
+			_defaultClass = new GenItemClass(ThemeConstants.GenItemClass.Styles.Full)
 			{
 				GetContentHandler = GetContent,
 			};

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellNavBar.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellNavBar.cs
@@ -26,8 +26,8 @@ namespace Xamarin.Forms.Platform.Tizen
 		EColor _foregroudColor = ShellRenderer.DefaultForegroundColor.ToNative();
 
 		// The source of icon resources is https://materialdesignicons.com/
-		const string _menuIcon = "Xamarin.Forms.Platform.Tizen.Resource.menu.png";
-		const string _backIcon = "Xamarin.Forms.Platform.Tizen.Resource.arrow_left.png";
+		const string _menuIcon = ThemeConstants.Shell.Resources.MenuIcon;
+		const string _backIcon = ThemeConstants.Shell.Resources.BackIcon;
 
 		bool _hasBackButton = false;
 
@@ -42,7 +42,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			_menu.Show();
 			_menuButton.Show();
 
-			_menuButton.SetPartContent("icon", _menu);
+			_menuButton.SetIconPart(_menu);
 
 			_title = new Native.Label(Forms.NativeParent)
 			{

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellRenderer.cs
@@ -9,9 +9,9 @@ namespace Xamarin.Forms.Platform.Tizen
 		INavigationView _navigationView;
 		ShellItemRenderer _shellItem;
 
-		public static readonly Color DefaultBackgroundColor = Color.FromRgb(33, 150, 243);
-		public static readonly Color DefaultForegroundColor = Color.White;
-		public static readonly Color DefaultTitleColor = Color.White;
+		public static readonly Color DefaultBackgroundColor = ThemeConstants.Shell.ColorClass.DefaultBackgroundColor;
+		public static readonly Color DefaultForegroundColor = ThemeConstants.Shell.ColorClass.DefaultForegroundColor;
+		public static readonly Color DefaultTitleColor = ThemeConstants.Shell.ColorClass.DefaultTitleColor;
 
 		public ShellRenderer()
 		{

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionRenderer.cs
@@ -183,7 +183,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			foreach (EToolbarItem item in _toolbarItemList)
 			{
-				item.SetPartColor("bg", color);
+				item.SetBackgroundColor(color);
 			}
 		}
 
@@ -193,11 +193,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				if (item != _tabs.SelectedItem)
 				{
-					item.SetPartColor("underline", EColor.Transparent);
+					item.DeleteUnderlineColor();
 				}
 				else
 				{
-					item.SetPartColor("underline", color);
+					item.SetUnderlineColor(color);
 				}
 			}
 		}
@@ -217,12 +217,10 @@ namespace Xamarin.Forms.Platform.Tizen
 		EToolbarItem InsertToolbarItem(ShellContent content)
 		{
 			EToolbarItem item = _tabs.Append(content.Title, null);
-			item.SetPartColor("bg", _backgroundColor);
-
+			item.SetBackgroundColor(_backgroundColor);
 			_toolbarItemList.AddLast(item);
 			_itemToContent.Add(item, content);
 			_contentToItem.Add(content, item);
-
 			return item;
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellTabs.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellTabs.cs
@@ -8,7 +8,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		ShellTabsType _type;
 		public ShellTabs(EvasObject parent) : base(parent)
 		{
-			Style = "material";
+			Style = ThemeConstants.Toolbar.Styles.Material;
 		}
 
 		public ShellTabsType Type

--- a/Xamarin.Forms.Platform.Tizen/Shell/Watch/NavigationDrawer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/Watch/NavigationDrawer.cs
@@ -14,9 +14,9 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 {
 	public class NavigationDrawer : ELayout, IAnimatable
 	{
-		static readonly int TouchWidth = 50;
-		static readonly int IconSize = 40;
-		static readonly string DefaultIcon = "Xamarin.Forms.Platform.Tizen.Resource.wc_visual_cue.png";
+		static readonly int TouchWidth = ThemeConstants.Shell.Resources.Watch.DefaultDrawerTouchWidth;
+		static readonly int IconSize = ThemeConstants.Shell.Resources.Watch.DefaultDrawerIconSize;
+		static readonly string DefaultIcon = ThemeConstants.Shell.Resources.Watch.DefaultDrawerIcon;
 
 		Box _mainLayout;
 		Box _contentGestureBox;
@@ -241,7 +241,7 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 				Color = EColor.Transparent,
 				BackgroundColor = EColor.Transparent,
 			};
-			_touchArea.SetPartColor("effect", EColor.Transparent);
+			_touchArea.SetEffectColor(EColor.Transparent);
 			_touchArea.Show();
 			_touchArea.RepeatEvents = true;
 			_touchArea.Clicked += OnIconClicked;

--- a/Xamarin.Forms.Platform.Tizen/Shell/Watch/NavigationView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/Watch/NavigationView.cs
@@ -12,7 +12,7 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 {
 	public class NavigationView : ELayout
 	{
-		readonly int _dafaultIconSize = 60;
+		readonly int _defaultIconSize = ThemeConstants.Shell.Resources.Watch.DefaultNavigationViewIconSize;
 
 		class Item : INotifyPropertyChanged
 		{
@@ -96,18 +96,18 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 		public event EventHandler<DraggedEventArgs> Dragged;
 
 
-		EColor _backgroundColor = EColor.Black;
+		EColor _backgroundColor = ThemeConstants.Shell.ColorClass.Watch.DefaultNavigationViewBackgroundColor;
 		public override EColor BackgroundColor
 		{
 			get => _backgroundColor;
 			set
 			{
-				_backgroundColor = value.IsDefault ? EColor.Black : value;
+				_backgroundColor = value.IsDefault ? ThemeConstants.Shell.ColorClass.Watch.DefaultNavigationViewBackgroundColor : value;
 				UpdateBackgroundColor();
 			}
 		}
 
-		EColor _foregroundColor = EColor.Default;
+		EColor _foregroundColor = ThemeConstants.Shell.ColorClass.Watch.DefaultNavigationViewForegroundColor;
 		public EColor ForegroundColor
 		{
 			get => _foregroundColor;
@@ -222,11 +222,11 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 
 			_surfaceLayout.StackAbove(_naviMenu);
 
-			_defaultClass = new GenItemClass("1icon_2text")
+			_defaultClass = new GenItemClass(ThemeConstants.GenItemClass.Styles.Watch.Text1Icon1)
 			{
 				GetTextHandler = (obj, part) =>
 				{
-					if (part == "elm.text")
+					if (part == ThemeConstants.GenItemClass.Parts.Text)
 					{
 						var text = (obj as Item).Text;
 						if (_foregroundColor != EColor.Default)
@@ -238,7 +238,7 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 				},
 				GetContentHandler = (obj, part) =>
 				{
-					if (part == "elm.swallow.icon" && obj is Item menuItem && !string.IsNullOrEmpty(menuItem.Icon))
+					if (part == ThemeConstants.GenItemClass.Parts.Watch.Icon && obj is Item menuItem && !string.IsNullOrEmpty(menuItem.Icon))
 					{
 						var icon = new ElmSharp.Image(Xamarin.Forms.Forms.NativeParent)
 						{
@@ -246,8 +246,8 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 							AlignmentY = -1,
 							WeightX = 1.0,
 							WeightY = 1.0,
-							MinimumWidth = _dafaultIconSize,
-							MinimumHeight = _dafaultIconSize,
+							MinimumWidth = _defaultIconSize,
+							MinimumHeight = _defaultIconSize,
 						};
 						icon.Show();
 						icon.Load(menuItem.Icon);

--- a/Xamarin.Forms.Platform.Tizen/Shell/Watch/ShellSectionItemsRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/Watch/ShellSectionItemsRenderer.cs
@@ -8,12 +8,6 @@ using ERect = ElmSharp.Rect;
 
 namespace Xamarin.Forms.Platform.Tizen.Watch
 {
-	internal static class IndexStyle
-	{
-		public const string Thumbnail = "thumbnail";
-		public const string Circle = "circle";
-	}
-
 	public class ShellSectionItemsRenderer : IShellItemRenderer
 	{
 		const int ItemMaxCount = 20;
@@ -77,8 +71,7 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 			{
 				IsHorizontal = true,
 				AutoHide = false,
-				Style = IndexStyle.Circle,
-			};
+			}.SetStyledIndex();
 			_indexIndicator.Show();
 
 			_scroller = new Scroller(_mainBox);
@@ -86,7 +79,7 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 			_scroller.PageScrolled += OnScrollStop;
 
 			//PageScrolled event is not invoked when a user scrolls beyond the end using bezel
-			var scrollAnimationStop = new SmartEvent(_scroller, "scroll,anim,stop");
+			var scrollAnimationStop = new SmartEvent(_scroller, ThemeConstants.Scroller.Signals.StopScrollAnimation);
 			scrollAnimationStop.On += OnScrollStop;
 
 			_scroller.Focused += OnFocused;
@@ -125,7 +118,7 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 			foreach (var item in ShellSection.Items)
 			{
 				var indexItem = _indexIndicator.Append(null);
-				indexItem.Style = GetItemStyle(ShellSection.Items.Count, _items.Count);
+				indexItem.SetIndexItemStyle(ShellSection.Items.Count, _items.Count, EvenMiddleItem, OddMiddleItem);
 				_items.Add(new ItemHolder
 				{
 					IsRealized = false,
@@ -315,27 +308,6 @@ namespace Xamarin.Forms.Platform.Tizen.Watch
 				_scroller.ScrollTo(_currentIndex, 0, false);
 				_updateByCode--;
 			}
-		}
-
-		static string GetItemStyle(int itemCount, int offset)
-		{
-			string returnValue = string.Empty;
-			int startItem;
-			int styleNumber;
-
-			if (itemCount % 2 == 0)  //Item count is even.
-			{
-				startItem = EvenMiddleItem - itemCount / 2;
-				styleNumber = startItem + offset;
-				returnValue = "item/even_" + styleNumber;
-			}
-			else  //Item count is odd.
-			{
-				startItem = OddMiddleItem - itemCount / 2;
-				styleNumber = startItem + offset;
-				returnValue = "item/odd_" + styleNumber;
-			}
-			return returnValue;
 		}
 
 		class ItemHolder

--- a/Xamarin.Forms.Platform.Tizen/ThemeConstants.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeConstants.cs
@@ -1,0 +1,597 @@
+using Tizen.Common;
+using EColor = ElmSharp.Color;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class ThemeConstants
+	{
+		#region Common
+		public class Common
+		{
+			public class Parts
+			{
+				public const string Text = "elm.text";
+				public const string Content = "elm.swallow.content";
+			}
+
+			public class ColorClass
+			{
+				public const string BackGround = "bg";
+				public const string Opacity = "opacity";
+			}
+		}
+		#endregion
+
+		#region Layout
+		public class Layout
+		{
+			public class Parts
+			{
+				public const string Text = Common.Parts.Text;
+				public const string Content = Common.Parts.Content;
+				public const string Background = "elm.swallow.background";
+				public const string Overlay = "elm.swallow.overlay";
+			}
+		}
+		#endregion
+
+		#region Button
+		public class Button
+		{
+			public class Styles
+			{
+				public const string Default = "default";
+				public const string Circle = "circle";
+				public const string Bottom = "bottom";
+				public const string Text = "textbutton";
+				public const string SelectMode = "select_mode";
+				public const string EditFieldClear = "editfield_clear";
+				public const string Transparent = "transparent";
+				public const string Popup = "popup";
+				public const string NavigationTitleLeft = "naviframe/title_left";
+				public const string NavigationTitleRight = "naviframe/title_right";
+				public const string NavigationBack = "naviframe/back_btn/default";
+				public const string NavigationDrawers = "naviframe/drawers";
+
+				public class Watch
+				{
+					public const string PopupLeft = "popup/circle/left_delete";
+					public const string PopupRight = "popup/circle/right_check";
+				}
+			}
+
+			public class Parts
+			{
+				public const string Icon = "elm.swallow.content";
+				public const string Button = "elm.swallow.button";
+			}
+
+			public class ColorClass
+			{
+				public const string Icon = "icon";
+				public const string IconPressed = "icon_pressed";
+				public const string Effect = "effect";
+				public const string EffectPressed = "effect_pressed";
+			}
+
+			public class Signals
+			{
+				public const string ElementaryCode = "elm";
+				public const string TextVisibleState = "elm,state,text,visible";
+				public const string TextHiddenState = "elm,state,text,hidden";
+			}
+		}
+		#endregion
+
+		#region Entry
+		public class Entry
+		{
+			public class Parts
+			{
+				public const string PlaceHolderText = "elm.guide";
+			}
+		}
+		#endregion
+
+		#region GenListItem
+		public class GenListItem
+		{
+			public class ColorClass
+			{
+				public const string BottomLine = "bottomline";
+				public const string Background = Common.ColorClass.BackGround;
+			}
+		}
+		#endregion
+
+		#region NaviItem
+		public class NaviItem
+		{
+			public class Styles
+			{
+				public const string Default = "default";
+				public const string NavigationBar = "navigationbar";
+
+				public class TV
+				{
+					public const string TabBar = "tabbar";
+				}
+			}
+
+			public class Parts
+			{
+				public const string Title = "default";
+				public const string BackButton = "elm.swallow.prev_btn";
+				public const string LeftToolbarButton = "title_left_btn";
+				public const string RightToolbarButton = "title_right_btn";
+				public const string NavigationBar = "navigationbar";
+			}
+
+			public class ColorClass
+			{
+				public const string TextUnderIconPressed = "text_under_icon_pressed";
+				public const string TextUnderIconSelected = "text_under_icon_selected";
+			}
+		}
+		#endregion
+
+		#region GenList
+		public static class GenList
+		{
+			public class Styles
+			{
+				public const string Solid = "solid/default";
+			}
+		}
+		#endregion
+
+		#region GenItemClass
+		public static class GenItemClass
+		{
+			public class Styles
+			{
+				public const string Default = "default";
+				public const string Full = "full";
+				public const string DoubleLabel = "double_label";
+				public const string GroupIndex = "group_index";
+
+				public class Watch
+				{
+					public const string Padding = "padding";
+					public const string SingleText = "1text";
+					public const string Text1Icon1 = "1text.1icon.1";
+					public const string TwoText1Icon1 = "2text.1icon.1";
+					public const string Icon2Text = "2text.1icon";//"1icon_2text"
+					public const string FullEffectOff = "full_effect_off";
+					public const string FullOff = "full_off";
+				}
+			}
+
+			public class Parts
+			{
+				public const string Text = Common.Parts.Text;
+				public const string Content = Common.Parts.Content;
+				public const string Icon = "elm.swallow.icon";
+				public const string End = "elm.swallow.end";
+				public const string SubText = "elm.text.sub";
+				public const string EndText = "elm.text.end";
+				public const string Ignore = "null";
+
+				public class Watch
+				{
+					public const string Icon = "elm.icon";
+					public const string Text = "elm.text.1";
+				}
+			}
+		}
+		#endregion
+
+		#region Popup
+		public class Popup
+		{
+			public class Styles
+			{
+				public class Watch
+				{
+					public const string Circle = "circle";
+					public const string ToastCircle = "toast/circle";
+				}
+			}
+
+			public class Parts
+			{
+				public const string Title = "title,text";
+				public const string Button1 = "button1";
+				public const string Button2 = "button2";
+				public const string Button3 = "button3";
+
+				public class Watch
+				{
+					public const string ToastIcon = "toast,icon";
+				}
+			}
+
+			public class ColorClass
+			{
+				public const string Title = "text_maintitle";
+
+				public class TV
+				{
+					public const string Title = "text_title";
+				}
+			}
+		}
+		#endregion
+
+		#region ContextPopup
+		public class ContextPopup
+		{
+			public class Styles
+			{
+				public const string SelectMode = "select_mode";
+			}
+		}
+		#endregion
+
+		#region DateTimeSelector
+		public class DateTimeSelector
+		{
+			public class Styles
+			{
+				public const string TimeLayout = "time_layout";
+				public const string DateLayout = "date_layout";
+			}
+		}
+		#endregion
+
+		#region CircleDateTimeSelector
+		public class CircleDateTimeSelector
+		{
+			public class Styles
+			{
+				public const string CircleDatePicker = "datepicker/circle";
+				public const string CircleTimePicker = "timepicker/circle";
+			}
+		}
+		#endregion
+
+		#region CircleSpinner
+		public class CircleSpinner
+		{
+			public class Styles
+			{
+				public const string Circle = "circle";
+			}
+
+			public class Signals
+			{
+				public static readonly string ShowList = DotnetUtil.TizenAPIVersion == 4 ? "genlist,show" : "list,show";
+				public static readonly string HideList = DotnetUtil.TizenAPIVersion == 4 ? "genlist,hide" : "list,hide";
+			}
+		}
+		#endregion
+
+		#region Toolbar
+		public class Toolbar
+		{
+			public class Styles
+			{
+				public const string Default = "default";
+				public const string NavigationBar = "navigationbar";
+				public const string Tabbar = "tabbar";
+				public const string Material = "material";
+
+				public class TV
+				{
+					public const string TabbarWithTitle = "tabbar_with_title";
+				}
+			}
+		}
+		#endregion
+
+		#region ToolbarItem
+		public class ToolbarItem
+		{
+			public class Parts
+			{
+				public const string Icon = "elm.swallow.icon";
+			}
+
+			public class ColorClass
+			{
+				public const string Background = Common.ColorClass.BackGround;
+				public const string Icon = "icon";
+				public const string IconPressed = "icon_pressed";
+				public const string IconSelected = "icon_selected";
+				public const string Text = "text";
+				public const string TextPressed = "text_pressed";
+				public const string TextSelected = "text_selected";
+				public const string TextUnderIcon = "text_under_icon";
+				public const string TextUnderIconPressed = "text_under_icon_pressed";
+				public const string TextUnderIconSelected = "text_under_icon_selected";
+				public const string Underline = "underline";
+			}
+		}
+		#endregion
+
+		#region ProgressBar
+		public class ProgressBar
+		{
+			public class Styles
+			{
+				public const string Default = "default";
+				public const string Pending = "pending";
+				public const string Small = "process_small";
+				public const string Large = "process_large";
+				
+				public class Watch
+				{
+					public const string PopupSmall = "process/popup/small";
+				}
+			}
+
+			public class ColorClass
+			{
+				public static readonly EColor Default = new EColor(129, 198, 255);
+			}
+		}
+		#endregion
+
+		#region Frame
+		public class Frame
+		{
+			public class ColorClass
+			{
+				public static readonly EColor DefaultBorderColor = Device.Idiom == TargetIdiom.TV || Device.Idiom == TargetIdiom.Watch ? EColor.Gray : EColor.Black;
+				public static readonly EColor DefaultShadowColor = EColor.FromRgba(80, 80, 80, 50);
+			}
+		}
+		#endregion
+
+		#region Panes
+		public class Panes
+		{
+			public class Parts
+			{
+				public const string Left = "left";
+				public const string Right = "right";
+			}
+		}
+		#endregion
+
+		#region Scroller
+		public class Scroller
+		{
+			public class Signals
+			{
+				public const string StartScrollAnimation = "scroll,anim,start";
+				public const string StopScrollAnimation = "scroll,anim,stop";
+			}
+		}
+		#endregion
+
+		#region Background
+		public class Background
+		{
+			public class Parts
+			{
+				public const string Overlay = "overlay";
+			}
+		}
+		#endregion
+
+		#region Check
+		public class Check
+		{
+			public class Styles
+			{
+				public const string Default = "default";
+				public const string Toggle = "toggle";
+				public const string Favorite = "favorite";
+				public const string OnOff = "on&off";
+				public const string Small = "small";
+
+				public class Watch
+				{
+					public const string ListSelectMode = "genlist/select_mode";
+				}
+			}
+
+			public class ColorClass
+			{
+				public const string BackgroundOn = "bg_on";
+				public const string Stroke = "stroke";
+
+				public class TV
+				{
+					public const string SliderOn = "slider_on";
+					public const string SliderFocusedOn = "slider_focused_on";
+				}
+
+				public class Watch
+				{
+					public const string OuterBackgroundOn = "outer_bg_on";
+					public const string OuterBackgroundOnPressed = "outer_bg_on_pressed";
+					public const string CheckOn = "check_on";
+					public const string CheckOnPressed = "check_on_pressed";
+				}
+			}
+		}
+		#endregion
+
+		#region Radio
+		public class Radio
+		{
+			public class Signals
+			{
+				public const string ElementaryCode = "elm";
+				public const string TextVisibleState = "elm,state,text,visible";
+				public const string TextHiddenState = "elm,state,text,hidden";
+			}
+		}
+		#endregion
+
+		#region Index
+		public class Index
+		{
+			public class Styles
+			{
+				public const string PageControl = "pagecontrol";
+				public const string Circle = "circle";
+				public const string Thumbnail = "thumbnail";
+			}
+		}
+		#endregion
+
+		#region IndexItem
+		public class IndexItem
+		{
+			public class Styles
+			{
+				public const string EvenItemPrefix = "item/even_";
+				public const string OddItemPrefix = "item/odd_";
+			}
+		}
+		#endregion
+
+		#region Slider
+		public class Slider
+		{
+			public class ColorClass
+			{
+				public const string Bar = "bar";
+				public const string Background = "bg";
+				public const string Handler = "handler";
+				public const string BarPressed = "bar_pressed";
+				public const string HandlerPressed = "handler_pressed";
+			}
+		}
+		#endregion
+
+		#region RefreshView
+		public class RefreshView
+		{
+			public class Resources
+			{
+				public const int IconSize = 48;
+				public const string IconPath = "Xamarin.Forms.Platform.Tizen.Resource.refresh_48dp.png";
+			}
+
+			public class ColorClass
+			{
+				public static readonly Color DefaultColor = Color.FromHex("#6200EE");
+			}
+		}
+		#endregion
+
+		#region Span
+		public class Span
+		{
+			public class ColorClass
+			{
+				public static readonly EColor DefaultUnderLineColor = EColor.Black;
+			}
+		}
+		#endregion
+
+		#region Cell
+		public class EntryCell
+		{
+			public class Resources
+			{
+				public const double DefaultHeight = 65;
+			}
+
+			public class ColorClass
+			{
+				public static readonly EColor DefaultLabelColor = EColor.Black;
+			}
+		}
+
+		public class ImageCell
+		{
+			public class Resources
+			{
+				public const double DefaultHeight = 55;
+			}
+		}
+		#endregion
+
+		#region Shell
+		public class Shell
+		{
+			public class Resources
+			{
+				// The source of icon resources is https://materialdesignicons.com/
+				public const string MenuIcon = "Xamarin.Forms.Platform.Tizen.Resource.menu.png";
+				public const string BackIcon = "Xamarin.Forms.Platform.Tizen.Resource.arrow_left.png";
+				public const string DotsIcon = "Xamarin.Forms.Platform.Tizen.Resource.dots_horizontal.png";
+
+				public class Watch
+				{
+					public const int DefaultNavigationViewIconSize = 60;
+					public const int DefaultDrawerTouchWidth = 50;
+					public const int DefaultDrawerIconSize = 40;
+					public const string DefaultDrawerIcon = "Xamarin.Forms.Platform.Tizen.Resource.wc_visual_cue.png";
+				}
+			}
+
+			public class ColorClass
+			{
+				public static readonly Color DefaultBackgroundColor = Color.FromRgb(33, 150, 243);
+				public static readonly Color DefaultForegroundColor = Color.White;
+				public static readonly Color DefaultTitleColor = Color.White;
+				public static readonly EColor DefaultNavigationViewBackgroundColor = EColor.White;
+				public static readonly EColor DefaultDrawerDimBackgroundColor = new EColor(0, 0, 0, 82);
+
+				public class Watch
+				{
+					public static readonly EColor DefaultNavigationViewForegroundColor = EColor.Default;
+					public static readonly EColor DefaultNavigationViewBackgroundColor = EColor.Black;
+				}
+			}
+		}
+		#endregion
+
+		#region CollectionView
+		public class CollectionView
+		{
+			public class ColorClass
+			{
+				public static readonly EColor DefaultFocusedColor = EColor.FromRgba(244, 244, 244, 200);
+				public static readonly EColor DefaultSelectedColor = EColor.FromRgba(227, 242, 253, 200);
+			}
+		}
+		#endregion
+
+		#region CarouselView
+		public class CarouselView
+		{
+			public class ColorClass
+			{
+				public static readonly EColor DefaultFocusedColor = EColor.Transparent;
+				public static readonly EColor DefaultSelectedColor = EColor.Transparent;
+			}
+		}
+		#endregion
+
+		#region MediaPlayer
+		public class MediaPlayer
+		{
+			public class Resources
+			{
+				public const string PlayImagePath = "Xamarin.Forms.Platform.Tizen.Resource.img_button_play.png";
+				public const string PauseImagePath = "Xamarin.Forms.Platform.Tizen.Resource.img_button_pause.png";
+			}
+
+			public class ColorClass
+			{
+				public static readonly Color DefaultProgressLabelColor = Color.FromHex("#eeeeeeee");
+				public static readonly Color DefaultProgressBarColor = Color.FromHex($"#4286f4");
+				public static readonly Color DefaultProgressAreaColor = Color.FromHex("#80000000");
+				public static readonly Color DefaultProgressAreaBackgroundColor = Color.FromHex("#50000000");
+			}
+		}
+		#endregion
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
@@ -1,0 +1,812 @@
+using ElmSharp;
+using ElmSharp.Wearable;
+using ELayout = ElmSharp.Layout;
+using EColor = ElmSharp.Color;
+using EButton = ElmSharp.Button;
+using EEntry = ElmSharp.Entry;
+using ELabel = ElmSharp.Label;
+using ESlider = ElmSharp.Slider;
+using ESize = ElmSharp.Size;
+using EToolbarItem = ElmSharp.ToolbarItem;
+using EProgressBar = ElmSharp.ProgressBar;
+using static Xamarin.Forms.Platform.Tizen.Native.TableView;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public static class ThemeManager
+	{
+		#region Layout
+		public static EdjeTextPartObject GetContentPartEdjeObject(this ELayout layout)
+		{
+			return layout?.EdjeObject[ThemeConstants.Layout.Parts.Content];
+		}
+
+		public static EdjeTextPartObject GetTextPartEdjeObject(this ELayout layout)
+		{
+			return layout?.EdjeObject[ThemeConstants.Layout.Parts.Text];
+		}
+
+		public static bool SetTextPart(this ELayout layout, string text)
+		{
+			return layout.SetPartText(ThemeConstants.Layout.Parts.Text, text);
+		}
+
+		public static bool SetContentPart(this ELayout layout, EvasObject content, bool preserveOldContent = false)
+		{
+			var ret = layout.SetPartContent(ThemeConstants.Layout.Parts.Content, content, preserveOldContent);
+			if (!ret)
+			{
+				// Restore theme to default if given layout is not available
+				layout.SetTheme("layout", "application", "default");
+				ret = layout.SetPartContent(ThemeConstants.Layout.Parts.Content, content, preserveOldContent);
+			}
+			return ret;
+		}
+
+		public static bool SetBackgroundPart(this ELayout layout, EvasObject content, bool preserveOldContent = false)
+		{
+			return layout.SetPartContent(ThemeConstants.Layout.Parts.Background, content, preserveOldContent);
+		}
+
+		public static bool SetOverlayPart(this ELayout layout, EvasObject content, bool preserveOldContent = false)
+		{
+			return layout.SetPartContent(ThemeConstants.Layout.Parts.Overlay, content, preserveOldContent);
+		}
+		#endregion
+
+		#region Entry
+		public static bool SetPlaceHolderTextPart(this EEntry entry, string text)
+		{
+			return entry.SetPartText(ThemeConstants.Entry.Parts.PlaceHolderText, text);
+		}
+
+		public static void SetVerticalTextAlignment(this EEntry entry, double valign)
+		{
+			entry.SetVerticalTextAlignment(ThemeConstants.Common.Parts.Text, valign);
+		}
+
+		public static void SetVerticalPlaceHolderTextAlignment(this EEntry entry, double valign)
+		{
+			entry.SetVerticalTextAlignment(ThemeConstants.Entry.Parts.PlaceHolderText, valign);
+		}
+
+		public static ESize GetTextBlockFormattedSize(this EEntry entry)
+		{
+			var textPart = entry.EdjeObject[ThemeConstants.Common.Parts.Text];
+			if (textPart == null)
+			{
+				Log.Error("There is no elm.text part");
+				return new ESize(0, 0);
+			}
+			return textPart.TextBlockFormattedSize;
+		}
+
+		public static ESize GetTextBlockNativeSize(this EEntry entry)
+		{
+			var textPart = entry.EdjeObject[ThemeConstants.Common.Parts.Text];
+			if (textPart == null)
+			{
+				Log.Error("There is no elm.text part");
+				return new ESize(0, 0);
+			}
+			return textPart.TextBlockNativeSize;
+		}
+
+		public static ESize GetPlaceHolderTextBlockFormattedSize(this EEntry entry)
+		{
+			var textPart = entry.EdjeObject[ThemeConstants.Entry.Parts.PlaceHolderText];
+			if (textPart == null)
+			{
+				Log.Error("There is no elm.guide part");
+				return new ESize(0, 0);
+			}
+			return textPart.TextBlockFormattedSize;
+		}
+
+		public static ESize GetPlaceHolderTextBlockNativeSize(this EEntry entry)
+		{
+			var textPart = entry.EdjeObject[ThemeConstants.Entry.Parts.PlaceHolderText];
+			if (textPart == null)
+			{
+				Log.Error("There is no elm.guide part");
+				return new ESize(0, 0);
+			}
+			return textPart.TextBlockNativeSize;
+		}
+		#endregion
+
+		#region Label
+		public static void SetVerticalTextAlignment(this ELabel label, double valign)
+		{
+			label.SetVerticalTextAlignment(ThemeConstants.Common.Parts.Text, valign);
+		}
+
+		public static double GetVerticalTextAlignment(this ELabel label)
+		{
+			return label.GetVerticalTextAlignment(ThemeConstants.Common.Parts.Text);
+		}
+
+		public static ESize GetTextBlockFormattedSize(this ELabel label)
+		{
+			var textPart = label.EdjeObject[ThemeConstants.Common.Parts.Text];
+			if (textPart == null)
+			{
+				Log.Error("There is no elm.text part");
+				return new ESize(0, 0);
+			}
+			return textPart.TextBlockFormattedSize;
+		}
+		#endregion
+
+		#region Button
+		public static ESize GetTextBlockNativeSize(this EButton button)
+		{
+			var textPart = button.EdjeObject[ThemeConstants.Common.Parts.Text];
+			if (textPart == null)
+			{
+				Log.Error("There is no elm.text part");
+				return new ESize(0, 0);
+			}
+			return textPart.TextBlockNativeSize;
+		}
+
+		public static void SetTextBlockStyle(this EButton button, string style)
+		{
+			var textBlock = button.EdjeObject[ThemeConstants.Common.Parts.Text];
+			if (textBlock != null)
+			{
+				textBlock.TextStyle = style;
+			}
+		}
+
+		public static void SendTextVisibleSignal(this EButton button, bool isVisible)
+		{
+			button.SignalEmit(isVisible ? ThemeConstants.Button.Signals.TextVisibleState : ThemeConstants.Button.Signals.TextHiddenState, ThemeConstants.Button.Signals.ElementaryCode);
+		}
+
+		public static EButton SetDefaultStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.Default;
+			return button;
+		}
+
+		public static EButton SetBottomStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.Bottom;
+			return button;
+		}
+
+		public static EButton SetPopupStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.Popup;
+			return button;
+		}
+
+		public static EButton SetNavigationTitleRightStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.NavigationTitleRight;
+			return button;
+		}
+
+		public static EButton SetNavigationTitleLeftStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.NavigationTitleLeft;
+			return button;
+		}
+
+		public static EButton SetNavigationBackStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.NavigationBack;
+			return button;
+		}
+
+		public static EButton SetNavigationDrawerStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.NavigationDrawers;
+			return button;
+		}
+
+		public static EButton SetTransparentStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.Transparent;
+			return button;
+		}
+
+		public static EButton SetWatchPopupRightStyle(this EButton button)
+		{
+			if (Device.Idiom != TargetIdiom.Watch)
+			{
+				Log.Error($"ToWatchPopupRightStyleButton is only supported on TargetIdiom.Watch : {0}", Device.Idiom);
+				return button;
+			}
+			button.Style = ThemeConstants.Button.Styles.Watch.PopupRight;
+			return button;
+		}
+
+		public static EButton SetWatchPopupLeftStyle(this EButton button)
+		{
+			if (Device.Idiom != TargetIdiom.Watch)
+			{
+				Log.Error($"WatchPopupLeftStyleButton is only supported on TargetIdiom.Watch : {0}", Device.Idiom);
+				return button;
+			}
+			button.Style = ThemeConstants.Button.Styles.Watch.PopupLeft;
+			return button;
+		}
+
+		public static bool SetIconPart(this EButton button, EvasObject content, bool preserveOldContent = false)
+		{
+			return button.SetPartContent(ThemeConstants.Button.Parts.Icon, content, preserveOldContent);
+		}
+
+		public static EButton SetEditFieldClearStyle(this EButton button)
+		{
+			button.Style = ThemeConstants.Button.Styles.EditFieldClear;
+			return button;
+		}
+
+		public static EColor GetIconColor(this EButton button)
+		{
+			var ret = EColor.Default;
+			if (button == null)
+				return ret;
+
+			ret = button.GetPartColor(ThemeConstants.Button.ColorClass.Icon);
+			return ret;
+		}
+
+		public static void SetIconColor(this EButton button, EColor color)
+		{
+			if (button == null)
+				return;
+
+			button.SetPartColor(ThemeConstants.Button.ColorClass.Icon, color);
+			button.SetPartColor(ThemeConstants.Button.ColorClass.IconPressed, color);
+		}
+
+		public static void SetEffectColor(this EButton button, EColor color)
+		{
+			if (button == null)
+				return;
+
+			button.SetPartColor(ThemeConstants.Button.ColorClass.Effect, color);
+			button.SetPartColor(ThemeConstants.Button.ColorClass.EffectPressed, color);
+		}
+		#endregion
+
+		#region Popup
+		public static Popup SetWatchCircleStyle(this Popup popup)
+		{
+			if (Device.Idiom != TargetIdiom.Watch)
+			{
+				Log.Error($"WatchCircleStylePopup is only supported on TargetIdiom.Watch : {0}", Device.Idiom);
+				return popup;
+			}
+			popup.Style = ThemeConstants.Popup.Styles.Watch.Circle;
+			return popup;
+		}
+
+		public static void SetTitleColor(this Popup popup, EColor color)
+		{
+			popup.SetPartColor(Device.Idiom == TargetIdiom.TV ? ThemeConstants.Popup.ColorClass.TV.Title : ThemeConstants.Popup.ColorClass.Title, color);
+		}
+
+		public static bool SetTitleTextPart(this Popup popup, string title)
+		{
+			return popup.SetPartText(ThemeConstants.Popup.Parts.Title, title);
+		}
+
+		public static bool SetButton1Part(this Popup popup, EvasObject content, bool preserveOldContent = false)
+		{
+			return popup.SetPartContent(ThemeConstants.Popup.Parts.Button1, content, preserveOldContent);
+		}
+
+		public static bool SetButton2Part(this Popup popup, EvasObject content, bool preserveOldContent = false)
+		{
+			return popup.SetPartContent(ThemeConstants.Popup.Parts.Button2, content, preserveOldContent);
+		}
+
+		public static bool SetButton3Part(this Popup popup, EvasObject content, bool preserveOldContent = false)
+		{
+			return popup.SetPartContent(ThemeConstants.Popup.Parts.Button3, content, preserveOldContent);
+		}
+		#endregion
+
+		#region ProgressBar
+		public static EProgressBar SetSmallStyle(this EProgressBar progressBar)
+		{
+			progressBar.Style = ThemeConstants.ProgressBar.Styles.Small;
+			return progressBar;
+		}
+
+		public static EProgressBar SetLargeStyle(this EProgressBar progressBar)
+		{
+			progressBar.Style = ThemeConstants.ProgressBar.Styles.Large;
+			return progressBar;
+		}
+		#endregion
+
+		#region Check
+
+		public static void SetOnColors(this Check check, EColor color)
+		{
+			foreach (string s in check.GetColorParts())
+			{
+				check.SetPartColor(s, color);
+			}
+		}
+
+		public static void DeleteOnColors(this Check check)
+		{
+			foreach (string s in check.GetColorEdjeParts())
+			{
+				check.EdjeObject.DeleteColorClass(s);
+			}
+		}
+
+		public static string[] GetColorParts(this Check check)
+		{
+			if (Device.Idiom == TargetIdiom.Watch)
+			{
+				if (check.Style == ThemeConstants.Check.Styles.Toggle)
+				{
+					return new string[] { ThemeConstants.Check.ColorClass.Watch.OuterBackgroundOn };
+				}
+				else
+				{
+					return new string[] {
+						ThemeConstants.Check.ColorClass.Watch.OuterBackgroundOn,
+						ThemeConstants.Check.ColorClass.Watch.OuterBackgroundOnPressed,
+						ThemeConstants.Check.ColorClass.Watch.CheckOn,
+						ThemeConstants.Check.ColorClass.Watch.CheckOnPressed
+					};
+				}	
+			}
+			else if (Device.Idiom == TargetIdiom.TV)
+			{
+				if (check.Style == ThemeConstants.Check.Styles.Toggle)
+				{
+					return new string[] { ThemeConstants.Check.ColorClass.TV.SliderOn, ThemeConstants.Check.ColorClass.TV.SliderFocusedOn };
+				}
+				else
+				{
+					return new string[] {
+						ThemeConstants.Check.ColorClass.TV.SliderOn,
+						ThemeConstants.Check.ColorClass.TV.SliderFocusedOn,
+					};
+				}
+			}
+			else
+			{
+				if (check.Style == ThemeConstants.Check.Styles.Toggle)
+				{
+					return new string[] { ThemeConstants.Check.ColorClass.BackgroundOn };
+				}
+				else
+				{
+					return new string[] { ThemeConstants.Check.ColorClass.BackgroundOn, ThemeConstants.Check.ColorClass.Stroke };
+				}
+			}
+		}
+
+		public static string[] GetColorEdjeParts(this Check check)
+		{
+			string[] ret = check.GetColorParts();
+			
+			for (int i = 0; i < ret.Length; i++)
+			{
+				ret[i] = check.ClassName.ToLower().Replace("elm_", "") + "/" + ret[i];
+			}
+			return ret;
+		}
+		#endregion
+
+		#region NaviItem
+		public static void SetTitle(this NaviItem item, string text)
+		{
+			item.SetPartText(ThemeConstants.NaviItem.Parts.Title, text);
+		}
+
+		public static void SetBackButton(this NaviItem item, EvasObject content, bool preserveOldContent = false)
+		{
+			item.SetPartContent(ThemeConstants.NaviItem.Parts.BackButton, content, preserveOldContent);
+		}
+
+		public static void SetLeftToolbarButton(this NaviItem item, EvasObject content, bool preserveOldContent = false)
+		{
+			item.SetPartContent(ThemeConstants.NaviItem.Parts.LeftToolbarButton, content, preserveOldContent);
+		}
+
+		public static void SetRightToolbarButton(this NaviItem item, EvasObject content, bool preserveOldContent = false)
+		{
+			item.SetPartContent(ThemeConstants.NaviItem.Parts.RightToolbarButton, content, preserveOldContent);
+		}
+
+		public static void SetNavigationBar(this NaviItem item, EvasObject content, bool preserveOldContent = false)
+		{
+			item.SetPartContent(ThemeConstants.NaviItem.Parts.NavigationBar, content, preserveOldContent);
+		}
+
+		public static NaviItem SetNavigationBarStyle(this NaviItem item)
+		{
+			item.Style = ThemeConstants.NaviItem.Styles.NavigationBar;
+			return item;
+		}
+
+		public static NaviItem SetTabBarStyle(this NaviItem item)
+		{
+			if (Device.Idiom == TargetIdiom.TV)
+			{
+				//According to TV UX Guideline, item style should be set to "tabbar" in case of TabbedPage only for TV profile.
+				item.Style = ThemeConstants.NaviItem.Styles.TV.TabBar;
+			}
+			else
+			{
+				item.Style = ThemeConstants.NaviItem.Styles.Default;
+			}
+			return item;
+		}
+		#endregion
+
+		#region Toolbar
+		public static Toolbar SetNavigationBarStyle(this Toolbar toolbar)
+		{
+			toolbar.Style = ThemeConstants.Toolbar.Styles.NavigationBar;
+			return toolbar;
+		}
+
+		public static Toolbar SetTVTabBarWithTitleStyle(this Toolbar toolbar)
+		{
+			if (Device.Idiom != TargetIdiom.TV)
+			{
+				Log.Error($"TabBarWithTitleStyle is only supported on TargetIdiom.TV : {0}", Device.Idiom);
+				return toolbar;
+			}
+			toolbar.Style = ThemeConstants.Toolbar.Styles.TV.TabbarWithTitle;
+			return toolbar;
+		}
+		#endregion
+
+		#region ToolbarItem
+		public static void SetIconPart(this EToolbarItem item, EvasObject content, bool preserveOldContent = false)
+		{
+			item.SetPartContent(ThemeConstants.ToolbarItem.Parts.Icon, content, preserveOldContent);
+		}
+
+		public static void SetBackgroundColor(this EToolbarItem item, EColor color)
+		{
+			item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Background, color);
+		}
+
+		public static void SetUnderlineColor(this EToolbarItem item, EColor color)
+		{
+			item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Underline, color);
+		}
+
+		public static void SetTextColor(this EToolbarItem item, EColor color)
+		{
+			if (string.IsNullOrEmpty(item.Icon))
+			{
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Text, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextPressed, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextSelected, color);
+			}
+			else
+			{
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIcon, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconPressed, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconSelected, color);
+			}
+			item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Underline, color);
+		}
+
+		public static void SetSelectedTabColor(this EToolbarItem item, EColor color)
+		{
+			if (string.IsNullOrEmpty(item.Icon))
+			{
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextSelected, color);
+			}
+			else
+			{
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconSelected, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.IconSelected, color);
+			}
+			item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Underline, color);
+		}
+
+		public static void SetUnselectedTabColor(this EToolbarItem item, EColor color)
+		{
+			if (string.IsNullOrEmpty(item.Icon))
+			{
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Text, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextPressed, color);
+			}
+			else
+			{
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIcon, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconPressed, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.Icon, color);
+				item.SetPartColor(ThemeConstants.ToolbarItem.ColorClass.IconPressed, color);
+			}
+		}
+
+		public static void DeleteBackgroundColor(this EToolbarItem item)
+		{
+			item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Background);
+		}
+
+		public static void DeleteUnderlineColor(this EToolbarItem item)
+		{
+			item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Underline);
+		}
+
+		public static void DeleteTextColor(this EToolbarItem item)
+		{
+			if (string.IsNullOrEmpty(item.Icon))
+			{
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Text);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextPressed);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextSelected);
+			}
+			else
+			{
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIcon);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconPressed);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconSelected);
+			}
+			item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Underline);
+		}
+
+		public static void DeleteSelectedTabColor(this EToolbarItem item)
+		{
+			if (string.IsNullOrEmpty(item.Icon))
+			{
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextSelected);
+			}
+			else
+			{
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconSelected);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.IconSelected);
+			}
+			item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Underline);
+		}
+
+		public static void DeleteUnselectedTabColor(this EToolbarItem item)
+		{
+			if (string.IsNullOrEmpty(item.Icon))
+			{
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Text);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextPressed);
+			}
+			else
+			{
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIcon);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.TextUnderIconPressed);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.Icon);
+				item.DeletePartColor(ThemeConstants.ToolbarItem.ColorClass.IconPressed);
+			}
+		}
+
+		#endregion
+
+		#region Background
+		public static bool SetOverlayPart(this Background bg, EvasObject content, bool preserveOldContent = false)
+		{
+			return bg.SetPartContent(ThemeConstants.Background.Parts.Overlay, content, preserveOldContent);
+		}
+		#endregion
+
+		#region Panes
+		public static bool SetLeftPart(this Panes panes, EvasObject content, bool preserveOldContent = false)
+		{
+			return panes.SetPartContent(ThemeConstants.Panes.Parts.Left, content, preserveOldContent);
+		}
+
+		public static bool SetRightPart(this Panes panes, EvasObject content, bool preserveOldContent = false)
+		{
+			return panes.SetPartContent(ThemeConstants.Panes.Parts.Right, content, preserveOldContent);
+		}
+		#endregion
+
+		#region CellRenderer
+		public static string GetTextCellRendererStyle()
+		{
+			return Device.Idiom == TargetIdiom.TV ? ThemeConstants.GenItemClass.Styles.Default : ThemeConstants.GenItemClass.Styles.DoubleLabel;
+		}
+
+		public static string GetTextCellGroupModeStyle(bool isGroupMode)
+		{
+			return isGroupMode ? ThemeConstants.GenItemClass.Styles.GroupIndex : GetTextCellRendererStyle();
+		}
+
+		public static string GetMainPart(this CellRenderer cell)
+		{
+			switch (cell.Style)
+			{
+				default:
+					return ThemeConstants.GenItemClass.Parts.Text;
+			}
+		}
+
+		public static string GetDetailPart(this TextCellRenderer textCell)
+		{
+			// TextCell.Detail property is not supported on TV profile due to UX limitation.
+			switch (textCell.Style)
+			{
+				case ThemeConstants.GenItemClass.Styles.Watch.TwoText1Icon1:
+				case ThemeConstants.GenItemClass.Styles.Watch.Icon2Text:
+					return ThemeConstants.GenItemClass.Parts.Watch.Text;
+				case ThemeConstants.GenItemClass.Styles.GroupIndex:
+					return textCell is SectionCellRenderer ? ThemeConstants.GenItemClass.Parts.Ignore : ThemeConstants.GenItemClass.Parts.EndText;
+				default:
+					return ThemeConstants.GenItemClass.Parts.SubText;
+			}
+		}
+
+		public static string GetSwitchCellRendererStyle()
+		{
+			return Device.Idiom == TargetIdiom.Watch ? ThemeConstants.GenItemClass.Styles.Watch.Text1Icon1 : ThemeConstants.GenItemClass.Styles.Default;
+		}
+
+		public static string GetSwitchPart(this SwitchCellRenderer switchCell)
+		{
+			return Device.Idiom == TargetIdiom.Watch ? ThemeConstants.GenItemClass.Parts.Watch.Icon : ThemeConstants.GenItemClass.Parts.End;
+		}
+
+		public static int GetDefaultHeightPixel(this EntryCellRenderer entryCell)
+		{
+			return Forms.ConvertToScaledPixel(ThemeConstants.EntryCell.Resources.DefaultHeight);
+		}
+
+		public static string GetImageCellRendererStyle()
+		{
+			return Device.Idiom == TargetIdiom.Watch ? ThemeConstants.GenItemClass.Styles.Watch.Icon2Text : Device.Idiom == TargetIdiom.TV ? ThemeConstants.GenItemClass.Styles.Default : ThemeConstants.GenItemClass.Styles.DoubleLabel;
+		} 
+
+		public static string GetImagePart(this ImageCellRenderer imageCell)
+		{
+			return Device.Idiom == TargetIdiom.Watch ? ThemeConstants.GenItemClass.Parts.Watch.Icon : ThemeConstants.GenItemClass.Parts.Icon;
+		}
+
+		public static int GetDefaultHeightPixel(this ImageCellRenderer imageCell)
+		{
+			return Forms.ConvertToScaledPixel(ThemeConstants.ImageCell.Resources.DefaultHeight);
+		}
+
+		public static string GetViewCellRendererStyle()
+		{
+			return ThemeConstants.GenItemClass.Styles.Full;
+		}
+
+		public static string GetMainContentPart(this ViewCellRenderer viewCell)
+		{
+			return ThemeConstants.GenItemClass.Parts.Content;
+		}
+		#endregion
+
+		#region GenItemClass
+		//public static string GetMainPart()
+		#endregion
+
+		#region GenList
+		public static GenList SetSolidStyle(this GenList list)
+		{
+			list.Style = ThemeConstants.GenList.Styles.Solid;
+			return list;
+		}
+		#endregion
+
+		#region GenListItem
+		public static void SetBottomlineColor(this GenListItem item, EColor color)
+		{
+			item.SetPartColor(ThemeConstants.GenListItem.ColorClass.BottomLine, color);
+		}
+
+		public static void SetBackgroundColor(this GenListItem item, EColor color)
+		{
+			item.SetPartColor(ThemeConstants.GenListItem.ColorClass.Background, color);
+		}
+
+		public static void DeleteBottomlineColor(this GenListItem item)
+		{
+			item.DeletePartColor(ThemeConstants.GenListItem.ColorClass.BottomLine);
+		}
+
+		public static void DeleteBackgroundColor(this GenListItem item)
+		{
+			item.DeletePartColor(ThemeConstants.GenListItem.ColorClass.Background);
+		}
+		#endregion
+
+		#region Radio
+		public static ESize GetTextBlockFormattedSize(this Radio radio)
+		{
+			return radio.EdjeObject[ThemeConstants.Common.Parts.Text].TextBlockFormattedSize;
+		}
+
+		public static void SetTextBlockStyle(this Radio radio, string style)
+		{
+			var textBlock = radio.EdjeObject[ThemeConstants.Common.Parts.Text];
+			if (textBlock != null)
+			{
+				textBlock.TextStyle = style;
+			}
+		}
+
+		public static void SendTextVisibleSignal(this Radio radio, bool isVisible)
+		{
+			radio.SignalEmit(isVisible ? ThemeConstants.Radio.Signals.TextVisibleState : ThemeConstants.Radio.Signals.TextHiddenState, ThemeConstants.Radio.Signals.ElementaryCode);
+		}
+		#endregion
+
+		#region Slider
+		public static EColor GetBarColor(this ESlider slider)
+		{
+			return slider.GetPartColor(ThemeConstants.Slider.ColorClass.Bar);
+		}
+
+		public static void SetBarColor(this ESlider slider, EColor color)
+		{
+			slider.SetPartColor(ThemeConstants.Slider.ColorClass.Bar, color);
+			slider.SetPartColor(ThemeConstants.Slider.ColorClass.BarPressed, color);
+		}
+
+		public static EColor GetBackgroundColor(this ESlider slider)
+		{
+			return slider.GetPartColor(ThemeConstants.Slider.ColorClass.Background);
+		}
+
+		public static void SetBackgroundColor(this ESlider slider, EColor color)
+		{
+			slider.SetPartColor(ThemeConstants.Slider.ColorClass.Background, color);
+		}
+
+		public static EColor GetHandlerColor(this ESlider slider)
+		{
+			return slider.GetPartColor(ThemeConstants.Slider.ColorClass.Handler);
+		}
+
+		public static void SetHandlerColor(this ESlider slider, EColor color)
+		{
+			slider.SetPartColor(ThemeConstants.Slider.ColorClass.Handler, color);
+			slider.SetPartColor(ThemeConstants.Slider.ColorClass.HandlerPressed, color);
+		}
+		#endregion
+
+		#region Index
+		public static Index SetStyledIndex(this Index index)
+		{
+			index.Style = Device.Idiom == TargetIdiom.Watch ? ThemeConstants.Index.Styles.Circle : ThemeConstants.Index.Styles.PageControl;
+			return index;
+		}
+		#endregion
+
+		#region IndexItem
+		public static void SetIndexItemStyle(this IndexItem item, int itemCount, int offset, int evenMiddleItem, int oddMiddleItem)
+		{
+			string style;
+			int position;
+
+			if (itemCount % 2 == 0)  //Item count is even.
+			{
+				position = evenMiddleItem - itemCount / 2 + offset;
+				style = ThemeConstants.IndexItem.Styles.EvenItemPrefix + position;
+			}
+			else  //Item count is odd.
+			{
+				position = oddMiddleItem - itemCount / 2 + offset;
+				style = ThemeConstants.IndexItem.Styles.OddItemPrefix + position;
+			}
+			item.Style = style;
+		}
+		#endregion
+
+		#region CircleSpinner
+		public static bool SetTitleTextPart(this CircleSpinner spinner, string title)
+		{
+			return spinner.SetPartText(ThemeConstants.Common.Parts.Text, title);
+		}
+		#endregion
+
+	}
+}


### PR DESCRIPTION
### Description of Change ###

This PR adds a theme manager to efficiently and consistently manage values (parts, styles, etc.) that are dependent on the platform theme file from various profiles (Phone, TV, Watch, and so on) and Tizen products.

The constant values provided from the platform theme file (*.edc) are unified and managed through the `ThemeConstants` class.  The `ThemeConstants` is composed of `Style`, `Part`, `Signal`, `Resource`, and `ColorClass` for each widget, and each item is also subdivided according to TargetIdiom.

`ThemeManager` is also newly added to make the each renderer implementation simpler and more intuitive. Instead of inconsistently hard-coded values in each renderer, you can use convenient and abstract utility methods provided by `ThemeManager`.

### Issues Resolved ### 
None

### API Changes ###
`namespace Xamarin.Forms.Platform.Tizen`
Added:
 - class ThemeConstants
 - class ThemeManager
 - class FormsLayout and it's subclasses

`namespace Xamarin.Forms.Platform.Tizen`
Added:
 - class FormsWatchLayout and it's subclasses

### Platforms Affected ### 
-Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
