### PR TITLE
Check if Logical Child is VE in ListViewRenderer

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -1,30 +1,17 @@
 using System;
 using System.Collections;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows.Input;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
-using Xamarin.Forms.Xaml.Diagnostics;
 
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_ListViewRenderer))]
 	public class ListView : ItemsView<Cell>, IListViewController, IElementConfiguration<ListView>
 	{
-		readonly List<Element> _logicalChildren = new List<Element>();
-
-#if NETSTANDARD1_0
-		ReadOnlyCollection<Element> _readOnlyLogicalChildren;
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _readOnlyLogicalChildren ?? 
-			(_readOnlyLogicalChildren = new ReadOnlyCollection<Element>(_logicalChildren));
-#else
-		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildren.AsReadOnly();
-#endif
-
 		public static readonly BindableProperty IsPullToRefreshEnabledProperty = BindableProperty.Create("IsPullToRefreshEnabled", typeof(bool), typeof(ListView), false);
 
 		public static readonly BindableProperty IsRefreshingProperty = BindableProperty.Create("IsRefreshing", typeof(bool), typeof(ListView), false, BindingMode.TwoWay);
@@ -60,7 +47,7 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty SeparatorColorProperty = BindableProperty.Create("SeparatorColor", typeof(Color), typeof(ListView), Color.Default);
 
 		public static readonly BindableProperty RefreshControlColorProperty = BindableProperty.Create(nameof(RefreshControlColor), typeof(Color), typeof(ListView), Color.Default);
-	
+
 		public static readonly BindableProperty HorizontalScrollBarVisibilityProperty = BindableProperty.Create(nameof(HorizontalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ListView), ScrollBarVisibility.Default);
 
 		public static readonly BindableProperty VerticalScrollBarVisibilityProperty = BindableProperty.Create(nameof(VerticalScrollBarVisibility), typeof(ScrollBarVisibility), typeof(ListView), ScrollBarVisibility.Default);
@@ -121,11 +108,17 @@ namespace Xamarin.Forms
 
 			object bc = BindingContext;
 
-			if (Header is Element header)
+			var header = Header as Element;
+			if (header != null)
+			{
 				SetChildInheritedBindingContext(header, bc);
+			}
 
-			if (Footer is Element footer)
+			var footer = Footer as Element;
+			if (footer != null)
+			{
 				SetChildInheritedBindingContext(footer, bc);
+			}
 		}
 
 		public BindingBase GroupDisplayBinding
@@ -391,27 +384,17 @@ namespace Xamarin.Forms
 		protected override void SetupContent(Cell content, int index)
 		{
 			base.SetupContent(content, index);
-			if (content is ViewCell viewCell && viewCell.View != null && HasUnevenRows)
+			var viewCell = content as ViewCell;
+			if (viewCell != null && viewCell.View != null && HasUnevenRows)
 				viewCell.View.ComputedConstraint = LayoutConstraint.None;
-
-			if (content != null)
-				_logicalChildren.Add(content);
-
 			content.Parent = this;
-			VisualDiagnostics.OnChildAdded(this, content);
+
 		}
 
 		protected override void UnhookContent(Cell content)
 		{
 			base.UnhookContent(content);
-
-			if (content == null || !_logicalChildren.Contains(content))
-				return;
-			var index = _logicalChildren.IndexOf(content);
-				_logicalChildren.Remove(content);
 			content.Parent = null;
-			VisualDiagnostics.OnChildRemoved(this, content, index);
-
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -1,17 +1,22 @@
 using System;
 using System.Collections;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.ComponentModel;
 using System.Diagnostics;
 using System.Linq;
 using System.Windows.Input;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform;
+using Xamarin.Forms.Xaml.Diagnostics;
 
 namespace Xamarin.Forms
 {
 	[RenderWith(typeof(_ListViewRenderer))]
 	public class ListView : ItemsView<Cell>, IListViewController, IElementConfiguration<ListView>
 	{
+		readonly List<Element> _logicalChildren = new List<Element>();
+
 		public static readonly BindableProperty IsPullToRefreshEnabledProperty = BindableProperty.Create("IsPullToRefreshEnabled", typeof(bool), typeof(ListView), false);
 
 		public static readonly BindableProperty IsRefreshingProperty = BindableProperty.Create("IsRefreshing", typeof(bool), typeof(ListView), false, BindingMode.TwoWay);
@@ -108,17 +113,11 @@ namespace Xamarin.Forms
 
 			object bc = BindingContext;
 
-			var header = Header as Element;
-			if (header != null)
-			{
+			if (Header is Element header)
 				SetChildInheritedBindingContext(header, bc);
-			}
 
-			var footer = Footer as Element;
-			if (footer != null)
-			{
+			if (Footer is Element footer)
 				SetChildInheritedBindingContext(footer, bc);
-			}
 		}
 
 		public BindingBase GroupDisplayBinding
@@ -384,17 +383,27 @@ namespace Xamarin.Forms
 		protected override void SetupContent(Cell content, int index)
 		{
 			base.SetupContent(content, index);
-			var viewCell = content as ViewCell;
-			if (viewCell != null && viewCell.View != null && HasUnevenRows)
+			if (content is ViewCell viewCell && viewCell.View != null && HasUnevenRows)
 				viewCell.View.ComputedConstraint = LayoutConstraint.None;
-			content.Parent = this;
 
+			if (content != null)
+				_logicalChildren.Add(content);
+
+			content.Parent = this;
+			VisualDiagnostics.OnChildAdded(this, content);
 		}
 
 		protected override void UnhookContent(Cell content)
 		{
 			base.UnhookContent(content);
+
+			if (content == null || !_logicalChildren.Contains(content))
+				return;
+			var index = _logicalChildren.IndexOf(content);
+			_logicalChildren.Remove(content);
 			content.Parent = null;
+			VisualDiagnostics.OnChildRemoved(this, content, index);
+
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]


### PR DESCRIPTION
### Description of Change ###

https://github.com/xamarin/Xamarin.Forms/commit/975577e837983d5fe656e2bf9caed893c42ffe97#diff-629e73745c456d7bcf063b0fb1290d62R18

Added LogicalChildren to ListView. 

On iOS when measuring a row the ListViewRenderer will descend the hierarchy of LogicalChildren and then dispose of all renderers on those LogicalChildren. 

ListView can have LogicalChildren that aren't VisualElements (SwitchCell) so this can cause an exception when trying to dispose. AFAICT this is a very specific issue related to running the application while Xamarin.UITest is observing it. When we retrieve the AccessibilityLabel from the nested UITableView this causes the nested UITableView to saturate with data. But this only happens when running from a state where the app is being observed by Xamarin.UITest

If you uninstall the device agent or just run the app without ever installing device agent then it works fine. AFAICT this also only happens on iOS 12

Regardless it's a good check to have



### Issues Resolved ### 
- partially fixes #12022 


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- UI Tests all pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
