### PR TITLE
Let developers choose the UITableViewStyle (enable developers to use the new iOS13 style InsetGrouped)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override UITableView CreateNativeControl()
 		{
-			return new UITableView(RectangleF.Empty, Element?.Intent ?? TableIntent.Form);
+			return new UITableView(RectangleF.Empty, GetTableViewStyle(Element?.Intent ?? TableIntent.Data));
 		}
 
 		protected UITableViewStyle GetTableViewStyle(TableIntent intent)

--- a/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs
@@ -60,13 +60,21 @@ namespace Xamarin.Forms.Platform.iOS
 			base.Dispose(disposing);
 		}
 
+		protected override UITableView CreateNativeControl()
+		{
+			return new UITableView(RectangleF.Empty, Element?.Intent ?? TableIntent.Form);
+		}
+
+		protected UITableViewStyle GetTableViewStyle(TableIntent intent)
+		{
+			return intent == TableIntent.Data ? UITableViewStyle.Plain : UITableViewStyle.Grouped;
+		}
+
 		protected override void OnElementChanged(ElementChangedEventArgs<TableView> e)
 		{
 			if (e.NewElement != null)
 			{
-				var style = UITableViewStyle.Plain;
-				if (e.NewElement.Intent != TableIntent.Data)
-					style = UITableViewStyle.Grouped;
+				var style = GetTableViewStyle(e.NewElement.Intent);
 
 				if (Control == null || Control.Style != style)
 				{
@@ -76,7 +84,7 @@ namespace Xamarin.Forms.Platform.iOS
 						Control.Dispose();
 					}
 
-					var tv = new UITableView(RectangleF.Empty, style);
+					var tv = CreateNativeControl();
 					_originalBackgroundView = tv.BackgroundView;
 
 					SetNativeControl(tv);


### PR DESCRIPTION
### Description of Change ###

iOS 13 introduced a new style for the UITableView: [InsetGrouped](https://developer.apple.com/documentation/uikit/uitableview/style/insetgrouped). However, Xamarin.Forms developers are not able to use this new style because the style can only be set in the constructor of the UITableView. Once a UITableView is constructed, the style cannot be changed.
In the [current implementation of the TableViewRenderer](https://github.com/xamarin/Xamarin.Forms/blob/6d9a4b0d80501b98c524ae1baf21c543c60f2953/Xamarin.Forms.Platform.iOS/Renderers/TableViewRenderer.cs#L67), the style gets chosen by the table's intent. There, the intent is mapped to the styles `Plain` and `Grouped`. The developer has no way to intercept this mapping.

Next, the TableViewRenderer instantiates a new UITableView after the style is chosen. This is done directly in `OnElementChanged()` and without calling the virtual, overridable method `CreateNativeControl()`.

The combination of these two makes it impossible to use styles other than the two hard coded ones: `Plain` and `Grouped`.

### API Changes ###

Added:
 - `UITableViewStyle GetTableViewStyle(TableIntent intent);` // to override the mapping from intent to style

Changed:
 - `OnElementChanged()` --> make use of `CreateNativeControl()`

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None. Developers are able to use new styles of a UITableView in their renderers but they are not forced to.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

A TableView intent should map to the same UITableView style as before.
`TableIntent.Data` maps to `UITableViewStyle.Plain`
Every other intent maps to `UITableViewStyle.Grouped`

### PR Checklist ###

- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
