### PR TITLE
[Tizen] Support Brushes to Tizen

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -32,6 +32,7 @@
       </group>
       <group targetFramework="tizen40">
         <dependency id="Tizen.NET" version="4.0.0"/>
+        <dependency id="SkiaSharp.Views" version="2.80.2"/>
       </group>
     </dependencies>
 

--- a/Xamarin.Forms.Platform.Tizen/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.Tizen/Extensions/BrushExtensions.cs
@@ -1,0 +1,97 @@
+using System;
+using System.Linq;
+using SkiaSharp;
+using SkiaSharp.Views.Tizen;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public static class BrushExtensions
+	{
+		public static SKPath ToPath(this SKRectI bounds)
+		{
+			var path = new SKPath();
+			path.AddRect(bounds);
+			path.Close();
+			return path;
+		}
+
+		public static SKPath ToPath(this SKRoundRect bounds)
+		{
+			var path = new SKPath();
+			path.AddRoundRect(bounds);
+			path.Close();
+			return path;
+		}
+
+		public static SKPath ToRoundedRectPath(this SKRectI bounds, CornerRadius cornerRadius)
+		{
+			var path = new SKPath();
+			var skRoundRect = new SKRoundRect(bounds);
+			SKPoint[] radii = new SKPoint[4]
+			{
+				new SKPoint((float)cornerRadius.TopLeft, (float)cornerRadius.TopLeft),
+				new SKPoint((float)cornerRadius.TopRight, (float)cornerRadius.TopRight),
+				new SKPoint((float)cornerRadius.BottomRight, (float)cornerRadius.BottomRight),
+				new SKPoint((float)cornerRadius.BottomLeft, (float)cornerRadius.BottomLeft)
+			};
+			skRoundRect.SetRectRadii(skRoundRect.Rect, radii);
+			path.AddRoundRect(skRoundRect);
+			path.Close();
+			return path;
+		}
+
+		public static SKPaint GetBackgroundPaint(this VisualElement element, SKRectI bounds)
+		{
+			var brush = element.Background;
+			if (Brush.IsNullOrEmpty(brush))
+				return null;
+
+			var paint = new SKPaint()
+			{
+				IsAntialias = true,
+				Style = SKPaintStyle.Fill
+			};
+
+			SKShader backgroundShader = null;
+			if (brush is GradientBrush fillGradientBrush)
+			{
+				if (fillGradientBrush is LinearGradientBrush linearGradientBrush)
+					backgroundShader = CreateLinearGradient(linearGradientBrush, bounds);
+
+				if (fillGradientBrush is RadialGradientBrush radialGradientBrush)
+					backgroundShader = CreateRadialGradient(radialGradientBrush, bounds);
+
+				paint.Shader = backgroundShader;
+			}
+			else
+			{
+				SKColor fillColor = Color.Default.ToNative().ToSKColor();
+				if (brush is SolidColorBrush solidColorBrush && solidColorBrush.Color != Color.Default)
+					fillColor = solidColorBrush.Color.ToNative().ToSKColor();
+
+				paint.Color = fillColor;
+			}
+			return paint;
+		}
+
+		static SKShader CreateLinearGradient(LinearGradientBrush linearGradientBrush, SKRect pathBounds)
+		{
+			var startPoint = new SKPoint(pathBounds.Left + (float)linearGradientBrush.StartPoint.X * pathBounds.Width, pathBounds.Top + (float)linearGradientBrush.StartPoint.Y * pathBounds.Height);
+			var endPoint = new SKPoint(pathBounds.Left + (float)linearGradientBrush.EndPoint.X * pathBounds.Width, pathBounds.Top + (float)linearGradientBrush.EndPoint.Y * pathBounds.Height);
+			var orderedGradientStops = linearGradientBrush.GradientStops.OrderBy(x => x.Offset).ToList();
+			var gradientColors = orderedGradientStops.Select(x => x.Color.ToNative().ToSKColor()).ToArray();
+			var gradientColorPos = orderedGradientStops.Select(x => x.Offset).ToArray();
+			return SKShader.CreateLinearGradient(startPoint, endPoint, gradientColors, gradientColorPos, SKShaderTileMode.Clamp);
+		}
+
+		static SKShader CreateRadialGradient(RadialGradientBrush radialGradientBrush, SKRect pathBounds)
+		{
+			var center = new SKPoint((float)radialGradientBrush.Center.X * pathBounds.Width + pathBounds.Left, (float)radialGradientBrush.Center.Y * pathBounds.Height + pathBounds.Top);
+			var radius = (float)radialGradientBrush.Radius * Math.Max(pathBounds.Height, pathBounds.Width);
+			var orderedGradientStops = radialGradientBrush.GradientStops.OrderBy(x => x.Offset).ToList();
+			var gradientColors = orderedGradientStops.Select(x => x.Color.ToNative().ToSKColor()).ToArray();
+			var gradientColorPos = orderedGradientStops.Select(x => x.Offset).ToArray();
+			return SKShader.CreateRadialGradient(center, radius, gradientColors, gradientColorPos, SKShaderTileMode.Clamp);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -32,6 +32,7 @@ namespace Xamarin.Forms
 	{
 		public CoreApplication Context { get; set; }
 		public bool UseDeviceIndependentPixel { get; set; }
+		public bool UseSkiaSharp { get; set; }
 		public HandlerAttribute[] Handlers { get; set; }
 		public Dictionary<Type, Func<IRegisterable>> CustomHandlers { get; set; } // for static registers
 		public Assembly[] Assemblies { get; set; }
@@ -267,6 +268,8 @@ namespace Xamarin.Forms
 
 		public static bool UseMessagingCenter => s_useMessagingCenter;
 
+		public static bool UseSkiaSharp { get; private set; }
+
 		public static DisplayResolutionUnit DisplayResolutionUnit { get; private set; }
 
 		public static int ScreenDPI => s_dpi.Value;
@@ -475,6 +478,7 @@ namespace Xamarin.Forms
 				{
 					s_platformType = options.PlatformType;
 					s_useMessagingCenter = options.UseMessagingCenter;
+					UseSkiaSharp = options.UseSkiaSharp;
 
 					if (options.Assemblies != null && options.Assemblies.Length > 0)
 					{
@@ -507,6 +511,9 @@ namespace Xamarin.Forms
 										typeof(ExportHandlerAttribute),
 										typeof(ExportFontAttribute)
 								});
+
+								if (UseSkiaSharp)
+									RegisterSkiaSharpRenderers();
 							}
 						}
 						else
@@ -521,6 +528,9 @@ namespace Xamarin.Forms
 								typeof(ExportHandlerAttribute),
 								typeof(ExportFontAttribute)
 							});
+
+							if (UseSkiaSharp)
+								RegisterSkiaSharpRenderers();
 						}
 					}
 
@@ -563,6 +573,14 @@ namespace Xamarin.Forms
 				s_platformType = PlatformType.Lightweight;
 
 			IsInitialized = true;
+		}
+
+		static void RegisterSkiaSharpRenderers()
+		{
+			// Register all skiasharp-based rednerers here.
+			Registrar.Registered.Register(typeof(Frame), typeof(Platform.Tizen.SkiaSharp.FrameRenderer));
+			Registrar.Registered.Register(typeof(BoxView), typeof(Platform.Tizen.SkiaSharp.BoxViewRenderer));
+			Registrar.Registered.Register(typeof(Image), typeof(Platform.Tizen.SkiaSharp.ImageRenderer));
 		}
 
 		static Color GetAccentColor(string profile)

--- a/Xamarin.Forms.Platform.Tizen/Native/Box.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Box.cs
@@ -33,11 +33,6 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 #endif
 
 		/// <summary>
-		/// The last processed geometry of the Box which was reported from the native layer.
-		/// </summary>
-		ERect _previousGeometry;
-
-		/// <summary>
 		/// Notifies that the layout has been updated.
 		/// </summary>
 		public event EventHandler<LayoutEventArgs> LayoutUpdated;
@@ -52,21 +47,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			if (null != LayoutUpdated)
 			{
-				var g = Geometry;
-
-				if (0 == g.Width || 0 == g.Height || g == _previousGeometry)
-				{
-					// ignore irrelevant dimensions
-					return;
-				}
-
-				LayoutUpdated(this, new LayoutEventArgs()
-				{
-					Geometry = g,
-				}
-				);
-
-				_previousGeometry = g;
+				LayoutUpdated(this, new LayoutEventArgs() { Geometry = Geometry });
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/VisualElementRenderer.cs
@@ -46,6 +46,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(VisualElement.IsEnabledProperty, UpdateIsEnabled);
 			RegisterPropertyHandler(VisualElement.InputTransparentProperty, UpdateInputTransparent);
 			RegisterPropertyHandler(VisualElement.BackgroundColorProperty, UpdateBackgroundColor);
+			RegisterPropertyHandler(VisualElement.BackgroundProperty, UpdateBackground);
 
 			RegisterPropertyHandler(Specific.StyleProperty, UpdateThemeStyle);
 			RegisterPropertyHandler(Specific.IsFocusAllowedProperty, UpdateFocusAllowed);
@@ -652,6 +653,17 @@ namespace Xamarin.Forms.Platform.Tizen
 			else
 			{
 				Log.Warn("{0} uses {1} which does not support background color", this, NativeView);
+			}
+		}
+
+		protected virtual void UpdateBackground(bool initialize)
+		{
+			if (!Forms.UseSkiaSharp || (initialize && Element.Background.Equals(Brush.Default)))
+				return;
+
+			if (this is SkiaSharp.IBackgroundCanvas canvasRenderer)
+			{
+				canvasRenderer.BackgroundCanvas.Invalidate();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/BoxViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/BoxViewRenderer.cs
@@ -1,0 +1,85 @@
+using Xamarin.Forms.Platform.Tizen.Native;
+using EColor = ElmSharp.Color;
+
+namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
+{
+	public class BoxViewRenderer : CanvasViewRenderer<BoxView, RoundRectangle>
+	{
+		public BoxViewRenderer()
+		{
+			RegisterPropertyHandler(BoxView.ColorProperty, UpdateColor);
+			RegisterPropertyHandler(BoxView.CornerRadiusProperty, UpdateRadius);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<BoxView> e)
+		{
+			if (RealControl == null)
+			{
+				SetRealNativeControl(new RoundRectangle(Forms.NativeParent));
+			}
+			base.OnElementChanged(e);
+
+		}
+
+		protected override void UpdateBackgroundColor(bool initialize)
+		{
+			if (initialize && Element.BackgroundColor.IsDefault)
+				return;
+
+			if (Element.Color.IsDefault)
+			{
+				UpdateColor();
+			}
+		}
+
+		protected override void UpdateLayout()
+		{
+			base.UpdateLayout();
+			RealControl.Draw(Control.Geometry);
+		}
+
+		protected override void UpdateOpacity(bool initialize)
+		{
+			if (initialize && Element.Opacity == 1d)
+				return;
+
+			UpdateColor();
+		}
+
+		void UpdateRadius(bool init)
+		{
+			CornerRadius = Element.CornerRadius;
+			int topLeft = Forms.ConvertToScaledPixel(Element.CornerRadius.TopLeft);
+			int topRight = Forms.ConvertToScaledPixel(Element.CornerRadius.TopRight);
+			int bottomLeft = Forms.ConvertToScaledPixel(Element.CornerRadius.BottomLeft);
+			int bottomRight = Forms.ConvertToScaledPixel(Element.CornerRadius.BottomRight);
+
+			if (!init)
+			{
+				RealControl.Draw();
+			}
+		}
+
+		void UpdateColor()
+		{
+			if (Element.Color.IsDefault)
+			{
+				if (Element.BackgroundColor.IsDefault)
+				{
+					// Set to default color. (Transparent)
+					RealControl.Color = EColor.Transparent;
+				}
+				else
+				{
+					// Use BackgroundColor only if color is default and background color is not default.
+					RealControl.Color = Element.BackgroundColor.MultiplyAlpha(Element.Opacity).ToNative();
+				}
+			}
+			else
+			{
+				// Color has higer priority than BackgroundColor.
+				RealControl.Color = Element.Color.MultiplyAlpha(Element.Opacity).ToNative();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/CanvasViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/CanvasViewRenderer.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Diagnostics;
+using ElmSharp;
+using SkiaSharp.Views.Tizen;
+
+namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
+{
+	public abstract class CanvasViewRenderer<TView, TNativeView> : ViewRenderer<TView, Native.Canvas>
+		where TView : View
+		where TNativeView : EvasObject
+	{
+		public TNativeView RealControl
+		{
+			get
+			{
+				return (TNativeView)RealNativeView;
+			}
+		}
+
+		Lazy<SKCanvasView> _backgroundCanvas;
+
+		public SKCanvasView BackgroundCanvas => _backgroundCanvas.Value;
+
+		public EvasObject RealNativeView { get; private set; }
+
+		public CornerRadius CornerRadius { get; set; }
+
+		protected override void OnElementChanged(ElementChangedEventArgs<TView> e)
+		{
+			if (Control == null)
+			{
+				SetNativeControl(new Native.Canvas(Forms.NativeParent));
+				Control.Show();
+				Control.LayoutUpdated += OnLayout;
+				Control.Children.Add(RealNativeView);
+			}
+
+			_backgroundCanvas = new Lazy<SKCanvasView>(() =>
+			{
+				var canvas = new SKCanvasView(Forms.NativeParent);
+				canvas.PassEvents = true;
+				canvas.PaintSurface += OnBackgroundPaint;
+				canvas.Show();
+				Control.Children.Add(canvas);
+				canvas.Lower();
+				RealNativeView?.RaiseTop();
+				return canvas;
+			});
+			base.OnElementChanged(e);
+		}
+
+		protected override void UpdateLayout()
+		{
+			base.UpdateLayout();
+			if (_backgroundCanvas.IsValueCreated)
+			{
+				BackgroundCanvas.Geometry = Control.Geometry;
+			}
+
+		}
+
+		protected void SetRealNativeControl(TNativeView control)
+		{
+			Debug.Assert(control != null);
+			RealNativeView = control;
+			RealNativeView.Show();
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				if (Control != null)
+				{
+					Control.LayoutUpdated -= OnLayout;
+				}
+				if (_backgroundCanvas.IsValueCreated)
+				{
+					BackgroundCanvas.PaintSurface -= OnBackgroundPaint;
+					BackgroundCanvas.Unrealize();
+					_backgroundCanvas = null;
+				}
+			}
+			base.Dispose(disposing);
+		}
+
+		protected virtual void OnLayout(object sender, Native.LayoutEventArgs e)
+		{
+			RealControl.Geometry = Control.Geometry;
+			if (_backgroundCanvas.IsValueCreated)
+			{
+				BackgroundCanvas.Geometry = Control.Geometry;
+			}
+		}
+
+		protected virtual void OnBackgroundPaint(object sender, SKPaintSurfaceEventArgs e)
+		{
+			var canvas = e.Surface.Canvas;
+			canvas.Clear();
+
+			var bounds = e.Info.Rect;
+			var paint = Element.GetBackgroundPaint(bounds);
+
+			if (paint != null)
+			{
+				using (paint)
+				using (var path = bounds.ToRoundedRectPath(CornerRadius))
+				{
+					canvas.DrawPath(path, paint);
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/FrameRenderer.cs
@@ -1,0 +1,148 @@
+﻿using SkiaSharp;
+using SkiaSharp.Views.Tizen;
+
+namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
+{
+	public class FrameRenderer : LayoutRenderer
+	{
+		static float s_borderWidth = 1.0f;
+		static SKColor s_defaultColor = SKColors.Transparent;
+
+		SKCanvasView _cliper;
+		new Frame Element => base.Element as Frame;
+
+		public FrameRenderer()
+		{
+			RegisterPropertyHandler(Frame.CornerRadiusProperty, UpdateCornerRadius);
+			RegisterPropertyHandler(Frame.BorderColorProperty, UpdateBorderColor);
+			RegisterPropertyHandler(Frame.HasShadowProperty, UpdateHasShadow);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Layout> e)
+		{
+			base.OnElementChanged(e);
+			_cliper = new SKCanvasView(Forms.NativeParent);
+			_cliper.Show();
+			_cliper.PassEvents = true;
+			_cliper.PaintSurface += OnCliperPaint;
+			Control.Children.Add(_cliper);
+			BackgroundCanvas?.StackAbove(_cliper);
+		}
+
+		protected override void UpdateBackgroundColor(bool initialize)
+		{
+			if (initialize && Element.BackgroundColor.IsDefault)
+				return;
+			else
+				BackgroundCanvas.Invalidate();
+		}
+
+		protected override void OnBackgroundLayoutUpdated(object sender, Native.LayoutEventArgs e)
+		{
+			base.OnBackgroundLayoutUpdated(sender, e);
+			if (_cliper != null)
+			{
+				_cliper.Geometry = Control.Geometry;
+				if (Element.Content != null)
+				{
+					var nativeView = Platform.GetOrCreateRenderer(Element.Content)?.NativeView;
+					nativeView?.SetClip(null);
+					nativeView?.SetClip(_cliper);
+				}
+			}
+		}
+
+		protected override void OnBackgroundPaint(object sender, SKPaintSurfaceEventArgs e)
+		{
+			var canvas = e.Surface.Canvas;
+			var bound = e.Info.Rect;
+			canvas.Clear();
+			var bgColor = Element.BackgroundColor == Color.Default ? SKColors.White : SKColor.Parse(Element.BackgroundColor.ToHex());
+			var borderColor = Element.BorderColor == Color.Default ? s_defaultColor : SKColor.Parse(Element.BorderColor.ToHex());
+			var roundRect = CreateRoundRect(bound);
+
+			using (var paint = new SKPaint
+			{
+				IsAntialias = true,
+				Style = SKPaintStyle.Fill,
+				Color = bgColor,
+			})
+			{
+				if (Element.HasShadow)
+				{
+					// Draw shadow
+					paint.ImageFilter = SKImageFilter.CreateDropShadowOnly(
+						Forms.ConvertToScaledPixel(0),
+						Forms.ConvertToScaledPixel(0),
+						Forms.ConvertToScaledPixel(s_borderWidth * 2),
+						Forms.ConvertToScaledPixel(s_borderWidth * 2),
+						SKColors.Black);
+					canvas.DrawRoundRect(roundRect, paint);
+				}
+				paint.ImageFilter = null;
+				// Draw background color
+				canvas.DrawRoundRect(roundRect, paint);
+
+				paint.Style = SKPaintStyle.Stroke;
+				paint.StrokeWidth = Forms.ConvertToScaledPixel(s_borderWidth);
+				paint.Color = borderColor;
+
+				// Draw Background (Brush)
+				using (var brushPaint = Element.GetBackgroundPaint(bound))
+				{
+					if (brushPaint != null)
+						canvas.DrawRoundRect(roundRect, brushPaint);
+				}
+
+				// Draw border
+				canvas.DrawRoundRect(roundRect, paint);
+			}
+		}
+
+		void OnCliperPaint(object sender, SKPaintSurfaceEventArgs e)
+		{
+			var canvas = e.Surface.Canvas;
+			var bound = e.Info.Rect;
+			canvas.Clear();
+
+			var bgColor = Element.BackgroundColor == Color.Default ? SKColors.White : SKColor.Parse(Element.BackgroundColor.ToHex());
+			var roundRect = CreateRoundRect(bound);
+
+			using (var paint = new SKPaint
+			{
+				IsAntialias = true,
+				Style = SKPaintStyle.Fill,
+				Color = bgColor,
+			})
+			{
+				canvas.DrawRoundRect(roundRect, paint);
+			}
+		}
+
+		void UpdateCornerRadius()
+		{
+			BackgroundCanvas.Invalidate();
+			_cliper?.Invalidate();
+		}
+
+		void UpdateBorderColor()
+		{
+			BackgroundCanvas.Invalidate();
+		}
+
+		void UpdateHasShadow()
+		{
+			BackgroundCanvas.Invalidate();
+			_cliper?.Invalidate();
+		}
+
+		SKRoundRect CreateRoundRect(SKRect bounds)
+		{
+			var border = Forms.ConvertToScaledPixel(s_borderWidth) * (Element.HasShadow ? 4 : 2);
+			var radius = Forms.ConvertToScaledPixel(Element.CornerRadius);
+			var roundRect = new SKRoundRect(bounds, radius);
+			roundRect.Deflate(border, border);
+			return roundRect;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/IBackgroundCanvas.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/IBackgroundCanvas.cs
@@ -1,0 +1,9 @@
+using SkiaSharp.Views.Tizen;
+
+namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
+{
+	public interface IBackgroundCanvas
+	{
+		public SKCanvasView BackgroundCanvas { get; }
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/ImageRenderer.cs
@@ -1,0 +1,110 @@
+using ESize = ElmSharp.Size;
+using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.Image;
+
+namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
+{
+	public class ImageRenderer : CanvasViewRenderer<Image, Native.Image>
+	{
+		public ImageRenderer()
+		{
+			RegisterPropertyHandler(Image.SourceProperty, UpdateSource);
+			RegisterPropertyHandler(Image.AspectProperty, UpdateAspect);
+			RegisterPropertyHandler(Image.IsOpaqueProperty, UpdateIsOpaque);
+			RegisterPropertyHandler(Image.IsAnimationPlayingProperty, UpdateIsAnimationPlaying);
+			RegisterPropertyHandler(Specific.BlendColorProperty, UpdateBlendColor);
+			RegisterPropertyHandler(Specific.FileProperty, UpdateFile);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Image> e)
+		{
+			if (RealControl == null)
+			{
+				SetRealNativeControl(new Native.Image(Forms.NativeParent));
+			}
+			base.OnElementChanged(e);
+		}
+
+		protected override ESize Measure(int availableWidth, int availableHeight)
+		{
+			return RealControl != null ? RealControl.Measure(availableWidth, availableHeight) : base.Measure(availableHeight, availableHeight);
+		}
+
+		async void UpdateSource(bool initialize)
+		{
+			if (initialize && Element.Source == default(ImageSource))
+				return;
+
+			ImageSource source = Element.Source;
+			((IImageController)Element).SetIsLoading(true);
+
+			if (RealControl != null)
+			{
+				bool success = await RealControl.LoadFromImageSourceAsync(source);
+				if (!IsDisposed && success)
+				{
+					((IVisualElementController)Element).NativeSizeChanged();
+					UpdateAfterLoading(initialize);
+				}
+			}
+
+			if (!IsDisposed)
+				((IImageController)Element).SetIsLoading(false);
+		}
+
+		void UpdateFile(bool initialize)
+		{
+			if (initialize && Specific.GetFile(Element) == default || Element.Source != default(ImageSource))
+				return;
+
+			if (RealControl != null)
+			{
+				bool success = RealControl.LoadFromFile(Specific.GetFile(Element));
+				if (!IsDisposed && success)
+				{
+					((IVisualElementController)Element).NativeSizeChanged();
+					UpdateAfterLoading(initialize);
+				}
+			}
+		}
+
+		protected virtual void UpdateAfterLoading(bool initialize)
+		{
+			UpdateIsOpaque(initialize);
+			UpdateBlendColor(initialize);
+			UpdateIsAnimationPlaying(initialize);
+		}
+
+		void UpdateAspect(bool initialize)
+		{
+			if (initialize && Element.Aspect == Aspect.AspectFit)
+				return;
+
+			RealControl.ApplyAspect(Element.Aspect);
+		}
+
+		void UpdateIsOpaque(bool initialize)
+		{
+			if (initialize && !Element.IsOpaque)
+				return;
+
+			RealControl.IsOpaque = Element.IsOpaque;
+		}
+
+		void UpdateIsAnimationPlaying(bool initialize)
+		{
+			if (initialize && !Element.IsAnimationPlaying)
+				return;
+
+			RealControl.IsAnimated = Element.IsAnimationPlaying;
+			RealControl.IsAnimationPlaying = Element.IsAnimationPlaying;
+		}
+
+		void UpdateBlendColor(bool initialize)
+		{
+			if (initialize && Specific.GetBlendColor(Element).IsDefault)
+				return;
+
+			RealControl.Color = Specific.GetBlendColor(Element).ToNative();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -138,6 +138,15 @@ namespace Xamarin.Forms.Platform.Tizen
 			DependencyService.Register<INativeBindingService, NativeBindingService>();
 			DependencyService.Register<INativeValueConverterService, NativeValueConverterService>();
 
+			//SkiaSharp Renderers
+			if (Forms.UseSkiaSharp)
+			{
+				// Register all skiasharp-based rednerers here for StaticRegistrar
+				Registered.Register(typeof(Frame), () => new SkiaSharp.FrameRenderer());
+				Registered.Register(typeof(BoxView), () => new SkiaSharp.BoxViewRenderer());
+				Registered.Register(typeof(Image), () => new SkiaSharp.ImageRenderer());
+			}
+
 			//Custom Handlers
 			if (customHandlers != null)
 			{

--- a/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
+++ b/Xamarin.Forms.Platform.Tizen/Xamarin.Forms.Platform.Tizen.csproj
@@ -25,6 +25,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="SkiaSharp.Views" Version="2.80.2" />
     <PackageReference Include="Tizen.NET" Version="4.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
### Description of Change ###
This PR adds Brushes (#9220) Tizen implementation. 

<img src="https://user-images.githubusercontent.com/1029134/96217793-4e7dc400-0fbe-11eb-80a3-9b52579364ec.gif" width="320"/>

This change also allows the user to choose whether to use the SkiaSharp-based renderer via the init option. Comparing the existing renderers, SkiaSharp-based renderer will bring huge functional advantages including Shapes, Brush, BorderElement and enhancing limited features which has been existed on default renderers.

To enable the SkiaSharp-based renderers, use `Forms.Init()` as shown below. (The default is `false`.)

```cs
var option = new InitializationOptions(app) { UseSkiaSharp = true }; 
Forms.Init(option);
```

Currently available SkiaSharp-based renderers are as follows.
- LayoutRenderer (StackLayout, AbsoluteLayout, Grid, ...)
- PageRenderer (ContentPage)
- FrameRenderer
- BoxViewRenderer
- ImageRenderer

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes (partially) #2452
- fixes (partially) #1856
- fixes (partially) #7293
- fixes #11995


### API Changes ###
**```namespace Xamarin.Forms```**
Added:
 - bool InitializationOptions.UseSkiaSharp {get; set;}
 - bool Forms.UseSkiaSharp {get;}

**```namespace Xamarin.Forms.Platform.Tizen```**
Added:
 - class BrushExtensions
 - SKCanvasView LayoutRenderer.BackgroundCanvas {get;}
 - void LayoutRenderer.OnBackgroundPaint()
 - void LayoutRenderer.OnBackgroundLayoutUpdated()
 - SKCanvasView PageRenderer.BackgroundCanvas {get;}

**```namespace Xamarin.Forms.Platform.Tizen.SkiaSharp```**
Added:
 - interface IBackgroundCanvas
 - abstract class CanvasViewRenderer
 - class BoxViewRenderer
 - class FrameRenderer
 - class ImageRenderer

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
- StackLayout
<img src="https://user-images.githubusercontent.com/1029134/96205499-b540b480-0fa1-11eb-849c-29308e703da7.gif" width="320"/>

- ContentPage
<img src="https://user-images.githubusercontent.com/1029134/96205512-ba9dff00-0fa1-11eb-82c0-87e85dca8c28.gif" width="320"/>

- BoxView
<img src="https://user-images.githubusercontent.com/1029134/96205559-cee1fc00-0fa1-11eb-9f15-cf71d22a2c51.gif" width="320"/>

- Frame
<img src="https://user-images.githubusercontent.com/1029134/96205572-d86b6400-0fa1-11eb-8a90-092a04b94942.gif" width="320"/>

- Image
<img src="https://user-images.githubusercontent.com/1029134/96205593-e325f900-0fa1-11eb-900e-06931f1bc244.gif" width="320"/>

### Testing Procedure ###
Launch Core Gallery and navigate to the new Gradients Gallery.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
