### PR TITLE
MacOS - Consume RightMouseDown if InputTransparent == false

### DIFF
--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -337,10 +337,14 @@ namespace Xamarin.Forms.Platform.MacOS
 #else
 		public override void MouseDown(NSEvent theEvent)
 		{
-			bool inViewCell = IsOnViewCell(Element);
-
-			if (Element.InputTransparent || inViewCell)
+			if (Element.InputTransparent || IsOnViewCell(Element))
 				base.MouseDown(theEvent);
+		}
+
+		public override void RightMouseDown(NSEvent theEvent)
+		{
+			if (Element.InputTransparent || IsOnViewCell(Element))
+				base.RightMouseDown(theEvent);
 		}
 
 		public override void RightMouseUp(NSEvent theEvent)


### PR DESCRIPTION
### Description of Change ###

Consume RightMouseDown if InputTransparent == false

### Platforms Affected ### 

- MacOS

### Behavioral/Visual Changes ###

For example, ViewB is empty and placed on top of ViewA, right-clicking on ViewB is currently always passed to ViewA.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
