### PR TITLE
Fix NRE on List Click

### DIFF
--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -470,7 +470,7 @@ namespace Xamarin.Forms
 			_previousGroupSelected = groupIndex;
 
 			// A11y: Keyboards and screen readers can deselect items, allowing -1 to be possible
-			if (cell == null && inGroupIndex != -1)
+			if (cell == null && inGroupIndex >= 0 && group.Count > inGroupIndex)
 			{
 				cell = group[inGroupIndex];
 			}


### PR DESCRIPTION
### Description of Change ###

Validate item exists by index

### Issue
Fixes: #12533

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)

### Testing Procedure ###
Run Gallery WPF. Search "list". Select GroupedList Gallery - Legacy. Click on white space (do not click on row)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
