### PR TITLE
[iOS] Fixing another NRE in ContextActionCell

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -485,7 +485,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnContextItemsChanged(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			var parentListView = _cell.RealParent as ListView;
+			var parentListView = _cell?.RealParent as ListView;
 			var recycling = parentListView != null && 
 				((parentListView.CachingStrategy & ListViewCachingStrategy.RecycleElement) != 0);
 			if (recycling)


### PR DESCRIPTION
### Description of Change ###

Fix another NRE when trying to clear ContextActions of a ListView (on iOS)

### Issues Resolved ### 
- fixes #11943

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###

See #11943 for repro steps

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
