### PR TITLE
[UWP] Allow to open ListView ContextActions using Ctrl+O 

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
+using Windows.System;
 using Windows.UI.Input;
 using Windows.UI.Xaml;
 using Windows.UI.Xaml.Automation.Peers;
@@ -110,6 +111,14 @@ namespace Xamarin.Forms.Platform.UWP
 			SetDefaultSwitchColor();
 
 			return result;
+		}
+
+		protected override void OnProcessKeyboardAccelerators(ProcessKeyboardAcceleratorEventArgs args)
+		{
+			base.OnProcessKeyboardAccelerators(args);
+
+			if (Cell.HasContextActions && args.Modifiers == VirtualKeyModifiers.Control && args.Key == VirtualKey.)
+				OpenContextMenu();
 		}
 
 		ListView GetListView()

--- a/Xamarin.Forms.Platform.UAP/CellControl.cs
+++ b/Xamarin.Forms.Platform.UAP/CellControl.cs
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			base.OnProcessKeyboardAccelerators(args);
 
-			if (Cell.HasContextActions && args.Modifiers == VirtualKeyModifiers.Control && args.Key == VirtualKey.)
+			if (Cell.HasContextActions && args.Modifiers == VirtualKeyModifiers.Control && args.Key == VirtualKey.O)
 				OpenContextMenu();
 		}
 


### PR DESCRIPTION
### Description of Change ###

Allow to open ListView ContextActions using Ctrl+O.

Perhaps working in .NET MAUI in the parity of Desktop APIs, we can cover in a better way these cases also allowing to define the Key and KeyModifiers. If we consider that this PR does not make sense without allowing to set a custom Key + KeyModifier, it can be closed.

### Issues Resolved ### 

- fixes #12355 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Open Core Gallery and navigate to the ContextActions sample. Use the Tab to se the focus on the ListView. Then can use the arrow keys to move to a specific cell. Press Tab and then, Ctrl+O to open the contextual menu. If the Flyout menu is opened, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
