### PR TITLE
[WPF] Fix RadioButton crash

### DIFF
--- a/Xamarin.Forms.Core/RadioButton.cs
+++ b/Xamarin.Forms.Core/RadioButton.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Runtime.CompilerServices;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Shapes;
 

--- a/Xamarin.Forms.Platform.WPF/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.WPF/Renderers/RadioButtonRenderer.cs
@@ -22,8 +22,6 @@ namespace Xamarin.Forms.Platform.WPF
 				{
 					_button = new FormsRadioButton();
 
-					_button.Click += OnButtonClick;
-					_button.AddHandler(System.Windows.Controls.Button.ClickEvent, (RoutedEventHandler)OnPointerPressed, true);
 					_button.Checked += OnRadioButtonCheckedOrUnchecked;
 					_button.Unchecked += OnRadioButtonCheckedOrUnchecked;
 
@@ -98,19 +96,6 @@ namespace Xamarin.Forms.Platform.WPF
 			{
 				UpdateCheck();
 			}
-		}
-
-
-
-		void OnButtonClick(object sender, RoutedEventArgs e)
-		{
-			((IButtonController)Element)?.SendReleased();
-			((IButtonController)Element)?.SendClicked();
-		}
-
-		void OnPointerPressed(object sender, RoutedEventArgs e)
-		{
-			((IButtonController)Element)?.SendPressed();
 		}
 
 		void OnRadioButtonCheckedOrUnchecked(object sender, RoutedEventArgs e)
@@ -193,10 +178,9 @@ namespace Xamarin.Forms.Platform.WPF
 		{
 			if (_isDisposed)
 				return;
+
 			if (_button != null)
 			{
-				_button.Click -= OnButtonClick;
-				_button.RemoveHandler(System.Windows.Controls.Button.ClickEvent, (RoutedEventHandler)OnPointerPressed);
 				_button.Checked -= OnRadioButtonCheckedOrUnchecked;
 				_button.Unchecked -= OnRadioButtonCheckedOrUnchecked;
 			}


### PR DESCRIPTION
### Description of Change ###

RadioButton is no longer implementing `IButtonController`.

### Issues Resolved ### 

- fixes #12405 

### API Changes ###

 None

### Platforms Affected ### 

- WPF

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the RadioButton Galleries. Select any sample and then tap any RadioButton. Without exceptions the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
