### PR TITLE
[UWP] Fix 11946 Entry Clear Button Visibility initial value not honored

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8836.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8836.cs
@@ -12,11 +12,12 @@ namespace Xamarin.Forms.Controls.Issues
 			var stack = new StackLayout();
 
 			stack.Children.Add(new Label {Text = "Click the button to toggle the clear button visibility."});
+			stack.Children.Add(new Label { Text = "The default state when this page loaded is NEVER.  The clear button should not be visible until you click toggle." });
 
 			Entry = new Entry
 			{
-				Text = "Clear Button: While Editing",
-				ClearButtonVisibility = ClearButtonVisibility.WhileEditing
+				Text = "Clear Button: Never",
+				ClearButtonVisibility = ClearButtonVisibility.Never
 			};
 			stack.Children.Add(Entry);
 

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -163,6 +163,7 @@ namespace Xamarin.Forms.Platform.UWP
 				_DeleteButtonVisibleStateGroups = stateGroups.SingleOrDefault(sg => sg.Name == "ButtonStates");
 				if (_DeleteButtonVisibleStateGroups != null)
 					_DeleteButtonVisibleState = _DeleteButtonVisibleStateGroups.States.SingleOrDefault(s => s.Name == "ButtonVisible");
+				UpdateClearButtonVisible();
 			}
 
 			_scrollViewer= GetTemplateChild("ContentElement") as ScrollViewer;
@@ -387,19 +388,24 @@ namespace Xamarin.Forms.Platform.UWP
 			SelectionStart = base.Text.Length;
 		}
 
-		static void ClearButtonVisibleChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+		void UpdateClearButtonVisible()
 		{
-			var textBox = (FormsTextBox)dependencyObject;
-			var visibleState = textBox._DeleteButtonVisibleState;
-			var states = textBox._DeleteButtonVisibleStateGroups?.States;
+			var visibleState = _DeleteButtonVisibleState;
+			var states = _DeleteButtonVisibleStateGroups?.States;
 
 			if (states != null && visibleState != null)
 			{
-				if (textBox.ClearButtonVisible && !states.Contains(visibleState))
+				if (ClearButtonVisible && !states.Contains(visibleState))
 					states.Add(visibleState);
 				else
 					states.Remove(visibleState);
 			}
+		}
+
+		static void ClearButtonVisibleChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)
+		{
+			var textBox = (FormsTextBox)dependencyObject;
+			textBox.UpdateClearButtonVisible();
 		}
 
 		static void TextPropertyChanged(DependencyObject dependencyObject, DependencyPropertyChangedEventArgs dependencyPropertyChangedEventArgs)


### PR DESCRIPTION
### Description of Change ###

Clear Button Visibility set before the control is loaded, in code or XAML wasn't being honored.

This change adds updating the visibility based on the ClearButtonVisible state during OnApplyTemplate since that is the first time the clear button could be removed.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11946 

### API Changes ###

 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Open issue page 8836 and follow the instructions

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
