### PR TITLE
Fix WebView Navigated Status Bug In Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsWebViewClient.cs
@@ -85,9 +85,12 @@ namespace Xamarin.Forms.Platform.Android
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public override void OnReceivedError(WView view, ClientError errorCode, string description, string failingUrl)
 		{
-			_navigationResult = WebNavigationResult.Failure;
-			if (errorCode == ClientError.Timeout)
-				_navigationResult = WebNavigationResult.Timeout;
+			if(failingUrl == _renderer?.Control.Url)
+			{
+				_navigationResult = WebNavigationResult.Failure;
+				if (errorCode == ClientError.Timeout)
+					_navigationResult = WebNavigationResult.Timeout;
+			}
 #pragma warning disable 618
 			base.OnReceivedError(view, errorCode, description, failingUrl);
 #pragma warning restore 618
@@ -95,9 +98,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override void OnReceivedError(WView view, IWebResourceRequest request, WebResourceError error)
 		{
-			_navigationResult = WebNavigationResult.Failure;
-			if (error.ErrorCode == ClientError.Timeout)
-				_navigationResult = WebNavigationResult.Timeout;
+			if(request.Url.ToString() == _renderer?.Control.Url)
+			{
+				_navigationResult = WebNavigationResult.Failure;
+				if (error.ErrorCode == ClientError.Timeout)
+					_navigationResult = WebNavigationResult.Timeout;
+			}
 			base.OnReceivedError(view, request, error);
 		}
 


### PR DESCRIPTION
On Android, Navigated event args contain wrong status of "Failed" when an asset request receives an error even though the page itself is loaded successfully. Instead, OnReceivedError should check if the request url of the OnReceivedError method is equal to the navigated url. (issue #11988)

This PR fixes the issue by adding the necessary url check.