### PR TITLE
[Shell] Don't use SplitView for iPad

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -238,8 +238,18 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			TapoffView.UpdateBackground(_backdropBrush);
+
 			if (Brush.IsNullOrEmpty(_backdropBrush))
-				TapoffView.BackgroundColor = ColorExtensions.BackgroundColor.ColorWithAlpha(0.5f);
+			{
+				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+				{
+					TapoffView.BackgroundColor = UIColor.Clear;
+				}
+				else
+				{
+					TapoffView.BackgroundColor = ColorExtensions.BackgroundColor.ColorWithAlpha(0.5f);
+				}
+			}
 		}
 
 		void AddTapoffView()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -133,11 +133,6 @@ namespace Xamarin.Forms.Platform.iOS
 				return new DesignerFlyoutRenderer(this);
 			}
 
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
-			{
-				return new TabletShellFlyoutRenderer();
-			}
-
 			return new ShellFlyoutRenderer()
 			{
 				FlyoutTransition = new SlideFlyoutTransition()

--- a/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
@@ -11,7 +11,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (behavior == FlyoutBehavior.Locked)
 				openPercent = 1;
 
-			nfloat flyoutWidth = (nfloat)(Math.Min(bounds.Width, bounds.Height) * 0.8);
+			nfloat flyoutWidth;
+
+			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+				flyoutWidth = 320;
+			else
+				flyoutWidth = (nfloat)(Math.Min(bounds.Width, bounds.Height) * 0.8);
+
 			nfloat openLimit = flyoutWidth;
 			nfloat openPixels = openLimit * openPercent;
 


### PR DESCRIPTION
### Description of Change ###

The UISplitView implementation of Shell on iOS doesn't really conform to how a UISplitView works on iOS. For example #8527.

The UISplitView is a hierarchical navigation controller that will collapse the left pane and the right pane into a stack of ViewControllers inside a UINavigationController when the user goes into SplitView mode. This breaks the app because the shell isn't configured to react to this type of change

If we want Shell to react this way then we should implement this at the xplat level so that it works this way across all platforms. 

### Issues Resolved ###

-  partially fixes #8527


### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
There shouldn't be any. This should result in a users application staying more consistent when the app is used on an iPad and we don't have to implement everything twice on iOS

One of these is a SplitViewController and the other isn't. As you can see the Search field color is different on both as well. Just having the same renderer will make the iPad more reliably consistent

![image](https://user-images.githubusercontent.com/5375137/92978525-a3756a00-f455-11ea-8192-5e1f55a7f59b.png)

Now when the user is in SplitView they won't have a broken app

![image](https://user-images.githubusercontent.com/5375137/92978766-580f8b80-f456-11ea-977c-3b5a5e95942f.png)

 
`TabletShellFlyoutRenderer` isn't going to be removed so if users want to switch back to UISplitViewController they can with the following code

```C#

[assembly: ExportRenderer(typeof(Shell), typeof(CustomShellFlyoutRenderer))]
namespace Xamarin.Forms.Sandbox.iOS
{
    public class CustomShellFlyoutRenderer : ShellRenderer
    {
        protected override IShellFlyoutRenderer CreateFlyoutRenderer()
        {
            if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
            {
                return new TabletShellFlyoutRenderer();
            }

            return base.CreateFlyoutRenderer();
        }
     }
}
```

### Testing Procedure ###
- Test Shell on the iPad

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
