### PR TITLE
[Tizen] Fixed getting the device type

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -104,7 +104,27 @@ namespace Xamarin.Forms
 
 		static Lazy<string> s_deviceType = new Lazy<string>(() =>
 		{
-			TSystemInfo.TryGetValue("http://tizen.org/system/device_type", out string deviceType);
+			if (!TSystemInfo.TryGetValue("http://tizen.org/system/device_type", out string deviceType))
+			{
+				// Since, above key("http://tizen.org/system/device_type") is not available on Tizen 4.0, we uses profile to decide the type of device on 4.0.
+				var profile = GetProfile();
+				if (profile == "mobile")
+				{
+					deviceType = "Mobile";
+				}
+				else if (profile == "tv")
+				{
+					deviceType = "TV";
+				}
+				else if (profile == "wearable")
+				{
+					deviceType = "Wearable";
+				}
+				else
+				{
+					deviceType = "Unknown";
+				}
+			}
 			return deviceType;
 		});
 


### PR DESCRIPTION
### Description of Change ###

Since, the SystemInfo API key to get the type of device (```http://tizen.org/system/device_type```) is not available on Tizen 4.0, we uses profile to decide the type of device for Tizen 4.0.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
