### PR TITLE
Pin 4.8.0 Xcode

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -196,23 +196,6 @@ if(buildForVS2017)
     macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/xcode10.2/9c8d8e0a50e68d9abc8cd48fcd47a669e981fcc9/53/package/xamarin.mac-5.4.0.64.pkg";
 
 }
-else if(releaseChannel == ReleaseChannel.Stable)
-{
-    if(IsXcodeVersionOver("11.8"))
-    {
-    }
-    else
-    {
-        // Xcode 11.3
-        monoMajorVersion = "";
-        monoPatchVersion = "";
-        //androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-        iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.ios-13.20.3.5.pkg";
-        macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.mac-6.20.3.5.pkg";
-        //monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
-
-    }
-}
 
 if(String.IsNullOrWhiteSpace(monoSDK_macos))
 {
@@ -234,10 +217,11 @@ string macSDK_windows = "";
 
 if(!buildForVS2017)
 {
+    iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.ios-13.20.3.5.pkg";
+    macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.mac-6.20.3.5.pkg";
+       
     androidSDK_macos = EnvironmentVariable("ANDROID_SDK_MAC", androidSDK_macos);
-    iOSSDK_macos = EnvironmentVariable("IOS_SDK_MAC", iOSSDK_macos);
     monoSDK_macos = EnvironmentVariable("MONO_SDK_MAC", monoSDK_macos);
-    macSDK_macos = EnvironmentVariable("MAC_SDK_MAC", macSDK_macos);
 
     androidSDK_windows = EnvironmentVariable("ANDROID_SDK_WINDOWS", "");
     iOSSDK_windows = EnvironmentVariable("IOS_SDK_WINDOWS", "");
@@ -1136,18 +1120,8 @@ Version XcodeVersion()
         {
             var xcodeVersion = Version.Parse(item.Replace("Xcode", ""));
             Information($"Xcode: {xcodeVersion}");
-            var xcodePath = xcodeVersion.ToString().Replace(".0", "");
 
-            if(isCIBuild)
-            {
-                StartProcess("xcode-select", 
-                    new ProcessSettings {
-                        Arguments = new ProcessArgumentBuilder().Append($"-s /Applications/Xcode_{xcodePath}.app")
-                    }
-                );
-            }
-
-            return Version.Parse(item.Replace("Xcode", "")); 
+            return xcodeVersion; 
         }
     }
 

--- a/build.cake
+++ b/build.cake
@@ -198,7 +198,7 @@ if(buildForVS2017)
 }
 else if(releaseChannel == ReleaseChannel.Stable)
 {
-    if(IsXcodeVersionOver("12.0"))
+    if(IsXcodeVersionOver("11.8"))
     {
     }
     else
@@ -1113,7 +1113,7 @@ bool IsXcodeVersionOver(string version)
     if(IsRunningOnWindows())
         return true;
 
-    return XcodeVersion() >= Version.Parse(version); 
+    return XcodeVersion() > Version.Parse(version); 
 }
 
 Version XcodeVersion()

--- a/build.cake
+++ b/build.cake
@@ -198,7 +198,7 @@ if(buildForVS2017)
 }
 else if(releaseChannel == ReleaseChannel.Stable)
 {
-    if(IsXcodeVersionOver("11.4"))
+    if(IsXcodeVersionOver("12.0"))
     {
     }
     else
@@ -206,10 +206,10 @@ else if(releaseChannel == ReleaseChannel.Stable)
         // Xcode 11.3
         monoMajorVersion = "";
         monoPatchVersion = "";
-        androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
-        iOSSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/21e09d8084eb7c15eaa07c970e0eccdc/xamarin.ios-13.14.1.39.pkg";
-        macSDK_macos = $"https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/979144aead55378df75482d35957cdc9/xamarin.mac-6.14.1.39.pkg";
-        monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
+        //androidSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/aa46188c5f7a2e0c6f2d4bd4dc261604/xamarin.android-10.2.0.100.pkg";
+        iOSSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.ios-13.20.3.5.pkg";
+        macSDK_macos = $"https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.mac-6.20.3.5.pkg";
+        //monoSDK_macos = "https://download.visualstudio.microsoft.com/download/pr/8f94ca38-039a-4c9f-a51a-a6cb33c76a8c/3a376d8c817ec4d720ecca2d95ceb4c1/monoframework-mdk-6.8.0.123.macos10.xamarin.universal.pkg";
 
     }
 }
@@ -1113,6 +1113,14 @@ bool IsXcodeVersionOver(string version)
     if(IsRunningOnWindows())
         return true;
 
+    return XcodeVersion() >= Version.Parse(version); 
+}
+
+Version XcodeVersion()
+{
+    if(IsRunningOnWindows())
+        return null;
+
     IEnumerable<string> redirectedStandardOutput;
     StartProcess("xcodebuild", 
         new ProcessSettings {
@@ -1139,11 +1147,11 @@ bool IsXcodeVersionOver(string version)
                 );
             }
 
-            return Version.Parse(item.Replace("Xcode", "")) >= Version.Parse(version); 
+            return Version.Parse(item.Replace("Xcode", "")); 
         }
     }
 
-    return true;
+    return null;
 }
 
 IReadOnlyList<AppleSimulator> iosSimulators = null;

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -8,7 +8,7 @@ if (IsMac)
 	}
     
 	ForceJavaCleanup();
-	Item (XreItem.Java_OpenJDK_1_8_0_25);
+	OpenJDK ("1.8.0-40");
 
 	string releaseChannel = Environment.GetEnvironmentVariable ("CHANNEL");
 	Console.WriteLine ("ANDROID_SDK_MAC: {0}", Environment.GetEnvironmentVariable ("ANDROID_SDK_MAC"));
@@ -36,11 +36,19 @@ if (IsMac)
 		await ResolveUrl (Environment.GetEnvironmentVariable ("IOS_SDK_MAC"));
 		specificSdkSet = true;
 	}
+	else
+	{
+		await ResolveUrl ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.mac-6.20.3.5.pkg");
+	}
 
 	if(!String.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable ("MAC_SDK_MAC")))
 	{
 		await ResolveUrl (Environment.GetEnvironmentVariable ("MAC_SDK_MAC"));
 		specificSdkSet = true;
+	}
+	else
+	{
+		await ResolveUrl ("https://bosstoragemirror.blob.core.windows.net/wrench/jenkins/d16-7-xcode11.7/3016ffe2b0ee27bf4a2d61e6161430d6bbd62f78/7/package/notarized/xamarin.ios-13.20.3.5.pkg");
 	}
 	
 	if(!specificSdkSet)

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -5,10 +5,7 @@ using static Xamarin.Provisioning.ProvisioningScript;
 using System;
 using System.Linq;
 
-var desiredXcode = Environment.GetEnvironmentVariable ("REQUIRED_XCODE");
-if (string.IsNullOrEmpty (desiredXcode)) {
-	desiredXcode = "11.7";
-}
+var desiredXcode = "11.7";
 
 desiredXcode = desiredXcode.Replace("Xcode_", "").Replace("_", ".");
 

--- a/build/provisioning/xcode.csx
+++ b/build/provisioning/xcode.csx
@@ -7,8 +7,7 @@ using System.Linq;
 
 var desiredXcode = Environment.GetEnvironmentVariable ("REQUIRED_XCODE");
 if (string.IsNullOrEmpty (desiredXcode)) {
-	Console.WriteLine ("The environment variable 'REQUIRED_XCODE' must be exported and the value must be a valid value from the 'XreItem' enumeration.");
-	return;
+	desiredXcode = "11.7";
 }
 
 desiredXcode = desiredXcode.Replace("Xcode_", "").Replace("_", ".");

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -4,7 +4,7 @@ steps:
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'
-    condition: and(ne(variables['REQUIRED_XCODE'], ''), eq(variables['buildForVS2017'], 'false'))
+    condition: and(eq(variables['buildForVS2017'], 'false'))
     inputs:
       provisioning_script: 'build/provisioning/xcode.csx'
 

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -4,7 +4,7 @@ steps:
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provision Xcode'
-    condition: and(eq(variables['buildForVS2017'], 'false'))
+    condition: eq(variables['buildForVS2017'], 'false')
     inputs:
       provisioning_script: 'build/provisioning/xcode.csx'
 


### PR DESCRIPTION
### Description of Change ###
Pin 4.8.0 OSX build lane to Xcode 11.7

The nugets from this lane will still build using Xcode 12.0 but if there are Xcode 11.7 incompatible APIs the OSX lane will fail

### Testing Procedure ###
- builds are green

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
