### PR TITLE
[iOS] Fixed NRE in SearchBarRenderer OnSearchButtonClicked

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11865.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11865.cs
@@ -1,0 +1,80 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SearchBar)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11865,
+		"iOS SearchBarRenderer throws a NullReferenceException when the SearchButton redirects to a new page",
+		PlatformAffected.iOS)]
+	public class Issue11865 : TestContentPage
+	{
+		public Issue11865()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 11865";
+
+			var layout = new StackLayout
+			{
+				BackgroundColor = Color.LightGreen
+			};
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Type something in the SearchBar and tap the search button."
+			};
+
+			var searchBar = new SearchBar();
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(searchBar);
+
+			Content = layout;
+
+			searchBar.SearchButtonPressed += (sender, args) =>
+			{
+				Application.Current.MainPage = new Issue11865SecondPage();
+			};
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue11865SecondPage : ContentPage
+	{
+		public Issue11865SecondPage()
+		{
+			var layout = new StackLayout
+			{
+				BackgroundColor = Color.LightCoral
+			};
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If you can read this message (after changing the MainPage), the test has passed.",
+				Margin = new Thickness(0, 36, 0, 0)
+			};
+
+			layout.Children.Add(instructions);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1471,6 +1471,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11430.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11247.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10608.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11865.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnSearchButtonClicked(object sender, EventArgs e)
 		{
 			Element.OnSearchButtonPressed();
-			Control.ResignFirstResponder();
+			Control?.ResignFirstResponder();
 		}
 
 		void OnTextChanged(object sender, UISearchBarTextChangedEventArgs a)

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -215,7 +215,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnSearchButtonClicked(object sender, EventArgs e)
 		{
-			Element.OnSearchButtonPressed();
+			Element?.OnSearchButtonPressed();
 			Control?.ResignFirstResponder();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fixed NRE in SearchBarRenderer OnSearchButtonClicked on iOS.

### Issues Resolved ### 

- fixes #11865 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix11865](https://user-images.githubusercontent.com/6755973/91033259-627ef800-e603-11ea-9c21-1cfae30b006c.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11865. Type something in the SearchBar and tap the search button. If can navigate without any crash (disposed Control), the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
