### PR TITLE
[Tizen] Fix the behavior of the DisplayAlert

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/PopupManager.cs
@@ -57,19 +57,15 @@ namespace Xamarin.Forms.Platform.Tizen
 
 				if (Device.Idiom == TargetIdiom.Phone)
 				{
-					_pageBusyDialog.SetPartColor("bg_title", EColor.Transparent);
-					_pageBusyDialog.SetPartColor("bg_content", EColor.Transparent);
+					_pageBusyDialog.SetTitleBackgroundColor(EColor.Transparent);
+					_pageBusyDialog.SetContentBackgroundColor(EColor.Transparent);
 				}
 				else if (Device.Idiom == TargetIdiom.Watch)
 				{
-					_pageBusyDialog.Style = "circle";
+					_pageBusyDialog.SetWatchCircleStyle();
 				}
 
-				var activity = new EProgressBar(_pageBusyDialog)
-				{
-					Style = "process_large",
-					IsPulseMode = true,
-				};
+				var activity = new EProgressBar(_pageBusyDialog) { IsPulseMode = true }.SetLargeStyle();
 				activity.PlayPulse();
 				activity.Show();
 
@@ -97,7 +93,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			var alert = Native.Dialog.CreateDialog(Forms.NativeParent, (arguments.Accept != null));
 
 			alert.Title = arguments.Title;
-			var message = arguments.Message.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace(Environment.NewLine, "<br>");
+			var message = arguments.Message?.Replace("&", "&amp;").Replace("<", "&lt;").Replace(">", "&gt;").Replace(Environment.NewLine, "<br>");
 			alert.Message = message;
 
 			var cancel = new EButton(alert) { Text = arguments.Cancel };

--- a/Xamarin.Forms.Platform.Tizen/ThemeConstants.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeConstants.cs
@@ -214,6 +214,8 @@ namespace Xamarin.Forms.Platform.Tizen
 			public class ColorClass
 			{
 				public const string Title = "text_maintitle";
+				public const string TitleBackground = "bg_title";
+				public const string ContentBackground = "bg_content";
 
 				public class TV
 				{

--- a/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
@@ -291,6 +291,16 @@ namespace Xamarin.Forms.Platform.Tizen
 			popup.SetPartColor(Device.Idiom == TargetIdiom.TV ? ThemeConstants.Popup.ColorClass.TV.Title : ThemeConstants.Popup.ColorClass.Title, color);
 		}
 
+		public static void SetTitleBackgroundColor(this Popup popup, EColor color)
+		{
+			popup.SetPartColor(ThemeConstants.Popup.ColorClass.TitleBackground, color);
+		}
+
+		public static void SetContentBackgroundColor(this Popup popup, EColor color)
+		{
+			popup.SetPartColor(ThemeConstants.Popup.ColorClass.ContentBackground, color);
+		}
+
 		public static bool SetTitleTextPart(this Popup popup, string title)
 		{
 			return popup.SetPartText(ThemeConstants.Popup.Parts.Title, title);


### PR DESCRIPTION
### Description of Change ###

This PR is to allow DisplayAlert's message to be null. 

```cs
 this.DisplayAlert("DisplayAlert Test", null, "OK", "Cancel");
```

Previously, `NullReferenceException` has been occured. But now it work fine just like other platforms.
Additionally, this change includes applying `ThemeManager`.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
