### PR TITLE
[UWP] Make Navigation and Transition overridable for NavigationPage

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/NavPageOverrideRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/NavPageOverrideRenderer.cs
@@ -1,0 +1,54 @@
+﻿using Windows.UI.Xaml.Media.Animation;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Platform.UWP;
+
+[assembly: ExportRenderer(typeof(NavPageOverrideUWP.CustomNavPageForOverride), typeof(NavPageOverrideRenderer))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class NavPageOverrideRenderer : NavigationPageRenderer
+	{
+		protected override void OnElementChanged(VisualElementChangedEventArgs e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+				System.Diagnostics.Debug.WriteLine($"{e.NewElement.GetType()} is replaced by NavPageOverrideRenderer");
+		}
+
+		protected override void SetupPageTransition(Transition transition, bool isAnimated, bool isPopping)
+		{
+			var newTransition = new EntranceThemeTransition { FromVerticalOffset = 0};
+
+			if (isPopping)
+			{
+				newTransition.FromHorizontalOffset = -ContainerElement.ActualWidth;
+			}
+			else
+			{
+				newTransition.FromHorizontalOffset = ContainerElement.ActualWidth;
+			}
+
+			base.SetupPageTransition(newTransition, isAnimated, isPopping);
+		}
+
+		protected override void OnPushRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			base.OnPushRequested(sender, e);
+			System.Diagnostics.Debug.WriteLine($"NavPageOverrideRenderer - OnPushRequested");
+		}
+
+		protected override void OnPopRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			base.OnPopRequested(sender, e);
+			System.Diagnostics.Debug.WriteLine($"NavPageOverrideRenderer - OnPopRequested");
+		}
+
+		protected override void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)
+		{
+			base.OnPopToRootRequested(sender, e);
+			System.Diagnostics.Debug.WriteLine($"NavPageOverrideRenderer - OnPopToRootRequested");
+		}
+	}
+}

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -134,6 +134,7 @@
     <Compile Include="BorderEffect.cs" />
     <Compile Include="CustomSwitchRenderer.cs" />
     <Compile Include="DisposePageRenderer.cs" />
+    <Compile Include="NavPageOverrideRenderer.cs" />
     <Compile Include="PlatformSpecificCoreGalleryFactory.cs" />
     <Compile Include="RegistrarValidationService.cs" />
     <Compile Include="SampleNativeControl.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/NavPageOverrideUWP.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/NavPageOverrideUWP.cs
@@ -1,0 +1,66 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "NavigationPage override UWP push pop", PlatformAffected.UWP, NavigationBehavior.Default)]
+	public class NavPageOverrideUWP : ContentPage
+	{
+		public NavPageOverrideUWP()
+		{
+			var pushModalButton = new Button() { Text = "Open NavPage with overrides", BackgroundColor = Color.Blue, TextColor = Color.White};
+			pushModalButton.Clicked += (s, a) => Navigation.PushModalAsync(new CustomNavPageForOverride(new Page1()));
+
+			Content = new StackLayout{Children = { pushModalButton }};
+		}
+
+		public class Page1 : ContentPage
+		{
+			public Page1()
+			{			
+				var pushButton = new Button() { Text = "Push with custom animation", BackgroundColor = Color.Blue, TextColor = Color.White};
+				pushButton.Clicked += (s, a) => Navigation.PushAsync(new Page2());
+
+				var popModalButton = new Button() { Text = "Pop modal", BackgroundColor = Color.Blue, TextColor = Color.White };
+				popModalButton.Clicked += (s, a) => Navigation.PopModalAsync();
+
+				Content = new StackLayout()
+				{
+					Padding           = 40,
+					VerticalOptions   = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					BackgroundColor   = Color.Red,
+					Children          = { pushButton, popModalButton }
+				};
+			}
+		}
+
+		public class Page2 : ContentPage
+		{
+			public Page2()
+			{			
+				var popButton = new Button() { Text = "Pop with custom animation", BackgroundColor = Color.Blue, TextColor = Color.White, HeightRequest = 50};
+				popButton.Clicked += (s, a) => Navigation.PopAsync();
+
+				Content = new StackLayout
+				{
+					Padding           = 40,
+					VerticalOptions   = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					BackgroundColor   = Color.Yellow,
+					Children          = { popButton }
+				};
+			}
+		}
+
+		
+		public class CustomNavPageForOverride : NavigationPage
+		{
+			public CustomNavPageForOverride(Page page) : base(page)
+			{
+				
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -294,6 +294,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue9833.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9929.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9088.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)NavPageOverrideUWP.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RefreshViewTests.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7338.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />

--- a/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/NavigationPageRenderer.cs
@@ -267,7 +267,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		protected void OnElementChanged(VisualElementChangedEventArgs e)
+		protected virtual void OnElementChanged(VisualElementChangedEventArgs e)
 		{
 			EventHandler<VisualElementChangedEventArgs> changed = ElementChanged;
 			if (changed != null)
@@ -438,18 +438,18 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		void OnPopRequested(object sender, NavigationRequestedEventArgs e)
+		protected virtual void OnPopRequested(object sender, NavigationRequestedEventArgs e)
 		{
 			var newCurrent = Element.Peek(1);
 			SetPage(newCurrent, e.Animated, true);
 		}
 
-		void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)
+		protected virtual void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)
 		{
 			SetPage(e.Page, e.Animated, true);
 		}
 
-		void OnPushRequested(object sender, NavigationRequestedEventArgs e)
+		protected virtual void OnPushRequested(object sender, NavigationRequestedEventArgs e)
 		{
 			SetPage(e.Page, e.Animated, false);
 		}
@@ -500,19 +500,30 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdateTitleOnParents();
 			UpdateTitleView();
 
-			if (isAnimated && _transition == null)
-			{
-				_transition = new EntranceThemeTransition();
-				_container.ContentTransitions = new TransitionCollection();
-			}
-
-			if (!isAnimated && _transition != null)
-				_container.ContentTransitions.Remove(_transition);
-			else if (isAnimated && _container.ContentTransitions.Count == 0)
-				_container.ContentTransitions.Add(_transition);
+			SetupPageTransition(_transition, isAnimated, isPopping);
 
 			_container.Content = renderer.ContainerElement;
 			_container.DataContext = page;
+		}
+
+		protected virtual void SetupPageTransition(Transition transition, bool isAnimated, bool isPopping)
+		{
+			if (isAnimated && transition == null)
+			{
+				transition  = new EntranceThemeTransition();
+				_transition = (EntranceThemeTransition)transition;
+				_container.ContentTransitions = new TransitionCollection();
+			}
+
+			if (!isAnimated && _container.ContentTransitions?.Count > 0)
+			{
+				_container.ContentTransitions.Clear();
+			}
+			else if (isAnimated && _container.ContentTransitions.Contains(transition) == false)
+			{
+				_container.ContentTransitions.Clear();
+				_container.ContentTransitions.Add(transition);
+			}
 		}
 
 		void UpdateBackButtonTitle()


### PR DESCRIPTION
### Description of Change ###

The `NavigationRenderer` for UWP doesn't expose any virtual method to override, closing a lot of possibilities expecially for plugin authors.

This PR comes after a conversation on Twitter with @PureWeen and adds the `protected virtual` access level to the following, existing, methods:

`OnPopRequested`
`OnPopToRootRequested`
`OnPushRequested`
`OnElementChanged`

Bringing the UWP NavigationRenderer in par with iOS & Android.

Plus i created a new method `SetupPageTransition` to override the default transition (but making sure to maintain the `_transition `cache for the default transition).

### API Changes ###

Added:
 - `void SetupPageTransition(Transition transition, bool isAnimated, bool isPopping)`
*isPopping is needed to create a custom transition based on push or pop*


Changed:
 - `protected virtual void OnPopRequested(object sender, NavigationRequestedEventArgs e)`
 - `protected virtual void OnPopToRootRequested(object sender, NavigationRequestedEventArgs e)`
 - `protected virtual void OnPushRequested(object sender, NavigationRequestedEventArgs e)`


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
 - Open the ControlGallery app
 - Click on "Test Cases"
 - Search for "Navigationpage override"
 - Tap it, then tap on "Open NavPage with overrides" and enjoy a custom navigation transition between pages in the modal stack :)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
