### PR TITLE
[Android] Fix NRE when trying to access the renderer View

### DIFF
--- a/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Android/ButtonLayoutManager.cs
@@ -191,6 +191,12 @@ namespace Xamarin.Forms.Platform.Android
 			if (View?.LayoutParameters == null && _hasLayoutOccurred)
 				return;
 
+			if (View != null && !_elementAlreadyChanged)
+			{
+				_defaultTransformationMethod = View.TransformationMethod;
+				_elementAlreadyChanged = true;
+			}
+
 			if (!UpdateTextAndImage())
 				UpdateImage();
 
@@ -209,12 +215,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_element = button;
 				_element.PropertyChanged += OnElementPropertyChanged;
-
-				if (!_elementAlreadyChanged)
-				{
-					_defaultTransformationMethod = _renderer.View.TransformationMethod;
-					_elementAlreadyChanged = true;
-				}
 			}
 
 			Update();
@@ -287,9 +287,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			// Use defaults only when user hasn't specified alternative TextTransform settings
 			if (textTransform == TextTransform.Default)
-				_renderer.View.TransformationMethod = _defaultTransformationMethod;
+				view.TransformationMethod = _defaultTransformationMethod;
 			else
-				_renderer.View.TransformationMethod = null;
+				view.TransformationMethod = null;
 
 			string oldText = view.Text;
 			view.Text = _element.UpdateFormsText(_element.Text, textTransform);


### PR DESCRIPTION
### Description of Change ###

Fix a issue when using non FastRenderers the ButtonLayoutManager was throwing a NRE because it was trying to access the NativeView (Control) before it's created on `SetNativeControl`

### Issues Resolved ### 

- Fixes failing tests

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Android UITEsts should pass (green) but should show also 100% (number of tests passing)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
