### PR TITLE
If the element's renderer has already been nulled or disposed, request zero space for it

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1335,8 +1335,12 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Performance.Start(out string reference);
 
-			// FIXME: potential crash
 			IVisualElementRenderer visualElementRenderer = GetRenderer(view);
+
+			if (visualElementRenderer == null || visualElementRenderer.View.IsDisposed())
+			{
+				return new SizeRequest(Size.Zero, Size.Zero);
+			}
 
 			var context = visualElementRenderer.View.Context;
 


### PR DESCRIPTION
### Description of Change ###

While we still can't seem to reproduce #10801 under controlled conditions to find a root cause, it's clear that it's occurring when the platform attempts to measure a renderer which has already been disposed. These changes add a disposal check before rendering to avoid crashing; if the renderer has already been disposed, the method returns a size of zero. 

### Issues Resolved ### 

- fixes #10801

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Still can't reproduce the issue locally, so no tests at the moment.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
