### PR TITLE
Shell FlyoutWidth and FlyoutHeight

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -395,7 +395,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" />
+      <UserProperties TriggeredFromHotReload="False" XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
@@ -113,10 +113,10 @@ namespace Xamarin.Forms.Controls.Issues
 			this.ShowFlyout();
 			var initialWidth = RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width;
 			var initialHeight = RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y;
-			RunningApp.Tap("ChangeFlyoutSizes");
+			TapInFlyout("ChangeFlyoutSizes", makeSureFlyoutStaysOpen: true);
 			Assert.AreNotEqual(initialWidth, RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width);
 			Assert.AreNotEqual(initialHeight, RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y);
-			RunningApp.Tap("ResetFlyoutSizes");
+			TapInFlyout("ResetFlyoutSizes", makeSureFlyoutStaysOpen: true);
 			Assert.AreEqual(initialWidth, RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width);
 			Assert.AreEqual(initialHeight, RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y);
 		}
@@ -126,10 +126,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("PageLoaded");
 			this.ShowFlyout();
-			RunningApp.Tap("ChangeFlyoutSizes");
+			TapInFlyout("ChangeFlyoutSizes", makeSureFlyoutStaysOpen: true);
 			var initialWidth = RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width;
 			var initialHeight = RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y;
-			RunningApp.Tap("DecreaseFlyoutSizes");
+			TapInFlyout("DecreaseFlyoutSizes", makeSureFlyoutStaysOpen: true);
 			var newWidth = RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width;
 			var newHeight = RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
@@ -1,0 +1,141 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Flyout Width and Height",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellFlyoutSizing : TestShell
+	{
+		protected override void Init()
+		{
+			AddContentPage(new ContentPage()
+			{
+				Title = "Main Page",
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Open the Flyout and click the button. The height and width should change. Click it again and it should go back to default",
+							AutomationId ="PageLoaded"
+						}
+					}
+				}
+			});
+
+			FlyoutHeader = new Label()
+			{
+				BackgroundColor = Color.LightBlue,
+				Text = "Header",
+				AutomationId = "FlyoutHeader"
+			};
+
+
+			FlyoutFooter = new Label()
+			{
+				BackgroundColor = Color.LightBlue,
+				Text = "Footer",
+				AutomationId = "FlyoutFooter"
+			};
+
+
+			var scale = 10 / Device.info.ScalingFactor;
+
+			var increaseMenuItem = new MenuItem()
+			{
+				Text = "Increase Height and Width",
+				Command = new Command(() =>
+				{
+					FlyoutWidth += scale;
+					FlyoutHeight += scale;
+				}),
+				AutomationId = "IncreaseFlyoutSizes"
+			};
+
+			var descreaseMenuItem = new MenuItem()
+			{
+				Text = "Decrease Height and Width",
+				Command = new Command(() =>
+				{
+					FlyoutWidth -= scale;
+					FlyoutHeight -= scale;
+				}),
+				AutomationId = "DecreaseFlyoutSizes"
+			};
+
+
+			Items.Add(new MenuItem() { 
+				Text = "Change Height and Width", 
+				Command = new Command(() =>
+				{
+					FlyoutWidth = 350;
+					FlyoutHeight = 350;
+					Items.Add(increaseMenuItem);
+					Items.Add(descreaseMenuItem);
+				}),
+				AutomationId = "ChangeFlyoutSizes"
+			});
+
+			Items.Add(new MenuItem()
+			{
+				Text = "Reset Height and Width",
+				Command = new Command(() =>
+				{
+					FlyoutWidth = -1;
+					FlyoutHeight = -1;
+					Items.Remove(increaseMenuItem);
+					Items.Remove(descreaseMenuItem);
+				}),
+				AutomationId = "ResetFlyoutSizes"
+			});
+		}
+
+
+#if UITEST
+		[Test]
+		public void FlyoutHeightAndWidthResetsBackToOriginalSize()
+		{
+			RunningApp.WaitForElement("PageLoaded");
+			this.ShowFlyout();
+			var initialWidth = RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width;
+			var initialHeight = RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y;
+			RunningApp.Tap("ChangeFlyoutSizes");
+			Assert.AreNotEqual(initialWidth, RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width);
+			Assert.AreNotEqual(initialHeight, RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y);
+			RunningApp.Tap("ResetFlyoutSizes");
+			Assert.AreEqual(initialWidth, RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width);
+			Assert.AreEqual(initialHeight, RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y);
+		}
+
+		[Test]
+		public void FlyoutHeightAndWidthIncreaseAndDecreaseCorrectly()
+		{
+			RunningApp.WaitForElement("PageLoaded");
+			this.ShowFlyout();
+			RunningApp.Tap("ChangeFlyoutSizes");
+			var initialWidth = RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width;
+			var initialHeight = RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y;
+			RunningApp.Tap("DecreaseFlyoutSizes");
+			var newWidth = RunningApp.WaitForElement("FlyoutHeader")[0].Rect.Width;
+			var newHeight = RunningApp.WaitForElement("FlyoutFooter")[0].Rect.Y;
+
+			Assert.That(initialWidth - newWidth, Is.EqualTo(10).Within(1));
+			Assert.That(initialHeight - newHeight, Is.EqualTo(10).Within(1));
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
@@ -37,6 +37,17 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			});
 
+			FlyoutBackground = new LinearGradientBrush
+			{
+				StartPoint = new Point(0, 0),
+				EndPoint = new Point(1, 0),
+				GradientStops = new GradientStopCollection
+				{
+					new GradientStop { Color = Color.Blue, Offset = 0.1f },
+					new GradientStop { Color = Color.BlueViolet, Offset = 1.0f },
+				}
+			};
+
 			FlyoutHeader = new Label()
 			{
 				BackgroundColor = Color.LightBlue,

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutSizing.cs
@@ -53,7 +53,10 @@ namespace Xamarin.Forms.Controls.Issues
 			};
 
 
-			var scale = 10 / Device.info.ScalingFactor;
+			var scale = 10d;
+
+			if (Device.RuntimePlatform == Device.Android)
+				scale = scale  / Device.info.ScalingFactor;
 
 			var increaseMenuItem = new MenuItem()
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -800,12 +800,24 @@ namespace Xamarin.Forms.Controls
 		}
 
 
-		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null)
+		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null, bool makeSureFlyoutStaysOpen = false)
 		{
 			timeoutMessage = timeoutMessage ?? text;
-			ShowFlyout(flyoutIcon, usingSwipe);
-			RunningApp.WaitForElement(text, timeoutMessage);
+			RunningApp.WaitForElement(flyoutIcon);
+			if (RunningApp.Query(text).Count() == 0)
+			{
+				ShowFlyout(flyoutIcon, usingSwipe);
+				RunningApp.WaitForElement(text, timeoutMessage);
+			}
+
 			RunningApp.Tap(text);
+
+			if (makeSureFlyoutStaysOpen)
+			{
+				System.Threading.Thread.Sleep(500);
+				if(RunningApp.Query(text).Count() == 0)
+					this.ShowFlyout(flyoutIcon);
+			}
 		}
 
 		public void DoubleTapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -803,7 +803,7 @@ namespace Xamarin.Forms.Controls
 		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null, bool makeSureFlyoutStaysOpen = false)
 		{
 			timeoutMessage = timeoutMessage ?? text;
-			RunningApp.WaitForElement(flyoutIcon);
+
 			if (RunningApp.Query(text).Count() == 0)
 			{
 				ShowFlyout(flyoutIcon, usingSwipe);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -807,19 +807,33 @@ namespace Xamarin.Forms.Controls
 			RunningApp.WaitForElement(flyoutIcon);
 #endif
 
-			if (RunningApp.Query(text).Count() == 0)
+			System.Threading.Thread.Sleep(500);
+			CheckIfOpen();
+			try
 			{
-				ShowFlyout(flyoutIcon, usingSwipe);
-				RunningApp.WaitForElement(text, timeoutMessage);
+				RunningApp.Tap(text);
 			}
-
-			RunningApp.Tap(text);
+			catch
+			{
+				// Give it one more try
+				CheckIfOpen();
+				RunningApp.Tap(text);
+			}
 
 			if (makeSureFlyoutStaysOpen)
 			{
 				System.Threading.Thread.Sleep(500);
 				if(RunningApp.Query(text).Count() == 0)
 					this.ShowFlyout(flyoutIcon);
+			}
+
+			void CheckIfOpen()
+			{
+				if (RunningApp.Query(text).Count() == 0)
+				{
+					ShowFlyout(flyoutIcon, usingSwipe);
+					RunningApp.WaitForElement(text, timeoutMessage);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -803,6 +803,9 @@ namespace Xamarin.Forms.Controls
 		public void TapInFlyout(string text, string flyoutIcon = FlyoutIconAutomationId, bool usingSwipe = false, string timeoutMessage = null, bool makeSureFlyoutStaysOpen = false)
 		{
 			timeoutMessage = timeoutMessage ?? text;
+#if __WINDOWS__
+			RunningApp.WaitForElement(flyoutIcon);
+#endif
 
 			if (RunningApp.Query(text).Count() == 0)
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -307,6 +307,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7339.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellAppearanceChange.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10234.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellModal.cs" />

--- a/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
+++ b/Xamarin.Forms.Controls/XamStore/Views/StorePages.cs
@@ -355,9 +355,39 @@ namespace Xamarin.Forms.Controls.XamStore
 					() => Shell.SetNavBarHasShadow(this, false)),
 				1, 21);
 
-			grid.Children.Add(MakeButton("Show Nav Shadow",
-					() => Shell.SetNavBarHasShadow(this, true)),
-				2, 21);
+            grid.Children.Add(MakeButton("Show Nav Shadow",
+                    () => Shell.SetNavBarHasShadow(this, true)),
+                2, 21);
+
+			Entry flyoutWidth = new Entry();
+			Entry flyoutHeight = new Entry();
+
+			flyoutWidth.TextChanged += FlyoutSizeTextChanged;
+			flyoutHeight.TextChanged += FlyoutSizeTextChanged;
+
+			grid.Children.Add(new Label() { Text = "Flyout WxH:" },
+				0, 22);
+
+			grid.Children.Add(flyoutWidth,
+				1, 22);
+
+			grid.Children.Add(flyoutHeight,
+				2, 22);
+
+			void FlyoutSizeTextChanged(object sender, TextChangedEventArgs e)
+			{
+				double result;
+
+				if (double.TryParse(flyoutWidth.Text, out result))
+				{
+					Shell.Current.FlyoutWidth = result;
+				}
+
+				if (double.TryParse(flyoutHeight.Text, out result))
+				{
+					Shell.Current.FlyoutHeight = result;
+				}
+			}
 		}
 
 		Switch _navBarVisibleSwitch;

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿
+using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
@@ -81,6 +82,13 @@ namespace Xamarin.Forms
 		public static FlyoutBehavior GetFlyoutBehavior(BindableObject obj) => (FlyoutBehavior)obj.GetValue(FlyoutBehaviorProperty);
 		public static void SetFlyoutBehavior(BindableObject obj, FlyoutBehavior value) => obj.SetValue(FlyoutBehaviorProperty, value);
 
+		public static double GetFlyoutWidth(BindableObject obj) => (double)obj.GetValue(FlyoutWidthProperty);
+		public static void SetFlyoutWidth(BindableObject obj, double value) => obj.SetValue(FlyoutWidthProperty, value);
+
+		public static double GetFlyoutHeight(BindableObject obj) => (double)obj.GetValue(FlyoutHeightProperty);
+		public static void SetFlyoutHeight(BindableObject obj, double value) => obj.SetValue(FlyoutHeightProperty, value);
+
+
 		public static bool GetNavBarIsVisible(BindableObject obj) => (bool)obj.GetValue(NavBarIsVisibleProperty);
 		public static void SetNavBarIsVisible(BindableObject obj, bool value) => obj.SetValue(NavBarIsVisibleProperty, value);
 
@@ -110,47 +118,55 @@ namespace Xamarin.Forms
 
 		public static readonly new BindableProperty BackgroundColorProperty =
 			BindableProperty.CreateAttached("BackgroundColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty DisabledColorProperty =
 			BindableProperty.CreateAttached("DisabledColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty ForegroundColorProperty =
 			BindableProperty.CreateAttached("ForegroundColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty TabBarBackgroundColorProperty =
 			BindableProperty.CreateAttached("TabBarBackgroundColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty TabBarDisabledColorProperty =
 			BindableProperty.CreateAttached("TabBarDisabledColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty TabBarForegroundColorProperty =
 			BindableProperty.CreateAttached("TabBarForegroundColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty TabBarTitleColorProperty =
 			BindableProperty.CreateAttached("TabBarTitleColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty TabBarUnselectedColorProperty =
 			BindableProperty.CreateAttached("TabBarUnselectedColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty TitleColorProperty =
 			BindableProperty.CreateAttached("TitleColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty UnselectedColorProperty =
 			BindableProperty.CreateAttached("UnselectedColor", typeof(Color), typeof(Shell), Color.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static readonly BindableProperty FlyoutBackdropProperty =
 			BindableProperty.CreateAttached("FlyoutBackdrop", typeof(Brush), typeof(Shell), Brush.Default,
-				propertyChanged: OnColorValueChanged);
+				propertyChanged: OnShellAppearanceValueChanged);
+
+		public static readonly BindableProperty FlyoutWidthProperty =
+			BindableProperty.CreateAttached("FlyoutWidth", typeof(double), typeof(Shell), -1d,
+				propertyChanged: OnShellAppearanceValueChanged);
+
+		public static readonly BindableProperty FlyoutHeightProperty =
+			BindableProperty.CreateAttached("FlyoutHeight", typeof(double), typeof(Shell), -1d,
+				propertyChanged: OnShellAppearanceValueChanged);
 
 		public static Color GetBackgroundColor(BindableObject obj) => (Color)obj.GetValue(BackgroundColorProperty);
 		public static void SetBackgroundColor(BindableObject obj, Color value) => obj.SetValue(BackgroundColorProperty, value);
@@ -185,7 +201,7 @@ namespace Xamarin.Forms
 		public static Brush GetFlyoutBackdrop(BindableObject obj) => (Brush)obj.GetValue(FlyoutBackdropProperty);
 		public static void SetFlyoutBackdrop(BindableObject obj, Brush value) => obj.SetValue(FlyoutBackdropProperty, value);
 
-		static void OnColorValueChanged(BindableObject bindable, object oldValue, object newValue)
+		static void OnShellAppearanceValueChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			var item = (Element)bindable;
 			var source = item;
@@ -978,6 +994,18 @@ namespace Xamarin.Forms
 		{
 			get => (Brush)GetValue(FlyoutBackdropProperty);
 			set => SetValue(FlyoutBackdropProperty, value);
+		}
+
+		public double FlyoutWidth
+		{
+			get => (double)GetValue(FlyoutWidthProperty);
+			set => SetValue(FlyoutWidthProperty, value);
+		}
+
+		public double FlyoutHeight
+		{
+			get => (double)GetValue(FlyoutHeightProperty);
+			set => SetValue(FlyoutHeightProperty, value);
 		}
 
 		public FlyoutBehavior FlyoutBehavior

--- a/Xamarin.Forms.Core/Shell/ShellAppearance.cs
+++ b/Xamarin.Forms.Core/Shell/ShellAppearance.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 
 namespace Xamarin.Forms
@@ -25,8 +26,15 @@ namespace Xamarin.Forms
 			Shell.FlyoutBackdropProperty
 		};
 
+		static readonly BindableProperty[] s_ingestDoubleArray = new[]
+		{
+			Shell.FlyoutWidthProperty,
+			Shell.FlyoutHeightProperty
+		};
+
 		Color?[] _colorArray = new Color?[s_ingestArray.Length];
 		Brush[] _brushArray = new Brush[s_ingestBrushArray.Length];
+		double[] _doubleArray = new double[s_ingestDoubleArray.Length];
 
 		public Color BackgroundColor => _colorArray[0].Value;
 
@@ -49,6 +57,8 @@ namespace Xamarin.Forms
 		public Color UnselectedColor => _colorArray[9].Value;
 
 		public Brush FlyoutBackdrop => _brushArray[0];
+		public double FlyoutWidth => _doubleArray[0];
+		public double FlyoutHeight => _doubleArray[1];
 
 		Color IShellAppearanceElement.EffectiveTabBarBackgroundColor =>
 			!TabBarBackgroundColor.IsDefault ? TabBarBackgroundColor : BackgroundColor;
@@ -68,7 +78,10 @@ namespace Xamarin.Forms
 		internal ShellAppearance()
 		{
 			for (int i = 0; i < _brushArray.Length; i++)
-				_brushArray[0] = Brush.Default;
+				_brushArray[i] = Brush.Default;
+
+			for (int i = 0; i < _doubleArray.Length; i++)
+				_doubleArray[i] = -1;			
 		}
 
 		public override bool Equals(object obj)
@@ -88,6 +101,12 @@ namespace Xamarin.Forms
 					return false;
 			}
 
+			for (int i = 0; i < _doubleArray.Length; i++)
+			{
+				if (!EqualityComparer<double>.Default.Equals(_doubleArray[i], appearance._doubleArray[i]))
+					return false;
+			}
+
 			return true;
 		}
 
@@ -99,6 +118,9 @@ namespace Xamarin.Forms
 
 			for (int i = 0; i < _brushArray.Length; i++)
 				hashCode = hashCode * -1521134295 + EqualityComparer<Brush>.Default.GetHashCode(_brushArray[i]);
+
+			for (int i = 0; i < _doubleArray.Length; i++)
+				hashCode = hashCode * -1521134295 + EqualityComparer<double>.Default.GetHashCode(_doubleArray[i]);
 
 			return hashCode;
 		}
@@ -120,10 +142,20 @@ namespace Xamarin.Forms
 			var brushDataSet = pivot.GetValues<Brush>(s_ingestBrushArray);
 			for (int i = 0; i < s_ingestBrushArray.Length; i++)
 			{
-				if (_brushArray[i] != Brush.Default && brushDataSet[i].IsSet)
+				if (Brush.IsNullOrEmpty(_brushArray[i]) && brushDataSet[i].IsSet)
 				{
 					anySet = true;
 					_brushArray[i] = brushDataSet[i].Value;
+				}
+			}
+
+			var doubleDataSet = pivot.GetValues<double>(s_ingestDoubleArray);
+			for (int i = 0; i < s_ingestDoubleArray.Length; i++)
+			{
+				if (_doubleArray[i] == -1 && doubleDataSet[i].IsSet)
+				{
+					anySet = true;
+					_doubleArray[i] = doubleDataSet[i].Value;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ContainerView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ContainerView.cs
@@ -37,6 +37,9 @@ namespace Xamarin.Forms.Platform.Android
 			get { return _view; }
 			set
 			{
+				if (_view == value)
+					return;
+
 				_view = value;
 				OnViewSet(value);
 			}
@@ -98,6 +101,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_renderer != null)
 			{
+				_renderer.Element.MeasureInvalidated -= ElementMeasureInvalidated;
 				_renderer.View.RemoveFromParent();
 				_renderer.Dispose();
 				_renderer = null;
@@ -107,8 +111,20 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_renderer = Platform.CreateRenderer(view, Context);
 				Platform.SetRenderer(view, _renderer);
-
 				AddView(_renderer.View);
+				view.MeasureInvalidated += ElementMeasureInvalidated;
+			}
+		}
+
+		void ElementMeasureInvalidated(object sender, EventArgs e)
+		{
+			if (this.IsAlive())
+			{
+				RequestLayout();
+			}
+			else if (sender is VisualElement ve)
+			{
+				ve.MeasureInvalidated -= ElementMeasureInvalidated;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -15,13 +15,38 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		#region IAppearanceObserver
 
+
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
+			var previousFlyoutWidth = FlyoutWidth;
+			var previousFlyoutHeight = FlyoutHeight;
+
 			if (appearance == null)
+			{
 				UpdateScrim(Brush.Transparent);
+				_flyoutWidth = _flyoutWidthDefault;
+				_flyoutHeight = LP.MatchParent;
+			}
 			else
 			{
 				UpdateScrim(appearance.FlyoutBackdrop);
+
+				if (appearance.FlyoutHeight != -1)
+					_flyoutHeight = Context.ToPixels(appearance.FlyoutHeight);
+				else
+					_flyoutHeight = LP.MatchParent;
+
+				if (appearance.FlyoutWidth != -1)
+					_flyoutWidth = Context.ToPixels(appearance.FlyoutWidth);
+				else
+					_flyoutWidth = -1;
+			}
+
+			if (previousFlyoutWidth != FlyoutWidth || previousFlyoutHeight != FlyoutHeight)
+			{
+				UpdateFlyoutSize();
+				if (_content != null)
+					UpdateDrawerLockMode(_behavior);
 			}
 		}
 		#endregion IAppearanceObserver
@@ -68,8 +93,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)
 		{
+			bool closeAfterUpdate = (behavior == FlyoutBehavior.Flyout && _behavior == FlyoutBehavior.Locked);
 			_behavior = behavior;
 			UpdateDrawerLockMode(behavior);
+
+			if (closeAfterUpdate)
+				CloseDrawer(_flyoutContent.AndroidView, false);
 		}
 
 		#endregion IFlyoutBehaviorObserver
@@ -78,7 +107,10 @@ namespace Xamarin.Forms.Platform.Android
 		readonly IShellContext _shellContext;
 		AView _content;
 		IShellFlyoutContentRenderer _flyoutContent;
-		int _flyoutWidth;
+		int _flyoutWidthDefault;
+		double _flyoutWidth;
+		double _flyoutHeight;
+
 		int _currentLockMode;
 		bool _disposed;
 		Brush _scrimBrush;
@@ -86,21 +118,33 @@ namespace Xamarin.Forms.Platform.Android
 		int _previousHeight;
 		int _previousWidth;
 		int _scrimOpacity;
-
 		FlyoutBehavior _behavior;
 
 		public ShellFlyoutRenderer(IShellContext shellContext, Context context) : base(context)
 		{
 			_scrimBrush = Brush.Default;
 			_shellContext = shellContext;
+			_flyoutHeight = LP.MatchParent;
 
 			Shell.PropertyChanged += OnShellPropertyChanged;
-
 			ShellController.AddAppearanceObserver(this, Shell);
 		}
 
-		Shell Shell => _shellContext.Shell;
+		double FlyoutWidth
+		{
+			get
+			{
+				if(_flyoutWidth == -1)
+				{
+					return _flyoutWidthDefault;
+				}
 
+				return _flyoutWidth;
+			}
+		}
+
+		int FlyoutHeight => (_flyoutHeight == -1) ? LP.MatchParent : (int)_flyoutHeight;
+		Shell Shell => _shellContext.Shell;
 		IShellController ShellController => _shellContext.Shell;
 
 		public override bool OnInterceptTouchEvent(MotionEvent ev)
@@ -171,10 +215,9 @@ namespace Xamarin.Forms.Platform.Android
 			var maxWidth = actionBarHeight * 6;
 			width = Math.Min(width, maxWidth);
 
-			_flyoutWidth = width;
+			_flyoutWidthDefault = width;
 
-			_flyoutContent.AndroidView.LayoutParameters =
-				new LayoutParams(width, LP.MatchParent) { Gravity = (int)GravityFlags.Start };
+			UpdateFlyoutSize();
 
 			Profile.FramePartition("AddView Content");
 			AddView(content);
@@ -206,6 +249,13 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		void OnDualScreenServiceScreenChanged(object sender, EventArgs e)
+		{
+			UpdateFlyoutSize();
+			if(_content != null)
+				UpdateDrawerLockMode(_behavior);
+		}
+
 		protected virtual void UpdateDrawerLockMode(FlyoutBehavior behavior)
 		{
 			switch (behavior)
@@ -228,11 +278,34 @@ namespace Xamarin.Forms.Platform.Android
 					Shell.SetValueFromRenderer(Shell.FlyoutIsPresentedProperty, true);
 					_currentLockMode = LockModeLockedOpen;
 					SetDrawerLockMode(_currentLockMode);
-					_content.SetPadding(_flyoutWidth, _content.PaddingTop, _content.PaddingRight, _content.PaddingBottom);
+
+					_content.SetPadding((int)FlyoutWidth, _content.PaddingTop, _content.PaddingRight, _content.PaddingBottom);
 					break;
 			}
 
 			UpdateScrim(_scrimBrush);
+		}
+
+		double _previouslyMeasuredFlyoutWidth;
+		int _previouslyMeasuredFlyoutHeight;
+
+		void UpdateFlyoutSize()
+		{
+			if (_flyoutContent?.AndroidView != null && 
+				(_previouslyMeasuredFlyoutWidth != FlyoutWidth || _previouslyMeasuredFlyoutHeight != FlyoutHeight))
+			{
+				_previouslyMeasuredFlyoutWidth = FlyoutWidth;
+				_previouslyMeasuredFlyoutHeight = FlyoutHeight;
+
+				_flyoutContent.AndroidView.LayoutParameters =
+					new LayoutParams((int)FlyoutWidth, FlyoutHeight) { Gravity = (int)GravityFlags.Start };
+
+				// This forces a redraw of the flyout
+				// without this the flyout will just be empty once you change
+				// the width
+				if (Shell.FlyoutIsPresented)
+					OpenDrawer(_flyoutContent.AndroidView, false);
+			}
 		}
 
 		void UpdateScrim(Brush backdrop)
@@ -292,5 +365,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			base.Dispose(disposing);
 		}
+
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -130,18 +130,7 @@ namespace Xamarin.Forms.Platform.Android
 			ShellController.AddAppearanceObserver(this, Shell);
 		}
 
-		double FlyoutWidth
-		{
-			get
-			{
-				if(_flyoutWidth == -1)
-				{
-					return _flyoutWidthDefault;
-				}
-
-				return _flyoutWidth;
-			}
-		}
+		double FlyoutWidth => (_flyoutWidth == -1) ? _flyoutWidthDefault : _flyoutWidth;
 
 		int FlyoutHeight => (_flyoutHeight == -1) ? LP.MatchParent : (int)_flyoutHeight;
 		Shell Shell => _shellContext.Shell;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRenderer.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.Android
 			if (appearance == null)
 			{
 				UpdateScrim(Brush.Transparent);
-				_flyoutWidth = _flyoutWidthDefault;
+				_flyoutWidth = -1;
 				_flyoutHeight = LP.MatchParent;
 			}
 			else
@@ -108,7 +108,7 @@ namespace Xamarin.Forms.Platform.Android
 		AView _content;
 		IShellFlyoutContentRenderer _flyoutContent;
 		int _flyoutWidthDefault;
-		double _flyoutWidth;
+		double _flyoutWidth = -1;
 		double _flyoutHeight;
 
 		int _currentLockMode;

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -25,6 +25,9 @@ namespace Xamarin.Forms.Platform.UWP
 		internal const string ShellStyle = "ShellNavigationView";
 		Shell _shell;
 		Brush _flyoutBackdrop;
+		double _flyoutHeight = -1d;
+		double _flyoutWidth = -1d;
+
 		FlyoutBehavior _flyoutBehavior;
 		List<List<Element>> _flyoutGrouping;
 		ShellItemRenderer ItemRenderer { get; }
@@ -79,6 +82,7 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
 			UpdateFlyoutBackdrop();
+			UpdateFlyoutPosition();
 			UpdateFlyoutVerticalScrollMode();
 		}
 
@@ -243,6 +247,20 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
+		void UpdateFlyoutPosition()
+		{
+			if (_flyoutBehavior == FlyoutBehavior.Disabled)
+				return;
+
+			var splitView = ShellSplitView;
+			if (splitView != null)
+			{
+				splitView.SetFlyoutSizes(_flyoutHeight, _flyoutWidth);
+				if (IsPaneOpen)
+					ShellSplitView.RefreshFlyoutPosition();
+			}
+		}
+		
 		void UpdateFlyoutBackdrop()
 		{
 			if (_flyoutBehavior != FlyoutBehavior.Flyout)
@@ -253,7 +271,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				splitView.FlyoutBackdrop = _flyoutBackdrop;
 				if (IsPaneOpen)
-					ShellSplitView.UpdateFlyoutBackdrop();
+					ShellSplitView.RefreshFlyoutBackdrop();
 			}
 		}
 
@@ -420,6 +438,9 @@ namespace Xamarin.Forms.Platform.UWP
 					titleColor = appearance.TitleColor.ToWindowsColor();
 
 				_flyoutBackdrop = appearance.FlyoutBackdrop;
+
+				_flyoutWidth = appearance.FlyoutWidth;
+				_flyoutHeight = appearance.FlyoutHeight;
 			}
 
 			var titleBar = Windows.UI.ViewManagement.ApplicationView.GetForCurrentView().TitleBar;
@@ -427,8 +448,8 @@ namespace Xamarin.Forms.Platform.UWP
 			titleBar.ForegroundColor = titleBar.ButtonForegroundColor = titleColor;
 			UpdatePaneButtonColor(TogglePaneButton, !IsPaneOpen);
 			UpdatePaneButtonColor(NavigationViewBackButton, !IsPaneOpen);
-
 			UpdateFlyoutBackdrop();
+			UpdateFlyoutPosition();
 		}
 
 		#endregion IAppearanceObserver

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSplitView.cs
@@ -1,4 +1,5 @@
-﻿using Windows.UI.Xaml.Controls;
+﻿using Windows.UI.Xaml;
+using Windows.UI.Xaml.Controls;
 using WBrush = Windows.UI.Xaml.Media.Brush;
 using WRectangle = Windows.UI.Xaml.Shapes.Rectangle;
 
@@ -10,15 +11,65 @@ namespace Xamarin.Forms.Platform.UWP
 		WBrush _flyoutPlatformBrush;
 		WBrush _defaultBrush;
 		LightDismissOverlayMode? _defaultLightDismissOverlayMode;
+		double _height = -1d;
+		double _width = -1d;
+		double _defaultOpenPaneLength = -1d;
+
 		public ShellSplitView()
 		{
 		}
 
+		internal void SetFlyoutSizes(double height, double width)
+		{
+			_height = height;
+			_width = width;
+		}
 
-		internal void UpdateFlyoutBackdrop()
+		internal void RefreshFlyoutPosition()
+		{
+			var paneRoot = (Windows.UI.Xaml.FrameworkElement)GetTemplateChild("PaneRoot");
+			if (paneRoot == null)
+				return;
+
+			var HCPaneBorder = (Windows.UI.Xaml.Shapes.Rectangle)GetTemplateChild("HCPaneBorder");
+
+			if (paneRoot != null)
+			{
+				if (_height == -1)
+				{
+					paneRoot.Height = double.NaN;
+					paneRoot.VerticalAlignment = Windows.UI.Xaml.VerticalAlignment.Stretch;
+
+					if (HCPaneBorder != null)
+						HCPaneBorder.Visibility = Windows.UI.Xaml.Visibility.Visible;
+				}
+				else
+				{
+					paneRoot.Height = _height;
+					paneRoot.VerticalAlignment = Windows.UI.Xaml.VerticalAlignment.Top;
+
+					if (HCPaneBorder != null)
+						HCPaneBorder.Visibility = Windows.UI.Xaml.Visibility.Collapsed;
+				}
+			}
+
+			if (_width != -1)
+			{
+				if(_defaultOpenPaneLength == -1)
+					_defaultOpenPaneLength = OpenPaneLength;
+
+				OpenPaneLength = _width;
+			}
+			else if(_defaultOpenPaneLength != -1)
+			{
+				OpenPaneLength = _defaultOpenPaneLength;
+			}
+		}
+
+		internal void RefreshFlyoutBackdrop()
 		{
 			var dismissLayer = ((WRectangle)GetTemplateChild("LightDismissLayer"));
-
+			
 			if (dismissLayer == null)
 				return;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -175,7 +175,10 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void UpdateBackground()
 		{
 			var color = _shellContext.Shell.FlyoutBackgroundColor;
-			View.BackgroundColor = color.ToUIColor(ColorExtensions.BackgroundColor);
+			var brush = _shellContext.Shell.FlyoutBackground;
+
+			var backgroundImage = View.GetBackgroundImage(brush);
+			View.BackgroundColor = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage) : color.ToUIColor(ColorExtensions.BackgroundColor);
 
 			if (View.BackgroundColor.CGColor.Alpha < 1)
 			{
@@ -186,9 +189,6 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_blurView.Superview != null)
 					_blurView.RemoveFromSuperview();
 			}
-
-			var brush = _shellContext.Shell.FlyoutBackground;
-			View.UpdateBackground(brush);
 
 			UpdateFlyoutBgImageAsync();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -15,9 +15,14 @@ namespace Xamarin.Forms.Platform.iOS
 		void IAppearanceObserver.OnAppearanceChanged(ShellAppearance appearance)
 		{
 			if (appearance == null)
+			{
 				_backdropBrush = Brush.Default;
+			}
 			else
+			{
 				_backdropBrush = appearance.FlyoutBackdrop;
+				SlideFlyoutTransition?.SetFlyoutSizes(appearance.FlyoutHeight, appearance.FlyoutWidth);
+			}
 
 			UpdateTapoffViewBackgroundColor();
 		}
@@ -39,10 +44,10 @@ namespace Xamarin.Forms.Platform.iOS
 			Shell.PropertyChanged += OnShellPropertyChanged;
 
 			PanGestureRecognizer = new UIPanGestureRecognizer(HandlePanGesture);
-			PanGestureRecognizer.ShouldRecognizeSimultaneously += (a,b) =>
+			PanGestureRecognizer.ShouldRecognizeSimultaneously += (a, b) =>
 			{
 				// This handles tapping outside the open flyout
-				if(a is UIPanGestureRecognizer pr && pr.State == UIGestureRecognizerState.Failed &&
+				if (a is UIPanGestureRecognizer pr && pr.State == UIGestureRecognizerState.Failed &&
 					b is UITapGestureRecognizer && b.State == UIGestureRecognizerState.Ended && IsOpen)
 				{
 					IsOpen = false;
@@ -66,7 +71,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				return true;
 			};
-						
+
 			ShellController.AddAppearanceObserver(this, Shell);
 			IsOpen = Shell.FlyoutIsPresented;
 		}
@@ -112,7 +117,17 @@ namespace Xamarin.Forms.Platform.iOS
 
 		double AnimationDurationInSeconds => ((double)AnimationDuration) / 1000.0;
 
-		public IShellFlyoutTransition FlyoutTransition { get; set; }
+		public IShellFlyoutTransition FlyoutTransition
+		{
+			get => _flyoutTransition;
+			set
+			{
+				_flyoutTransition = value;
+				SlideFlyoutTransition = value as SlideFlyoutTransition;
+			}
+		}
+
+		SlideFlyoutTransition SlideFlyoutTransition { get; set; }
 
 		IShellContext Context { get; set; }
 
@@ -145,7 +160,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewDidLayoutSubviews();
 
-			if(_flyoutAnimation == null)
+			if (_flyoutAnimation == null)
 				LayoutSidebar(false);
 		}
 
@@ -289,6 +304,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UIKeyCommand.Create ((Foundation.NSString)"\t", 0, new ObjCRuntime.Selector ("tabForward:")),
 			UIKeyCommand.Create ((Foundation.NSString)"\t", UIKeyModifierFlags.Shift, new ObjCRuntime.Selector ("tabBackward:"))
 		};
+		private IShellFlyoutTransition _flyoutTransition;
 
 		public override UIKeyCommand[] KeyCommands => tabCommands;
 
@@ -366,7 +382,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_gestureActive)
 				return;
 
-			if(cancelExisting && _flyoutAnimation != null)
+			if (cancelExisting && _flyoutAnimation != null)
 			{
 				_flyoutAnimation.StopAnimation(true);
 				_flyoutAnimation = null;
@@ -375,7 +391,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (animate && _flyoutAnimation != null)
 				return;
 
-			if(!animate && _flyoutAnimation != null)
+			if (!animate && _flyoutAnimation != null)
 			{
 				_flyoutAnimation.StopAnimation(true);
 				_flyoutAnimation = null;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -21,7 +21,15 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				_backdropBrush = appearance.FlyoutBackdrop;
-				SlideFlyoutTransition?.SetFlyoutSizes(appearance.FlyoutHeight, appearance.FlyoutWidth);
+
+				if (appearance.FlyoutHeight != SlideFlyoutTransition.Height ||
+					appearance.FlyoutWidth != SlideFlyoutTransition.Width)
+				{
+					SlideFlyoutTransition?.SetFlyoutSizes(appearance.FlyoutHeight, appearance.FlyoutWidth);
+
+					if(_layoutOccured)
+						LayoutSidebar(false, true);
+				}
 			}
 
 			UpdateTapoffViewBackgroundColor();
@@ -110,6 +118,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _isOpen;
 		UIViewPropertyAnimator _flyoutAnimation;
 		Brush _backdropBrush;
+		bool _layoutOccured;
 
 		public UIViewAnimationCurve AnimationCurve { get; set; } = UIViewAnimationCurve.EaseOut;
 
@@ -379,6 +388,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void LayoutSidebar(bool animate, bool cancelExisting = false)
 		{
+			_layoutOccured = true;
 			if (_gestureActive)
 				return;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -68,7 +68,15 @@ namespace Xamarin.Forms.Platform.iOS
 		ShellSection _shellSection;
 		bool _ignorePopCall;
 
-		public ShellSectionRenderer(IShellContext context)
+		public ShellSectionRenderer(IShellContext context) : base()
+		{
+			Delegate = new NavDelegate(this);
+			_context = context;
+			_context.Shell.PropertyChanged += HandleShellPropertyChanged;
+		}
+
+		public ShellSectionRenderer(IShellContext context, Type navigationBarType, Type toolbarType) 
+			: base(navigationBarType, toolbarType)
 		{
 			Delegate = new NavDelegate(this);
 			_context = context;

--- a/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
@@ -6,23 +6,40 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class SlideFlyoutTransition : IShellFlyoutTransition
 	{
+		double _height = -1d;
+		double _width = -1d;
+
+		internal void SetFlyoutSizes(double height, double width)
+		{
+			_height = height;
+			_width = width;
+		}
+
 		public void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)
 		{
 			if (behavior == FlyoutBehavior.Locked)
 				openPercent = 1;
 
+			nfloat flyoutHeight;
 			nfloat flyoutWidth;
 
-			if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
+			if (_width != -1d)
+				flyoutWidth = (nfloat)_width;
+			else if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 				flyoutWidth = 320;
 			else
 				flyoutWidth = (nfloat)(Math.Min(bounds.Width, bounds.Height) * 0.8);
+
+			if (_height == -1d)
+				flyoutHeight = bounds.Height;
+			else
+				flyoutHeight = (nfloat)_height;
 
 			nfloat openLimit = flyoutWidth;
 			nfloat openPixels = openLimit * openPercent;
 
 			if (behavior == FlyoutBehavior.Locked)
-				shell.Frame = new CGRect(bounds.X + flyoutWidth, bounds.Y, bounds.Width - flyoutWidth, bounds.Height);
+				shell.Frame = new CGRect(bounds.X + flyoutWidth, bounds.Y, bounds.Width - flyoutWidth, flyoutHeight);
 			else
 				shell.Frame = bounds;
 
@@ -31,11 +48,11 @@ namespace Xamarin.Forms.Platform.iOS
 			if(shell.SemanticContentAttribute == UISemanticContentAttribute.ForceRightToLeft)
 			{
 				var positionY = shellWidth - openPixels;
-				flyout.Frame = new CGRect(positionY, 0, flyoutWidth, bounds.Height);
+				flyout.Frame = new CGRect(positionY, 0, flyoutWidth, flyoutHeight);
 			}
 			else
 			{
-				flyout.Frame = new CGRect(-openLimit + openPixels, 0, flyoutWidth, bounds.Height);
+				flyout.Frame = new CGRect(-openLimit + openPixels, 0, flyoutWidth, flyoutHeight);
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
@@ -6,13 +6,13 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	public class SlideFlyoutTransition : IShellFlyoutTransition
 	{
-		double _height = -1d;
-		double _width = -1d;
+		internal double Height { get; private set; } = -1d;
+		internal double Width { get; private set; } = -1d;
 
 		internal void SetFlyoutSizes(double height, double width)
 		{
-			_height = height;
-			_width = width;
+			Height = height;
+			Width = width;
 		}
 
 		public void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)
@@ -23,17 +23,17 @@ namespace Xamarin.Forms.Platform.iOS
 			nfloat flyoutHeight;
 			nfloat flyoutWidth;
 
-			if (_width != -1d)
-				flyoutWidth = (nfloat)_width;
+			if (Width != -1d)
+				flyoutWidth = (nfloat)Width;
 			else if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad)
 				flyoutWidth = 320;
 			else
 				flyoutWidth = (nfloat)(Math.Min(bounds.Width, bounds.Height) * 0.8);
 
-			if (_height == -1d)
-				flyoutHeight = bounds.Height;
+			if (Height == -1d)
+				flyoutHeight = bounds.Height;	
 			else
-				flyoutHeight = (nfloat)_height;
+				flyoutHeight = (nfloat)Height;
 
 			nfloat openLimit = flyoutWidth;
 			nfloat openPixels = openLimit * openPercent;


### PR DESCRIPTION
### Description of Change ###

Allow users to specify the Width and Height of the flyout on shell. This let's you expand the flyout to git across the entire screen or raise the flyout up for DualScreen cases or if you want it to be just above the TabBar

### API Changes ###

Added:
 - double Shell.FlyoutWidth { get; set; } //Bindable Property
 - double Shell.FlyoutHeight {get; set;}  //Bindable Property


### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
#### UWP

Default

![image](https://user-images.githubusercontent.com/5375137/93532065-7dd8dc80-f8fd-11ea-9bf5-85e7acb5236f.png)

Modified WxH

![image](https://user-images.githubusercontent.com/5375137/93532110-947f3380-f8fd-11ea-9d7f-ed7b3d9be665.png)

#### Android

Default

![image](https://user-images.githubusercontent.com/5375137/93532297-fa6bbb00-f8fd-11ea-8697-3c5bd9160d43.png)


Modified WxH

![image](https://user-images.githubusercontent.com/5375137/93532364-21c28800-f8fe-11ea-8284-b852ad1c2c4c.png)

#### iOS

Default

![image](https://user-images.githubusercontent.com/5375137/93533141-8e8a5200-f8ff-11ea-9fbc-a0fea5bee1a8.png)


Modified WxH
![image](https://user-images.githubusercontent.com/5375137/93533206-a7930300-f8ff-11ea-8c1d-3f75d55b4fc0.png)



### Testing Procedure ###
- Shell store has a demo of these properties that you can play with 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
