### PR TITLE
[Core] Replace "can not" to "cannot" in error messages

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -355,13 +355,13 @@ namespace Xamarin.Forms
 				throw new ArgumentNullException(nameof(property));
 			if (checkAccess && property.IsReadOnly)
 			{
-				Log.Warning("BindableObject", $"Can not set the BindableProperty \"{property.PropertyName}\" because it is readonly.");
+				Log.Warning("BindableObject", $"Cannot set the BindableProperty \"{property.PropertyName}\" because it is readonly.");
 				return;
 			}
 
 			if (!converted && !property.TryConvert(ref value))
 			{
-				Log.Warning("SetValue", $"Can not convert {value} to type '{property.ReturnType}'");
+				Log.Warning("SetValue", $"Cannot convert {value} to type '{property.ReturnType}'");
 				return;
 			}
 

--- a/Xamarin.Forms.Core/Binding.cs
+++ b/Xamarin.Forms.Core/Binding.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms
 			if (path == null)
 				throw new ArgumentNullException(nameof(path));
 			if (string.IsNullOrWhiteSpace(path))
-				throw new ArgumentException("path can not be an empty string", nameof(path));
+				throw new ArgumentException("path cannot be an empty string", nameof(path));
 
 			Path = path;
 			Converter = converter;

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -62,10 +62,10 @@ namespace Xamarin.Forms
 			_targetProperty = property;
 
 			if (_weakTarget != null && _weakTarget.TryGetTarget(out BindableObject prevTarget) && !ReferenceEquals(prevTarget, target))
-				throw new InvalidOperationException("Binding instances can not be reused");
+				throw new InvalidOperationException("Binding instances cannot be reused");
 
 			if (_weakSource != null && _weakSource.TryGetTarget(out var previousSource) && !ReferenceEquals(previousSource, sourceObject))
-				throw new InvalidOperationException("Binding instances can not be reused");
+				throw new InvalidOperationException("Binding instances cannot be reused");
 
 			_weakSource = new WeakReference<object>(sourceObject);
 			_weakTarget = new WeakReference<BindableObject>(target);
@@ -152,8 +152,8 @@ namespace Xamarin.Forms
 
 				if (!TryConvert(ref value, property, property.ReturnType, true))
 				{
-					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, property.ReturnType);
-					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, "{0} can not be converted to type '{1}'", new[] { value, property.ReturnType });
+					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, property.ReturnType);
+					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, property.ReturnType });
 					return;
 				}
 
@@ -165,8 +165,8 @@ namespace Xamarin.Forms
 
 				if (!TryConvert(ref value, property, part.SetterType, false))
 				{
-					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, part.SetterType);
-					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, "{0} can not be converted to type '{1}'", new[] { value, part.SetterType });
+					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, part.SetterType);
+					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, part.SetterType });
 					return;
 				}
 

--- a/Xamarin.Forms.Core/CompressedLayout.cs
+++ b/Xamarin.Forms.Core/CompressedLayout.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 			if (ve == null)
 				return;
 			if (ve.IsPlatformEnabled)
-				throw new InvalidOperationException("IsHeadless can not be modified when the view is rendered");
+				throw new InvalidOperationException("IsHeadless cannot be modified when the view is rendered");
 		}
 
 		static readonly BindablePropertyKey HeadlessOffsetPropertyKey =

--- a/Xamarin.Forms.Core/ImageSource.cs
+++ b/Xamarin.Forms.Core/ImageSource.cs
@@ -81,7 +81,7 @@ namespace Xamarin.Forms
 				}
 				else
 				{
-					Internals.Log.Warning("Warning", "Can not find CallingAssembly, pass resolvingType to FromResource to ensure proper resolution");
+					Internals.Log.Warning("Warning", "Cannot find CallingAssembly, pass resolvingType to FromResource to ensure proper resolution");
 					return null;
 				}
 			}

--- a/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/BindingCondition.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms
 				if (_binding == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Binding once the Condition has been applied.");
+					throw new InvalidOperationException("Cannot change Binding once the Condition has been applied.");
 				_binding = value;
 			}
 		}
@@ -38,7 +38,7 @@ namespace Xamarin.Forms
 				if (_triggerValue == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Value once the Condition has been applied.");
+					throw new InvalidOperationException("Cannot change Value once the Condition has been applied.");
 				_triggerValue = value;
 			}
 		}

--- a/Xamarin.Forms.Core/Interactivity/Condition.cs
+++ b/Xamarin.Forms.Core/Interactivity/Condition.cs
@@ -20,7 +20,7 @@ namespace Xamarin.Forms
 				if (_conditionChanged == value)
 					return;
 				if (_conditionChanged != null)
-					throw new InvalidOperationException("The same condition instance can not be reused");
+					throw new InvalidOperationException("The same condition instance cannot be reused");
 				_conditionChanged = value;
 			}
 		}
@@ -33,7 +33,7 @@ namespace Xamarin.Forms
 				if (_isSealed == value)
 					return;
 				if (!value)
-					throw new InvalidOperationException("What is sealed can not be unsealed.");
+					throw new InvalidOperationException("What is sealed cannot be unsealed.");
 				_isSealed = value;
 				OnSealed();
 			}

--- a/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
+++ b/Xamarin.Forms.Core/Interactivity/DataTrigger.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 				if (((BindingCondition)Condition).Binding == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Binding once the Trigger has been applied.");
+					throw new InvalidOperationException("Cannot change Binding once the Trigger has been applied.");
 				OnPropertyChanging();
 				((BindingCondition)Condition).Binding = value;
 				OnPropertyChanged();
@@ -41,7 +41,7 @@ namespace Xamarin.Forms
 				if (((BindingCondition)Condition).Value == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Value once the Trigger has been applied.");
+					throw new InvalidOperationException("Cannot change Value once the Trigger has been applied.");
 				OnPropertyChanging();
 				((BindingCondition)Condition).Value = value;
 				OnPropertyChanged();

--- a/Xamarin.Forms.Core/Interactivity/EventTrigger.cs
+++ b/Xamarin.Forms.Core/Interactivity/EventTrigger.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms
 			}
 			catch (Exception)
 			{
-				Log.Warning("EventTrigger", "Can not attach EventTrigger to {0}.{1}. Check if the handler exists and if the signature is right.", bindable.GetType(), Event);
+				Log.Warning("EventTrigger", "Cannot attach EventTrigger to {0}.{1}. Check if the handler exists and if the signature is right.", bindable.GetType(), Event);
 			}
 			if (_eventinfo != null && _handlerdelegate != null)
 				_eventinfo.AddEventHandler(bindable, _handlerdelegate);

--- a/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
+++ b/Xamarin.Forms.Core/Interactivity/PropertyCondition.cs
@@ -27,7 +27,7 @@ namespace Xamarin.Forms
 				if (_property == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Property once the Trigger has been applied.");
+					throw new InvalidOperationException("Cannot change Property once the Trigger has been applied.");
 				_property = value;
 
 				//convert the value
@@ -57,7 +57,7 @@ namespace Xamarin.Forms
 				if (_triggerValue == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Value once the Trigger has been applied.");
+					throw new InvalidOperationException("Cannot change Value once the Trigger has been applied.");
 
 				//convert the value
 				if (_property != null && s_valueConverter != null)

--- a/Xamarin.Forms.Core/Interactivity/Trigger.cs
+++ b/Xamarin.Forms.Core/Interactivity/Trigger.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 				if (((PropertyCondition)Condition).Property == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Property once the Trigger has been applied.");
+					throw new InvalidOperationException("Cannot change Property once the Trigger has been applied.");
 				OnPropertyChanging();
 				((PropertyCondition)Condition).Property = value;
 				OnPropertyChanged();
@@ -41,7 +41,7 @@ namespace Xamarin.Forms
 				if (((PropertyCondition)Condition).Value == value)
 					return;
 				if (IsSealed)
-					throw new InvalidOperationException("Can not change Value once the Trigger has been applied.");
+					throw new InvalidOperationException("Cannot change Value once the Trigger has been applied.");
 				OnPropertyChanging();
 				((PropertyCondition)Condition).Value = value;
 				OnPropertyChanged();

--- a/Xamarin.Forms.Core/Interactivity/TriggerBase.cs
+++ b/Xamarin.Forms.Core/Interactivity/TriggerBase.cs
@@ -38,7 +38,7 @@ namespace Xamarin.Forms
 				if (_isSealed == value)
 					return;
 				if (!value)
-					throw new InvalidOperationException("What is sealed can not be unsealed.");
+					throw new InvalidOperationException("What is sealed cannot be unsealed.");
 				_isSealed = value;
 				OnSeal();
 			}

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -429,7 +429,7 @@ namespace Xamarin.Forms
 						continue;
 
 					if (item == this)
-						throw new InvalidOperationException("Can not add self to own child collection.");
+						throw new InvalidOperationException("Cannot add self to own child collection.");
 
 					OnInternalAdded(v);
 				}

--- a/Xamarin.Forms.Core/ListView.cs
+++ b/Xamarin.Forms.Core/ListView.cs
@@ -563,7 +563,7 @@ namespace Xamarin.Forms
 			if (newValue != null && lv.GroupHeaderTemplate != null)
 			{
 				lv.GroupHeaderTemplate = null;
-				Log.Warning("ListView", "GroupHeaderTemplate and GroupDisplayBinding can not be set at the same time, setting GroupHeaderTemplate to null");
+				Log.Warning("ListView", "GroupHeaderTemplate and GroupDisplayBinding cannot be set at the same time, setting GroupHeaderTemplate to null");
 			}
 		}
 
@@ -573,7 +573,7 @@ namespace Xamarin.Forms
 			if (newValue != null && lv.GroupDisplayBinding != null)
 			{
 				lv.GroupDisplayBinding = null;
-				Log.Warning("ListView", "GroupHeaderTemplate and GroupDisplayBinding can not be set at the same time, setting GroupDisplayBinding to null");
+				Log.Warning("ListView", "GroupHeaderTemplate and GroupDisplayBinding cannot be set at the same time, setting GroupDisplayBinding to null");
 			}
 		}
 

--- a/Xamarin.Forms.Core/LockableObservableListWrapper.cs
+++ b/Xamarin.Forms.Core/LockableObservableListWrapper.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Internals
 		void ThrowOnLocked()
 		{
 			if (IsLocked)
-				throw new InvalidOperationException("The Items list can not be manipulated if the ItemsSource property is set");
+				throw new InvalidOperationException("The Items list cannot be manipulated if the ItemsSource property is set");
 		}
 
 		public string this[int index]

--- a/Xamarin.Forms.Core/MultiBinding.cs
+++ b/Xamarin.Forms.Core/MultiBinding.cs
@@ -90,8 +90,8 @@ namespace Xamarin.Forms
 					_applying = true;
 					if (!BindingExpression.TryConvert(ref value, _targetProperty, _targetProperty.ReturnType, true))
 					{
-						Log.Warning("MultiBinding", "'{0}' can not be converted to type '{1}'.", value, _targetProperty.ReturnType);
-						BindingDiagnostics.SendBindingFailure(this, null, _targetObject, _targetProperty, null, "{0} can not be converted to type '{1}'", new[] { value, _targetProperty.ReturnType });
+						Log.Warning("MultiBinding", "'{0}' cannot be converted to type '{1}'.", value, _targetProperty.ReturnType);
+						BindingDiagnostics.SendBindingFailure(this, null, _targetObject, _targetProperty, null, "{0} cannot be converted to type '{1}'", new[] { value, _targetProperty.ReturnType });
 						return;
 					}
 					_targetObject.SetValueCore(_targetProperty, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
@@ -164,8 +164,8 @@ namespace Xamarin.Forms
 				_applying = true;
 				if (!BindingExpression.TryConvert(ref value, _targetProperty, _targetProperty.ReturnType, true))
 				{
-					Log.Warning("MultiBinding", "'{0}' can not be converted to type '{1}'.", value, _targetProperty.ReturnType);
-					BindingDiagnostics.SendBindingFailure(this, context, _targetObject, _targetProperty, null, "{0} can not be converted to type '{1}'", new[] { value, _targetProperty.ReturnType });
+					Log.Warning("MultiBinding", "'{0}' cannot be converted to type '{1}'.", value, _targetProperty.ReturnType);
+					BindingDiagnostics.SendBindingFailure(this, context, _targetObject, _targetProperty, null, "{0} cannot be converted to type '{1}'", new[] { value, _targetProperty.ReturnType });
 					return;
 				}
 				_targetObject.SetValueCore(_targetProperty, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);

--- a/Xamarin.Forms.Core/NavigationModel.cs
+++ b/Xamarin.Forms.Core/NavigationModel.cs
@@ -67,7 +67,7 @@ namespace Xamarin.Forms.Internals
 				if (stack.Contains(ancestralNav))
 				{
 					if (stack.Count <= 1)
-						throw new InvalidNavigationException("Can not pop final item in stack");
+						throw new InvalidNavigationException("Cannot pop final item in stack");
 					Page result = stack.Last();
 					stack.Remove(result);
 					return result;
@@ -117,7 +117,7 @@ namespace Xamarin.Forms.Internals
 				if (stack.Contains(ancestralNav))
 				{
 					if (stack.Count <= 1)
-						throw new InvalidNavigationException("Can not pop final item in stack");
+						throw new InvalidNavigationException("Cannot pop final item in stack");
 					stack.RemoveRange(1, stack.Count - 1);
 					return;
 				}

--- a/Xamarin.Forms.Core/ResourceDictionary.cs
+++ b/Xamarin.Forms.Core/ResourceDictionary.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms
 					return;
 
 				if (_source != null)
-					throw new ArgumentException("MergedWith can not be used with Source");
+					throw new ArgumentException("MergedWith cannot be used with Source");
 
 				if (!typeof(ResourceDictionary).GetTypeInfo().IsAssignableFrom(value.GetTypeInfo()))
 					throw new ArgumentException("MergedWith should inherit from ResourceDictionary");
@@ -66,7 +66,7 @@ namespace Xamarin.Forms
 		{
 			_source = value;
 			if (_mergedWith != null)
-				throw new ArgumentException("Source can not be used with MergedWith");
+				throw new ArgumentException("Source cannot be used with MergedWith");
 
 			//this will return a type if the RD as an x:Class element, and codebehind
 			var type = XamlResourceIdAttribute.GetTypeForPath(assembly, resourcePath);

--- a/Xamarin.Forms.Core/TemplateBinding.cs
+++ b/Xamarin.Forms.Core/TemplateBinding.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms
 			if (path == null)
 				throw new ArgumentNullException("path");
 			if (string.IsNullOrWhiteSpace(path))
-				throw new ArgumentException("path can not be an empty string", "path");
+				throw new ArgumentException("path cannot be an empty string", "path");
 
 			AllowChaining = true;
 			Path = path;

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -132,11 +132,11 @@ namespace Xamarin.Forms.Internals
 #if (!DO_NOT_CHECK_FOR_BINDING_REUSE)
 			BindableObject prevTarget;
 			if (_weakTarget.TryGetTarget(out prevTarget) && !ReferenceEquals(prevTarget, bindObj))
-				throw new InvalidOperationException("Binding instances can not be reused");
+				throw new InvalidOperationException("Binding instances cannot be reused");
 
 			object previousSource;
 			if (_weakSource.TryGetTarget(out previousSource) && !ReferenceEquals(previousSource, source))
-				throw new InvalidOperationException("Binding instances can not be reused");
+				throw new InvalidOperationException("Binding instances cannot be reused");
 #endif
 			_weakSource.SetTarget(source);
 			_weakTarget.SetTarget(bindObj);
@@ -229,8 +229,8 @@ namespace Xamarin.Forms.Internals
 				}
 				if (!BindingExpression.TryConvert(ref value, property, property.ReturnType, true))
 				{
-					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, property.ReturnType);
-					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, null, "{0} can not be converted to type '{1}'", new[] { value, property.ReturnType });
+					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, property.ReturnType);
+					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, property.ReturnType });
 					return;
 				}
 				target.SetValueCore(property, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
@@ -243,8 +243,8 @@ namespace Xamarin.Forms.Internals
 				var value = GetTargetValue(target.GetValue(property), typeof(TProperty));
 				if (!BindingExpression.TryConvert(ref value, property, typeof(TProperty), false))
 				{
-					Log.Warning("Binding", "'{0}' can not be converted to type '{1}'.", value, typeof(TProperty));
-					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, null, "{0} can not be converted to type '{1}'", new[] { value, property.ReturnType });
+					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, typeof(TProperty));
+					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, property.ReturnType });
 					return;
 				}
 				_setter((TSource)sourceObject, (TProperty)value);


### PR DESCRIPTION
### Description of Change ###

Replace _"can not"_ to _"cannot"_ in error messages.

### Issues Resolved ### 

- fixes #12560 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
