### PR TITLE
First round of Drag and drop fixes

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropBetweenLayouts.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropBetweenLayouts.xaml
@@ -1,0 +1,44 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Move Items Around a Layout"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries.DragAndDropBetweenLayouts">
+    <ContentPage.Resources>
+        <DataTemplate x:Key="colorTemplate">
+            <BoxView HeightRequest="100" Background="{Binding .}">
+                <BoxView.GestureRecognizers>
+                    <DragGestureRecognizer DropCompleted="OnDropCompleted" DragStarting="OnDragStarting">
+                    </DragGestureRecognizer>
+                </BoxView.GestureRecognizers>
+            </BoxView>
+        </DataTemplate>
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <StackLayout Orientation="Horizontal">
+            <ScrollView HorizontalOptions="FillAndExpand">
+                <StackLayout 
+                    x:Name="SLAllColors" 
+                    BindableLayout.ItemTemplate="{StaticResource colorTemplate}" BindableLayout.ItemsSource="{Binding AllColors}">
+                    <StackLayout.GestureRecognizers>
+                        <DropGestureRecognizer 
+                            DragOver="OnDragOver"
+                            DragLeave="OnDragLeave"
+                            Drop="OnDrop">
+                        </DropGestureRecognizer>
+                    </StackLayout.GestureRecognizers>
+                </StackLayout>
+            </ScrollView>
+            <ScrollView HorizontalOptions="FillAndExpand">
+                <StackLayout x:Name="SLRainbow" BindableLayout.ItemTemplate="{StaticResource colorTemplate}" BindableLayout.ItemsSource="{Binding RainbowColors}">
+                    <StackLayout.GestureRecognizers>
+                        <DropGestureRecognizer 
+                            DragOver="OnDragOver"
+                            DragLeave="OnDragLeave"
+                            Drop="OnDrop">
+                        </DropGestureRecognizer>
+                    </StackLayout.GestureRecognizers>
+                </StackLayout>
+            </ScrollView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropBetweenLayouts.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropBetweenLayouts.xaml.cs
@@ -1,0 +1,125 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries
+{
+    [XamlCompilation(XamlCompilationOptions.Compile)]
+    public partial class DragAndDropBetweenLayouts : ContentPage
+    {
+		public ObservableCollection<Brush> AllColors { get; }
+		public ObservableCollection<Brush> RainbowColors { get; }
+		public DragAndDropBetweenLayouts()
+		{
+			InitializeComponent();
+			AllColors = new ObservableCollection<Brush>();
+			RainbowColors = new ObservableCollection<Brush>();
+
+			AllColors.Add(SolidColorBrush.Red);
+			AllColors.Add(SolidColorBrush.Orange);
+			AllColors.Add(SolidColorBrush.Yellow);
+			AllColors.Add(SolidColorBrush.Green);
+			AllColors.Add(SolidColorBrush.Blue);
+			AllColors.Add(SolidColorBrush.Indigo);
+			AllColors.Add(SolidColorBrush.Violet);
+			AllColors.Add(SolidColorBrush.Black);
+			AllColors.Add(SolidColorBrush.Brown);
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			BindingContext = this;
+		}
+
+		private void OnDragStarting(object sender, DragStartingEventArgs e)
+		{
+			// e.Cancel = true;
+			var boxView = (sender as Element).Parent as BoxView;
+			var sl = boxView.Parent as StackLayout;
+			e.Data.Properties.Add("Color", boxView.Background);
+			e.Data.Properties.Add("Source", sl);
+
+			if (sl == SLAllColors)
+				SLRainbow.Background = SolidColorBrush.LightBlue;
+			else
+				SLAllColors.Background = SolidColorBrush.LightBlue;
+		}
+
+		private void OnDropCompleted(object sender, DropCompletedEventArgs e)
+		{
+			var sl = (sender as Element).Parent.Parent as StackLayout;
+
+			if (sl == SLAllColors)
+				SLRainbow.Background = SolidColorBrush.White;
+			else
+				SLAllColors.Background = SolidColorBrush.White;
+
+		}
+
+		private void OnDragOver(object sender, DragEventArgs e)
+		{
+			if (!e.Data.Properties.ContainsKey("Source"))
+				return;
+
+			//e.AcceptedOperation = DataPackageOperation.None;
+			var sl = (sender as Element).Parent as StackLayout;
+			if (e.Data.Properties["Source"] == sl)
+			{
+				e.AcceptedOperation = DataPackageOperation.None;
+				return;
+			}
+
+			sl.Background = SolidColorBrush.LightPink;
+		}
+
+		private void OnDragLeave(object sender, DragEventArgs e)
+		{
+			if (!e.Data.Properties.ContainsKey("Source"))
+				return;
+
+			var sl = (sender as Element).Parent as StackLayout;
+			if (e.Data.Properties["Source"] == sl)
+			{
+				e.AcceptedOperation = DataPackageOperation.None;
+				return;
+			}
+
+			sl.Background = SolidColorBrush.LightBlue;
+		}
+
+		private void OnDrop(object sender, DropEventArgs e)
+		{
+			if (!e.Data.Properties.ContainsKey("Source"))
+				return;
+
+			var sl = (sender as Element).Parent as StackLayout;
+			if (e.Data.Properties["Source"] == sl)
+			{
+				return;
+			}
+
+			var color = e.Data.Properties["Color"] as SolidColorBrush;
+
+			if (AllColors.Contains(color))
+			{
+				AllColors.Remove(color);
+				RainbowColors.Add(color);
+			}
+			else
+			{
+				RainbowColors.Remove(color);
+				AllColors.Add(color);
+			}
+
+			SLAllColors.Background = SolidColorBrush.White;
+			SLRainbow.Background = SolidColorBrush.White;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropEvents.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropEvents.xaml
@@ -1,0 +1,28 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Events"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries.DragAndDropEvents">
+    <ContentPage.Content>
+        <StackLayout>
+            <StackLayout Orientation="Horizontal">
+                <Label HeightRequest="200" WidthRequest="200"
+                   Text="Drag me Over the Purple Box, off the purple box, drop me on the purple box, and then verify all the correct events fired">
+                    <Label.GestureRecognizers>
+                        <DragGestureRecognizer DragStarting="DragStarting" DropCompleted="DropCompleted"></DragGestureRecognizer>
+                    </Label.GestureRecognizers>
+                </Label>
+                <BoxView HeightRequest="200" HorizontalOptions="FillAndExpand" Background="Purple">
+                    <BoxView.GestureRecognizers>
+                        <DropGestureRecognizer DragLeave="DragLeave" DragOver="DragOver" Drop="Drop"></DropGestureRecognizer>
+                    </BoxView.GestureRecognizers>
+                </BoxView>
+            </StackLayout>
+            <Label x:Name="events">
+                <Label.GestureRecognizers>
+                    <DropGestureRecognizer></DropGestureRecognizer>
+                </Label.GestureRecognizers>
+            </Label>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropEvents.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropEvents.xaml.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class DragAndDropEvents : ContentPage
+	{
+		public DragAndDropEvents()
+		{
+			InitializeComponent();
+		}
+		void AddEvent(string name)
+		{
+			events.Text += $"{name},";
+		}
+
+		void DragStarting(object sender, DragStartingEventArgs e)
+		{
+			AddEvent(nameof(DragStarting));
+		}
+
+		void DropCompleted(object sender, DropCompletedEventArgs e)
+		{
+			AddEvent(nameof(DropCompleted));
+		}
+
+		void DragLeave(object sender, DragEventArgs e)
+		{
+			AddEvent(nameof(DragLeave));
+		}
+
+		void DragOver(object sender, DragEventArgs e)
+		{
+			AddEvent(nameof(DragOver));
+		}
+
+		void Drop(object sender, DropEventArgs e)
+		{
+			AddEvent(nameof(Drop));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragAndDropGallery.cs
@@ -8,9 +8,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries
 	{
 		public DragAndDropGallery()
 		{
-			Device.SetFlags(new List<string> { ExperimentalFlags.DragAndDropExperimental, ExperimentalFlags.ShellUWPExperimental });
+			Device.SetFlags(new List<string> { ExperimentalFlags.DragAndDropExperimental, ExperimentalFlags.ShellUWPExperimental, ExperimentalFlags.ShapesExperimental });
 			Items.Add(new EnablingAndDisablingGestureTests());
 			Items.Add(new VariousDragAndDropPermutations());
+			Items.Add(new DragAndDropBetweenLayouts());
+			Items.Add(new DragAndDropEvents());
+			Items.Add(new DragPaths());
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragPaths.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragPaths.xaml
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             Title="Path" x:Class="Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries.DragPaths">
+    <StackLayout Margin="20">
+        <Label Text="Drag the cat to the grey rectangle." />
+        <Image Source="coffee.png"
+               HorizontalOptions="Center">
+            <Image.GestureRecognizers>
+                <DragGestureRecognizer CanDrag="True"
+                                       DragStarting="OnMonkeyDragStarting"/>
+            </Image.GestureRecognizers>
+        </Image>
+        <Path Stroke="Black"
+              StrokeThickness="4"
+              RenderTransform="0.5 0 0 0.5 0 0"
+              HorizontalOptions="Center">
+            <Path.GestureRecognizers>
+                <DragGestureRecognizer CanDrag="True"
+                                       DragStarting="OnCatDragStarting" />
+            </Path.GestureRecognizers>
+            <Path.Data>
+                <PathGeometry Figures="M 160 140 L 150 50 220 103
+                                       M 320 140 L 330 50 260 103
+                                       M 215 230 L 40 200
+                                       M 215 240 L 40 240
+                                       M 215 250 L 40 280
+                                       M 265 230 L 440 200
+                                       M 265 240 L 440 240
+                                       M 265 250 L 440 280
+                                       M 240 100
+                                       A 100 100 0 0 1 240 300
+                                       A 100 100 0 0 1 240 100 
+                                       M 180 170
+                                       A 40 40 0 0 1 220 170
+                                       A 40 40 0 0 1 180 170
+                                       M 300 170
+                                       A 40 40 0 0 1 260 170
+                                       A 40 40 0 0 1 300 170" />
+            </Path.Data>
+        </Path>
+        <Frame CornerRadius="0"
+               HasShadow="False"
+               BackgroundColor="Silver"
+               HeightRequest="200">
+            <Frame.GestureRecognizers>
+                <DropGestureRecognizer AllowDrop="True"
+                                       Drop="OnDrop" />
+            </Frame.GestureRecognizers>
+        </Frame>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragPaths.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/DragAndDropGalleries/DragPaths.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.DragAndDropGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class DragPaths : ContentPage
+	{
+		public DragPaths()
+		{
+			InitializeComponent();
+		}
+
+		void OnMonkeyDragStarting(object sender, DragStartingEventArgs e)
+		{
+			e.Data.Text = "Monkey";
+		}
+
+		void OnCatDragStarting(object sender, DragStartingEventArgs e)
+		{
+			e.Data.Text = "Cat";
+		}
+
+		async void OnDrop(object sender, DropEventArgs e)
+		{
+			string text = await e.Data.GetTextAsync();
+
+			if (text.Equals("Cat"))
+			{
+				await DisplayAlert("Correct", "Congratulations!", "OK");
+			}
+			else if (text.Equals("Monkey"))
+			{
+				await DisplayAlert("Incorrect", "Try again.", "OK");
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -63,6 +63,12 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="GalleryPages\DragAndDropGalleries\DragAndDropBetweenLayouts.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\DragAndDropGalleries\DragPaths.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\RadioButtonGalleries\RadioButtonGroupGalleryPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Core.UnitTests/DragGestureRecognizerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DragGestureRecognizerTests.cs
@@ -61,6 +61,36 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void UserSpecifiedTextIsntOverwritten()
+		{
+			var dragRec = new DragGestureRecognizer();
+			var element = new Label() { Text = "WRONG TEXT" };
+			dragRec.DragStarting += (_, args) =>
+			{
+				args.Data.Text = "Right Text";
+			};
+
+			var returnedArgs = dragRec.SendDragStarting(element);
+			Assert.AreEqual("Right Text", returnedArgs.Data.Text);
+		}
+
+		[Test]
+		public void UserSpecifiedImageIsntOverwritten()
+		{
+			var dragRec = new DragGestureRecognizer();
+			var element = new Image() { Source = "http://www.someimage.com" };
+			FileImageSource fileImageSource = new FileImageSource() { File = "yay.jpg" };
+
+			dragRec.DragStarting += (_, args) =>
+			{
+				args.Data.Image = fileImageSource;
+			};
+
+			var returnedArgs = dragRec.SendDragStarting(element);
+			Assert.AreEqual(fileImageSource, returnedArgs.Data.Image);
+		}
+
+		[Test]
 		public void DropCompletedCommandFires()
 		{
 			var dragRec = new DragGestureRecognizer();
@@ -68,11 +98,28 @@ namespace Xamarin.Forms.Core.UnitTests
 			object commandExecuted = null;
 			Command cmd = new Command(() => commandExecuted = parameter);
 
+			dragRec.SendDragStarting(new Label());
 			dragRec.DropCompletedCommand = cmd;
 			dragRec.DropCompletedCommandParameter = parameter;
 			dragRec.SendDropCompleted(new DropCompletedEventArgs());
 
 			Assert.AreEqual(commandExecuted, parameter);
+		}
+
+		[Test]
+		public void DropCompletedCommandFiresOnce()
+		{
+			int counter = 0;
+			var dragRec = new DragGestureRecognizer();
+			Command cmd = new Command(() => counter++);
+
+			dragRec.SendDragStarting(new Label());
+			dragRec.DropCompletedCommand = cmd;
+			dragRec.SendDropCompleted(new DropCompletedEventArgs());
+			dragRec.SendDropCompleted(new DropCompletedEventArgs());
+			dragRec.SendDropCompleted(new DropCompletedEventArgs());
+
+			Assert.AreEqual(1, counter);
 		}
 
 		[TestCase(typeof(Entry), "EntryTest")]

--- a/Xamarin.Forms.Core.UnitTests/DropGestureRecognizerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DropGestureRecognizerTests.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			dropRec.DropCommand = cmd;
 			dropRec.DropCommandParameter = parameter;
-			await dropRec.SendDrop(new DropEventArgs(new DataPackageView(new DataPackage())), new Label());
+			await dropRec.SendDrop(new DropEventArgs(new DataPackageView(new DataPackage())));
 
 			Assert.AreEqual(commandExecuted, parameter);
 		}
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var element = (View)Activator.CreateInstance(fieldType);
 			element.GestureRecognizers.Add(dropRec);
 			var args = new DropEventArgs(new DataPackageView(new DataPackage() { Text = result }));
-			await dropRec.SendDrop(args, element);
+			await dropRec.SendDrop(args);
 			Assert.AreEqual(element.GetStringValue(), result);
 		}
 
@@ -102,7 +102,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			element.Text = "Text Shouldn't change";
 			var args = new DropEventArgs(new DataPackageView(new DataPackage() { Text = testString }));
 			args.Handled = true;
-			await dropTec.SendDrop(args, element);
+			await dropTec.SendDrop(args);
 			Assert.AreNotEqual(element.Text, testString);
 		}
 	}

--- a/Xamarin.Forms.Core/DragAndDrop/DataPackageOperation.cs
+++ b/Xamarin.Forms.Core/DragAndDrop/DataPackageOperation.cs
@@ -2,9 +2,12 @@
 
 namespace Xamarin.Forms
 {
+	// These are copied from UWP so if you add additional values please use those
+	// https://docs.microsoft.com/en-us/uwp/api/windows.applicationmodel.datatransfer.datapackageoperation?view=winrt-19041
 	[Flags]
 	public enum DataPackageOperation
 	{
-		None, Copy
+		None = 0, 
+		Copy = 1
 	}
 }

--- a/Xamarin.Forms.Core/DragAndDrop/DropGestureRecognizer.cs
+++ b/Xamarin.Forms.Core/DragAndDrop/DropGestureRecognizer.cs
@@ -9,21 +9,26 @@ namespace Xamarin.Forms
 {
 	public class DropGestureRecognizer : GestureRecognizer
 	{
-		public static readonly BindableProperty AllowDropProperty = BindableProperty.Create(nameof(AllowDrop), typeof(bool), typeof(DropGestureRecognizer), false);
-		
-		public static readonly BindableProperty DragOverCommandProperty = BindableProperty.Create(nameof(DragOverCommand), typeof(ICommand), typeof(DragGestureRecognizer), null);
+		public static readonly BindableProperty AllowDropProperty = BindableProperty.Create(nameof(AllowDrop), typeof(bool), typeof(DropGestureRecognizer), true);
 
-		public static readonly BindableProperty DragOverCommandParameterProperty = BindableProperty.Create(nameof(DragOverCommandParameter), typeof(object), typeof(DragGestureRecognizer), null);
+		public static readonly BindableProperty DragOverCommandProperty = BindableProperty.Create(nameof(DragOverCommand), typeof(ICommand), typeof(DropGestureRecognizer), null);
+
+		public static readonly BindableProperty DragOverCommandParameterProperty = BindableProperty.Create(nameof(DragOverCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
+		
+		public static readonly BindableProperty DragLeaveCommandProperty = BindableProperty.Create(nameof(DragLeaveCommand), typeof(ICommand), typeof(DropGestureRecognizer), null);
+
+		public static readonly BindableProperty DragLeaveCommandParameterProperty = BindableProperty.Create(nameof(DragLeaveCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
 
 		public static readonly BindableProperty DropCommandProperty = BindableProperty.Create(nameof(DropCommand), typeof(ICommand), typeof(DragGestureRecognizer), null);
 
-		public static readonly BindableProperty DropCommandParameterProperty = BindableProperty.Create(nameof(DropCommandParameter), typeof(object), typeof(DragGestureRecognizer), null);
-
+		public static readonly BindableProperty DropCommandParameterProperty = BindableProperty.Create(nameof(DropCommandParameter), typeof(object), typeof(DropGestureRecognizer), null);
+		
 		public DropGestureRecognizer()
 		{
 			ExperimentalFlags.VerifyFlagEnabled(nameof(DropGestureRecognizer), ExperimentalFlags.DragAndDropExperimental);
 		}
 
+		public event EventHandler<DragEventArgs> DragLeave;
 		public event EventHandler<DragEventArgs> DragOver;
 		public event EventHandler<DropEventArgs> Drop;
 
@@ -43,6 +48,17 @@ namespace Xamarin.Forms
 		{
 			get { return (object)GetValue(DragOverCommandParameterProperty); }
 			set { SetValue(DragOverCommandParameterProperty, value); }
+		}
+		public ICommand DragLeaveCommand
+		{
+			get { return (ICommand)GetValue(DragLeaveCommandProperty); }
+			set { SetValue(DragLeaveCommandProperty, value); }
+		}
+
+		public object DragLeaveCommandParameter
+		{
+			get { return (object)GetValue(DragLeaveCommandParameterProperty); }
+			set { SetValue(DragLeaveCommandParameterProperty, value); }
 		}
 
 		public ICommand DropCommand
@@ -65,7 +81,14 @@ namespace Xamarin.Forms
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
-		public async Task SendDrop(DropEventArgs args, VisualElement element)
+		public void SendDragLeave(DragEventArgs args)
+		{
+			DragLeaveCommand?.Execute(DragLeaveCommandParameter);
+			DragLeave?.Invoke(this, args);
+		}
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public async Task SendDrop(DropEventArgs args)
 		{
 			if (!AllowDrop)
 				return;
@@ -81,7 +104,6 @@ namespace Xamarin.Forms
 				ImageSource sourceTarget = await dataView.GetImageAsync();
 				string text = await dataView.GetTextAsync();
 
-				// TODO: Shane Generalize the retrieval of "values" from elements to provide the text for
 				if (internalProperties.ContainsKey("DragSource"))
 				{
 					dragSource = (VisualElement)internalProperties["DragSource"];

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -108,6 +108,23 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
+		void HandleDragLeave(object sender, Windows.UI.Xaml.DragEventArgs e)
+		{
+			var package = e.DataView.Properties["_XFPropertes_DONTUSE"] as DataPackage;
+			var dragEventArgs = new DragEventArgs(package);
+			
+			SendEventArgs<DropGestureRecognizer>(rec =>
+			{
+				if (!rec.AllowDrop)
+				{
+					return;
+				}
+
+				e.AcceptedOperation = Windows.ApplicationModel.DataTransfer.DataPackageOperation.Copy;
+				rec.SendDragLeave(dragEventArgs);
+			});
+		}
+
 		void HandleDragOver(object sender, Windows.UI.Xaml.DragEventArgs e)
 		{
 			var package = e.DataView.Properties["_XFPropertes_DONTUSE"] as DataPackage;
@@ -150,7 +167,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				try
 				{
-					await rec.SendDrop(args, element);
+					await rec.SendDrop(args);
 				}
 				catch (Exception dropExc)
 				{
@@ -778,6 +795,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_container.DragOver += HandleDragOver;
 				_container.Drop += HandleDrop;
+				_container.DragLeave += HandleDragLeave;
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

- Added additional samples
- wired up DragLeave event
- fixed various timing issues if an element loses its renderer before a drop is complete
- Changed drag and drop to have EnableDrag/AllowDrop enabled by default so it all just works by default when adding the recognizers
- Fixed a few issues on Android with processing clip data from an external app

### Issues Resolved ### 
- partially fixes #11663
- fixes #11833

### API Changes ###

Added:
- public static readonly BindableProperty DragLeaveCommandProperty;
- public static readonly BindableProperty DragLeaveCommandParameterProperty;
- public event EventHandler<DragEventArgs> DragLeave;


### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- unit tests and UI tests all pass
- Gallery additions work as expected (FYI The Cat doesn't drag super well on UWP but this is most likely a bug with gestures/paths)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
