### PR TITLE
[Tests] Stop running the performance rendering tests

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -192,7 +192,7 @@ namespace Xamarin.Forms.Controls.Issues
 			ViewModel.RunTest(_TestCases[_TestNumber++]);
 		}
 
-#if UITEST
+#if false && UITEST
 
 		double TopThreshold => 1 + Threshold;
 		double BottomThreshold => 1 - Threshold;


### PR DESCRIPTION
### Description of Change ###

Stop running the performance rendering tests. These are slow and not producing reliable results.


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
