### PR TITLE
Fix WkWebViewRenderer to properly dispose and clear renderers

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11962.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11962.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11962, "[iOS] Cannot access a disposed object. Object name: 'WkWebViewRenderer",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11962 : TestShell
+	{
+		protected override void Init()
+		{
+			ContentPage contentPage = new ContentPage()
+			{
+				Content = new Button()
+				{
+					Text = "Go to the next page and back twice. If app doesn't crash test has passed.",
+					Command = new Command(async () =>
+					{
+						await GoToAsync("//user");
+					}),
+					AutomationId = "NextButton"
+				}
+			};
+
+			ContentPage webViewPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new WebView()
+						{
+							Source = new HtmlWebViewSource { Html = GetHtml("string some Text") },
+							VerticalOptions = LayoutOptions.StartAndExpand
+						},
+						new Button()
+						{
+							Text = "Go Back",
+							Command = new Command(async () =>
+							{
+								await GoToAsync("//usersearch");
+							}),
+							AutomationId = "BackButton"
+						}
+					}
+				}
+			};
+
+
+			AddFlyoutItem(contentPage, "User Search").Route = "usersearch";
+			AddFlyoutItem(webViewPage, "Web View Page").Route = "user";
+		}
+
+        string GetHtml(string uid)
+		{
+			var htmlHeader = @"<header><meta name='viewport' content='width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no'></header>";
+			if ("UserOne".Equals(uid))
+				return htmlHeader + @"<h3>Welcome <b style=""color:red;"">User One</b>,</h3><div>Displaying Html message</div>";
+			return htmlHeader + @"<h3>Welcome <b style=""color:blue;"">User Two</b>,</h3><div>Displaying Html message</div>";
+		}
+
+#if UITEST
+		[Test]
+		public void WkWebViewDisposesProperly()
+		{
+			RunningApp.Tap("NextButton");
+			RunningApp.Tap("BackButton");
+			RunningApp.Tap("NextButton");
+			RunningApp.Tap("BackButton");
+			RunningApp.Tap("NextButton");
+			RunningApp.Tap("BackButton");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12134.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12134.cs
@@ -1,0 +1,126 @@
+﻿using System;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12134, "[iOS] WkWebView does not handle cookies consistently",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.WebView)]
+#endif
+	public class Issue12134 : TestContentPage
+	{
+		Button button;
+		Guid _guid = Guid.NewGuid();
+		Label _label = new Label();
+		protected override void Init()
+		{
+			WebView webView = new WebView()
+			{
+				HeightRequest = 400
+			};
+
+			button = new Button()
+			{
+				Text = "Load another webview",
+				Command = new Command(() =>
+				{
+					OnButtonClicked(this, EventArgs.Empty);
+				}),
+				AutomationId = "LoadNewWebView"
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					GetWebView(),
+					_label,
+					new Button(){ Text = "Display Cookies", Command = new Command(DisplayCookies) },
+					button,
+				}
+			};
+
+		}
+
+		private async void DisplayCookies()
+		{
+			var result = await (Content as StackLayout).Children.OfType<WebView>().Last().EvaluateJavaScriptAsync("document.cookie");
+			await DisplayAlert("Cookies", result, "Ok");
+		}
+
+		private async void WebViewOnNavigated(object sender, WebNavigatedEventArgs e)
+		{
+			var result = await ((WebView)sender).EvaluateJavaScriptAsync("document.cookie");
+			_label.Text = result.Contains(_guid.ToString()) ? "Success" : "Failed";
+		}
+
+		private void OnButtonClicked(object sender, EventArgs e)
+		{
+			_label.Text = "";
+			if (GetWebViews().Length >= 2)
+			{
+				foreach (var wv in GetWebViews())
+					(Content as StackLayout).Children.Remove(wv);
+				(Content as StackLayout).Children.Insert(0, GetWebView());
+			}
+			else
+			{
+				
+				(Content as StackLayout).Children.Add(GetWebView());
+				button.Text = "Reload the page";
+			}
+		}
+
+		WebView[] GetWebViews() => (Content as StackLayout).Children.OfType<WebView>().ToArray();
+
+		private Cookie GetTestCookie()
+		{
+			return new Cookie("TestCookie", $"{_guid}", "/", "dotnet.microsoft.com");
+		}
+
+		private WebView GetWebView()
+		{
+			var anotherWebView = new WebView
+			{
+				HeightRequest = 400
+			};
+
+			SetCookieContainer(anotherWebView);
+			anotherWebView.Navigated += WebViewOnNavigated;
+			anotherWebView.Source = "https://dotnet.microsoft.com/apps/xamarin";
+			return anotherWebView;
+		}
+
+		private void SetCookieContainer(WebView wv)
+		{
+			wv.Cookies = new CookieContainer();
+			wv.Cookies.Add(GetTestCookie());
+		}
+
+#if UITEST
+		[Test]
+		public void CookiesCorrectlyLoadWithMultipleWebViews()
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				RunningApp.WaitForElement("Success", $"Failied on: {i}");
+				RunningApp.Tap("LoadNewWebView");
+			}
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -24,6 +24,7 @@
       <DependentUpon>Issue10672.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11962.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11769.cs" />
@@ -1483,6 +1484,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11764.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11573.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12134.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11963.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
@@ -312,9 +312,9 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Loaded");
 			// add a couple cookies
 			RunningApp.Tap("ChangeDuringNavigating");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 			RunningApp.Tap("ChangeDuringNavigating");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 		}
 
 		[Test]
@@ -323,9 +323,9 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Loaded");
 			// add a couple cookies
 			RunningApp.Tap("AdditionalCookie");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 			RunningApp.Tap("AdditionalCookie");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 		}
 
 		[Test]
@@ -333,7 +333,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			RunningApp.WaitForElement("Loaded");
 			RunningApp.Tap("OneCookie");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 		}
 
 		[Test]
@@ -342,9 +342,9 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Loaded");
 			// add a cookie to verify said cookie remains
 			RunningApp.Tap("AdditionalCookie");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 			RunningApp.Tap("NullAllCookies");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 		}
 
 		[Test]
@@ -353,9 +353,22 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Loaded");
 			// add a cookie so you can remove a cookie
 			RunningApp.Tap("AdditionalCookie");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
 			RunningApp.Tap("EmptyAllCookies");
-			RunningApp.WaitForElement("Success");
+			ValidateSuccess();
+		}
+
+		void ValidateSuccess()
+		{
+			try
+			{
+				RunningApp.WaitForElement("Success");
+			}
+			catch
+			{
+				RunningApp.Tap("DisplayAllCookies");
+				throw;
+			}
 		}
 #endif
 	}

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS9OrNewer;
 		static bool? s_isiOS10OrNewer;
 		static bool? s_isiOS11OrNewer;
+		static bool? s_isiOS12OrNewer;
 		static bool? s_isiOS13OrNewer;
 		static bool? s_isiOS14OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
@@ -69,6 +70,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS11OrNewer.HasValue)
 					s_isiOS11OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(11, 0);
 				return s_isiOS11OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS12OrNewer
+		{
+			get
+			{
+				if (!s_isiOS12OrNewer.HasValue)
+					s_isiOS12OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(12, 0);
+				return s_isiOS12OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -6,6 +6,7 @@ using System.Drawing;
 using System.Linq;
 using System.Net;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 using Foundation;
 using ObjCRuntime;
@@ -27,16 +28,35 @@ namespace Xamarin.Forms.Platform.iOS
 		VisualElementTracker _tracker;
 #pragma warning restore 0414
 
+		static WKProcessPool _sharedPool;
+		bool _disposed;
+		static int _sharedPoolCount = 0;
 
 		[Preserve(Conditional = true)]
-		public WkWebViewRenderer() : base(RectangleF.Empty, new WKWebViewConfiguration())
+		public WkWebViewRenderer() : this(CreateConfiguration())
 		{
+
 		}
 
 
 		[Preserve(Conditional = true)]
 		public WkWebViewRenderer(WKWebViewConfiguration config) : base(RectangleF.Empty, config)
 		{
+		
+		}
+
+		static WKWebViewConfiguration CreateConfiguration()
+		{
+			var config = new WKWebViewConfiguration();
+			if (_sharedPool == null)
+			{
+				_sharedPool = config.ProcessPool;
+			}
+			else
+			{
+				config.ProcessPool = _sharedPool;
+			}
+			return config;
 		}
 
 		WebView WebView => Element as WebView;
@@ -53,29 +73,42 @@ namespace Xamarin.Forms.Platform.iOS
 		public void SetElement(VisualElement element)
 		{
 			var oldElement = Element;
-			Element = element;
-			Element.PropertyChanged += HandlePropertyChanged;
-			WebView.EvalRequested += OnEvalRequested;
-			WebView.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
-			WebView.GoBackRequested += OnGoBackRequested;
-			WebView.GoForwardRequested += OnGoForwardRequested;
-			WebView.ReloadRequested += OnReloadRequested;
-			NavigationDelegate = new CustomWebViewNavigationDelegate(this);
-			UIDelegate = new CustomWebViewUIDelegate();
 
-			BackgroundColor = UIColor.Clear;
+			if (oldElement != null)
+			{
+				oldElement.PropertyChanged -= HandlePropertyChanged;
+			}
 
-			AutosizesSubviews = true;
+			if (element != null)
+			{
+				Element = element;
+				Element.PropertyChanged += HandlePropertyChanged;
 
-			_tracker = new VisualElementTracker(this);
+				if (_packager == null)
+				{
+					WebView.EvalRequested += OnEvalRequested;
+					WebView.EvaluateJavaScriptRequested += OnEvaluateJavaScriptRequested;
+					WebView.GoBackRequested += OnGoBackRequested;
+					WebView.GoForwardRequested += OnGoForwardRequested;
+					WebView.ReloadRequested += OnReloadRequested;
+					NavigationDelegate = new CustomWebViewNavigationDelegate(this);
+					UIDelegate = new CustomWebViewUIDelegate();
 
-			_packager = new VisualElementPackager(this);
-			_packager.Load();
+					BackgroundColor = UIColor.Clear;
 
-			_events = new EventTracker(this);
-			_events.LoadEvents(this);
+					AutosizesSubviews = true;
 
-			Load();
+					_tracker = new VisualElementTracker(this);
+
+					_packager = new VisualElementPackager(this);
+					_packager.Load();
+
+					_events = new EventTracker(this);
+					_events.LoadEvents(this);
+				}
+
+				Load();
+			}
 
 			OnElementChanged(new VisualElementChangedEventArgs(oldElement, element));
 
@@ -99,15 +132,43 @@ namespace Xamarin.Forms.Platform.iOS
 				LoadHtmlString(html, baseUrl == null ? new NSUrl(NSBundle.MainBundle.BundlePath, true) : new NSUrl(baseUrl, true));
 		}
 
+		static bool _firstLoadFinished = false;
+		string _pendingUrl;
+
+		public override void MovedToWindow()
+		{
+			base.MovedToWindow();
+			_firstLoadFinished = true;
+			if (!string.IsNullOrWhiteSpace(_pendingUrl))
+			{
+				var closure = _pendingUrl;
+				_pendingUrl = null;
+
+				InvokeOnMainThread(async () =>
+				{
+					await Task.Delay(500);
+					LoadUrl(closure);
+				});
+			}
+		}
+
 		public async void LoadUrl(string url)
 		{
 			try
 			{
+				
 				var uri = new Uri(url);
 				var safeHostUri = new Uri($"{uri.Scheme}://{uri.Authority}", UriKind.Absolute);
 				var safeRelativeUri = new Uri($"{uri.PathAndQuery}{uri.Fragment}", UriKind.Relative);
 				NSUrlRequest request = new NSUrlRequest(new Uri(safeHostUri, safeRelativeUri));
 
+				if (!_firstLoadFinished && HasCookiesToLoad(url) && !Forms.IsiOS13OrNewer)
+				{
+					_pendingUrl = url;
+					return;
+				}
+
+				_firstLoadFinished = true;
 				await SyncNativeCookies(url);
 				LoadRequest(request);
 			}
@@ -115,6 +176,24 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				Log.Warning(nameof(WkWebViewRenderer), $"Unable to Load Url {exc}");
 			}
+		}
+
+		bool HasCookiesToLoad(string url)
+		{
+			var uri = CreateUriForCookies(url);
+
+			if (uri == null)
+				return false;
+
+			var myCookieJar = WebView.Cookies;
+			if (myCookieJar == null)
+				return false;
+
+			var cookies = myCookieJar.GetCookies(uri);
+			if (cookies == null)
+				return false;
+
+			return cookies.Count > 0;
 		}
 
 		public override void LayoutSubviews()
@@ -127,6 +206,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void Dispose(bool disposing)
 		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+			if (Interlocked.Decrement(ref _sharedPoolCount) == 0 && Forms.IsiOS12OrNewer)
+				_sharedPool = null;
+
 			if (disposing)
 			{
 				if (IsLoading)
@@ -139,19 +225,23 @@ namespace Xamarin.Forms.Platform.iOS
 				WebView.GoForwardRequested -= OnGoForwardRequested;
 				WebView.ReloadRequested -= OnReloadRequested;
 
+				Element?.ClearValue(Platform.RendererProperty);
+				SetElement(null);
+
+				_events?.Dispose();
 				_tracker?.Dispose();
 				_packager?.Dispose();
+
+				_events = null;
+				_tracker = null;
+				_events = null;
 			}
 
 			base.Dispose(disposing);
 		}
 
-		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
-		{
-			var changed = ElementChanged;
-			if (changed != null)
-				changed(this, e);
-		}
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e) =>
+			ElementChanged?.Invoke(this, e);
 
 		HashSet<string> _loadedCookies = new HashSet<string>();
 
@@ -198,7 +288,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 					var extracted = extractCookies.GetCookies(uri);
 					_initialCookiesLoaded = new NSHttpCookie[extracted.Count];
-					for(int i = 0; i < extracted.Count; i++)
+					for (int i = 0; i < extracted.Count; i++)
 					{
 						_initialCookiesLoaded[i] = new NSHttpCookie(extracted[i]);
 					}
@@ -282,9 +372,9 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				NSHttpCookie nSHttpCookie = null;
 
-				foreach(var findCookie in retrieveCurrentWebCookies)
+				foreach (var findCookie in retrieveCurrentWebCookies)
 				{
-					if(findCookie.Name == cookie.Name)
+					if (findCookie.Name == cookie.Name)
 					{
 						nSHttpCookie = findCookie;
 						break;
@@ -366,7 +456,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Forms.IsiOS11OrNewer)
 			{
-				foreach(var cookie in cookies)
+				foreach (var cookie in cookies)
 					await Configuration.WebsiteDataStore.HttpCookieStore.SetCookieAsync(new NSHttpCookie(cookie));
 			}
 			else
@@ -396,13 +486,15 @@ namespace Xamarin.Forms.Platform.iOS
 				// This is the only way I've found to delete cookies on pre ios 11
 				// I tried to set an expired cookie but it doesn't delete the cookie
 				// So, just deleting the whole domain is the best option I've found
-				WKWebsiteDataStore.DefaultDataStore.FetchDataRecordsOfTypes(WKWebsiteDataStore.AllWebsiteDataTypes, (NSArray records) =>
+				WKWebsiteDataStore
+					.DefaultDataStore
+					.FetchDataRecordsOfTypes(WKWebsiteDataStore.AllWebsiteDataTypes, (NSArray records) =>
 				{
 					for (nuint i = 0; i < records.Count; i++)
 					{
 						var record = records.GetItem<WKWebsiteDataRecord>(i);
 
-						foreach(var deleteme in cookies)
+						foreach (var deleteme in cookies)
 						{
 							if (record.DisplayName.Contains(deleteme.Domain) || deleteme.Domain.Contains(record.DisplayName))
 							{
@@ -472,7 +564,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			try
 			{
-			
+
 				await SyncNativeCookies(Url?.AbsoluteUrl?.ToString());
 			}
 			catch (Exception exc)
@@ -575,10 +667,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				try
 				{
-					if(_renderer?.WebView?.Cookies != null)
+					if (_renderer?.WebView?.Cookies != null)
 						await _renderer.SyncNativeCookiesToElement(url);
 				}
-				catch(Exception exc)
+				catch (Exception exc)
 				{
 					Log.Warning(nameof(WkWebViewRenderer), $"Failed to Sync Cookies {exc}");
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Forms.Platform.iOS
 		static WKProcessPool _sharedPool;
 		bool _disposed;
 		static int _sharedPoolCount = 0;
+		static bool _firstLoadFinished = false;
+		string _pendingUrl;
 
 		[Preserve(Conditional = true)]
 		public WkWebViewRenderer() : this(CreateConfiguration())
@@ -45,6 +47,11 @@ namespace Xamarin.Forms.Platform.iOS
 		
 		}
 
+		// https://developer.apple.com/forums/thread/99674
+		// WKWebView and making sure cookies synchronize is really quirky
+		// The main workaround I've found for ensuring that cookies synchronize 
+		// is to share the Process Pool between all WkWebView instances.
+		// It also has to be shared at the point you call init
 		static WKWebViewConfiguration CreateConfiguration()
 		{
 			var config = new WKWebViewConfiguration();
@@ -132,9 +139,6 @@ namespace Xamarin.Forms.Platform.iOS
 				LoadHtmlString(html, baseUrl == null ? new NSUrl(NSBundle.MainBundle.BundlePath, true) : new NSUrl(baseUrl, true));
 		}
 
-		static bool _firstLoadFinished = false;
-		string _pendingUrl;
-
 		public override void MovedToWindow()
 		{
 			base.MovedToWindow();
@@ -144,6 +148,18 @@ namespace Xamarin.Forms.Platform.iOS
 				var closure = _pendingUrl;
 				_pendingUrl = null;
 
+				// I realize this looks like the worst hack ever but iOS 11 and cookies are super quirky
+				// and this is the only way I could figure out how to get iOS 11 to inject a cookie 
+				// the first time a WkWebView is used in your app. This only has to run the first time a WkWebView is used 
+				// anywhere in the application. All subsequents uses of WkWebView won't hit this hack
+				// Even if it's a WkWebView on a new page.
+				// read through this thread https://developer.apple.com/forums/thread/99674
+				// Or Bing "WkWebView and Cookies" to see the myriad of hacks that exist
+				// Most of them all came down to different variations of synching the cookies before or after the
+				// WebView is added to the controller. This is the only one I was able to make work
+				// I think if we could delay adding the WebView to the Controller until after ViewWillAppear fires that might also work
+				// But we're not really setup for that
+				// If you'd like to try your hand at cleaning this up then UI Test Issue12134 and Issue3262 are your final bosses
 				InvokeOnMainThread(async () =>
 				{
 					await Task.Delay(500);


### PR DESCRIPTION
### Description of Change ###

- fixed WkWebViewRenderer to check for double dispose
- fixed WkWebViewRenderer to properly remove and dispose of associated renderers
- After I started cleaning up the WkWebViewRenderer the UI tests around cookie management started failing on iOS11 so I had to add less then ideal hacks to make all that work. WkWebView and Cookie management on iOS 11 is really really quirky. I'm guessing that it was working fine before the dispose because the leaked WkWebView probably was keeping around a reference to the process pool which caused it to all just work. 

### Issues Resolved ### 
- fixes #11962 
- fixes #12134


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- ui tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
