### PR TITLE
Fix SelectedItem in Picker set to null when bound ItemsSource raises CollectionChanged reset event (#2032)

### DIFF
--- a/Xamarin.Forms.Core/Picker.cs
+++ b/Xamarin.Forms.Core/Picker.cs
@@ -263,10 +263,11 @@ namespace Xamarin.Forms
 		{
 			if (ItemsSource == null)
 				return;
+			var currentSelectedItem = SelectedItem;
 			((LockableObservableListWrapper)Items).InternalClear();
 			foreach (object item in ItemsSource)
 				((LockableObservableListWrapper)Items).InternalAdd(GetDisplayMember(item));
-			UpdateSelectedItem(SelectedIndex);
+			UpdateSelectedIndex(currentSelectedItem);
 		}
 
 		static void OnSelectedIndexChanged(object bindable, object oldValue, object newValue)


### PR DESCRIPTION
### Description of Change ###

Fixes SelectedItem in Picker set to null when bound ItemsSource raises CollectionChanged reset event by storing the previously selected item before refreshing the picker items.  After the refresh the previously selected item attempts to be reselected.

### Issues Resolved ### 

- fixes #2032

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Unit test added as part of the PR.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
