### PR TITLE
[Tizen] Support Vertical/HorizontalScrollStep to ScrollView

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/ScrollView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/ScrollView.cs
@@ -1,0 +1,61 @@
+namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
+{
+	using FormsElement = Forms.ScrollView;
+
+	public static class ScrollView
+	{
+		public static readonly BindableProperty VerticalScrollStepProperty = BindableProperty.Create("VerticalScrollStep", typeof(int), typeof(FormsElement), -1, 
+			coerceValue: (bindable, value) =>
+			{
+				return ((int)value < 0) ? -1 : value;
+			});
+
+		public static readonly BindableProperty HorizontalScrollStepProperty = BindableProperty.Create("HorizontalScrollStep", typeof(int), typeof(FormsElement), -1,
+			coerceValue: (bindable, value) =>
+			{
+				return ((int)value < 0) ? -1 : value;
+			});
+
+		public static int GetVerticalScrollStep(BindableObject element)
+		{
+			return (int)element.GetValue(VerticalScrollStepProperty);
+		}
+
+		public static void SetVerticalScrollStep(BindableObject element, int scrollStep)
+		{
+			element.SetValue(VerticalScrollStepProperty, scrollStep);
+		}
+
+		public static int GetVerticalScrollStep(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetVerticalScrollStep(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetVerticalScrollStep(this IPlatformElementConfiguration<Tizen, FormsElement> config, int scrollStep)
+		{
+			SetVerticalScrollStep(config.Element, scrollStep);
+			return config;
+		}
+
+		public static int GetHorizontalScrollStep(BindableObject element)
+		{
+			return (int)element.GetValue(HorizontalScrollStepProperty);
+		}
+
+		public static void SetHorizontalScrollStep(BindableObject element, int scrollStep)
+		{
+			element.SetValue(HorizontalScrollStepProperty, scrollStep);
+		}
+
+		public static int GetHorizontalScrollStep(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetHorizontalScrollStep(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetHorizontalScrollStep(this IPlatformElementConfiguration<Tizen, FormsElement> config, int scrollStep)
+		{
+			SetHorizontalScrollStep(config.Element, scrollStep);
+			return config;
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###
This PR is about supporting the scroll step (both vertical and horizontal) to move `ScrollView` by key event on Tizen. This can be especially useful when moving the scroll of the scroll view on a remote control keystroke based TV device. As you can see in the screenshot below, you can adjust the `VerticalScrollStep` to make the scroll view move smoother.

- **Before (default)**
<img src="https://user-images.githubusercontent.com/1029134/95814322-10ca3280-0d55-11eb-9f6e-d2ffb5e2d649.gif" width=720/>

- **After (adjust the vertical scroll step properly)**
<img src="https://user-images.githubusercontent.com/1029134/95814328-13c52300-0d55-11eb-9724-10136aa056c9.gif" width=720/>

#### Developers Guide ####
This Tizen platform-specific is used to set the scroll step to move `ScrollView` by key event. It can be consumed from XAML and C# as follows.

- XAML
```xml

<ContentPage ...
    xmlns:tizen="clr-namespace:Xamarin.Forms.PlatformConfiguration.TizenSpecific;assembly=Xamarin.Forms.Core">
    <ScrollView tizen:VerticalScrollStep="500">
        ....
    </ScrollView>
</ContentPage>
```

- C#
```cs
using Xamarin.Forms.PlatformConfiguration;
using Xamarin.Forms.PlatformConfiguration.TizenSpecific;
...

var scrollView = new Xamarin.Forms.ScrollView();
scrollView.On<Tizen>().SetHorizontalScrollStep(500); // set 
var step = scrollView.On<Tizen>().GetHorizontalScrollStep(); //get
```

### Issues Resolved ### 
None

### API Changes ###
`namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific`

Added:
 - int ScrollView.VerticalScrollSize { get; set; } //Bindable Property
 - int ScrollView.HorizontalScrollSize { get; set; } //Bindable Property

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
