### PR TITLE
Added implementation for failure handling method for WkWe…

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -664,6 +664,16 @@ namespace Xamarin.Forms.Platform.iOS
 				_renderer.UpdateCanGoBackForward();
 			}
 
+			public override void DidFailProvisionalNavigation(WKWebView webView, WKNavigation navigation, NSError error)
+			{
+				var url = GetCurrentUrl();
+				WebView.SendNavigated(
+					new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = url }, url, WebNavigationResult.Failure)
+				);
+
+				_renderer.UpdateCanGoBackForward();
+			}
+
 			public override void DidFinishNavigation(WKWebView webView, WKNavigation navigation)
 			{
 				if (webView.IsLoading)


### PR DESCRIPTION
…bview.

### Description of Change ###

Added implementation for failure handling method for `WkWebViewRenderer`. 

- `WkNavigationDelegate` has 2 methods for failure handling as can be seen [here](https://developer.apple.com/documentation/webkit/wknavigationdelegate). 

- Only one of them was implemented as can be seen from the source of `WkWebViewRenderer` [here](https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs#L588).


### Issues Resolved ### 
- fixes #12312 
- fixes #12732

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

On iOS, when loading a url in the `WebView`, if there is no internet connection available, the `WebView` should fire a [Navigated](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.webview.navigated?view=xamarin-forms) event with [WebNavigationResult.Failure](https://docs.microsoft.com/en-us/dotnet/api/xamarin.forms.webnavigationresult?view=xamarin-forms).


### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Tested with iOS 14 simulator. 

- Hook into `WebView.Navigated` event.
- Run app on iOS (simulator or device) without internet connection.
- Handler for `WebView.Navigated` should be called now.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
