### PR TITLE
Remove Microsoft.NETCore.UniversalWindowsPlatform From nuspec

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -29,13 +29,11 @@
       </group>
       <group targetFramework="uap10.0.14393">
         <dependency id="NETStandard.Library" version="2.0.1"/>
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10" />
         <dependency id="Win2D.uwp" version="1.20.0" />
         <dependency id="Microsoft.UI.Xaml" version="2.1.190606001" />
         <dependency id="System.ValueTuple" version="4.5.0" />
       </group>
       <group targetFramework="uap10.0.16299">
-        <dependency id="Microsoft.NETCore.UniversalWindowsPlatform" version="6.2.10" />
         <dependency id="Win2D.uwp" version="1.20.0" />
         <dependency id="Microsoft.UI.Xaml" version="2.4.2" />
       </group>

--- a/DualScreen/DualScreen.UWP/DualScreen.UWP.csproj
+++ b/DualScreen/DualScreen.UWP/DualScreen.UWP.csproj
@@ -143,7 +143,7 @@
     </Page>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.1.9" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\DualScreen\DualScreen.csproj">

--- a/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
+++ b/EmbeddingTestBeds/Embedding.UWP/Embedding.UWP.csproj
@@ -150,7 +150,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform">
-      <Version>6.0.15</Version>
+      <Version>6.2.10</Version>
     </PackageReference>
   </ItemGroup>
   <PropertyGroup Condition=" '$(VisualStudioVersion)' == '' or '$(VisualStudioVersion)' &lt; '14.0' ">

--- a/UWP.Build.targets
+++ b/UWP.Build.targets
@@ -13,6 +13,6 @@
     </SDKReference>
   </ItemGroup>
   <ItemGroup  Condition="$(TargetFramework.StartsWith('uap10.0')) AND '$(OS)' == 'Windows_NT' ">
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -42,7 +42,7 @@
     <Compile Include="**\*.uwp.*.cs" />
     <ProjectReference Include="..\Xamarin.Forms.Platform.UAP\Xamarin.Forms.Platform.UAP.csproj">
     </ProjectReference>
-    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.0.15" />
+    <PackageReference Include="Microsoft.NETCore.UniversalWindowsPlatform" Version="6.2.10" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) ">
     <Compile Include="**\*.android.cs" />


### PR DESCRIPTION
### Description of Change ###

The version of `Microsoft.NETCore.UniversalWindowsPlatform` should be settable by the application developer. By default we'll have our templates always pointing at the latest tested version 

Having this in our nuspec and inside the templates just leads to nuget dependency confusions


### Platforms Affected ### 
- UWP

### Testing Procedure ###
- UI tests pass
- make sure you can install this nuget into a new UWP app and it runs

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
