### PR TITLE
UI Test reliability updates

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml
@@ -36,7 +36,7 @@
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition Width="*" />
                                 </Grid.ColumnDefinitions>
-                                <Image Aspect="AspectFill" AutomationId="MonkeyImages">
+                                <Image Aspect="AspectFit" AutomationId="MonkeyImages">
                                     <Image.Source>
                                         <UriImageSource Uri="{Binding Image}" CachingEnabled="False"></UriImageSource>
                                     </Image.Source>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
@@ -50,15 +50,17 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				var images = RunningApp.WaitForElement("MonkeyImages");
 
-				if (images[0].Rect.Height < 30 || images[0].Rect.Width < 30)
+				if (images[0].Rect.Height < 20 || images[0].Rect.Width < 20)
 					return null;
 
 				return images;
 			});
 
+			monkeyImages = monkeyImages ?? RunningApp.WaitForElement("MonkeyImages");
+
 			Assert.IsNotNull(monkeyImages);
-			Assert.GreaterOrEqual(monkeyImages[0].Rect.Height, 50);
-			Assert.GreaterOrEqual(monkeyImages[0].Rect.Width, 50);
+			Assert.GreaterOrEqual(monkeyImages[0].Rect.Height, 20);
+			Assert.GreaterOrEqual(monkeyImages[0].Rect.Width, 20);
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
@@ -133,8 +133,46 @@ namespace Xamarin.Forms.Controls.Issues
 			try
 			{
 				IsBusy = true;
-				var json = await Client.GetStringAsync("https://montemagno.com/monkeys.json");
-				Monkey[] monkeys = Monkey.FromJson(json);
+				await Task.Delay(500);
+				Monkey[] monkeys = new[]
+				{
+					new Monkey()
+					{
+						Details = "Climbs high buildings and enjoys swatting at planes",
+						Latitude = 42,
+						Longitude = 42,
+						Location = "Empire State Building",
+						Name = "King Kong",
+						Image = "https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/Fruits.jpg?raw=true"
+					},
+					new Monkey()
+					{
+						Details = "Monkeys aren't donkeys, Quit messing with my head!",
+						Latitude = 42,
+						Longitude = 42,
+						Location = "The 90s",
+						Name = "Donkey Kong",
+						Image = "https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/FlowerBuds.jpg?raw=true"
+					},
+					new Monkey()
+					{
+						Details = "Grape Ape, Grape Ape! Grape Ape, Grape Ape! Grape Ape, Grape Ape! Grape Ape, Grape Ape!",
+						Latitude = 42,
+						Longitude = 42,
+						Location = "Sunday Mornings",
+						Name = "Grape Ape",
+						Image = "https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/games.png?raw=true"
+					},
+					new Monkey()
+					{
+						Details = "Pretty but easily persuaded into doing others biddings",
+						Latitude = 42,
+						Longitude = 42,
+						Location = "The Sky",
+						Name = "Flying Monkey",
+						Image = "https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/gear.png?raw=true"
+					},
+				};
 
 				Monkeys.Clear();
 				foreach (var monkey in monkeys)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				var images = RunningApp.WaitForElement("MonkeyImages");
 
-				if (images[0].Rect.Height < 50 || images[0].Rect.Width < 50)
+				if (images[0].Rect.Height < 30 || images[0].Rect.Width < 30)
 					return null;
 
 				return images;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -224,13 +224,27 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.EnterText(EntryCommandParameter, "parameter");
 			ShowFlyout();
 
-			var commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
+			// API 19 workaround
+			var commandResult = RunningApp.QueryUntilPresent(() =>
+			{
+				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
+					return RunningApp.WaitForElement(CommandResultId);
+
+				return null;
+			})[0].ReadText();
 
 			Assert.AreEqual("parameter", commandResult);
 			RunningApp.EnterText(EntryCommandParameter, "canexecutetest");
 			RunningApp.Tap(ToggleCommandCanExecuteId);
 
-			commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
+			commandResult = RunningApp.QueryUntilPresent(() =>
+			{
+				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
+					return RunningApp.WaitForElement(CommandResultId);
+
+				return null;
+			})[0].ReadText();
+
 			Assert.AreEqual("parameter", commandResult);
 		}
 
@@ -247,7 +261,15 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("Page 0");
 #endif
 
-			var commandResult = RunningApp.WaitForElement(CommandResultId)[0].ReadText();
+			// API 19 workaround
+			var commandResult = RunningApp.QueryUntilPresent(() =>
+			{
+				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
+					return RunningApp.WaitForElement(CommandResultId);
+
+				return null;
+			})[0].ReadText();
+
 			Assert.AreEqual(commandResult, "parameter");
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -237,7 +237,7 @@ namespace Xamarin.Forms.Controls.Issues
 					return RunningApp.WaitForElement(CommandResultId);
 
 				return null;
-			}).FirstOrDefault()?.ReadText();
+			})?.FirstOrDefault()?.ReadText();
 
 			Assert.AreEqual("parameter", commandResult);
 			RunningApp.EnterText(EntryCommandParameter, "canexecutetest");
@@ -249,7 +249,7 @@ namespace Xamarin.Forms.Controls.Issues
 					return RunningApp.WaitForElement(CommandResultId);
 
 				return null;
-			}).FirstOrDefault()?.ReadText();
+			})?.FirstOrDefault()?.ReadText();
 
 			Assert.AreEqual("parameter", commandResult);
 		}
@@ -275,7 +275,7 @@ namespace Xamarin.Forms.Controls.Issues
 					return RunningApp.WaitForElement(CommandResultId);
 
 				return null;
-			}).FirstOrDefault()?.ReadText();
+			})?.FirstOrDefault()?.ReadText();
 
 			Assert.AreEqual(commandResult, "parameter");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -48,7 +48,12 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			BackButtonBehavior behavior = new BackButtonBehavior();
 			Entry _commandParameter;
-			Label _commandResult = new Label() { AutomationId = CommandResultId };
+			Label _commandResult = new Label()
+			{
+				AutomationId = CommandResultId,
+				BackgroundColor = Color.LightBlue,
+				Text = "Label"
+			};
 
 			public BackButtonPage()
 			{
@@ -227,6 +232,7 @@ namespace Xamarin.Forms.Controls.Issues
 			// API 19 workaround
 			var commandResult = RunningApp.QueryUntilPresent(() =>
 			{
+				ShowFlyout();
 				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
 					return RunningApp.WaitForElement(CommandResultId);
 
@@ -239,6 +245,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			commandResult = RunningApp.QueryUntilPresent(() =>
 			{
+				ShowFlyout();
 				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
 					return RunningApp.WaitForElement(CommandResultId);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellBackButtonBehavior.cs
@@ -237,7 +237,7 @@ namespace Xamarin.Forms.Controls.Issues
 					return RunningApp.WaitForElement(CommandResultId);
 
 				return null;
-			})[0].ReadText();
+			}).FirstOrDefault()?.ReadText();
 
 			Assert.AreEqual("parameter", commandResult);
 			RunningApp.EnterText(EntryCommandParameter, "canexecutetest");
@@ -245,12 +245,11 @@ namespace Xamarin.Forms.Controls.Issues
 
 			commandResult = RunningApp.QueryUntilPresent(() =>
 			{
-				ShowFlyout();
 				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
 					return RunningApp.WaitForElement(CommandResultId);
 
 				return null;
-			})[0].ReadText();
+			}).FirstOrDefault()?.ReadText();
 
 			Assert.AreEqual("parameter", commandResult);
 		}
@@ -262,20 +261,21 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(ToggleCommandId);
 			RunningApp.EnterText(EntryCommandParameter, "parameter");
 
-#if __ANDROID__
-			base.TapBackArrow();
-#else
-			RunningApp.Tap("Page 0");
-#endif
-
 			// API 19 workaround
 			var commandResult = RunningApp.QueryUntilPresent(() =>
 			{
+
+#if __ANDROID__
+				TapBackArrow();
+#else
+				RunningApp.Tap("Page 0");
+#endif
+
 				if (RunningApp.WaitForElement(CommandResultId)[0].ReadText() == "parameter")
 					return RunningApp.WaitForElement(CommandResultId);
 
 				return null;
-			})[0].ReadText();
+			}).FirstOrDefault()?.ReadText();
 
 			Assert.AreEqual(commandResult, "parameter");
 		}


### PR DESCRIPTION
### Description of Change ###

- retry text request on API 19
- change monkeys to load all from internal URLS

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP


### Testing Procedure ###
run the android tests a few times against this PR to see if any failures happen from 
- MonkiesShouldLoad
- CommandTest
- CommandWorksWhenItsTheOnlyThingSet

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
