### PR TITLE
When popping multiple pages remove middle pages first

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -5,6 +5,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
 {
@@ -259,9 +260,128 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(2, tab.NavigationsFired.Count);
 		}
 
+		[Test]
+		public async Task PopToRootRemovesMiddlePagesBeforePoppingVisibleModalPages()
+		{
+			Routing.RegisterRoute("ModalTestPage", typeof(ShellModalTests.ModalTestPage));
+			TestShell testShell = new TestShell(
+				CreateShellSection<NavigationMonitoringTab>(shellContentRoute: "rootpage")
+			);
+
+			var middlePage = new ContentPage();
+			var tab = (NavigationMonitoringTab)testShell.CurrentItem.CurrentItem;
+			await testShell.Navigation.PushAsync(middlePage);
+			await testShell.GoToAsync("ModalTestPage");			
+			tab.NavigationsFired.Clear();
+						
+			await testShell.GoToAsync("../..");
+			Assert.That(testShell.CurrentState.Location.ToString(),
+				Is.EqualTo($"//rootpage"));
+
+			Assert.AreEqual("OnRemovePage", tab.NavigationsFired[0]);
+			Assert.AreEqual("OnPopModal", tab.NavigationsFired[1]);
+			Assert.AreEqual(2, tab.NavigationsFired.Count);
+		}
+
+
+
+		[Test]
+		public async Task MultiplePopsRemoveMiddlePagesBeforeFinalPopWhenUsingModal()
+		{
+			Routing.RegisterRoute("ModalTestPage", typeof(ShellModalTests.ModalTestPage));
+			TestShell testShell = new TestShell(
+				CreateShellSection<NavigationMonitoringTab>(shellContentRoute: "rootpage")
+			);
+
+			var pageLeftOnStack = new ContentPage();
+			var middlePage = new ContentPage();
+			var tab = (NavigationMonitoringTab)testShell.CurrentItem.CurrentItem;
+			await testShell.Navigation.PushAsync(pageLeftOnStack);
+			await testShell.Navigation.PushAsync(middlePage);
+			await testShell.GoToAsync("ModalTestPage");
+			tab.NavigationsFired.Clear();
+
+			await testShell.GoToAsync("../..");
+
+			Assert.That(testShell.CurrentState.Location.ToString(),
+				Is.EqualTo($"//rootpage/{Routing.GetRoute(pageLeftOnStack)}"));
+
+			Assert.AreEqual("OnRemovePage", tab.NavigationsFired[0]);
+			Assert.AreEqual("OnPopModal", tab.NavigationsFired[1]);
+			Assert.AreEqual(2, tab.NavigationsFired.Count);
+		}
+
+
+		[Test]
+		public async Task SwappingOutVisiblePageDoesntRevealPreviousPage()
+		{
+			TestShell testShell = new TestShell(
+				CreateShellSection<NavigationMonitoringTab>(shellContentRoute: "rootpage")
+			);
+
+
+			testShell.RegisterPage("firstPage");
+			testShell.RegisterPage("pageToSwapIn");
+
+			var tab = (NavigationMonitoringTab)testShell.CurrentItem.CurrentItem;
+			await testShell.GoToAsync("firstPage");
+			tab.NavigationsFired.Clear();
+
+			await testShell.GoToAsync($"../pageToSwapIn");
+			Assert.That(testShell.CurrentState.Location.ToString(),
+				Is.EqualTo($"//rootpage/pageToSwapIn"));
+
+			Assert.AreEqual("OnPushAsync", tab.NavigationsFired[0]);
+			Assert.AreEqual("OnRemovePage", tab.NavigationsFired[1]);
+			Assert.AreEqual(2, tab.NavigationsFired.Count);
+		}
+
+
+		[Test]
+		public async Task MiddleRoutesAreRemovedWithoutPoppingStack()
+		{
+			TestShell testShell = new TestShell(
+				CreateShellSection<NavigationMonitoringTab>(shellContentRoute: "rootpage")
+			);
+
+			testShell.RegisterPage("firstPage");
+			testShell.RegisterPage("secondPage");
+			testShell.RegisterPage("thirdPage");
+			testShell.RegisterPage("fourthPage");
+			testShell.RegisterPage("fifthPage");
+
+			var tab = (NavigationMonitoringTab)testShell.CurrentItem.CurrentItem;
+			await testShell.GoToAsync("firstPage/secondPage/thirdPage/fourthPage/fifthPage");
+			tab.NavigationsFired.Clear();
+
+			Assert.That(testShell.CurrentState.Location.ToString(),
+				Is.EqualTo($"//rootpage/firstPage/secondPage/thirdPage/fourthPage/fifthPage"));
+
+			await testShell.GoToAsync($"//rootpage/thirdPage/fifthPage");
+			Assert.That(testShell.CurrentState.Location.ToString(),
+				Is.EqualTo($"//rootpage/thirdPage/fifthPage"));
+
+			Assert.AreEqual("OnRemovePage", tab.NavigationsFired[0]);
+			Assert.AreEqual("OnRemovePage", tab.NavigationsFired[1]);
+			Assert.AreEqual("OnRemovePage", tab.NavigationsFired[2]);
+			Assert.AreEqual(3, tab.NavigationsFired.Count);
+		}
+
 		public class NavigationMonitoringTab : Tab
 		{
 			public List<string> NavigationsFired = new List<string>();
+ 
+			public NavigationMonitoringTab()
+			{
+				Navigation = new NavigationImpl(this, Navigation);
+			}
+
+			protected override Task OnPushAsync(Page page, bool animated)
+			{
+				NavigationsFired.Add(nameof(OnPushAsync));
+				return base.OnPushAsync(page, animated);
+			}
+
 			protected override void OnRemovePage(Page page)
 			{
 				base.OnRemovePage(page);
@@ -272,6 +392,46 @@ namespace Xamarin.Forms.Core.UnitTests
 			{
 				NavigationsFired.Add(nameof(OnPopAsync));
 				return base.OnPopAsync(animated);
+			}
+
+			public class NavigationImpl : NavigationProxy
+			{
+				readonly NavigationMonitoringTab _navigationMonitoringTab;
+				readonly INavigation _navigation;
+
+				public NavigationImpl(
+					NavigationMonitoringTab navigationMonitoringTab, 
+					INavigation navigation)
+				{
+					_navigationMonitoringTab = navigationMonitoringTab;
+					_navigation = navigation;
+				}
+
+				protected override IReadOnlyList<Page> GetModalStack() => _navigation.ModalStack;
+
+				protected override IReadOnlyList<Page> GetNavigationStack() => _navigation.NavigationStack;
+
+				protected override void OnInsertPageBefore(Page page, Page before) => _navigation.InsertPageBefore(page, before);
+
+				protected override Task<Page> OnPopAsync(bool animated) => _navigation.PopAsync(animated);
+
+				protected override Task<Page> OnPopModal(bool animated)
+				{
+					_navigationMonitoringTab.NavigationsFired.Add(nameof(OnPopModal));
+					return _navigation.PopModalAsync(animated);
+				}
+
+				protected override Task OnPopToRootAsync(bool animated) => _navigation.PopToRootAsync(animated);
+				
+				protected override Task OnPushAsync(Page page, bool animated) => _navigation.PushAsync(page, animated);
+
+				protected override Task OnPushModal(Page modal, bool animated)
+				{
+					_navigationMonitoringTab.NavigationsFired.Add(nameof(OnPushModal));
+					return _navigation.PushModalAsync(modal, animated);
+				}
+
+				protected override void OnRemovePage(Page page) => _navigation.RemovePage(page);
 			}
 		}
 

--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -304,6 +304,31 @@ namespace Xamarin.Forms.Core.UnitTests
 				shellItems.ForEach(x => Items.Add(x));
 			}
 
+			public ContentPage RegisterPage(string route)
+			{
+				ContentPage page = new ContentPage();
+				RegisterPage(route, page);
+				return page;
+			}
+
+			public void RegisterPage(string route, ContentPage contentPage)
+			{
+				Routing.SetRoute(contentPage, route);
+				Routing.RegisterRoute(route, new ConcretePageFactory(contentPage));
+			}
+
+			public class ConcretePageFactory : RouteFactory
+			{
+				ContentPage _contentPage;
+
+				public ConcretePageFactory(ContentPage contentPage)
+				{
+					_contentPage = contentPage;
+				}
+
+				public override Element GetOrCreate() => _contentPage;
+			}
+
 			public Action<ShellNavigatedEventArgs> OnNavigatedHandler { get; set; }
 			protected override void OnNavigated(ShellNavigatedEventArgs args)
 			{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -602,6 +602,14 @@ namespace Xamarin.Forms
 					// - or route contains no global route requests
 					if (navigatedToNewShellElement || navigationRequest.Request.GlobalRoutes.Count == 0)
 					{
+						// remove all non visible pages first so the transition just smoothly goes from
+						// currently visible modal to base page
+						if(navigationRequest.Request.GlobalRoutes.Count == 0)
+						{
+							for (int i = currentShellSection.Stack.Count - 1; i >= 1; i--)
+								currentShellSection.Navigation.RemovePage(currentShellSection.Stack[i]);
+						}
+
 						await currentShellSection.PopModalStackToPage(null, animate);
 					}
 				}

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -565,13 +565,6 @@ namespace Xamarin.Forms
 				{
 					modalPageStacks.Add(content);
 				}
-				/*else if (modalPageStacks.Count > 0)
-				{
-					if (modalPageStacks[modalPageStacks.Count - 1] is NavigationPage navigationPage)
-						await navigationPage.Navigation.PushAsync(content, animate ?? IsNavigationAnimated(content));
-					else
-						throw new InvalidOperationException($"Shell cannot push a page to the following type: {modalPageStacks[modalPageStacks.Count - 1]}. The visible modal page needs to be a NavigationPage");
-				}*/
 				else
 				{
 					nonModalPageStacks.Add(content);

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -332,9 +332,8 @@ namespace Xamarin.Forms
 			return (ShellSection)(ShellContent)page;
 		}
 
-		async Task<int> PrepareCurrentStackForBeingReplaced(NavigationRequest request, IDictionary<string, string> queryData, bool? animate, List<string> globalRoutes)
+		async Task PrepareCurrentStackForBeingReplaced(NavigationRequest request, IDictionary<string, string> queryData, bool? animate, List<string> globalRoutes)
 		{
-			int whereToStartNavigation = 0;
 			string route = "";
 			List<Page> navStack = null;
 
@@ -394,7 +393,6 @@ namespace Xamarin.Forms
 
 				for (int i = 0; i < globalRoutes.Count; i++)
 				{
-					whereToStartNavigation = i;
 					bool isLast = i == globalRoutes.Count - 1;
 					route = globalRoutes[i];
 
@@ -416,7 +414,6 @@ namespace Xamarin.Forms
 							// if the routes do match and this is the last in the loop
 							// pop everything after this route
 							popCount = i + 2;
-							whereToStartNavigation++;
 							Shell.ApplyQueryAttributes(navPage, queryData, isLast);
 
 							// If we're not on the last loop of the stack then continue
@@ -465,8 +462,6 @@ namespace Xamarin.Forms
 					}
 				}
 			}
-
-			return whereToStartNavigation;
 
 			void RemoveExcessPathsWithinTheRoute()
 			{
@@ -544,9 +539,6 @@ namespace Xamarin.Forms
 			List<Page> modalPageStacks = new List<Page>();
 			List<Page> nonModalPageStacks = new List<Page>();
 			var currentNavStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
-
-			//if (Navigation?.ModalStack?.Count > 0)
-			//	modalPageStacks.AddRange(Navigation.ModalStack);
 
 			// populate global routes and build modal stacks
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -332,34 +332,73 @@ namespace Xamarin.Forms
 			return (ShellSection)(ShellContent)page;
 		}
 
-		internal async Task GoToAsync(NavigationRequest request, IDictionary<string, string> queryData, bool? animate)
+		async Task<int> PrepareCurrentStackForBeingReplaced(NavigationRequest request, IDictionary<string, string> queryData, bool? animate, List<string> globalRoutes)
 		{
-			List<string> globalRoutes = request.Request.GlobalRoutes;
-			List<Page> navStack = null;
-			string route = String.Empty;
-
-			if (globalRoutes == null || globalRoutes.Count == 0)
-			{
-				if (_navStack.Count == 2)
-					await OnPopAsync(animate ?? false);
-				else
-					await OnPopToRootAsync(animate ?? false);
-
-				return;
-			}
-
 			int whereToStartNavigation = 0;
+			string route = "";
+			List<Page> navStack = null;
 
 			// Pop the stack down to where it no longer matches 
 			if (request.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
 			{
+				// If there's a visible Modal Stack then let's remove the pages under it that
+				// are going to be popped so they never become visible and never fire OnAppearing
+				if (Navigation.ModalStack.Count > 0)
+				{
+					var navStackCopy = new List<Page>(_navStack);
+					for (int i = 1; i < navStackCopy.Count; i++)
+					{
+						var routeToRemove = Routing.GetRoute(navStackCopy[i]);
+						if (i > globalRoutes.Count || routeToRemove != globalRoutes[i - 1])
+						{
+							OnRemovePage(navStackCopy[i]);
+						}
+					}
+				}
+
+				RemoveExcessPathsWithinTheRoute();
+
+
+				// now that we've removed all the extra pages let's find the page on the stack that 
+				// will be visible so we can push that as the first visible thing
+				// If we already have a modal stack then we don't worry about doing this
+				// Modal pages can't be selectively inserted/removed so this only matters when there are
+				// no modal pages present
+				if (Navigation.ModalStack.Count == 0)
+				{
+					List<Page> pagesToInsert = new List<Page>();
+					for (int i = 0; i < globalRoutes.Count; i++)
+					{
+						int navIndex = i + 1;
+						// Routes match so don't do anything
+						if (navIndex < _navStack.Count && Routing.GetRoute(_navStack[navIndex]) == globalRoutes[i])
+						{
+							continue;
+						}
+
+						var page = GetOrCreateFromRoute(globalRoutes[i], queryData, i == globalRoutes.Count - 1);
+						if (IsModal(page))
+						{
+							await Navigation.PushModalAsync(page, IsNavigationAnimated(page));
+							break;
+						}
+						else
+						{
+							pagesToInsert.Add(page);
+						}
+					}
+
+					await PushStackOfPages(pagesToInsert, animate);
+					RemoveExcessPathsWithinTheRoute();
+				}
+
 				for (int i = 0; i < globalRoutes.Count; i++)
 				{
 					whereToStartNavigation = i;
 					bool isLast = i == globalRoutes.Count - 1;
 					route = globalRoutes[i];
 
-					navStack = BuildFlattenedNavigationStack(new List<Page>(_navStack), Navigation?.ModalStack);
+					navStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 
 					// if the navStack count is one that means there is nothing pushed
 					if (navStack.Count == 1)
@@ -387,6 +426,7 @@ namespace Xamarin.Forms
 						}
 
 						IsPoppingModalStack = true;
+
 						while (navStack.Count > popCount && Navigation.ModalStack.Count > 0)
 						{
 							bool isAnimated = animate ?? IsNavigationAnimated(navStack[navStack.Count - 1]);
@@ -399,11 +439,13 @@ namespace Xamarin.Forms
 								await Navigation.ModalStack[Navigation.ModalStack.Count - 1].Navigation.PopAsync(isAnimated);
 							}
 
-							navStack = BuildFlattenedNavigationStack(new List<Page>(_navStack), Navigation?.ModalStack);
+							navStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 						}
 
 						while (_navStack.Count > popCount)
 						{
+							// Remove middle pages before doing a pop on the visible page so that the transition
+							// is seamless
 							if ((_navStack.Count - popCount) == 1)
 							{
 								bool isAnimated = animate ?? IsNavigationAnimated(_navStack[_navStack.Count - 1]);
@@ -415,105 +457,199 @@ namespace Xamarin.Forms
 							}
 						}
 
-						navStack = BuildFlattenedNavigationStack(new List<Page>(_navStack), Navigation?.ModalStack);
+						navStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 
 						IsPoppingModalStack = false;
 
 						break;
 					}
-
-					var content = Routing.GetOrCreateContent(route) as Page;
-					if (content == null)
-						break;
-
-					Shell.ApplyQueryAttributes(content, queryData, isLast);
 				}
 			}
 
+			return whereToStartNavigation;
+
+			void RemoveExcessPathsWithinTheRoute()
+			{
+				// locate middle routes that were removed
+				// //route/page1/page2 => //route/page2
+				// Let's just remove page1 instead of pop, pop, add
+				for (int i = 0; i < globalRoutes.Count; i++)
+				{
+					int foundMatchAt = -1;
+					for (int j = 1; j < _navStack.Count; j++)
+					{
+						if (Routing.GetRoute(_navStack[j]) == globalRoutes[i])
+						{
+							foundMatchAt = j;
+							break;
+						}
+					}
+
+					// If we found a matching route then let's remove all the middle pages
+					for (int j = foundMatchAt - 1; j >= (i + 1); j--)
+					{
+						OnRemovePage(_navStack[j]);
+					}
+				}
+			}
+		}
+
+		List<Page> BuildFlattenedNavigationStack(List<Page> startingList, IReadOnlyList<Page> modalStack)
+		{
+			startingList = startingList.ToList();
+			if (modalStack == null)
+				return startingList;
+
+			for (int i = 0; i < modalStack.Count; i++)
+			{
+				startingList.Add(modalStack[i]);
+				for (int j = 1; j < modalStack[i].Navigation.NavigationStack.Count; j++)
+				{
+					startingList.Add(modalStack[i].Navigation.NavigationStack[j]);
+				}
+			}
+
+			return startingList;
+		}
+
+		Page GetOrCreateFromRoute(string route, IDictionary<string, string> queryData, bool isLast)
+		{
+			var content = Routing.GetOrCreateContent(route) as Page;
+			if (content == null)
+			{
+				Internals.Log.Warning(nameof(Shell), $"Failed to Create Content For: {route}");
+			}
+
+			Shell.ApplyQueryAttributes(content, queryData, isLast);
+			return content;
+		}
+
+		internal async Task GoToAsync(NavigationRequest request, IDictionary<string, string> queryData, bool? animate)
+		{
+			List<string> globalRoutes = request.Request.GlobalRoutes;
+			string route = String.Empty;
+
+			if (globalRoutes == null || globalRoutes.Count == 0)
+			{
+				if (_navStack.Count == 2)
+					await OnPopAsync(animate ?? false);
+				else
+					await OnPopToRootAsync(animate ?? false);
+
+				return;
+			}
+
+			await PrepareCurrentStackForBeingReplaced(request, queryData, animate, globalRoutes);
+
 			List<Page> modalPageStacks = new List<Page>();
 			List<Page> nonModalPageStacks = new List<Page>();
+			var currentNavStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 
-			if (Navigation?.ModalStack?.Count > 0)
-				modalPageStacks.AddRange(Navigation.ModalStack);
+			//if (Navigation?.ModalStack?.Count > 0)
+			//	modalPageStacks.AddRange(Navigation.ModalStack);
 
 			// populate global routes and build modal stacks
+
+			// If the currentNavStack is larger than _navStack then we have modal pages
+			bool weveGoneTotalModal = currentNavStack.Count > _navStack.Count;
+			int whereToStartNavigation = 0;
+
+			if(request.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
+				whereToStartNavigation = currentNavStack.Count - 1;
+
 			for (int i = whereToStartNavigation; i < globalRoutes.Count; i++)
 			{
 				bool isLast = i == globalRoutes.Count - 1;
 				route = globalRoutes[i];
-				var content = Routing.GetOrCreateContent(route) as Page;
+				var content = GetOrCreateFromRoute(route, queryData, isLast);
 				if (content == null)
 				{
 					break;
 				}
 
-				var isModal = (Shell.GetPresentationMode(content) & PresentationMode.Modal) == PresentationMode.Modal;
+				weveGoneTotalModal = weveGoneTotalModal || IsModal(content);
 
-				Shell.ApplyQueryAttributes(content, queryData, isLast);
-				if (isModal)
+				if (weveGoneTotalModal)
 				{
 					modalPageStacks.Add(content);
 				}
-				else if (modalPageStacks.Count > 0)
+				/*else if (modalPageStacks.Count > 0)
 				{
 					if (modalPageStacks[modalPageStacks.Count - 1] is NavigationPage navigationPage)
 						await navigationPage.Navigation.PushAsync(content, animate ?? IsNavigationAnimated(content));
 					else
 						throw new InvalidOperationException($"Shell cannot push a page to the following type: {modalPageStacks[modalPageStacks.Count - 1]}. The visible modal page needs to be a NavigationPage");
-				}
+				}*/
 				else
 				{
 					nonModalPageStacks.Add(content);
 				}
 			}
 
-			for (int i = Navigation.ModalStack.Count; i < modalPageStacks.Count; i++)
+			// Check if we have an active Navigation Page
+			NavigationPage activeModalNavigationPage = null;
+			for (int i = Navigation.ModalStack.Count - 1; i >= 0; i--)
+			{
+				if (Navigation.ModalStack[i] is NavigationPage np)
+				{
+					activeModalNavigationPage = np;
+					break;
+				}
+			}
+
+			for (int i = 0; i < modalPageStacks.Count; i++)
 			{
 				bool isLast = i == modalPageStacks.Count - 1;
-				bool isAnimated = animate ?? IsNavigationAnimated(modalPageStacks[i]);
+				var modalPage = modalPageStacks[i];
+				bool isAnimated = animate ?? IsNavigationAnimated(modalPage);
 				IsPushingModalStack = !isLast;
-				await ((NavigationImpl)Navigation).PushModalAsync(modalPageStacks[i], isAnimated);
-			}
 
-			for (int i = nonModalPageStacks.Count - 1; i >= 0; i--)
-			{
-				bool isLast = i == nonModalPageStacks.Count - 1;
-
-				if (isLast)
+				if (modalPage is NavigationPage np)
 				{
-					bool isAnimated = animate ?? IsNavigationAnimated(nonModalPageStacks[i]);
-					await OnPushAsync(nonModalPageStacks[i], isAnimated);
+					await Navigation.PushModalAsync(modalPage, isAnimated);
+					activeModalNavigationPage = np;
 				}
 				else
-					Navigation.InsertPageBefore(nonModalPageStacks[i], nonModalPageStacks[nonModalPageStacks.Count - 1]);
+				{
+					if(activeModalNavigationPage != null)
+						await activeModalNavigationPage.Navigation.PushAsync(modalPage, animate ?? IsNavigationAnimated(modalPage));
+					else
+						await Navigation.PushModalAsync(modalPage, isAnimated);
+				}
 			}
+
+			await PushStackOfPages(nonModalPageStacks, animate);
 
 			if (Parent?.Parent is IShellController shell)
 			{
 				shell.UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
 			}
+		}
 
-			bool IsNavigationAnimated(BindableObject bo)
+		async Task PushStackOfPages(List<Page> pages, bool? animate)
+		{
+			for (int i = pages.Count - 1; i >= 0; i--)
 			{
-				return (Shell.GetPresentationMode(bo) & PresentationMode.NotAnimated) != PresentationMode.NotAnimated;
-			}
+				bool isLast = i == pages.Count - 1;
 
-			List<Page> BuildFlattenedNavigationStack(List<Page> startingList, IReadOnlyList<Page> modalStack)
-			{
-				if (modalStack == null)
-					return startingList;
-
-				for (int i = 0; i < modalStack.Count; i++)
+				if (isLast)
 				{
-					startingList.Add(modalStack[i]);
-					for (int j = 1; j < modalStack[i].Navigation.NavigationStack.Count; j++)
-					{
-						startingList.Add(modalStack[i].Navigation.NavigationStack[j]);
-					}
+					bool isAnimated = animate ?? IsNavigationAnimated(pages[i]);
+					await OnPushAsync(pages[i], isAnimated);
 				}
-
-				return startingList;
+				else
+					Navigation.InsertPageBefore(pages[i], pages[i + 1]);
 			}
+		}
+
+		bool IsModal(BindableObject bo)
+		{
+			return (Shell.GetPresentationMode(bo) & PresentationMode.Modal) == PresentationMode.Modal;
+		}
+
+		bool IsNavigationAnimated(BindableObject bo)
+		{
+			return (Shell.GetPresentationMode(bo) & PresentationMode.NotAnimated) != PresentationMode.NotAnimated;
 		}
 
 		internal void SendStructureChanged()

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -387,7 +387,7 @@ namespace Xamarin.Forms
 						}
 
 						IsPoppingModalStack = true;
-						while (navStack.Count > popCount)
+						while (navStack.Count > popCount && Navigation.ModalStack.Count > 0)
 						{
 							bool isAnimated = animate ?? IsNavigationAnimated(navStack[navStack.Count - 1]);
 							if (Navigation.ModalStack.Contains(navStack[navStack.Count - 1]))
@@ -398,13 +398,25 @@ namespace Xamarin.Forms
 							{
 								await Navigation.ModalStack[Navigation.ModalStack.Count - 1].Navigation.PopAsync(isAnimated);
 							}
-							else
-							{
-								await OnPopAsync(isAnimated);
-							}
 
 							navStack = BuildFlattenedNavigationStack(new List<Page>(_navStack), Navigation?.ModalStack);
 						}
+
+						while (_navStack.Count > popCount)
+						{
+							if ((_navStack.Count - popCount) == 1)
+							{
+								bool isAnimated = animate ?? IsNavigationAnimated(_navStack[_navStack.Count - 1]);
+								await OnPopAsync(isAnimated);
+							}
+							else
+							{
+								OnRemovePage(_navStack[_navStack.Count - 2]);
+							}
+						}
+
+						navStack = BuildFlattenedNavigationStack(new List<Page>(_navStack), Navigation?.ModalStack);
+
 						IsPoppingModalStack = false;
 
 						break;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRendererBase.cs
@@ -163,11 +163,14 @@ namespace Xamarin.Forms.Platform.Android
 				case ShellNavigationSource.Remove:
 					if (_fragmentMap.TryGetValue(page, out var removeFragment))
 					{
-						if (removeFragment.Fragment.IsAdded)
+						if (removeFragment.Fragment.IsAdded && !isForCurrentTab && removeFragment != _currentFragment)
 							RemoveFragment(removeFragment.Fragment);
 						_fragmentMap.Remove(page);
 					}
-					return Task.FromResult(true);
+
+					if (!isForCurrentTab && removeFragment != _currentFragment)
+						return Task.FromResult(true);
+					break;
 
 				case ShellNavigationSource.PopToRoot:
 					RemoveAllPushedPages(shellSection, isForCurrentTab);
@@ -231,6 +234,7 @@ namespace Xamarin.Forms.Platform.Android
 				case ShellNavigationSource.Pop:
 				case ShellNavigationSource.PopToRoot:
 				case ShellNavigationSource.ShellSectionChanged:
+				case ShellNavigationSource.Remove:
 					trackFragment = _currentFragment;
 
 					if (_currentFragment != null)

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					case ShellNavigationSource.Insert:
 						{
-							var pageIndex = FormsNavigationStack.IndexOf(page);
+							var pageIndex = ShellSection.Stack.ToList().IndexOf(page);
 							if (pageIndex == Frame.BackStack.Count - 1)
 								Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
 							else

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -1,6 +1,10 @@
-﻿using System;
+using System;
+using System.Collections.Generic;
 using System.ComponentModel;
+using System.Linq;
+using Windows.ApplicationModel.Contacts;
 using Windows.Foundation.Metadata;
+using Windows.Media.Devices.Core;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using Windows.UI.Xaml.Media.Animation;
@@ -17,7 +21,7 @@ namespace Xamarin.Forms.Platform.UWP
 		ShellContent CurrentContent;
 		ShellSection ShellSection;
 		IShellSectionController ShellSectionController => ShellSection;
-
+		List<Page> FormsNavigationStack;
 		public ShellSectionRenderer()
 		{
 			Xamarin.Forms.Shell.VerifyShellUWPFlagEnabled(nameof(ShellSectionRenderer));
@@ -40,6 +44,7 @@ namespace Xamarin.Forms.Platform.UWP
 			Resources["TopNavigationViewItemForeground"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultForegroundColor);
 			Resources["TopNavigationViewItemForegroundSelected"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultForegroundColor);
 			Resources["NavigationViewSelectionIndicatorForeground"] = new Windows.UI.Xaml.Media.SolidColorBrush(ShellRenderer.DefaultForegroundColor);
+			FormsNavigationStack = new List<Page>();
 		}
 
 		void OnShellSectionRendererSizeChanged(object sender, Windows.UI.Xaml.SizeChangedEventArgs e)
@@ -111,8 +116,13 @@ namespace Xamarin.Forms.Platform.UWP
 
 		internal void NavigateToContent(ShellNavigationSource source, ShellContent shellContent, Page page, bool animate = true)
 		{
-			Page nextPage = (ShellSection as IShellSectionController)
-				.PresentedPage ?? ((IShellContentController)shellContent)?.GetOrCreateContent();
+			Page nextPage = null;
+
+			if (source == ShellNavigationSource.PopToRoot)
+				nextPage = (shellContent as IShellContentController).GetOrCreateContent();
+			else
+				nextPage = (ShellSection as IShellSectionController)
+					.PresentedPage ?? ((IShellContentController)shellContent)?.GetOrCreateContent();
 
 			if (CurrentContent != null && Page != null)
 			{
@@ -128,7 +138,14 @@ namespace Xamarin.Forms.Platform.UWP
 				switch (source)
 				{
 					case ShellNavigationSource.Insert:
-						break;
+						{
+							var pageIndex = FormsNavigationStack.IndexOf(page);
+							if (pageIndex == Frame.BackStack.Count - 1)
+								Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
+							else
+								Frame.BackStack.Insert(pageIndex, new PageStackEntry(typeof(ShellPageWrapper), null, GetTransitionInfo(source)));
+							break;
+						}
 					case ShellNavigationSource.Pop:
 						Frame.GoBack(GetTransitionInfo(source));
 						break;
@@ -138,11 +155,21 @@ namespace Xamarin.Forms.Platform.UWP
 						Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
 						break;
 					case ShellNavigationSource.PopToRoot:
-						while(Frame.BackStackDepth > 1)
-							Frame.GoBack(GetTransitionInfo(source));
+						while (Frame.BackStackDepth > 2)
+						{
+							Frame.BackStack.RemoveAt(1);
+						}
+						Frame.GoBack(GetTransitionInfo(source));
 						break;
 					case ShellNavigationSource.Remove:
-						break;
+						{
+							var pageIndex = FormsNavigationStack.IndexOf(page);
+							if (pageIndex == Frame.BackStack.Count - 1)
+								Frame.GoBack(GetTransitionInfo(source));
+							else
+								Frame.BackStack.RemoveAt(pageIndex);
+							break;
+						}
 					case ShellNavigationSource.ShellItemChanged:
 						break;
 					case ShellNavigationSource.ShellSectionChanged:
@@ -160,6 +187,7 @@ namespace Xamarin.Forms.Platform.UWP
 				}
 
 				wrapper.LoadPage();
+				FormsNavigationStack = ShellSection.Stack.ToList();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -421,7 +421,9 @@ namespace Xamarin.Forms.Platform.iOS
 					OnPopRequested(e);
 				}
 
-				ViewControllers = ViewControllers.Remove(viewController);
+				if(ViewControllers.Contains(viewController))
+					ViewControllers = ViewControllers.Remove(viewController);
+
 				DisposePage(page);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

This PR adds a number of optimization for interpreting a new route and trying to minimize the amount of operations that happen 


- When popping multiple pages on Shell via `GotoAsync("../..")` just remove the middle pages before popping the currently visible page. This way OnAppearing won't fire on pages being removed and they won't appear and then disappear
- If you're at `/page1/page2' and then you want to navigate to `/page1/page3' it will now first push page3 and then remove page2 so that you never see page 1
- If you're at `/page1/page2/page3` and you navigate to `/page1/page3' it'll just remove page2 


### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
Users will no longer see the middle when the user is requesting that multiple pages pop. The middle pages will no longer throw "OnAppearing" and then "OnDisappearing" as they are popped

### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
