### PR TITLE
Check TargetPlatformIdentifier for UAP

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -230,13 +230,13 @@
       <MicrosoftUIXamlTargetPlatformMinCheckValue>$([System.Version]::Parse('$(TargetPlatformMinVersion)').Build)</MicrosoftUIXamlTargetPlatformMinCheckValue>
     </PropertyGroup>
     <Warning
-        Text="Xamarin.Forms recommends TargetPlatformMinVersion &gt;= 10.0.14393.0 (current project is $(MicrosoftUIXamlTargetPlatformMinCheckValue))"
-        Condition="$(MicrosoftUIXamlTargetPlatformMinCheckValue) &lt; 14393" />
+        Text="Xamarin.Forms recommends TargetPlatformMinVersion &gt;= 10.0.15063.0 (current project is $(MicrosoftUIXamlTargetPlatformMinCheckValue))"
+        Condition="$(MicrosoftUIXamlTargetPlatformMinCheckValue) &lt; 15063" />
     <PropertyGroup>
       <MicrosoftUIXamlTargetPlatformCheckValue>$([System.Version]::Parse('$(TargetPlatformVersion)').Build)</MicrosoftUIXamlTargetPlatformCheckValue>
     </PropertyGroup>
     <Warning
-        Text="Xamarin.Forms recommends TargetPlatformVersion &gt;= 10.0.17763.0 (current project is $(MicrosoftUIXamlTargetPlatformCheckValue))"
-        Condition="$(MicrosoftUIXamlTargetPlatformCheckValue) &lt; 17763" />
+        Text="Xamarin.Forms recommends TargetPlatformVersion &gt;= 10.0.18362.0 (current project is $(MicrosoftUIXamlTargetPlatformCheckValue))"
+        Condition="$(MicrosoftUIXamlTargetPlatformCheckValue) &lt; 18362" />
   </Target>
 </Project>

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -225,7 +225,7 @@
 
   <!-- UWP Targets-->
   <Target Name="WinUICheckTargetPlatformVersion" BeforeTargets="PrepareForBuild"
-      Condition="'$(TargetPlatformVersion)' != '' and '$(TargetPlatformMinVersion)' != ''">
+      Condition="'$(TargetPlatformIdentifier)' == 'UAP' AND '$(TargetPlatformVersion)' != '' AND '$(TargetPlatformMinVersion)' != ''">
     <PropertyGroup>
       <MicrosoftUIXamlTargetPlatformMinCheckValue>$([System.Version]::Parse('$(TargetPlatformMinVersion)').Build)</MicrosoftUIXamlTargetPlatformMinCheckValue>
     </PropertyGroup>


### PR DESCRIPTION
### Description of Change ###
VS 16.8 now sets TargetPlatformMinVersion to `7.0` on the shared project which is causing the UWP specific target to run and give a bogus warning message

![image](https://user-images.githubusercontent.com/5375137/97226540-1f2b3c00-17a2-11eb-9bbb-ee80e724d1ad.png)

This PR checks that the TargetPlatformIdentifier matches UAP so it only runs for UAP projects

This PR also updates the Target and Min Target to match WinUI 2.4 suggestions

### Issues Resolved ### 
https://devdiv.visualstudio.com/DevDiv/_workitems/edit/1237998

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- create a new Xamarin.Forms project  with UWP
- add this nuget
- make sure the warning doesn't show up for the shared project. Set the UWP project min version to < 17763 and make sure you still get the warning

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
