### PR TITLE
[iOS] Fix crash with TimePicker on iOS14 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11963.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11963, "Time Picker is broken in Xamarin.Forms as of iOS 14 Public Beta 6", PlatformAffected.iOS)]
+	public class Issue11963 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var timePicker = new TimePicker();
+			var timePickerCompact = new TimePicker();
+			var timePickerInline = new TimePicker();
+
+			timePickerCompact.On<iOS>().SetUIPickerStyle(UIDatePickerStyle.Compact);
+			timePickerInline.On<iOS>().SetUIPickerStyle(UIDatePickerStyle.Inline);
+
+			Content = new StackLayout
+			{
+				Spacing = 20,
+				VerticalOptions = LayoutOptions.Center,
+				Children = { timePicker, timePickerCompact, timePickerInline }
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11963.cs
@@ -21,17 +21,12 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 			var timePicker = new TimePicker();
-			var timePickerCompact = new TimePicker();
-			var timePickerInline = new TimePicker();
-
-			timePickerCompact.On<iOS>().SetUIPickerStyle(UIDatePickerStyle.Compact);
-			timePickerInline.On<iOS>().SetUIPickerStyle(UIDatePickerStyle.Inline);
-
+		
 			Content = new StackLayout
 			{
 				Spacing = 20,
 				VerticalOptions = LayoutOptions.Center,
-				Children = { timePicker, timePickerCompact, timePickerInline }
+				Children = { timePicker }
 			};
 		}
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1483,7 +1483,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11764.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11573.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11963.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1483,6 +1483,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11764.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11573.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11963.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1754,7 +1756,7 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11653.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
-    </EmbeddedResource>      
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11737.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -38,6 +38,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
 		static bool? s_isiOS13OrNewer;
+		static bool? s_isiOS14OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
 
 		internal static bool IsiOS9OrNewer
@@ -78,6 +79,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS13OrNewer.HasValue)
 					s_isiOS13OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(13, 0);
 				return s_isiOS13OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS14OrNewer
+		{
+			get
+			{
+				if (!s_isiOS14OrNewer.HasValue)
+					s_isiOS14OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(14, 0);
+				return s_isiOS14OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -82,6 +82,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 					_picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new NSTimeZone("UTC") };
 
+					if (Forms.IsiOS14OrNewer)
+					{
+						_picker.PreferredDatePickerStyle = UIKit.UIDatePickerStyle.Wheels;
+					}
+
 					var width = UIScreen.MainScreen.Bounds.Width;
 					var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
 					var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -81,12 +81,12 @@ namespace Xamarin.Forms.Platform.iOS
 					entry.EditingDidEnd += OnEnded;
 
 					_picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new NSTimeZone("UTC") };
-
+#if __XCODE11__
 					if (Forms.IsiOS14OrNewer)
 					{
 						_picker.PreferredDatePickerStyle = UIKit.UIDatePickerStyle.Wheels;
 					}
-
+#endif
 					var width = UIScreen.MainScreen.Bounds.Width;
 					var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
 					var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);


### PR DESCRIPTION
### Description of Change ###

Fix the TimePicker crash on iOS14 by forcing the PreferredDatePickerStyle to UIDatePickerStyle.Wheels.

### Issues Resolved ### 

- fixes #11963

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Use Xcode12, iOS14 device, and Xamarin.iOS for IOS14.
Go to issue 11943, click on the date , make sure the time picker wheels appear and you able to select a time.

make sure it also works on iOS13

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)