### PR TITLE
[UWP] Changes in CollectionViewSource dispose logic

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -117,21 +117,18 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					observableItemTemplateCollection.CleanUp();
 				}
-			}
 
-			if (Element?.ItemsSource == null)
-			{
 				if (CollectionViewSource?.Source is INotifyCollectionChanged incc)
 				{
 					incc.CollectionChanged -= ItemsChanged;
 				}
 
-				if (CollectionViewSource != null)
-				{
-					CollectionViewSource.Source = null;
-				}
-
+				CollectionViewSource.Source = null;		
 				CollectionViewSource = null;
+			}
+
+			if (Element?.ItemsSource == null)
+			{
 				ListViewBase.ItemsSource = null;
 				return;
 			}

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.UWP
 					observableItemTemplateCollection.CleanUp();
 				}
 
-				if (CollectionViewSource?.Source is INotifyCollectionChanged incc)
+				if (CollectionViewSource.Source is INotifyCollectionChanged incc)
 				{
 					incc.CollectionChanged -= ItemsChanged;
 				}


### PR DESCRIPTION
### Description of Change ###

Changes in CollectionViewSource dispose logic on UWP.

### Issues Resolved ### 

- fixes #11908 

### API Changes ###

 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the CollectionView galleries. Use the profiler to debug and verify that the CollectionViewSource is disposed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
