### PR TITLE
Fix layout cycle in ViewToRendererConverter

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
+++ b/Xamarin.Forms.Platform.UAP/ViewToRendererConverter.cs
@@ -115,8 +115,6 @@ namespace Xamarin.Forms.Platform.UWP
 					result = new Windows.Foundation.Size(request.Width, request.Height);
 				}
 
-				Layout.LayoutChildIntoBoundingRegion(_view, new Rectangle(0, 0, result.Width, result.Height));
-
 				FrameworkElement?.Measure(availableSize);
 
 				return result;


### PR DESCRIPTION
### Description of Change

ViewToRendererConverter was triggering a cross-platform layout pass from its MeasureOverride ... override, which resulted in a layout cycle. This change removes that layout pass, which appears to now be unnecessary. 

The original layout call was added here:
https://github.com/xamarin/Xamarin.Forms/pull/2586/files#diff-70db430b24c262668bdb1ee9c4ad76ccR96

The call was added to address TitleView layout issues which I _suspect_ may have been a symptom of deferring layout changes on the UI thread; or they may have been a symptom of some other bug entirely. Either way, after removing this line the TitleView layout still appears to be correct.


### Issues Resolved ### 

- fixes failing test 57910 on UWP

### API Changes ###

None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test 57910

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
