### PR TITLE
[Tizen] Enhances the EntryRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Extensions/TextAlignmentExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/TextAlignmentExtensions.cs
@@ -22,5 +22,26 @@ namespace Xamarin.Forms.Platform.Tizen
 					return Native.TextAlignment.Auto;
 			}
 		}
+
+		public static double ToNativeDouble(this TextAlignment alignment)
+		{
+			switch (alignment)
+			{
+				case TextAlignment.Center:
+					return 0.5d;
+
+				case TextAlignment.Start:
+					return 0;
+
+				case TextAlignment.End:
+					return 1d;
+
+				default:
+					Log.Warn("Warning: unrecognized HorizontalTextAlignment value {0}. " +
+						"Expected: {Start|Center|End}.", alignment);
+					Log.Debug("Falling back to platform's default settings.");
+					return 0.5d;
+			}
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EditfieldEntry.cs
@@ -73,9 +73,22 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			// If the height of a TextBlock is shorter than Editfield, use the minimun height of the Editfield.
 			// Or add the height of the EditField to the TextBlock
 			if (textBlockSize.Height < _editfieldLayout.MinimumHeight)
-				textBlockSize.Height = _editfieldLayout.MinimumHeight;
+			{
+				if (Device.Idiom == TargetIdiom.TV || Device.Idiom == TargetIdiom.Watch)
+				{
+					textBlockSize.Height = _editfieldLayout.MinimumHeight;
+				}
+				else
+				{
+					// Since the minimum height of EditFieldLayout too large, adjust it to an appropriate height.
+					var adjustedMinHeight = _editfieldLayout.MinimumHeight - (_editfieldLayout.MinimumHeight - _heightPadding) / 2;
+					textBlockSize.Height = textBlockSize.Height < adjustedMinHeight ? adjustedMinHeight : _editfieldLayout.MinimumHeight;
+				}
+			}
 			else
+			{
 				textBlockSize.Height += _heightPadding;
+			}
 
 			return textBlockSize;
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.FontFamilyProperty, UpdateFontFamily);
 			RegisterPropertyHandler(Entry.FontAttributesProperty, UpdateFontAttributes);
 			RegisterPropertyHandler(Entry.HorizontalTextAlignmentProperty, UpdateHorizontalTextAlignment);
+			RegisterPropertyHandler(Entry.VerticalTextAlignmentProperty, UpdateVerticalTextAlignment);
 			RegisterPropertyHandler(InputView.KeyboardProperty, UpdateKeyboard);
 			RegisterPropertyHandler(Entry.PlaceholderProperty, UpdatePlaceholder);
 			RegisterPropertyHandler(Entry.PlaceholderColorProperty, UpdatePlaceholderColor);
@@ -27,6 +28,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Entry.SelectionLengthProperty, UpdateSelectionLength);
 			RegisterPropertyHandler(InputView.IsReadOnlyProperty, UpdateIsReadOnly);
 			RegisterPropertyHandler(Entry.ClearButtonVisibilityProperty, UpdateClearButtonVisibility);
+			RegisterPropertyHandler(Entry.CursorPositionProperty, UpdateSelectionLength);
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Entry> e)
@@ -34,8 +36,6 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control == null)
 			{
 				var entry = CreateNativeControl();
-				entry.SetVerticalTextAlignment(0.5);
-				entry.SetVerticalPlaceHolderTextAlignment(0.5);
 				entry.Activated += OnCompleted;
 				entry.CursorChanged += OnCursorChanged;
 
@@ -45,8 +45,6 @@ namespace Xamarin.Forms.Platform.Tizen
 				}
 				entry.PrependMarkUpFilter(MaxLengthFilter);
 				SetNativeControl(entry);
-
-				
 			}
 			base.OnElementChanged(e);
 		}
@@ -154,7 +152,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control is IEntry ie)
 			{
 				ie.FontAttributes = Element.FontAttributes;
-			}			
+			}
 		}
 
 		void UpdateHorizontalTextAlignment()
@@ -162,7 +160,13 @@ namespace Xamarin.Forms.Platform.Tizen
 			if (Control is IEntry ie)
 			{
 				ie.HorizontalTextAlignment = Element.HorizontalTextAlignment.ToNative();
-			}			
+			}
+		}
+
+		void UpdateVerticalTextAlignment()
+		{
+			Control.SetVerticalTextAlignment(Element.VerticalTextAlignment.ToNativeDouble());
+			Control.SetVerticalPlaceHolderTextAlignment(Element.VerticalTextAlignment.ToNativeDouble());
 		}
 
 		void UpdateKeyboard(bool initialize)
@@ -223,28 +227,84 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateSelectionLength()
 		{
-			var selectionLength = Control.GetSelection()?.Length ?? 0;
-			if (selectionLength != Element.SelectionLength)
+			int start = GetSelectionStart();
+			int end = GetSelectionEnd(start);
+
+			if (start != end)
 			{
-				if (Element.SelectionLength == 0)
-				{
-					Control.SelectNone();
-				}
-				else
-				{
-					Control.SetSelectionRegion(Element.CursorPosition, Element.CursorPosition + Element.SelectionLength);
-				}
+				Control.SetSelectionRegion(start, end);
 			}
-			else if (selectionLength == 0)
+			else
 			{
+				Control.CursorPosition = start;
 				Control.SelectNone();
+				Control.SetFocus(true);
 			}
+		}
+
+		int GetSelectionEnd(int start)
+		{
+			int end = start;
+			int selectionLength = Element.SelectionLength;
+
+			if (Element.IsSet(Entry.SelectionLengthProperty))
+				end = Math.Max(start, Math.Min(Control.Text.Length, start + selectionLength));
+
+			int newSelectionLength = Math.Max(0, end - start);
+			if (newSelectionLength != selectionLength)
+				SetSelectionLengthFromRenderer(newSelectionLength);
+
+			return end;
+		}
+
+		int GetSelectionStart()
+		{
+			int start = Element.Text.Length;
+			int cursorPosition = Element.CursorPosition;
+
+			if (Element.IsSet(Entry.CursorPositionProperty))
+				start = Math.Min(start, cursorPosition);
+
+			if (start != cursorPosition)
+				SetCursorPositionFromRenderer(start);
+
+			return start;
 		}
 
 		void OnCursorChanged(object sender, EventArgs e)
 		{
-			Element.SetValueFromRenderer(Entry.CursorPositionProperty, GetCursorPosition());
-			Element.SetValueFromRenderer(Entry.SelectionLengthProperty, Control.GetSelection()?.Length ?? 0);
+			int cursorPosition = Element.CursorPosition;
+			int selectionStart = GetCursorPosition();
+
+			if (selectionStart != cursorPosition)
+				SetCursorPositionFromRenderer(selectionStart);
+
+			SetSelectionLengthFromRenderer(Control.GetSelection()?.Length ?? 0);
+
+		}
+
+		void SetCursorPositionFromRenderer(int start)
+		{
+			try
+			{
+				Element?.SetValueFromRenderer(Entry.CursorPositionProperty, start);
+			}
+			catch (Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set CursorPosition from renderer: {ex}");
+			}
+		}
+
+		void SetSelectionLengthFromRenderer(int selectionLength)
+		{
+			try
+			{
+				Element?.SetValueFromRenderer(Entry.SelectionLengthProperty, selectionLength);
+			}
+			catch (Exception ex)
+			{
+				Internals.Log.Warning("Entry", $"Failed to set SelectionLength from renderer: {ex}");
+			}
 		}
 
 		int GetCursorPosition()


### PR DESCRIPTION
### Description of Change ###
This PR is to enhance `CursorPosition` / `SelectionLength` and support `VerticalTextAlignment` of `Entry`.  Plus, I've adjusted the height of entry appropriately. (Previously, it was too big unnecessarily.)

 Before| After
---- | ----
 <img src="https://user-images.githubusercontent.com/1029134/91797349-4d3a4700-ec5d-11ea-9fde-df0ec4eb7e8b.gif" width=320 /> |  <img src="https://user-images.githubusercontent.com/1029134/91797353-4f040a80-ec5d-11ea-9629-4d962fb3f0ac.gif" width=320 />

### Issues Resolved ### 
 None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
See above description

### Testing Procedure ###
Run ControlGallery - [Issue3343](https://github.com/xamarin/Xamarin.Forms/blob/a8bcaa9a609cfa6f3026775b26ab7adfb4947772/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue3343.cs#L9)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
