### PR TITLE
[macOS] Change Bordered in NSButton in case necessary

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12222.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12222.cs
@@ -1,0 +1,89 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12222, "[Bug] [MacOS] Buttons don't render correctly when given a HeightRequest", PlatformAffected.macOS)]
+	public class Issue12222 : TestContentPage
+	{
+		public Issue12222()
+		{
+		}
+
+		protected override void Init()
+		{
+			var layout = new StackLayout();
+
+			var defaultLabel = new Label
+			{
+				Text = "Default Button"
+			};
+
+			var defaultButton = new Button
+			{
+				Text = "Button"
+			};
+
+			var heightLabel = new Label
+			{
+				Text = "Button using a custom HeightRequest (60)"
+			};
+
+			var heightButton = new Button
+			{
+				HeightRequest = 60,
+				Text = "Button"
+			};
+
+			var backgroundLabel = new Label
+			{
+				Text = "Button using a custom HeightRequest (60)"
+			};
+
+			var backgroundButton = new Button
+			{
+				HeightRequest = 60,
+				BackgroundColor = Color.OrangeRed,
+				Text = "Button"
+			};
+
+			var borderLabel = new Label
+			{
+				Text = "Button using a custom HeightRequest (60)"
+			};
+
+			var borderButton = new Button
+			{
+				HeightRequest = 60,
+				BackgroundColor = Color.OrangeRed,
+				BorderColor = Color.YellowGreen,
+				BorderWidth = 2,
+				Text = "Button"
+			};
+
+			layout.Children.Add(defaultLabel);
+			layout.Children.Add(defaultButton);
+
+			layout.Children.Add(heightLabel);
+			layout.Children.Add(heightButton);
+
+			layout.Children.Add(backgroundButton);
+			layout.Children.Add(backgroundButton);
+
+			layout.Children.Add(borderLabel);
+			layout.Children.Add(borderButton);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1487,6 +1487,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12134.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11963.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12222.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ButtonRenderer.cs
@@ -96,7 +96,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					var btn = new FormsNSButton();
 					btn.SetButtonType(NSButtonType.MomentaryPushIn);
-					btn.BezelStyle = NSBezelStyle.RoundRect;
+					btn.BezelStyle = NSBezelStyle.TexturedSquare;
+			
 					btn.Pressed += HandleButtonPressed;
 					btn.Released += HandleButtonReleased;
 					SetNativeControl(btn);
@@ -117,7 +118,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			base.OnElementPropertyChanged(sender, e);
 
-			if (e.PropertyName == Button.TextProperty.PropertyName || 
+			if (e.PropertyName == Button.TextProperty.PropertyName ||
 				e.PropertyName == Button.TextColorProperty.PropertyName ||
 				e.PropertyName == Button.TextTransformProperty.PropertyName)
 				UpdateText();
@@ -167,6 +168,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				else
 					Control.Cell.BackgroundColor = backgroundColor.ToNSColor();
 			}
+
+			UpdateBordered();
 		}
 
 		void UpdateBorder()
@@ -227,6 +230,13 @@ namespace Xamarin.Forms.Platform.MacOS
 		void UpdateCharacterSpacing()
 		{
 			Control.AttributedTitle = Control.AttributedTitle.AddCharacterSpacing(Element.Text ?? string.Empty, Element.CharacterSpacing);
+		}
+
+		void UpdateBordered()
+		{
+			bool hasBackground = Element.BackgroundColor != Color.Default || !Brush.IsNullOrEmpty(Element.Background);
+			bool hasBorder = Element.BorderColor != Color.Default && Element.BorderWidth > 0;
+			Control.Bordered = !(hasBackground || hasBorder);
 		}
 
 		void HandleButtonPressed()


### PR DESCRIPTION
### Description of Change ###

Change Bordered in NSButton in case necessary (using a background a border color).

### Issues Resolved ### 

- fixes #12222 

### API Changes ###

 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="664" alt="Captura de pantalla 2020-10-05 a las 17 57 46" src="https://user-images.githubusercontent.com/6755973/95103381-d1885a00-0734-11eb-89b7-a89667047a19.png">


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12222. If the button renders correctly in all cases, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
