### PR TITLE
Make OnPlatform helpers public

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfigurationRegistry.cs
+++ b/Xamarin.Forms.Core/PlatformConfigurationRegistry.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms
 		readonly TElement _element;
 		readonly Dictionary<Type, object> _platformSpecifics = new Dictionary<Type, object>();
 
-		internal PlatformConfigurationRegistry(TElement element)
+		public PlatformConfigurationRegistry(TElement element)
 		{
 			_element = element;
 		}

--- a/Xamarin.Forms.Core/PlatformConfigurationRegistry.cs
+++ b/Xamarin.Forms.Core/PlatformConfigurationRegistry.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 
 namespace Xamarin.Forms
 {
@@ -7,7 +8,8 @@ namespace Xamarin.Forms
 	/// Helper that handles storing and lookup of platform specifics implementations
 	/// </summary>
 	/// <typeparam name="TElement">The Element type</typeparam>
-	internal class PlatformConfigurationRegistry<TElement> : IElementConfiguration<TElement>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class PlatformConfigurationRegistry<TElement> : IElementConfiguration<TElement>
 		where TElement : Element
 	{
 		readonly TElement _element;

--- a/Xamarin.Forms.Core/PlatformConfigurationRegistry.cs
+++ b/Xamarin.Forms.Core/PlatformConfigurationRegistry.cs
@@ -8,7 +8,6 @@ namespace Xamarin.Forms
 	/// Helper that handles storing and lookup of platform specifics implementations
 	/// </summary>
 	/// <typeparam name="TElement">The Element type</typeparam>
-	[EditorBrowsable(EditorBrowsableState.Never)]
 	public class PlatformConfigurationRegistry<TElement> : IElementConfiguration<TElement>
 		where TElement : Element
 	{


### PR DESCRIPTION

### Description of Change ###

This PR changes the visibility of the ` PlatformConfigurationRegistry<TElement>` class to public decorated with the `EditorBrowsableState.Never` attribute. We need this into the XCT.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- Related to #12136

### API Changes ###
<!-- List all API changes here (or just put None), example:

Changed:
 - object FakeControl.MakeShinyclass PlatformConfigurationRegistry<TElement> => public class PlatformConfigurationRegistry<TElement>
 
- internal PlatformConfigurationRegistry(TElement element) => public PlatformConfigurationRegistry(TElement element)
 

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
None.
### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
