### PR TITLE
Fix Shell to better handle delayed setting of Items

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11769.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11769.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11769, "[Bug] Shell throws exception when delay adding Shell Content", issueTestNumber: 2)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+
+	public class Issue11769_DelayedShellContent : TestShell
+	{
+		protected override void Init()
+		{
+			Items.Add(new FlyoutItem() 
+			{
+				Items =
+				{
+					new Tab()
+				}
+			});
+
+			Device.InvokeOnMainThreadAsync(() =>
+			{
+				var shellContent = new ShellContent()
+				{
+					Content = new ContentPage()
+					{
+						Content = new Label() { Text = "Success" }
+					}
+				};
+
+				Items[0].Items[0].Items.Add(shellContent);
+			});
+		}
+
+#if UITEST
+		[Test]
+		public void DelayedAddingOfShellContentDoesntCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11769, "[Bug] Shell throws exception when delay adding Shell Section", issueTestNumber: 1)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+
+	public class Issue11769_DelayedShellSection : TestShell
+	{
+		protected override void Init()
+		{
+			Items.Add(new FlyoutItem());
+			Device.InvokeOnMainThreadAsync(() =>
+			{
+				var tab = new Tab()
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Content = new ContentPage()
+							{
+								Content = new Label() { Text = "Success" }
+							}
+						}
+					}
+				};
+
+				Items[0].Items.Add(tab);
+			});
+		}
+
+#if UITEST
+		[Test]
+		public void DelayedAddingOfShellSectionDoesntCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11769, "[Bug] Shell throws exception when delay adding Shell Item", issueTestNumber: 0)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+
+	public class Issue11769_DelayedShellItem : TestShell
+	{
+		protected override void Init()
+		{
+			Device.InvokeOnMainThreadAsync(() =>
+			{
+				var page = AddBottomTab("Success");
+				page.Content = new Label() { Text = "Success" };
+			});
+		}
+
+#if UITEST
+		[Test]
+		public void DelayedAddingOfShellItemDoesntCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -26,6 +26,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11769.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -380,12 +380,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void DefaultShellRoutesWorksWithNavigation()
-		{
-
-		}
-
-		[Test]
 		public async Task ConvertToStandardFormat()
 		{
 			var shell = new Shell();

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -379,6 +379,11 @@ namespace Xamarin.Forms.Core.UnitTests
 
 		}
 
+		[Test]
+		public void DefaultShellRoutesWorksWithNavigation()
+		{
+
+		}
 
 		[Test]
 		public async Task ConvertToStandardFormat()

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -802,7 +802,7 @@ namespace Xamarin.Forms
 					try
 					{
 						var location = CurrentState.Location;
-						var navRequest = ShellUriHandler.GetNavigationRequest(this, ((ShellNavigationState)location).FullLocation, false);
+						var navRequest = ShellUriHandler.GetNavigationRequest(this, ((ShellNavigationState)location).FullLocation, false, false);
 
 						if (navRequest != null)
 						{

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -79,7 +79,7 @@ namespace Xamarin.Forms
 			return new Uri(uri);
 		}
 
-		internal static NavigationRequest GetNavigationRequest(Shell shell, Uri uri, bool enableRelativeShellRoutes = false)
+		internal static NavigationRequest GetNavigationRequest(Shell shell, Uri uri, bool enableRelativeShellRoutes = false, bool throwNavigationErrorAsException = true)
 		{
 			uri = FormatUri(uri, shell);
 			// figure out the intent of the Uri
@@ -97,7 +97,12 @@ namespace Xamarin.Forms
 
 
 			if (possibleRouteMatches.Count == 0)
-				throw new ArgumentException($"unable to figure out route for: {uri}", nameof(uri));
+			{
+				if(throwNavigationErrorAsException)
+					throw new ArgumentException($"unable to figure out route for: {uri}", nameof(uri));
+
+				return null;
+			}
 			else if (possibleRouteMatches.Count > 1)
 			{
 				string[] matches = new string[possibleRouteMatches.Count];
@@ -109,8 +114,11 @@ namespace Xamarin.Forms
 				}
 
 				string matchesFound = String.Join(",", matches);
-				throw new ArgumentException($"Ambiguous routes matched for: {uri} matches found: {matchesFound}", nameof(uri));
 
+				if (throwNavigationErrorAsException)
+					throw new ArgumentException($"Ambiguous routes matched for: {uri} matches found: {matchesFound}", nameof(uri));
+
+				return null;
 			}
 
 			var theWinningRoute = possibleRouteMatches[0];

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
@@ -98,6 +98,10 @@ namespace Xamarin.Forms.Platform.UWP
 		internal void NavigateToShellItem(ShellItem newItem, bool animate)
 		{
 			UnhookEvents(ShellItem);
+
+			if (newItem?.CurrentItem?.CurrentItem == null)
+				return;
+
 			ShellItem = newItem;
 
 			if (newItem.CurrentItem == null)

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -259,6 +259,9 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateToolBar()
 		{
+			if (SelectedItem == null)
+				return;
+
 			if(_shell.Navigation.NavigationStack.Count > 1)
 			{
 				IsBackEnabled = true;

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -44,7 +44,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnShellSectionRendererSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
 		{
-			Page.ContainerArea = new Rectangle(0, 0, e.NewSize.Width, e.NewSize.Height);
+			if(Page != null)
+				Page.ContainerArea = new Rectangle(0, 0, e.NewSize.Width, e.NewSize.Height);
 		}
 
 		void OnMenuItemInvoked(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewItemInvokedEventArgs args)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -286,7 +286,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Shell.CurrentItem == null)
 			{
 				return;
-				//throw new InvalidOperationException("Shell CurrentItem should not be null");
 			}
 			else if (_currentShellItemRenderer == null)
 			{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -109,7 +109,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
-			_currentShellItemRenderer.ViewController.View.Frame = View.Bounds;
+			if(_currentShellItemRenderer != null)
+				_currentShellItemRenderer.ViewController.View.Frame = View.Bounds;
 
 			SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));
 		}
@@ -284,7 +285,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Shell.CurrentItem == null)
 			{
-				throw new InvalidOperationException("Shell CurrentItem should not be null");
+				return;
+				//throw new InvalidOperationException("Shell CurrentItem should not be null");
 			}
 			else if (_currentShellItemRenderer == null)
 			{


### PR DESCRIPTION
### Description of Change ###
Don't hard crash if user hasn't specified Items for Shell and make that behavior work more consistently across all platforms

### Issues Resolved ### 
- fixes #11769

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
- ui tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
