### PR TITLE
Fixes 7913 Add UWP shell flyout scroll mode support

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -77,6 +77,7 @@ namespace Xamarin.Forms.Platform.UWP
 			UpdatePaneButtonColor(NavigationViewBackButton, false);
 			UpdateFlyoutBackgroundColor();
 			UpdateFlyoutBackdrop();
+			UpdateFlyoutVerticalScrollMode();
 		}
 
 		void OnPaneOpened(Microsoft.UI.Xaml.Controls.NavigationView sender, object args)
@@ -187,6 +188,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		#endregion IVisualElementRenderer
 		ShellSplitView ShellSplitView => (ShellSplitView)GetTemplateChild("RootSplitView");
+		ScrollViewer ShellLeftNavScrollViewer => (ScrollViewer)GetTemplateChild("LeftNavScrollViewer");
 		protected internal Shell Element { get; set; }
 
 		internal Shell Shell => Element;
@@ -209,6 +211,33 @@ namespace Xamarin.Forms.Platform.UWP
 			else if (e.PropertyName == Shell.FlyoutBackgroundColorProperty.PropertyName)
 			{
 				UpdateFlyoutBackgroundColor();
+			}
+			else if (e.PropertyName == Shell.FlyoutVerticalScrollModeProperty.PropertyName)
+			{
+				UpdateFlyoutVerticalScrollMode();
+			}
+		}
+
+		void UpdateFlyoutVerticalScrollMode()
+		{
+			var scrollViewer = ShellLeftNavScrollViewer;
+			if (scrollViewer != null)
+			{
+				switch (Shell.FlyoutVerticalScrollMode)
+				{
+					case ScrollMode.Disabled:
+						scrollViewer.VerticalScrollMode = Windows.UI.Xaml.Controls.ScrollMode.Disabled;
+						scrollViewer.VerticalScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility.Hidden;
+						break;
+					case ScrollMode.Enabled:
+						scrollViewer.VerticalScrollMode = Windows.UI.Xaml.Controls.ScrollMode.Enabled;
+						scrollViewer.VerticalScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility.Visible;
+						break;
+					default:
+						scrollViewer.VerticalScrollMode = Windows.UI.Xaml.Controls.ScrollMode.Auto;
+						scrollViewer.VerticalScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility.Auto;
+						break;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
@@ -476,6 +476,7 @@
                                             HorizontalAlignment="Stretch"
                                             VerticalAlignment="Top">
                                             <ScrollViewer
+                                                x:Name="LeftNavScrollViewer"
                                                 TabNavigation="Once"
                                                 VerticalScrollBarVisibility="Auto">
                                                 <winui:ItemsRepeater


### PR DESCRIPTION
### Description of Change ###

Adds UWP support for #4765

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #7913

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch UWP Gallery, go to test page 4765.  Add enough shell items to make the nav flyout need to scroll.  Change the scroll mode and verify behavior.

When scrolling is disabled, the scroll bar will also be hidden.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
