### PR TITLE
[Tizen] Fix the lifecycle of application

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -19,13 +19,11 @@ namespace Xamarin.Forms.Platform.Tizen
 	{
 		ITizenPlatform _platform;
 		Application _application;
-		bool _isInitialStart;
 		Window _window;
 		bool _useBezelInteration;
 
 		protected FormsApplication()
 		{
-			_isInitialStart = true;
 		}
 
 		/// <summary>
@@ -91,17 +89,6 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				_platform.Dispose();
 			}
-		}
-
-		protected override void OnAppControlReceived(AppControlReceivedEventArgs e)
-		{
-			base.OnAppControlReceived(e);
-
-			if (!_isInitialStart && _application != null)
-			{
-				_application.SendResume();
-			}
-			_isInitialStart = false;
 		}
 
 		protected override void OnPause()


### PR DESCRIPTION
### Description of Change ###
This PR prevents unnecessary `Application.OnResume()` calls in a specific case, and invokes `Application.OnResume()` exactly according to the lifecycle of native Tizen Application.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
