### PR TITLE
Remove references to XreItem when using XCODE on Provisionsator

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -200,8 +200,6 @@ else if(releaseChannel == ReleaseChannel.Stable)
 {
     if(IsXcodeVersionOver("11.4"))
     {
-        // Xcode 11.4 just uses boots enums
-        Information ("XCODE 11.4");
     }
     else
     {
@@ -1130,6 +1128,17 @@ bool IsXcodeVersionOver(string version)
         {
             var xcodeVersion = Version.Parse(item.Replace("Xcode", ""));
             Information($"Xcode: {xcodeVersion}");
+            var xcodePath = xcodeVersion.ToString().Replace(".0", "");
+
+            if(isCIBuild)
+            {
+                StartProcess("xcode-select", 
+                    new ProcessSettings {
+                        Arguments = new ProcessArgumentBuilder().Append($"-s /Applications/Xcode_{xcodePath}.app")
+                    }
+                );
+            }
+
             return Version.Parse(item.Replace("Xcode", "")) >= Version.Parse(version); 
         }
     }

--- a/build.cake
+++ b/build.cake
@@ -42,8 +42,8 @@ string workingDirectory = EnvironmentVariable("SYSTEM_DEFAULTWORKINGDIRECTORY", 
 var configuration = Argument("BUILD_CONFIGURATION", "Debug");
 
 var target = Argument("target", "Default");
-var IOS_SIM_NAME = Argument("IOS_SIM_NAME", "iPhone 7");
-var IOS_SIM_RUNTIME = Argument("IOS_SIM_RUNTIME", "com.apple.CoreSimulator.SimRuntime.iOS-12-4");
+var IOS_SIM_NAME = GetBuildVariable("IOS_SIM_NAME", "iPhone 7");
+var IOS_SIM_RUNTIME = GetBuildVariable("IOS_SIM_RUNTIME", "com.apple.CoreSimulator.SimRuntime.iOS-12-4");
 var IOS_TEST_PROJ = "./Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj";
 var IOS_TEST_LIBRARY = Argument("IOS_TEST_LIBRARY", $"./Xamarin.Forms.Core.iOS.UITests/bin/{configuration}/Xamarin.Forms.Core.iOS.UITests.dll");
 var IOS_IPA_PATH = Argument("IOS_IPA_PATH", $"./Xamarin.Forms.ControlGallery.iOS/bin/iPhoneSimulator/{configuration}/XamarinFormsControlGalleryiOS.app");
@@ -969,6 +969,7 @@ Task("cg-ios-build-tests")
                 .WithProperty("MtouchArch", "x86_64")
                 .WithProperty("iOSPlatform", "iPhoneSimulator")
                 .WithProperty("BuildIpa", $"true")
+                .WithProperty("CI", $"true")
                 .WithRestore();
 
         if(isCIBuild)

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -1,3 +1,7 @@
+#r "_provisionator/provisionator.dll"
+
+using static Xamarin.Provisioning.ProvisioningScript;
+
 using System;
 using System.Linq;
 
@@ -12,7 +16,16 @@ desiredXcode = desiredXcode.Replace("Xcode_", "").Replace("_", ".");
 Item item;
 
 if(desiredXcode == "Latest")
+{
 	item = XcodeBeta();
+
+	if(item.Version.StartsWith("12.0.0-beta."))
+	{
+		Console.WriteLine ("CheckInstalledDevOpsBetaXcodeAndSymlink");
+		int expectedBeta = Convert.ToInt32(item.Version.Replace("12.0.0-beta.", ""));
+    	CheckInstalledDevOpsBetaXcodeAndSymlink("17200.1", expectedBeta: expectedBeta);
+	}
+}
 else if (desiredXcode == "Stable")
 	item = XcodeStable();
 else
@@ -20,3 +33,62 @@ else
 
 Console.WriteLine ("InstallPath: {0}", item.Version);
 item.XcodeSelect ();
+
+LogInstalledXcodes();
+
+var appleSdkOverride = Path.Combine(Environment.GetFolderPath (Environment.SpecialFolder.Personal), "Library", "Preferences", "Xamarin", "Settings.plist");
+Item("Override Apple SDK Settings")
+    .Condition(item => !File.Exists(appleSdkOverride) || GetSettingValue(appleSdkOverride, "AppleSdkRoot") != GetSelectedXcodePath())
+    .Action (item => {
+        DeleteSafe(appleSdkOverride);
+        CreateSetting(appleSdkOverride, "AppleSdkRoot", GetSelectedXcodePath ());
+        Console.WriteLine($"New VSMac iOS SDK Location: {GetSelectedXcodePath ()}");
+    });
+
+
+
+void DeleteSafe(string file)
+{
+    if (File.Exists(file))
+        File.Delete(file);
+}
+
+void CreateSetting(string settingFile, string key, string value)
+{
+    Exec("defaults", "write", settingFile, key, value);
+}
+
+string GetSettingValue(string settingFile, string keyName)
+{
+    return Exec("defaults", "read", settingFile, keyName).FirstOrDefault();
+}
+
+bool CheckInstalledDevOpsBetaXcodeAndSymlink (string expectedBundleVersion, int expectedBeta)
+{
+    var devOpsXcodeBetaPath = "/Applications/Xcode_12_beta.app";
+    if (!Directory.Exists (devOpsXcodeBetaPath))
+        return false;
+
+    var infoPlist = Plist (devOpsXcodeBetaPath);
+    var bundleVersion = (string)infoPlist.CFBundleVersion;
+    if (bundleVersion != expectedBundleVersion)
+        return false;
+
+    if (RunningInCI) {
+        SafeSymlink (devOpsXcodeBetaPath, $"/Applications/Xcode_12.0.0-beta{expectedBeta}.app");
+        SafeSymlink (devOpsXcodeBetaPath, $"/Applications/Xcode_12_beta_{expectedBeta}.app");
+    }
+
+    Console.WriteLine ($"CFBundleVersion found: {bundleVersion}");
+    return true;
+}
+
+void SafeSymlink (string source, string destination)
+{
+    if (Directory.Exists (destination) || Config.DryRun)
+        return;
+
+    Console.WriteLine ($"ln -sf {source} {destination}");
+    Exec ("/bin/ln", "-sf", source, destination);
+    Console.WriteLine ($"Symlink created: '{source}' links to '{destination}'");
+}

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -18,6 +18,5 @@ else if (desiredXcode == "Stable")
 else
 	item = Xcode(desiredXcode);
 
-var item = Item (xreItem);
 Console.WriteLine ("InstallPath: {0}", item.Version);
 item.XcodeSelect ();

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -7,12 +7,16 @@ if (string.IsNullOrEmpty (desiredXcode)) {
 	return;
 }
 
-XreItem xreItem;
+desiredXcode = desiredXcode.Replace("Xcode_", "").Replace("_", ".");
+
+Item item;
 
 if(desiredXcode == "Latest")
-	xreItem = (XreItem)Enum.GetValues(typeof(XreItem)).Cast<int>().Max();
+	item = XcodeBeta();
+else if (desiredXcode == "Stable")
+	item = XcodeStable();
 else
-	xreItem = (XreItem) Enum.Parse (typeof (XreItem), desiredXcode);
+	item = Xcode(desiredXcode);
 
 var item = Item (xreItem);
 Console.WriteLine ("InstallPath: {0}", item.Version);


### PR DESCRIPTION
### Description of Change ###

Switch to using the XCode method

### Testing Procedure ###
Ensure XCode provisions successfully 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
