### PR TITLE
[iOS] Add null-check to Entry

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -390,7 +390,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool ShouldChangeCharacters(UITextField textField, NSRange range, string replacementString)
 		{
-			var newLength = textField?.Text?.Length + replacementString.Length - range.Length;
+			var newLength = textField?.Text?.Length + replacementString?.Length - range.Length;
 			return newLength <= Element?.MaxLength;
 		}
 


### PR DESCRIPTION
### Description of Change ###

As per #11965 there is a bug causing a NullReference NRE, but is only seen in App Center logs. Therefore, I haven't been able to reproduce. This seems to be the only place for the root cause, and I guess it doesn't hurt to add a null check here and see if this fixes it.

If you think differently, feel free to close this one :)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11965

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Also none; this is the worst PR ever.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch (I think)
- [x] Tests are passing (or failures are unrelated, doh)
