### PR TITLE
[Core] Fixed wrong RoundRectangleGeometry calculation

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ClipGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ClipGallery.xaml
@@ -42,6 +42,16 @@
                     </Image.Clip>
                 </Image>
                 <Label
+                    Text="Clipped Image using RoundRectangleGeometry"/>
+                <Image  
+                    Source="crimson.jpg">
+                    <Image.Clip>
+                        <RoundRectangleGeometry
+                            CornerRadius="6"
+                            Rect="0, 15, 150, 150" />
+                    </Image.Clip>
+                </Image>
+                <Label
                     Text="Clipped Image using EllipseGeometry"/>
                 <Image  
                     Source="crimson.jpg">

--- a/Xamarin.Forms.Core/Shapes/RoundRectangleGeometry.cs
+++ b/Xamarin.Forms.Core/Shapes/RoundRectangleGeometry.cs
@@ -61,7 +61,7 @@
 
 			if (CornerRadius.TopLeft > 0)
 				roundedRectGeometry.Children.Add(
-					new EllipseGeometry(new Point(Rect.Location.X + CornerRadius.TopLeft, Rect.Location.Y + CornerRadius.TopLeft), Rect.Location.Y + CornerRadius.TopLeft, Rect.Location.Y + CornerRadius.TopLeft));
+					new EllipseGeometry(new Point(Rect.Location.X + CornerRadius.TopLeft, Rect.Location.Y + CornerRadius.TopLeft), CornerRadius.TopLeft, CornerRadius.TopLeft));
 
 			if (CornerRadius.TopRight > 0)
 				roundedRectGeometry.Children.Add(


### PR DESCRIPTION
### Description of Change ###

Fixed wrong RoundRectangleGeometry calculation (Top Left Corner).

### Issues Resolved ### 

- fixes #12285 

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="425" alt="Captura de pantalla 2020-09-28 a las 16 12 43" src="https://user-images.githubusercontent.com/6755973/94443811-e5b4e000-01a5-11eb-8608-ddf293b8fc28.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the shapes gallery. Select the Clip Gallery and verify that the Clip using RoundRectangleGeometry is correct.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
