### PR TITLE
Fix Grid regressions with text in star rows/columns

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/GridTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GridTests.cs
@@ -1,7 +1,9 @@
 using NUnit.Framework;
+using NUnit.Framework.Constraints;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Reflection;
 using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Core.UnitTests
@@ -12,31 +14,31 @@ namespace Xamarin.Forms.Core.UnitTests
 		[SetUp]
 		public override void Setup()
 		{
-			base.Setup ();
-			Device.PlatformServices = new MockPlatformServices ();
+			base.Setup();
+			Device.PlatformServices = new MockPlatformServices();
 		}
 
 		[TearDown]
 		public override void TearDown()
 		{
-			base.TearDown ();
+			base.TearDown();
 			Device.PlatformServices = null;
 		}
 
 		[Test]
-		public void ThrowsOnNullAdd ()
+		public void ThrowsOnNullAdd()
 		{
 			var layout = new Grid();
 
-			Assert.Throws<ArgumentNullException> (() => layout.Children.Add (null));
+			Assert.Throws<ArgumentNullException>(() => layout.Children.Add(null));
 		}
 
 		[Test]
-		public void ThrowsOnNullRemove ()
+		public void ThrowsOnNullRemove()
 		{
 			var layout = new Grid();
 
-			Assert.Throws<ArgumentNullException> (() => layout.Children.Remove (null));
+			Assert.Throws<ArgumentNullException>(() => layout.Children.Remove(null));
 		}
 
 		[Test]
@@ -152,8 +154,10 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void ColumnsLessThanOneStarShouldBeTallerThanOneStarColumns() 
+		public void ColumnsLessThanOneStarShouldBeTallerThanOneStarColumns()
 		{
+			var gridWidth = 400;
+
 			var grid1 = new Grid() { ColumnSpacing = 0 };
 
 			grid1.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
@@ -167,17 +171,13 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 
 			grid1.Children.Add(label1, 0, 0);
-
-			var gridWidth = 400;
 			grid1.Measure(gridWidth, double.PositiveInfinity);
-			var column0Width = grid1.ColumnDefinitions[0].ActualWidth;
-			var column1Width = grid1.ColumnDefinitions[1].ActualWidth;
-
-			Assert.That(column0Width, Is.EqualTo(column1Width));
 			var grid1Height = grid1.RowDefinitions[0].ActualHeight;
 
 			var grid2 = new Grid() { ColumnSpacing = 0 };
 
+			// Because the column with the label in it is narrower in this grid (0.5* vs 1*), the label will have 
+			// grow taller to fit the text. So we expect this grid to grow vertically to accommodate it. 
 			grid2.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(0.5, GridUnitType.Star) });
 			grid2.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
 
@@ -193,8 +193,136 @@ namespace Xamarin.Forms.Core.UnitTests
 			grid2.Measure(gridWidth, double.PositiveInfinity);
 			var grid2Height = grid2.RowDefinitions[0].ActualHeight;
 
-
 			Assert.That(grid2Height, Is.GreaterThan(grid1Height));
+		}
+
+
+		[Test]
+		public void ContentHeightSumShouldMatchGridHeightWithAutoRows()
+		{
+			var widthConstraint = 400;
+
+			var grid1 = new Grid() { ColumnSpacing = 0, Padding = 0, RowSpacing = 0 };
+
+			grid1.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			grid1.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+
+			grid1.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+			grid1.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			var label1 = new ColumnTestLabel { Text = "label1" };
+			var label2 = new ColumnTestLabel { Text = "label2" };
+
+			grid1.Children.Add(label1, 0, 0);
+			grid1.Children.Add(label2, 0, 1);
+			var grid1Size = grid1.Measure(widthConstraint, double.PositiveInfinity, MeasureFlags.IncludeMargins);
+			grid1.Layout(new Rectangle(0, 0, grid1Size.Request.Width, grid1Size.Request.Height));
+			var grid1Height = grid1.Height;
+
+			var expectedHeight = label1.Height + label2.Height + grid1.RowSpacing;
+			Assert.That(grid1Height, Is.EqualTo(expectedHeight));
+		}
+
+		[Test]
+		public void UnconstrainedStarRowWithMultipleStarColumnsAllowsTextToGrow() 
+		{
+			var outerGrid = new Grid() { ColumnSpacing = 0, Padding = 0, RowSpacing = 0, IsPlatformEnabled = true };
+			outerGrid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Star });
+
+			outerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			outerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+
+			var sl = new StackLayout { Padding = 0, IsPlatformEnabled = true };
+
+			var label1 = new HeightBasedOnTextLengthLabel
+			{ 
+				Text = "The actual text here doesn't matter, just the length. The length determines the height."
+			};
+			
+			var label2 = new ColumnTestLabel { FontSize = 13, LineBreakMode = LineBreakMode.NoWrap, Text = "Description" };
+
+			sl.Children.Add(label1);
+			sl.Children.Add(label2);
+
+			var bv = new BoxView { WidthRequest = 50, BackgroundColor = Color.Blue, IsPlatformEnabled = true };
+
+			outerGrid.Children.Add(sl);
+			outerGrid.Children.Add(bv);
+			Grid.SetColumn(bv, 1);
+
+			var width = 400;
+			var expectedColumnWidth = width / 2;
+
+			// Measure and layout the grid
+			var firstMeasure = outerGrid.Measure(width, double.PositiveInfinity, MeasureFlags.IncludeMargins).Request;
+			outerGrid.Layout(new Rectangle(0, 0, firstMeasure.Width, firstMeasure.Height));
+
+			// Verify that the actual height of the label is what we would expect (within a tolerance)
+			Assert.That(label1.Height, Is.EqualTo(label1.DesiredHeight(expectedColumnWidth)).Within(2));
+
+			var label1OriginalHeight = label1.Height;
+
+			// Increase the text
+			label1.Text += label1.Text;
+
+			// And measure/layout again
+			var secondMeasure = outerGrid.Measure(width, double.PositiveInfinity, MeasureFlags.IncludeMargins).Request;
+			outerGrid.Layout(new Rectangle(0, 0, secondMeasure.Width, secondMeasure.Height));
+
+			// Verify that the actual height of the label is what we would expect (within a tolerance)
+			Assert.That(label1.Height, Is.EqualTo(label1.DesiredHeight(expectedColumnWidth)).Within(2));
+
+			// And that the new height is taller than the old one (since there's more text, and the column width did not change)
+			Assert.That(label1.Height, Is.GreaterThan(label1OriginalHeight));
+		}
+
+		[Test]
+		[TestCase(0.1), TestCase(0.2), TestCase(0.3), TestCase(0.4), TestCase(0.5)]
+		[TestCase(0.6), TestCase(0.7), TestCase(0.8), TestCase(0.9)]
+		public void AbsoluteColumnShouldNotBloatStarredColumns(double firstColumnWidth)
+		{
+			// This is a re-creation of the layout from Issue 12292
+			// The problem is that a huge label in a star column between a partial star column and
+			// an absolute column causes the container to get the wrong width during an early measure pass.
+			// The big label gets the wrong dimensions for measurement, and returns a height that won't actually
+			// work in the final layout.
+
+			var outerGrid = new Grid { ColumnSpacing = 0, Padding = 0, RowSpacing = 0, IsPlatformEnabled = true };
+
+			outerGrid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			outerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(firstColumnWidth, GridUnitType.Star) }); // 0.3, but 0.2 works fine
+			outerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			
+			// This last column is the trouble spot; MeasureAndContractStarredColumns needs to account for this width 
+			// when measuring and distributing the starred column space. Otherwise it reports the wrong width and every
+			// measure after that is wrong.
+			outerGrid.ColumnDefinitions.Add(new ColumnDefinition() { Width = 36 });
+
+			var innerGrid = new Grid() { ColumnSpacing = 0, Padding = 0, RowSpacing = 0, IsPlatformEnabled = true };
+
+			outerGrid.Children.Add(innerGrid);
+			Grid.SetColumn(innerGrid, 1);
+
+			innerGrid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+			innerGrid.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			var hugeLabel = new _12292TestLabel() {  };
+			var tinyLabel = new ColumnTestLabel { Text = "label1" };
+
+			innerGrid.Children.Add(hugeLabel);
+			innerGrid.Children.Add(tinyLabel);
+			Grid.SetRow(tinyLabel, 1);
+
+			var scrollView = new ScrollView() { IsPlatformEnabled = true };
+			scrollView.Content = outerGrid;
+
+			var layoutSize = scrollView.Measure(411, 603, MeasureFlags.IncludeMargins);
+
+			// The containing ScrollView should measure a width of about 411; the absolute column at the end of the grid
+			// shouldn't expand the ScrollView's measure to 447-ish. It's this expansion of the ScrollView that causes
+			// all subsequent parts of layout to go pear-shaped.
+			Assert.That(layoutSize.Request.Width, Is.EqualTo(411).Within(2));
 		}
 
 		[Test]
@@ -294,21 +422,28 @@ namespace Xamarin.Forms.Core.UnitTests
 			grid.Children.Add(label1, 1, 0);
 
 			// requested total height is 300, so this will force a contraction to 200
-			grid.Measure(200, 200); 
+			grid.Measure(200, 200);
 			var column0Height = grid.RowDefinitions[0].ActualHeight;
 			var column1Height = grid.RowDefinitions[1].ActualHeight;
 
 			Assert.That(column0Height, Is.EqualTo(column1Height / 2));
 		}
 
-		class FixedSizeLabel : Label 
+		abstract class TestLabel : Label
+		{
+			protected TestLabel()
+			{
+				IsPlatformEnabled = true;
+			}
+		}
+
+		class FixedSizeLabel : TestLabel
 		{
 			readonly Size _minimumSize;
 			readonly Size _requestedSize;
 
-			public FixedSizeLabel(Size minimumSize, Size requestedSize) 
+			public FixedSizeLabel(Size minimumSize, Size requestedSize)
 			{
-				IsPlatformEnabled = true;
 				_minimumSize = minimumSize;
 				_requestedSize = requestedSize;
 			}
@@ -319,13 +454,75 @@ namespace Xamarin.Forms.Core.UnitTests
 			}
 		}
 
-		class ColumnTestLabel : Label
+		class _12292TestLabel : Label 
 		{
-			public ColumnTestLabel() 
+			// We need a label that simulates a fairly specific layout/measure pattern to reproduce
+			// the circumstances of issue 12292.
+
+			int _counter;
+
+			public _12292TestLabel()
 			{
 				IsPlatformEnabled = true;
+				Text = "dfghjkl;SCAsdnlv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh dvjhdbcviaijdlvnkhubv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh dvjhdbcviaijdlvnkhubv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh dvjhdbcviaijdlvnkhubv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh dvjhdbcviaijdlvnkhubv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh dvjhdbcviaijdlvnkhubv  oebwepuvjlvsdiljh dvjhdbcviaijdlvnkhubv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh oebwepuvjlvsdiljhssdlncaCSN SNCAascsbdn  sciwohwfwef wbodlaoj bcwhuofw9qph nxaxhsavcgsdcvewp ibewfwfhpo sbcshclcsdc aasusos 9 p;fqpnwuvaycxaslucn;we;oivwemopv mre]bn ;nvw  modcefin e['vmdkv wqs vwlj vqur;/ b;bnoerbor blk evoneifb;4rbkk-eq'o ge  vlfbmokfen wov mdkqncvw;bnzdFCGHSIAJDOKFBLKVSCBAXVCGFAYGUIOK;LBMDF, NZBCHGFSYUGAEUHRPK;LBMFNVBCFYEWYGUIOPBK; M,MNBCDTFYYU9GIPL;LMVNCX KOEKFULIDJOPKWLFSBVHGIROIQWDMC, ;QLKHFEUHFIJOKPDS;LMNDFVGUHFIDJXHFJOKPEOEJGHRIFJEWODK;LMNBVJHGIOJFEPKWD;LMNDBF VBIWOPKWFKBNRGJOFKPELDWKNVDSHFIOEFIEPKLMDWNDVSFBDIHOFEPDKWL;MNVFBF C,P POIUYFUYGIHOJ;LMFE WGREBFX CUOUIGYUFCHJDKJLFK;EGRHMNBHIOKVEJKVNERNVOEIV OWIEFNIENEKEDLC,WP,EFF dfghjkl;SCAsdnlv dvjhdbcviaijdlvnkhubv oebwepuvjlvsdiljh ssdlncaCSN SNCAascsbdn  sciwohwfwef wbodlaoj bcwhuofw9qph nxaxhsavcgsdcvewp ibewfwfhpo sbcshclcsdc aasusos 9 p;fqpnwuvaycxaslucn;we;oivwemopv mre]bn ;nvw  modcefin e['vmdkv wqs vwlj vqur;/ b;bnoerbor blk evoneifb;4rbkk-eq'o ge  vlfbmokfen wov mdkqncvw;bnzdFCGHSIAJDOKFBLKVSCBAXVCGFAYGUIOK;LBMDF, NZBCHGFSYUGAEUHRPK;LBMFNVBCFYEWYGUIOPBK; M,MNBCDTFYYU9GIPL;LMVNCX KOEKFULIDJOPKWLFSBVHGIROIQWDMC, ;QLKHFEUHFIJOKPDS;LMNDFVGUHFIDJXHFJOKPEOEJGHRIFJEWODK;LMNBVJHGIOJFEPKWD;LMNDBF VBIWOPKWFKBNRGJOFKPELDWKNVDSHFIOEFIEPKLMDWNDVSFBDIHOFEPDKWL;MNVFBF C,P POIUYFUYGIHOJ;LMFE WGREBFX CUOUIGYUFCHJDKJLFK;EGRHMNBHIOKVEJKVNERNVOEIV OWIEFNIENEKEDLC,WP,1234567890234567890";
 			}
-			
+
+			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+			{
+				double minWidth = 10.2857142857143;
+
+				_counter += 1;
+
+				switch (_counter % 6)
+				{
+					case 1:
+						return new SizeRequest(
+							new Size(375.619047619048, 673.904761904762),
+							new Size(minWidth, 673.904761904762));
+					case 2:
+						return new SizeRequest(
+							new Size(411.428571428571, 575.619047619048),
+							new Size(minWidth, 575.619047619048));
+					case 3:
+						return new SizeRequest(
+							new Size(336.380952380952, 755.809523809524),
+							new Size(minWidth, 755.809523809524));
+					case 4:
+						return new SizeRequest(
+							new Size(375.619047619048, 673.904761904762),
+							new Size(minWidth, 673.904761904762));
+					case 5:
+						return new SizeRequest(
+							new Size(313.142857142857, 772.190476190476),
+							new Size(minWidth, 772.190476190476));
+					case 0:
+						return new SizeRequest(
+							new Size(313.142857142857, 772.190476190476),
+							new Size(minWidth, 772.190476190476));
+				}
+
+				throw new Exception("This shouldn't happen, unless we make measure/layout more or less efficient and " +
+					"OnMeasure isn't called 6 times during this test.");
+			}
+		}
+
+		class HeightBasedOnTextLengthLabel : TestLabel
+		{
+			public double DesiredHeight(double widthConstraint) 
+			{ 
+				return (Text.Length / widthConstraint) * 200;
+			}
+
+			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
+			{
+				var minimumSize = new Size(20, 20);
+				var height = DesiredHeight(widthConstraint);
+				return new SizeRequest(new Size(widthConstraint, height), minimumSize);
+			}
+		}
+
+		class ColumnTestLabel : TestLabel
+		{
 			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 			{
 				var minimumSize = new Size(20, 20);
@@ -334,13 +531,8 @@ namespace Xamarin.Forms.Core.UnitTests
 			}
 		}
 
-		class RowTestLabel : Label
+		class RowTestLabel : TestLabel
 		{
-			public RowTestLabel()
-			{
-				IsPlatformEnabled = true;
-			}
-
 			protected override SizeRequest OnMeasure(double widthConstraint, double heightConstraint)
 			{
 				var minimumSize = new Size(20, 20);
@@ -513,81 +705,81 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void TestBasicVerticalLayout ()
+		public void TestBasicVerticalLayout()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.Children.AddVertical (new View[] {
+			layout.Children.AddVertical(new View[] {
 				label1,
 				label2,
 				label3
 			});
 
-			layout.Layout (new Rectangle(0, 0, 912, 912));
+			layout.Layout(new Rectangle(0, 0, 912, 912));
 
-			Assert.AreEqual (912, layout.Width);
-			Assert.AreEqual (912, layout.Height);
+			Assert.AreEqual(912, layout.Width);
+			Assert.AreEqual(912, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 912, 300), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 306, 912, 300), label2.Bounds);
-			Assert.AreEqual (new Rectangle(0, 612, 912, 300), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 912, 300), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 306, 912, 300), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 612, 912, 300), label3.Bounds);
 		}
 
 		[Test]
-		public void TestBasicHorizontalLayout ()
+		public void TestBasicHorizontalLayout()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.Children.AddHorizontal (new View[] {
+			layout.Children.AddHorizontal(new View[] {
 				label1,
 				label2,
 				label3
 			});
 
-			layout.Layout (new Rectangle(0, 0, 912, 912));
+			layout.Layout(new Rectangle(0, 0, 912, 912));
 
-			Assert.AreEqual (912, layout.Width);
-			Assert.AreEqual (912, layout.Height);
+			Assert.AreEqual(912, layout.Width);
+			Assert.AreEqual(912, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 300, 912), label1.Bounds);
-			Assert.AreEqual (new Rectangle(306, 0, 300, 912), label2.Bounds);
-			Assert.AreEqual (new Rectangle(612, 0, 300, 912), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 300, 912), label1.Bounds);
+			Assert.AreEqual(new Rectangle(306, 0, 300, 912), label2.Bounds);
+			Assert.AreEqual(new Rectangle(612, 0, 300, 912), label3.Bounds);
 		}
 
 		[Test]
-		public void TestVerticalExpandStart ()
+		public void TestVerticalExpandStart()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
 
 			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = new GridLength (1, GridUnitType.Star) },
 				new RowDefinition { Height = GridLength.Auto},
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 0, 1);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 0, 1);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 1000, 1000 - 20 - layout.RowSpacing), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 1000 - 20, 1000, 20), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 1000, 1000 - 20 - layout.RowSpacing), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 1000 - 20, 1000, 20), label2.Bounds);
 		}
 
 		[Test]
-		public void TestHorizontalExpandStart ()
+		public void TestHorizontalExpandStart()
 		{
 			var layout = new Grid();
 
@@ -598,103 +790,103 @@ namespace Xamarin.Forms.Core.UnitTests
 				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
 				new ColumnDefinition { Width = GridLength.Auto },
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 1000 - 106, 1000), label1.Bounds);
-			Assert.AreEqual (new Rectangle(1000 - 100, 0, 100, 1000), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 1000 - 106, 1000), label1.Bounds);
+			Assert.AreEqual(new Rectangle(1000 - 100, 0, 100, 1000), label2.Bounds);
 		}
 
 		[Test]
-		public void TestVerticalExpandEnd ()
+		public void TestVerticalExpandEnd()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
 
 			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = GridLength.Auto},
 				new RowDefinition { Height = new GridLength (1, GridUnitType.Star) },
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 0, 1);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 0, 1);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 1000, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 26, 1000, 1000 - 26), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 1000, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 26, 1000, 1000 - 26), label2.Bounds);
 		}
 
 		[Test]
-		public void TestHorizontalExpandEnd ()
+		public void TestHorizontalExpandEnd()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
 				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
 			};
 
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 100, 1000), label1.Bounds);
-			Assert.AreEqual (new Rectangle(106, 0, 1000 - 106, 1000), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 100, 1000), label1.Bounds);
+			Assert.AreEqual(new Rectangle(106, 0, 1000 - 106, 1000), label2.Bounds);
 		}
 
 		[Test]
-		public void TestVerticalExpandMiddle ()
+		public void TestVerticalExpandMiddle()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
 			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition { Height = GridLength.Auto},
-				new RowDefinition { Height = new GridLength (1, GridUnitType.Star) }, 
+				new RowDefinition { Height = new GridLength (1, GridUnitType.Star) },
 				new RowDefinition { Height = GridLength.Auto}
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 0, 1);
-			layout.Children.Add (label3, 0, 2);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 0, 1);
+			layout.Children.Add(label3, 0, 2);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 1000, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 26, 1000, 1000 - 52), label2.Bounds);
-			Assert.AreEqual (new Rectangle(0, 980, 1000, 20), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 1000, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 26, 1000, 1000 - 52), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 980, 1000, 20), label3.Bounds);
 		}
 
 		[Test]
-		public void TestHorizontalExpandMiddle ()
+		public void TestHorizontalExpandMiddle()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -702,98 +894,34 @@ namespace Xamarin.Forms.Core.UnitTests
 				new ColumnDefinition { Width = GridLength.Auto },
 			};
 
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
-			layout.Children.Add (label3, 2, 0);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
+			layout.Children.Add(label3, 2, 0);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 100, 1000), label1.Bounds);
-			Assert.AreEqual (new Rectangle(106, 0, 1000 - 212, 1000), label2.Bounds);
-			Assert.AreEqual (new Rectangle(900, 0, 100, 1000), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 100, 1000), label1.Bounds);
+			Assert.AreEqual(new Rectangle(106, 0, 1000 - 212, 1000), label2.Bounds);
+			Assert.AreEqual(new Rectangle(900, 0, 100, 1000), label3.Bounds);
 		}
 
 		[Test]
-		public void TestTableNoExpand ()
+		public void TestTableNoExpand()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
-			var label4 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
+			var label4 = new Label { IsPlatformEnabled = true };
 
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
-			layout.Children.Add (label3, 0, 1);
-			layout.Children.Add (label4, 1, 1);
-
-			layout.ColumnDefinitions = new ColumnDefinitionCollection {
-				new ColumnDefinition { Width = GridLength.Auto },
-				new ColumnDefinition { Width = GridLength.Auto },
-			};
-			layout.RowDefinitions = new RowDefinitionCollection {
-				new RowDefinition { Height = GridLength.Auto},
-				new RowDefinition { Height = GridLength.Auto}
-			};
-
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
-
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
-
-			Assert.AreEqual (new Rectangle(0, 0, 100, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(106, 0, 100, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle(0, 26, 100, 20), label3.Bounds);
-			Assert.AreEqual (new Rectangle(106, 26, 100, 20), label4.Bounds);
-		}
-
-		[Test]
-		public void TestTableExpand ()
-		{
-			var layout = new Grid();
-
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
-			var label4 = new Label { IsPlatformEnabled = true};
-
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
-				new ColumnDefinition { Width = GridLength.Auto },
-				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
-			};
-
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
-			layout.Children.Add (label3, 0, 1);
-			layout.Children.Add (label4, 1, 1);
-
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
-
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
-
-			Assert.AreEqual (new Rectangle(0, 0, 100, 497), label1.Bounds);
-			Assert.AreEqual (new Rectangle(106, 0, 894, 497), label2.Bounds);
-			Assert.AreEqual (new Rectangle(0, 503, 100, 497), label3.Bounds);
-			Assert.AreEqual (new Rectangle(106, 503, 894, 497), label4.Bounds);
-		}
-
-		[Test]
-		public void TestTableSpan ()
-		{
-			var layout = new Grid();
-
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
-
-			layout.Children.Add (label1, 0, 2, 0, 1);
-			layout.Children.Add (label2, 0, 1, 1, 2);
-			layout.Children.Add (label3, 1, 2, 1, 2);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
+			layout.Children.Add(label3, 0, 1);
+			layout.Children.Add(label4, 1, 1);
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -804,26 +932,90 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto}
 			};
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 206, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 26, 100, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle(106, 26, 100, 20), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 100, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(106, 0, 100, 20), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 26, 100, 20), label3.Bounds);
+			Assert.AreEqual(new Rectangle(106, 26, 100, 20), label4.Bounds);
 		}
 
 		[Test]
-		public void TestTableExpandedSpan ()
+		public void TestTableExpand()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
+			var label4 = new Label { IsPlatformEnabled = true };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
+				new ColumnDefinition { Width = GridLength.Auto },
+				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
+			};
+
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
+			layout.Children.Add(label3, 0, 1);
+			layout.Children.Add(label4, 1, 1);
+
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
+
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
+
+			Assert.AreEqual(new Rectangle(0, 0, 100, 497), label1.Bounds);
+			Assert.AreEqual(new Rectangle(106, 0, 894, 497), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 503, 100, 497), label3.Bounds);
+			Assert.AreEqual(new Rectangle(106, 503, 894, 497), label4.Bounds);
+		}
+
+		[Test]
+		public void TestTableSpan()
+		{
+			var layout = new Grid();
+
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
+
+			layout.Children.Add(label1, 0, 2, 0, 1);
+			layout.Children.Add(label2, 0, 1, 1, 2);
+			layout.Children.Add(label3, 1, 2, 1, 2);
+
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
+				new ColumnDefinition { Width = GridLength.Auto },
+				new ColumnDefinition { Width = GridLength.Auto },
+			};
+			layout.RowDefinitions = new RowDefinitionCollection {
+				new RowDefinition { Height = GridLength.Auto},
+				new RowDefinition { Height = GridLength.Auto}
+			};
+
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
+
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
+
+			Assert.AreEqual(new Rectangle(0, 0, 206, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 26, 100, 20), label2.Bounds);
+			Assert.AreEqual(new Rectangle(106, 26, 100, 20), label3.Bounds);
+		}
+
+		[Test]
+		public void TestTableExpandedSpan()
+		{
+			var layout = new Grid();
+
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
+
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
 				new ColumnDefinition { Width = new GridLength (1, GridUnitType.Star) },
 			};
@@ -832,267 +1024,273 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto}
 			};
 
-			layout.Children.Add (label1, 0, 2, 0, 1);
-			layout.Children.Add (label2, 0, 1, 1, 2);
-			layout.Children.Add (label3, 1, 2, 1, 2);
+			layout.Children.Add(label1, 0, 2, 0, 1);
+			layout.Children.Add(label2, 0, 1, 1, 2);
+			layout.Children.Add(label3, 1, 2, 1, 2);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 1000, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 26, 497, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle(503, 26, 497, 20), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 1000, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 26, 497, 20), label2.Bounds);
+			Assert.AreEqual(new Rectangle(503, 26, 497, 20), label3.Bounds);
 		}
 
 		[Test]
-		public void TestInvalidSet ()
+		public void TestInvalidSet()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
 
 			bool thrown = false;
 
-			try {
-				layout.Children.Add (label1, 2, 1, 0, 1);
-			} catch (ArgumentOutOfRangeException) {
+			try
+			{
+				layout.Children.Add(label1, 2, 1, 0, 1);
+			}
+			catch (ArgumentOutOfRangeException)
+			{
 				thrown = true;
 			}
 
-			Assert.True (thrown);
+			Assert.True(thrown);
 		}
 
 		[Test]
-		public void TestCentering ()
+		public void TestCentering()
 		{
 			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.Center, VerticalOptions = LayoutOptions.Center };
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition () {Width = new GridLength (1, GridUnitType.Star)},
 			};
-			layout.RowDefinitions = new RowDefinitionCollection { 
+			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition () {Height = new GridLength (1,GridUnitType.Star)},
 			};
 
-			layout.Children.Add (label1);
+			layout.Children.Add(label1);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (new Rectangle(450, 490, 100, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(450, 490, 100, 20), label1.Bounds);
 		}
 
 		[Test]
-		public void TestStart ()
+		public void TestStart()
 		{
 			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.Start, VerticalOptions = LayoutOptions.StartAndExpand };
 
-			layout.Children.AddVertical (label1);
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.Children.AddVertical(label1);
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition () {Width = new GridLength (1, GridUnitType.Star)},
 			};
-			layout.RowDefinitions = new RowDefinitionCollection { 
+			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition () {Height = new GridLength (1,GridUnitType.Star)},
 			};
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (new Rectangle(0, 0, 100, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 100, 20), label1.Bounds);
 		}
 
 		[Test]
-		public void TestEnd ()
+		public void TestEnd()
 		{
 			var layout = new Grid();
 
 			var label1 = new Label { IsPlatformEnabled = true, HorizontalOptions = LayoutOptions.End, VerticalOptions = LayoutOptions.EndAndExpand };
 
-			layout.Children.AddVertical (label1);
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.Children.AddVertical(label1);
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition () {Width = new GridLength (1, GridUnitType.Star)},
 			};
-			layout.RowDefinitions = new RowDefinitionCollection { 
+			layout.RowDefinitions = new RowDefinitionCollection {
 				new RowDefinition () {Height = new GridLength (1,GridUnitType.Star)},
 			};
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (new Rectangle(900, 980, 100, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(900, 980, 100, 20), label1.Bounds);
 		}
 
 		[Test]
-		public void TestDefaultRowSpacing ()
+		public void TestDefaultRowSpacing()
 		{
 			var layout = new Grid();
 
 			bool preferredSizeChanged = false;
-			layout.MeasureInvalidated += (sender, args) => {
+			layout.MeasureInvalidated += (sender, args) =>
+			{
 				preferredSizeChanged = true;
 			};
 
 			layout.RowSpacing = layout.RowSpacing;
 
-			Assert.False (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
 
 			layout.RowSpacing = 10;
 
-			Assert.True (preferredSizeChanged);
+			Assert.True(preferredSizeChanged);
 		}
 
 		[Test]
-		public void TestDefaultColumnSpacing ()
+		public void TestDefaultColumnSpacing()
 		{
 			var layout = new Grid();
 
 			bool preferredSizeChanged = false;
-			layout.MeasureInvalidated += (sender, args) => {
+			layout.MeasureInvalidated += (sender, args) =>
+			{
 				preferredSizeChanged = true;
 			};
 
 			layout.ColumnSpacing = layout.ColumnSpacing;
 
-			Assert.False (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
 
 			layout.ColumnSpacing = 10;
 
-			Assert.True (preferredSizeChanged);
+			Assert.True(preferredSizeChanged);
 		}
 
 		[Test]
-		public void TestAddCell ()
+		public void TestAddCell()
 		{
 			var layout = new Grid();
 			bool preferredSizeChanged = false;
 			layout.MeasureInvalidated += (sender, args) => preferredSizeChanged = true;
 
-			Assert.False (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
 
-			layout.Children.Add (new Label(), 0, 0);
+			layout.Children.Add(new Label(), 0, 0);
 
-			Assert.True (preferredSizeChanged);
+			Assert.True(preferredSizeChanged);
 		}
 
 		[Test]
-		public void TestMoveCell ()
+		public void TestMoveCell()
 		{
 			var layout = new Grid();
 			var label = new Label();
-			layout.Children.Add (label, 0, 0);
+			layout.Children.Add(label, 0, 0);
 
 			bool preferredSizeChanged = false;
-			layout.MeasureInvalidated += (sender, args) => {
+			layout.MeasureInvalidated += (sender, args) =>
+			{
 				preferredSizeChanged = true;
 			};
 
-			Assert.False (preferredSizeChanged);
-			Grid.SetRow (label, 2);
-			Assert.True (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
+			Grid.SetRow(label, 2);
+			Assert.True(preferredSizeChanged);
 
 			preferredSizeChanged = false;
-			Assert.False (preferredSizeChanged);
-			Grid.SetColumn (label, 2);
-			Assert.True (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
+			Grid.SetColumn(label, 2);
+			Assert.True(preferredSizeChanged);
 
 			preferredSizeChanged = false;
-			Assert.False (preferredSizeChanged);
-			Grid.SetRowSpan (label, 2);
-			Assert.True (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
+			Grid.SetRowSpan(label, 2);
+			Assert.True(preferredSizeChanged);
 
 			preferredSizeChanged = false;
-			Assert.False (preferredSizeChanged);
-			Grid.SetColumnSpan (label, 2);
-			Assert.True (preferredSizeChanged);
+			Assert.False(preferredSizeChanged);
+			Grid.SetColumnSpan(label, 2);
+			Assert.True(preferredSizeChanged);
 		}
 
 		[Test]
-		public void TestInvalidBottomAdd ()
+		public void TestInvalidBottomAdd()
 		{
 			var layout = new Grid();
 
-			Assert.Throws<ArgumentOutOfRangeException> (() => layout.Children.Add (new View(), 0, 1, 1, 0));
+			Assert.Throws<ArgumentOutOfRangeException>(() => layout.Children.Add(new View(), 0, 1, 1, 0));
 		}
 
 		[Test]
-		public void TestZeroSizeConstraints ()
+		public void TestZeroSizeConstraints()
 		{
 			var layout = new Grid();
 
-			Assert.AreEqual (new Size(0, 0), layout.GetSizeRequest (0, 0).Request);
-			Assert.AreEqual (new Size(0, 0), layout.GetSizeRequest (0, 10).Request);
-			Assert.AreEqual (new Size(0, 0), layout.GetSizeRequest (10, 0).Request);
+			Assert.AreEqual(new Size(0, 0), layout.GetSizeRequest(0, 0).Request);
+			Assert.AreEqual(new Size(0, 0), layout.GetSizeRequest(0, 10).Request);
+			Assert.AreEqual(new Size(0, 0), layout.GetSizeRequest(10, 0).Request);
 		}
 
 		[Test]
-		public void TestSizeRequest ()
+		public void TestSizeRequest()
 		{
-			var layout = new Grid { IsPlatformEnabled = true};
-			layout.Children.AddVertical (new[] {
+			var layout = new Grid { IsPlatformEnabled = true };
+			layout.Children.AddVertical(new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true}
 			});
 
-			var result = layout.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity).Request;
-			Assert.AreEqual (new Size(100, 72), result);
+			var result = layout.GetSizeRequest(double.PositiveInfinity, double.PositiveInfinity).Request;
+			Assert.AreEqual(new Size(100, 72), result);
 		}
 
 		[Test]
-		public void TestLimitedSizeRequest ()
+		public void TestLimitedSizeRequest()
 		{
-			var layout = new Grid { IsPlatformEnabled = true};
-			layout.Children.AddVertical (new[] {
+			var layout = new Grid { IsPlatformEnabled = true };
+			layout.Children.AddVertical(new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true}
 			});
 
-			var result = layout.GetSizeRequest (10, 10).Request;
-			Assert.AreEqual (new Size(100, 72), result);
+			var result = layout.GetSizeRequest(10, 10).Request;
+			Assert.AreEqual(new Size(100, 72), result);
 		}
 
 		[Test]
-		public void TestLimitedWidthSizeRequest ()
+		public void TestLimitedWidthSizeRequest()
 		{
-			var layout = new Grid { IsPlatformEnabled = true};
-			layout.Children.AddVertical (new[] {
+			var layout = new Grid { IsPlatformEnabled = true };
+			layout.Children.AddVertical(new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true}
 			});
 
-			var result = layout.GetSizeRequest (10, double.PositiveInfinity).Request;
-			Assert.AreEqual (new Size(100, 72), result);
+			var result = layout.GetSizeRequest(10, double.PositiveInfinity).Request;
+			Assert.AreEqual(new Size(100, 72), result);
 		}
 
 		[Test]
-		public void TestLimitedHeightSizeRequest ()
+		public void TestLimitedHeightSizeRequest()
 		{
 
-			var layout = new Grid { IsPlatformEnabled = true};
-			layout.Children.AddVertical (new[] {
+			var layout = new Grid { IsPlatformEnabled = true };
+			layout.Children.AddVertical(new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true}
 			});
 
-			var result = layout.GetSizeRequest (double.PositiveInfinity, 10).Request;
-			Assert.AreEqual (new Size(100, 72), result);
+			var result = layout.GetSizeRequest(double.PositiveInfinity, 10).Request;
+			Assert.AreEqual(new Size(100, 72), result);
 		}
 
 		[Test]
-		public void IgnoresInvisibleChildren ()
+		public void IgnoresInvisibleChildren()
 		{
 			var layout = new Grid();
 
 			var label1 = new Label { IsVisible = false, IsPlatformEnabled = true, VerticalOptions = LayoutOptions.FillAndExpand };
-			var label2 = new Label { IsPlatformEnabled = true};
+			var label2 = new Label { IsPlatformEnabled = true };
 
-			layout.Children.AddVertical (label1);
-			layout.Children.AddVertical (label2);
+			layout.Children.AddVertical(label1);
+			layout.Children.AddVertical(label2);
 
 			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
@@ -1102,84 +1300,40 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition { Height = GridLength.Auto},
 			};
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, -1, -1), label1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 6, 100, 20), label2.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, -1, -1), label1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 6, 100, 20), label2.Bounds);
 		}
 
 		[Test]
-		public void TestSizeRequestWithPadding ()
+		public void TestSizeRequestWithPadding()
 		{
-			var layout = new Grid { IsPlatformEnabled = true, Padding = new Thickness(20, 10, 15, 5)};
-			layout.Children.AddVertical (new[] {
+			var layout = new Grid { IsPlatformEnabled = true, Padding = new Thickness(20, 10, 15, 5) };
+			layout.Children.AddVertical(new[] {
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true},
 				new View {IsPlatformEnabled = true}
 			});
 
-			var result = layout.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity).Request;
-			Assert.AreEqual (new Size(135, 87), result);
+			var result = layout.GetSizeRequest(double.PositiveInfinity, double.PositiveInfinity).Request;
+			Assert.AreEqual(new Size(135, 87), result);
 		}
 
 		[Test]
-		public void InvalidCallsToStaticMethods ()
+		public void InvalidCallsToStaticMethods()
 		{
-			Assert.Throws<ArgumentException> (() => Grid.SetRow (new Label(), -1));
-			Assert.Throws<ArgumentException> (() => Grid.SetColumn (new Label(), -1));
-			Assert.Throws<ArgumentException> (() => Grid.SetRowSpan (new Label(), 0));
-			Assert.Throws<ArgumentException> (() => Grid.SetColumnSpan (new Label(), 0));
+			Assert.Throws<ArgumentException>(() => Grid.SetRow(new Label(), -1));
+			Assert.Throws<ArgumentException>(() => Grid.SetColumn(new Label(), -1));
+			Assert.Throws<ArgumentException>(() => Grid.SetRowSpan(new Label(), 0));
+			Assert.Throws<ArgumentException>(() => Grid.SetColumnSpan(new Label(), 0));
 		}
 
 		[Test]
-		public void TestAddedBP ()
-		{
-			var labela0 = new Label { IsPlatformEnabled = true};
-			var labela1 = new Label { IsPlatformEnabled = true };
-			Grid.SetColumn (labela1, 1);
-			var labelb1 = new Label { IsPlatformEnabled = true};
-			Grid.SetRow (labelb1, 1);
-			Grid.SetColumn (labelb1, 1);
-			var labelc = new Label { IsPlatformEnabled = true};
-			Grid.SetRow (labelc, 2);
-			Grid.SetColumnSpan (labelc, 2);
-
-			var layout = new Grid
-			{
-				Children = {
-					labela0,
-					labela1,
-					labelb1,
-					labelc
-				}
-			};
-
-			layout.ColumnDefinitions = new ColumnDefinitionCollection {
-				new ColumnDefinition { Width = GridLength.Auto },
-				new ColumnDefinition { Width = GridLength.Auto },
-			};
-			layout.RowDefinitions = new RowDefinitionCollection {
-				new RowDefinition { Height = GridLength.Auto},
-				new RowDefinition { Height = GridLength.Auto},
-				new RowDefinition { Height = GridLength.Auto},
-			};
-
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
-
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
-
-			Assert.AreEqual (new Rectangle(0, 0, 100, 20), labela0.Bounds);
-			Assert.AreEqual (new Rectangle(106, 0, 100, 20), labela1.Bounds);
-			Assert.AreEqual (new Rectangle(106, 26, 100, 20), labelb1.Bounds);
-			Assert.AreEqual (new Rectangle(0, 52, 206, 20), labelc.Bounds);
-		}
-
-		[Test]
-		public void Remove ()
+		public void TestAddedBP()
 		{
 			var labela0 = new Label { IsPlatformEnabled = true };
 			var labela1 = new Label { IsPlatformEnabled = true };
@@ -1201,20 +1355,64 @@ namespace Xamarin.Forms.Core.UnitTests
 				}
 			};
 
-			layout.Children.Remove (labela0);
-			Assert.False (((IElementController)layout).LogicalChildren.Contains (labela0));
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
+				new ColumnDefinition { Width = GridLength.Auto },
+				new ColumnDefinition { Width = GridLength.Auto },
+			};
+			layout.RowDefinitions = new RowDefinitionCollection {
+				new RowDefinition { Height = GridLength.Auto},
+				new RowDefinition { Height = GridLength.Auto},
+				new RowDefinition { Height = GridLength.Auto},
+			};
+
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
+
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
+
+			Assert.AreEqual(new Rectangle(0, 0, 100, 20), labela0.Bounds);
+			Assert.AreEqual(new Rectangle(106, 0, 100, 20), labela1.Bounds);
+			Assert.AreEqual(new Rectangle(106, 26, 100, 20), labelb1.Bounds);
+			Assert.AreEqual(new Rectangle(0, 52, 206, 20), labelc.Bounds);
 		}
 
 		[Test]
-		public void TestAbsoluteLayout ()
+		public void Remove()
+		{
+			var labela0 = new Label { IsPlatformEnabled = true };
+			var labela1 = new Label { IsPlatformEnabled = true };
+			Grid.SetColumn(labela1, 1);
+			var labelb1 = new Label { IsPlatformEnabled = true };
+			Grid.SetRow(labelb1, 1);
+			Grid.SetColumn(labelb1, 1);
+			var labelc = new Label { IsPlatformEnabled = true };
+			Grid.SetRow(labelc, 2);
+			Grid.SetColumnSpan(labelc, 2);
+
+			var layout = new Grid
+			{
+				Children = {
+					labela0,
+					labela1,
+					labelb1,
+					labelc
+				}
+			};
+
+			layout.Children.Remove(labela0);
+			Assert.False(((IElementController)layout).LogicalChildren.Contains(labela0));
+		}
+
+		[Test]
+		public void TestAbsoluteLayout()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = new GridLength (150)},
 				new ColumnDefinition {Width = new GridLength (150)},
 				new ColumnDefinition {Width = new GridLength (150)},
@@ -1224,31 +1422,31 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition {Height = new GridLength (30)},
 				new RowDefinition {Height = new GridLength (30)},
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 1);
-			layout.Children.Add (label3, 2, 2);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 1);
+			layout.Children.Add(label3, 2, 2);
 
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 150, 30), label1.Bounds);
-			Assert.AreEqual (new Rectangle(156, 36, 150, 30), label2.Bounds);
-			Assert.AreEqual (new Rectangle(312, 72, 150, 30), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 150, 30), label1.Bounds);
+			Assert.AreEqual(new Rectangle(156, 36, 150, 30), label2.Bounds);
+			Assert.AreEqual(new Rectangle(312, 72, 150, 30), label3.Bounds);
 		}
 
 		[Test]
-		public void TestAbsoluteLayoutWithSpans ()
+		public void TestAbsoluteLayoutWithSpans()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = new GridLength (150)},
 				new ColumnDefinition {Width = new GridLength (150)},
 				new ColumnDefinition {Width = new GridLength (150)},
@@ -1258,31 +1456,31 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition {Height = new GridLength (30)},
 				new RowDefinition {Height = new GridLength (30)},
 			};
-			layout.Children.Add (label1, 0, 2, 0, 1);
-			layout.Children.Add (label2, 2, 3, 0, 2);
-			layout.Children.Add (label3, 1, 2);
+			layout.Children.Add(label1, 0, 2, 0, 1);
+			layout.Children.Add(label2, 2, 3, 0, 2);
+			layout.Children.Add(label3, 1, 2);
 
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 306, 30), label1.Bounds);
-			Assert.AreEqual (new Rectangle(312, 0, 150, 66), label2.Bounds);
-			Assert.AreEqual (new Rectangle(156, 72, 150, 30), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 306, 30), label1.Bounds);
+			Assert.AreEqual(new Rectangle(312, 0, 150, 66), label2.Bounds);
+			Assert.AreEqual(new Rectangle(156, 72, 150, 30), label3.Bounds);
 		}
 
 		[Test]
-		public void TestStarLayout ()
+		public void TestStarLayout()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
@@ -1292,33 +1490,33 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition {Height = new GridLength (1, GridUnitType.Star)},
 				new RowDefinition {Height = new GridLength (1, GridUnitType.Star)},
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 1);
-			layout.Children.Add (label3, 2, 2);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 1);
+			layout.Children.Add(label3, 2, 2);
 
-			var request = layout.GetSizeRequest (1002, 462);
-			Assert.AreEqual (312, request.Request.Width);
-			Assert.AreEqual (72, request.Request.Height);
+			var request = layout.GetSizeRequest(1002, 462);
+			Assert.AreEqual(312, request.Request.Width);
+			Assert.AreEqual(72, request.Request.Height);
 
-			layout.Layout (new Rectangle(0, 0, 1002, 462));
-			Assert.AreEqual (1002, layout.Width);
-			Assert.AreEqual (462, layout.Height);
+			layout.Layout(new Rectangle(0, 0, 1002, 462));
+			Assert.AreEqual(1002, layout.Width);
+			Assert.AreEqual(462, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 330, 150), label1.Bounds);
-			Assert.AreEqual (new Rectangle(336, 156, 330, 150), label2.Bounds);
-			Assert.AreEqual (new Rectangle(672, 312, 330, 150), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 330, 150), label1.Bounds);
+			Assert.AreEqual(new Rectangle(336, 156, 330, 150), label2.Bounds);
+			Assert.AreEqual(new Rectangle(672, 312, 330, 150), label3.Bounds);
 		}
 
 		[Test]
-		public void TestStarLayoutWithSpans ()
+		public void TestStarLayoutWithSpans()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
 				new ColumnDefinition {Width = new GridLength (1, GridUnitType.Star)},
@@ -1328,30 +1526,30 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition {Height = new GridLength (1, GridUnitType.Star)},
 				new RowDefinition {Height = new GridLength (1, GridUnitType.Star)},
 			};
-			layout.Children.Add (label1, 0, 2, 0, 1);
-			layout.Children.Add (label2, 2, 3, 0, 2);
-			layout.Children.Add (label3, 1, 2);
+			layout.Children.Add(label1, 0, 2, 0, 1);
+			layout.Children.Add(label2, 2, 3, 0, 2);
+			layout.Children.Add(label3, 1, 2);
 
-			layout.Layout (new Rectangle(0, 0, 1002, 462));
+			layout.Layout(new Rectangle(0, 0, 1002, 462));
 
-			Assert.AreEqual (1002, layout.Width);
-			Assert.AreEqual (462, layout.Height);
+			Assert.AreEqual(1002, layout.Width);
+			Assert.AreEqual(462, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 666, 150), label1.Bounds);
-			Assert.AreEqual (new Rectangle(672, 0, 330, 306), label2.Bounds);
-			Assert.AreEqual (new Rectangle(336, 312, 330, 150), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 666, 150), label1.Bounds);
+			Assert.AreEqual(new Rectangle(672, 0, 330, 306), label2.Bounds);
+			Assert.AreEqual(new Rectangle(336, 312, 330, 150), label3.Bounds);
 		}
 
 		[Test]
-		public void TestAutoLayout ()
+		public void TestAutoLayout()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = GridLength.Auto},
 				new ColumnDefinition {Width = GridLength.Auto},
 				new ColumnDefinition {Width = GridLength.Auto},
@@ -1361,23 +1559,23 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition {Height = GridLength.Auto},
 				new RowDefinition {Height = GridLength.Auto},
 			};
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 1);
-			layout.Children.Add (label3, 2, 2);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 1);
+			layout.Children.Add(label3, 2, 2);
 
 
-			layout.Layout (new Rectangle(0, 0, 1000, 1000));
+			layout.Layout(new Rectangle(0, 0, 1000, 1000));
 
-			Assert.AreEqual (1000, layout.Width);
-			Assert.AreEqual (1000, layout.Height);
+			Assert.AreEqual(1000, layout.Width);
+			Assert.AreEqual(1000, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 100, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(106, 26, 100, 20), label2.Bounds);
-			Assert.AreEqual (new Rectangle(212, 52, 100, 20), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 100, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(106, 26, 100, 20), label2.Bounds);
+			Assert.AreEqual(new Rectangle(212, 52, 100, 20), label3.Bounds);
 		}
 
 		[Test]
-		public void TestAutoLayoutWithSpans ()
+		public void TestAutoLayoutWithSpans()
 		{
 			var layout = new Grid();
 
@@ -1385,7 +1583,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			var label2 = new Label { IsPlatformEnabled = true, HeightRequest = 50, Text = "label2" };
 			var label3 = new Label { IsPlatformEnabled = true, Text = "label3" };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = GridLength.Auto},
 				new ColumnDefinition {Width = GridLength.Auto},
 				new ColumnDefinition {Width = GridLength.Auto},
@@ -1395,33 +1593,33 @@ namespace Xamarin.Forms.Core.UnitTests
 				new RowDefinition {Height = GridLength.Auto},
 				new RowDefinition {Height = GridLength.Auto},
 			};
-			layout.Children.Add (label1, 0, 2, 0, 1);
-			layout.Children.Add (label2, 2, 3, 0, 2);
-			layout.Children.Add (label3, 1, 2);
+			layout.Children.Add(label1, 0, 2, 0, 1);
+			layout.Children.Add(label2, 2, 3, 0, 2);
+			layout.Children.Add(label3, 1, 2);
 
-			layout.Layout (new Rectangle(0, 0, 1002, 462));
+			layout.Layout(new Rectangle(0, 0, 1002, 462));
 
-			Assert.AreEqual (1002, layout.Width);
-			Assert.AreEqual (462, layout.Height);
+			Assert.AreEqual(1002, layout.Width);
+			Assert.AreEqual(462, layout.Height);
 
-			Assert.AreEqual (new Rectangle(0, 0, 150, 20), label1.Bounds);
-			Assert.AreEqual (new Rectangle(156, 0, 100, 50), label2.Bounds);
-			Assert.AreEqual (new Rectangle(50, 56, 100, 20), label3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 150, 20), label1.Bounds);
+			Assert.AreEqual(new Rectangle(156, 0, 100, 50), label2.Bounds);
+			Assert.AreEqual(new Rectangle(50, 56, 100, 20), label3.Bounds);
 		}
 
 		[Test]
-		public void AutoLayoutWithComplexSpans ()
+		public void AutoLayoutWithComplexSpans()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true};
-			var label4 = new Label { IsPlatformEnabled = true, WidthRequest = 206};
-			var label5 = new Label { IsPlatformEnabled = true, WidthRequest = 312};
-			var label6 = new Label { IsPlatformEnabled = true, WidthRequest = 312};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true };
+			var label4 = new Label { IsPlatformEnabled = true, WidthRequest = 206 };
+			var label5 = new Label { IsPlatformEnabled = true, WidthRequest = 312 };
+			var label6 = new Label { IsPlatformEnabled = true, WidthRequest = 312 };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition {Width = GridLength.Auto},
 				new ColumnDefinition {Width = GridLength.Auto},
 				new ColumnDefinition {Width = GridLength.Auto},
@@ -1429,119 +1627,119 @@ namespace Xamarin.Forms.Core.UnitTests
 				new ColumnDefinition {Width = GridLength.Auto},
 			};
 
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
-			layout.Children.Add (label3, 4, 0);
-			layout.Children.Add (label4, 2, 4, 0, 1);
-			layout.Children.Add (label5, 0, 3, 0, 1);
-			layout.Children.Add (label6, 2, 6, 0, 1);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
+			layout.Children.Add(label3, 4, 0);
+			layout.Children.Add(label4, 2, 4, 0, 1);
+			layout.Children.Add(label5, 0, 3, 0, 1);
+			layout.Children.Add(label6, 2, 6, 0, 1);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 500));
+			layout.Layout(new Rectangle(0, 0, 1000, 500));
 
-			Assert.AreEqual (100, layout.ColumnDefinitions [0].ActualWidth);
-			Assert.AreEqual (100, layout.ColumnDefinitions [1].ActualWidth);
-			Assert.AreEqual (100, layout.ColumnDefinitions [2].ActualWidth);
-			Assert.AreEqual (100, layout.ColumnDefinitions [3].ActualWidth);
-			Assert.AreEqual (100, layout.ColumnDefinitions [4].ActualWidth);
+			Assert.AreEqual(100, layout.ColumnDefinitions[0].ActualWidth);
+			Assert.AreEqual(100, layout.ColumnDefinitions[1].ActualWidth);
+			Assert.AreEqual(100, layout.ColumnDefinitions[2].ActualWidth);
+			Assert.AreEqual(100, layout.ColumnDefinitions[3].ActualWidth);
+			Assert.AreEqual(100, layout.ColumnDefinitions[4].ActualWidth);
 		}
 
 		[Test]
-		public void AutoLayoutExpandColumns ()
+		public void AutoLayoutExpandColumns()
 		{
 			var layout = new Grid();
 
-			var label1 = new Label { IsPlatformEnabled = true};
-			var label2 = new Label { IsPlatformEnabled = true};
-			var label3 = new Label { IsPlatformEnabled = true, WidthRequest = 300};
+			var label1 = new Label { IsPlatformEnabled = true };
+			var label2 = new Label { IsPlatformEnabled = true };
+			var label3 = new Label { IsPlatformEnabled = true, WidthRequest = 300 };
 
-			layout.ColumnDefinitions = new ColumnDefinitionCollection { 
+			layout.ColumnDefinitions = new ColumnDefinitionCollection {
 				new ColumnDefinition { Width = GridLength.Auto },
 				new ColumnDefinition { Width = GridLength.Auto },
 			};
 
-			layout.Children.Add (label1, 0, 0);
-			layout.Children.Add (label2, 1, 0);
-			layout.Children.Add (label3, 0, 2, 0, 1);
+			layout.Children.Add(label1, 0, 0);
+			layout.Children.Add(label2, 1, 0);
+			layout.Children.Add(label3, 0, 2, 0, 1);
 
-			layout.Layout (new Rectangle(0, 0, 1000, 500));
+			layout.Layout(new Rectangle(0, 0, 1000, 500));
 
-			Assert.AreEqual (100, layout.ColumnDefinitions [0].ActualWidth);
-			Assert.AreEqual (194, layout.ColumnDefinitions [1].ActualWidth);
+			Assert.AreEqual(100, layout.ColumnDefinitions[0].ActualWidth);
+			Assert.AreEqual(194, layout.ColumnDefinitions[1].ActualWidth);
 		}
 
 		[Test]
-		public void GridHasDefaultDefinitions ()
+		public void GridHasDefaultDefinitions()
 		{
 			var grid = new Grid();
-			Assert.NotNull (grid.ColumnDefinitions);
-			Assert.NotNull (grid.RowDefinitions);
+			Assert.NotNull(grid.ColumnDefinitions);
+			Assert.NotNull(grid.RowDefinitions);
 		}
 
 		[Test]
-		public void DefaultDefinitionsArentSharedAccrossInstances ()
+		public void DefaultDefinitionsArentSharedAccrossInstances()
 		{
 			var grid0 = new Grid();
 			var coldefs = grid0.ColumnDefinitions;
 			var rowdefs = grid0.RowDefinitions;
 
 			var grid1 = new Grid();
-			Assert.AreNotSame (grid0, grid1);
-			Assert.AreNotSame (coldefs, grid1.ColumnDefinitions);
-			Assert.AreNotSame (rowdefs, grid1.RowDefinitions);
+			Assert.AreNotSame(grid0, grid1);
+			Assert.AreNotSame(coldefs, grid1.ColumnDefinitions);
+			Assert.AreNotSame(rowdefs, grid1.RowDefinitions);
 		}
 
 		[Test]
-		public void ChildrenLayoutRespectAlignment ()
+		public void ChildrenLayoutRespectAlignment()
 		{
 			var grid = new Grid
-			{ 
+			{
 				ColumnDefinitions = { new ColumnDefinition { Width = new GridLength(300) } },
 				RowDefinitions = { new RowDefinition { Height = new GridLength(100) } },
 			};
 			var label = new Label
-			{ 
+			{
 				IsPlatformEnabled = true,
 				VerticalOptions = LayoutOptions.Center,
 				HorizontalOptions = LayoutOptions.End,
 			};
 
-			grid.Children.Add (label);
-			grid.Layout (new Rectangle(0, 0, 500, 500));
+			grid.Children.Add(label);
+			grid.Layout(new Rectangle(0, 0, 500, 500));
 
-			Assert.AreEqual (new Rectangle(200, 40, 100, 20), label.Bounds);
+			Assert.AreEqual(new Rectangle(200, 40, 100, 20), label.Bounds);
 		}
 
 		[Test]
-		public void BothChildrenPropertiesUseTheSameBackendStore ()
+		public void BothChildrenPropertiesUseTheSameBackendStore()
 		{
 			var view = new View();
 			var grid = new Grid();
-			Assert.AreEqual (0, grid.Children.Count);
-			(grid as Layout<View>).Children.Add (view);
-			Assert.AreEqual (1, grid.Children.Count);
-			Assert.AreEqual (1, (grid as Layout<View>).Children.Count);
-			Assert.AreSame (view, (grid as Layout<View>).Children.First ());
-			Assert.AreSame (view, grid.Children.First ());
+			Assert.AreEqual(0, grid.Children.Count);
+			(grid as Layout<View>).Children.Add(view);
+			Assert.AreEqual(1, grid.Children.Count);
+			Assert.AreEqual(1, (grid as Layout<View>).Children.Count);
+			Assert.AreSame(view, (grid as Layout<View>).Children.First());
+			Assert.AreSame(view, grid.Children.First());
 		}
 
 		[Test]
 		//Issue 1384
-		public void ImageInAutoCellIsProperlyConstrained ()
+		public void ImageInAutoCellIsProperlyConstrained()
 		{
 			var content = new Image
-			{ 
-				Aspect= Aspect.AspectFit,
-				IsPlatformEnabled = true 
+			{
+				Aspect = Aspect.AspectFit,
+				IsPlatformEnabled = true
 			};
 			var grid = new Grid
 			{
 				IsPlatformEnabled = true,
-				BackgroundColor = Color.Red, 
-				VerticalOptions= LayoutOptions.Start,
+				BackgroundColor = Color.Red,
+				VerticalOptions = LayoutOptions.Start,
 				Children = {
 					content
 				},
-				RowDefinitions = { new RowDefinition { Height = GridLength.Auto} },
+				RowDefinitions = { new RowDefinition { Height = GridLength.Auto } },
 				ColumnDefinitions = { new ColumnDefinition { Width = GridLength.Auto } }
 			};
 			var view = new ContentView
@@ -1549,31 +1747,31 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 				Content = grid,
 			};
-			view.Layout (new Rectangle(0, 0, 100, 100));
-			Assert.AreEqual (100, grid.Width);
-			Assert.AreEqual (20, grid.Height);
+			view.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.AreEqual(100, grid.Width);
+			Assert.AreEqual(20, grid.Height);
 
-			view.Layout (new Rectangle(0, 0, 50, 50));
-			Assert.AreEqual (50, grid.Width);
-			Assert.AreEqual (10, grid.Height);
+			view.Layout(new Rectangle(0, 0, 50, 50));
+			Assert.AreEqual(50, grid.Width);
+			Assert.AreEqual(10, grid.Height);
 		}
 
 		[Test]
 		//Issue 1384
-		public void ImageInStarCellIsProperlyConstrained ()
+		public void ImageInStarCellIsProperlyConstrained()
 		{
 			var content = new Image
-			{ 
-				Aspect= Aspect.AspectFit,
+			{
+				Aspect = Aspect.AspectFit,
 				MinimumHeightRequest = 10,
 				MinimumWidthRequest = 50,
-				IsPlatformEnabled = true 
+				IsPlatformEnabled = true
 			};
 			var grid = new Grid
 			{
 				IsPlatformEnabled = true,
-				BackgroundColor = Color.Red, 
-				VerticalOptions= LayoutOptions.Start,
+				BackgroundColor = Color.Red,
+				VerticalOptions = LayoutOptions.Start,
 				Children = {
 					content
 				}
@@ -1583,20 +1781,20 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 				Content = grid,
 			};
-			view.Layout (new Rectangle(0, 0, 100, 100));
-			Assert.AreEqual (100, grid.Width);
-			Assert.AreEqual (20, grid.Height);
+			view.Layout(new Rectangle(0, 0, 100, 100));
+			Assert.AreEqual(100, grid.Width);
+			Assert.AreEqual(20, grid.Height);
 
-			view.Layout (new Rectangle(0, 0, 50, 50));
-			Assert.AreEqual (50, grid.Width);
-			Assert.AreEqual (10, grid.Height);
+			view.Layout(new Rectangle(0, 0, 50, 50));
+			Assert.AreEqual(50, grid.Width);
+			Assert.AreEqual(10, grid.Height);
 		}
 
 		[Test]
-		public void SizeRequestForStar ()
+		public void SizeRequestForStar()
 		{
 			var grid = new Grid
-			{ 
+			{
 				RowDefinitions = new RowDefinitionCollection {
 					new RowDefinition {Height = new GridLength (1, GridUnitType.Star)},
 					new RowDefinition {Height = GridLength.Auto},
@@ -1606,26 +1804,26 @@ namespace Xamarin.Forms.Core.UnitTests
 					new ColumnDefinition {Width = GridLength.Auto},
 				}
 			};
-			grid.Children.Add (new Label { BackgroundColor = Color.Lime, Text="Foo", IsPlatformEnabled = true});
-			grid.Children.Add (new Label { Text = "Bar", IsPlatformEnabled = true},0,1);
-			grid.Children.Add (new Label { Text = "Baz", XAlign = TextAlignment.End, IsPlatformEnabled = true},1,0);
-			grid.Children.Add (new Label { Text = "Qux", XAlign = TextAlignment.End, IsPlatformEnabled = true},1,1);
+			grid.Children.Add(new Label { BackgroundColor = Color.Lime, Text = "Foo", IsPlatformEnabled = true });
+			grid.Children.Add(new Label { Text = "Bar", IsPlatformEnabled = true }, 0, 1);
+			grid.Children.Add(new Label { Text = "Baz", XAlign = TextAlignment.End, IsPlatformEnabled = true }, 1, 0);
+			grid.Children.Add(new Label { Text = "Qux", XAlign = TextAlignment.End, IsPlatformEnabled = true }, 1, 1);
 
-			var request = grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);
-			Assert.AreEqual (206, request.Request.Width);
-			Assert.AreEqual (46, request.Request.Height);
+			var request = grid.GetSizeRequest(double.PositiveInfinity, double.PositiveInfinity);
+			Assert.AreEqual(206, request.Request.Width);
+			Assert.AreEqual(46, request.Request.Height);
 
-			Assert.AreEqual (106, request.Minimum.Width);
-			Assert.AreEqual (26, request.Minimum.Height);
+			Assert.AreEqual(106, request.Minimum.Width);
+			Assert.AreEqual(26, request.Minimum.Height);
 			//
 		}
 
 		[Test]
 		//Issue 1497
-		public void StarRowsShouldOccupyTheSpace ()
+		public void StarRowsShouldOccupyTheSpace()
 		{
 			var label = new Label
-			{ 
+			{
 				IsPlatformEnabled = true,
 			};
 			var Button = new Button
@@ -1646,15 +1844,15 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true,
 			};
 
-			grid.Children.Add (label);
-			grid.Children.Add (Button, 0, 1);
+			grid.Children.Add(label);
+			grid.Children.Add(Button, 0, 1);
 
-			grid.Layout (new Rectangle(0, 0, 300, 300));
-			Assert.AreEqual (new Rectangle(0, 280, 300, 20), Button.Bounds);
+			grid.Layout(new Rectangle(0, 0, 300, 300));
+			Assert.AreEqual(new Rectangle(0, 280, 300, 20), Button.Bounds);
 		}
 
 		[Test]
-		public void StarColumnsWithSpansDoNotExpandAutos ()
+		public void StarColumnsWithSpansDoNotExpandAutos()
 		{
 			var grid = new Grid
 			{
@@ -1670,40 +1868,40 @@ namespace Xamarin.Forms.Core.UnitTests
 				IsPlatformEnabled = true
 			};
 
-			var spanBox = new BoxView { WidthRequest = 70, HeightRequest = 20, IsPlatformEnabled = true};
-			var box1 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
-			var box2 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
-			var box3 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true};
+			var spanBox = new BoxView { WidthRequest = 70, HeightRequest = 20, IsPlatformEnabled = true };
+			var box1 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true };
+			var box2 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true };
+			var box3 = new BoxView { WidthRequest = 20, HeightRequest = 20, IsPlatformEnabled = true };
 
-			grid.Children.Add (spanBox, 0, 3, 0, 1);
-			grid.Children.Add (box1, 0, 1);
-			grid.Children.Add (box2, 1, 1);
-			grid.Children.Add (box3, 2, 1);
+			grid.Children.Add(spanBox, 0, 3, 0, 1);
+			grid.Children.Add(box1, 0, 1);
+			grid.Children.Add(box2, 1, 1);
+			grid.Children.Add(box3, 2, 1);
 
-			grid.Layout (new Rectangle(0, 0, 300, 46));
+			grid.Layout(new Rectangle(0, 0, 300, 46));
 
-			Assert.AreEqual (new Rectangle(0, 0, 300, 20), spanBox.Bounds);
-			Assert.AreEqual (new Rectangle(0, 26, 20, 20), box1.Bounds);
-			Assert.AreEqual (new Rectangle(26, 26, 20, 20), box2.Bounds);
-			Assert.AreEqual (new Rectangle(52, 26, 248, 20), box3.Bounds);
+			Assert.AreEqual(new Rectangle(0, 0, 300, 20), spanBox.Bounds);
+			Assert.AreEqual(new Rectangle(0, 26, 20, 20), box1.Bounds);
+			Assert.AreEqual(new Rectangle(26, 26, 20, 20), box2.Bounds);
+			Assert.AreEqual(new Rectangle(52, 26, 248, 20), box3.Bounds);
 		}
 
-		static SizeRequest GetResizableSize (VisualElement view, double widthconstraint, double heightconstraint)
+		static SizeRequest GetResizableSize(VisualElement view, double widthconstraint, double heightconstraint)
 		{
 			if (!(view is Editor))
 				return new SizeRequest(new Size(100, 20));
 			if (widthconstraint < 100)
-				return new SizeRequest(new Size(widthconstraint, 2000/widthconstraint));
+				return new SizeRequest(new Size(widthconstraint, 2000 / widthconstraint));
 			if (heightconstraint < 20)
-				return new SizeRequest(new Size(2000/heightconstraint, heightconstraint));
+				return new SizeRequest(new Size(2000 / heightconstraint, heightconstraint));
 			return new SizeRequest(new Size(100, 20));
 		}
-			
+
 		[Test]
 		//Issue 1893
-		public void EditorSpanningOnMultipleAutoRows ()
+		public void EditorSpanningOnMultipleAutoRows()
 		{
-			Device.PlatformServices = new MockPlatformServices(getNativeSizeFunc:GetResizableSize);
+			Device.PlatformServices = new MockPlatformServices(getNativeSizeFunc: GetResizableSize);
 
 			var grid0 = new Grid
 			{
@@ -1720,11 +1918,11 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var label0 = new Label { IsPlatformEnabled = true };
 			var editor0 = new Editor { IsPlatformEnabled = true };
-			grid0.Children.Add (label0, 0, 0);
-			grid0.Children.Add (editor0, 1, 2, 0, 2);
+			grid0.Children.Add(label0, 0, 0);
+			grid0.Children.Add(editor0, 1, 2, 0, 2);
 
-			grid0.Layout (new Rectangle(0, 0, 156, 200));
-			Assert.AreEqual (new Rectangle(106, 0, 50, 40), editor0.Bounds);
+			grid0.Layout(new Rectangle(0, 0, 156, 200));
+			Assert.AreEqual(new Rectangle(106, 0, 50, 40), editor0.Bounds);
 
 			var grid1 = new Grid
 			{
@@ -1740,17 +1938,17 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			var label1 = new Label { IsPlatformEnabled = true };
 			var editor1 = new Editor { IsPlatformEnabled = true };
-			grid1.Children.Add (label1, 0, 0);
-			grid1.Children.Add (editor1, 1, 0);
+			grid1.Children.Add(label1, 0, 0);
+			grid1.Children.Add(editor1, 1, 0);
 
-			grid1.Layout (new Rectangle(0, 0, 156, 200));
-			Assert.AreEqual (new Rectangle(106, 0, 50, 40), editor1.Bounds);
+			grid1.Layout(new Rectangle(0, 0, 156, 200));
+			Assert.AreEqual(new Rectangle(106, 0, 50, 40), editor1.Bounds);
 		}
 
 		[Test]
-		public void WidthBoundRequestRespected ()
+		public void WidthBoundRequestRespected()
 		{
-			Device.PlatformServices = new MockPlatformServices(getNativeSizeFunc:GetResizableSize);
+			Device.PlatformServices = new MockPlatformServices(getNativeSizeFunc: GetResizableSize);
 
 			var grid = new Grid
 			{
@@ -1767,72 +1965,73 @@ namespace Xamarin.Forms.Core.UnitTests
 				ColumnSpacing = 0,
 			};
 
-			var topLabel = new Editor { IsPlatformEnabled = true};
-			var leftLabel = new Label { IsPlatformEnabled = true, WidthRequest = 10};
-			var rightLabel = new Label { IsPlatformEnabled = true, WidthRequest = 10};
+			var topLabel = new Editor { IsPlatformEnabled = true };
+			var leftLabel = new Label { IsPlatformEnabled = true, WidthRequest = 10 };
+			var rightLabel = new Label { IsPlatformEnabled = true, WidthRequest = 10 };
 
-			grid.Children.Add (topLabel, 0, 2, 0, 1);
-			grid.Children.Add (leftLabel, 0, 1);
-			grid.Children.Add (rightLabel, 1, 1);
+			grid.Children.Add(topLabel, 0, 2, 0, 1);
+			grid.Children.Add(leftLabel, 0, 1);
+			grid.Children.Add(rightLabel, 1, 1);
 
-			var unboundRequest = grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity);
-			var widthBoundRequest = grid.GetSizeRequest (50, double.PositiveInfinity);
+			var unboundRequest = grid.GetSizeRequest(double.PositiveInfinity, double.PositiveInfinity);
+			var widthBoundRequest = grid.GetSizeRequest(50, double.PositiveInfinity);
 
-			Assert.AreEqual (new SizeRequest(new Size(20, 120), new Size(0, 120)), unboundRequest);
-			Assert.AreEqual (new SizeRequest(new Size(50, 60), new Size(0, 60)), widthBoundRequest);
+			Assert.AreEqual(new SizeRequest(new Size(20, 120), new Size(0, 120)), unboundRequest);
+			Assert.AreEqual(new SizeRequest(new Size(50, 60), new Size(0, 60)), widthBoundRequest);
 		}
 
 		[Test]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=31608
-		public void ColAndRowDefinitionsAreActuallyBindable ()
+		public void ColAndRowDefinitionsAreActuallyBindable()
 		{
 			var rowdef = new RowDefinition();
-			rowdef.SetBinding (RowDefinition.HeightProperty, "Height");
+			rowdef.SetBinding(RowDefinition.HeightProperty, "Height");
 			var grid = new Grid
 			{
 				RowDefinitions = new RowDefinitionCollection { rowdef },
 			};
-			Assert.AreEqual (RowDefinition.HeightProperty.DefaultValue, rowdef.Height);
-			grid.BindingContext = new {Height = 32};
-			Assert.AreEqual (new GridLength(32), rowdef.Height);
+			Assert.AreEqual(RowDefinition.HeightProperty.DefaultValue, rowdef.Height);
+			grid.BindingContext = new { Height = 32 };
+			Assert.AreEqual(new GridLength(32), rowdef.Height);
 		}
 
 		[Test]
 		//https://bugzilla.xamarin.com/show_bug.cgi?id=31967
-		public void ChangingRowHeightViaBindingTriggersRedraw ()
+		public void ChangingRowHeightViaBindingTriggersRedraw()
 		{
 			var rowdef = new RowDefinition();
-			rowdef.SetBinding (RowDefinition.HeightProperty, "Height");
+			rowdef.SetBinding(RowDefinition.HeightProperty, "Height");
 			var grid = new Grid
 			{
-//				RowDefinitions = new RowDefinitionCollection {
-//					new RowDefinition { Height = GridLength.Auto },
-//					rowdef
-//				},
+				//				RowDefinitions = new RowDefinitionCollection {
+				//					new RowDefinition { Height = GridLength.Auto },
+				//					rowdef
+				//				},
 				RowSpacing = 0,
 				IsPlatformEnabled = true,
 			};
-			grid.RowDefinitions.Add (new RowDefinition { Height = GridLength.Auto });
-			grid.RowDefinitions.Add (rowdef);
+			grid.RowDefinitions.Add(new RowDefinition { Height = GridLength.Auto });
+			grid.RowDefinitions.Add(rowdef);
 
 			var label0 = new Label { IsPlatformEnabled = true };
-			Grid.SetRow (label0, 0);
+			Grid.SetRow(label0, 0);
 			var label1 = new Label { IsPlatformEnabled = true };
-			Grid.SetRow (label1, 1);
+			Grid.SetRow(label1, 1);
 
-			grid.BindingContext = new {Height = 0};
-			grid.Children.Add (label0);
-			grid.Children.Add (label1);
+			grid.BindingContext = new { Height = 0 };
+			grid.Children.Add(label0);
+			grid.Children.Add(label1);
 
-			Assert.AreEqual (new SizeRequest(new Size(100, 20), new Size(0, 20)), grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity));
-			grid.BindingContext = new {Height = 42};
-			Assert.AreEqual (new SizeRequest(new Size(100, 62), new Size(0, 62)), grid.GetSizeRequest (double.PositiveInfinity, double.PositiveInfinity));
+			Assert.AreEqual(new SizeRequest(new Size(100, 20), new Size(0, 20)), grid.GetSizeRequest(double.PositiveInfinity, double.PositiveInfinity));
+			grid.BindingContext = new { Height = 42 };
+			Assert.AreEqual(new SizeRequest(new Size(100, 62), new Size(0, 62)), grid.GetSizeRequest(double.PositiveInfinity, double.PositiveInfinity));
 		}
 
 		[Test]
-		public void InvalidationBlockedForAbsoluteCell ()
+		public void InvalidationBlockedForAbsoluteCell()
 		{
-			var grid = new Grid() {
+			var grid = new Grid()
+			{
 				IsPlatformEnabled = true,
 				RowDefinitions = {
 					new RowDefinition { Height = new GridLength (100, GridUnitType.Absolute) }
@@ -1843,16 +2042,17 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 
 			var label = new Label { IsPlatformEnabled = true };
-			grid.Children.Add (label);
+			grid.Children.Add(label);
 
 			bool invalidated = false;
-			grid.MeasureInvalidated += (sender, args) => {
+			grid.MeasureInvalidated += (sender, args) =>
+			{
 				invalidated = true;
 			};
 
 			label.Text = "Testing";
 
-			Assert.False (invalidated);
+			Assert.False(invalidated);
 		}
 
 		[Test]
@@ -1977,7 +2177,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 			view.Layout(new Rectangle(0, 0, 800, 800));
 
-
 			Assert.AreEqual(boxRow0Column0.MinimumHeightRequest, boxRow0Column0.Height);
 			Assert.AreEqual(boxRow0Column1.MinimumHeightRequest, boxRow0Column1.Height);
 		}
@@ -1991,47 +2190,47 @@ namespace Xamarin.Forms.Core.UnitTests
 			Fixed = LayoutConstraint.Fixed
 		}
 
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Star, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.None, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Star, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.VerticallyFixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Star, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.HorizontallyFixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Star, GridUnitType.Star, ExpectedResult = true)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
-		[TestCase (HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
-		public bool InvalidationPropogationTests (HackLayoutConstraint gridConstraint, GridUnitType horizontalType, GridUnitType verticalType)
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Star, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.None, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Star, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.VerticallyFixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Star, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.HorizontallyFixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Absolute, GridUnitType.Absolute, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Star, GridUnitType.Absolute, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Absolute, GridUnitType.Star, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Absolute, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Absolute, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Star, GridUnitType.Star, ExpectedResult = true)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Star, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Star, GridUnitType.Auto, ExpectedResult = false)]
+		[TestCase(HackLayoutConstraint.Fixed, GridUnitType.Auto, GridUnitType.Auto, ExpectedResult = false)]
+		public bool InvalidationPropogationTests(HackLayoutConstraint gridConstraint, GridUnitType horizontalType, GridUnitType verticalType)
 		{
 			var grid = new Grid
 			{
-				ComputedConstraint = (LayoutConstraint) gridConstraint,
+				ComputedConstraint = (LayoutConstraint)gridConstraint,
 				IsPlatformEnabled = true,
 				RowDefinitions = {
 					new RowDefinition { Height = new GridLength (1, verticalType) }
@@ -2042,10 +2241,11 @@ namespace Xamarin.Forms.Core.UnitTests
 			};
 
 			var label = new Label { IsPlatformEnabled = true };
-			grid.Children.Add (label);
+			grid.Children.Add(label);
 
 			bool invalidated = false;
-			grid.MeasureInvalidated += (sender, args) => {
+			grid.MeasureInvalidated += (sender, args) =>
+			{
 				invalidated = true;
 			};
 
@@ -2058,24 +2258,24 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class GridMeasureTests : BaseTestFixture
 	{
-		static List<Action> delayActions = new List<Action> ();
+		static List<Action> delayActions = new List<Action>();
 
 		[SetUp]
 		public override void Setup()
 		{
-			base.Setup ();
-			Device.PlatformServices = new MockPlatformServices (invokeOnMainThread: a => { delayActions.Add (a); });
+			base.Setup();
+			Device.PlatformServices = new MockPlatformServices(invokeOnMainThread: a => { delayActions.Add(a); });
 		}
 
 		[TearDown]
 		public override void TearDown()
 		{
-			base.TearDown ();
+			base.TearDown();
 			Device.PlatformServices = null;
 		}
-		
+
 		[Test]
-		public void NestedInvalidateMeasureDoesNotCrash ()
+		public void NestedInvalidateMeasureDoesNotCrash()
 		{
 			var grid = new Grid
 			{
@@ -2086,25 +2286,27 @@ namespace Xamarin.Forms.Core.UnitTests
 			{
 				IsPlatformEnabled = true
 			};
-			grid.Children.Add (child);
+			grid.Children.Add(child);
 
 			var child2 = new Label
 			{
 				IsPlatformEnabled = true
 			};
-			grid.Children.Add (child2);
+			grid.Children.Add(child2);
 
 			bool fire = true;
-			child.SizeChanged += (sender, args) => {
+			child.SizeChanged += (sender, args) =>
+			{
 				if (fire)
 					((IVisualElementController)child).InvalidateMeasure(InvalidationTrigger.Undefined);
 				fire = false;
 			};
 
-			grid.Layout (new Rectangle(0, 0, 100, 100));
+			grid.Layout(new Rectangle(0, 0, 100, 100));
 
-			foreach (var delayAction in delayActions) {
-				delayAction ();
+			foreach (var delayAction in delayActions)
+			{
+				delayAction();
 			}
 		}
 	}

--- a/Xamarin.Forms.Core.UnitTests/GridTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GridTests.cs
@@ -142,11 +142,59 @@ namespace Xamarin.Forms.Core.UnitTests
 			var column0Width = grid.ColumnDefinitions[0].ActualWidth;
 			var column1Width = grid.ColumnDefinitions[1].ActualWidth;
 
-			Assert.That(column0Width, Is.LessThan(column1Width)); 
+			Assert.That(column0Width, Is.LessThan(column1Width));
 
 			// Having a first column which is a fraction of a Star width should not cause the grid
 			// to contract below the target width
-			Assert.That(column0Width + column1Width, Is.GreaterThanOrEqualTo(gridWidth));
+			var totalColumnSpacing = (grid.ColumnDefinitions.Count - 1) * grid.ColumnSpacing;
+
+			Assert.That(column0Width + column1Width + totalColumnSpacing, Is.GreaterThanOrEqualTo(gridWidth));
+		}
+
+		[Test]
+		public void ColumnsLessThanOneStarShouldBeTallerThanOneStarColumns() 
+		{
+			var grid1 = new Grid() { ColumnSpacing = 0 };
+
+			grid1.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+			grid1.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+
+			grid1.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			var label1 = new ColumnTestLabel
+			{
+				Text = "label1"
+			};
+
+			grid1.Children.Add(label1, 0, 0);
+
+			var gridWidth = 400;
+			grid1.Measure(gridWidth, double.PositiveInfinity);
+			var column0Width = grid1.ColumnDefinitions[0].ActualWidth;
+			var column1Width = grid1.ColumnDefinitions[1].ActualWidth;
+
+			Assert.That(column0Width, Is.EqualTo(column1Width));
+			var grid1Height = grid1.RowDefinitions[0].ActualHeight;
+
+			var grid2 = new Grid() { ColumnSpacing = 0 };
+
+			grid2.ColumnDefinitions.Add(new ColumnDefinition() { Width = new GridLength(0.5, GridUnitType.Star) });
+			grid2.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Star });
+
+			grid2.RowDefinitions.Add(new RowDefinition() { Height = GridLength.Auto });
+
+			var label2 = new ColumnTestLabel
+			{
+				Text = "label2"
+			};
+
+			grid2.Children.Add(label2, 0, 0);
+
+			grid2.Measure(gridWidth, double.PositiveInfinity);
+			var grid2Height = grid2.RowDefinitions[0].ActualHeight;
+
+
+			Assert.That(grid2Height, Is.GreaterThan(grid1Height));
 		}
 
 		[Test]
@@ -1807,7 +1855,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.False (invalidated);
 		}
 
-
 		[Test]
 		//https://github.com/xamarin/Xamarin.Forms/issues/4933
 		public void GridHeightCorrectWhenAspectFitImageGetsShrinked()
@@ -1827,7 +1874,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(50, measurement.Request.Width);
 			Assert.AreEqual(10, measurement.Request.Height);
 		}
-
 
 		[Test]
 		public void MinimumWidthRequestInAutoCells()
@@ -1935,8 +1981,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(boxRow0Column0.MinimumHeightRequest, boxRow0Column0.Height);
 			Assert.AreEqual(boxRow0Column1.MinimumHeightRequest, boxRow0Column1.Height);
 		}
-
-
 
 		// because the constraint is internal, we need this
 		public enum HackLayoutConstraint

--- a/Xamarin.Forms.Core/GridCalc.cs
+++ b/Xamarin.Forms.Core/GridCalc.cs
@@ -515,7 +515,7 @@ namespace Xamarin.Forms
 		void MeasureAndContractStarredColumns(double width, double height, double totalStarsWidth)
 		{
 			double starColWidth;
-			starColWidth = MeasuredStarredColumns(width, height);
+			starColWidth = MeasuredStarredColumns(width, height, totalStarsWidth);
 
 			if (!double.IsPositiveInfinity(width) && double.IsPositiveInfinity(height))
 			{
@@ -543,7 +543,7 @@ namespace Xamarin.Forms
 		void MeasureAndContractStarredRows(double width, double height, double totalStarsHeight)
 		{
 			double starRowHeight;
-			starRowHeight = MeasureStarredRows(width, height); 
+			starRowHeight = MeasureStarredRows(width, height, totalStarsHeight); 
 
 			if (!double.IsPositiveInfinity(height) && double.IsPositiveInfinity(width))
 			{
@@ -613,7 +613,7 @@ namespace Xamarin.Forms
 			ExpandLastAutoColumnIfNeeded(width, requestSize);
 		}
 
-		double MeasuredStarredColumns(double widthConstraint, double heightConstraint)
+		double MeasuredStarredColumns(double widthConstraint, double heightConstraint, double totalStarsWidth)
 		{
 			double starColWidth;
 			for (var iteration = 0; iteration < 2; iteration++)
@@ -638,8 +638,9 @@ namespace Xamarin.Forms
 							double assignedWidth = GetAssignedColumnWidth(child);
 
 							SizeRequest sizeRequest = child.Measure(widthConstraint, heightConstraint, MeasureFlags.IncludeMargins);
-							actualWidth = Math.Max(actualWidth, sizeRequest.Request.Width - assignedWidth - (GetColumnSpan(child) - 1) * ColumnSpacing);
-							minimumWidth = Math.Max(minimumWidth, sizeRequest.Minimum.Width - assignedWidth - (GetColumnSpan(child) - 1) * ColumnSpacing);
+							var columnSpacing = (GetColumnSpan(child) - 1) * ColumnSpacing;
+							actualWidth = Math.Max(actualWidth, sizeRequest.Request.Width - assignedWidth - columnSpacing);
+							minimumWidth = Math.Max(minimumWidth, sizeRequest.Minimum.Width - assignedWidth - columnSpacing);
 						}
 						if (actualWidth >= 0)
 							col.ActualWidth = actualWidth;
@@ -650,19 +651,20 @@ namespace Xamarin.Forms
 				}
 			}
 
-			starColWidth = 1;
+			starColWidth = 0;
 			for (var index = 0; index < _columns.Count; index++)
 			{
 				ColumnDefinition col = _columns[index];
-				if (!col.Width.IsStar)
+				if (!col.Width.IsStar || col.Width.Value == 0)
 					continue;
-				starColWidth = col.Width.Value != 0 ? Math.Max(starColWidth, col.ActualWidth / col.Width.Value) : 0;
+				
+				starColWidth += col.ActualWidth;
 			}
 
-			return starColWidth;
+			return Math.Max(starColWidth / totalStarsWidth, 1);
 		}
 
-		double MeasureStarredRows(double widthConstraint, double heightConstraint)
+		double MeasureStarredRows(double widthConstraint, double heightConstraint, double totalStarsHeight)
 		{
 			double starRowHeight;
 			for (var iteration = 0; iteration < 2; iteration++)
@@ -687,8 +689,9 @@ namespace Xamarin.Forms
 							double assignedHeight = GetAssignedRowHeight(child);
 
 							SizeRequest sizeRequest = child.Measure(widthConstraint, heightConstraint, MeasureFlags.IncludeMargins);
-							actualHeight = Math.Max(actualHeight, sizeRequest.Request.Height - assignedHeight -  (GetRowSpan(child) - 1) * RowSpacing);
-							minimumHeight = Math.Max(minimumHeight, sizeRequest.Minimum.Height - assignedHeight - (GetRowSpan(child) - 1) * RowSpacing);
+							var rowSpacing = (GetRowSpan(child) - 1) * RowSpacing;
+							actualHeight = Math.Max(actualHeight, sizeRequest.Request.Height - assignedHeight - rowSpacing);
+							minimumHeight = Math.Max(minimumHeight, sizeRequest.Minimum.Height - assignedHeight - rowSpacing);
 						}
 						if (actualHeight >= 0)
 							row.ActualHeight = actualHeight;
@@ -699,16 +702,17 @@ namespace Xamarin.Forms
 				}
 			}
 
-			starRowHeight = 1;
+			starRowHeight = 0;
 			for (var index = 0; index < _rows.Count; index++)
 			{
 				RowDefinition row = _rows[index];
-				if (!row.Height.IsStar)
+				if (!row.Height.IsStar || row.Height.Value == 0)
 					continue;
-				starRowHeight = row.Height.Value != 0 ? Math.Max(starRowHeight, row.ActualHeight / row.Height.Value) : 0;
+
+				starRowHeight += row.ActualHeight;
 			}
 
-			return starRowHeight;
+			return Math.Max(starRowHeight / totalStarsHeight, 1);
 		}
 
 		void ZeroUnassignedCells()


### PR DESCRIPTION
### Description of Change ###

Fixes for some regressions on 4.8 with Grid layout. Unconstrained star rows affected by star columns now constrain Labels correctly when measuring to allow the text to grow vertically by the correct amount. Star row/column computations no longer include "unmeasured" (i.e. -1) values in size calculations. Star column calculations now account for absolute column widths and partial star column (e.g. "0.7*") when measuring elements where width/height are interdependent (e.g., Labels).

Also adds automated tests for the regressed scenarios.

### Issues Resolved ### 

- fixes #12001
- fixes #12175
- fixes #12462
- fixes #12363
- fixes #12292

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated tests

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
