### PR TITLE
[Tizen] Fix ShellSectionNavigation

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionNavigation.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionNavigation.cs
@@ -179,10 +179,13 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		EvasObject GetOrCreatePage(Page page)
 		{
-			Native.Page native = Platform.GetOrCreateRenderer(page).NativeView as Native.Page;
+			var native = Platform.GetOrCreateRenderer(page).NativeView;
 			_pageToNative[page] = native;
 			_nativeToPage[native] = page;
-			native.BackgroundColor = (page.BackgroundColor != Xamarin.Forms.Color.Default ? page.BackgroundColor.ToNative() : ElmSharp.Color.White);
+			if(native is Native.Page np)
+			{
+				np.BackgroundColor = (page.BackgroundColor != Xamarin.Forms.Color.Default ? page.BackgroundColor.ToNative() : ElmSharp.Color.White);
+			}
 			PackEnd(native);
 			return native;
 		}


### PR DESCRIPTION
### Description of Change ###

`Shell` is only for `ContentPage`.
But an `ArgumentNullException` has occured when used with multi-page.
This patch is intended to prevent a crash in the following cases on `Tizen` platform.
`Shell` with `CarouselPage`, `TabbedPage`, `NavigationPage`, `MasterDetailPage`.

### Issues Resolved ### 

- fixes #

### API Changes ###
 
 None

### Platforms Affected ### 

- Tizen

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

`Shell` with `CarouselPage`, `TabbedPage`, `NavigationPage`, `MasterDetailPage`.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
