### PR TITLE
When navigating between Shell Items disconnect the renderers from the xplat elements

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11723.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11723.cs
@@ -1,0 +1,122 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+using System.Runtime.CompilerServices;
+using System.Linq;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11723, "[Bug] ContentPage in NavigationStack misplaced initially",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11723 : TestShell
+	{
+		ContentPage CreateContentPage()
+		{
+			var page = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "As you navigate this text should show up in the correct spot. If it's hidden and then shows up this test has failed."
+						},
+						new Label()
+						{
+							AutomationId = "LabelResult"
+						},
+						new Button()
+						{
+							Text = "Push Page",
+							AutomationId = "PushPage",
+							Command = new Command(async () =>
+							{
+								await Navigation.PushAsync(CreateContentPage());
+							})
+						}
+					}
+				}
+			};
+
+			page.PropertyChanged += OnPagePropertyChanged;
+			return page;
+		}
+
+		bool navigated = false;
+		protected override void OnNavigating(ShellNavigatingEventArgs args)
+		{
+			navigated = false;
+			base.OnNavigating(args);
+		}
+
+		protected override void OnNavigated(ShellNavigatedEventArgs args)
+		{
+			base.OnNavigated(args);
+			Device.BeginInvokeOnMainThread(() => navigated = true);
+		}
+
+		void OnPagePropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if(sender is ContentPage page && e.PropertyName == "Padding")
+			{
+				page.PropertyChanged -= OnPagePropertyChanged;
+
+				var label = page.Content
+					.LogicalChildren
+					.OfType<Label>()
+					.First(x=> x.AutomationId == "LabelResult");
+
+				if (navigated)
+				{
+					label.Text = "Failed";
+				}
+				else
+				{
+					label.Text = "Success";
+				}
+			}
+		}
+
+		protected override void Init()
+		{
+			AddContentPage(CreateContentPage());
+		}
+
+
+#if UITEST
+		[Test]
+		public void PaddingIsSetOnPageBeforeItsVisible()
+		{
+			RunningApp.WaitForElement("Success");
+			RunningApp.WaitForElement("PushPage");
+			RunningApp.WaitForElement("Success");
+			RunningApp.WaitForElement("PushPage");
+			RunningApp.WaitForElement("Success");
+			RunningApp.WaitForElement("PushPage");
+			TapBackArrow();
+			RunningApp.WaitForElement("PushPage");
+			TapBackArrow();
+			RunningApp.WaitForElement("PushPage");
+			TapBackArrow();
+			RunningApp.WaitForElement("PushPage");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11723.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11723.cs
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 
-#if UITEST && __IOS__
+#if UITEST
 		[Test]
 		public void PaddingIsSetOnPageBeforeItsVisible()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11723.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11723.cs
@@ -105,17 +105,17 @@ namespace Xamarin.Forms.Controls.Issues
 		public void PaddingIsSetOnPageBeforeItsVisible()
 		{
 			RunningApp.WaitForElement("Success");
-			RunningApp.WaitForElement("PushPage");
+			RunningApp.Tap("PushPage");
 			RunningApp.WaitForElement("Success");
-			RunningApp.WaitForElement("PushPage");
+			RunningApp.Tap("PushPage");
 			RunningApp.WaitForElement("Success");
-			RunningApp.WaitForElement("PushPage");
+			RunningApp.Tap("PushPage");
 			TapBackArrow();
-			RunningApp.WaitForElement("PushPage");
+			RunningApp.WaitForElement("Success");
 			TapBackArrow();
-			RunningApp.WaitForElement("PushPage");
+			RunningApp.WaitForElement("Success");
 			TapBackArrow();
-			RunningApp.WaitForElement("PushPage");
+			RunningApp.WaitForElement("Success");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1445,6 +1445,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10608.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11723.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/EventTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/EventTracker.cs
@@ -57,6 +57,12 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 		}
 
+		internal void Disconnect()
+		{
+			if (ElementGestureRecognizers != null)
+				ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
+		}
+
 		public void Dispose()
 		{
 			if (_disposed)
@@ -75,8 +81,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			_gestureRecognizers.Clear();
 
-			if (ElementGestureRecognizers != null)
-				ElementGestureRecognizers.CollectionChanged -= _collectionChangedHandler;
+			Disconnect();
 
 			_handler = null;
 		}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -27,6 +27,15 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 #endif
 				var view = bindable as VisualElement;
+
+
+#if DEBUG
+				if (view.IsPlatformEnabled && newvalue != null)
+				{
+					
+				}
+#endif
+
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
 			});

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -27,15 +27,6 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 #endif
 				var view = bindable as VisualElement;
-
-
-#if DEBUG
-				if (view.IsPlatformEnabled && newvalue != null)
-				{
-					
-				}
-#endif
-
 				if (view != null)
 					view.IsPlatformEnabled = newvalue != null;
 			});

--- a/Xamarin.Forms.Platform.iOS/Renderers/IDisconnectable.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IDisconnectable.cs
@@ -1,0 +1,8 @@
+﻿using System;
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal interface IDisconnectable
+	{
+		void Disconnect();
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -398,9 +398,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!IsPartOfShell && !Forms.IsiOS11OrNewer)
 				return;
 
-			if (IsPartOfShell && !_appeared)
-				return;
-
 			var tabThickness = _tabThickness;
 			if (!_isInItems)
 				tabThickness = 0;

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -172,7 +172,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLayoutSubviews();
 
-			if (_disposed)
+			if (_disposed || Element == null)
 				return;
 
 			if (Element.Parent is BaseShellItem)
@@ -195,7 +195,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidAppear(animated);
 
-			if (_appeared || _disposed)
+			if (_appeared || _disposed || Element == null)
 				return;
 
 			_appeared = true;
@@ -213,7 +213,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidDisappear(animated);
 
-			if (!_appeared || _disposed)
+			if (!_appeared || _disposed || Element == null)
 				return;
 
 			_appeared = false;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -10,7 +10,7 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class ShellItemRenderer : UITabBarController, IShellItemRenderer, IAppearanceObserver, IUINavigationControllerDelegate
+	public class ShellItemRenderer : UITabBarController, IShellItemRenderer, IAppearanceObserver, IUINavigationControllerDelegate, IDisconnectable
 	{
 		#region IShellItemRenderer
 
@@ -113,36 +113,60 @@ namespace Xamarin.Forms.Platform.iOS
 			};
 		}
 
+		void IDisconnectable.Disconnect()
+		{
+			if (_sectionRenderers != null)
+			{
+				foreach (var kvp in _sectionRenderers.ToList())
+				{
+					var renderer = kvp.Value as IDisconnectable;
+					renderer?.Disconnect();
+					kvp.Value.ShellSection.PropertyChanged -= OnShellSectionPropertyChanged;
+				}
+			}
+
+			if (_displayedPage != null)
+				_displayedPage.PropertyChanged -= OnDisplayedPagePropertyChanged;
+
+			if (_currentSection != null)
+				((IShellSectionController)_currentSection).RemoveDisplayedPageObserver(this);
+
+
+			if(ShellItem != null)
+				ShellItem.PropertyChanged -= OnElementPropertyChanged;
+
+			if(_context?.Shell is IShellController shellController)
+				shellController.RemoveAppearanceObserver(this);
+
+			if(ShellItemController != null)
+				ShellItemController.ItemsCollectionChanged -= OnItemsCollectionChanged;
+		}
+
 		protected override void Dispose(bool disposing)
 		{
-			base.Dispose(disposing);
+			if (_disposed)
+				return;
 
-			if (disposing && !_disposed)
+			_disposed = true;
+
+			if (disposing)
 			{
-				_disposed = true;
+				(this as IDisconnectable).Disconnect();
+
 				foreach (var kvp in _sectionRenderers.ToList())
 				{
 					var renderer = kvp.Value;
 					RemoveRenderer(renderer);
 				}
 
-				if (_displayedPage != null)
-					_displayedPage.PropertyChanged -= OnDisplayedPagePropertyChanged;
-
-				if (_currentSection != null)
-					((IShellSectionController)_currentSection).RemoveDisplayedPageObserver(this);
-
-
 				_sectionRenderers.Clear();
-				ShellItem.PropertyChanged -= OnElementPropertyChanged;
-				((IShellController)_context.Shell).RemoveAppearanceObserver(this);
-				ShellItemController.ItemsCollectionChanged -= OnItemsCollectionChanged;
-
 				CurrentRenderer = null;
 				_shellItem = null;
 				_currentSection = null;
 				_displayedPage = null;
 			}
+
+			base.Dispose(disposing);
 		}
 
 		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemTransition.cs
@@ -10,6 +10,7 @@ namespace Xamarin.Forms.Platform.iOS
 			TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
 			var oldView = oldRenderer.ViewController.View;
 			var newView = newRenderer.ViewController.View;
+			oldView.Layer.RemoveAllAnimations();
 			newView.Alpha = 0;
 
 			newView.Superview.InsertSubviewAbove(newView, oldView);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -249,6 +249,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected async void SetCurrentShellItemController(IShellItemRenderer value)
 		{
 			var oldRenderer = _currentShellItemRenderer;
+			(oldRenderer as IDisconnectable)?.Disconnect();
 			var newRenderer = value;
 
 			_currentShellItemRenderer = value;
@@ -258,7 +259,7 @@ namespace Xamarin.Forms.Platform.iOS
 			View.SendSubviewToBack(newRenderer.ViewController.View);
 
 			newRenderer.ViewController.View.Frame = View.Bounds;
-
+			
 			if (oldRenderer != null)
 			{
 				var transition = CreateShellItemTransition();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -11,7 +11,7 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class ShellSectionRenderer : UINavigationController, IShellSectionRenderer, IAppearanceObserver
+	public class ShellSectionRenderer : UINavigationController, IShellSectionRenderer, IAppearanceObserver, IDisconnectable
 	{
 		#region IShellContentRenderer
 
@@ -171,6 +171,31 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateFlowDirection();
 		}
 
+
+
+		void IDisconnectable.Disconnect()
+		{
+			(_renderer as IDisconnectable)?.Disconnect();
+
+			if (_displayedPage != null)
+				_displayedPage.PropertyChanged -= OnDisplayedPagePropertyChanged;
+
+			if (_shellSection != null)
+			{
+				_shellSection.PropertyChanged -= HandlePropertyChanged;
+				((IShellSectionController)ShellSection).NavigationRequested -= OnNavigationRequested;
+				((IShellSectionController)ShellSection).RemoveDisplayedPageObserver(this);
+			}
+
+
+			if (_context.Shell != null)
+			{
+				_context.Shell.PropertyChanged -= HandleShellPropertyChanged;
+				((IShellController)_context.Shell).RemoveAppearanceObserver(this);
+			}
+
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_disposed)
@@ -182,15 +207,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_disposed = true;
 				_renderer.Dispose();
 				_appearanceTracker.Dispose();
-				_shellSection.PropertyChanged -= HandlePropertyChanged;
-				_context.Shell.PropertyChanged -= HandleShellPropertyChanged;
-
-				if (_displayedPage != null)
-					_displayedPage.PropertyChanged -= OnDisplayedPagePropertyChanged;
-
-				((IShellSectionController)_shellSection).NavigationRequested -= OnNavigationRequested;
-				((IShellController)_context.Shell).RemoveAppearanceObserver(this);
-				((IShellSectionController)ShellSection).RemoveDisplayedPageObserver(this);
+				(this as IDisconnectable).Disconnect();
 
 				foreach (var tracker in ShellSection.Stack)
 				{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -7,7 +7,7 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class ShellSectionRootRenderer : UIViewController, IShellSectionRootRenderer
+	public class ShellSectionRootRenderer : UIViewController, IShellSectionRootRenderer, IDisconnectable
 	{
 		#region IShellSectionRootRenderer
 
@@ -117,17 +117,39 @@ namespace Xamarin.Forms.Platform.iOS
 			LayoutHeader();
 		}
 
+
+
+		void IDisconnectable.Disconnect()
+		{
+			if (ShellSection != null)
+				ShellSection.PropertyChanged -= OnShellSectionPropertyChanged;
+
+			if (ShellSectionController != null)
+				ShellSectionController.ItemsCollectionChanged -= OnShellSectionItemsChanged;
+
+			if (_shellContext?.Shell != null)
+				_shellContext.Shell.PropertyChanged -= HandleShellPropertyChanged;
+
+			if (_renderers != null)
+			{
+				foreach (var renderer in _renderers)
+				{
+					var oldRenderer = renderer.Value;
+					var element = oldRenderer.Element;
+					element?.ClearValue(Platform.RendererProperty);
+					(renderer.Value as IDisconnectable)?.Disconnect();
+				}
+			}
+		}
+
 		protected override void Dispose(bool disposing)
 		{
 			if (_isDisposed)
 				return;
 
-
 			if (disposing && ShellSection != null)
 			{
-				ShellSection.PropertyChanged -= OnShellSectionPropertyChanged;
-				ShellSectionController.ItemsCollectionChanged -= OnShellSectionItemsChanged;
-
+				(this as IDisconnectable).Disconnect();
 
 				this.RemoveFromParentViewController();
 
@@ -145,8 +167,8 @@ namespace Xamarin.Forms.Platform.iOS
 						oldRenderer.ViewController.RemoveFromParentViewController();
 
 					var element = oldRenderer.Element;
-					oldRenderer.Dispose();
 					element?.ClearValue(Platform.RendererProperty);
+					oldRenderer?.Dispose();
 				}
 
 				_renderers.Clear();
@@ -213,8 +235,8 @@ namespace Xamarin.Forms.Platform.iOS
 					contentItems = ShellSectionController.GetItems();
 				}
 
-				var renderer = Platform.CreateRenderer(page);
-				Platform.SetRenderer(page, renderer);
+				var renderer = SetPageRenderer(page, item);
+
 				AddChildViewController(renderer.ViewController);
 
 				if (item == currentItem)
@@ -223,8 +245,6 @@ namespace Xamarin.Forms.Platform.iOS
 					_currentContent = currentItem;
 					_currentIndex = i;
 				}
-
-				_renderers[item] = renderer;
 			}
 		}
 
@@ -402,13 +422,30 @@ namespace Xamarin.Forms.Platform.iOS
 						continue;
 
 					var page = ((IShellContentController)newItem).GetOrCreateContent();
-					var renderer = Platform.CreateRenderer(page);
-					Platform.SetRenderer(page, renderer);
+					var renderer = SetPageRenderer(page, newItem);
 
 					AddChildViewController(renderer.ViewController);
-					_renderers[newItem] = renderer;
 				}
 			}
+		}
+
+		IVisualElementRenderer SetPageRenderer(Page page, ShellContent shellContent)
+		{
+			var oldRenderer = Platform.GetRenderer(page);
+			if(oldRenderer != null)
+				oldRenderer?.Dispose();
+
+			var renderer = Platform.CreateRenderer(page);
+			Platform.SetRenderer(page, renderer);
+
+			if(_renderers.ContainsKey(shellContent))
+			{
+				throw new Exception("BAD");
+			}
+
+			_renderers[shellContent] = renderer;
+
+			return renderer;
 		}
 
 		void LayoutHeader()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -437,12 +437,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var renderer = Platform.CreateRenderer(page);
 			Platform.SetRenderer(page, renderer);
-
-			if(_renderers.ContainsKey(shellContent))
-			{
-				throw new Exception("BAD");
-			}
-
 			_renderers[shellContent] = renderer;
 
 			return renderer;

--- a/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementPackager.cs
@@ -49,6 +49,21 @@ namespace Xamarin.Forms.Platform.MacOS
 					OnChildAdded(child);
 			}
 		}
+		
+		internal void Disconnect()
+		{
+			Disconnect(_element);
+		}
+
+		void Disconnect(VisualElement oldElement)
+		{
+			if (oldElement == null)
+				return;
+
+			oldElement.ChildAdded -= OnChildAdded;
+			oldElement.ChildRemoved -= OnChildRemoved;
+			oldElement.ChildrenReordered -= UpdateChildrenOrder;
+		}
 
 		protected virtual void Dispose(bool disposing)
 		{
@@ -182,9 +197,7 @@ namespace Xamarin.Forms.Platform.MacOS
 
 			if (oldElement != null)
 			{
-				oldElement.ChildAdded -= OnChildAdded;
-				oldElement.ChildRemoved -= OnChildRemoved;
-				oldElement.ChildrenReordered -= UpdateChildrenOrder;
+				Disconnect(oldElement);
 
 				if (newElement != null)
 				{

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -65,6 +65,21 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		public event EventHandler NativeControlUpdated;
 
+		internal void Disconnect()
+		{
+			Disconnect(_element);
+		}
+
+		void Disconnect(VisualElement oldElement)
+		{
+			if (oldElement == null)
+				return;
+
+			oldElement.PropertyChanged -= _propertyChangedHandler;
+			oldElement.SizeChanged -= _sizeChangedEventHandler;
+			oldElement.BatchCommitted -= _batchCommittedHandler;
+		}
+
 		protected virtual void Dispose(bool disposing)
 		{
 			if (_disposed)
@@ -344,9 +359,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (oldElement != null)
 			{
-				oldElement.PropertyChanged -= _propertyChangedHandler;
-				oldElement.SizeChanged -= _sizeChangedEventHandler;
-				oldElement.BatchCommitted -= _batchCommittedHandler;
+				Disconnect(oldElement);
 			}
 
 			_element = newElement;

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -280,6 +280,7 @@
     <Compile Include="Shapes\PolygonRenderer.cs" />
     <Compile Include="Shapes\PolylineRenderer.cs" />
     <Compile Include="Shapes\RectangleRenderer.cs" />
+    <Compile Include="Renderers\IDisconnectable.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />


### PR DESCRIPTION
### Description of Change ###
When you navigate between FlyoutIItems on shell it uses a transition which doesn't dispose of the previous items until after the transition. If the user navigates between Flyout Items too quickly the previous animation hasn't completed so the renderer stack hasn't disposed. Because the renderer stack hasn't disposed the old renderers are still part of the old pages which causes a doubling up of renderers on the same page.

This PR attempts to disconnect all the communication points between the xplat components and the native components so that the native components can just finish their business in isolation without triggering any behavior from the xplat side of the code.

### Issues Resolved ### 
- fixes #11784
- fixes #11777

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
