### PR TITLE
Removed RadioButton Experimental flag

### DIFF
--- a/Xamarin.Forms.Controls/CoreGalleryPages/RadioButtonCoreGalleryPage.cs
+++ b/Xamarin.Forms.Controls/CoreGalleryPages/RadioButtonCoreGalleryPage.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Controls
 		protected override void Initialize()
 		{
 			base.Initialize();
-			Device.SetFlags(new List<string> { ExperimentalFlags.RadioButtonExperimental });
 		}
 
 		protected override void OnDisappearing()

--- a/Xamarin.Forms.Controls/GalleryPages/RadioButtonGalleries/RadioButtonGalleries.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RadioButtonGalleries/RadioButtonGalleries.cs
@@ -9,13 +9,6 @@
 
 			Title = "RadioButton Galleries";
 
-			var button = new Button
-			{
-				Text = "Enable RadioButton",
-				AutomationId = "EnableRadioButton"
-			};
-			button.Clicked += ButtonClicked;
-
 			Content = new ScrollView
 			{
 				Content = new StackLayout
@@ -23,7 +16,6 @@
 					Children =
 					{
 						descriptionLabel,
-						button,
 						GalleryBuilder.NavButton("RadioButton Group Gallery", () =>
 							new RadioButtonGroupGalleryPage(), Navigation),
 						GalleryBuilder.NavButton("RadioButton Group (Attached Property)", () =>
@@ -41,17 +33,6 @@
 					}
 				}
 			};
-		}
-
-		void ButtonClicked(object sender, System.EventArgs e)
-		{
-			var button = sender as Button;
-
-			button.Text = "RadioButton Enabled!";
-			button.TextColor = Color.Black;
-			button.IsEnabled = false;
-
-			Device.SetFlags(new[] { ExperimentalFlags.RadioButtonExperimental });
 		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/DragGestureRecognizerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DragGestureRecognizerTests.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			base.Setup();
 			Device.PlatformServices = new MockPlatformServices();
-			Device.SetFlags(new[] { ExperimentalFlags.RadioButtonExperimental });
 		}
 
 		[TearDown]

--- a/Xamarin.Forms.Core.UnitTests/DropGestureRecognizerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/DropGestureRecognizerTests.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			base.Setup();
 			Device.PlatformServices = new MockPlatformServices();
-			Device.SetFlags(new[] { ExperimentalFlags.RadioButtonExperimental });
 		}
 
 		[TearDown]

--- a/Xamarin.Forms.Core.UnitTests/RadioButtonTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RadioButtonTests.cs
@@ -5,15 +5,6 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class RadioButtonTests : BaseTestFixture
 	{
-		[SetUp]
-		public void SetUp()
-		{
-			Device.SetFlags(new[]
-			{
-				ExperimentalFlags.RadioButtonExperimental
-			});
-		}
-
 		[Test]
 		public void RadioButtonAddedToGroupGetsGroupName()
 		{

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Forms
 	{
 		internal const string ShellUWPExperimental = "Shell_UWP_Experimental";
 		internal const string MarkupExperimental = "Markup_Experimental";
-		internal const string RadioButtonExperimental = "RadioButton_Experimental";
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void VerifyFlagEnabled(

--- a/Xamarin.Forms.Core/RadioButton.cs
+++ b/Xamarin.Forms.Core/RadioButton.cs
@@ -153,8 +153,6 @@ namespace Xamarin.Forms
 
 		public RadioButton()
 		{
-			ExperimentalFlags.VerifyFlagEnabled(nameof(RadioButton), ExperimentalFlags.RadioButtonExperimental, nameof(RadioButton));
-
 			_platformConfigurationRegistry = new Lazy<PlatformConfigurationRegistry<RadioButton>>(() =>
 				new PlatformConfigurationRegistry<RadioButton>(this));
 		}


### PR DESCRIPTION
### Description of Change ###

Removed RadioButton Experimental flag.

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

It is no longer necessary to use the experimental flag to use RadioButton.

### Testing Procedure ###
Launch Core Gallery and navigate to the RadioButton Gallery. Select any sample. If can navigate to the sample, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
