### PR TITLE
Set Backdrop Color after Pane Opened

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -42,6 +42,10 @@ namespace Xamarin.Forms.Platform.UWP
 				PaneClosing += (s, e) => OnPaneClosed();
 			if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpening"))
 				PaneOpening += (s, e) => OnPaneOpening();
+			if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpened"))
+				PaneOpened += (s, e) => OnPaneOpened();
+
+
 			ItemInvoked += OnMenuItemInvoked;
 			BackRequested += OnBackRequested;
 			Style = Windows.UI.Xaml.Application.Current.Resources["ShellNavigationView"] as Windows.UI.Xaml.Style;
@@ -80,9 +84,13 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
 			UpdateFlyoutBackdrop();
+		}
 
-			if(_flyoutBehavior == FlyoutBehavior.Flyout)
-				ShellSplitView.UpdateFlyoutBackdrop();
+		void OnPaneOpened()
+		{
+			// UWP likes to sometimes set the back drop back to the
+			// default color
+			UpdateFlyoutBackdrop();
 		}
 
 		void OnPaneClosed()

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateFlyoutBackdrop();
 		}
 
-		void OnPaneClosed(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs args)
+		void OnPaneClosing(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs args)
 		{
 			if (Shell != null)
 				Shell.FlyoutIsPresented = false;
@@ -148,7 +148,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 
 				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneClosing"))
-					PaneClosing += OnPaneClosed;
+					PaneClosing += OnPaneClosing;
 				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpening"))
 					PaneOpening += OnPaneOpening;
 				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpened"))
@@ -171,7 +171,7 @@ namespace Xamarin.Forms.Platform.UWP
 				Element.PropertyChanged -= OnElementPropertyChanged;
 
 				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneClosing"))
-					PaneClosing -= OnPaneClosed;
+					PaneClosing -= OnPaneClosing;
 				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpening"))
 					PaneOpening -= OnPaneOpening;
 				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpened"))

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -38,16 +38,6 @@ namespace Xamarin.Forms.Platform.UWP
 			IsPaneOpen = false;
 			Content = ItemRenderer = CreateShellItemRenderer();
 			MenuItemTemplateSelector = CreateShellFlyoutTemplateSelector();
-			if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneClosing"))
-				PaneClosing += (s, e) => OnPaneClosed();
-			if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpening"))
-				PaneOpening += (s, e) => OnPaneOpening();
-			if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpened"))
-				PaneOpened += (s, e) => OnPaneOpened();
-
-
-			ItemInvoked += OnMenuItemInvoked;
-			BackRequested += OnBackRequested;
 			Style = Windows.UI.Xaml.Application.Current.Resources["ShellNavigationView"] as Windows.UI.Xaml.Style;
 		}
 
@@ -76,24 +66,25 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(NavigationViewBackButton, !IsPaneOpen);
 		}
 
-		void OnPaneOpening()
+		void OnPaneOpening(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
 		{
 			if (Shell != null)
 				Shell.FlyoutIsPresented = true;
+
 			UpdatePaneButtonColor(TogglePaneButton, false);
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
 			UpdateFlyoutBackdrop();
 		}
 
-		void OnPaneOpened()
+		void OnPaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
 		{
 			// UWP likes to sometimes set the back drop back to the
 			// default color
 			UpdateFlyoutBackdrop();
 		}
 
-		void OnPaneClosed()
+		void OnPaneClosed(Microsoft.UI.Xaml.Controls.NavigationView sender, Microsoft.UI.Xaml.Controls.NavigationViewPaneClosingEventArgs args)
 		{
 			if (Shell != null)
 				Shell.FlyoutIsPresented = false;
@@ -155,6 +146,18 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (element != null)
 			{
+
+				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneClosing"))
+					PaneClosing += OnPaneClosed;
+				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpening"))
+					PaneOpening += OnPaneOpening;
+				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpened"))
+					PaneOpened += OnPaneOpened;
+
+				ItemInvoked += OnMenuItemInvoked;
+				BackRequested += OnBackRequested;
+
+
 				Element = (Shell)element;
 				Element.SizeChanged += OnElementSizeChanged;
 				OnElementSet(Element);
@@ -166,12 +169,20 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Element.SizeChanged -= OnElementSizeChanged;
 				Element.PropertyChanged -= OnElementPropertyChanged;
+
+				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneClosing"))
+					PaneClosing -= OnPaneClosed;
+				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpening"))
+					PaneOpening -= OnPaneOpening;
+				if (ApiInformation.IsEventPresent("Windows.UI.Xaml.Controls.NavigationView", "PaneOpened"))
+					PaneOpened -= OnPaneOpened;
+
+				ItemInvoked -= OnMenuItemInvoked;
+				BackRequested -= OnBackRequested;
 			}
 		}
 
 		#endregion IVisualElementRenderer
-
-
 		ShellSplitView ShellSplitView => (ShellSplitView)GetTemplateChild("RootSplitView");
 		protected internal Shell Element { get; set; }
 


### PR DESCRIPTION
### Description of Change ###

On the first initial opening of the side pane UWP resets the light layer back to the default color. This sets the color after the pane has opened just to ensure the back drop color has propagated to the light layer

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #12018 


### Platforms Affected ### 
- UWP


### Testing Procedure ###
- test setting back drop layer on uwp

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
