### PR TITLE
[Core] Add an overload for async ImageSource

### DIFF
--- a/Xamarin.Forms.Core/ImageSource.cs
+++ b/Xamarin.Forms.Core/ImageSource.cs
@@ -94,6 +94,11 @@ namespace Xamarin.Forms
 			return new StreamImageSource { Stream = token => Task.Run(stream, token) };
 		}
 
+		public static ImageSource FromStream(Func<CancellationToken, Task<Stream>> stream)
+		{
+			return new StreamImageSource { Stream = stream };
+		}
+
 		public static ImageSource FromUri(Uri uri)
 		{
 			if (!uri.IsAbsoluteUri)


### PR DESCRIPTION
### Description of Change ###

The default overload for `ImageSource.FromStream` does 2 things which may not be desirable:
 - starts a new background task
 - requires a blocking operation

If I have some local caching system for images, I might already have a task cache or does other bad things when forcing a synchronous execution.


Here is an example with some "HTTP cache" 😄  - I know about the URI image source, but this is an example that is also exciting to write.

```csharp
var imageSource = ImageSource.FromStream(async token =>
{
	var client = new HttpClient();
	var msg = await client.GetAsync("http://example.org", token);
	if (!msg.IsSuccessStatusCode)
		return null;
	return await msg.Content.ReadAsStreamAsync();
});
```

### Issues Resolved ### 

- fixes a case where I have to take an async operation and call `.Result` 😱

### API Changes ###

Added:

 - public static ImageSource ImageSource.FromStream(Func<CancellationToken, Task<Stream>> stream);

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
This is already tested in the `ImageSourceTests.cs` test case

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
