### PR TITLE
Shift YAML and contributor documents to reference main-xf in preparation for handler branches

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -72,6 +72,6 @@ Once a pull request has two approvals, it will receive an "approved" label. As l
 Bug fixes should be targeted at the earliest appropriate branch.
 - The _current stable branch_ corresponds to the latest stable version available on NuGet.org. This branch will now only accept regressions or fixes that meet a very high bar and low risk.
 - The _current prerelease branch_ corresponds to the latest prerelease version available on NuGet.org. This branch will only accept bug fixes without API changes or breaking changes, with the exception of any API that is under an experimental flag.
-- _Main_ corresponds to a version that is not yet tagged. This is also the "nightly" branch. This is where anything that doesn't fit into the stable or prerelease branches should be targeted.
+- _main-xf_ corresponds to a version that is not yet tagged. This is also the "nightly" branch. This is where anything that doesn't fit into the stable or prerelease branches should be targeted.
 
-Commits will be merged up from stable to prerelease to main branches on a regular basis (typically every Monday and whenever a new release is tagged).
+Commits will be merged up from stable to prerelease to main-xf branches on a regular basis (typically every Monday and whenever a new release is tagged).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,10 +3,10 @@
 After July 15, 2020, feature related pull requests cannot be guaranteed to merge by Xamarin.Forms 5.0. They will be labeled "maui" for transition to dotnet/maui. See the [transition to .NET MAUI](https://github.com/xamarin/Xamarin.Forms/wiki/Feature-Roadmap#transition-to-net-maui) for more information.
 
 Before you submit this PR, make sure you're building on and targeting the right branch!
-     - If this is an enhancement or contains API changes or breaking changes, target main.
+     - If this is an enhancement or contains API changes or breaking changes, target main-xf.
      - If the issue you're working on has a milestone, target the corresponding branch.
-     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
-     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/main/.github/CONTRIBUTING.md) for more tips!
+     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main-xf, of course!).
+     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/main-xf/.github/CONTRIBUTING.md) for more tips!
 
      PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
  -->

--- a/README.md
+++ b/README.md
@@ -9,11 +9,11 @@ Read more about the platform at https://www.xamarin.com/forms.
 
 ## Build Status ##
 
-[![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/Xamarin%20Forms%20Yaml?repoName=xamarin%2FXamarin.Forms&branchName=main)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=10386&repoName=xamarin%2FXamarin.Forms&branchName=main)
+[![Build Status](https://devdiv.visualstudio.com/DevDiv/_apis/build/status/Xamarin%20Forms%20Yaml?repoName=xamarin%2FXamarin.Forms&branchName=main-xf)](https://devdiv.visualstudio.com/DevDiv/_build/latest?definitionId=10386&repoName=xamarin%2FXamarin.Forms&branchName=main-xf)
 
 ## Packages ##
 
-Platform/Feature               | Package name                              | Stable      | Prerelease | Nightly Feed [Azure](https://aka.ms/xf-ci/index.json)  (main branch)
+Platform/Feature               | Package name                              | Stable      | Prerelease | Nightly Feed [Azure](https://aka.ms/xf-ci/index.json)  (main-xf branch)
 -----------------------|-------------------------------------------|-----------------------------|------------------------- |-------------------------|
 Core             | `Xamarin.Forms` | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms/) | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.Forms.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms/) |
 AppLinks  | `Xamarin.Forms.AppLinks`  | [![NuGet](https://img.shields.io/nuget/v/Xamarin.Forms.AppLinks.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms.AppLinks/) | [![NuGet](https://img.shields.io/nuget/vpre/Xamarin.Forms.AppLinks.svg?style=flat-square&label=nuget)](https://www.nuget.org/packages/Xamarin.Forms.AppLinks/) | 
@@ -151,7 +151,7 @@ We follow the style used by the [.NET Foundation](https://github.com/dotnet/runt
 
 ## Contributing ##
 
-- [How to Contribute](https://github.com/xamarin/Xamarin.Forms/blob/main/.github/CONTRIBUTING.md)
+- [How to Contribute](https://github.com/xamarin/Xamarin.Forms/blob/main-xf/.github/CONTRIBUTING.md)
 
 ### Reporting Bugs ###
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,7 +25,7 @@ resources:
 trigger:
   branches:
     include:
-    - main
+    - main-xf
     - 3.*
     - 4.*
     - 5.*
@@ -40,7 +40,7 @@ pr:
   autoCancel: false
   branches:
     include:
-    - main
+    - main-xf
     - 3.*
     - 4.*
     - 5.*
@@ -50,7 +50,7 @@ schedules:
   displayName: Daily midnight build
   branches:
     include:
-    - main
+    - main-xf
 
 stages:
   - stage: windows
@@ -263,6 +263,6 @@ stages:
               msbuild
           steps:
             - template: build/steps/build-sign.yml
-          condition: and(succeeded(), ne(variables['signVmImage'], ''), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+          condition: and(succeeded(), ne(variables['signVmImage'], ''), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main-xf'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
 
 

--- a/build/steps/build-nuget.yml
+++ b/build/steps/build-nuget.yml
@@ -52,7 +52,7 @@ steps:
        }
     failOnStderr: true
     displayName: 'Update nuspecs'
-    condition: and(succeeded(), or(eq(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: and(succeeded(), or(eq(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/main-xf'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: NuGetCommand@2
     displayName: 'Make NuGet Package Release'
@@ -63,7 +63,7 @@ steps:
       packDestination: '$(Build.ArtifactStagingDirectory)/nuget/release'
       versioningScheme: byEnvVar
       versionEnvVar: nugetPackageVersion
-    condition: and(succeeded(), or(eq(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
+    condition: and(succeeded(), or(eq(variables['DefaultBuildConfiguration'], 'Release'), eq(variables['Build.SourceBranch'], 'refs/heads/main-xf'), startsWith(variables['Build.SourceBranch'],'refs/tags/')))
 
   - task: PublishBuildArtifacts@1
     displayName: 'Publish Artifact: nuget'


### PR DESCRIPTION
### Description of Change ###

Change nightlies and nugets to generate from main-xf

Update related documentation


### Testing Procedure ###
- Make sure @rmarinho is happy

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
