### PR TITLE
[iOS] Fix position of placeholder (#11889)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.iOS
 					new NSObject[] { _placeholderLabel }, new NSObject[] { new NSString("_placeholderLabel") })
 			);
 
-			_placeholderLabel.TranslatesAutoresizingMaskIntoConstraints = true;
+			_placeholderLabel.TranslatesAutoresizingMaskIntoConstraints = false;
 			_placeholderLabel.AttributedText = _placeholderLabel.AttributedText.AddCharacterSpacing(Element.Placeholder, Element.CharacterSpacing);
 
 			Control.AddConstraints(hConstraints);


### PR DESCRIPTION
### Description of Change ###

Fixed the position of the placeholder of an Editor control on iOS.

### Issues Resolved ### 

- fixes #11889

### API Changes ## 
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
The position of the placeholder of an Editor control on iOS should be correct now.

### Before/After Screenshots ### 
![XamarinBug_EditorPlaceholder](https://user-images.githubusercontent.com/17462039/90989272-768e0f80-e599-11ea-89c2-057753d781b5.png)
![XamarinBug_EditorPlaceholder_fixed](https://user-images.githubusercontent.com/17462039/90989280-7857d300-e599-11ea-9fb4-ac648678267b.png)


### Testing Procedure ###
Check CoreGalleryPages/EditorCoreGalleryPage.cs

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
