### PR TITLE
Change Accessors for UWP Specific APIs to public [Xamarin Community Toolkit]

### DIFF
--- a/Xamarin.Forms.Platform.UAP/PageExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/PageExtensions.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.UWP
 			return contentPage.ToFrameworkElement();
 		}
 
-		internal static FrameworkElement ToFrameworkElement(this VisualElement visualElement)
+		public static FrameworkElement ToFrameworkElement(this VisualElement visualElement)
 		{
 			if (!Forms.IsInitialized)
 			{

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -59,7 +59,7 @@ namespace Xamarin.Forms.Platform.UWP
 			return renderer;
 		}
 
-		internal static Platform Current
+		public static Platform Current
 		{
 			get
 			{

--- a/Xamarin.Forms.Platform.UAP/VisualElementExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementExtensions.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.UWP
 			return renderer;
 		}
 
-		internal static void Cleanup(this VisualElement self)
+		public static void Cleanup(this VisualElement self)
 		{
 			if (self == null)
 				throw new ArgumentNullException("self");


### PR DESCRIPTION
### Description of Change ###
Changed accessor modifier for several UWP APIs from internal to public. This is required as part of the Xamarin Community Toolkit implementation of the Popup control.

Related to Xamarin/XamarinCommunityToolkit#292


### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- related to #12136 

### API Changes ###

**Changed:**
Platform.cs
- internal static Platform Current => public static Platform Current

VisualElementExtensions.cs
- internal static void Cleanup => public static void Cleanup

PageExtensions.cs
- internal static FrameworkElement ToFrameworkElement => public static FrameworkElement ToFrameworkElement

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Not applicable

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
