### PR TITLE
Fix miss font 

### DIFF
--- a/Xamarin.Forms.Platform.WPF/Extensions/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.WPF/Extensions/FontExtensions.cs
@@ -127,6 +127,13 @@ namespace Xamarin.Forms.Platform.WPF
 				return f;
 			}
 
+			const string packUri = "pack://application:,,,/";
+			if (fontFamily.StartsWith(packUri))
+			{
+				var fontName = fontFamily.Remove(0, packUri.Length);
+				return new FontFamily(new Uri(packUri), fontName);
+			}
+
 			var embeddedResult = fontFamily.TryGetFromAssets();
 
 			if (embeddedResult.success)


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

We should not re-splice a font file uri

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11789

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- WPF

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Before the change, the application will display the square, and after the change, the application will display the correct font

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before Screenshots

![](https://user-images.githubusercontent.com/16054566/91783866-fec48280-ec33-11ea-9960-5e64a6425118.png)


After Screenshots：

![](https://user-images.githubusercontent.com/16054566/91783831-ec4a4900-ec33-11ea-840c-e81258f169f7.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
