### PR TITLE
[yml] Remove second copy of UI Tests that deletes dsyms

### DIFF
--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -140,31 +140,6 @@ steps:
       flattenFolders: true
 
   - task: CopyFiles@2
-    displayName: 'Copy iOS Files for UITest'
-    condition: eq(variables['buildForVS2017'], 'false')
-    inputs:
-      Contents: |
-        **/XamarinFormsControlGalleryiOS.ipa
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
-      TargetFolder: '$(build.artifactstagingdirectory)/ios'
-      CleanTargetFolder: true
-      flattenFolders: true
-
-  - task: CopyFiles@2
-    displayName: 'Copy iOS dSYM'
-    condition: eq(variables['buildForVS2017'], 'false')
-    inputs:
-      Contents: |
-        **/*.dSYM/**/*.*
-      TargetFolder: '$(build.artifactstagingdirectory)/ios'
-      CleanTargetFolder: false
-      flattenFolders: false
-
-  - task: CopyFiles@2
     displayName: 'Copy iOS Files for UITest 2017'
     condition: eq(variables['buildForVS2017'], 'true')
     inputs:


### PR DESCRIPTION
### Description of Change ###

When the YML file from 4.6 was merged up to 4.7 the duplicate 'Copy iOS Files for UITest' wasn't removed which is removing the dSYM files that were already copied up 

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- Ensure that the dsyms folder is over 60 MBs or so and actually has the dSYM files in it

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
