### PR TITLE
[X] Add a TrySetPropertyValue overload for HR

### DIFF
--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Bz47950.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Bz47950.xaml.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using NUnit.Framework;
 using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
 
 namespace Xamarin.Forms.Xaml.UnitTests
 {
@@ -29,9 +30,11 @@ namespace Xamarin.Forms.Xaml.UnitTests
 		[TestFixture]
 		class Tests
 		{
-			[TestCase(true)]
-			[TestCase(false)]
-			public void BehaviorAndStaticResource(bool useCompiledXaml)
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void BehaviorAndStaticResource([Values(false, true)] bool useCompiledXaml)
 			{
 				var page = new Bz47950(useCompiledXaml);
 			}


### PR DESCRIPTION
### Description of Change ###

Add a `TrySetPropertyValue()` that doesn't require the parsing and hydration context. For most case, it will be enough if the serviceProvider contains an `IValueConverterProvider` and a default `IValueConverterProvider`. (see https://github.com/xamarin/Xamarin.Forms/blob/main/Xamarin.Forms.Xaml/XamlServiceProvider.cs). More complex cases might require extra services.

### Issues Resolved ### 

- fixes [AB#1192221](https://devdiv.visualstudio.com/0bdbc590-a062-4c3f-b0f6-9383f67865ee/_workitems/edit/1192221)

### API Changes ###
 
 None

### Platforms Affected ### 

None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
