### PR TITLE
MacOS - Fix crash when invoking VisualElement.Focus()

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -305,8 +305,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			if (Control == null)
 				return;
-
+				
+#if __MOBILE__
 			focusRequestArgs.Result = focusRequestArgs.Focus ? Control.BecomeFirstResponder() : Control.ResignFirstResponder();
+#else
+			focusRequestArgs.Result = focusRequestArgs.Focus ? Control.Window.MakeFirstResponder(Control) : Control.Window.MakeFirstResponder(null);
+#endif
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

**NSInternalInconsistencyException**: NSWindow: -_oldFirstResponderBeforeBecoming is not a valid message outside of a responder's implementation of -becomeFirstResponder.

https://developer.apple.com/documentation/appkit/nsresponder/1526750-becomefirstresponder?language=objc
https://developer.apple.com/documentation/appkit/nsresponder/1532115-resignfirstresponder?language=objc

Use the **NSWindow makeFirstResponder:** method, not this method, to make an object the first responder. Never invoke this method directly.


### Issues Resolved ### 
### API Changes ###
 
 None

### Platforms Affected ### 

- MacOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
