### PR TITLE
[iOS] Fix crash using OnPlatform if no default Padding given

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12371.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12371.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"      
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue12371"
+    Title="Issue 12371">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Style x:Key="BackgroundMenu" TargetType="Button">
+                <Setter Property="Padding" Value="{OnPlatform UWP=2}" />
+            </Style>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Without exceptions the test has passed."/>
+        <Button
+            Text="Issue 12371"
+            Style="{StaticResource BackgroundMenu}"/>
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12371.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12371.xaml.cs
@@ -1,0 +1,21 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 12371, "[Bug] OnPlatform crashes app on iOS if no default value given",
+		PlatformAffected.iOS)]
+	public partial class Issue12371 : TestContentPage
+	{
+		public Issue12371()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1487,6 +1487,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12134.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11963.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12371.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1769,6 +1770,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11496.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12371.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Core/PaddingElement.cs
+++ b/Xamarin.Forms.Core/PaddingElement.cs
@@ -4,22 +4,22 @@
 	{
 		public static readonly BindableProperty PaddingProperty =
 			BindableProperty.Create(nameof(IPaddingElement.Padding), typeof(Thickness), typeof(IPaddingElement), default(Thickness),
-									propertyChanged: OnPaddingPropertyChanged,
-									defaultValueCreator: PaddingDefaultValueCreator);
+				propertyChanged: OnPaddingPropertyChanged,
+				defaultValueCreator: PaddingDefaultValueCreator);
 
 		static void OnPaddingPropertyChanged(BindableObject bindable, object oldValue, object newValue)
 		{
-			((IPaddingElement)bindable).OnPaddingPropertyChanged((Thickness)oldValue, (Thickness)newValue);
+			(bindable as IPaddingElement)?.OnPaddingPropertyChanged((Thickness)oldValue, (Thickness)newValue);
 		}
 
 		static object PaddingDefaultValueCreator(BindableObject bindable)
 		{
-			return ((IPaddingElement)bindable).PaddingDefaultValueCreator();
+			return (bindable as IPaddingElement)?.PaddingDefaultValueCreator();
 		}
 
 		public static readonly BindableProperty PaddingLeftProperty =
 			BindableProperty.Create("PaddingLeft", typeof(double), typeof(IPaddingElement), default(double),
-									propertyChanged: OnPaddingLeftChanged);
+				propertyChanged: OnPaddingLeftChanged);
 
 		static void OnPaddingLeftChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -30,7 +30,7 @@
 
 		public static readonly BindableProperty PaddingTopProperty =
 			BindableProperty.Create("PaddingTop", typeof(double), typeof(IPaddingElement), default(double),
-									propertyChanged: OnPaddingTopChanged);
+				propertyChanged: OnPaddingTopChanged);
 
 		static void OnPaddingTopChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -41,7 +41,7 @@
 
 		public static readonly BindableProperty PaddingRightProperty =
 			BindableProperty.Create("PaddingRight", typeof(double), typeof(IPaddingElement), default(double),
-									propertyChanged: OnPaddingRightChanged);
+				propertyChanged: OnPaddingRightChanged);
 
 		static void OnPaddingRightChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -52,7 +52,7 @@
 
 		public static readonly BindableProperty PaddingBottomProperty =
 			BindableProperty.Create("PaddingBottom", typeof(double), typeof(IPaddingElement), default(double),
-									propertyChanged: OnPaddingBottomChanged);
+				propertyChanged: OnPaddingBottomChanged);
 
 		static void OnPaddingBottomChanged(BindableObject bindable, object oldValue, object newValue)
 		{


### PR DESCRIPTION
### Description of Change ###

Changes in `PaddingElement` to check NRE.

### Issues Resolved ### 

- fixes #12371 

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery on iOS device or simulator and navigate to the issue 12371. Without exceptions the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
