### PR TITLE
[UWP] Fix CarouselView scroll issue

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -399,6 +399,9 @@ namespace Xamarin.Forms.Platform.UWP
 					Style = (Windows.UI.Xaml.Style)UWPApp.Current.Resources["HorizontalCarouselListStyle"],
 					ItemsPanel = (ItemsPanelTemplate)UWPApp.Current.Resources["HorizontalListItemsPanel"]
 				};
+
+				ScrollViewer.SetHorizontalScrollBarVisibility(listView, WScrollBarVisibility.Auto);
+				ScrollViewer.SetVerticalScrollBarVisibility(listView, WScrollBarVisibility.Disabled);
 			}
 			else
 			{
@@ -406,6 +409,9 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					Style = (Windows.UI.Xaml.Style)UWPApp.Current.Resources["VerticalCarouselListStyle"]
 				};
+
+				ScrollViewer.SetHorizontalScrollBarVisibility(listView, WScrollBarVisibility.Disabled);
+				ScrollViewer.SetVerticalScrollBarVisibility(listView, WScrollBarVisibility.Auto);
 			}
 
 			listView.Padding = new Windows.UI.Xaml.Thickness(Carousel.PeekAreaInsets.Left, Carousel.PeekAreaInsets.Top, Carousel.PeekAreaInsets.Right, Carousel.PeekAreaInsets.Bottom);


### PR DESCRIPTION
# Description of Change ###

The CarouselView use in UWP the `FormsListView` control. In the constructor of the control we are setting the default scrollbar behavior. This PRs applies changes to set the correct scroll behavior using a Horizontal and Vertical CarouselView.

### Issues Resolved ### 

- fixes #12349

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
 Not applied

### Testing Procedure ###
Launch Core Gallery and navigate to the CarouselView Gallery. Select the Horizontal/Vertical CarouselView Gallery and try to swipe to the next item. If can navigate to the next item, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
