### PR TITLE
[Android] Update gradients based on offset changes in Frame and BoxView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11795">
+    <controls:TestContentPage.Resources>
+        <ResourceDictionary>
+
+            <LinearGradientBrush x:Key="LinearBrush" StartPoint="0, 0" EndPoint="1, 0">
+                <LinearGradientBrush.GradientStops>
+                    <GradientStop Color="YellowGreen" Offset="0.1"/>
+                    <GradientStop Color="Green" Offset="0.9"/>
+                </LinearGradientBrush.GradientStops>
+            </LinearGradientBrush>
+
+            <Style TargetType="Slider">
+                <Setter Property="MinimumTrackColor" Value="LightGray" />
+                <Setter Property="MaximumTrackColor" Value="Gray" />
+            </Style>
+
+        </ResourceDictionary>
+    </controls:TestContentPage.Resources>
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Modify the Brush Offset values. If you modify the gradient, the test has passed."/>
+          <Grid>
+              <!-- EXPLORER -->
+              <Grid>
+                  <Grid.RowDefinitions>
+                      <RowDefinition Height="Auto" />
+                      <RowDefinition Height="*" />
+                  </Grid.RowDefinitions>
+                  <Grid
+                      Grid.Row="0"
+                      Margin="12, 0"
+                      Padding="12">
+                      <Frame
+                          x:Name="GradientView"
+                          HasShadow="True"
+                          HeightRequest="120"
+                          WidthRequest="120"
+                          CornerRadius="12"
+                          Background="{StaticResource LinearBrush}">
+                          <Grid>
+                              <Label
+                                  HorizontalOptions="Center"
+                                  VerticalOptions="Center"
+                                  Text="LinearGradientBrush"/>
+                          </Grid>
+                      </Frame>
+                  </Grid>
+                  <ScrollView
+                      Grid.Row="1"
+                      Margin="12, 0"
+                      Padding="12">
+                     <StackLayout>
+                         <Label
+                             Text="Color 1 Offset"/>
+                         <Slider
+                             x:Name="Offset1Slider"
+                             Minimum="0.0"
+                             Maximum="1.0"
+                             Value="0.1"
+                             ValueChanged="OnOffset1SliderValueChanged"/>
+                         <Label
+                             Text="Color 2 Offset"/>
+                         <Slider
+                             x:Name="Offset2Slider"
+                             Minimum="0.0"
+                             Margin="1.0"
+                             Value="0.9"
+                             ValueChanged="OnOffset2SliderValueChanged"/>
+                      </StackLayout>
+                  </ScrollView>
+              </Grid>
+          </Grid>
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml
@@ -6,6 +6,7 @@
     xmlns:d="http://xamarin.com/schemas/2014/forms/design"
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
+    Title="Issue 11795"
     x:Class="Xamarin.Forms.Controls.Issues.Issue11795">
     <controls:TestContentPage.Resources>
         <ResourceDictionary>
@@ -37,12 +38,22 @@
                       <RowDefinition Height="Auto" />
                       <RowDefinition Height="*" />
                   </Grid.RowDefinitions>
-                  <Grid
+                  <StackLayout
                       Grid.Row="0"
                       Margin="12, 0"
                       Padding="12">
+                      <Label
+                          Text="BoxView"/>
+                      <BoxView
+                          x:Name="GradientBoxView"
+                          HeightRequest="120"
+                          WidthRequest="120"
+                          CornerRadius="12"
+                          Background="{StaticResource LinearBrush}"/>
+                      <Label
+                          Text="Frame"/>
                       <Frame
-                          x:Name="GradientView"
+                          x:Name="GradientFrame"
                           HasShadow="True"
                           HeightRequest="120"
                           WidthRequest="120"
@@ -55,7 +66,7 @@
                                   Text="LinearGradientBrush"/>
                           </Grid>
                       </Frame>
-                  </Grid>
+                  </StackLayout>
                   <ScrollView
                       Grid.Row="1"
                       Margin="12, 0"

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml.cs
@@ -1,0 +1,73 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Brush)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11795, "[Bug] Brushes API - gradient offset does nothing on Android", PlatformAffected.Android)]
+	public partial class Issue11795 : TestContentPage
+	{
+#if APP
+		float _offset1, _offset2;
+#endif
+		public Issue11795()
+		{
+#if APP
+			Title = "Issue 11795";
+			InitializeComponent();
+
+			_offset1 = 0.1f;
+			_offset2 = 0.9f;
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+#if APP
+		void OnOffset1SliderValueChanged(object sender, ValueChangedEventArgs e)
+		{
+			_offset1 = (float)e.NewValue;
+			UpdateBackground(_offset1, _offset2);
+		}
+
+		void OnOffset2SliderValueChanged(object sender, ValueChangedEventArgs e)
+		{
+			_offset2 = (float)e.NewValue;
+			UpdateBackground(_offset1, _offset2);
+		}
+
+		void UpdateBackground(float offset1, float offset2)
+		{
+			LinearGradientBrush linearGradient = new LinearGradientBrush
+			{
+				StartPoint = new Point(0, 0),
+				EndPoint = new Point(1, 0),
+				GradientStops = new GradientStopCollection
+				{
+					new GradientStop { Color = Color.YellowGreen, Offset = offset1 },
+					new GradientStop { Color = Color.Green, Offset = offset2 }
+				}
+			};
+
+			GradientView.Background = linearGradient;
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11795.xaml.cs
@@ -66,7 +66,8 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 
-			GradientView.Background = linearGradient;
+			GradientBoxView.Background = linearGradient;
+			GradientFrame.Background = linearGradient;
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1765,6 +1765,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12150.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12590.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2204,6 +2205,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13726.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11795.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialFrameRenderer.cs
@@ -1,8 +1,8 @@
-﻿
-using System;
+﻿using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Graphics.Drawables;
+using Android.Graphics.Drawables.Shapes;
 using Android.Views;
 using AndroidX.Core.View;
 using Xamarin.Forms.Platform.Android;
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Material.Android
 		readonly EffectControlProvider _effectControlProvider;
 		readonly MotionEventHelper _motionEventHelper;
 		Drawable _defaultBackgroundDrawable;
-		GradientDrawable _backgroundGradientDrawable;
+		GradientStrokeDrawable _backgroundGradientDrawable;
 
 		public MaterialFrameRenderer(Context context)
 			: base(MaterialContextThemeWrapper.Create(context))
@@ -265,11 +265,13 @@ namespace Xamarin.Forms.Material.Android
 				if (_defaultBackgroundDrawable == null)
 					_defaultBackgroundDrawable = Background;
 
-				_backgroundGradientDrawable = new GradientDrawable();
-				_backgroundGradientDrawable.SetShape(ShapeType.Rectangle);
+				_backgroundGradientDrawable = new GradientStrokeDrawable
+				{
+					Shape = new RectShape()
+				};
 
 				_backgroundGradientDrawable.SetCornerRadius(Radius);
-				_backgroundGradientDrawable.UpdateBackground(bgBrush, Height, Width);
+				_backgroundGradientDrawable.UpdateBackground(bgBrush);
 
 				Background = _backgroundGradientDrawable;
 			}

--- a/Xamarin.Forms.Platform.Android/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/BrushExtensions.cs
@@ -170,6 +170,22 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		public static void UpdateBackground(this GradientStrokeDrawable gradientStrokeDrawable, Brush brush)
+		{
+			if (gradientStrokeDrawable == null || brush == null || brush.IsEmpty)
+				return;
+
+			gradientStrokeDrawable.SetStroke(0, Color.Default.ToAndroid());
+
+			if (brush is SolidColorBrush solidColorBrush)
+			{
+				var color = solidColorBrush.Color.IsDefault ? Color.Default.ToAndroid() : solidColorBrush.Color.ToAndroid();
+				gradientStrokeDrawable.SetColor(color);
+			}
+			else
+				gradientStrokeDrawable.SetGradient(brush);
+		}
+
 		public static bool UseGradients(this GradientDrawable gradientDrawable)
 		{
 			if (!Forms.IsNougatOrNewer)
@@ -177,6 +193,17 @@ namespace Xamarin.Forms.Platform.Android
 
 			var colors = gradientDrawable.GetColors();
 			return colors != null && colors.Length > 1;
+		}
+
+		public static bool UseGradients(this GradientStrokeDrawable gradientDrawable)
+		{
+			if (!Forms.IsNougatOrNewer)
+				return false;
+
+			var color = gradientDrawable.GetColor();
+			var shaderFactory = gradientDrawable.GetShaderFactory();
+
+			return color != null || shaderFactory != null;
 		}
 
 		internal static bool IsValidGradient(GradientStopCollection gradients)

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -2,7 +2,7 @@ using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Graphics;
-using Android.Graphics.Drawables;
+using Android.Graphics.Drawables.Shapes;
 using Android.Views;
 using AndroidX.CardView.Widget;
 using AndroidX.Core.View;
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		bool _hasLayoutOccurred;
 		bool _disposed;
 		Frame _element;
-		GradientDrawable _backgroundDrawable;
+		GradientStrokeDrawable _backgroundDrawable;
 
 		VisualElementPackager _visualElementPackager;
 		VisualElementTracker _visualElementTracker;
@@ -176,8 +176,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (e.NewElement != null)
 			{
 				this.EnsureId();
-				_backgroundDrawable = new GradientDrawable();
-				_backgroundDrawable.SetShape(ShapeType.Rectangle);
+				_backgroundDrawable = new GradientStrokeDrawable
+				{
+					Shape = new RectShape()
+				};
 				this.SetBackground(_backgroundDrawable);
 
 				if (_visualElementTracker == null)
@@ -291,28 +293,32 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (_disposed)
 				return;
 
+			if (_backgroundDrawable.UseGradients())
+			{
+				_backgroundDrawable.Dispose();
+				_backgroundDrawable = null;
+				this.SetBackground(null);
+
+				_backgroundDrawable = new GradientStrokeDrawable
+				{
+					Shape = new RectShape()
+				};
+
+				this.SetBackground(_backgroundDrawable);
+				UpdateBorderColor();
+				UpdateCornerRadius();
+			}
+
 			Brush background = Element.Background;
 
 			if (Brush.IsNullOrEmpty(background))
-			{
-				if (_backgroundDrawable.UseGradients())
-				{
-					_backgroundDrawable.Dispose();
-					_backgroundDrawable = null;
-					this.SetBackground(null);
-
-					_backgroundDrawable = new GradientDrawable();
-					_backgroundDrawable.SetShape(ShapeType.Rectangle);
-					this.SetBackground(_backgroundDrawable);
-				}
-
 				UpdateBackgroundColor();
-			}
 			else
 			{
 				_height = Control.Height;
 				_width = Control.Width;
-				_backgroundDrawable.UpdateBackground(background, _height, _width);
+
+				_backgroundDrawable.UpdateBackground(background);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/GradientStrokeDrawable.cs
+++ b/Xamarin.Forms.Platform.Android/GradientStrokeDrawable.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.Android
 	public class GradientStrokeDrawable : PaintDrawable
 	{
 		readonly Paint _strokePaint;
-		AColor _backgroundColor;
+		AColor? _backgroundColor;
 
 		public GradientStrokeDrawable()
 		{
@@ -27,6 +27,14 @@ namespace Xamarin.Forms.Platform.Android
 			InvalidateSelf();
 		}
 
+		public AColor? GetColor()
+		{
+			if (_backgroundColor.HasValue)
+				return _backgroundColor.Value;
+
+			return null;
+		}
+
 		public void SetStroke(int strokeWidth, AColor strokeColor)
 		{
 			_strokePaint.StrokeWidth = strokeWidth;
@@ -36,6 +44,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void SetGradient(Brush brush)
 		{
+			_backgroundColor = null;
+
 			if (brush is LinearGradientBrush linearGradientBrush)
 			{
 				var p1 = linearGradientBrush.StartPoint;
@@ -74,8 +84,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnDraw(shape, canvas, paint);
 
-			if (_backgroundColor != null)
-				paint.Color = _backgroundColor;
+			if (_backgroundColor.HasValue)
+				paint.Color = _backgroundColor.Value;
 
 			shape.Draw(canvas, _strokePaint);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BoxRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Graphics.Drawables;
+using Android.Graphics.Drawables.Shapes;
 using Android.Views;
 
 namespace Xamarin.Forms.Platform.Android
@@ -9,7 +10,7 @@ namespace Xamarin.Forms.Platform.Android
 	public class BoxRenderer : VisualElementRenderer<BoxView>
 	{
 		bool _disposed;
-		GradientDrawable _backgroundDrawable;
+		GradientStrokeDrawable _backgroundDrawable;
 
 		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
 
@@ -80,11 +81,14 @@ namespace Xamarin.Forms.Platform.Android
 			if (!Brush.IsNullOrEmpty(brushToSet))
 			{
 				if (_backgroundDrawable != null)
-					_backgroundDrawable.UpdateBackground(brushToSet, Height, Width);
+					_backgroundDrawable.UpdateBackground(brushToSet);
 				else
 				{
-					_backgroundDrawable = new GradientDrawable();
-					_backgroundDrawable.UpdateBackground(brushToSet, Height, Width);
+					_backgroundDrawable = new GradientStrokeDrawable
+					{
+						Shape = new RectShape()
+					};
+					_backgroundDrawable.UpdateBackground(brushToSet);
 					this.SetBackground(_backgroundDrawable);
 				}
 			}
@@ -152,7 +156,10 @@ namespace Xamarin.Forms.Platform.Android
 			}
 			else
 			{
-				this.SetBackground(_backgroundDrawable = new GradientDrawable());
+				this.SetBackground(_backgroundDrawable = new GradientStrokeDrawable
+				{
+					Shape = new RectShape()
+				});
 				if (Background is GradientDrawable backgroundGradient)
 				{
 					var cornerRadii = new[] {


### PR DESCRIPTION
### Description of Change ###

Update gradients based on offset changes in Frame and BoxView on Android.
The problem was that both BoxView and Frame in Android used a **GradientDrawable** (it did not allow setting offsets except in API >= 29).

### Issues Resolved ### 

- fixes #11795 
- fixes #13493

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix11795](https://user-images.githubusercontent.com/6755973/90414433-120e1480-e0b0-11ea-89fa-27ff489c03db.gif)
_NOTE: It is difficult to see the changeS well with this gif quality, but to see it correctly the size is larger than allowed._

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11795.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
