### PR TITLE
Remove Element.Owned

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ObservableWrapperTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ObservableWrapperTests.cs
@@ -19,19 +19,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void IgnoresInternallyAdded ()
-		{
-			var observableCollection = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, Button> (observableCollection);
-
-			var child = new View ();
-
-			observableCollection.Add (child);
-
-			Assert.IsEmpty (wrapper);
-		}
-
-		[Test]
 		public void TracksExternallyAdded ()
 		{
 			var observableCollection = new ObservableCollection<View> ();
@@ -46,40 +33,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void AddWithInternalItemsAlreadyAdded ()
-		{
-			var observableCollection = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, Button> (observableCollection);
-
-			var view = new View ();
-			observableCollection.Add (view);
-
-			var btn = new Button ();
-
-			wrapper.Add (btn);
-
-			Assert.AreEqual (btn, wrapper[0]);
-			Assert.AreEqual (1, wrapper.Count);
-
-			Assert.Contains (btn, observableCollection);
-			Assert.Contains (view, observableCollection);
-			Assert.AreEqual (2, observableCollection.Count);
-		}
-
-		[Test]
-		public void IgnoresInternallyAddedSameType ()
-		{
-			var observableCollection = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, View> (observableCollection);
-
-			var child = new View ();
-
-			observableCollection.Add (child);
-
-			Assert.IsEmpty (wrapper);
-		}
-
-		[Test]
 		public void TracksExternallyAddedSameType ()
 		{
 			var observableCollection = new ObservableCollection<View> ();
@@ -91,44 +44,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual (child, wrapper[0]);
 			Assert.AreEqual (child, observableCollection[0]);
-		}
-
-		[Test]
-		public void AddWithInternalItemsAlreadyAddedSameType ()
-		{
-			var observableCollection = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, View> (observableCollection);
-
-			var view = new View ();
-			observableCollection.Add (view);
-
-			var btn = new Button ();
-
-			wrapper.Add (btn);
-
-			Assert.AreEqual (btn, wrapper[0]);
-			Assert.AreEqual (1, wrapper.Count);
-
-			Assert.Contains (btn, observableCollection);
-			Assert.Contains (view, observableCollection);
-			Assert.AreEqual (2, observableCollection.Count);
-		}
-
-		[Test]
-		public void CannotRemoveInternalItem ()
-		{
-			var observableCollection = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, View> (observableCollection);
-
-			var child = new View ();
-
-			observableCollection.Add (child);
-
-			Assert.IsEmpty (wrapper);
-
-			Assert.False (wrapper.Remove (child));
-
-			Assert.Contains (child, observableCollection);
 		}
 
 		[Test]
@@ -183,37 +98,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void CopyTo ()
-		{
-			var observableCollection = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, View> (observableCollection);
-
-			var child1 = new Button ();
-			var child2 = new Button ();
-			var child3 = new Button ();
-			var child4 = new Button ();
-			var child5 = new Button ();
-
-			observableCollection.Add (new Stepper ());
-			wrapper.Add (child1);
-			observableCollection.Add (new Button ());
-			wrapper.Add (child2);
-			wrapper.Add (child3);
-			wrapper.Add (child4);
-			wrapper.Add (child5);
-			observableCollection.Add (new Button ());
-
-			var target = new View[30];
-			wrapper.CopyTo (target, 2);
-
-			Assert.AreEqual (target[2], child1);
-			Assert.AreEqual (target[3], child2);
-			Assert.AreEqual (target[4], child3);
-			Assert.AreEqual (target[5], child4);
-			Assert.AreEqual (target[6], child5);
-		}
-
-		[Test]
 		public void INCCSimpleAdd ()
 		{
 			var oc = new ObservableCollection<View> ();
@@ -232,27 +116,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual (0, addIndex);
 			Assert.AreEqual (child, addedResult);
-		}
-
-		[Test]
-		public void INCCSimpleAddToInner ()
-		{
-			var oc = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, View> (oc);
-
-			var child = new Button ();
-
-			Button addedResult = null;
-			int addIndex = -1;
-			wrapper.CollectionChanged += (sender, args) => {
-				addedResult = args.NewItems[0] as Button;
-				addIndex = args.NewStartingIndex;
-			};
-
-			oc.Add (child);
-
-			Assert.AreEqual (-1, addIndex);
-			Assert.AreEqual (null, addedResult);
 		}
 
 		[Test]
@@ -298,28 +161,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.AreEqual (0, removeIndex);
 			Assert.AreEqual (child, removedResult);
-		}
-
-		[Test]
-		public void INCCSimpleRemoveFromInner ()
-		{
-			var oc = new ObservableCollection<View> ();
-			var wrapper = new ObservableWrapper<View, Button> (oc);
-
-			var child = new Button ();
-			oc.Add (child);
-
-			Button addedResult = null;
-			int addIndex = -1;
-			wrapper.CollectionChanged += (sender, args) => {
-				addedResult = args.OldItems[0] as Button;
-				addIndex = args.OldStartingIndex;
-			};
-
-			oc.Remove (child);
-
-			Assert.AreEqual (-1, addIndex);
-			Assert.AreEqual (null, addedResult);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -132,8 +132,6 @@ namespace Xamarin.Forms
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public ReadOnlyCollection<Element> LogicalChildren => LogicalChildrenInternal;
 
-		internal bool Owned { get; set; }
-
 		internal Element ParentOverride
 		{
 			get { return _parentOverride; }

--- a/Xamarin.Forms.Core/MultiPage.cs
+++ b/Xamarin.Forms.Core/MultiPage.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
@@ -213,7 +212,6 @@ namespace Xamarin.Forms
 					for (var i = 0; i < e.NewItems.Count; i++)
 					{
 						var page = (T)e.NewItems[i];
-						page.Owned = true;
 						int index = i + e.NewStartingIndex;
 						SetIndex(page, index);
 						InternalChildren.Insert(index, (T)e.NewItems[i]);
@@ -231,9 +229,7 @@ namespace Xamarin.Forms
 
 					for (var i = 0; i < e.OldItems.Count; i++)
 					{
-						Element element = InternalChildren[e.OldStartingIndex];
 						InternalChildren.RemoveAt(e.OldStartingIndex);
-						element.Owned = false;
 					}
 
 					break;
@@ -284,12 +280,9 @@ namespace Xamarin.Forms
 
 					for (int i = e.OldStartingIndex; i - e.OldStartingIndex < e.OldItems.Count; i++)
 					{
-						Element element = InternalChildren[i];
 						InternalChildren.RemoveAt(i);
-						element.Owned = false;
 
 						T page = _templatedItems.GetOrCreateContent(i, e.NewItems[i - e.OldStartingIndex]);
-						page.Owned = true;
 						SetIndex(page, i);
 						InternalChildren.Insert(i, page);
 					}
@@ -311,13 +304,9 @@ namespace Xamarin.Forms
 
 			InternalChildren.Clear();
 
-			foreach (Element element in snapshot)
-				element.Owned = false;
-
 			for (var i = 0; i < _templatedItems.Count; i++)
 			{
 				T page = _templatedItems.GetOrCreateContent(i, _templatedItems.ListProxy[i]);
-				page.Owned = true;
 				SetIndex(page, i);
 				InternalChildren.Add(page);
 			}

--- a/Xamarin.Forms.Core/ObservableWrapper.cs
+++ b/Xamarin.Forms.Core/ObservableWrapper.cs
@@ -31,7 +31,6 @@ namespace Xamarin.Forms
 			if (_list.Contains(item))
 				return;
 
-			item.Owned = true;
 			_list.Add(item);
 		}
 
@@ -43,13 +42,12 @@ namespace Xamarin.Forms
 			foreach (TRestrict item in _list.OfType<TRestrict>().ToArray())
 			{
 				_list.Remove(item);
-				item.Owned = false;
 			}
 		}
 
 		public bool Contains(TRestrict item)
 		{
-			return item.Owned && _list.Contains(item);
+			return _list.Contains(item);
 		}
 
 		public void CopyTo(TRestrict[] array, int destIndex)
@@ -72,7 +70,7 @@ namespace Xamarin.Forms
 				for (int i = 0; i < _list.Count; i++)
 				{
 					var item = _list[i];
-					if (item.Owned && item is TRestrict)
+					if (item is TRestrict)
 						result++;
 				}
 				return result;
@@ -88,12 +86,8 @@ namespace Xamarin.Forms
 			if (IsReadOnly)
 				throw new NotSupportedException("The collection is read-only.");
 
-			if (!item.Owned)
-				return false;
-
 			if (_list.Remove(item))
 			{
-				item.Owned = false;
 				return true;
 			}
 			return false;
@@ -106,7 +100,7 @@ namespace Xamarin.Forms
 
 		public IEnumerator<TRestrict> GetEnumerator()
 		{
-			return _list.Where(i => i.Owned).OfType<TRestrict>().GetEnumerator();
+			return _list.OfType<TRestrict>().GetEnumerator();
 		}
 
 		public int IndexOf(TRestrict value)
@@ -124,7 +118,6 @@ namespace Xamarin.Forms
 			if (IsReadOnly)
 				throw new NotSupportedException("The collection is read-only.");
 
-			item.Owned = true;
 			_list.Insert(ToInnerIndex(index), item);
 		}
 
@@ -134,13 +127,7 @@ namespace Xamarin.Forms
 			set
 			{
 				int innerIndex = ToInnerIndex(index);
-				if (value != null)
-					value.Owned = true;
-				TTrack old = _list[innerIndex];
 				_list[innerIndex] = value;
-
-				if (old != null)
-					old.Owned = false;
 			}
 		}
 
@@ -150,11 +137,8 @@ namespace Xamarin.Forms
 				throw new NotSupportedException("The collection is read-only");
 			int innerIndex = ToInnerIndex(index);
 			TTrack item = _list[innerIndex];
-			if (item.Owned)
-			{
-				_list.RemoveAt(innerIndex);
-				item.Owned = false;
-			}
+		
+			_list.RemoveAt(innerIndex);
 		}
 
 		public event NotifyCollectionChangedEventHandler CollectionChanged;
@@ -172,7 +156,7 @@ namespace Xamarin.Forms
 						goto case NotifyCollectionChangedAction.Reset;
 
 					var newItem = e.NewItems[0] as TRestrict;
-					if (newItem == null || !newItem.Owned)
+					if (newItem == null)
 						break;
 
 					int outerIndex = ToOuterIndex(e.NewStartingIndex);
@@ -183,7 +167,7 @@ namespace Xamarin.Forms
 						goto case NotifyCollectionChangedAction.Reset;
 
 					var movedItem = e.NewItems[0] as TRestrict;
-					if (movedItem == null || !movedItem.Owned)
+					if (movedItem == null)
 						break;
 
 					int outerOldIndex = ToOuterIndex(e.OldStartingIndex);
@@ -195,7 +179,7 @@ namespace Xamarin.Forms
 						goto case NotifyCollectionChangedAction.Reset;
 
 					var removedItem = e.OldItems[0] as TRestrict;
-					if (removedItem == null || !removedItem.Owned)
+					if (removedItem == null)
 						break;
 
 					int outerRemovedIndex = ToOuterIndex(e.OldStartingIndex);
@@ -209,11 +193,11 @@ namespace Xamarin.Forms
 					var newReplaceItem = e.NewItems[0] as TRestrict;
 					var oldReplaceItem = e.OldItems[0] as TRestrict;
 
-					if ((newReplaceItem == null || !newReplaceItem.Owned) && (oldReplaceItem == null || !oldReplaceItem.Owned))
+					if ((newReplaceItem == null) && (oldReplaceItem == null))
 					{
 						break;
 					}
-					if (newReplaceItem == null || !newReplaceItem.Owned || oldReplaceItem == null || !oldReplaceItem.Owned)
+					if (newReplaceItem == null || oldReplaceItem == null)
 					{
 						goto case NotifyCollectionChangedAction.Reset;
 					}
@@ -238,7 +222,7 @@ namespace Xamarin.Forms
 			for (innerIndex = 0; innerIndex < _list.Count; innerIndex++)
 			{
 				TTrack item = _list[innerIndex];
-				if (item is TRestrict && item.Owned)
+				if (item is TRestrict)
 				{
 					if (outerIndex == outterIndex)
 						return innerIndex;
@@ -255,7 +239,7 @@ namespace Xamarin.Forms
 			for (var index = 0; index < innerIndex; index++)
 			{
 				TTrack item = _list[index];
-				if (item is TRestrict && item.Owned)
+				if (item is TRestrict)
 				{
 					outerIndex++;
 				}


### PR DESCRIPTION
### Description of Change ###

I'm fairly certain that Element.Owned hasn't been doing anything useful (or anything at all) for some time. Setting this up to run all the UI tests to make sure I'm not missing something.

### Issues Resolved ### 

Possible wasted cycles and allocations. 

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

All the usual stuff

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
