### PR TITLE
iOS: CollectionView: ItemsViewLayout: Fix null reference on invalidate layout

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -532,7 +532,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void InvalidateLayout()
 		{
-			UpdateConstraints(CollectionView.Frame.Size);
+			if (CollectionView != null && CollectionView.Frame != null) {
+				UpdateConstraints(CollectionView.Frame.Size);
+			}
 			base.InvalidateLayout();
 		}
 	}


### PR DESCRIPTION
### Description of Change ###

On changing the layout of collection at runtime, the iOS app gets crashed showing an null reference exception on invalidate layout which clearly mentioned that CollectionView is getting null here. Whereas in Android it works just fine without any issue/exception.

### API Changes ###

 None

### Platforms Affected ### 

- iOS
