### PR TITLE
Change Accessors for iOS Specific APIs to public [Xamarin Community Toolkit]

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Forms
 
 		public static event EventHandler<ViewInitializedEventArgs> ViewInitialized;
 
-		internal static void SendViewInitialized(this VisualElement self, TNativeView nativeView)
+		public static void SendViewInitialized(this VisualElement self, TNativeView nativeView)
 		{
 			ViewInitialized?.Invoke(self, new ViewInitializedEventArgs { View = self, NativeView = nativeView });
 		}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		, IPlatform
 #pragma warning restore
 	{
-		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
+		public static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 #if DEBUG

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		, IPlatform
 #pragma warning restore
 	{
-		public static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
+		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer", typeof(IVisualElementRenderer), typeof(Platform), default(IVisualElementRenderer),
 			propertyChanged: (bindable, oldvalue, newvalue) =>
 			{
 #if DEBUG


### PR DESCRIPTION
### Description of Change ###
Changes several internal APIs to public for iOS. This change is required for the Popup Control implementation that is being ported from a Xamarin.Forms PR to the Xamarin Community Toolkit.

related to Xamarin/XamarinCommunityToolkit#292

### Issues Resolved ### 
Related to #12136 

### API Changes ###
**Changed:**
Platform.cs
- internal static readonly BindableProperty RendererProperty => public static readonly BindableProperty RendererProperty

Forms.cs
- internal static void SendViewInitialized => public static void SendViewInitialized

### Platforms Affected ###
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
