### PR TITLE
[iOS]  TextDecoration Strikethrough not working on iOS together with LineHeight

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11829.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11829.cs
@@ -1,0 +1,53 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Label)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11829,
+		"[Bug] TextDecoration Strikethrough not working on iOS together with LineHeight",
+		PlatformAffected.All)]
+	public class Issue11829 : TestContentPage
+	{
+		public Issue11829()
+		{
+
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 11829";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If the text below is underline, the test has passed."
+			};
+
+			var label = new Label
+			{
+				TextDecorations = TextDecorations.Underline,
+				LineHeight = 2,
+				Text = "Underline using LineHeight"
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(label);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11829.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11829.cs
@@ -41,13 +41,74 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				TextDecorations = TextDecorations.Underline,
 				LineHeight = 2,
-				Text = "Underline using LineHeight"
+				Text = "Underline using LineHeight",
+				Margin = new Thickness(0, 12)
 			};
+
+			var textDecorationsLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var textDecorationsCheckBox = new CheckBox
+			{
+				IsChecked = true,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var textDecorationsText = new Label
+			{
+				Text = "Underline",
+				WidthRequest = 100,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			textDecorationsLayout.Children.Add(textDecorationsText);
+			textDecorationsLayout.Children.Add(textDecorationsCheckBox);
+
+			var lineHeightLayout = new StackLayout
+			{
+				Orientation = StackOrientation.Horizontal
+			};
+
+			var lineHeightSlider = new Slider
+			{
+				Maximum = 4,
+				Minimum = 2,
+				Value = 2,
+				WidthRequest = 150,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			var lineHeightText = new Label
+			{
+				Text = "LineHeight",
+				WidthRequest = 100,
+				VerticalOptions = LayoutOptions.Center
+			};
+
+			lineHeightLayout.Children.Add(lineHeightText);
+			lineHeightLayout.Children.Add(lineHeightSlider);
 
 			layout.Children.Add(instructions);
 			layout.Children.Add(label);
+			layout.Children.Add(textDecorationsLayout);
+			layout.Children.Add(lineHeightLayout);
 
 			Content = layout;
+
+			textDecorationsCheckBox.CheckedChanged += (sender, args) =>
+			{
+				if (args.Value)
+					label.TextDecorations = TextDecorations.Underline;
+				else
+					label.TextDecorations = TextDecorations.None;
+			};
+
+			lineHeightSlider.ValueChanged += (sender, args) =>
+			{
+				label.LineHeight = args.NewValue;
+			};
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11829.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11829.cs
@@ -34,12 +34,12 @@ namespace Xamarin.Forms.Controls.Issues
 				Padding = 12,
 				BackgroundColor = Color.Black,
 				TextColor = Color.White,
-				Text = "If the text below is underline, the test has passed."
+				Text = "If the text below is underline & strike through, the test has passed."
 			};
 
 			var label = new Label
 			{
-				TextDecorations = TextDecorations.Underline,
+				TextDecorations = TextDecorations.Underline | TextDecorations.Strikethrough,
 				LineHeight = 2,
 				Text = "Underline using LineHeight",
 				Margin = new Thickness(0, 12)
@@ -100,7 +100,7 @@ namespace Xamarin.Forms.Controls.Issues
 			textDecorationsCheckBox.CheckedChanged += (sender, args) =>
 			{
 				if (args.Value)
-					label.TextDecorations = TextDecorations.Underline;
+					label.TextDecorations = TextDecorations.Strikethrough | TextDecorations.Underline;
 				else
 					label.TextDecorations = TextDecorations.None;
 			};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1719,7 +1719,6 @@
       <DependentUpon>Issue11938.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
     <Compile Include="$(MSBuildThisFileDirectory)Issue11829.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" >
       <DependentUpon>Issue11496.xaml</DependentUpon>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1720,6 +1720,8 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11829.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" >
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1827,6 +1827,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14757.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14897.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11829.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1828,8 +1828,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14757.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14897.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11829.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -174,9 +174,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				UpdateLineBreakMode();
 				UpdateText();
-				UpdateTextDecorations();
 				UpdateTextColor();
 				UpdateFont();
+				UpdateTextDecorations();
 				UpdateMaxLines();
 				UpdateCharacterSpacing();
 				UpdatePadding();

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -219,7 +219,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateHorizontalTextAlignment();
 			else if (e.PropertyName == Label.LineHeightProperty.PropertyName)
+			{
 				UpdateText();
+				UpdateTextDecorations();
+			}
 			else if (e.PropertyName == Label.MaxLinesProperty.PropertyName)
 				UpdateMaxLines();
 			else if (e.PropertyName == Label.PaddingProperty.PropertyName)


### PR DESCRIPTION
### Description of Change ###
Fix issue on iOS Label using TextDecoration Strikethrough together with LineHeight.

### Issues Resolved ### 

- fixes #11829 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix11829](https://user-images.githubusercontent.com/6755973/91303071-c17d7200-e7a7-11ea-91a5-c026f13a5629.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11928. If text is underline, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
