### PR TITLE
Fix APK to build with Fast Renderer switch when running on CI

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -156,7 +156,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 
 	public class AttachedStateEffectLabelRenderer :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.LabelRenderer
 #else
 		LabelRenderer

--- a/Xamarin.Forms.ControlGallery.Android/DisposeLabelRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/DisposeLabelRenderer.cs
@@ -5,7 +5,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 {
 #pragma warning disable 618
 	public class DisposeLabelRenderer :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.LabelRenderer
 #else
 		LabelRenderer

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -96,7 +96,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			
 			LoadApplication(_app);
 
-#if !!LEGACY_RENDERERS
+#if LEGACY_RENDERERS
 			if ((int)Build.VERSION.SdkInt >= 21)
 			{
 				// Show a purple status bar if we're looking at legacy renderers

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 
 			base.OnCreate(bundle);
 
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 #else
 			Forms.SetFlags("UseLegacyRenderers", "SwipeView_Experimental", "MediaElement_Experimental");
 #endif
@@ -96,7 +96,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 			
 			LoadApplication(_app);
 
-#if !TEST_EXPERIMENTAL_RENDERERS
+#if !!LEGACY_RENDERERS
 			if ((int)Build.VERSION.SdkInt >= 21)
 			{
 				// Show a purple status bar if we're looking at legacy renderers

--- a/Xamarin.Forms.ControlGallery.Android/Issue10182Activity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/Issue10182Activity.cs
@@ -63,7 +63,9 @@ namespace Xamarin.Forms.ControlGallery.Android
 				finally
 				{
 					this.Finish();
+#if !FORMS_APPLICATION_ACTIVITY
 					_activity1.ReloadApplication();
+#endif
 					currentApplication.MainPage = new Issue10182.Issue10182SuccessPage();
 				}
 			});

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -34,9 +34,9 @@
     <!-- default locally to using fast renderers but if we're running on CI don't set a value for ANDROID_RENDERERS.
       This will let the old and new yaml configurations coexist -->
     <ANDROID_RENDERERS Condition="'$(ANDROID_RENDERERS)' == ''">FAST</ANDROID_RENDERERS>
-    <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'FAST'">$(DefineConstants);TEST_EXPERIMENTAL_RENDERERS</DefineConstants>
+    <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'FAST'">$(DefineConstants)</DefineConstants>
     <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'PREAPPCOMPAT'">$(DefineConstants);FORMS_APPLICATION_ACTIVITY</DefineConstants>
-    <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'LEGACY'">$(DefineConstants)</DefineConstants>
+    <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'LEGACY'">$(DefineConstants);LEGACY_RENDERERS</DefineConstants>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)' == 'Debug'">
     <DefineConstants>$(DefineConstants);HAVE_OPENTK</DefineConstants>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -33,7 +33,7 @@
   <PropertyGroup>
     <!-- default locally to using fast renderers but if we're running on CI don't set a value for ANDROID_RENDERERS.
       This will let the old and new yaml configurations coexist -->
-    <ANDROID_RENDERERS Condition="'$(ANDROID_RENDERERS)' == '' AND '$(CI)' == 'false'">FAST</ANDROID_RENDERERS>
+    <ANDROID_RENDERERS Condition="'$(ANDROID_RENDERERS)' == ''">FAST</ANDROID_RENDERERS>
     <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'FAST'">$(DefineConstants);TEST_EXPERIMENTAL_RENDERERS</DefineConstants>
     <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'PREAPPCOMPAT'">$(DefineConstants);FORMS_APPLICATION_ACTIVITY</DefineConstants>
     <DefineConstants Condition="'$(ANDROID_RENDERERS)' == 'LEGACY'">$(DefineConstants)</DefineConstants>

--- a/Xamarin.Forms.ControlGallery.Android/_1909CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_1909CustomRenderer.cs
@@ -10,7 +10,7 @@ using Xamarin.Forms.Controls.Issues;
 namespace Xamarin.Forms.ControlGallery.Android
 {
 		public class FlatButtonRenderer :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.ButtonRenderer
 #else
 		ButtonRenderer

--- a/Xamarin.Forms.ControlGallery.Android/_5724CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_5724CustomRenderers.cs
@@ -11,7 +11,7 @@ using System.ComponentModel;
 namespace Xamarin.Forms.ControlGallery.Android
 {
 	public class CustomButtonRenderer5724 :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.ButtonRenderer
 #else
 		ButtonRenderer
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 
 	public class CustomImageRenderer5724 :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.ImageRenderer
 #else
 		ImageRenderer
@@ -53,7 +53,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 
 	public class CustomFrameRenderer5724 :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.FrameRenderer
 #else
 		FrameRenderer
@@ -76,7 +76,7 @@ namespace Xamarin.Forms.ControlGallery.Android
 	}
 
 	public class CustomLabelRenderer5724 :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.LabelRenderer
 #else
 		LabelRenderer

--- a/Xamarin.Forms.ControlGallery.Android/_60122ImageRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_60122ImageRenderer.cs
@@ -11,7 +11,7 @@ using Xamarin.Forms.Platform.Android;
 namespace Xamarin.Forms.ControlGallery.Android
 {
 	public class _60122ImageRenderer :
-#if TEST_EXPERIMENTAL_RENDERERS
+#if !LEGACY_RENDERERS
 		Platform.Android.FastRenderers.ImageRenderer
 #else
 		ImageRenderer

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/PerformanceGallery/PerformanceGallery.cs
@@ -51,7 +51,7 @@ namespace Xamarin.Forms.Controls.Issues
 			_DeviceIdentifier = CrossDeviceInfo.Current.Id;
 			_DeviceIdiom = CrossDeviceInfo.Current.Idiom.ToString();
 			_DeviceModel = CrossDeviceInfo.Current.Model;
-#if __ANDROID__ && TEST_EXPERIMENTAL_RENDERERS
+#if __ANDROID__ && !LEGACY_RENDERERS
 			_DevicePlatform = "Android Fast Renderers";
 #else
 			_DevicePlatform = CrossDeviceInfo.Current.Platform.ToString();

--- a/build.cake
+++ b/build.cake
@@ -1083,6 +1083,7 @@ MSBuildSettings GetMSBuildSettings(PlatformTarget? platformTarget = PlatformTarg
         Configuration = buildConfiguration ?? configuration,
     };
 
+    buildSettings = buildSettings.WithProperty("ANDROID_RENDERERS", $"{ANDROID_RENDERERS}");
     if(!String.IsNullOrWhiteSpace(XamarinFormsVersion))
     {
         buildSettings = buildSettings.WithProperty("XamarinFormsVersion", XamarinFormsVersion);


### PR DESCRIPTION
### Description of Change ###

- Replaced the "TEXT_EXPERIMENTAL_RENDERERS" constant with "LEGACY_RENDERERS" as that's a more accurate indicator of the current state of the renderers
- Fixed CI to default to Fast Renderers instead of Legacy Renderers

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Make sure a Legacy Renderer and Fast Renderer APK is built
- Even if the tests are failing we should merge this PR in and then fix the tests on other PRs

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
