### PR TITLE
[C] INamescope.UnregisterName

### DIFF
--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -275,10 +275,14 @@ namespace Xamarin.Forms
 
 		void INameScope.RegisterName(string name, object scopedElement)
 		{
-			var namescope = GetNameScope();
-			if (namescope == null)
-				throw new InvalidOperationException("this element is not in a namescope");
+			var namescope = GetNameScope() ?? throw new InvalidOperationException("this element is not in a namescope");
 			namescope.RegisterName(name, scopedElement);
+		}
+
+		void INameScope.UnregisterName(string name)
+		{
+			var namescope = GetNameScope() ?? throw new InvalidOperationException("this element is not in a namescope");
+			namescope.UnregisterName(name);
 		}
 
 		public event EventHandler<ElementEventArgs> ChildAdded;

--- a/Xamarin.Forms.Core/Internals/INameScope.cs
+++ b/Xamarin.Forms.Core/Internals/INameScope.cs
@@ -9,5 +9,6 @@ namespace Xamarin.Forms.Internals
 	{
 		object FindByName(string name);
 		void RegisterName(string name, object scopedElement);
+		void UnregisterName(string name);
 	}
 }

--- a/Xamarin.Forms.Core/Internals/NameScope.cs
+++ b/Xamarin.Forms.Core/Internals/NameScope.cs
@@ -30,5 +30,19 @@ namespace Xamarin.Forms.Internals
 			if (bindable.GetValue(NameScopeProperty) == null)
 				bindable.SetValue(NameScopeProperty, value);
 		}
+
+		void INameScope.UnregisterName(string name)
+		{
+			if (name == null)
+				throw new ArgumentNullException(nameof(name));
+
+			if (name == "")
+				throw new ArgumentException("name was provided as empty string.", nameof(name));
+
+			if (!_names.ContainsKey(name))
+				throw new ArgumentException("name provided had not been registered.", nameof(name));
+
+			_names.Remove(name);
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
[C] INamescope.UnregisterName

note that it only unregister the name, and do not even try to invalidate
the references to this name.

### Issues Resolved ### 
- fixes #12401

### API Changes ###

Added:
 - void INamescope.UnregisterName(string name);

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
