### PR TITLE
Trigger pop logic when you replace back button with icon

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12126.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12126.cs
@@ -15,7 +15,7 @@ using Xamarin.Forms.Core.UITests;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 12126, "[iOS] TabBarIsVisible = True/False doesn't work on Back Navigation When using BackButtonBehavior",
+	[Issue(IssueTracker.Github, 12126, "[iOS] TabBarIsVisible = True/False breaking for multiple nested pages",
 		PlatformAffected.iOS)]
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
@@ -54,7 +54,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 				Shell.SetTabBarIsVisible(contentPage2, false);
 				await Navigation.PushAsync(contentPage);
-				await Navigation.PopAsync();
+				await Navigation.PushAsync(contentPage2);
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12126.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12126.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12126, "[iOS] TabBarIsVisible = True/False doesn't work on Back Navigation When using BackButtonBehavior",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue12126 : TestShell
+	{
+		bool firstNavigated = true;
+		protected override void Init()
+		{
+			var page1 = AddFlyoutItem("Tab 1");
+			AddBottomTab("Tab 2");
+			Shell.SetTabBarIsVisible(page1, true);
+
+			page1.Content = new Label()
+			{
+				Text = "If you don't see any bottom tabs the test has failed"
+			};
+		}
+
+		protected override async void OnNavigated(ShellNavigatedEventArgs args)
+		{
+			base.OnNavigated(args);
+
+			if(firstNavigated)
+			{
+				firstNavigated = false;
+				ContentPage contentPage = new ContentPage();
+				contentPage.Content = new Label()
+				{
+					Text = "Click the Coffee Cup in the Nav Bar"
+				};
+
+				Shell.SetTabBarIsVisible(contentPage, false);
+				Shell.SetBackButtonBehavior(contentPage, new BackButtonBehavior() { IconOverride = "coffee.png" });
+				await Navigation.PushAsync(contentPage);
+			}
+		}
+
+
+#if UITEST && __SHELL__
+		[Test]
+		public void PopLogicExecutesWhenUsingBackButtonBehavior()
+		{
+			base.TapBackArrow();
+			RunningApp.WaitForElement("Tab 1");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12126.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12126.cs
@@ -46,11 +46,18 @@ namespace Xamarin.Forms.Controls.Issues
 				Shell.SetTabBarIsVisible(contentPage, true);
 
 				ContentPage contentPage2 = new ContentPage();
-				contentPage2.Content = new Label()
-				{
-					Text = "Click The Back Arrow",
-					AutomationId = "TestReady"
-				};
+				contentPage2.Content =
+					new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "Click The Back Arrow",
+								AutomationId = "TestReady"
+							}
+						}
+					};
 
 				Shell.SetTabBarIsVisible(contentPage2, false);
 				await Navigation.PushAsync(contentPage);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12320.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12320.cs
@@ -15,13 +15,13 @@ using Xamarin.Forms.Core.UITests;
 namespace Xamarin.Forms.Controls.Issues
 {
 	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 12126, "[iOS] TabBarIsVisible = True/False doesn't work on Back Navigation When using BackButtonBehavior",
+	[Issue(IssueTracker.Github, 12320, "[iOS] TabBarIsVisible = True/False doesn't work on Back Navigation When using BackButtonBehavior",
 		PlatformAffected.iOS)]
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
 	[NUnit.Framework.Category(UITestCategories.Shell)]
 #endif
-	public class Issue12126 : TestShell
+	public class Issue12320 : TestShell
 	{
 		bool firstNavigated = true;
 		protected override void Init()
@@ -29,6 +29,11 @@ namespace Xamarin.Forms.Controls.Issues
 			var page1 = AddFlyoutItem("Tab 1");
 			AddBottomTab("Tab 2");
 			Shell.SetTabBarIsVisible(page1, true);
+
+			page1.Content = new Label()
+			{
+				Text = "If you don't see any bottom tabs the test has failed"
+			};
 		}
 
 		protected override async void OnNavigated(ShellNavigatedEventArgs args)
@@ -41,30 +46,21 @@ namespace Xamarin.Forms.Controls.Issues
 				ContentPage contentPage = new ContentPage();
 				contentPage.Content = new Label()
 				{
-					Text = "If you don't see any bottom tabs the test has failed"
-				};
-				Shell.SetTabBarIsVisible(contentPage, true);
-
-				ContentPage contentPage2 = new ContentPage();
-				contentPage2.Content = new Label()
-				{
-					Text = "Click The Back Arrow",
-					AutomationId = "TestReady"
+					Text = "Click the Coffee Cup in the Nav Bar"
 				};
 
-				Shell.SetTabBarIsVisible(contentPage2, false);
+				Shell.SetTabBarIsVisible(contentPage, false);
+				Shell.SetBackButtonBehavior(contentPage, new BackButtonBehavior() { IconOverride = "coffee.png" });
 				await Navigation.PushAsync(contentPage);
-				await Navigation.PopAsync();
 			}
 		}
 
 
 #if UITEST && __SHELL__
 		[Test]
-		public void NavigatingBackFromMultiplePushPagesChangesTabVisibilityCorrectly()
+		public void PopLogicExecutesWhenUsingBackButtonBehavior()
 		{
-			RunningApp.WaitForElement("TestReady");
-			TapBackArrow();
+			base.TapBackArrow();
 			RunningApp.WaitForElement("Tab 1");
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12320.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12320.cs
@@ -26,14 +26,15 @@ namespace Xamarin.Forms.Controls.Issues
 		bool firstNavigated = true;
 		protected override void Init()
 		{
-			var page1 = AddFlyoutItem("Tab 1");
-			AddBottomTab("Tab 2");
-			Shell.SetTabBarIsVisible(page1, true);
-
+			var page1 = new ContentPage();
 			page1.Content = new Label()
 			{
 				Text = "If you don't see any bottom tabs the test has failed"
 			};
+
+			AddFlyoutItem(page1, "Tab 1");
+			AddBottomTab("Tab 2");
+			Shell.SetTabBarIsVisible(page1, true);
 		}
 
 		protected override async void OnNavigated(ShellNavigatedEventArgs args)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12320.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12320.cs
@@ -47,7 +47,8 @@ namespace Xamarin.Forms.Controls.Issues
 				ContentPage contentPage = new ContentPage();
 				contentPage.Content = new Label()
 				{
-					Text = "Click the Coffee Cup in the Nav Bar"
+					Text = "Click the Coffee Cup in the Nav Bar",
+					AutomationId = "TestReady"
 				};
 
 				Shell.SetTabBarIsVisible(contentPage, false);
@@ -61,6 +62,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void PopLogicExecutesWhenUsingBackButtonBehavior()
 		{
+			RunningApp.WaitForElement("TestReady");
 			base.TapBackArrow();
 			RunningApp.WaitForElement("Tab 1");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12320.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12153.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10324.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github9536.xaml.cs">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1593,6 +1593,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)HeaderFooterShellFlyout.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12134.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11963.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12126.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11831.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemRenderer.cs
@@ -49,7 +49,6 @@ namespace Xamarin.Forms.Platform.iOS
 		Page _displayedPage;
 		bool _disposed;
 		ShellItem _shellItem;
-		bool _switched = true;
 
 		IShellSectionRenderer CurrentRenderer { get; set; }
 
@@ -330,7 +329,6 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_currentSection != null)
 			{
 				((IShellSectionController)_currentSection).AddDisplayedPageObserver(this, OnDisplayedPageChanged);
-				_switched = true;
 			}
 		}
 
@@ -347,12 +345,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_displayedPage != null)
 			{
 				_displayedPage.PropertyChanged += OnDisplayedPagePropertyChanged;
-
-				if (!_currentSection.Stack.Contains(_displayedPage) || _switched)
-				{
-					_switched = false;
-					UpdateTabBarHidden();
-				}
+				UpdateTabBarHidden();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -245,16 +245,7 @@ namespace Xamarin.Forms.Platform.iOS
 			
 			if (String.IsNullOrWhiteSpace(text) && image == null)
 			{
-				Element item = Page;
-				while (!Application.IsApplicationOrNull(item))
-				{
-					if (item is IShellController shell)
-					{
-						image = shell.FlyoutIcon;
-						item = null;
-					}
-					item = item?.Parent;
-				}
+				image = _context.Shell.FlyoutIcon;
 			}
 
 			if (image != null)
@@ -284,9 +275,16 @@ namespace Xamarin.Forms.Platform.iOS
 			if (NavigationItem.LeftBarButtonItem != null)
 			{
 				if (String.IsNullOrWhiteSpace(image?.AutomationId))
-					NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
+				{
+					if (IsRootPage)
+						NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "OK";
+					else
+						NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = "Back";
+				}
 				else
+				{
 					NavigationItem.LeftBarButtonItem.AccessibilityIdentifier = image.AutomationId;
+				}
 
 				if (image != null)
 				{
@@ -309,7 +307,9 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else if (!isRootPage)
 			{
-				if (controller?.ParentViewController is UINavigationController navigationController)
+				if (controller?.ParentViewController is ShellSectionRenderer ssr)
+					ssr.SendPop();
+				else if (controller?.ParentViewController is UINavigationController navigationController)
 					navigationController.PopViewController(true);
 			}
 			else if(_flyoutBehavior == FlyoutBehavior.Flyout)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -77,8 +77,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		[Export("navigationBar:shouldPopItem:")]
 		[Internals.Preserve(Conditional = true)]
-		public bool ShouldPopItem(UINavigationBar navigationBar, UINavigationItem item)
-		{	
+		public bool ShouldPopItem(UINavigationBar navigationBar, UINavigationItem item) =>
+			SendPop();
+
+		internal bool SendPop()
+		{ 
 			// this means the pop is already done, nothing we can do
 			if (ViewControllers.Length < NavigationBar.Items.Length)
 				return true;


### PR DESCRIPTION
### Description of Change ###

When replacing the back button with your own image `[Export("navigationBar:shouldPopItem:")]` no longer fires on the UINavigationController so we need to trigger it as part of our own logic

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #12126 
- fixes #12144 
- fixes #6485
- fixes #12505

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
