### PR TITLE
[UWP] Fix crash when specifying non-embedded font families (fixes #12153)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12153.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12153.cs
@@ -31,6 +31,11 @@ namespace Xamarin.Forms.Controls.Issues
 					new Image() { Source = new FontImageSource() { FontFamily = "fa-regular-400.ttf", Glyph = "\xf0f3", Color = Color.Black, Size = 50}, HorizontalOptions = LayoutOptions.Start},
 
 					new Label() { Text = "This text should be shown using the Lobster font, which is included as an asset", FontFamily = "Lobster-Regular", Margin = new Thickness(10)},
+
+
+					new Label() { Text = "Below a PLAY icon should be visible (if the \"Segoe MDL2 Assets\" font is installed)", Margin = new Thickness(10)},
+
+					new Image() { Source = new FontImageSource{Glyph = "\xe102",FontFamily = "Segoe MDL2 Assets", Size = 50, Color = Color.Green}, HorizontalOptions = LayoutOptions.Start },
 				}
 			};
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12153.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12153.cs
@@ -23,7 +23,7 @@ namespace Xamarin.Forms.Controls.Issues
 				Children =
 				{
 					// Setting the font family to "Tahoma" or any other built-in Windows font would crash on UWP
-					new Label() { Text = "Four bell icons should be visible below and it shouldn't crash on UWP", FontFamily = "Tahoma", Margin = new Thickness(10)},
+					new Label() { Text = "Four bell icons should be visible below and it shouldn't crash on UWP", FontFamily = "Tahoma", Margin = new Thickness(10), AutomationId = "Success"},
 
 					new Label { FontFamily = "FontAwesome", FontSize = 50, TextColor = Color.Black, Text = "\xf0f3" },
 					new Label { FontFamily = "fa-regular-400.ttf", FontSize = 50, TextColor = Color.Black, Text = "\xf0f3" },
@@ -35,9 +35,17 @@ namespace Xamarin.Forms.Controls.Issues
 
 					new Label() { Text = "Below a PLAY icon should be visible (if the \"Segoe MDL2 Assets\" font is installed)", Margin = new Thickness(10)},
 
-					new Image() { Source = new FontImageSource{Glyph = "\xe102",FontFamily = "Segoe MDL2 Assets", Size = 50, Color = Color.Green}, HorizontalOptions = LayoutOptions.Start },
+					new Image() { Source = new FontImageSource{Glyph = "\xe102",FontFamily = "Segoe MDL2 Assets", Size = 50, Color = Color.Green}, HorizontalOptions = LayoutOptions.Start },					
 				}
 			};
 		}
+
+#if UITEST
+		[Test]
+		public void InvalidFontDoesntCauseAppToCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12153.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12153.cs
@@ -1,0 +1,38 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12153, "Setting FontFamily to pre-installed fonts on UWP crashes", PlatformAffected.UWP)]
+	public class Issue12153 : TestContentPage // or TestMasterDetailPage, etc ...
+	{
+		protected override void Init()
+		{
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					// Setting the font family to "Tahoma" or any other built-in Windows font would crash on UWP
+					new Label() { Text = "Four bell icons should be visible below and it shouldn't crash on UWP", FontFamily = "Tahoma", Margin = new Thickness(10)},
+
+					new Label { FontFamily = "FontAwesome", FontSize = 50, TextColor = Color.Black, Text = "\xf0f3" },
+					new Label { FontFamily = "fa-regular-400.ttf", FontSize = 50, TextColor = Color.Black, Text = "\xf0f3" },
+					new Image() { Source = new FontImageSource() { FontFamily = "FontAwesome", Glyph = "\xf0f3", Color = Color.Black, Size = 50}, HorizontalOptions = LayoutOptions.Start},
+					new Image() { Source = new FontImageSource() { FontFamily = "fa-regular-400.ttf", Glyph = "\xf0f3", Color = Color.Black, Size = 50}, HorizontalOptions = LayoutOptions.Start},
+
+					new Label() { Text = "This text should be shown using the Lobster font, which is included as an asset", FontFamily = "Lobster-Regular", Margin = new Thickness(10)},
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12153.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10324.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github9536.xaml.cs">
       <DependentUpon>Github9536.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -109,12 +109,26 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static string FindFontFamilyName(string fontFile)
 		{
-			using (var fontSet = new CanvasFontSet(new Uri(fontFile)))
+			try
 			{
-				if (fontSet.Fonts.Count == 0)
-					return null;
+				var fontUri = new Uri(fontFile, UriKind.RelativeOrAbsolute);
 
-				return fontSet.GetPropertyValues(CanvasFontPropertyIdentifier.FamilyName).FirstOrDefault().Value;
+				// CanvasFontSet only supports ms-appx:// and ms-appdata:// font URIs
+				if (fontUri.IsAbsoluteUri && (fontUri.Scheme == "ms-appx" || fontUri.Scheme == "ms-appdata"))
+				{
+					using (var fontSet = new CanvasFontSet(fontUri))
+					{
+						if (fontSet.Fonts.Count != 0) 
+							return fontSet.GetPropertyValues(CanvasFontPropertyIdentifier.FamilyName).FirstOrDefault().Value;
+					}
+				}
+
+				return null;
+			}
+			catch
+			{
+				// the CanvasFontSet constructor can throw an exception in case something's wrong with the font. It should not crash the app
+				return null;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -125,9 +125,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 				return null;
 			}
-			catch
+			catch(Exception ex)
 			{
 				// the CanvasFontSet constructor can throw an exception in case something's wrong with the font. It should not crash the app
+				Internals.Log.Warning("Font",$"Error loading font {fontFile}: {ex.Message}");
 				return null;
 			}
 		}

--- a/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
@@ -23,9 +23,19 @@ namespace Xamarin.Forms.Platform.UWP
 			var device = CanvasDevice.GetSharedDevice();
 			var dpi = Math.Max(_minimumDpi, Windows.Graphics.Display.DisplayInformation.GetForCurrentView().LogicalDpi);
 
+			// There's really no perfect solution to handle font families with fallbacks (comma-separated)
+			// So if the font family has fallbacks, only the first one is taken, because CanvasTextFormat
+			// only supports one font family
+
+			var fontFamily = fontsource.FontFamily.ToFontFamily();
+			var allFamilies = fontFamily.Source.Split(new[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+
+			if (allFamilies.Length < 1)
+				return null;
+
 			var textFormat = new CanvasTextFormat
 			{
-				FontFamily = fontsource.FontFamily.ToFontFamily().Source,
+				FontFamily = allFamilies[0],
 				FontSize = (float)fontsource.Size,
 				HorizontalAlignment = CanvasHorizontalAlignment.Center,
 				VerticalAlignment = CanvasVerticalAlignment.Center,
@@ -44,7 +54,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 					// offset by 1 as we added a 1 inset
 					var x = (float)layout.DrawBounds.X * -1;
-
+					
 					ds.DrawTextLayout(layout, x, 1f, iconcolor);
 				}
 
@@ -65,10 +75,10 @@ namespace Xamarin.Forms.Platform.UWP
 					Foreground = fontImageSource.Color.ToBrush()
 				};
 
-				var uwpFontFamily = fontImageSource.FontFamily.ToFontFamily().Source;
+				var uwpFontFamily = fontImageSource.FontFamily.ToFontFamily();
 
-				if (!string.IsNullOrEmpty(uwpFontFamily))
-					((WFontIconSource)image).FontFamily = new FontFamily(uwpFontFamily);
+				if (!string.IsNullOrEmpty(uwpFontFamily.Source))
+					((WFontIconSource)image).FontFamily = uwpFontFamily;
 			}
 
 			return Task.FromResult(image);
@@ -87,10 +97,10 @@ namespace Xamarin.Forms.Platform.UWP
 					Foreground = fontImageSource.Color.ToBrush()
 				};
 
-				var uwpFontFamily = fontImageSource.FontFamily.ToFontFamily().Source;
+				var uwpFontFamily = fontImageSource.FontFamily.ToFontFamily();
 
-				if (!string.IsNullOrEmpty(uwpFontFamily))
-					((FontIcon)image).FontFamily = new FontFamily(uwpFontFamily);
+				if (!string.IsNullOrEmpty(uwpFontFamily.Source))
+					((FontIcon)image).FontFamily = uwpFontFamily;
 			}
 
 			return Task.FromResult(image);


### PR DESCRIPTION
### Description of Change ###

Fix crash on UWP that was introduced by PR #11741. The crash happened when fonts were used on UWP that were not embedded.

### Issues Resolved ### 

- fixes #12153 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
