### PR TITLE
fix 11853 - concurrency problem in ObservableItemsSource

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11853.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11853.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 11853,
+		"[Bug][iOS] Concurrent issue leading to crash in SemaphoreSlim.Release in ObservableItemsSource",
+		platformsAffected: PlatformAffected.iOS)]
+	public class Issue11853 : TestContentPage
+	{
+		const string Success = "Success";
+		const string Run = "Run";
+
+		ObservableCollection<string> _items;
+
+		protected override void Init()
+		{
+			Title = "Issue 11853";
+
+			var descriptionLabel = new Label { Text = "Press \"Start test\", if the App doesn't crash, it passed." };
+			var successLabel = new Label { Text = Success, FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)), IsVisible = false };
+
+			var collectionView = new CollectionView();
+			ResetItemsSource(collectionView);
+
+			var startButton = new Button { Text = Run };
+			startButton.Clicked += (sender, args) =>
+			{
+				ResetTest(successLabel, collectionView);
+
+				var random = new Random();
+				_items.RemoveAt(random.Next(0, 99));
+				_items.RemoveAt(random.Next(0, 98));
+				_items.RemoveAt(random.Next(0, 97));
+				_items.Clear();
+				successLabel.IsVisible = true;
+			};
+			var resetButton = new Button { Text = "Reset test" };
+			resetButton.Clicked += (sender, args) =>
+			{
+				ResetTest(successLabel, collectionView);
+			};
+
+			Content = new StackLayout { Children = { descriptionLabel, successLabel, collectionView, startButton, resetButton } };
+		}
+
+		void ResetTest(VisualElement successLabel, ItemsView collectionView)
+		{
+			successLabel.IsVisible = false;
+			if (_items.Count != 100)
+				ResetItemsSource(collectionView);
+		}
+
+		void ResetItemsSource(ItemsView collectionView)
+		{
+			_items = new ObservableCollection<string>(Create100StringItems());
+
+			void OnItemsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs args) =>
+				System.Diagnostics.Debug.WriteLine("items.CollectionChanged: {0} (new: {1}, old: {2})", args.Action,
+					args.NewItems?.Count, args.OldItems?.Count);
+
+			_items.CollectionChanged += OnItemsOnCollectionChanged;
+
+			collectionView.ItemsSource = _items;
+		}
+
+		static IEnumerable<string> Create100StringItems()
+		{
+			// create 100 items from Item 1 - Item 100
+			return Enumerable.Range(1, 100).Select(i => $"Item {i}");
+		}
+		
+#if UITEST
+		[Category(UITestCategories.CollectionView)]
+		[Test]
+		public void GivenAnObservableCollection_WhenItemsAreRemovedAndCollectionIsCleared_ThenApplicationDoesNotCrash()
+		{
+			RunningApp.WaitForElement(Run);
+			RunningApp.Tap(Run);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7700.cs
@@ -66,11 +66,19 @@ namespace Xamarin.Forms.Controls.Issues
 			var button2 = new Button() { Text = Add2Label, AutomationId = Add2 };
 			button2.Clicked += Button2Clicked;
 
-			var layout = new StackLayout { Children = { instructions, button1, button2 } };
+			var button3 = new Button { Text = "Go back" };
+			button3.Clicked += Button3OnClicked;
+
+			var layout = new StackLayout { Children = { instructions, button1, button2, button3 } };
 
 			page.Content = layout;
 
 			return page;
+		}
+
+		void Button3OnClicked(object sender, EventArgs e)
+		{
+			Navigation.PopModalAsync();
 		}
 
 		void Button1Clicked(object sender, EventArgs e)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11853.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12153.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10324.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github9536.xaml.cs">

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
@@ -7,21 +7,25 @@ namespace Xamarin.Forms.Platform.iOS
 {
 	sealed class ListSource : List<object>, IItemsViewSource
 	{
-		public ListSource()
+		readonly int _section;
+
+		public ListSource(int section = 0)
 		{
+			_section = section;
 		}
 
-		public ListSource(IEnumerable<object> enumerable) : base(enumerable)
+		public ListSource(IEnumerable<object> enumerable, int section = 0) : base(enumerable)
 		{
-			
+			_section = section;
 		}
 
-		public ListSource(IEnumerable enumerable)
+		public ListSource(IEnumerable enumerable, int section = 0)
 		{
 			foreach (object item in enumerable)
 			{
 				Add(item);
 			}
+			_section = section;
 		}
 
 		public void Dispose()
@@ -33,7 +37,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			get
 			{
-				if (indexPath.Section > 0)
+				if (indexPath.Section != _section)
 				{
 					throw new ArgumentOutOfRangeException(nameof(indexPath));
 				}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -2,8 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Linq;
 using Foundation;
 using UIKit;
 
@@ -13,76 +12,50 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		readonly UICollectionView _collectionView;
 		readonly UICollectionViewController _collectionViewController;
-		readonly IList _groupSource;
+		readonly IList _originalItemsSource;
 		bool _disposed;
-		SemaphoreSlim _batchUpdating = new SemaphoreSlim(1, 1);
-		List<ObservableItemsSource> _groups = new List<ObservableItemsSource>();
+		readonly List<IItemsViewSource> _groups = new List<IItemsViewSource>();
 
 		public ObservableGroupedSource(IEnumerable groupSource, UICollectionViewController collectionViewController)
 		{
 			_collectionViewController = collectionViewController;
 			_collectionView = _collectionViewController.CollectionView;
-			_groupSource = groupSource as IList ?? new ListSource(groupSource);
+			
+			_originalItemsSource = groupSource as IList ?? new ListSource(groupSource);
 
-			if (_groupSource is INotifyCollectionChanged incc)
+			if (_originalItemsSource is INotifyCollectionChanged incc)
 			{
 				incc.CollectionChanged += CollectionChanged;
 			}
 
-			ResetGroupTracking();
+			ResetGroups();
 		}
 
-		public object this[NSIndexPath indexPath]
-		{
-			get
-			{
-				return GetGroupItemAt(indexPath.Section, (int)indexPath.Item);
-			}
-		}
+		public object this[NSIndexPath indexPath] => _groups[indexPath.Section][indexPath];
 
-		public int GroupCount => _groupSource.Count;
+		public int GroupCount => _groups.Count;
 
-		public int ItemCount
-		{
-			get
-			{
-				var total = 0;
-
-				for (int n = 0; n < _groupSource.Count; n++)
-				{
-					total += GetGroupCount(n);
-				}
-
-				return total;
-			}
-		}
+		public int ItemCount => _groups.Sum(g => g.ItemCount);
 
 		public NSIndexPath GetIndexForItem(object item)
 		{
-			for (int i = 0; i < _groupSource.Count; i++)
+			foreach (var group in _groups)
 			{
-				var j = IndexInGroup(item, _groupSource[i]);
-
-				if (j == -1)
+				var index = group.GetIndexForItem(item);
+				if (index.Item == -1)
 				{
 					continue;
 				}
 
-				return NSIndexPath.Create(i, j);
+				return index;
 			}
 
 			return NSIndexPath.Create(-1, -1);
 		}
 
-		public object Group(NSIndexPath indexPath)
-		{
-			return _groupSource[indexPath.Section];
-		}
+		public object Group(NSIndexPath indexPath) => _originalItemsSource[indexPath.Section];
 
-		public int ItemCountInGroup(nint group)
-		{
-			return GetGroupCount((int)group);
-		}
+		public int ItemCountInGroup(nint group) => _groups[(int)group].ItemCount;
 
 		public void Dispose()
 		{
@@ -100,15 +73,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				ClearGroupTracking();
-				if (_groupSource is INotifyCollectionChanged incc)
+				ClearGroups();
+				if (_originalItemsSource is INotifyCollectionChanged incc)
 				{
 					incc.CollectionChanged -= CollectionChanged;
 				}
 			}
 		}
 
-		void ClearGroupTracking()
+		void ClearGroups()
 		{
 			for (int n = _groups.Count - 1; n >= 0; n--)
 			{
@@ -117,16 +90,29 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		void ResetGroupTracking()
+		void ResetGroups()
 		{
-			ClearGroupTracking();
+			ClearGroups();
 
-			for (int n = 0; n < _groupSource.Count; n++)
+			var index = 0;
+			foreach (var group in _originalItemsSource)
 			{
-				if (_groupSource[n] is INotifyCollectionChanged && _groupSource[n] is IEnumerable list)
+				if (group is IEnumerable list)
 				{
-					_groups.Add(new ObservableItemsSource(list, _collectionViewController, n));
+					if (group is INotifyCollectionChanged)
+					{
+						_groups.Add(new ObservableItemsSource(list, _collectionViewController, index));
+					}
+					else
+					{
+						_groups.Add(new ListSource(list, index));
+					}
 				}
+				else
+				{
+					_groups.Add(new ListSource(index));
+				}
+				index++;
 			}
 		}
 
@@ -134,49 +120,57 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Device.IsInvokeRequired)
 			{
-				await Device.InvokeOnMainThreadAsync(async () => await CollectionChanged(args));
+				await Device.InvokeOnMainThreadAsync(() => CollectionChanged(args));
 			}
 			else
 			{
-				await CollectionChanged(args);
+				CollectionChanged(args);
 			}
 		}
 
-		async Task CollectionChanged(NotifyCollectionChangedEventArgs args)
+		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
+			if (NotLoadedYet())
+			{
+				Reload();
+				return;
+			}
+
 			switch (args.Action)
 
 			{
 				case NotifyCollectionChangedAction.Add:
-					await Add(args);
+					Add(args);
 					break;
 				case NotifyCollectionChangedAction.Remove:
-					await Remove(args);
+					Remove(args);
 					break;
 				case NotifyCollectionChangedAction.Replace:
-					await Replace(args);
+					Replace(args);
 					break;
 				case NotifyCollectionChangedAction.Move:
 					Move(args);
 					break;
 				case NotifyCollectionChangedAction.Reset:
-					await Reload();
+					Reload();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
 		}
 
-		async Task Reload()
+		void Reload()
 		{
-			ResetGroupTracking();
+			ResetGroups();
 
-			await _batchUpdating.WaitAsync();
-
-			_collectionView.ReloadData();
+			// update the collection view without using animation to avoid concurrency
+			// code source: https://stackoverflow.com/a/64146094/13005218
+			UIView.PerformWithoutAnimation(() =>
+			{
+				// [!] Do not use BatchUpdate here, it will cause concurrency problems
+				_collectionView.ReloadData();
+			});
 			_collectionView.CollectionViewLayout.InvalidateLayout();
-
-			_batchUpdating.Release();
 		}
 
 		NSIndexSet CreateIndexSetFrom(int startIndex, int count)
@@ -188,29 +182,32 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			// If the UICollectionView hasn't actually been loaded, then calling InsertSections or DeleteSections is 
 			// going to crash or get in an unusable state; instead, ReloadData should be used
-			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
+			return !_collectionViewController.IsViewLoaded || _collectionViewController.View?.Window == null;
 		}
 
-		async Task Add(NotifyCollectionChangedEventArgs args)
+		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			if (ReloadRequired())
+			if (_collectionView.NumberOfSections() == 0 || _collectionView.VisibleCells.Length == 0)
 			{
-				await Reload();
+				Reload();
 				return;
 			}
 
-			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
+			var startIndex = args.NewStartingIndex > -1
+				? args.NewStartingIndex
+				: _originalItemsSource.IndexOf(args.NewItems[0]);
 			var count = args.NewItems.Count;
 
 			// Adding a group will change the section index for all subsequent groups, so the easiest thing to do
 			// is to reset all the group tracking to get it up-to-date
-			ResetGroupTracking();
+			ResetGroups();
 
-			// Queue up the updates to the UICollectionView
-			BatchUpdate(() => _collectionView.InsertSections(CreateIndexSetFrom(startIndex, count)));
+			// apply the updates to the UICollectionView
+			// [!] Do not use BatchUpdate here, it will cause concurrency problems
+			_collectionView.InsertSections(CreateIndexSetFrom(startIndex, count));
 		}
 
-		async Task Remove(NotifyCollectionChangedEventArgs args)
+		void Remove(NotifyCollectionChangedEventArgs args)
 		{
 			var startIndex = args.OldStartingIndex;
 
@@ -218,56 +215,55 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				// INCC implementation isn't giving us enough information to know where the removed items were in the
 				// collection. So the best we can do is a complete reload
-				await Reload();
-				return;
-			}
-
-			if (ReloadRequired())
-			{
-				await Reload();
+				Reload();
 				return;
 			}
 
 			// Removing a group will change the section index for all subsequent groups, so the easiest thing to do
 			// is to reset all the group tracking to get it up-to-date
-			ResetGroupTracking();
+			ResetGroups();
 
 			// Since we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
 			var count = args.OldItems.Count;
 
-			// Queue up the updates to the UICollectionView
-			BatchUpdate(() => _collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count)));
+			// apply the updates to the UICollectionView
+			// [!] Do not use BatchUpdate here, it will cause concurrency problems
+			_collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count));
 		}
 
-		async Task Replace(NotifyCollectionChangedEventArgs args)
+		void Replace(NotifyCollectionChangedEventArgs args)
 		{
 			var newCount = args.NewItems.Count;
 
 			if (newCount == args.OldItems.Count)
 			{
-				ResetGroupTracking();
+				ResetGroups();
 
-				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
+				var startIndex = args.NewStartingIndex > -1
+					? args.NewStartingIndex
+					: _originalItemsSource.IndexOf(args.NewItems[0]);
 
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
+				// [!] Do not use BatchUpdate here, it will cause concurrency problems
 				_collectionView.ReloadSections(CreateIndexSetFrom(startIndex, newCount));
 				return;
 			}
 
 			// The original and replacement sets are of unequal size; this means that everything currently in view will 
 			// have to be updated. So we just have to use ReloadData and let the UICollectionView update everything
-			await Reload();
+			Reload();
 		}
 
 		void Move(NotifyCollectionChangedEventArgs args)
 		{
 			var count = args.NewItems.Count;
 
-			ResetGroupTracking();
+			ResetGroups();
 
 			if (count == 1)
 			{
 				// For a single item, we can use MoveSection and get the animation
+				// [!] Do not use BatchUpdate here, it will cause concurrency problems
 				_collectionView.MoveSection(args.OldStartingIndex, args.NewStartingIndex);
 				return;
 			}
@@ -275,102 +271,8 @@ namespace Xamarin.Forms.Platform.iOS
 			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
 			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
 
+			// [!] Do not use BatchUpdate here, it will cause concurrency problems
 			_collectionView.ReloadSections(CreateIndexSetFrom(start, end));
-		}
-
-		int GetGroupCount(int groupIndex)
-		{
-			switch (_groupSource[groupIndex])
-			{
-				case IList list:
-					return list.Count;
-				case IEnumerable enumerable:
-					var count = 0;
-					var enumerator = enumerable.GetEnumerator();
-					while (enumerator.MoveNext())
-					{
-						count += 1;
-					}
-					return count;
-			}
-
-			return 0;
-		}
-
-		object GetGroupItemAt(int groupIndex, int index)
-		{
-			switch (_groupSource[groupIndex])
-			{
-				case IList list:
-					return list[index];
-				case IEnumerable enumerable:
-					var count = -1;
-					var enumerator = enumerable.GetEnumerator();
-
-					do
-					{
-						enumerator.MoveNext();
-						count += 1;
-					}
-					while (count < index);
-
-					return enumerator.Current;
-			}
-
-			return null;
-		}
-
-		int IndexInGroup(object item, object group)
-		{
-			switch (group)
-			{
-				case IList list:
-					return list.IndexOf(item);
-				case IEnumerable enumerable:
-					var enumerator = enumerable.GetEnumerator();
-					var index = 0;
-					while (enumerator.MoveNext())
-					{
-						if (enumerator.Current == item)
-						{
-							return index;
-						}
-					}
-					return -1;
-			}
-
-			return -1;
-		}
-
-		bool ReloadRequired()
-		{
-			// If the UICollectionView has never been loaded, or doesn't yet have any sections, or has no actual
-			// cells (just supplementary views like Header/Footer), any insert/delete operations are gonna crash
-			// hard. We'll need to reload the data instead.
-
-			return NotLoadedYet()
-				|| _collectionView.NumberOfSections() == 0
-				|| _collectionView.VisibleCells.Length == 0;
-		}
-
-		void BatchUpdate(Action update)
-		{
-			_collectionView.PerformBatchUpdates(() =>
-			{
-				if (_batchUpdating.CurrentCount > 0)
-				{
-					_batchUpdating.Wait();
-				}
-
-				update();
-			},
-					(_) =>
-					{
-						if (_batchUpdating.CurrentCount == 0)
-						{
-							_batchUpdating.Release();
-						}
-					});
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -1,39 +1,54 @@
 ﻿using System;
 using System.Collections;
+using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Threading;
-using System.Threading.Tasks;
+using System.Linq;
 using Foundation;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	internal class ObservableItemsSource : IItemsViewSource
+	class ObservableItemsSource : IItemsViewSource
 	{
 		readonly UICollectionViewController _collectionViewController;
 		readonly UICollectionView _collectionView;
 		readonly bool _grouped;
 		readonly int _section;
-		readonly IEnumerable _itemsSource;
+		readonly List<object> _internalItemsSource;
+		readonly IEnumerable _originalItemsSource;
 		bool _disposed;
-		SemaphoreSlim _batchUpdating = new SemaphoreSlim(1, 1);
 
-		public ObservableItemsSource(IEnumerable itemSource, UICollectionViewController collectionViewController, int group = -1)
+		public ObservableItemsSource(IEnumerable itemSource, UICollectionViewController collectionViewController,
+			int group = -1)
 		{
 			_collectionViewController = collectionViewController;
 			_collectionView = _collectionViewController.CollectionView;
-		
+
 			_section = group < 0 ? 0 : group;
 			_grouped = group >= 0;
 
-			_itemsSource = itemSource;
+			// we basically keep a copy of the original items source, so that we have control over
+			// when updates are applied. This is necessary when updates to the collection
+			// view are performed asynchronously -> they may lead to an inconsistent state.
+			_internalItemsSource = itemSource.Cast<object>().ToList();
+			_originalItemsSource = itemSource;
 
 			Count = ItemsCount();
 
 			((INotifyCollectionChanged)itemSource).CollectionChanged += CollectionChanged;
 		}
 
-		internal event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged;
+		internal event NotifyCollectionChangedEventHandler CollectionItemsSourceChanged
+		{
+			add
+			{
+				if (_originalItemsSource is INotifyCollectionChanged incc) incc.CollectionChanged += value;
+			}
+			remove
+			{
+				if (_originalItemsSource is INotifyCollectionChanged incc) incc.CollectionChanged -= value;
+			}
+		}
 
 		public int Count { get; private set; }
 
@@ -50,7 +65,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (disposing)
 				{
-					((INotifyCollectionChanged)_itemsSource).CollectionChanged -= CollectionChanged;
+					((INotifyCollectionChanged)_originalItemsSource).CollectionChanged -= CollectionChanged;
 				}
 
 				_disposed = true;
@@ -101,49 +116,59 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (Device.IsInvokeRequired)
 			{
-				await Device.InvokeOnMainThreadAsync(async () => await CollectionChanged(args));
+				await Device.InvokeOnMainThreadAsync(() => CollectionChanged(args));
 			}
 			else
 			{
-				await CollectionChanged(args);
+				CollectionChanged(args);
 			}
 		}
 
-		async Task CollectionChanged(NotifyCollectionChangedEventArgs args)
+		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
+			if (NotLoadedYet())
+			{
+				Reload();
+				return;
+			}
+
 			switch (args.Action)
 			{
 				case NotifyCollectionChangedAction.Add:
-					await Add(args);
+					Add(args);
 					break;
 				case NotifyCollectionChangedAction.Remove:
-					await Remove(args);
+					Remove(args);
 					break;
 				case NotifyCollectionChangedAction.Replace:
-					await Replace(args);
+					Replace(args);
 					break;
 				case NotifyCollectionChangedAction.Move:
 					Move(args);
 					break;
 				case NotifyCollectionChangedAction.Reset:
-					await Reload();
+					Reload();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
-
-			CollectionItemsSourceChanged?.Invoke(this, args);
 		}
 
-		async Task Reload()
+		void Reload()
 		{
-			await _batchUpdating.WaitAsync();
-
-			_collectionView.ReloadData();
-			_collectionView.CollectionViewLayout.InvalidateLayout();
+			// update the internal items source
+			_internalItemsSource.Clear();
+			_internalItemsSource.AddRange(_originalItemsSource.Cast<object>());
 			Count = ItemsCount();
 
-			_batchUpdating.Release();
+			// update the collection view without using animation to avoid concurrency
+			// code source: https://stackoverflow.com/a/64146094/13005218
+			UIView.PerformWithoutAnimation(() =>
+			{
+				// [!] Do not use BatchUpdate here, it will cause concurrency problems
+				_collectionView.ReloadData();
+			});
+			_collectionView.CollectionViewLayout.InvalidateLayout();
 		}
 
 		NSIndexPath[] CreateIndexesFrom(int startIndex, int count)
@@ -158,11 +183,17 @@ namespace Xamarin.Forms.Platform.iOS
 			return result;
 		}
 
-		async Task Add(NotifyCollectionChangedEventArgs args)
+		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			if (ReloadRequired())
+			// UICollectionView doesn't like when we insert items into a completely empty un-grouped CV,
+			// and it doesn't like when we insert items into a grouped CV with no actual cells (just empty groups)
+			// In those circumstances, we just need to ask it to reload the data so it can get its internal
+			// accounting in order
+
+			if (!_grouped && _collectionView.NumberOfItemsInSection(_section) == 0 ||
+			    _collectionView.VisibleCells.Length == 0)
 			{
-				await Reload();
+				Reload();
 				return;
 			}
 
@@ -170,52 +201,54 @@ namespace Xamarin.Forms.Platform.iOS
 			Count += count;
 			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
 
-			// Queue up the updates to the UICollectionView
-			BatchUpdate(() => _collectionView.InsertItems(CreateIndexesFrom(startIndex, count)));
+			// update the internal items source
+			_internalItemsSource.InsertRange(args.NewStartingIndex, args.NewItems.Cast<object>());
+			// update the collection view
+			// [!] Do not use BatchUpdate here, it will cause concurrency problems
+			_collectionView.InsertItems(CreateIndexesFrom(startIndex, count));
 		}
 
-		async Task Remove(NotifyCollectionChangedEventArgs args)
+		void Remove(NotifyCollectionChangedEventArgs args)
 		{
 			var startIndex = args.OldStartingIndex;
-
 			if (startIndex < 0)
 			{
-				// INCC implementation isn't giving us enough information to know where the removed items were in the
-				// collection. So the best we can do is a ReloadData()
-				await Reload();
-				return;
-			}
-
-			if (ReloadRequired())
-			{
-				await Reload();
-				return;
+				startIndex = _internalItemsSource.IndexOf(args.OldItems[0]);
 			}
 
 			// If we have a start index, we can be more clever about removing the item(s) (and get the nifty animations)
 			var count = args.OldItems.Count;
 			Count -= count;
 
-			// Queue up the updates to the UICollectionView
-			BatchUpdate(() => _collectionView.DeleteItems(CreateIndexesFrom(startIndex, count)));
+			// update the internal items source
+			_internalItemsSource.RemoveRange(args.OldStartingIndex, args.OldItems.Count);
+			// update the collection view
+			// [!] Do not use BatchUpdate here, it will cause concurrency problems
+			_collectionView.DeleteItems(CreateIndexesFrom(startIndex, count));
 		}
 
-		async Task Replace(NotifyCollectionChangedEventArgs args)
+		void Replace(NotifyCollectionChangedEventArgs args)
 		{
 			var newCount = args.NewItems.Count;
-
 			if (newCount == args.OldItems.Count)
 			{
+				// We are replacing one set of items with a set of equal size; we can do a simple item range update
 				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
 
-				// We are replacing one set of items with a set of equal size; we can do a simple item range update
+				// update the internal items source
+				_internalItemsSource.RemoveRange(args.OldStartingIndex, args.OldItems.Count);
+				_internalItemsSource.InsertRange(args.OldStartingIndex, args.NewItems.Cast<object>());
+
+				// update the collection view
+				// [!] Do not use BatchUpdate here, it will cause concurrency problems
 				_collectionView.ReloadItems(CreateIndexesFrom(startIndex, newCount));
+
 				return;
 			}
 
 			// The original and replacement sets are of unequal size; this means that everything currently in view will 
 			// have to be updated. So we just have to use ReloadData and let the UICollectionView update everything
-			await Reload();
+			Reload();
 		}
 
 		void Move(NotifyCollectionChangedEventArgs args)
@@ -228,103 +261,34 @@ namespace Xamarin.Forms.Platform.iOS
 				var oldPath = NSIndexPath.Create(_section, args.OldStartingIndex);
 				var newPath = NSIndexPath.Create(_section, args.NewStartingIndex);
 
+				// update the internal items source
+				var item = _internalItemsSource[args.OldStartingIndex];
+				_internalItemsSource.Remove(item);
+				_internalItemsSource.Insert(args.NewStartingIndex, item);
+
+				// update the collection view
+				// [!] Do not use BatchUpdate here, it will cause concurrency problems
 				_collectionView.MoveItem(oldPath, newPath);
 				return;
 			}
 
 			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
-			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
+			var end = Math.Max(args.OldStartingIndex + args.OldItems.Count, args.NewStartingIndex + count);
+			// [!] Do not use BatchUpdate here, it will cause concurrency problems
 			_collectionView.ReloadItems(CreateIndexesFrom(start, end));
 		}
 
-		internal int ItemsCount()
-		{
-			if (_itemsSource is IList list)
-				return list.Count;
+		internal int ItemsCount() => _internalItemsSource.Count;
 
-			int count = 0;
-			foreach (var item in _itemsSource)
-				count++;
-			return count;
-		}
+		internal object ElementAt(int index) => _internalItemsSource[index];
 
-		internal object ElementAt(int index)
-		{
-			if (_itemsSource is IList list)
-				return list[index];
-
-			int count = 0;
-			foreach (var item in _itemsSource)
-			{
-				if (count == index)
-					return item;
-				count++;
-			}
-
-			return -1;
-		}
-
-		internal int IndexOf(object item)
-		{
-			if (_itemsSource is IList list)
-				return list.IndexOf(item);
-
-			int count = 0;
-			foreach (var i in _itemsSource)
-			{
-				if (i == item)
-					return count;
-				count++;
-			}
-
-			return -1;
-		}
+		internal int IndexOf(object item) => _internalItemsSource.IndexOf(item);
 
 		bool NotLoadedYet()
 		{
 			// If the UICollectionView hasn't actually been loaded, then calling InsertItems or DeleteItems is 
 			// going to crash or get in an unusable state; instead, ReloadData should be used
-			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
-		}
-
-		bool ReloadRequired()
-		{
-			if (NotLoadedYet())
-			{
-				return true;
-			}
-
-			// UICollectionView doesn't like when we insert items into a completely empty un-grouped CV,
-			// and it doesn't like when we insert items into a grouped CV with no actual cells (just empty groups)
-			// In those circumstances, we just need to ask it to reload the data so it can get its internal
-			// accounting in order
-
-			if (!_grouped && _collectionView.NumberOfItemsInSection(_section) == 0)
-			{
-				return true;
-			}
-
-			return _collectionView.VisibleCells.Length == 0;
-		}
-
-		void BatchUpdate(Action update)
-		{
-			_collectionView.PerformBatchUpdates(() =>
-			{
-				if (_batchUpdating.CurrentCount > 0)
-				{
-					_batchUpdating.Wait();
-				}
-
-				update();
-			},
-					(_) =>
-					{
-						if (_batchUpdating.CurrentCount == 0)
-						{
-							_batchUpdating.Release();
-						}
-					});
+			return !_collectionViewController.IsViewLoaded || _collectionViewController.View?.Window is null;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

This PR is a refactoring of the classes `ObservableItemsSource` and `ObservableGroupedSource` for two reasons,

1. the workarounds that grew in these classes eventually lead to Issue #11853 (and maybe others?), and
2. the code did not have optimal quality in both readability and control flow.

The workarounds were removed (including the incorrect usage of the `SemaphoreSlim` class) and the implementation was aligned more with the functionality of the underlying platform (UIKit.UICollectionView). The `SemaphoreSlim` was introduced in commit 7cfe6155, to fix a concurrency issue that could be easier fixed with this refactoring. Instead, it introduced #11853 which crashes the application. The concurrency problems that this commit fixed were mainly caused by commit 0a11a184, which unnecessarily wrapped **all** operations on the `UICollectionView` inside `PerformBatchUpdates`.

Additionally, after fixing the above, I noticed that there is a conceptual problem in the `ObservableItemsSource`, namely that there is an inconsistency between the `ItemsSource` and the actual items that the `UICollectionView` uses. Following example demonstrates the issue:

1. `ItemsSource` is changed.
2. `UICollectionView` processes the update asynchronously on the MainThread (possibly concurrent)
3. `ItemsSource` is cleared
4. `UI CollectionView`, while processing the previous update, requests the item that was changed -> but the collection is empty -> `IndexOutOfRangeException`

To address this issue, I created a field that holds a copy of the original `ItemsSource`, which is updated with every `INotifyCollectionChange` update to resemble the state of the collection **before** the update occurs. The original items source is only subscribed to and used when the `Reset` event is handled.

### Issues Resolved ### 

- fixes #11853

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

Does not crash anymore when applying multiple changes to an `ObservableCollection` that is the `ItemsSource` of a `CollectionView`.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

The test procedure is automated in the class Issue11853.cs. Just press the Start button and wait for the Success to appear. The test fails if the app crashes.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
