### PR TITLE
Add protected Accessor to VisualElement Constructor

### DIFF
--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -314,7 +314,7 @@ namespace Xamarin.Forms
 
 		LayoutConstraint _selfConstraint;
 
-		internal VisualElement()
+		protected internal VisualElement()
 		{
 		}
 


### PR DESCRIPTION
### Description of Change ###
Updates the constructor of the `VisualElement` from `internal` to `protected internal`. This allows external code to inherit directly from the `VisualElement` instead of the `View`.

The Xamarin Community Toolkit requires access to some of the internal objects of the Xamarin.Forms platform. I am currently working on migrating the Popup Control Pull Request (#9616) to the Xamarin Community Toolkit (Xamarin/XamarinCommunityToolkit#292) as I discussed with @PureWeen @jsuarezruiz and @jfversluis the other week. In the original Pull Request (#9616) to Xamarin.Forms @myroot suggested we have the `BasePopup` inherit from `VisualElement` instead of `View`. This would prevent developers from adding the `BasePopup` to a `StackLayout` since it's children accept a standard `View`. This feedback made a lot of sense and we updated that code to support `VisualElement`. [Code Review Link](https://github.com/xamarin/Xamarin.Forms/pull/9616#discussion_r412654995).

Now that I am actively working on porting this code over to the Xamarin Community Toolkit I am unable to have the `BasePopup` inherit from `VisualElement`. If I try to use `Element` instead I am unable to properly implement the `IVisualElementRenderer` in the platform specific custom renderers. The `BasePopup` is not a `View` so it does not make sense to inherit directly from `View`,

I am not aware of the reason why this constructor was made internal, but I think it makes a lot of sense to open it up as I have done in this PR. This will allow developers to build their controls inheriting from `VisualElement` instead of `View` when it makes sense to do so.

### Related GitHub Issues
- Original Popup Spec - #1778 
- Original Popup PR - #9616 
- Xamarin Community Toolkit Popup Spec - Xamarin/XamarinCommunityToolkit#292


### Issues Resolved ### 
N/A

### API Changes ###
`VisualElement`

Changed:
 - `internal VisualElement()` => `protected internal VisualElement()`
 
### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Build still passes

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
