### PR TITLE
Resolve Layout changes during native measure/arrange pass

### DIFF
--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -90,6 +90,8 @@ namespace Xamarin.Forms
 			set { s_platformServices = value; }
 		}
 
+		public static IPlatformInvalidate PlatformInvalidator { get; set; }
+
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IReadOnlyList<string> Flags { get; private set; }
 
@@ -282,6 +284,11 @@ namespace Xamarin.Forms
 			public static readonly Style ListItemDetailTextStyle = new Style(typeof(Label)) { BaseResourceKey = ListItemDetailTextStyleKey };
 
 			public static readonly Style CaptionStyle = new Style(typeof(Label)) { BaseResourceKey = CaptionStyleKey };
+		}
+
+		public static void Invalidate(VisualElement visualElement) 
+		{
+			PlatformInvalidator?.Invalidate(visualElement);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/IPlatformInvalidate.cs
+++ b/Xamarin.Forms.Core/IPlatformInvalidate.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms.Internals
+{
+	public interface IPlatformInvalidate
+
+	{
+		void Invalidate(VisualElement visualElement);
+	}
+}

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -663,7 +663,10 @@ namespace Xamarin.Forms
 		{
 			_batched = Math.Max(0, _batched - 1);
 			if (!Batched)
+			{
 				BatchCommitted?.Invoke(this, new EventArg<VisualElement>(this));
+				Device.Invalidate(this);
+			}
 		}
 
 		ResourceDictionary _resources;

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -296,7 +296,11 @@ namespace Xamarin.Forms
 			// We want this to be updated when we have a new activity (e.g. on a configuration change)
 			// because AndroidPlatformServices needs a current activity to launch URIs from
 			Profile.FramePartition("Device.PlatformServices");
-			Device.PlatformServices = new AndroidPlatformServices(activity);
+
+			var androidServices = new AndroidPlatformServices(activity);
+
+			Device.PlatformServices = androidServices;
+			Device.PlatformInvalidator = androidServices;
 
 			// use field and not property to avoid exception in getter
 			if (Device.info != null)
@@ -610,7 +614,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		class AndroidPlatformServices : IPlatformServices
+		class AndroidPlatformServices : IPlatformServices, IPlatformInvalidate
 		{
 			double _buttonDefaultSize;
 			double _editTextDefaultSize;
@@ -915,6 +919,18 @@ namespace Xamarin.Forms
 			public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 			{
 				return Platform.Android.Platform.GetNativeSize(view, widthConstraint, heightConstraint);
+			}
+
+			public void Invalidate(VisualElement visualElement)
+			{
+				var renderer = visualElement.GetRenderer();
+				if (renderer == null)
+				{
+					return;
+				}
+
+				renderer.View.Invalidate();
+				renderer.View.RequestLayout();
 			}
 
 			public OSAppTheme RequestedTheme

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -924,7 +924,7 @@ namespace Xamarin.Forms
 			public void Invalidate(VisualElement visualElement)
 			{
 				var renderer = visualElement.GetRenderer();
-				if (renderer == null)
+				if (renderer == null || renderer.View.IsDisposed())
 				{
 					return;
 				}

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1312,6 +1312,16 @@ namespace Xamarin.Forms.Platform.Android
 
 			bool ILayoutChanges.HasLayoutOccurred => _hasLayoutOccurred;
 
+			protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+			{
+				if (Element is Layout layout)
+				{
+					layout.ResolveLayoutChanges();
+				}
+
+				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+			}
+
 			protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
 			{
 				base.OnLayout(changed, left, top, right, bottom);

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -336,6 +336,9 @@ namespace Xamarin.Forms.Platform.Android
 				aview.Visibility = ViewStates.Visible;
 			if (!view.IsVisible && aview.Visibility != ViewStates.Gone)
 				aview.Visibility = ViewStates.Gone;
+
+			aview.Invalidate();
+			aview.RequestLayout();
 		}
 
 		void UpdateNativeView(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -49,7 +49,12 @@ namespace Xamarin.Forms
 
 			Device.SetIdiom(TargetIdiom.Tablet);
 			Device.SetFlowDirection(GetFlowDirection());
-			Device.PlatformServices = new WindowsPlatformServices(Window.Current.Dispatcher);
+
+			var platformServices = new WindowsPlatformServices(Window.Current.Dispatcher);
+
+			Device.PlatformServices = platformServices;
+			Device.PlatformInvalidator = platformServices;
+			
 			Device.SetFlags(s_flags);
 			Device.Info = new WindowsDeviceInfo();
 

--- a/Xamarin.Forms.Platform.UAP/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/LayoutRenderer.cs
@@ -80,5 +80,11 @@ namespace Xamarin.Forms.Platform.UWP
 				Clip = new RectangleGeometry { Rect = new WRect(0, 0, ActualWidth, ActualHeight) };
 			}
 		}
+
+		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
+		{
+			Element?.ResolveLayoutChanges();
+			return base.MeasureOverride(availableSize);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -25,7 +25,7 @@ using IOPath = System.IO.Path;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	internal abstract class WindowsBasePlatformServices : IPlatformServices
+	internal abstract class WindowsBasePlatformServices : IPlatformServices, IPlatformInvalidate
 	{
 		const string WrongThreadError = "RPC_E_WRONG_THREAD";
 		readonly CoreDispatcher _dispatcher;
@@ -254,6 +254,17 @@ namespace Xamarin.Forms.Platform.UWP
 			});
 
 			return await taskCompletionSource.Task;
+		}
+
+		public void Invalidate(VisualElement visualElement)
+		{
+			var renderer = Platform.GetRenderer(visualElement);
+			if (renderer == null)
+			{
+				return;
+			}
+
+			renderer.ContainerElement.InvalidateMeasure();
 		}
 
 		public OSAppTheme RequestedTheme => Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Dark ? OSAppTheme.Dark : OSAppTheme.Light;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -66,7 +66,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_emptyUIView?.Dispose();
 				_emptyUIView = null;
-	
+
 				_emptyViewFormsElement = null;
 
 				ItemsViewLayout?.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -180,8 +180,12 @@ namespace Xamarin.Forms
 			}
 #endif
 			Device.SetFlags(s_flags);
-			Device.PlatformServices = new IOSPlatformServices();
+			var platformServices = new IOSPlatformServices();
+
+			Device.PlatformServices = platformServices;
+
 #if __MOBILE__
+			Device.PlatformInvalidator = platformServices;
 			Device.Info = new IOSDeviceInfo();
 #else
 			Device.Info = new Platform.macOS.MacDeviceInfo();
@@ -227,6 +231,9 @@ namespace Xamarin.Forms
 		}
 
 		class IOSPlatformServices : IPlatformServices
+#if __MOBILE__
+			, IPlatformInvalidate
+#endif
 		{
 			readonly double _fontScalingFactor = 1;
 			public IOSPlatformServices()
@@ -781,6 +788,18 @@ namespace Xamarin.Forms
 					throw new InvalidOperationException("Could not find current view controller.");
 
 				return viewController;
+			}
+
+			public void Invalidate(VisualElement visualElement)
+			{
+				var renderer = Platform.iOS.Platform.GetRenderer(visualElement);
+
+				if (renderer == null)
+				{
+					return;
+				}
+
+				renderer.NativeView.SetNeedsLayout();
 			}
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -582,6 +582,26 @@ namespace Xamarin.Forms.Platform.iOS
 
 				return result;
 			}
+
+			void ResolveLayoutChanges() 
+			{
+				if (Element is Layout layout)
+				{
+					layout.ResolveLayoutChanges();
+				}
+			}
+
+			public override void LayoutSubviews()
+			{
+				ResolveLayoutChanges();
+				base.LayoutSubviews();
+			}
+
+			public override CGSize SizeThatFits(CGSize size)
+			{
+				ResolveLayoutChanges();
+				return base.SizeThatFits(size);
+			}
 		}
 
 		internal static string ResolveMsAppDataUri(Uri uri)


### PR DESCRIPTION
### Description of Change ###

To avoid excessive re-layouts, any property changes which trigger a layout in a Forms Layout (StackLayout, FlexLayout, etc.) are currently batched up and executed later on the UI thread. While this avoids "layout storms", it also introduces a slight delay in layout changes in the UI and in some rare cases can cause consistency issues. It also means that for many UI changes the native layout engine ends up being invoked an extra time to handle the queued layout changes.

These changes handle the queued layout changes as part of the next measure/layout pass of the native engine on the supported platforms (UWP, iOS, and Android) rather than queueing them up on the UI thread for later processing. This reduces the number of measure/layout passes on those platforms, and eliminates some of the potential consistency issues. 

These changes also retain support for the old behavior on platforms which have not added layout resolution to their measure/layout process. Other platforms can opt into the new behavior by implementing the `IPlatformInvalidate` interface and setting the `PlatformInvalidator` property on the `Device` class during `Forms.Init`.

### Issues Resolved ### 

Delays and extra measure/layout passes on the supported platforms.

### API Changes ###
 
New interface:

```
interface IPlatformInvalidate {
    void Invalidate(VisualElement element);
}
```

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

All the tests.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
