### PR TITLE
[WPF] Fix assembly version conflicts

### DIFF
--- a/Xamarin.Forms.ControlGallery.WPF/Xamarin.Forms.ControlGallery.WPF.csproj
+++ b/Xamarin.Forms.ControlGallery.WPF/Xamarin.Forms.ControlGallery.WPF.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+﻿<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
   <PropertyGroup>
     <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">netcoreapp3.1;net461;</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">net461;</TargetFrameworks>
@@ -7,7 +7,7 @@
     <OutputType>WinExe</OutputType>
     <UseWPF>true</UseWPF>
     <AppendTargetFrameworkToOutputPath>true</AppendTargetFrameworkToOutputPath>
-    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>    
+    <GenerateAssemblyInfo>true</GenerateAssemblyInfo>    
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
   <PropertyGroup>

--- a/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
@@ -1,4 +1,5 @@
-﻿using System.Windows;
+﻿using System.Reflection;
+using System.Windows;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.WPF;
 using Xamarin.Forms.Shapes;
@@ -72,3 +73,5 @@ using Rectangle = Xamarin.Forms.Shapes.Rectangle;
 // Others
 [assembly: Xamarin.Forms.Dependency(typeof(ResourcesProvider))]
 [assembly: Xamarin.Forms.Dependency(typeof(Deserializer))]
+
+[assembly: AssemblyVersion("2.0.0.0")]

--- a/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.WPF/Properties/AssemblyInfo.cs
@@ -75,3 +75,13 @@ using Rectangle = Xamarin.Forms.Shapes.Rectangle;
 [assembly: Xamarin.Forms.Dependency(typeof(Deserializer))]
 
 [assembly: AssemblyVersion("2.0.0.0")]
+[assembly: AssemblyFileVersion(ThisAssembly.Git.BaseVersion.Major + "."
+			+ ThisAssembly.Git.BaseVersion.Minor + "."
+			+ ThisAssembly.Git.BaseVersion.Patch + "."
+			+ ThisAssembly.Git.Commits)]
+[assembly: AssemblyInformationalVersion(ThisAssembly.Git.SemVer.Major + "."
+			+ ThisAssembly.Git.SemVer.Minor + "."
+			+ ThisAssembly.Git.SemVer.Patch
+			+ ThisAssembly.Git.SemVer.DashLabel + "+"
+			+ ThisAssembly.Git.Commits + "-sha."
+			+ ThisAssembly.Git.Commit)]


### PR DESCRIPTION
### Description of Change ###

There are currently assembly version missmatches when working with the WPF .NET Core backend. 
The modifications to the assembly version information in this PR solve these issues when running the control gallery application. This is more of a workaround currently and I hope this could help in finding a longterm solution.
Some things I currently dont understand:
* Why is the control gallery explicitly asking for Version 2.0.0.0 of the WPF platform assembly. I could not find a reference to this version anywhere and a runtime error occures when I change the version to something else.
* In the Xamarin.Forms.Platform.WPF project we have to set `<GenerateAssemblyInfo>false</GenerateAssemblyInfo>`, otherwise the following compile error will show up: "The specified version string does not conform to the recommended format - major.minor.build.revision". When setting a version using the Version property, this error persists. In the control gallery, we can and have to set `<GenerateAssemblyInfo>true</GenerateAssemblyInfo>`.
* Why does this error occur in the control gallery? I created an empty wpf .net core and .net framework project, referenced the assemblies and could start up the code shown in https://github.com/xamarin/Xamarin.Forms/issues/10489 without modifications to the assembly infos.


### Issues Resolved ### 
* fixes #11328
* fixes #10489

### Platforms Affected ### 

- WPF

None

Not applicable

### Testing Procedure ###

* Clean bin folder of the Xamarin.Forms.Platform.WPF and Xamarin.Forms.ControlGallery.WPF project
* Build and run
* Application should show up.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
