### PR TITLE
[iOS] Fix DatePicker on iOS14

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11963.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11963.cs
@@ -15,18 +15,19 @@ namespace Xamarin.Forms.Controls.Issues
 	[Category(UITestCategories.ManualReview)]
 #endif
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 11963, "Time Picker is broken in Xamarin.Forms as of iOS 14 Public Beta 6", PlatformAffected.iOS)]
+	[Issue(IssueTracker.Github, 11963, "Time and Date Picker is broken in Xamarin.Forms as of iOS 14 Public Beta 6", PlatformAffected.iOS)]
 	public class Issue11963 : TestContentPage
 	{
 		protected override void Init()
 		{
 			var timePicker = new TimePicker();
-		
+			var datePicker = new DatePicker();
+
 			Content = new StackLayout
 			{
 				Spacing = 20,
 				VerticalOptions = LayoutOptions.Center,
-				Children = { timePicker }
+				Children = { timePicker, datePicker }
 			};
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -71,6 +71,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new NSTimeZone("UTC") };
 
+#if __XCODE11__
+				if (Forms.IsiOS14OrNewer)
+				{
+					_picker.PreferredDatePickerStyle = UIKit.UIDatePickerStyle.Wheels;
+				}
+#endif
 				_picker.ValueChanged += HandleValueChanged;
 
 				var width = UIScreen.MainScreen.Bounds.Width;


### PR DESCRIPTION
### Description of Change ###

Fix the DatePicker crash on iOS14 by forcing the PreferredDatePickerStyle to UIDatePickerStyle.Wheels.

### Issues Resolved ### 

- fixes #11963

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Use Xcode12, iOS14 device, and Xamarin.iOS for IOS14.
Go to issue 11943, click on the date , make sure the date picker wheels appear and you able to select a time.

make sure it also works on iOS13

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)