### PR TITLE
[UWP] Fix SwipeItem NRE no setting the Text 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
@@ -16,6 +16,8 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 12079, "SwipeView crash if Text not is set on SwipeItem", PlatformAffected.UWP)]
 	public class Issue12079 : TestContentPage
 	{
+		const string SwipeViewId = "SwipeViewId";
+
 		protected override void Init()
 		{
 			Title = "Issue 12079";
@@ -38,7 +40,10 @@ namespace Xamarin.Forms.Controls.Issues
 				IconImageSource = "calculator.png"
 			};
 
-			swipeItem.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Invoked", "Ok"); };
+			swipeItem.Invoked += (sender, e) =>
+			{
+				DisplayAlert("Issue12079", "Invoked", "Ok");
+			};
 
 			var swipeItems = new SwipeItems { swipeItem };
 
@@ -60,16 +65,38 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var swipeView = new SwipeView
 			{
+				AutomationId = SwipeViewId,
 				HeightRequest = 60,
 				WidthRequest = 300,
 				LeftItems = swipeItems,
 				Content = swipeContent
 			};
 
+			var result = new Label();
+
+			swipeView.SwipeEnded += (sender, args) =>
+			{
+				result.Text = "Success";
+			};
+
 			layout.Children.Add(instructions);
 			layout.Children.Add(swipeView);
+			layout.Children.Add(result);
 
 			Content = layout;
 		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.SwipeView)]
+		public void SwipeItemNoTextWindows()
+		{
+			RunningApp.WaitForElement(SwipeViewId);
+			RunningApp.SwipeLeftToRight(SwipeViewId);
+			RunningApp.Tap(SwipeViewId);
+			RunningApp.WaitForElement( c => c.Marked("Success"));
+			RunningApp.Screenshot ("The test has passed");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
@@ -88,7 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		[Ignore]
+		[Ignore("Selenium cannot find the SwipeControl, we have to review the reason.")]
 		[Category(UITestCategories.SwipeView)]
 		public void SwipeItemNoTextWindows()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
@@ -88,6 +88,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[Ignore]
 		[Category(UITestCategories.SwipeView)]
 		public void SwipeItemNoTextWindows()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12079.cs
@@ -1,0 +1,75 @@
+﻿using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12079, "SwipeView crash if Text not is set on SwipeItem", PlatformAffected.UWP)]
+	public class Issue12079 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 12079";
+
+			var layout = new StackLayout
+			{
+				Margin = new Thickness(12)
+			};
+
+			var instructions = new Label
+			{
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Swipe to the right, if can open the SwipeView the test has passed."
+			};
+
+			var swipeItem = new SwipeItem
+			{
+				BackgroundColor = Color.Red,
+				IconImageSource = "calculator.png"
+			};
+
+			swipeItem.Invoked += (sender, e) => { DisplayAlert("SwipeView", "Invoked", "Ok"); };
+
+			var swipeItems = new SwipeItems { swipeItem };
+
+			swipeItems.Mode = SwipeMode.Reveal;
+
+			var swipeContent = new Grid
+			{
+				BackgroundColor = Color.Gray
+			};
+
+			var swipeLabel = new Label
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.Center,
+				Text = "Swipe to Right (No Text)"
+			};
+
+			swipeContent.Children.Add(swipeLabel);
+
+			var swipeView = new SwipeView
+			{
+				HeightRequest = 60,
+				WidthRequest = 300,
+				LeftItems = swipeItems,
+				Content = swipeContent
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(swipeView);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -44,6 +44,7 @@
       <DependentUpon>Issue11794.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11769.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12079.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12060.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12344.xaml.cs">
       <DependentUpon>Issue12344.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.UAP/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/SwipeViewRenderer.cs
@@ -328,7 +328,7 @@ namespace Xamarin.Forms.Platform.UWP
 						Background = formsSwipeItem.BackgroundColor.IsDefault ? null : formsSwipeItem.BackgroundColor.ToBrush(),
 						Foreground = textColor.ToBrush(),
 						IconSource = formsSwipeItem.IconImageSource.ToWindowsIconSource(),
-						Text = formsSwipeItem.Text,
+						Text = !string.IsNullOrEmpty(formsSwipeItem.Text) ? formsSwipeItem.Text : string.Empty,
 						BehaviorOnInvoked = GetSwipeBehaviorOnInvoked(items.SwipeBehaviorOnInvoked)
 					};
 


### PR DESCRIPTION
### Description of Change ###

Fix SwipeItem NRE no setting the Text in UWP.

### Issues Resolved ### 

- fixes #12079 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the Issue12079. Swipe to the right, if can open the SwipeView the test has passed.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
