### PR TITLE
Workaround for iOS material entry application freeze

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12246.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12246.cs
@@ -38,7 +38,15 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var password = new Entry { Visual = VisualMarker.Material, IsPassword = true, Placeholder = "Password", 
 				TextColor = Color.Purple };
-			
+
+			var passwordConfirmation = new Entry
+			{
+				Visual = VisualMarker.Material,
+				IsPassword = true,
+				Placeholder = "Confirm Password",
+				TextColor = Color.Purple
+			};
+
 			password.Unfocused += (sender, args) => {
 				result.IsVisible = true;
 			};
@@ -46,6 +54,7 @@ namespace Xamarin.Forms.Controls.Issues
 			layout.Children.Add(instructions);
 			layout.Children.Add(entry);
 			layout.Children.Add(password);
+			layout.Children.Add(passwordConfirmation);
 			layout.Children.Add(result);
 
 			Content = layout;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12246.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12246.cs
@@ -1,0 +1,71 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Entry)]
+	[Category(UITestCategories.Visual)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12246, "[Bug] iOS 14 App freezes when password is entered after email", PlatformAffected.iOS)]
+	public class Issue12246 : TestContentPage
+	{
+		const string Entry = "Entry";
+		const string Password = "Password";
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var layout = new StackLayout() { Margin = 40, Spacing = 10, VerticalOptions = LayoutOptions.Center };
+
+			var instructions = new Label { Text = $"Focus the 'Email' Entry. Type in some text. Then focus the 'Password' Entry." +
+				$" Type in some text. Now focus the 'Email' Entry again. The '{Success}' Label should appear. " +
+				$"If the '{Success}' Label does not appear or the application hangs, this test has failed." };
+
+			var result = new Label { Text = Success, IsVisible = false };
+
+			var entry = new Entry() { Visual = VisualMarker.Material, Keyboard = Keyboard.Email, Placeholder = "Email", 
+				TextColor = Color.Purple };
+
+			var password = new Entry { Visual = VisualMarker.Material, IsPassword = true, Placeholder = "Password", 
+				TextColor = Color.Purple };
+			
+			password.Unfocused += (sender, args) => {
+				result.IsVisible = true;
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(entry);
+			layout.Children.Add(password);
+			layout.Children.Add(result);
+
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void UnfocusingPasswordDoesNotHang()
+		{
+			RunningApp.WaitForElement(Entry);
+			RunningApp.Tap(Entry);
+			RunningApp.EnterText("test");
+
+			RunningApp.WaitForElement(Password);
+			RunningApp.Tap(Password);
+			RunningApp.EnterText("test");
+
+			RunningApp.Tap(Entry);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12246.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12246.cs
@@ -34,10 +34,10 @@ namespace Xamarin.Forms.Controls.Issues
 			var result = new Label { Text = Success, IsVisible = false };
 
 			var entry = new Entry() { Visual = VisualMarker.Material, Keyboard = Keyboard.Email, Placeholder = "Email", 
-				TextColor = Color.Purple };
+				TextColor = Color.Purple, AutomationId = Entry };
 
 			var password = new Entry { Visual = VisualMarker.Material, IsPassword = true, Placeholder = "Password", 
-				TextColor = Color.Purple };
+				TextColor = Color.Purple, AutomationId = Password };
 
 			var passwordConfirmation = new Entry
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -29,6 +29,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10744.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10909.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11769.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12246.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />

--- a/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
@@ -10,6 +10,8 @@ namespace Xamarin.Forms.Material.iOS
 {
 	internal static class MaterialTextManager
 	{
+		static double AlphaAdjustment = 0.0;
+
 		public static void Init(IMaterialEntryRenderer element, IMaterialTextField textField, IFontElement fontElement)
 		{
 			var containerScheme = textField.ContainerScheme;
@@ -49,8 +51,10 @@ namespace Xamarin.Forms.Material.iOS
 			textField.ContainerScheme.ColorScheme = (SemanticColorScheme)CreateColorScheme();
 			ApplyContainerTheme(textField);
 
-			var textColor = MaterialColors.GetEntryTextColor(element.TextColor);
-			var placeHolderColors = MaterialColors.GetPlaceHolderColor(element.PlaceholderColor, element.TextColor);
+			var adjustedTextColor = AdjustTextColor(element);
+
+			var textColor = MaterialColors.GetEntryTextColor(adjustedTextColor);
+			var placeHolderColors = MaterialColors.GetPlaceHolderColor(element.PlaceholderColor, adjustedTextColor);
 			var underlineColors = MaterialColors.GetUnderlineColor(element.PlaceholderColor);
 
 			textField.TextInput.TextColor = textColor;
@@ -63,7 +67,7 @@ namespace Xamarin.Forms.Material.iOS
 			if (Brush.IsNullOrEmpty(brush))
 			{
 				// BackgroundColor
-				textField.ActiveTextInputController.BorderFillColor = MaterialColors.CreateEntryFilledInputBackgroundColor(element.BackgroundColor, element.TextColor);
+				textField.ActiveTextInputController.BorderFillColor = MaterialColors.CreateEntryFilledInputBackgroundColor(element.BackgroundColor, adjustedTextColor);
 			}
 			else
 			{
@@ -114,9 +118,43 @@ namespace Xamarin.Forms.Material.iOS
 
 		public static void UpdateTextColor(IMaterialTextField textField, IMaterialEntryRenderer element)
 		{
-			var uIColor = MaterialColors.GetEntryTextColor(element.TextColor);
+			var adjustedTextColor = AdjustTextColor(element);
+
+			var uIColor = MaterialColors.GetEntryTextColor(adjustedTextColor);
 			textField.ContainerScheme.ColorScheme.OnSurfaceColor = uIColor;
 			textField.ContainerScheme.ColorScheme.PrimaryColor = uIColor;
+		}
+
+		static Color AdjustTextColor(IMaterialEntryRenderer element) 
+		{
+			if (Forms.IsiOS14OrNewer)
+			{
+				// This is a workaround for an iOS/Material bug; https://github.com/xamarin/Xamarin.Forms/issues/12246
+				// If we are on iOS 14, and we have multiple material text entry fields of the same color,
+				// and any of them are password fields, setting them to the same TextColor value will cause the application
+				// to hang when a password field loses focus. 
+
+				// So to work around this, we make an impercetible adjustment to the alpha value of the color each time
+				// we set it; that way, none of the text entry fields have _exactly_ the same color and we avoid the bug
+
+				// Obviously this will start to become noticeable after the first 20 million or so text entry fields are displayed.
+				// We apologize for the inconvenience.
+
+				var elementTextColor = element.TextColor;
+				AlphaAdjustment += 0.0000001;
+
+				var adjustedAlpha = elementTextColor.A - AlphaAdjustment;
+				if (adjustedAlpha < 0)
+				{
+					// Below an alpha of 0.01 stuff on iOS doesn't show up in hit tests anyway, so it seems unlikely
+					// that the entry will get focus and cause the issue. 
+					adjustedAlpha = 0;
+				}
+
+				return new Color(elementTextColor.R, elementTextColor.G, elementTextColor.B, adjustedAlpha);
+			}
+
+			return element.TextColor;
 		}
 
 		static IColorScheming CreateColorScheme()

--- a/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Forms.Material.iOS
 				// and any of them are password fields, setting them to the same TextColor value will cause the application
 				// to hang when a password field loses focus. 
 
-				// So to work around this, we make an impercetible adjustment to the alpha value of the color each time
+				// So to work around this, we make an imperceptible adjustment to the alpha value of the color each time
 				// we set it; that way, none of the text entry fields have _exactly_ the same color and we avoid the bug
 
 				// Obviously this will start to become noticeable after the first 20 million or so text entry fields are displayed.


### PR DESCRIPTION
### Description of Change ###

If we are on iOS 14, and we have multiple material text entry fields of the same color, and any of them are password fields, setting them to the same TextColor value will cause the application to hang when a password field loses focus. 

So to work around this, we make an imperceptible adjustment to the alpha value of the color each time we set it; that way, none of the text entry fields have _exactly_ the same color and we avoid running into the bug. 

This is a temporary fix until the underlying iOS/Material issues are fixed. 

### Issues Resolved ### 

- fixes #12246

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated UI test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
