### PR TITLE
[Core] Handle Timer with TimeSpan of 0

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/TimerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/TimerUnitTest.cs
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Core.UnitTests
 				return count < 10;
 			});
 
-			Assert.AreEqual(11, count);
+			Assert.AreEqual(10, count);
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/TimerUnitTest.cs
+++ b/Xamarin.Forms.Core.UnitTests/TimerUnitTest.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+
+	[TestFixture]
+	public class TimerUnitTest : BaseTestFixture
+	{
+		[Test]
+		public void TestTimeSpanOneTime()
+		{
+			int count = 0;
+			Device.StartTimer(TimeSpan.FromMilliseconds(0), () =>
+			{
+				count++;
+				return false;
+			});
+
+			Assert.AreEqual(1, count);
+		}
+
+		[Test]
+		public void TestTimeSpanLoop()
+		{
+			int count = 0;
+			Device.StartTimer(TimeSpan.FromMilliseconds(0), () =>
+			{
+				count++;
+				return count < 10;
+			});
+
+			Assert.AreEqual(11, count);
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -117,6 +117,7 @@
     <Compile Include="CheckBoxUnitTests.cs" />
     <Compile Include="StyleSheets\BaseClassSelectorTests.cs" />
     <Compile Include="StateTriggerTests.cs" />
+    <Compile Include="TimerUnitTest.cs" />
     <Compile Include="VisualTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="ImageButtonUnitTest.cs" />

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -232,6 +232,12 @@ namespace Xamarin.Forms
 
 		public static void StartTimer(TimeSpan interval, Func<bool> callback)
 		{
+			if (interval.TotalMilliseconds == 0)
+			{
+				while (callback())
+					;
+				return;
+			}
 			PlatformServices.StartTimer(interval, callback);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix issue when we want a timer with a TimeSpan with 0 seconds, this case we want it to fire immediatly
### Issues Resolved ### 

- fixes #12220

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Added unit test

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
