### PR TITLE
Reinstate loading of local HTML files in WKWebViewRenderer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -104,6 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 			try
 			{
 				var uri = new Uri(url);
+
 				var safeHostUri = new Uri($"{uri.Scheme}://{uri.Authority}", UriKind.Absolute);
 				var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
 				NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri));
@@ -111,10 +113,47 @@ namespace Xamarin.Forms.Platform.iOS
 				await SyncNativeCookies(url);
 				LoadRequest(request);
 			}
+			catch (UriFormatException formatException) 
+			{
+				// If we got a format exception trying to parse the URI, it might be because
+				// someone is passing in a local bundled file page. If we can find a better way
+				// to detect that scenario, we should use it; until then, we'll fall back to 
+				// local file loading here and see if that works:
+				if (!LoadFile(url))
+				{
+					Log.Warning(nameof(WkWebViewRenderer), $"Unable to Load Url {url}: {formatException}");
+				}
+			}
 			catch (Exception exc)
 			{
-				Log.Warning(nameof(WkWebViewRenderer), $"Unable to Load Url {exc}");
+				Log.Warning(nameof(WkWebViewRenderer), $"Unable to Load Url {url}: {exc}");
 			}
+		}
+
+		bool LoadFile(string url) 
+		{
+			try
+			{
+				var file = Path.GetFileNameWithoutExtension(url);
+				var ext = Path.GetExtension(url);
+
+				var nsUrl = NSBundle.MainBundle.GetUrlForResource(file, ext);
+
+				if (nsUrl == null)
+				{
+					return false;
+				}
+
+				LoadFileUrl(nsUrl, nsUrl);
+
+				return true;
+			}
+			catch (Exception ex)
+			{
+				Log.Warning(nameof(WkWebViewRenderer), $"Could not load {url} as local file: {ex}");
+			}
+
+			return false;
 		}
 
 		public override void LayoutSubviews()
@@ -198,7 +237,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var extracted = extractCookies.GetCookies(uri);
 					_initialCookiesLoaded = new NSHttpCookie[extracted.Count];
-					for(int i = 0; i < extracted.Count; i++)
+					for (int i = 0; i < extracted.Count; i++)
 					{
 						_initialCookiesLoaded[i] = new NSHttpCookie(extracted[i]);
 					}
@@ -282,9 +321,9 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				NSHttpCookie nSHttpCookie = null;
 
-				foreach(var findCookie in retrieveCurrentWebCookies)
+				foreach (var findCookie in retrieveCurrentWebCookies)
 				{
-					if(findCookie.Name == cookie.Name)
+					if (findCookie.Name == cookie.Name)
 					{
 						nSHttpCookie = findCookie;
 						break;
@@ -366,7 +405,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Forms.IsiOS11OrNewer)
 			{
-				foreach(var cookie in cookies)
+				foreach (var cookie in cookies)
 					await Configuration.WebsiteDataStore.HttpCookieStore.SetCookieAsync(new NSHttpCookie(cookie));
 			}
 			else
@@ -402,7 +441,7 @@ namespace Xamarin.Forms.Platform.iOS
 					{
 						var record = records.GetItem<WKWebsiteDataRecord>(i);
 
-						foreach(var deleteme in cookies)
+						foreach (var deleteme in cookies)
 						{
 							if (record.DisplayName.Contains(deleteme.Domain) || deleteme.Domain.Contains(record.DisplayName))
 							{
@@ -472,7 +511,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			try
 			{
-			
+
 				await SyncNativeCookies(Url?.AbsoluteUrl?.ToString());
 			}
 			catch (Exception exc)
@@ -575,10 +614,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				try
 				{
-					if(_renderer?.WebView?.Cookies != null)
+					if (_renderer?.WebView?.Cookies != null)
 						await _renderer.SyncNativeCookiesToElement(url);
 				}
-				catch(Exception exc)
+				catch (Exception exc)
 				{
 					Log.Warning(nameof(WkWebViewRenderer), $"Failed to Sync Cookies {exc}");
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
-using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;
@@ -113,7 +112,7 @@ namespace Xamarin.Forms.Platform.iOS
 				await SyncNativeCookies(url);
 				LoadRequest(request);
 			}
-			catch (UriFormatException formatException) 
+			catch (UriFormatException formatException)
 			{
 				// If we got a format exception trying to parse the URI, it might be because
 				// someone is passing in a local bundled file page. If we can find a better way
@@ -130,7 +129,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		bool LoadFile(string url) 
+		bool LoadFile(string url)
 		{
 			try
 			{
@@ -237,7 +236,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var extracted = extractCookies.GetCookies(uri);
 					_initialCookiesLoaded = new NSHttpCookie[extracted.Count];
-					for (int i = 0; i < extracted.Count; i++)
+					for(int i = 0; i < extracted.Count; i++)
 					{
 						_initialCookiesLoaded[i] = new NSHttpCookie(extracted[i]);
 					}
@@ -321,9 +320,9 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				NSHttpCookie nSHttpCookie = null;
 
-				foreach (var findCookie in retrieveCurrentWebCookies)
+				foreach(var findCookie in retrieveCurrentWebCookies)
 				{
-					if (findCookie.Name == cookie.Name)
+					if(findCookie.Name == cookie.Name)
 					{
 						nSHttpCookie = findCookie;
 						break;
@@ -405,7 +404,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Forms.IsiOS11OrNewer)
 			{
-				foreach (var cookie in cookies)
+				foreach(var cookie in cookies)
 					await Configuration.WebsiteDataStore.HttpCookieStore.SetCookieAsync(new NSHttpCookie(cookie));
 			}
 			else
@@ -441,7 +440,7 @@ namespace Xamarin.Forms.Platform.iOS
 					{
 						var record = records.GetItem<WKWebsiteDataRecord>(i);
 
-						foreach (var deleteme in cookies)
+						foreach(var deleteme in cookies)
 						{
 							if (record.DisplayName.Contains(deleteme.Domain) || deleteme.Domain.Contains(record.DisplayName))
 							{
@@ -511,7 +510,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			try
 			{
-
+			
 				await SyncNativeCookies(Url?.AbsoluteUrl?.ToString());
 			}
 			catch (Exception exc)
@@ -614,10 +613,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				try
 				{
-					if (_renderer?.WebView?.Cookies != null)
+					if(_renderer?.WebView?.Cookies != null)
 						await _renderer.SyncNativeCookiesToElement(url);
 				}
-				catch (Exception exc)
+				catch(Exception exc)
 				{
 					Log.Warning(nameof(WkWebViewRenderer), $"Failed to Sync Cookies {exc}");
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
+using System.IO;
 using System.Linq;
 using System.Net;
 using System.Text;


### PR DESCRIPTION
### Description of Change ###

The move to WKWebView on iOS broke the ability to load local html documents. These changes reinstate that ability.

### Issues Resolved ### 

- (re)fixes Bugzilla 32033

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Manual test 32033 (the first option).

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
