### PR TITLE
Make Frames with Labels work in ListViews again

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7823.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7823.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			var frameClippedToBouds = new Frame
+			var frameClippedToBounds = new Frame
 			{
 				AutomationId = SecondaryFrame,
 				CornerRadius = 10,
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.Controls.Issues
 						CornerRadius = 5,
 						BackgroundColor = Color.Red,
 						Padding = 10,
-						Content = frameClippedToBouds
+						Content = frameClippedToBounds
 					},
 					new Button
 					{
@@ -61,8 +61,8 @@ namespace Xamarin.Forms.Controls.Issues
 						Text = "Manually set Frame.IsClippedToBounds = false",
 						Command = new Command(()=>
 						{
-							frameClippedToBouds.IsClippedToBounds = false;
-							frameClippedToBouds.CornerRadius = 11;
+							frameClippedToBounds.IsClippedToBounds = false;
+							frameClippedToBounds.CornerRadius = 11;
 						})
 					}
 				}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -252,7 +252,6 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return;
 			}
 
-
 			if (e.PropertyName == Frame.HasShadowProperty.PropertyName)
 				UpdateShadow();
 			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
@@ -269,7 +268,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		void UpdateClippedToBounds()
 		{
-			this.SetClipToOutline(Element.IsClippedToBounds, Element);
+			var shouldClip = Element.IsSet(Xamarin.Forms.Layout.IsClippedToBoundsProperty)
+					? Element.IsClippedToBounds : Element.CornerRadius > 0f;
+
+			this.SetClipToOutline(shouldClip);
 		}
 
 		void UpdateBackgroundColor()

--- a/Xamarin.Forms.Platform.Android/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ViewExtensions.cs
@@ -102,53 +102,6 @@ namespace Xamarin.Forms.Platform.Android
 			view.ClipToOutline = value;
 		}
 
-		public static void SetClipToOutline(this AView view, bool value, VisualElement element)
-		{
-			if (view.IsDisposed())
-				return;
-
-			var shouldClip = value;
-			if (element is Frame frame)
-			{
-				shouldClip = frame.IsSet(Layout.IsClippedToBoundsProperty)
-					? frame.IsClippedToBounds : frame.CornerRadius > 0f;
-			}
-
-			if (view is FastRenderers.FrameRenderer && Forms.IsLollipopOrNewer)
-			{
-				view.SetClipToOutline(shouldClip);
-				return;
-			}
-
-			// setClipBounds is only available in API 18 +
-			if ((int)Build.VERSION.SdkInt >= 18)
-			{
-				if (!(view is ViewGroup viewGroup))
-				{
-					return;
-				}
-
-				// Forms layouts should not impose clipping on their children
-				viewGroup.SetClipChildren(false);
-
-				// But if IsClippedToBounds is true, they _should_ enforce clipping at their own edges
-				viewGroup.ClipBounds = shouldClip ? new ARect(0, 0, viewGroup.Width, viewGroup.Height) : null;
-			}
-			else
-			{
-				// For everything in 17 and below, use the setClipChildren method
-				if (!(view.Parent is ViewGroup parent))
-					return;
-
-				if ((int)Build.VERSION.SdkInt >= 18 && parent.ClipChildren == shouldClip)
-					return;
-
-				parent.SetClipChildren(shouldClip);
-				parent.Invalidate();
-			}
-		}
-
-
 		public static bool SetElevation(this AView view, float value)
 		{
 			if (view.IsDisposed() || !Forms.IsLollipopOrNewer)

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -291,7 +291,34 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
-			_renderer.View.SetClipToOutline(layout.IsClippedToBounds, _renderer.Element);
+			bool shouldClip = layout.IsClippedToBounds;
+
+			// setClipBounds is only available in API 18 +	
+			if ((int)Forms.SdkInt >= 18)
+			{
+				if (!(_renderer.View is ViewGroup viewGroup))
+				{
+					return;
+				}
+
+				// Forms layouts should not impose clipping on their children	
+				viewGroup.SetClipChildren(false);
+
+				// But if IsClippedToBounds is true, they _should_ enforce clipping at their own edges	
+				viewGroup.ClipBounds = shouldClip ? new global::Android.Graphics.Rect(0, 0, viewGroup.Width, viewGroup.Height) : null;
+			}
+			else
+			{
+				// For everything in 17 and below, use the setClipChildren method	
+				if (!(_renderer.View.Parent is ViewGroup parent))
+					return;
+
+				if ((int)Forms.SdkInt >= 18 && parent.ClipChildren == shouldClip)
+					return;
+
+				parent.SetClipChildren(shouldClip);
+				parent.Invalidate();
+			}
 		}
 
 		void UpdateClip()


### PR DESCRIPTION
### Description of Change ###

PR #8032 broke Labels inside of Frames in ListView ViewCells - this can be seen by running UI test for issue #1415; the ListView items should have text in them, and after #8032 they do not.

These changes restore the functionality used in the #1415 test while preserving the corner radius clipping changes from #8032.

### Issues Resolved ### 

Text not displaying inside of Frames used as the DataTemplate for a ListView's ViewCells.

### API Changes ###
 
None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test for #7823 (should still pass); also make sure to run #1415 (sadly, manual) and verify that text displays in the ListView items.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
