### PR TITLE
Fix Shapes drawing issue on iOS 14

### DIFF
--- a/Xamarin.Forms.Core/Shapes/Shape.cs
+++ b/Xamarin.Forms.Core/Shapes/Shape.cs
@@ -14,7 +14,7 @@
             BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(Shape), null);
 
         public static readonly BindableProperty StrokeThicknessProperty =
-            BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 0.0);
+            BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0);
 
         public static readonly BindableProperty StrokeDashArrayProperty =
             BindableProperty.Create(nameof(StrokeDashArray), typeof(DoubleCollection), typeof(Shape), null,


### PR DESCRIPTION
### Description of Change ###

Changed the `StrokeThickness` default value to 1.0d, as in other frameworks (UWP, etc).

<img width="1450" alt="Captura de pantalla 2020-09-14 a las 10 23 16" src="https://user-images.githubusercontent.com/6755973/93061812-5fac7b80-f674-11ea-9e4d-bca7aa39d665.png">

### Issues Resolved ### 

- fixes #12081 
- fixes #12082
- fixes #12083

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="464" alt="Captura de pantalla 2020-09-14 a las 10 23 38" src="https://user-images.githubusercontent.com/6755973/93061817-60dda880-f674-11ea-9faf-8e5fe912389a.png">

### Testing Procedure ###
Launch Core Gallery on iOS 14. Navigate to the Shapes Gallery and select the Line sample. If all the lines are rendering (see attached screenshot), the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
