### PR TITLE
[Core] Notify changes in a GradientStop (Color, Offset) 

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientsGallery.cs
@@ -58,6 +58,8 @@
 						new RadialGradientExplorerGallery(), Navigation),
 					GalleryBuilder.NavButton("Bindable Brush Gallery", () =>
 						new BindableBrushGallery(), Navigation),
+					GalleryBuilder.NavButton("Update Brush Colors Gallery", () =>
+						new UpdateGradientColorGallery(), Navigation),
 					GalleryBuilder.NavButton("Animate Brush Gallery", () =>
 						new AnimateBrushGallery(), Navigation),
 					navigationBarButton,

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml
@@ -7,6 +7,8 @@
     <ContentPage.Content>
         <StackLayout
             Padding="12">
+            <Label
+                Text="SolidColorBrush"/>
             <Frame
                 BorderColor="LightGray"
                 HasShadow="True"
@@ -14,7 +16,22 @@
                 HeightRequest="120"
                 WidthRequest="120">
                 <Frame.Background>
-                    <LinearGradientBrush x:Name="linearBrush" StartPoint="0,1" EndPoint="0,0">
+                    <SolidColorBrush x:Name="SolidBrush" Color="Red" />
+                </Frame.Background>
+            </Frame>
+            <Button
+                Text="Update Color"
+                Clicked="OnUpdateSolidColorClicked"/>
+            <Label
+                Text="LinearGradientBrush"/>
+            <Frame
+                BorderColor="LightGray"
+                HasShadow="True"
+                CornerRadius="12"
+                HeightRequest="120"
+                WidthRequest="120">
+                <Frame.Background>
+                    <LinearGradientBrush x:Name="LinearBrush" StartPoint="0,1" EndPoint="0,0">
                         <GradientStop Color="Blue" Offset="0.3"/>
                         <GradientStop Color="Purple" Offset="0.6"/>
                         <GradientStop Color="Green" Offset="0.9"/>
@@ -23,7 +40,26 @@
             </Frame>
             <Button
                 Text="Update Colors"
-                Clicked="OnUpdateColorsClicked"/>
+                Clicked="OnUpdateLinearColorsClicked"/>
+            <Label
+                Text="RadialGradientBrush"/>
+            <Frame
+                BorderColor="LightGray"
+                HasShadow="True"
+                CornerRadius="12"
+                HeightRequest="120"
+                WidthRequest="120">
+                <Frame.Background>
+                    <RadialGradientBrush x:Name="RadialBrush" Center="0.5, 0.5" Radius="60">
+                        <GradientStop Color="Blue" Offset="0.3"/>
+                        <GradientStop Color="Purple" Offset="0.6"/>
+                        <GradientStop Color="Green" Offset="0.9"/>
+                    </RadialGradientBrush>
+                </Frame.Background>
+            </Frame>
+            <Button
+                Text="Update Colors"
+                Clicked="OnUpdateRadialColorsClicked"/>
         </StackLayout>
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.GradientGalleries.UpdateGradientColorGallery"
+    Title="Update Gradient Color Gallery">
+    <ContentPage.Content>
+        <StackLayout
+            Padding="12">
+            <Frame
+                BorderColor="LightGray"
+                HasShadow="True"
+                CornerRadius="12"
+                HeightRequest="120"
+                WidthRequest="120">
+                <Frame.Background>
+                    <LinearGradientBrush x:Name="linearBrush" StartPoint="0,1" EndPoint="0,0">
+                        <GradientStop Color="Blue" Offset="0.3"/>
+                        <GradientStop Color="Purple" Offset="0.6"/>
+                        <GradientStop Color="Green" Offset="0.9"/>
+                    </LinearGradientBrush>
+                </Frame.Background>
+            </Frame>
+            <Button
+                Text="Update Colors"
+                Clicked="OnUpdateColorsClicked"/>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml.cs
@@ -12,9 +12,20 @@ namespace Xamarin.Forms.Controls.GalleryPages.GradientGalleries
 			_random = new Random();
 		}
 
-		void OnUpdateColorsClicked(object sender, EventArgs e)
+		void OnUpdateSolidColorClicked(object sender, EventArgs e)
 		{
-			GradientStop firstStop = linearBrush.GradientStops[GetRandomGradientStop()];
+			SolidBrush.Color = GetRandomColor();
+		}
+
+		void OnUpdateLinearColorsClicked(object sender, EventArgs e)
+		{
+			GradientStop randomStop = LinearBrush.GradientStops[GetRandomGradientStop()];
+			randomStop.Color = GetRandomColor();
+		}
+
+		void OnUpdateRadialColorsClicked(object sender, EventArgs e)
+		{
+			GradientStop firstStop = RadialBrush.GradientStops[GetRandomGradientStop()];
 			firstStop.Color = GetRandomColor();
 		}
 

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/UpdateGradientColorGallery.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.GradientGalleries
+{
+	public partial class UpdateGradientColorGallery : ContentPage
+	{
+		readonly Random _random;
+
+		public UpdateGradientColorGallery()
+		{
+			InitializeComponent();
+			_random = new Random();
+		}
+
+		void OnUpdateColorsClicked(object sender, EventArgs e)
+		{
+			GradientStop firstStop = linearBrush.GradientStops[GetRandomGradientStop()];
+			firstStop.Color = GetRandomColor();
+		}
+
+		int GetRandomGradientStop()
+		{
+			return _random.Next(3);
+		}
+
+		Color GetRandomColor()
+		{
+			return Color.FromRgb(_random.Next(256), _random.Next(256), _random.Next(256));
+		}
+	}
+}

--- a/Xamarin.Forms.Core/GradientBrush.cs
+++ b/Xamarin.Forms.Core/GradientBrush.cs
@@ -1,4 +1,7 @@
-﻿using System.Runtime.CompilerServices;
+﻿using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -14,6 +17,8 @@ namespace Xamarin.Forms
 			GradientStops = new GradientStopCollection();
 		}
 
+		public event EventHandler InvalidateGradientBrushRequested;
+
 		internal static void VerifyExperimental([CallerMemberName] string memberName = "", string constructorHint = null)
 		{
 			if (IsExperimentalFlagSet)
@@ -24,13 +29,79 @@ namespace Xamarin.Forms
 			IsExperimentalFlagSet = true;
 		}
 
-		public static readonly BindableProperty GradientStopsProperty = BindableProperty.Create(
-			nameof(GradientStops), typeof(GradientStopCollection), typeof(GradientBrush), null);
+		public static readonly BindableProperty GradientStopsProperty =
+			BindableProperty.Create(nameof(GradientStops), typeof(GradientStopCollection), typeof(GradientBrush), null,
+				propertyChanged: OnGradientStopsChanged);
 
 		public GradientStopCollection GradientStops
 		{
 			get => (GradientStopCollection)GetValue(GradientStopsProperty);
 			set => SetValue(GradientStopsProperty, value);
+		}
+
+		static void OnGradientStopsChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			(bindable as GradientBrush)?.UpdateGradientStops(oldValue as GradientStopCollection, newValue as GradientStopCollection);
+		}
+
+		void UpdateGradientStops(GradientStopCollection oldCollection, GradientStopCollection newCollection)
+		{
+			if (oldCollection != null)
+			{
+				oldCollection.CollectionChanged -= OnGradientStopCollectionChanged;
+
+				foreach (var oldStop in oldCollection)
+				{
+					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
+				}
+			}
+
+			if (newCollection == null)
+				return;
+
+			newCollection.CollectionChanged += OnGradientStopCollectionChanged;
+
+			foreach (var newStop in newCollection)
+			{
+				newStop.PropertyChanged += OnGradientStopPropertyChanged;
+			}
+		}
+
+		void OnGradientStopCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			if (e.OldItems != null)
+			{
+				foreach (var oldItem in e.OldItems)
+				{
+					if (!(oldItem is GradientStop oldStop))
+						continue;
+
+					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
+				}
+			}
+
+			if (e.NewItems != null)
+			{
+				foreach (var newItem in e.NewItems)
+				{
+					if (!(newItem is GradientStop newStop))
+						continue;
+
+					newStop.PropertyChanged += OnGradientStopPropertyChanged;
+				}
+			}
+
+			Invalidate();
+		}
+
+		void OnGradientStopPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			Invalidate();
+		}
+
+		void Invalidate()
+		{
+			InvalidateGradientBrushRequested?.Invoke(this, EventArgs.Empty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -171,8 +171,10 @@ namespace Xamarin.Forms
 		{
 			if (Background != null)
 			{
-				Background.PropertyChanging += OnBackgroundChanging;
 				Background.PropertyChanged += OnBackgroundChanged;
+
+				if (Background is GradientBrush gradientBrush)
+					gradientBrush.InvalidateGradientBrushRequested += InvalidateGradientBrushRequested;
 			}
 		}
 
@@ -181,16 +183,18 @@ namespace Xamarin.Forms
 			if (Background != null)
 			{
 				Background.PropertyChanged -= OnBackgroundChanged;
-				Background.PropertyChanging -= OnBackgroundChanging;
+
+				if (Background is GradientBrush gradientBrush)
+					gradientBrush.InvalidateGradientBrushRequested -= InvalidateGradientBrushRequested;
 			}
 		}
 
-		void OnBackgroundChanging(object sender, PropertyChangingEventArgs e)
+		void OnBackgroundChanged(object sender, PropertyChangedEventArgs e)
 		{
-			OnPropertyChanging(nameof(Background));
+			OnPropertyChanged(nameof(Background));
 		}
 
-		void OnBackgroundChanged(object sender, PropertyChangedEventArgs e)
+		void InvalidateGradientBrushRequested(object sender, EventArgs e)
 		{
 			OnPropertyChanged(nameof(Background));
 		}


### PR DESCRIPTION
### Description of Change ###

Detect GradientStop changes and update the Brush.

### Fixes ###

- fixes #11898 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix-gradientstop-changes](https://user-images.githubusercontent.com/6755973/90246960-ec75d680-de35-11ea-9867-e59b02447517.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the brushes gallery. Select the Gallery "Update Brush Colors Gallery" and tap the "Update Colors" Button. If the GradientBrush is updated, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
