### PR TITLE
[Android] Fix Bottom Tab IsVisible with Shell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11869.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11869.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11869, "[Bug] ShellContent.IsVisible issue on Android",
+		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11869 : TestShell
+	{
+		protected override void Init()
+		{
+			ContentPage contentPage = new ContentPage();
+			var tabbar = AddContentPage<TabBar, Tab>(contentPage, title: "Tab 1");
+			AddBottomTab("Tab 2");
+			AddBottomTab("Tab 3");
+			AddTopTab("TopTab2");
+			AddTopTab("TopTab3");
+
+			contentPage.Content =
+				new StackLayout()
+				{
+					Children =
+					{
+						new Button
+						{
+							Text = "Hide Bottom Tab 2",
+							Command = new Command(() =>
+							{
+								Items[0].Items[1].Items[0].IsVisible = false;
+							}),
+							AutomationId = "HideBottom2"
+						},
+						new Button
+						{
+							Text = "Hide Bottom Tab 3",
+							Command = new Command(() =>
+							{
+								Items[0].Items[2].Items[0].IsVisible = false;
+							}),
+							AutomationId = "HideBottom3"
+						},
+						new Button
+						{
+							Text = "Hide Top Tab 2",
+							Command = new Command(() =>
+							{
+								Items[0].Items[0].Items[1].IsVisible = false;
+							}),
+							AutomationId = "HideTop2"
+						},
+						new Button
+						{
+							Text = "Hide Top Tab 3",
+							Command = new Command(() =>
+							{
+								Items[0].Items[0].Items[2].IsVisible = false;
+							}),
+							AutomationId = "HideTop3"
+						},
+						new Button
+						{
+							Text = "Show All Tabs",
+							Command = new Command(() =>
+							{
+								Items[0].Items[1].Items[0].IsVisible = true;
+								Items[0].Items[2].Items[0].IsVisible = true;
+								Items[0].Items[0].Items[1].IsVisible = true;
+								Items[0].Items[0].Items[2].IsVisible = true;
+							}),
+							AutomationId = "ShowAllTabs"
+						}
+					}
+				};
+		}
+
+
+#if UITEST && __SHELL__
+		[Test]
+		public void IsVisibleWorksForShowingHidingTabs()
+		{
+			RunningApp.WaitForElement("TopTab2");
+			RunningApp.Tap("HideTop2");
+			RunningApp.WaitForNoElement("TopTab2");
+
+			RunningApp.WaitForElement("TopTab3");
+			RunningApp.Tap("HideTop3");
+			RunningApp.WaitForNoElement("TopTab3");
+
+			RunningApp.WaitForElement("Tab 2");
+			RunningApp.Tap("HideBottom2");
+			RunningApp.WaitForNoElement("Tab 2");
+
+			RunningApp.WaitForElement("Tab 3");
+			RunningApp.Tap("HideBottom3");
+			RunningApp.WaitForNoElement("Tab 3");
+
+			RunningApp.Tap("ShowAllTabs");
+			RunningApp.WaitForElement("TopTab2");
+			RunningApp.WaitForElement("TopTab3");
+			RunningApp.WaitForElement("Tab 2");
+			RunningApp.WaitForElement("Tab 3");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1471,6 +1471,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10608.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11869.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -158,7 +158,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			return CreateMoreBottomSheet((int index, BottomSheetDialog dialog) =>
 			{
-				selectCallback(ShellItem.Items[index], dialog);
+				selectCallback(ShellItemController.GetItems()[index], dialog);
 			});
 		}
 
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Platform.Android
 			for (int i = _bottomView.MaxItemCount - 1; i < items.Count; i++)
 			{
 				var closure_i = i;
-				var shellContent = ShellItem.Items[i];
+				var shellContent = items[i];
 
 				using (var innerLayout = new LinearLayout(Context))
 				{
@@ -305,7 +305,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void OnMoreItemSelected(int shellSectionIndex, BottomSheetDialog dialog)
 		{
-			OnMoreItemSelected(ShellItem.Items[shellSectionIndex], dialog);
+			OnMoreItemSelected(ShellItemController.GetItems()[shellSectionIndex], dialog);
 		}
 
 		protected virtual void OnMoreItemSelected(ShellSection shellSection, BottomSheetDialog dialog)
@@ -320,10 +320,11 @@ namespace Xamarin.Forms.Platform.Android
 		List<(string title, ImageSource icon, bool tabEnabled)> CreateTabList(ShellItem shellItem)
 		{
 			var items = new List<(string title, ImageSource icon, bool tabEnabled)>();
+			var shellItems = ((IShellItemController)shellItem).GetItems();
 
-			for (int i = 0; i < shellItem.Items.Count; i++)
+			for (int i = 0; i < shellItems.Count; i++)
 			{
-				var item = shellItem.Items[i];
+				var item = shellItems[i];
 				items.Add((item.Title, item.Icon, item.IsEnabled));
 			}
 			return items;


### PR DESCRIPTION
### Description of Change ###

Androids ShellItemRenderer is using the wrong data structures for pulling in Visible Items

### Issues Resolved ### 
- fixes #11869


### Platforms Affected ### 
- Android

### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
