### PR TITLE
Ignore Issue6472 and reopened associated issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6472.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6472.cs
@@ -160,6 +160,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST && __IOS__
 		[Test]
+		[Ignore("Fails occasionally on iOS 12 https://github.com/xamarin/Xamarin.Forms/issues/6472")]
 		public void ListViewDoesNotThrowExceptionWithObservableCollection() 
 		{
 			RunningApp.WaitForElement (ListViewAutomationId);


### PR DESCRIPTION
### Description of Change ###

Issue6472 occasionally crashes when running on AppCenter. This test deals with ListView which is being replaced by CollectionView so for now I'm reopening the issue connected to the test (#6472) and ignoring the UI test

Failure:
https://dev.azure.com/xamarin/public/_releaseProgress?releaseId=2131&_a=release-environment-extension&environmentId=84004&extensionId=ms.vss-test-web.test-result-in-release-environment-editor-tab

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- run the iOS tests a few times and ensure they pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
