### PR TITLE
Move the intention of PageLifecycleManager up to the App level opposed to being at the Page level

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52318.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52318.cs
@@ -1,5 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System;
 
 #if UITEST
 using Xamarin.UITest;
@@ -8,23 +9,100 @@ using NUnit.Framework;
 
 namespace Xamarin.Forms.Controls.Issues
 {
+
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Bugzilla, 52318, "OnAppearing/Disappearing triggers for all pages in navigationstack backgrounding/foregrounding app", PlatformAffected.Android)]
-	public class Bugzilla52318 : TestMasterDetailPage // or TestMasterDetailPage, etc ...
+	[Issue(IssueTracker.Bugzilla, 52318, "MDP OnAppearing/Disappearing triggers for all pages in navigationstack backgrounding/foregrounding app", PlatformAffected.Android)]
+	public class MasterDetailPage52318 : TestMasterDetailPage
 	{
 		protected override void Init()
 		{
 			Master = new ContentPage { Title = "Master page", Content = new Label { Text = "Master page" } };
 			Detail = new NavigationPage(new ContentPage52318());
 		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CorrectOnAppearingEventsFire()
+		{
+			ContentPage52318.CorrectOnAppearingEventsFire(RunningApp);
+		}
+#endif
 	}
 
 	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52318, "NavigationPage OnAppearing/Disappearing triggers for all pages in navigationstack backgrounding/foregrounding app", PlatformAffected.iOS, NavigationBehavior.SetApplicationRoot, issueTestNumber: 1)]
+	public class NavigationPage52318 : TestNavigationPage
+	{
+		public NavigationPage52318() : base()
+		{
+
+		}
+
+		protected async override void Init()
+		{
+			await PushAsync(new ContentPage52318());
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CorrectOnAppearingEventsFire()
+		{
+			ContentPage52318.CorrectOnAppearingEventsFire(RunningApp);
+		}
+#endif
+	}
+
+
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52318, "TabbedPage OnAppearing/Disappearing triggers for all pages in navigationstack backgrounding/foregrounding app", PlatformAffected.Android, issueTestNumber: 2)]
+	public class TabbedPage52318 : TestTabbedPage
+	{
+		protected override void Init()
+		{
+			Children.Add(new NavigationPage(new ContentPage52318()));
+			Children.Add(new NavigationPage(new ContentPage52318()));
+			Children.Add(new NavigationPage(new ContentPage52318()));
+			Children.Add(new NavigationPage(new ContentPage52318()));
+			Children.Add(new NavigationPage(new ContentPage52318()));
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CorrectOnAppearingEventsFire()
+		{
+			ContentPage52318.CorrectOnAppearingEventsFire(RunningApp);
+		}
+#endif
+	}
+
 	public class ContentPage52318 : ContentPage
 	{
+
+#if UITEST && __IOS__
+		public static void CorrectOnAppearingEventsFire(IApp RunningApp)
+		{
+			RunningApp.WaitForElement("Page: 1 appearing.");
+			RunningApp.Tap("OK");
+			RunningApp.Tap("PushPage");
+			RunningApp.WaitForElement("Page: 2 appearing.");
+			RunningApp.Tap("OK");
+			RunningApp.Tap("PushPage");
+			RunningApp.WaitForElement("Page: 3 appearing.");
+			RunningApp.Tap("OK");
+			RunningApp.SendAppToBackground(TimeSpan.FromSeconds(2));
+			RunningApp.WaitForElement("Page: 3 appearing.");
+			RunningApp.Tap("OK");
+			RunningApp.WaitForNoElement("Page: 1 appearing.");
+			RunningApp.WaitForNoElement("Page: 2 appearing.");
+		}
+#endif
+
 		public ContentPage52318()
 		{
 			var stackLayout = new StackLayout();
@@ -40,7 +118,8 @@ namespace Xamarin.Forms.Controls.Issues
 				Command = new Command(async () =>
 				{
 					await Navigation.PushAsync(new ContentPage52318());
-				})
+				}),
+				AutomationId = "PushPage"
 			};
 			stackLayout.Children.Add(button);
 
@@ -54,5 +133,6 @@ namespace Xamarin.Forms.Controls.Issues
 			DisplayAlert("", Title + " appearing.", "OK");
 			base.OnAppearing();
 		}
+
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52318.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla52318.cs
@@ -81,6 +81,27 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	}
 
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Bugzilla)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Bugzilla, 52318, "Shell OnAppearing/Disappearing triggers for all pages in navigationstack backgrounding/foregrounding app", PlatformAffected.Android, issueTestNumber: 3)]
+	public class ShellPage52318 : TestShell
+	{
+		protected override void Init()
+		{
+			AddFlyoutItem(new ContentPage52318(), "Flyout Item");
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CorrectOnAppearingEventsFire()
+		{
+			ContentPage52318.CorrectOnAppearingEventsFire(RunningApp);
+		}
+#endif
+	}
+
 	public class ContentPage52318 : ContentPage
 	{
 
@@ -128,11 +149,10 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void OnAppearing()
 		{
-			int count = (Parent as NavigationPage).Navigation.NavigationStack.Count;
+			int count = (Parent as NavigableElement).Navigation.NavigationStack.Count;
 			Title = $"Page: {count}";
-			DisplayAlert("", Title + " appearing.", "OK");
+			Device.BeginInvokeOnMainThread(() => DisplayAlert("", Title + " appearing.", "OK"));
 			base.OnAppearing();
 		}
-
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12055.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12055.cs
@@ -1,0 +1,81 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12055, "Multiple PageAppearing/OnAppearing Issues",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.LifeCycle)]
+#endif
+	public class Issue12055 : TestShell
+	{
+		Label label1;
+		Label label2;
+		Label label3;
+
+		protected override void Init()
+		{
+			var page1 = AddTopTab("Tab 1");
+			var page2 = AddTopTab("Tab 2");
+			var page3 = AddBottomTab("Tab 3");
+
+			label1 = new Label();
+			label2 = new Label();
+			label3 = new Label();
+
+			page1.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label(){ Text = "If you see `Test Failed` it means too many OnAppearing events fired"},
+					label1,
+					label2,
+					label3
+				}
+			};
+			
+			page1.Appearing += OnPage1Appearing;
+			page2.Appearing += OnPage2Appearing;
+			page3.Appearing += OnPage3Appearing;
+		}
+
+		private void OnPage1Appearing(object sender, EventArgs e)
+		{
+			label1.Text = "Correct Appearing Fired";
+		}
+
+		private void OnPage2Appearing(object sender, EventArgs e)
+		{
+			label2.Text = "Test Failed";
+		}
+
+		private void OnPage3Appearing(object sender, EventArgs e)
+		{
+			label3.Text = "Test Failed";
+		}
+
+#if UITEST
+		[Test]
+		public void OnApperingOnlyFiresForVisibleTab()
+		{
+			RunningApp.WaitForElement("Correct Appearing Fired");
+			RunningApp.WaitForNoElement("Test Failed");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1483,6 +1483,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11764.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11573.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12055.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core.UnitTests/MasterDetailFormUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/MasterDetailFormUnitTests.cs
@@ -401,6 +401,63 @@ namespace Xamarin.Forms.Core.UnitTests
 			var mdp = new MasterDetailPage ();
 			Assert.Throws<InvalidOperationException> (() => mdp.Master = master);
 		}
+
+		[Test]
+		public void AppearingAndDisappearingFiresOnFlyoutAndDetailsPage()
+		{
+			var mdp = new MasterDetailPage()
+			{
+				Master = new ContentPage { Title = "Foo" },
+				Detail = new ContentPage { Title = "Foo" },
+			};
+
+			bool flyoutAppear = false;
+			bool detailAppear = false;
+			bool flyoutDisappear = false;
+			bool detailDisappear = false;
+
+			mdp.Master.Appearing += (_, __) =>
+			{
+				if (flyoutAppear)
+					throw new Exception("Flyout Appear shouldn't already be set to true");
+
+				flyoutAppear = true;
+			};
+
+			mdp.Detail.Appearing += (_, __) =>
+			{
+				if (detailAppear)
+					throw new Exception("Detail Appear shouldn't already be set to true");
+
+				detailAppear = true;
+			};
+
+			mdp.Master.Disappearing += (_, __) =>
+			{
+				if (flyoutDisappear)
+					throw new Exception("Flyout Disappear shouldn't already be set to true");
+
+				flyoutDisappear = true;
+			};
+
+			mdp.Detail.Disappearing += (_, __) =>
+			{
+				if (detailDisappear)
+					throw new Exception("Detail Disappear shouldn't already be set to true");
+
+				detailDisappear = true;
+			};
+
+			mdp.SendAppearing();
+
+			Assert.IsTrue(flyoutAppear);
+			Assert.IsTrue(detailAppear);
+
+			mdp.SendDisappearing();
+
+			Assert.IsTrue(flyoutDisappear);
+			Assert.IsTrue(detailDisappear);
+		}
 	}
 	
 }

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -324,13 +324,26 @@ namespace Xamarin.Forms
 		{
 			Current = this;
 			OnResume();
-			MainPage?.SendAppearing();
+			if(MainPage != null)
+			{
+				if (MainPage.Navigation.ModalStack.Count > 0)
+					MainPage.Navigation.ModalStack[MainPage.Navigation.ModalStack.Count - 1].SendAppearing();
+				else
+					MainPage.SendAppearing();
+			}
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendSleep()
 		{
-			MainPage?.SendDisappearing();
+			if (MainPage != null)
+			{
+				if (MainPage.Navigation.ModalStack.Count > 0)
+					MainPage.Navigation.ModalStack[MainPage.Navigation.ModalStack.Count - 1].SendDisappearing();
+				else
+					MainPage.SendDisappearing();
+			}
+
 			OnSleep();
 			SavePropertiesAsFireAndForget();
 		}

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -324,11 +324,13 @@ namespace Xamarin.Forms
 		{
 			Current = this;
 			OnResume();
+			MainPage?.SendAppearing();
 		}
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public void SendSleep()
 		{
+			MainPage?.SendDisappearing();
 			OnSleep();
 			SavePropertiesAsFireAndForget();
 		}

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -424,6 +424,9 @@ namespace Xamarin.Forms
 			if (RealParent is ShellContent sc && !sc.IsVisibleContent)
 				return;
 
+			if (RealParent is IPageContainer<Page> multipage && multipage.CurrentPage != this)
+				return;
+
 			_hasAppeared = true;
 
 			if (IsBusy)
@@ -439,6 +442,12 @@ namespace Xamarin.Forms
 
 			var pageContainer = this as IPageContainer<Page>;
 			pageContainer?.CurrentPage?.SendAppearing();
+
+			if(this is MasterDetailPage mdp)
+			{
+				mdp.Master?.SendAppearing();
+				mdp.Detail?.SendAppearing();
+			}
 
 			FindApplication(this)?.OnPageAppearing(this);
 		}
@@ -456,6 +465,12 @@ namespace Xamarin.Forms
 
 			var pageContainer = this as IPageContainer<Page>;
 			pageContainer?.CurrentPage?.SendDisappearing();
+
+			if (this is MasterDetailPage mdp)
+			{
+				mdp.Master?.SendDisappearing();
+				mdp.Detail?.SendDisappearing();
+			}
 
 			OnDisappearing();
 			Disappearing?.Invoke(this, EventArgs.Empty);

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -285,7 +285,7 @@ namespace Xamarin.Forms
 
 		protected virtual bool OnBackButtonPressed()
 		{
-			if (RealParent is BaseShellItem || RealParent is Shell)
+			if (IsShell)
 				return false;
 
 			var application = RealParent as Application;
@@ -421,6 +421,9 @@ namespace Xamarin.Forms
 			if (_hasAppeared)
 				return;
 
+			if (RealParent is ShellContent sc && !sc.IsVisibleContent)
+				return;
+
 			_hasAppeared = true;
 
 			if (IsBusy)
@@ -542,6 +545,8 @@ namespace Xamarin.Forms
 			}
 			return !any;
 		}
+
+		bool IsShell => RealParent is BaseShellItem || RealParent is Shell;
 
 		public IPlatformElementConfiguration<T, Page> On<T>() where T : IConfigPlatform
 		{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -13,8 +13,10 @@ using Xamarin.Forms.StyleSheets;
 namespace Xamarin.Forms
 {
 	[ContentProperty(nameof(Items))]
-	public class Shell : Page, IShellController, IPropertyPropagationController
+	public class Shell : Page, IShellController, IPropertyPropagationController, IPageContainer<Page>
 	{
+		Page IPageContainer<Page>.CurrentPage => (CurrentSection as IShellSectionController)?.PresentedPage;
+
 		public static readonly BindableProperty BackButtonBehaviorProperty =
 			BindableProperty.CreateAttached("BackButtonBehavior", typeof(BackButtonBehavior), typeof(Shell), null, BindingMode.OneTime,
 				propertyChanged: OnBackButonBehaviorPropertyChanged);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1115,6 +1115,12 @@ namespace Xamarin.Forms
 			}
 		}
 
+		protected override void OnParentSet()
+		{
+			base.OnParentSet();
+			SendAppearing();
+		}
+
 		internal void ProcessNavigated(ShellNavigatedEventArgs args)
 		{
 			if (_accumulateNavigatedEvents)

--- a/Xamarin.Forms.Core/Shell/ShellContent.cs
+++ b/Xamarin.Forms.Core/Shell/ShellContent.cs
@@ -86,6 +86,7 @@ namespace Xamarin.Forms
 		public ShellContent() => ((INotifyCollectionChanged)MenuItems).CollectionChanged += MenuItemsCollectionChanged;
 
 		internal bool IsVisibleContent => Parent is ShellSection shellSection && shellSection.IsVisibleSection && shellSection.CurrentItem == this;
+
 		internal override ReadOnlyCollection<Element> LogicalChildrenInternal => _logicalChildrenReadOnly ?? (_logicalChildrenReadOnly = new ReadOnlyCollection<Element>(_logicalChildren));
 
 		internal override void SendDisappearing()

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms
 
 	[ContentProperty(nameof(Items))]
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public class ShellItem : ShellGroupItem, IShellItemController, IElementConfiguration<ShellItem>, IPropertyPropagationController
+	public class ShellItem : ShellGroupItem, IShellItemController, IElementConfiguration<ShellItem>, IPropertyPropagationController, IPageContainer<Page>
 	{
 		#region PropertyKeys
 
@@ -133,6 +133,10 @@ namespace Xamarin.Forms
 		{
 			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, Items);
 		}
+		#endregion
+
+		#region IPageContainer<Page>
+		Page IPageContainer<Page>.CurrentPage => (CurrentItem as IShellSectionController)?.PresentedPage;
 		#endregion
 
 		public static readonly BindableProperty CurrentItemProperty =

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms
 
 	[ContentProperty(nameof(Items))]
 	[EditorBrowsable(EditorBrowsableState.Never)]
-	public class ShellSection : ShellGroupItem, IShellSectionController, IPropertyPropagationController
+	public class ShellSection : ShellGroupItem, IShellSectionController, IPropertyPropagationController, IPageContainer<Page>
 	{
 		#region PropertyKeys
 
@@ -219,6 +219,10 @@ namespace Xamarin.Forms
 		{
 			PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, Items);
 		}
+		#endregion
+
+		#region IPageContainer<Page>
+		Page IPageContainer<Page>.CurrentPage => (this as IShellSectionController)?.PresentedPage;
 		#endregion
 
 		public static readonly BindableProperty CurrentItemProperty =

--- a/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/MasterDetailPageRenderer.cs
@@ -128,8 +128,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				((IMasterDetailPageController)oldElement).BackButtonPressed -= OnBackButtonPressed;
 
 				oldElement.PropertyChanged -= HandlePropertyChanged;
-				oldElement.Appearing -= MasterDetailPageAppearing;
-				oldElement.Disappearing -= MasterDetailPageDisappearing;
 
 				RemoveDrawerListener(this);
 			
@@ -182,8 +180,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				((IMasterDetailPageController)newElement).BackButtonPressed += OnBackButtonPressed;
 				newElement.PropertyChanged += HandlePropertyChanged;
-				newElement.Appearing += MasterDetailPageAppearing;
-				newElement.Disappearing += MasterDetailPageDisappearing;
 
 				SetGestureState();
 
@@ -238,8 +234,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					MasterDetailPageController.BackButtonPressed -= OnBackButtonPressed;
 					Element.PropertyChanged -= HandlePropertyChanged;
-					Element.Appearing -= MasterDetailPageAppearing;
-					Element.Disappearing -= MasterDetailPageDisappearing;
 				}
 
 				if (_masterLayout?.ChildView != null)
@@ -366,18 +360,6 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				UpdateBackgroundColor(Element);
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 				UpdateFlowDirection();
-		}
-
-		void MasterDetailPageAppearing(object sender, EventArgs e)
-		{
-			MasterPageController?.SendAppearing();
-			DetailPageController?.SendAppearing();
-		}
-
-		void MasterDetailPageDisappearing(object sender, EventArgs e)
-		{
-			MasterPageController?.SendDisappearing();
-			DetailPageController?.SendDisappearing();
 		}
 
 		void OnBackButtonPressed(object sender, BackButtonPressedEventArgs backButtonPressedEventArgs)

--- a/Xamarin.Forms.Platform.iOS/Extensions/ViewExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ViewExtensions.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return result;
 		}
 
-		internal static T FindParentOfType<T>(this VisualElement element)
+		internal static T FindParentOfType<T>(this Element element)
 		{
 			var navPage = element.GetParentsPath()
 										.OfType<T>()
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return navPage;
 		}
 
-		internal static IEnumerable<Element> GetParentsPath(this VisualElement self)
+		internal static IEnumerable<Element> GetParentsPath(this Element self)
 		{
 			Element current = self;
 

--- a/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
+++ b/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
@@ -96,6 +96,9 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_pageController.RealParent is IPageContainer<Page> multipage)
 				return multipage.CurrentPage == _pageController;
 
+			if (_pageController.RealParent is ShellContent sc && sc.Parent is IPageContainer<Page> shellSection)
+				return shellSection.CurrentPage == _pageController;
+
 			return true;
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
+++ b/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
@@ -96,9 +96,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_pageController.RealParent is IPageContainer<Page> multipage)
 				return multipage.CurrentPage == _pageController;
 
-			if (_pageController.RealParent is ShellContent sc && sc.Parent is IPageContainer<Page> shellSection)
-				return shellSection.CurrentPage == _pageController;
-
 			return true;
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
+++ b/Xamarin.Forms.Platform.iOS/PageLifecycleManager.cs
@@ -9,7 +9,6 @@ namespace Xamarin.Forms.Platform.iOS
 		NSObject _activateObserver;
 		NSObject _resignObserver;
 		bool _disposed;
-		bool _appeared;
 		IPageController _pageController;
 
 		public PageLifecycleManager(IPageController pageController)
@@ -69,24 +68,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void HandlePageAppearing()
 		{
-			if (_appeared)
-				return;
-
-			_appeared = true;
 			_pageController?.SendAppearing();
-
 		}
 
 		public void HandlePageDisappearing()
 		{
-			if (!_appeared || _pageController == null)
+			if (_pageController == null)
 				return;
 
-			_appeared = false;
 			_pageController.SendDisappearing();
 		}
-
-		public bool Appeared => _appeared;
 
 		bool CheckIfWeAreTheCurrentPage()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -276,7 +276,7 @@ namespace Xamarin.Forms.Platform.iOS
 				navPage.RemovePageRequested -= OnRemovedPageRequested;
 				navPage.InsertPageBeforeRequested -= OnInsertPageBeforeRequested;
 
-				_pageLifecycleManager?.Dispose();
+				_pageLifecycleManager?.HandlePageDisappearing();
 				_pageLifecycleManager = null;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -282,7 +282,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				(this as IDisconnectable).Disconnect();
 
-				_pageLifecycleManager?.Dispose();
+				_pageLifecycleManager?.HandlePageDisappearing();
 				_events?.Dispose();
 				_packager?.Dispose();
 				_tracker?.Dispose();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -195,6 +195,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_disposed = true;
 				FlyoutRenderer?.Dispose();
+				SetCurrentShellItemController(null);
 			}
 
 			FlyoutRenderer = null;
@@ -255,16 +256,21 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_currentShellItemRenderer = value;
 
-			AddChildViewController(newRenderer.ViewController);
-			View.AddSubview(newRenderer.ViewController.View);
-			View.SendSubviewToBack(newRenderer.ViewController.View);
-
-			newRenderer.ViewController.View.Frame = View.Bounds;
+			if (newRenderer != null)
+			{
+				AddChildViewController(newRenderer.ViewController);
+				View.AddSubview(newRenderer.ViewController.View);
+				View.SendSubviewToBack(newRenderer.ViewController.View);
+				newRenderer.ViewController.View.Frame = View.Bounds;
+			}
 			
 			if (oldRenderer != null)
 			{
-				var transition = CreateShellItemTransition();
-				await transition.Transition(oldRenderer, newRenderer);
+				if (newRenderer != null)
+				{
+					var transition = CreateShellItemTransition();
+					await transition.Transition(oldRenderer, newRenderer);
+				}
 
 				oldRenderer.ViewController.RemoveFromParentViewController();
 				oldRenderer.ViewController.View.RemoveFromSuperview();

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -157,7 +157,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (disposing)
 			{
-				_pageLifecycleManager?.Dispose();
+				_pageLifecycleManager?.HandlePageDisappearing();
 				_pageLifecycleManager = null;
 				Tabbed.PropertyChanged -= OnPropertyChanged;
 				Tabbed.PagesChanged -= OnPagesChanged;


### PR DESCRIPTION
### Description of Change ###

PageLifecycleManager added in 4.8 needed some extra logic to detect the valid page to call OnAppearing for on iOS

### Issues Resolved ### 
- fixes #12055 

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- UI Test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
