### PR TITLE
[Android] Fix processing push and pop operations before attached to window

### DIFF
--- a/Xamarin.Forms.Platform.Android.UnitTests/NavigationPageTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/NavigationPageTests.cs
@@ -1,0 +1,128 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Android.Content;
+using Android.Support.Design.Widget;
+using Android.Views;
+using Android.Widget;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Platform.Android.UnitTests;
+
+#if __ANDROID_29__
+using AndroidX.AppCompat.App;
+using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
+#else
+#endif
+
+namespace Xamarin.Forms.Platform.Android.UnitTests
+{
+
+	public class NavigationPageTests : PlatformTestFixture
+	{
+		[Test, Category("NavigationPage")]
+		[Description("Pushing initial page before NavigationPageRenderer is attached leaves renderer in confused state")]
+		public async Task PushInitialPageBeforeAttachingToWindowBreaksApp()
+		{
+			await Device.InvokeOnMainThreadAsync(async () =>
+			{
+				var navPage = new NavigationPage();
+				TestActivity testSurface = null;
+				try
+				{
+					testSurface = await TestActivity.GetTestSurface(Context, navPage);
+					await navPage.PushAsync(new ContentPage());
+					await testSurface.WindowAttachedTask;
+					await navPage.PushAsync(new ContentPage());
+					var manager = testSurface.GetFragmentManager();
+					Assert.AreEqual(2, manager.Fragments.Count);
+				}
+				finally
+				{
+					testSurface?.Finish();
+				}
+			});
+		}
+
+		[Test, Category("NavigationPage")]
+		[Description("Pushing page before NavigationPageRenderer is attached leaves renderer in confused state")]
+		public async Task PagePushedBeforeAttachingToWindowBreaksApp()
+		{
+			await Device.InvokeOnMainThreadAsync(async () =>
+			{
+				var navPage = new NavigationPage(new ContentPage());
+				TestActivity testSurface = null;
+				try
+				{
+					testSurface = await TestActivity.GetTestSurface(Context, navPage);
+					await navPage.PushAsync(new ContentPage());
+					await testSurface.WindowAttachedTask;
+					await navPage.PushAsync(new ContentPage());
+					var manager = testSurface.GetFragmentManager();
+					Assert.AreEqual(3, manager.Fragments.Count);
+				}
+				finally
+				{
+					testSurface?.Finish();
+				}
+			});
+		}
+
+		[Test, Category("NavigationPage")]
+		[Description("Popping page before NavigationPageRenderer is attached leaves renderer in confused state")]
+		public async Task PagePoppedBeforeAttachingToWindowBreaksApp()
+		{
+			var navPage = new NavigationPage(new ContentPage());
+			await navPage.PushAsync(new ContentPage());
+
+			await Device.InvokeOnMainThreadAsync(async () =>
+			{
+				TestActivity testSurface = null;
+				try
+				{
+					testSurface = await TestActivity.GetTestSurface(Context, navPage);
+					await navPage.PopAsync();
+					await testSurface.WindowAttachedTask;
+					await navPage.PushAsync(new ContentPage());
+					var manager = testSurface.GetFragmentManager();
+					Assert.AreEqual(2, manager.Fragments.Count);
+				}
+				finally
+				{
+					testSurface?.Finish();
+				}
+			});
+		}
+
+		[Test, Category("NavigationPage")]
+		[Description("Pop to Root before NavigationPageRenderer is attached leaves renderer in confused state")]
+		public async Task PopToRootBeforeAttachingToWindowBreaksApp()
+		{
+			var navPage = new NavigationPage(new ContentPage());
+			await navPage.PushAsync(new ContentPage());
+			await navPage.PushAsync(new ContentPage());
+			await navPage.PushAsync(new ContentPage());
+
+			await Device.InvokeOnMainThreadAsync(async () =>
+			{
+				TestActivity testSurface = null;
+				try
+				{
+					testSurface = await TestActivity.GetTestSurface(Context, navPage);
+					await navPage.PopToRootAsync();
+					await testSurface.WindowAttachedTask;
+					await navPage.PushAsync(new ContentPage());
+					var manager = testSurface.GetFragmentManager();
+					Assert.AreEqual(2, manager.Fragments.Count);
+				}
+				finally
+				{
+					testSurface?.Finish();
+				}
+			});
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android.UnitTests/PlatformTestFixture.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/PlatformTestFixture.cs
@@ -11,6 +11,7 @@ using ASearchView = Android.Widget.SearchView;
 using System.Collections.Generic;
 using NUnit.Framework;
 using System.Threading.Tasks;
+using Xamarin.Forms.Platform.Android.AppCompat;
 using AndroidX.AppCompat.Widget;
 using AndroidX.CardView.Widget;
 
@@ -146,6 +147,12 @@ namespace Xamarin.Forms.Platform.Android.UnitTests
 			}
 
 			throw new NotImplementedException($"Don't know how to get the native control for {element}");
+		}
+
+		protected NavigationPageRenderer GetNativeControl(NavigationPage navPage)
+		{
+			var renderer = GetRenderer(navPage);
+			return renderer as NavigationPageRenderer;
 		}
 
 		protected BoxRenderer GetNativeControl(BoxView boxView)

--- a/Xamarin.Forms.Platform.Android.UnitTests/TestActivity.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/TestActivity.cs
@@ -11,6 +11,7 @@ using System.Threading;
 using System;
 using AndroidX.AppCompat.App;
 using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
+using AndroidX.AppCompat.Widget;
 
 namespace Xamarin.Forms.Platform.Android.UnitTests
 {

--- a/Xamarin.Forms.Platform.Android.UnitTests/TestActivity.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/TestActivity.cs
@@ -8,55 +8,119 @@ using Android.Views;
 using Xamarin.Forms;
 using Xamarin.Forms.Platform.Android.UnitTests;
 using System.Threading;
+using System;
 using AndroidX.AppCompat.App;
 using AToolbar = AndroidX.AppCompat.Widget.Toolbar;
 
-[assembly: ExportRenderer(typeof(TestShell), typeof(TestShellRenderer))]
 namespace Xamarin.Forms.Platform.Android.UnitTests
 {
-    [Activity(Label = "TestActivity", Icon = "@drawable/icon", Theme = "@style/MyTheme",
-        MainLauncher = false, HardwareAccelerated = true,
-        ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.UiMode)]
-    public class TestActivity : AppCompatActivity
-    {
-        public static SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
-        public static TaskCompletionSource<TestActivity> Surface { get; set; }
+	[Preserve(AllMembers = true)]
+	[Activity(Label = "TestActivity", Icon = "@drawable/icon", Theme = "@style/MyTheme",
+		MainLauncher = false, HardwareAccelerated = true,
+		ConfigurationChanges = ConfigChanges.ScreenSize | ConfigChanges.Orientation | ConfigChanges.ScreenLayout | ConfigChanges.SmallestScreenSize | ConfigChanges.UiMode)]
+	public class TestActivity : AppCompatActivity
+	{
+		public static SemaphoreSlim semaphore = new SemaphoreSlim(1, 1);
+		public static TaskCompletionSource<TestActivity> Surface { get; set; }
 
-        protected override void OnCreate(Bundle savedInstanceState)
-        {
-            base.OnCreate(savedInstanceState);
-            var bar = LayoutInflater.Inflate(FormsAppCompatActivity.ToolbarResource, null).JavaCast<AToolbar>();
-            SetSupportActionBar(bar);
-        }
+		TestLinearLayoutCompat _linearLayoutCompat;
+		TaskCompletionSource<bool> _windowAttached = new TaskCompletionSource<bool>();
+		TaskCompletionSource<bool> _windowDetached = new TaskCompletionSource<bool>();
+		public Task<bool> WindowAttachedTask => _windowAttached.Task;
+		public Task<bool> WindowDetachedTask => _windowDetached.Task;
+		VisualElement Element { get; set; }
+		protected override void OnCreate(Bundle savedInstanceState)
+		{
+			base.OnCreate(savedInstanceState);
 
-        protected override void OnResume()
-        {
-            base.OnResume();
-            Surface.SetResult(this);
-        }
+			_linearLayoutCompat = new TestLinearLayoutCompat(this);
 
-        public static async Task<TestActivity> GetTestSurface(Context context, VisualElement visualElement)
-        {
-            await semaphore.WaitAsync();
-            Surface = new TaskCompletionSource<TestActivity>();
-            Intent intent = new Intent(context, typeof(TestActivity));
-            context.StartActivity(intent);
-            var result = await Surface.Task;
+			SetContentView(_linearLayoutCompat,
+				new LinearLayoutCompat.LayoutParams(LinearLayoutCompat.LayoutParams.MatchParent, LinearLayoutCompat.LayoutParams.MatchParent));
 
-            if(visualElement != null)
+			var bar = LayoutInflater.Inflate(FormsAppCompatActivity.ToolbarResource, null).JavaCast<AToolbar>();
+			SetSupportActionBar(bar);
+		}
+
+		public static async Task<TestActivity> GetTestSurface(Context context, VisualElement visualElement)
+		{
+			await semaphore.WaitAsync();
+			Surface = new TaskCompletionSource<TestActivity>();
+			Intent intent = new Intent(context, typeof(TestActivity));
+			context.StartActivity(intent);
+			var result = await Surface.Task;
+
+			if (visualElement != null)
 			{
-                var renderer = Platform.CreateRendererWithContext(visualElement, result);
-                Platform.SetRenderer(visualElement, renderer);
-                result.SetContentView(renderer.View);
-            }
+				result.Element = visualElement;
+				var maintainApp = Xamarin.Forms.Application.Current;
+				visualElement.Parent = new Application();
+				Xamarin.Forms.Application.Current = maintainApp;
+				var renderer = Platform.CreateRendererWithContext(visualElement, result);
 
-            return result;
-        }
+				renderer.View.ViewAttachedToWindow += result.OnViewAttachedToWindow;
+				renderer.View.ViewDetachedFromWindow += result.OnViewDetachedToWindow;
 
-        protected override void OnDestroy()
-        {
-            base.OnDestroy();
-            semaphore.Release();
-        }
-    }
+				Platform.SetRenderer(visualElement, renderer);
+				result._linearLayoutCompat.AddView(renderer.View, new LinearLayoutCompat.LayoutParams(LinearLayoutCompat.LayoutParams.MatchParent, LinearLayoutCompat.LayoutParams.MatchParent));
+			}
+
+			return result;
+		}
+
+		void OnViewDetachedToWindow(object sender, global::Android.Views.View.ViewDetachedFromWindowEventArgs e)
+		{
+			if (sender is global::Android.Views.View view)
+				view.ViewDetachedFromWindow -= OnViewDetachedToWindow;
+
+			_windowDetached.SetResult(true);
+		}
+
+		void OnViewAttachedToWindow(object sender, global::Android.Views.View.ViewAttachedToWindowEventArgs e)
+		{
+			if (sender is global::Android.Views.View view)
+				view.ViewAttachedToWindow -= OnViewAttachedToWindow;
+
+			_windowAttached.SetResult(true);
+		}
+
+		public override void Finish()
+		{
+			if (Element != null)
+			{
+				Element.Parent = null;
+				Platform.SetRenderer(Element, null);
+			}
+
+			var view = _linearLayoutCompat.GetChildAt(0);
+			if (view.IsAlive())
+			{
+				view.ViewAttachedToWindow -= OnViewAttachedToWindow;
+				view.ViewDetachedFromWindow -= OnViewDetachedToWindow;
+			}
+
+			_linearLayoutCompat.RemoveAllViews();
+			base.Finish();
+		}
+
+		protected override void OnDestroy()
+		{
+			base.OnDestroy();
+			semaphore.Release();
+		}
+
+		protected override void OnResume()
+		{
+			base.OnResume();
+			Surface.SetResult(this);
+		}
+
+		[Preserve(AllMembers = true)]
+		class TestLinearLayoutCompat : LinearLayoutCompat
+		{
+			public TestLinearLayoutCompat(Context context) : base(context)
+			{
+			}
+		}
+	}
 }

--- a/Xamarin.Forms.Platform.Android.UnitTests/TestClasses/_5560Model.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/TestClasses/_5560Model.cs
@@ -28,13 +28,11 @@ namespace Xamarin.Forms.Platform.Android.UnitTests
 			set
 			{
 				_text = value;
-
-				if (!TestCompleted)
-					OnPropertyChanged(nameof(Text));
-
 				_textChangedCounter++;
 				if (_textChangedCounter > 100)
 					MarkTestCompleted();
+				else
+					OnPropertyChanged(nameof(Text));
 			}
 		}
 
@@ -61,7 +59,7 @@ namespace Xamarin.Forms.Platform.Android.UnitTests
 
 		public Task WaitForTestToComplete()
 		{
-			return Task.WhenAny( new Task[] { _testCompleted.Task, Task.Delay(3000) });
+			return Task.WhenAny(new Task[] { _testCompleted.Task, Task.Delay(3000) });
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android.UnitTests/ToolbarExtensionsTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/ToolbarExtensionsTests.cs
@@ -20,7 +20,6 @@ using Xamarin.Forms.Platform.Android.UnitTests;
 using AToolBar = AndroidX.AppCompat.Widget.Toolbar;
 using AView = Android.Views.View;
 
-[assembly: ExportRenderer(typeof(TestShell), typeof(TestShellRenderer))]
 namespace Xamarin.Forms.Platform.Android.UnitTests
 {
 	public class ToolbarExtensionsTests : PlatformTestFixture

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="IsEnabledTests.cs" />
     <Compile Include="Issues.cs" />
     <Compile Include="IsVisibleTests.cs" />
+    <Compile Include="NavigationPageTests.cs" />
     <Compile Include="ObservrableItemsSourceTests.cs" />
     <Compile Include="OpacityTests.cs" />
     <Compile Include="RendererTests.cs" />


### PR DESCRIPTION
### Description of Change ###

If the user triggers push/pop operations before the navigation renderer has been made consistent with the Navigation.Pages then those push/pop operations will leave the NavigationRenderer in a confused state.

If a user issues a pop before the NavigationRenderer has updated to match the current page stack queue then these changes just ignore the pop. There's no reason to process a pop if no fragments have been pushed

If the user issues a push this will force the NavigationRenderer to become consistent with the Navigation.Pages

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11909 


### Platforms Affected ### 
- Android


### Testing Procedure ###
- tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
