### PR TITLE
[UWP] [Shell] Make Navigation and Transition overridable for Shell

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
@@ -308,23 +308,18 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected virtual void OnShellSectionChanged(ShellSection oldSection, ShellSection newSection)
 		{
-			SwitchSection(ShellNavigationSource.ShellSectionChanged, newSection, null, oldSection != null);
+			if (newSection == null)
+				throw new InvalidOperationException($"Content not found for active {ShellItem} - {ShellItem.Title}.");
+
+			if (newSection.CurrentItem == null)
+				throw new InvalidOperationException($"Content not found for active {newSection} - {newSection.Title}.");
+
+			SectionRenderer.NavigateToShellSection(newSection);
 		}
 
 		void OnShellStructureChanged(object sender, EventArgs e)
 		{
 			UpdateBottomBarVisibility();
-		}
-
-		void SwitchSection(ShellNavigationSource source, ShellSection section, Page page, bool animate = true)
-		{
-			if (section == null)
-				throw new InvalidOperationException($"Content not found for active {ShellItem} - {ShellItem.Title}.");
-
-			if (section.CurrentItem == null)
-				throw new InvalidOperationException($"Content not found for active {section} - {section.Title}.");
-
-			SectionRenderer.NavigateToShellSection(source, section, page, animate);
 		}
 
 		Page DisplayedPage { get; set; }
@@ -393,7 +388,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void OnNavigationRequested(object sender, NavigationRequestedEventArgs e)
 		{
-			SwitchSection((ShellNavigationSource)e.RequestType, (ShellSection)sender, e.Page, e.Animated);
+			SectionRenderer.NavigateToContent(e, (ShellSection)sender);
 		}
 
 		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -135,7 +135,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		internal void NavigateToContent(ShellNavigationSource source, ShellContent shellContent, Page page, bool animate = true)
+		protected virtual void NavigateToContent(ShellNavigationSource source, ShellContent shellContent, Page page, bool animate = true)
 		{
 			Page nextPage = null;
 
@@ -212,7 +212,7 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		NavigationTransitionInfo GetTransitionInfo(ShellNavigationSource navSource)
+		protected virtual NavigationTransitionInfo GetTransitionInfo(ShellNavigationSource navSource)
 		{
 			switch (navSource)
 			{

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -196,12 +196,12 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 		}
 
-		protected void OnPopRequested(ShellNavigationSource source)
+		protected virtual void OnPopRequested(ShellNavigationSource source)
 		{
 			Frame.GoBack(GetTransitionInfo(source));
 		}
 
-		protected void OnPopToRootRequested(ShellNavigationSource source)
+		protected virtual void OnPopToRootRequested(ShellNavigationSource source)
 		{
 			while (Frame.BackStackDepth > 2)
 			{
@@ -210,12 +210,12 @@ namespace Xamarin.Forms.Platform.UWP
 			Frame.GoBack(GetTransitionInfo(source));
 		}
 
-		protected void OnPushRequested(ShellNavigationSource source)
+		protected virtual void OnPushRequested(ShellNavigationSource source)
 		{
 			Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
 		}
 
-		protected void OnInsertRequested(ShellNavigationSource source, Page page)
+		protected virtual void OnInsertRequested(ShellNavigationSource source, Page page)
 		{
 			var pageIndex = ShellSection.Stack.ToList().IndexOf(page);
 			if (pageIndex == Frame.BackStack.Count - 1)
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Platform.UWP
 				Frame.BackStack.Insert(pageIndex, new PageStackEntry(typeof(ShellPageWrapper), null, GetTransitionInfo(source)));
 		}
 
-		protected void OnRemoveRequested(ShellNavigationSource source, Page page)
+		protected virtual void OnRemoveRequested(ShellNavigationSource source, Page page)
 		{
 			var pageIndex = FormsNavigationStack.IndexOf(page);
 			if (pageIndex == Frame.BackStack.Count - 1)
@@ -233,7 +233,7 @@ namespace Xamarin.Forms.Platform.UWP
 				Frame.BackStack.RemoveAt(pageIndex);
 		}
 
-		protected void OnShellSectionChanged(ShellNavigationSource source)
+		protected virtual void OnShellSectionChanged(ShellNavigationSource source)
 		{
 			Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
 		}

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -159,42 +159,26 @@ namespace Xamarin.Forms.Platform.UWP
 				switch (source)
 				{
 					case ShellNavigationSource.Insert:
-						{
-							var pageIndex = ShellSection.Stack.ToList().IndexOf(page);
-							if (pageIndex == Frame.BackStack.Count - 1)
-								Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
-							else
-								Frame.BackStack.Insert(pageIndex, new PageStackEntry(typeof(ShellPageWrapper), null, GetTransitionInfo(source)));
-							break;
-						}
+						OnInsertRequested(source, page);
+						break;
 					case ShellNavigationSource.Pop:
-						Frame.GoBack(GetTransitionInfo(source));
+						OnPopRequested(source);
 						break;
 					case ShellNavigationSource.Unknown:
 						break;
 					case ShellNavigationSource.Push:
-						Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
+						OnPushRequested(source);
 						break;
 					case ShellNavigationSource.PopToRoot:
-						while (Frame.BackStackDepth > 2)
-						{
-							Frame.BackStack.RemoveAt(1);
-						}
-						Frame.GoBack(GetTransitionInfo(source));
+						OnPopToRootRequested(source);
 						break;
 					case ShellNavigationSource.Remove:
-						{
-							var pageIndex = FormsNavigationStack.IndexOf(page);
-							if (pageIndex == Frame.BackStack.Count - 1)
-								Frame.GoBack(GetTransitionInfo(source));
-							else
-								Frame.BackStack.RemoveAt(pageIndex);
-							break;
-						}
+						OnRemoveRequested(source, page);
+						break;
 					case ShellNavigationSource.ShellItemChanged:
 						break;
 					case ShellNavigationSource.ShellSectionChanged:
-						Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
+						OnShellSectionChanged(source);
 						break;
 					case ShellNavigationSource.ShellContentChanged:
 						break;
@@ -210,6 +194,48 @@ namespace Xamarin.Forms.Platform.UWP
 				wrapper.LoadPage();
 				FormsNavigationStack = ShellSection.Stack.ToList();
 			}
+		}
+
+		protected void OnPopRequested(ShellNavigationSource source)
+		{
+			Frame.GoBack(GetTransitionInfo(source));
+		}
+
+		protected void OnPopToRootRequested(ShellNavigationSource source)
+		{
+			while (Frame.BackStackDepth > 2)
+			{
+				Frame.BackStack.RemoveAt(1);
+			}
+			Frame.GoBack(GetTransitionInfo(source));
+		}
+
+		protected void OnPushRequested(ShellNavigationSource source)
+		{
+			Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
+		}
+
+		protected void OnInsertRequested(ShellNavigationSource source, Page page)
+		{
+			var pageIndex = ShellSection.Stack.ToList().IndexOf(page);
+			if (pageIndex == Frame.BackStack.Count - 1)
+				Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
+			else
+				Frame.BackStack.Insert(pageIndex, new PageStackEntry(typeof(ShellPageWrapper), null, GetTransitionInfo(source)));
+		}
+
+		protected void OnRemoveRequested(ShellNavigationSource source, Page page)
+		{
+			var pageIndex = FormsNavigationStack.IndexOf(page);
+			if (pageIndex == Frame.BackStack.Count - 1)
+				Frame.GoBack(GetTransitionInfo(source));
+			else
+				Frame.BackStack.RemoveAt(pageIndex);
+		}
+
+		protected void OnShellSectionChanged(ShellNavigationSource source)
+		{
+			Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(source));
 		}
 
 		protected virtual NavigationTransitionInfo GetTransitionInfo(ShellNavigationSource navSource)


### PR DESCRIPTION
### Description of Change ###

The `ShellSectionRenderer` for UWP doesn't expose any virtual method to override, closing a lot of possibilities expecially for plugin authors.

This PR comes after a conversation on Twitter with @PureWeen and adds a bunch of `protected virtual` methods to the navigation process (splitting up the `NavigateToContent` method in submethods).
Also i also made the `GetTransitionInfo` method virtual so we can change the animation transition between pages.

Please note that i also made virtual the `NavigateToContent` method, so we have the ability to to jump in the navigation process before the destination page has been created (or after with the new virtual methods).

### API Changes ###

Added:
 - `protected void OnPopRequested(ShellNavigationSource source)`
 - `protected void OnPopToRootRequested(ShellNavigationSource source)`
 - `protected void OnPushRequested(ShellNavigationSource source)`
 - `protected void OnInsertRequested(ShellNavigationSource source, Page page)`
 - `protected void OnRemoveRequested(ShellNavigationSource source, Page page)`
 - `protected void OnShellSectionChanged(ShellNavigationSource source)`

Changed:
 - `protected virtual void NavigateToContent(ShellNavigationSource source, ShellContent shellContent, Page page, bool animate = true)`
 - `protected virtual NavigationTransitionInfo GetTransitionInfo(ShellNavigationSource navSource)`


### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
I think the current tests are enough, i have just moved some code inside virtual methods, no need to special test cases.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
