### PR TITLE
[Tizen] Fix the DisplayActionSheet

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/PopupManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/PopupManager.cs
@@ -142,10 +142,12 @@ namespace Xamarin.Forms.Platform.Tizen
 				var destruction = new Native.Button(alert)
 				{
 					Text = arguments.Destruction,
-					Style = ButtonStyle.Text,
-					TextColor = EColor.Red,
 					AlignmentX = -1
 				};
+				destruction.SetWatchTextStyle();
+				//TextColor should be set after applying style
+				destruction.TextColor = EColor.Red;
+
 				destruction.Clicked += (s, evt) =>
 				{
 					arguments.SetResult(arguments.Destruction);
@@ -160,9 +162,10 @@ namespace Xamarin.Forms.Platform.Tizen
 				var button = new Native.Button(alert)
 				{
 					Text = buttonName,
-					Style = ButtonStyle.Text,
 					AlignmentX = -1
 				};
+				button.SetWatchTextStyle();
+
 				button.Clicked += (s, evt) =>
 				{
 					arguments.SetResult(buttonName);

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EditorRenderer.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateText()
 		{
-			Control.Text = Element.Text;
+			Control.Text = Element.Text ?? "";
 			if (!Control.IsFocused)
 			{
 				Control.MoveCursorEnd();

--- a/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/EntryRenderer.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateText()
 		{
-			Control.Text = Element.Text;
+			Control.Text = Element.Text ?? "";
 			if (!Control.IsFocused)
 			{
 				Control.MoveCursorEnd();
@@ -259,7 +259,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		int GetSelectionStart()
 		{
-			int start = Element.Text.Length;
+			int start = Element.Text?.Length ?? 0;
 			int cursorPosition = Element.CursorPosition;
 
 			if (Element.IsSet(Entry.CursorPositionProperty))

--- a/Xamarin.Forms.Platform.Tizen/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/LabelRenderer.cs
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateText()
 		{
-			Control.Text = Element.Text;
+			Control.Text = Element.Text ?? "";
 		}
 
 		void UpdateTextColor()

--- a/Xamarin.Forms.Platform.Tizen/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/RadioButtonRenderer.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void UpdateText(bool isInitialized)
 		{
-			_span.Text = Element.ContentAsString();
+			_span.Text = Element.ContentAsString() ?? "";
 			if (!isInitialized)
 				ApplyTextAndStyle();
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/SearchBarRenderer.cs
@@ -175,7 +175,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		/// </summary>
 		void TextPropertyHandler()
 		{
-			Control.Text = Element.Text;
+			Control.Text = Element.Text ?? "";
 		}
 
 		void UpdateKeyboard(bool initialize)

--- a/Xamarin.Forms.Platform.Tizen/ThemeConstants.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeConstants.cs
@@ -81,6 +81,7 @@ namespace Xamarin.Forms.Platform.Tizen
 				{
 					public const string PopupLeft = "popup/circle/left_delete";
 					public const string PopupRight = "popup/circle/right_check";
+					public const string Text = "textbutton";
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
@@ -235,6 +235,17 @@ namespace Xamarin.Forms.Platform.Tizen
 			return button;
 		}
 
+		public static EButton SetWatchTextStyle(this EButton button)
+		{
+			if (Device.Idiom != TargetIdiom.Watch)
+			{
+				Log.Error($"ToWatchPopupRightStyleButton is only supported on TargetIdiom.Watch : {0}", Device.Idiom);
+				return button;
+			}
+			button.Style = ThemeConstants.Button.Styles.Watch.Text;
+			return button;
+		}
+
 		public static bool SetIconPart(this EButton button, EvasObject content, bool preserveOldContent = false)
 		{
 			return button.SetPartContent(ThemeConstants.Button.Parts.Icon, content, preserveOldContent);
@@ -273,6 +284,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			button.SetPartColor(ThemeConstants.Button.ColorClass.Effect, color);
 			button.SetPartColor(ThemeConstants.Button.ColorClass.EffectPressed, color);
 		}
+
 		#endregion
 
 		#region Popup


### PR DESCRIPTION
### Description of Change ###
This PR includes two changes as below
 - Fix DisplayActionSheet to be displayed properly on Mobile(F-hub)
 - Add null check for Text value

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->
| F-hub(Before) | F-hub(After) |
|--|--|
| <img src="https://user-images.githubusercontent.com/20968023/93738163-0f0ec280-fc20-11ea-8586-72a766072798.png" width="250" /> | <img src="https://user-images.githubusercontent.com/20968023/93738168-10d88600-fc20-11ea-876e-6987c3bfe341.png" width="250" /> |

And, It will be displayed on other profiles as following.

 - TV 
<img src="https://user-images.githubusercontent.com/20968023/93738176-159d3a00-fc20-11ea-8ed0-c1a762df1343.png" width="500" />

- Mobile
<img src="https://user-images.githubusercontent.com/20968023/93738180-17ff9400-fc20-11ea-857d-2e4fd7a576be.png" width="250" />

- Wearable
<img src="https://user-images.githubusercontent.com/20968023/93738193-22219280-fc20-11ea-84ad-b2c7161ec816.png" width="200" />


### Before/After Screenshots ### 
The action items will be shown as a button without any style.

### Testing Procedure ###

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
