### PR TITLE
Leave IMasterDetailPageController intact

### DIFF
--- a/Xamarin.Forms.Core/FlyoutPage.cs
+++ b/Xamarin.Forms.Core/FlyoutPage.cs
@@ -315,5 +315,10 @@ namespace Xamarin.Forms
 		{
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
+
+		public void UpdateMasterBehavior()
+		{
+			base.UpdateFlyoutLayoutBehavior();
+		}
 	}
 }

--- a/Xamarin.Forms.Core/FlyoutPage.cs
+++ b/Xamarin.Forms.Core/FlyoutPage.cs
@@ -316,9 +316,8 @@ namespace Xamarin.Forms
 			return _platformConfigurationRegistry.Value.On<T>();
 		}
 
-		public void UpdateMasterBehavior()
-		{
-			base.UpdateFlyoutLayoutBehavior();
-		}
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public void UpdateMasterBehavior() =>
+			(this as IFlyoutPageController).UpdateFlyoutLayoutBehavior();
 	}
 }

--- a/Xamarin.Forms.Core/IFlyoutPageController.cs
+++ b/Xamarin.Forms.Core/IFlyoutPageController.cs
@@ -17,8 +17,18 @@ namespace Xamarin.Forms
 		event EventHandler<BackButtonPressedEventArgs> BackButtonPressed;
 	}
 
-	public interface IMasterDetailPageController : IFlyoutPageController
+	public interface IMasterDetailPageController
 	{
+		bool CanChangeIsPresented { get; set; }
+
+		Rectangle DetailBounds { get; set; }
+
 		Rectangle MasterBounds { get; set; }
+
+		bool ShouldShowSplitMode { get; }
+
+		void UpdateMasterBehavior();
+
+		event EventHandler<BackButtonPressedEventArgs> BackButtonPressed;
 	}
 }

--- a/Xamarin.Forms.Core/IFlyoutPageController.cs
+++ b/Xamarin.Forms.Core/IFlyoutPageController.cs
@@ -16,7 +16,8 @@ namespace Xamarin.Forms
 
 		event EventHandler<BackButtonPressedEventArgs> BackButtonPressed;
 	}
-
+	
+	[Obsolete("IMasterDetailPageController is obsolete as of version 5.0.0. Please use IFlyoutPageController instead.")]
 	public interface IMasterDetailPageController
 	{
 		bool CanChangeIsPresented { get; set; }


### PR DESCRIPTION
### Description of Change ###

Separate out IMasterDetailPageController  from IFlyoutPageController so it's not an ABI break

### Issues Resolved ### 
- fixes #12224

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Testing Procedure ###
- I'll reach out to user to verify

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
