### PR TITLE
[Tizen] Fixed Tizen 4.0 regression issue

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
+++ b/Xamarin.Forms.Platform.Tizen/FormsApplication.cs
@@ -11,6 +11,7 @@ using DeviceOrientation = Xamarin.Forms.Internals.DeviceOrientation;
 using ElmSharp.Wearable;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Application;
 using Xamarin.Forms.Platform.Tizen.Native;
+using Tizen.Common;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -59,6 +60,12 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			base.OnPreCreate();
 			Application.ClearCurrent();
+
+			if (DotnetUtil.TizenAPIVersion < 5)
+			{
+				// We should set the env variable to support IsolatedStorageFile on tizen 4.0 or lower version.
+				Environment.SetEnvironmentVariable("XDG_DATA_HOME", Current.DirectoryInfo.Data);
+			}
 
 			var type = typeof(Window);
 			// Use reflection to avoid breaking compatibility. ElmSharp.Window.CreateWindow() is has been added since API6.


### PR DESCRIPTION
### Description of Change ###

This PR fixes below Tizen 4.0 regression issue.
- In Tizen 4.0, `Application.Properties` did not work properly due to an issue related to `IsolatedStorageFile` support.  Thus, if you used ` Application.Properties`  (or on exiting the app), you will find the following exception in the log:
```
W/Xamarin ( 8668): XamarinLogListener.cs: Warning(15) > [Application] Exception while saving Application Properties: System.AggregateException: One or more errors occurred. (Access to the path '/opt/usr/home/owner/IsolatedStorage/inhsmjuv.isa/skix3szd.kzj' is denied.) ---> System.UnauthorizedAccessException: Access to the path '/opt/usr/home/owner/IsolatedStorage/inhsmjuv.isa/skix3szd.kzj' is denied. ---> System.IO.IOException: Permission denied
W/Xamarin ( 8668):    --- End of inner exception stack trace ---
W/Xamarin ( 8668):    at System.IO.UnixFileSystem.CreateDirectory(String fullPath)
W/Xamarin ( 8668):    at System.IO.Directory.CreateDirectory(String path)
W/Xamarin ( 8668):    at System.IO.IsolatedStorage.Helper.GetRandomDirectory(String rootDirectory, IsolatedStorageScope scope)
W/Xamarin ( 8668):    at System.IO.IsolatedStorage.Helper.GetRootDirectory(IsolatedStorageScope scope)
W/Xamarin ( 8668):    at System.IO.IsolatedStorage.IsolatedStorageFile.Initialize(IsolatedStorageScope scope)
W/Xamarin ( 8668):    at System.IO.IsolatedStorage.IsolatedStorageFile.GetUserStoreForApplication()
W/Xamarin ( 8668):    at Xamarin.Forms.Platform.Tizen.Deserializer.<>
```

### Issues Resolved ### 
None

### API Changes ###
None

### Platforms Affected ### 
- Tizen

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
