### PR TITLE
Fix input for decimal/float/double and nullable

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github7996.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github7996.cs
@@ -1,0 +1,77 @@
+﻿using System.ComponentModel;
+using System.Globalization;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 7996, "Xamarin.Forms.Entry does not enter decimal when binding a float/double and decimal to it", PlatformAffected.Default)]
+	public class Issue7996 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var picker = new Picker();
+			picker.ItemsSource = new[]
+			{
+				new CultureInfo("de"),
+				new CultureInfo("en"),
+			};
+			picker.SelectedIndexChanged += (s, e) =>
+			{
+				if (picker.SelectedItem is CultureInfo culture)
+				{
+					CultureInfo.CurrentUICulture = culture;
+				}
+			};
+			var entry = new Entry();
+			entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModelIssue7996.MyDecimal), BindingMode.TwoWay));
+
+			var stackLayout = new StackLayout
+			{
+				Children =
+				{
+					picker,
+					entry
+				}
+			};
+
+			Content = stackLayout;
+			BindingContext = new ViewModelIssue7996();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue7996 : INotifyPropertyChanged
+	{
+
+		decimal? myDecimal = 4.2m;
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		public decimal? MyDecimal
+		{
+			get
+			{
+				return myDecimal;
+			}
+			set
+			{
+				myDecimal = value;
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(nameof(MyDecimal)));
+			}
+		}
+
+		public ViewModelIssue7996()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github7996.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github7996.cs
@@ -18,6 +18,12 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			var vm = new ViewModelIssue7996();
+			BindingContext = vm;
+			var textLabel1 = new Label
+			{
+				Text = "Select culture:"
+			};
 			var picker = new Picker();
 			picker.ItemsSource = new[]
 			{
@@ -31,20 +37,48 @@ namespace Xamarin.Forms.Controls.Issues
 					CultureInfo.CurrentUICulture = culture;
 				}
 			};
+			
+			var textLabel2 = new Label
+			{
+				Text = "Resolved Binding Value:"
+			};
+			var bindingLable = new Label();
+			bindingLable.SetBinding(Label.TextProperty, new Binding(nameof(ViewModelIssue7996.MyDecimal), BindingMode.TwoWay));
+
+			var textLabel3 = new Label
+			{
+				Text = "Actual Value:"
+			};
+			var bindingLable2 = new Label();
+			bindingLable2.SetBinding(Label.TextProperty, new Binding(nameof(ViewModelIssue7996.MyDecimal), BindingMode.TwoWay));
+
+			var textLabel4 = new Label
+			{
+				Text = "Enter a number and watch result:"
+			};
 			var entry = new Entry();
-			entry.SetBinding(Entry.TextProperty, new Binding(nameof(ViewModelIssue7996.MyDecimal), BindingMode.TwoWay));
+			entry.Text = vm.MyDecimal.ToString();
+			entry.TextChanged += (s, e) =>
+			{
+				bindingLable.Text = e.NewTextValue;
+			};
 
 			var stackLayout = new StackLayout
 			{
 				Children =
 				{
+					textLabel1,
 					picker,
-					entry
+					textLabel2,
+					bindingLable,
+					textLabel3,
+					bindingLable2,
+					textLabel4,
+					entry,
 				}
 			};
 
 			Content = stackLayout;
-			BindingContext = new ViewModelIssue7996();
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -969,6 +969,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue14544.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Github7996.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Core.UnitTests/BindingExpressionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingExpressionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -79,6 +80,53 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var binding = new Binding(path);
 			Assert.DoesNotThrow(() => new BindingExpression(binding, path));
+		}
+
+		static object[] TryConvertWithNumbersAndCulturesCases => new object[]
+		{
+			new object[]{ "4.2", new CultureInfo("en"), 4.2m },
+			new object[]{ "4,2", new CultureInfo("de"), 4.2m },
+			new object[]{ "-4.2", new CultureInfo("en"), -4.2m },
+			new object[]{ "-4,2", new CultureInfo("de"), -4.2m },
+
+			new object[]{ "4.2", new CultureInfo("en"), new decimal?(4.2m)},
+			new object[]{ "4,2", new CultureInfo("de"), new decimal?(4.2m) },
+			new object[]{ "-4.2", new CultureInfo("en"), new decimal?(-4.2m)},
+			new object[]{ "-4,2", new CultureInfo("de"), new decimal?(-4.2m) },
+
+			new object[]{ "4.2", new CultureInfo("en"), 4.2d },
+			new object[]{ "4,2", new CultureInfo("de"), 4.2d },
+			new object[]{ "-4.2", new CultureInfo("en"), -4.2d },
+			new object[]{ "-4,2", new CultureInfo("de"), -4.2d },
+
+			new object[]{ "4.2", new CultureInfo("en"), new double?(4.2d)},
+			new object[]{ "4,2", new CultureInfo("de"), new double?(4.2d) },
+			new object[]{ "-4.2", new CultureInfo("en"), new double?(-4.2d)},
+			new object[]{ "-4,2", new CultureInfo("de"), new double?(-4.2d) },
+
+			new object[]{ "4.2", new CultureInfo("en"), 4.2f },
+			new object[]{ "4,2", new CultureInfo("de"), 4.2f },
+			new object[]{ "-4.2", new CultureInfo("en"), -4.2f },
+			new object[]{ "-4,2", new CultureInfo("de"), -4.2f },
+
+			new object[]{ "4.2", new CultureInfo("en"), new float?(4.2f)},
+			new object[]{ "4,2", new CultureInfo("de"), new float?(4.2f) },
+			new object[]{ "-4.2", new CultureInfo("en"), new float?(-4.2f)},
+			new object[]{ "-4,2", new CultureInfo("de"), new float?(-4.2f) },
+
+			new object[]{ "4.", new CultureInfo("en"), "4." },
+			new object[]{ "4,", new CultureInfo("de"), "4," },
+			new object[]{ "-0", new CultureInfo("en"), "-0" },
+			new object[]{ "-0", new CultureInfo("de"), "-0" },
+		};
+
+		[TestCaseSource(nameof(TryConvertWithNumbersAndCulturesCases))]
+		public void TryConvertWithNumbersAndCultures(object inputString, CultureInfo culture, object expected)
+		{
+			CultureInfo.CurrentUICulture = culture;
+			BindingExpression.TryConvert(ref inputString, Entry.TextProperty, expected.GetType(), false);
+
+			Assert.AreEqual(expected, inputString);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -1998,21 +1998,22 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 #if !WINDOWS_PHONE
-		[TestCase("en-US"), TestCase("pt-PT")]
-		public void ConvertIsCultureInvariant(string culture)
+		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
+		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
+		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 
 			var slider = new Slider();
-			var vm = new MockViewModel { Text = "0.5" };
+			var vm = new MockViewModel { Text = sliderSetStringValue };
 			slider.BindingContext = vm;
 			slider.SetBinding(Slider.ValueProperty, "Text", BindingMode.TwoWay);
 
-			Assert.That(slider.Value, Is.EqualTo(0.5));
+			Assert.That(slider.Value, Is.EqualTo(sliderExpectedDoubleValue));
 
-			slider.Value = 0.9;
+			slider.Value = sliderSetDoubleValue;
 
-			Assert.That(vm.Text, Is.EqualTo("0.9"));
+			Assert.That(vm.Text, Is.EqualTo(sliderExpectedStringValue));
 		}
 #endif
 

--- a/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
@@ -1270,21 +1270,22 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 #if !WINDOWS_PHONE
-		[TestCase("en-US"), TestCase("pt-PT")]
-		public void ConvertIsCultureInvariant(string culture)
+		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
+		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
+		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 
 			var slider = new Slider();
-			var vm = new MockViewModel { Text = "0.5" };
+			var vm = new MockViewModel { Text = sliderSetStringValue };
 			slider.BindingContext = vm;
 			slider.SetBinding(Slider.ValueProperty, new TypedBinding<MockViewModel, string>(mvm => mvm.Text, (mvm, s) => mvm.Text = s, null) { Mode = BindingMode.TwoWay });
 
-			Assert.That(slider.Value, Is.EqualTo(0.5));
+			Assert.That(slider.Value, Is.EqualTo(sliderExpectedDoubleValue));
 
-			slider.Value = 0.9;
+			slider.Value = sliderSetDoubleValue;
 
-			Assert.That(vm.Text, Is.EqualTo("0.9"));
+			Assert.That(vm.Text, Is.EqualTo(sliderExpectedStringValue));
 		}
 #endif
 

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -455,13 +455,14 @@ namespace Xamarin.Forms
 			}
 
 			object original = value;
-			try
+			try 
 			{
+				convertTo = Nullable.GetUnderlyingType(convertTo) ?? convertTo;
+
 				var stringValue = value as string ?? string.Empty;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
-				if (stringValue.EndsWith(".", StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
-				{
+				if (stringValue.EndsWith(CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo)) {
 					value = original;
 					return false;
 				}
@@ -473,9 +474,8 @@ namespace Xamarin.Forms
 					return false;
 				}
 
-				convertTo = Nullable.GetUnderlyingType(convertTo) ?? convertTo;
+				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentUICulture);
 
-				value = Convert.ChangeType(value, convertTo, CultureInfo.InvariantCulture);
 				return true;
 			}
 			catch (Exception ex) when (ex is InvalidCastException || ex is FormatException || ex is InvalidOperationException || ex is OverflowException)


### PR DESCRIPTION
### Description of Change ###

The input for floating numbers had some errors in different cultures.
When using german for example, the decimal seperator is a ',' and not a dot.

You can also use Nullable Types now. Before the Decimal Seperator would be cut off for Nullables.

### Issues Resolved ### 

- fixes #7996 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
The user of an app can now use the correct decimal sperator for his language.


### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
I have tested this on android.
I added a UI Test to the Gallery (G7996).
Unfortunately i cant test this on other platforms right now.
I also added a new Unit Test to prove the behaviour.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
