### PR TITLE
[Android] Fix SwipeView with gestures issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml
@@ -19,7 +19,7 @@
             Padding="12"
             BackgroundColor="Black"
             TextColor="White"
-            Text="If you don't see a red line between each item when swipe, the test has passed."/>
+            Text="If tapping an item appear a dialog, the test has passed."/>
         <StackLayout
             Orientation="Vertical"
             BindableLayout.ItemsSource="{Binding Items}">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11496"
+    x:Name="Issue11496Page"
+    Title="Issue 11496">
+    <controls:TestContentPage.BindingContext>
+        <issues:Issue11496ViewModel />
+    </controls:TestContentPage.BindingContext>
+    <StackLayout
+        Padding="0">
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If you don't see a red line between each item when swipe, the test has passed."/>
+        <StackLayout
+            Orientation="Vertical"
+            BindableLayout.ItemsSource="{Binding Items}">
+            <BindableLayout.ItemTemplate>
+                <DataTemplate>
+                    <SwipeView>
+                        <SwipeView.RightItems>
+                            <SwipeItems>
+                                <SwipeItemView>
+                                    <StackLayout>
+                                        <Button
+                                            Text="Delete"
+                                            VerticalOptions="Fill"/>
+                                    </StackLayout>
+                                </SwipeItemView>
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                        <StackLayout
+                            HeightRequest="60"
+                            BackgroundColor="LightGray">
+                            <issues:Issue11496ItemControl 
+                                TestItem="{Binding}"
+                                HorizontalOptions="FillAndExpand"
+                                VerticalOptions="FillAndExpand"/>
+                        </StackLayout>
+                    </SwipeView>
+                </DataTemplate>
+            </BindableLayout.ItemTemplate>
+        </StackLayout>
+    </StackLayout> 
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml
@@ -49,5 +49,5 @@
                 </DataTemplate>
             </BindableLayout.ItemTemplate>
         </StackLayout>
-    </StackLayout> 
+    </StackLayout>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml.cs
@@ -31,26 +31,26 @@ namespace Xamarin.Forms.Controls.Issues
 			Device.SetFlags(new List<string> { ExperimentalFlags.SwipeViewExperimental });
 			InitializeComponent();
 #endif
-        }
+		}
 
-        protected override void Init()
+		protected override void Init()
 		{
 
 		}
 	}
 
-    [Preserve(AllMembers = true)]
-    public partial class Issue11496ItemControl : ContentView
-    {
+	[Preserve(AllMembers = true)]
+	public partial class Issue11496ItemControl : ContentView
+	{
 		readonly Label _label;
 
-        public Issue11496ItemControl()
-        {
-            var layout = new Grid();
+		public Issue11496ItemControl()
+		{
+			var layout = new Grid();
 
 			_label = new Label
 			{
-                HorizontalOptions = LayoutOptions.Center,
+				HorizontalOptions = LayoutOptions.Center,
 				VerticalOptions = LayoutOptions.Center
 			};
 
@@ -64,108 +64,108 @@ namespace Xamarin.Forms.Controls.Issues
 				CommandParameter = CommandParameter
 			};
 
-            layout.GestureRecognizers.Add(tapCommand);
+			layout.GestureRecognizers.Add(tapCommand);
 
-            tapCommand.Tapped += (sender, args) =>
-            {
-                if (TestItem != null)
-                    Application.Current.MainPage.DisplayAlert("Issue11496", $"Tapped {((Issue11496Item)TestItem).Name}", "Ok");
-            };
-        }
+			tapCommand.Tapped += (sender, args) =>
+			{
+				if (TestItem != null)
+					Application.Current.MainPage.DisplayAlert("Issue11496", $"Tapped {((Issue11496Item)TestItem).Name}", "Ok");
+			};
+		}
 
-        public static readonly BindableProperty TestItemProperty =
-            BindableProperty.Create(nameof(TestItem), typeof(object), typeof(Issue11496ItemControl));
+		public static readonly BindableProperty TestItemProperty =
+			BindableProperty.Create(nameof(TestItem), typeof(object), typeof(Issue11496ItemControl));
 
-        public static readonly BindableProperty CommandProperty =
-            BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(Issue11496ItemControl));
+		public static readonly BindableProperty CommandProperty =
+			BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(Issue11496ItemControl));
 
-        public static readonly BindableProperty CommandParameterProperty =
-            BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(Issue11496ItemControl));
+		public static readonly BindableProperty CommandParameterProperty =
+			BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(Issue11496ItemControl));
 
-        public object TestItem
-        {
-            get => GetValue(TestItemProperty);
-            set => SetValue(TestItemProperty, value);
-        }
+		public object TestItem
+		{
+			get => GetValue(TestItemProperty);
+			set => SetValue(TestItemProperty, value);
+		}
 
-        public ICommand Command
-        {
-            get => (ICommand)GetValue(CommandProperty);
-            set => SetValue(CommandProperty, value);
-        }
+		public ICommand Command
+		{
+			get => (ICommand)GetValue(CommandProperty);
+			set => SetValue(CommandProperty, value);
+		}
 
-        public object CommandParameter
-        {
-            get => GetValue(CommandParameterProperty);
-            set => SetValue(CommandParameterProperty, value);
-        }
+		public object CommandParameter
+		{
+			get => GetValue(CommandParameterProperty);
+			set => SetValue(CommandParameterProperty, value);
+		}
 
 		protected override void OnBindingContextChanged()
 		{
 			base.OnBindingContextChanged();
 
-            if (TestItem != null)
-                _label.Text = ((Issue11496Item)TestItem).Name;
+			if (TestItem != null)
+				_label.Text = ((Issue11496Item)TestItem).Name;
 
-        }
+		}
 	}
 
-    [Preserve(AllMembers = true)]
-    public class Issue11496Item
-    {
-        public string Name { get; set; }
-    }
+	[Preserve(AllMembers = true)]
+	public class Issue11496Item
+	{
+		public string Name { get; set; }
+	}
 
-    [Preserve(AllMembers = true)]
-    public class Issue11496ViewModel : BindableObject
-    {
+	[Preserve(AllMembers = true)]
+	public class Issue11496ViewModel : BindableObject
+	{
 		List<Issue11496Item> _items;
 		ICommand _command;
-        object _commandParam;
+		object _commandParam;
 
-        public List<Issue11496Item> Items
-        {
-            get => _items;
-            set
-            {
-                _items = value;
-                OnPropertyChanged();
-            }
-        }
+		public List<Issue11496Item> Items
+		{
+			get => _items;
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
 
-        public ICommand Command
-        {
-            get => _command;
-            set
-            {
-                _command = value;
-                OnPropertyChanged();
-            }
-        }
+		public ICommand Command
+		{
+			get => _command;
+			set
+			{
+				_command = value;
+				OnPropertyChanged();
+			}
+		}
 
-        public object CommandParameter
-        {
-            get => _commandParam;
-            set
-            {
-                _commandParam = value;
-                OnPropertyChanged();
-            }
-        }
+		public object CommandParameter
+		{
+			get => _commandParam;
+			set
+			{
+				_commandParam = value;
+				OnPropertyChanged();
+			}
+		}
 
-        public Issue11496ViewModel()
-        {
-            Items = new List<Issue11496Item>()
-            {
-                new Issue11496Item() { Name = "Test One" },
-                new Issue11496Item() { Name = "Test Two" },
-                new Issue11496Item() { Name = "Test Three" },
-                new Issue11496Item() { Name = "Test Four" },
-                new Issue11496Item() { Name = "Test Five" },
-                new Issue11496Item() { Name = "Test Six" },
-                new Issue11496Item() { Name = "Test Seven" },
-                new Issue11496Item() { Name = "Test Eight" },
-            };
-        }
-    }
+		public Issue11496ViewModel()
+		{
+			Items = new List<Issue11496Item>()
+			{
+				new Issue11496Item() { Name = "Test One" },
+				new Issue11496Item() { Name = "Test Two" },
+				new Issue11496Item() { Name = "Test Three" },
+				new Issue11496Item() { Name = "Test Four" },
+				new Issue11496Item() { Name = "Test Five" },
+				new Issue11496Item() { Name = "Test Six" },
+				new Issue11496Item() { Name = "Test Seven" },
+				new Issue11496Item() { Name = "Test Eight" },
+			};
+		}
+	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11496.xaml.cs
@@ -1,0 +1,171 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+using System.Collections.Generic;
+using System.Windows.Input;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.SwipeView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11496, "[Bug] Issue with SwipeView not working since Xamarin.Forms update v4.7.0.1080 and above on Android",
+		PlatformAffected.Android)]
+	public partial class Issue11496 : TestContentPage
+	{
+		public Issue11496()
+		{
+#if APP
+			Title = "Issue 11496";
+			Device.SetFlags(new List<string> { ExperimentalFlags.SwipeViewExperimental });
+			InitializeComponent();
+#endif
+        }
+
+        protected override void Init()
+		{
+
+		}
+	}
+
+    [Preserve(AllMembers = true)]
+    public partial class Issue11496ItemControl : ContentView
+    {
+		readonly Label _label;
+
+        public Issue11496ItemControl()
+        {
+            var layout = new Grid();
+
+			_label = new Label
+			{
+                HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			layout.Children.Add(_label);
+
+			Content = layout;
+
+			var tapCommand = new TapGestureRecognizer
+			{
+				Command = Command,
+				CommandParameter = CommandParameter
+			};
+
+            layout.GestureRecognizers.Add(tapCommand);
+
+            tapCommand.Tapped += (sender, args) =>
+            {
+                if (TestItem != null)
+                    Application.Current.MainPage.DisplayAlert("Issue11496", $"Tapped {((Issue11496Item)TestItem).Name}", "Ok");
+            };
+        }
+
+        public static readonly BindableProperty TestItemProperty =
+            BindableProperty.Create(nameof(TestItem), typeof(object), typeof(Issue11496ItemControl));
+
+        public static readonly BindableProperty CommandProperty =
+            BindableProperty.Create(nameof(Command), typeof(ICommand), typeof(Issue11496ItemControl));
+
+        public static readonly BindableProperty CommandParameterProperty =
+            BindableProperty.Create(nameof(CommandParameter), typeof(object), typeof(Issue11496ItemControl));
+
+        public object TestItem
+        {
+            get => GetValue(TestItemProperty);
+            set => SetValue(TestItemProperty, value);
+        }
+
+        public ICommand Command
+        {
+            get => (ICommand)GetValue(CommandProperty);
+            set => SetValue(CommandProperty, value);
+        }
+
+        public object CommandParameter
+        {
+            get => GetValue(CommandParameterProperty);
+            set => SetValue(CommandParameterProperty, value);
+        }
+
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+            if (TestItem != null)
+                _label.Text = ((Issue11496Item)TestItem).Name;
+
+        }
+	}
+
+    [Preserve(AllMembers = true)]
+    public class Issue11496Item
+    {
+        public string Name { get; set; }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class Issue11496ViewModel : BindableObject
+    {
+		List<Issue11496Item> _items;
+		ICommand _command;
+        object _commandParam;
+
+        public List<Issue11496Item> Items
+        {
+            get => _items;
+            set
+            {
+                _items = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ICommand Command
+        {
+            get => _command;
+            set
+            {
+                _command = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public object CommandParameter
+        {
+            get => _commandParam;
+            set
+            {
+                _commandParam = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public Issue11496ViewModel()
+        {
+            Items = new List<Issue11496Item>()
+            {
+                new Issue11496Item() { Name = "Test One" },
+                new Issue11496Item() { Name = "Test Two" },
+                new Issue11496Item() { Name = "Test Three" },
+                new Issue11496Item() { Name = "Test Four" },
+                new Issue11496Item() { Name = "Test Five" },
+                new Issue11496Item() { Name = "Test Six" },
+                new Issue11496Item() { Name = "Test Seven" },
+                new Issue11496Item() { Name = "Test Eight" },
+            };
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1384,7 +1384,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9734.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8767.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8778.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue9088.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9646.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9735.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9305.xaml.cs" />
@@ -1477,6 +1476,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11653.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11869.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11723.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11737.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11764.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11573.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1747,6 +1750,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11653.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11496.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -309,8 +309,13 @@ namespace Xamarin.Forms.Platform.Android
 				if (CanProcessTouchSwipeItems(touchUpPoint))
 					ProcessTouchSwipeItems(touchUpPoint);
 				else
+				{
+					if (!_isSwiping && _isOpen && TouchInsideContent(touchUpPoint))
+						ResetSwipe();
+
 					PropagateParentTouch();
-			}	
+				}
+			}
 
 			return base.DispatchTouchEvent(e);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -275,16 +275,16 @@ namespace Xamarin.Forms.Platform.Android
 
 			SwipeDirection swipeDirection;
 
-			if(Math.Abs(diffX) > Math.Abs(diffY))
+			if (Math.Abs(diffX) > Math.Abs(diffY))
 				swipeDirection = diffX > 0 ? SwipeDirection.Right : SwipeDirection.Left;
 			else
 				swipeDirection = diffY > 0 ? SwipeDirection.Down : SwipeDirection.Up;
-			
+
 			var items = GetSwipeItemsByDirection(swipeDirection);
 
 			if (items == null || items.Count == 0)
 				return false;
-			
+
 			return true;
 		}
 
@@ -296,8 +296,8 @@ namespace Xamarin.Forms.Platform.Android
 		public override bool DispatchTouchEvent(MotionEvent e)
 		{
 			if (e.Action == MotionEventActions.Down)
-			{ 
-				   _downX = e.RawX;
+			{
+				_downX = e.RawX;
 				_downY = e.RawY;
 				_initialPoint = new APointF(e.GetX() / _density, e.GetY() / _density);
 			}
@@ -330,7 +330,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (itemContentView != null && !((ISwipeViewController)Element).IsOpen)
 				itemContentView.ClickOn();
 		}
-		
+
 		void UpdateContent()
 		{
 			if (Element.Content == null)
@@ -1370,7 +1370,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateIsOpen(bool isOpen)
 		{
-			if (Element == null) 
+			if (Element == null)
 				return;
 
 			((ISwipeViewController)Element).IsOpen = isOpen;


### PR DESCRIPTION
### Description of Change ###

Since Xamarin.Forms 4.8 the content gesture works, this PR manages the closing of the SwipeView when tapping the content.

### Issues Resolved ### 

- fixes #11496

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix11496](https://user-images.githubusercontent.com/6755973/90532966-287fa300-e178-11ea-9d6b-8df08b21f11b.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11496. If tapping an item appear a dialog, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
