### PR TITLE
Correction of CollectionView to work properly with selected item color

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBoundSingleSelection.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/CollectionViewBoundSingleSelection.cs
@@ -36,8 +36,8 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("Selected: Item: 2");
 
 			// Tapping Item 3 should select it and updating the binding
-			RunningApp.Tap("Item 3");	
-			RunningApp.WaitForElement("Selected: Item: 3");
+			RunningApp.Tap("Item 1");	
+			RunningApp.WaitForElement("Selected: Item: 1");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
@@ -1,29 +1,74 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
-             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
+    <ContentPage.Resources>
+        <Style
+            TargetType="Frame">
+            <Setter
+                Property="VisualStateManager.VisualStateGroups">
+                <VisualStateGroupList>
+                    <VisualStateGroup
+                        x:Name="CommonStates">
+                        <VisualState
+                            x:Name="Normal" />
+                        <VisualState
+                            x:Name="Selected">
+                            <VisualState.Setters>
+                                <Setter
+                                    Property="BackgroundColor"
+                                    Value="RoyalBlue" />
+                            </VisualState.Setters>
+                        </VisualState>
+                    </VisualStateGroup>
+                </VisualStateGroupList>
+            </Setter>
+        </Style>
+    </ContentPage.Resources>
     <ContentPage.Content>
-        <StackLayout Spacing="5">
+        <StackLayout
+            Spacing="5">
 
-            <Label Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
-                VerticalOptions="CenterAndExpand" 
+            <Label
+                Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
+                VerticalOptions="CenterAndExpand"
                 HorizontalOptions="CenterAndExpand" />
 
-            <Label Text="{Binding SelectedItem, StringFormat='{}Selected: {0}'}"
-                VerticalOptions="CenterAndExpand" 
+            <Label
+                Text="{Binding SelectedItem, StringFormat='{}Selected: {0}'}"
+                VerticalOptions="CenterAndExpand"
                 HorizontalOptions="CenterAndExpand" />
 
-            <Button AutomationId="Reset" Text="Reset Selection to Item 0" Clicked="ResetClicked" />
-            
-            <Button AutomationId="Clear" Text="Clear Selection" Clicked="ClearClicked" />
+            <Button
+                AutomationId="Reset"
+                Text="Reset Selection to Item 0"
+                Clicked="ResetClicked" />
 
-            <CollectionView ItemsSource="{Binding Items}" SelectionMode="Single" SelectedItem="{Binding SelectedItem}">
+            <Button
+                AutomationId="Clear"
+                Text="Clear Selection"
+                Clicked="ClearClicked" />
+
+            <CollectionView
+                ItemsSource="{Binding Items}"
+                SelectionMode="Single"
+                SelectedItem="{Binding SelectedItem}">
                 <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <StackLayout>
-                            <Image Source="{Binding Image}" HeightRequest="50" />
-                            <Label Text="{Binding Caption}"></Label>
-                        </StackLayout>
+                        <Frame
+                            HasShadow="False"
+                            Margin="10"
+                            BackgroundColor="LightBlue"
+                            CornerRadius="20">
+                            <StackLayout>
+                                <Image
+                                    Source="{Binding Image}"
+                                    HeightRequest="50" />
+                                <Label
+                                    Text="{Binding Caption}"></Label>
+                            </StackLayout>
+                        </Frame>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
@@ -3,29 +3,7 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
-    <ContentPage.Resources>
-        <Style
-            TargetType="Frame">
-            <Setter
-                Property="VisualStateManager.VisualStateGroups">
-                <VisualStateGroupList>
-                    <VisualStateGroup
-                        x:Name="CommonStates">
-                        <VisualState
-                            x:Name="Normal" />
-                        <VisualState
-                            x:Name="Selected">
-                            <VisualState.Setters>
-                                <Setter
-                                    Property="BackgroundColor"
-                                    Value="RoyalBlue" />
-                            </VisualState.Setters>
-                        </VisualState>
-                    </VisualStateGroup>
-                </VisualStateGroupList>
-            </Setter>
-        </Style>
-    </ContentPage.Resources>
+    
     <ContentPage.Content>
         <StackLayout
             Spacing="5">
@@ -68,6 +46,25 @@
                                 <Label
                                     Text="{Binding Caption}"></Label>
                             </StackLayout>
+
+                            <VisualStateManager.VisualStateGroups>
+                                <VisualStateGroupList>
+                                    <VisualStateGroup x:Name="CommonStates">
+                                        <VisualState x:Name="Normal" />
+                                        <VisualState x:Name="Selected">
+                                            <VisualState.Setters>
+                                                <Setter
+                                                    Property="BackgroundColor"
+                                                    Value="RoyalBlue" />
+                                                <Setter
+                                                    Property="Scale"
+                                                    Value="0.9" />
+                                            </VisualState.Setters>
+                                        </VisualState>
+                                    </VisualStateGroup>
+                                </VisualStateGroupList>
+                            </VisualStateManager.VisualStateGroups>
+                            
                         </Frame>
                     </DataTemplate>
                 </CollectionView.ItemTemplate>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
@@ -1,75 +1,75 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ContentPage
-    xmlns="http://xamarin.com/schemas/2014/forms"
-    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
-    x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
-    
-    <ContentPage.Content>
-        <StackLayout
-            Spacing="5">
+	xmlns="http://xamarin.com/schemas/2014/forms"
+	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+	x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
 
-            <Label
-                Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
-                VerticalOptions="CenterAndExpand"
-                HorizontalOptions="CenterAndExpand" />
+	<ContentPage.Content>
+		<StackLayout
+			Spacing="5">
 
-            <Label
-                Text="{Binding SelectedItem, StringFormat='{}Selected: {0}'}"
-                VerticalOptions="CenterAndExpand"
-                HorizontalOptions="CenterAndExpand" />
+			<Label
+				Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
+				VerticalOptions="CenterAndExpand"
+				HorizontalOptions="CenterAndExpand" />
 
-            <Button
-                AutomationId="Reset"
-                Text="Reset Selection to Item 0"
-                Clicked="ResetClicked" />
+			<Label
+				Text="{Binding SelectedItem, StringFormat='{}Selected: {0}'}"
+				VerticalOptions="CenterAndExpand"
+				HorizontalOptions="CenterAndExpand" />
 
-            <Button
-                AutomationId="Clear"
-                Text="Clear Selection"
-                Clicked="ClearClicked" />
+			<Button
+				AutomationId="Reset"
+				Text="Reset Selection to Item 0"
+				Clicked="ResetClicked" />
 
-            <CollectionView
-                ItemsSource="{Binding Items}"
-                SelectionMode="Single"
-                SelectedItem="{Binding SelectedItem}">
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Frame
-                            HasShadow="False"
-                            Margin="10"
-                            BackgroundColor="LightBlue"
-                            CornerRadius="20">
-                            <StackLayout>
-                                <Image
-                                    Source="{Binding Image}"
-                                    HeightRequest="50" />
-                                <Label
-                                    Text="{Binding Caption}"></Label>
-                            </StackLayout>
+			<Button
+				AutomationId="Clear"
+				Text="Clear Selection"
+				Clicked="ClearClicked" />
 
-                            <VisualStateManager.VisualStateGroups>
-                                <VisualStateGroupList>
-                                    <VisualStateGroup x:Name="CommonStates">
-                                        <VisualState x:Name="Normal" />
-                                        <VisualState x:Name="Selected">
-                                            <VisualState.Setters>
-                                                <Setter
-                                                    Property="BackgroundColor"
-                                                    Value="RoyalBlue" />
-                                                <Setter
-                                                    Property="Scale"
-                                                    Value="0.9" />
-                                            </VisualState.Setters>
-                                        </VisualState>
-                                    </VisualStateGroup>
-                                </VisualStateGroupList>
-                            </VisualStateManager.VisualStateGroups>
-                            
-                        </Frame>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
+			<CollectionView
+				ItemsSource="{Binding Items}"
+				SelectionMode="Single"
+				SelectedItem="{Binding SelectedItem}">
+				<CollectionView.ItemTemplate>
+					<DataTemplate>
+						<Frame
+							HasShadow="False"
+							Margin="10"
+							BackgroundColor="LightBlue"
+							CornerRadius="20">
+							<StackLayout>
+								<Image
+									Source="{Binding Image}"
+									HeightRequest="50" />
+								<Label
+									Text="{Binding Caption}"></Label>
+							</StackLayout>
 
-        </StackLayout>
-    </ContentPage.Content>
+							<VisualStateManager.VisualStateGroups>
+								<VisualStateGroupList>
+									<VisualStateGroup x:Name="CommonStates">
+										<VisualState x:Name="Normal" />
+										<VisualState x:Name="Selected">
+											<VisualState.Setters>
+												<Setter
+													Property="BackgroundColor"
+													Value="RoyalBlue" />
+												<Setter
+													Property="Scale"
+													Value="0.9" />
+											</VisualState.Setters>
+										</VisualState>
+									</VisualStateGroup>
+								</VisualStateGroupList>
+							</VisualStateManager.VisualStateGroups>
+
+						</Frame>
+					</DataTemplate>
+				</CollectionView.ItemTemplate>
+			</CollectionView>
+
+		</StackLayout>
+	</ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
@@ -34,6 +34,8 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		internal bool UseAndroidDefaultColorsForSelection { get; set; }
+
 		public void OnClick(global::Android.Views.View view)
 		{
 			if (_isSelectionEnabled)
@@ -55,6 +57,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SetSelectionStates(bool isSelected)
 		{
+			if (!UseAndroidDefaultColorsForSelection)
+			{
+				return;
+			}
+
 			if (Forms.IsMarshmallowOrNewer)
 			{
 				// We're looking for the foreground ripple effect, which is not available on older APIs

--- a/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SelectableViewHolder.cs
@@ -34,7 +34,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		internal bool UseAndroidDefaultColorsForSelection { get; set; }
+		protected virtual bool UseDefaultSelectionColor => true;
 
 		public void OnClick(global::Android.Views.View view)
 		{
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void SetSelectionStates(bool isSelected)
 		{
-			if (!UseAndroidDefaultColorsForSelection)
+			if (!UseDefaultSelectionColor)
 			{
 				return;
 			}

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -7,6 +7,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public class TemplatedItemViewHolder : SelectableViewHolder
 	{
+		bool? _useAndroidDefaultsDrawableSelectionColors;
 		readonly ItemContentView _itemContentView;
 		readonly DataTemplate _template;
 		DataTemplate _selectedTemplate;
@@ -95,50 +96,48 @@ namespace Xamarin.Forms.Platform.Android
 			// with Selected State, overriding the Android default
 			// selection color
 
-			bool useAndroidDefaultsDrawableSelectionColors = true;
+			if (_useAndroidDefaultsDrawableSelectionColors.HasValue)
+            {
+                return _useAndroidDefaultsDrawableSelectionColors.Value;
+            }
 
-			if (itemsView.FindParentOfType<Page>() is Page page)
-			{
-				foreach (var resourceDictionary in page.Resources)
-				{
-					if (resourceDictionary.Value is Style style
-							&& style.TargetType.IsAssignableFrom(View.GetType()))
-					{
-						foreach (var setter in style.Setters)
-						{
-							if (setter.Property == VisualStateManager.VisualStateGroupsProperty)
-							{
-								if (setter.Value is VisualStateGroupList visualStateGroups)
-								{
-									foreach (var group in visualStateGroups)
-									{
-										foreach (var state in group.States)
-										{
-											if (state.Name == "Selected")
-											{
-												foreach (var visualStateSetter in state.Setters)
-												{
-													if (visualStateSetter.Property == VisualElement.BackgroundColorProperty)
-													{
-														useAndroidDefaultsDrawableSelectionColors = false;
-													}
-												}
-											}
-										}
-									}
-								}
-							}
-							else
-							{
-								continue;
-							}
-						}
-					}
+            if (itemsView.FindParentOfType<Page>() is Page page)
+            {
+                foreach (var resourceDictionary in page.Resources)
+                {
+                    if (resourceDictionary.Value is Style style
+						&& style.TargetType.IsAssignableFrom(View.GetType()))
+                    {
+                        foreach (var setter in style.Setters)
+                        {
+                            if (setter.Property == VisualStateManager.VisualStateGroupsProperty
+								&& setter.Value is VisualStateGroupList visualStateGroups)
+                            {
+                                foreach (var group in visualStateGroups)
+                                {
+                                    foreach (var state in group.States)
+                                    {
+                                        if (state.Name == "Selected")
+                                        {
+                                            foreach (var visualStateSetter in state.Setters)
+                                            {
+                                                if (visualStateSetter.Property == VisualElement.BackgroundColorProperty)
+                                                {
+                                                    _useAndroidDefaultsDrawableSelectionColors = false;
+                                                    return false;
+                                                }
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
 
-				}
-			}
-
-			return useAndroidDefaultsDrawableSelectionColors;
+			_useAndroidDefaultsDrawableSelectionColors = true;
+            return true;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/TemplatedItemViewHolder.cs
@@ -90,28 +90,31 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (View != null)
 				{
-					return !IsUsingCustomSelectionColor(View);
+					return !IsUsingVSMForSelectionColor(View);
 				}
 
 				return base.UseDefaultSelectionColor;
 			}
 		}
 
-		bool IsUsingCustomSelectionColor(View view)
+		bool IsUsingVSMForSelectionColor(View view)
 		{
 			var groups = VisualStateManager.GetVisualStateGroups(view);
-			foreach (var group in groups)
+			for (var groupIndex = 0; groupIndex < groups.Count; groupIndex++)
 			{
-				foreach (var state in group.States)
+				var group = groups[groupIndex];
+				for (var stateIndex = 0; stateIndex < group.States.Count; stateIndex++)
 				{
+					var state = group.States[stateIndex];
 					if (state.Name != VisualStateManager.CommonStates.Selected)
 					{
 						continue;
 					}
 
-					foreach (var setter in state.Setters)
+					for (var setterIndex = 0; setterIndex < state.Setters.Count; setterIndex++)
 					{
-						if (setter.Property.PropertyName == View.BackgroundColorProperty.PropertyName)
+						var setter = state.Setters[setterIndex];
+						if (setter.Property.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 						{
 							return true;
 						}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -16,8 +16,6 @@ namespace Xamarin.Forms.Platform.iOS
 
         DataTemplate _currentTemplate;
 
-        bool? _useDefaultSelectionColors;
-
         // Keep track of the cell size so we can verify whether a measure invalidation 
         // actually changed the size of the cell
         Size _size;
@@ -93,7 +91,7 @@ namespace Xamarin.Forms.Platform.iOS
                 var view = itemTemplate.CreateContent() as View;
 
                 // Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
-                if (!UseDefaultsSelectionColor(itemsView, view))
+                if (IsUsingCustomSelectionColor(view) && SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray)
                 {
                     SelectedBackgroundView = new UIView
                     {
@@ -157,57 +155,82 @@ namespace Xamarin.Forms.Platform.iOS
             }
         }
 
-        bool UseDefaultsSelectionColor(ItemsView itemsView, View view)
-        {
-            // Walks through the resource dictionary to know
-            // if there is a resource dictionary that have VisualStateGroups
-            // with Selected State overrides the selection
-            // background color
+		bool IsUsingCustomSelectionColor(View view) 
+		{
+			var groups = VisualStateManager.GetVisualStateGroups(view);
+			foreach (var group in groups)
+			{
+				foreach (var state in group.States)
+				{
+					if (state.Name != VisualStateManager.CommonStates.Selected)
+					{
+						continue;
+					}
 
-            if (_useDefaultSelectionColors.HasValue)
-            {
-                return _useDefaultSelectionColors.Value;
-            }
+					foreach (var setter in state.Setters)
+					{
+						if (setter.Property.PropertyName == View.BackgroundColorProperty.PropertyName)
+						{
+							return true;
+						}
+					}
+				}
+			}
 
-            if (itemsView.FindParentOfType<Page>() is Page page)
-            {
-                foreach (var resourceDictionary in page.Resources)
-                {
-                    if (resourceDictionary.Value is Style style
-                        && style.TargetType.IsAssignableFrom(view.GetType()))
-                    {
-                        foreach (var setter in style.Setters)
-                        {
-                            if (setter.Property == VisualStateManager.VisualStateGroupsProperty
-                                && setter.Value is VisualStateGroupList visualStateGroups)
-                            {
-                                foreach (var group in visualStateGroups)
-                                {
-                                    foreach (var state in group.States)
-                                    {
-                                        if (state.Name == "Selected")
-                                        {
-                                            foreach (var visualStateSetter in state.Setters)
-                                            {
-                                                if (visualStateSetter.Property == VisualElement.BackgroundColorProperty)
-                                                {
-                                                    _useDefaultSelectionColors = false;
-                                                    return false;
-                                                }
-                                            }
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
+			return false;
+		}
 
-                }
-            }
+        //bool UseDefaultsSelectionColor(ItemsView itemsView, View view)
+        //{
+        //    // Walks through the resource dictionary to know
+        //    // if there is a resource dictionary that have VisualStateGroups
+        //    // with Selected State overrides the selection
+        //    // background color
 
-            _useDefaultSelectionColors = true;
-            return true;
-        }
+        //    if (_useDefaultSelectionColors.HasValue)
+        //    {
+        //        return _useDefaultSelectionColors.Value;
+        //    }
+
+        //    if (itemsView.FindParentOfType<Page>() is Page page)
+        //    {
+        //        foreach (var resourceDictionary in page.Resources)
+        //        {
+        //            if (resourceDictionary.Value is Style style
+        //                && style.TargetType.IsAssignableFrom(view.GetType()))
+        //            {
+        //                foreach (var setter in style.Setters)
+        //                {
+        //                    if (setter.Property == VisualStateManager.VisualStateGroupsProperty
+        //                        && setter.Value is VisualStateGroupList visualStateGroups)
+        //                    {
+        //                        foreach (var group in visualStateGroups)
+        //                        {
+        //                            foreach (var state in group.States)
+        //                            {
+        //                                if (state.Name == "Selected")
+        //                                {
+        //                                    foreach (var visualStateSetter in state.Setters)
+        //                                    {
+        //                                        if (visualStateSetter.Property == VisualElement.BackgroundColorProperty)
+        //                                        {
+        //                                            _useDefaultSelectionColors = false;
+        //                                            return false;
+        //                                        }
+        //                                    }
+        //                                }
+        //                            }
+        //                        }
+        //                    }
+        //                }
+        //            }
+
+        //        }
+        //    }
+
+        //    _useDefaultSelectionColors = true;
+        //    return true;
+        //}
 
         public override bool Selected
         {

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -6,158 +6,158 @@ using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-    public abstract class TemplatedCell : ItemsViewCell
-    {
-        public event EventHandler<EventArgs> ContentSizeChanged;
+	public abstract class TemplatedCell : ItemsViewCell
+	{
+		public event EventHandler<EventArgs> ContentSizeChanged;
 
-        protected CGSize ConstrainedSize;
+		protected CGSize ConstrainedSize;
 
-        protected nfloat ConstrainedDimension;
+		protected nfloat ConstrainedDimension;
 
-        DataTemplate _currentTemplate;
+		DataTemplate _currentTemplate;
 
-        // Keep track of the cell size so we can verify whether a measure invalidation 
-        // actually changed the size of the cell
-        Size _size;
+		// Keep track of the cell size so we can verify whether a measure invalidation 
+		// actually changed the size of the cell
+		Size _size;
 
-        [Export("initWithFrame:")]
-        [Internals.Preserve(Conditional = true)]
-        protected TemplatedCell(CGRect frame) : base(frame)
-        {
-        }
+		[Export("initWithFrame:")]
+		[Internals.Preserve(Conditional = true)]
+		protected TemplatedCell(CGRect frame) : base(frame)
+		{
+		}
 
-        internal IVisualElementRenderer VisualElementRenderer { get; private set; }
+		internal IVisualElementRenderer VisualElementRenderer { get; private set; }
 
-        public override void ConstrainTo(CGSize constraint)
-        {
-            ClearConstraints();
-            ConstrainedSize = constraint;
-        }
+		public override void ConstrainTo(CGSize constraint)
+		{
+			ClearConstraints();
+			ConstrainedSize = constraint;
+		}
 
-        public override void ConstrainTo(nfloat constant)
-        {
-            ClearConstraints();
-            ConstrainedDimension = constant;
-        }
+		public override void ConstrainTo(nfloat constant)
+		{
+			ClearConstraints();
+			ConstrainedDimension = constant;
+		}
 
-        protected void ClearConstraints()
-        {
-            ConstrainedSize = default;
-            ConstrainedDimension = default;
-        }
+		protected void ClearConstraints()
+		{
+			ConstrainedSize = default;
+			ConstrainedDimension = default;
+		}
 
-        public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(
-            UICollectionViewLayoutAttributes layoutAttributes)
-        {
-            var preferredAttributes = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);
+		public override UICollectionViewLayoutAttributes PreferredLayoutAttributesFittingAttributes(
+			UICollectionViewLayoutAttributes layoutAttributes)
+		{
+			var preferredAttributes = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);
 
-            // Measure this cell (including the Forms element) if there is no constrained size
-            var size = ConstrainedSize == default(CGSize) ? Measure() : ConstrainedSize;
+			// Measure this cell (including the Forms element) if there is no constrained size
+			var size = ConstrainedSize == default(CGSize) ? Measure() : ConstrainedSize;
 
-            // Update the size of the root view to accommodate the Forms element
-            var nativeView = VisualElementRenderer.NativeView;
-            nativeView.Frame = new CGRect(CGPoint.Empty, size);
+			// Update the size of the root view to accommodate the Forms element
+			var nativeView = VisualElementRenderer.NativeView;
+			nativeView.Frame = new CGRect(CGPoint.Empty, size);
 
-            // Layout the Forms element 
-            var nativeBounds = nativeView.Frame.ToRectangle();
-            VisualElementRenderer.Element.Layout(nativeBounds);
-            _size = nativeBounds.Size;
+			// Layout the Forms element 
+			var nativeBounds = nativeView.Frame.ToRectangle();
+			VisualElementRenderer.Element.Layout(nativeBounds);
+			_size = nativeBounds.Size;
 
-            // Adjust the preferred attributes to include space for the Forms element
-            preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, size);
+			// Adjust the preferred attributes to include space for the Forms element
+			preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, size);
 
-            return preferredAttributes;
-        }
+			return preferredAttributes;
+		}
 
-        public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
-        {
-            var oldElement = VisualElementRenderer?.Element;
+		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
+		{
+			var oldElement = VisualElementRenderer?.Element;
 
-            // Run this through the extension method in case it's really a DataTemplateSelector
-            var itemTemplate = template.SelectDataTemplate(bindingContext, itemsView);
+			// Run this through the extension method in case it's really a DataTemplateSelector
+			var itemTemplate = template.SelectDataTemplate(bindingContext, itemsView);
 
-            if (itemTemplate != _currentTemplate)
-            {
-                // Remove the old view, if it exists
-                if (oldElement != null)
-                {
-                    oldElement.MeasureInvalidated -= MeasureInvalidated;
-                    itemsView.RemoveLogicalChild(oldElement);
-                    ClearSubviews();
-                    _size = Size.Zero;
-                }
+			if (itemTemplate != _currentTemplate)
+			{
+				// Remove the old view, if it exists
+				if (oldElement != null)
+				{
+					oldElement.MeasureInvalidated -= MeasureInvalidated;
+					itemsView.RemoveLogicalChild(oldElement);
+					ClearSubviews();
+					_size = Size.Zero;
+				}
 
-                // Create the content and renderer for the view 
-                var view = itemTemplate.CreateContent() as View;
+				// Create the content and renderer for the view 
+				var view = itemTemplate.CreateContent() as View;
 
-                // Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
+				// Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
 				// First we check whether the cell has the default selected background color; if it does, then we should check
 				// to see if the cell content is the VSM to set a selected color 
-                if (SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray && IsUsingVSMForSelectionColor(view))
-                {
-                    SelectedBackgroundView = new UIView
-                    {
-                        BackgroundColor = UIColor.Clear
-                    };
-                }
+				if (SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray && IsUsingVSMForSelectionColor(view))
+				{
+					SelectedBackgroundView = new UIView
+					{
+						BackgroundColor = UIColor.Clear
+					};
+				}
 
-                // Set the binding context _before_ we create the renderer; that way, it's available during OnElementChanged
-                view.BindingContext = bindingContext;
+				// Set the binding context _before_ we create the renderer; that way, it's available during OnElementChanged
+				view.BindingContext = bindingContext;
 
-                var renderer = TemplateHelpers.CreateRenderer(view);
-                SetRenderer(renderer);
+				var renderer = TemplateHelpers.CreateRenderer(view);
+				SetRenderer(renderer);
 
-                // And make the new Element a "child" of the ItemsView
-                // We deliberately do this _after_ setting the binding context for the new element;
-                // if we do it before, the element briefly inherits the ItemsView's bindingcontext and we 
-                // emit a bunch of needless binding errors
-                itemsView.AddLogicalChild(view);
-            }
-            else
-            {
-                // Same template, different data
-                var currentElement = VisualElementRenderer?.Element;
+				// And make the new Element a "child" of the ItemsView
+				// We deliberately do this _after_ setting the binding context for the new element;
+				// if we do it before, the element briefly inherits the ItemsView's bindingcontext and we 
+				// emit a bunch of needless binding errors
+				itemsView.AddLogicalChild(view);
+			}
+			else
+			{
+				// Same template, different data
+				var currentElement = VisualElementRenderer?.Element;
 
-                if (currentElement != null)
-                    currentElement.BindingContext = bindingContext;
-            }
+				if (currentElement != null)
+					currentElement.BindingContext = bindingContext;
+			}
 
-            _currentTemplate = itemTemplate;
-        }
+			_currentTemplate = itemTemplate;
+		}
 
-        void SetRenderer(IVisualElementRenderer renderer)
-        {
-            VisualElementRenderer = renderer;
-            var nativeView = VisualElementRenderer.NativeView;
+		void SetRenderer(IVisualElementRenderer renderer)
+		{
+			VisualElementRenderer = renderer;
+			var nativeView = VisualElementRenderer.NativeView;
 
-            InitializeContentConstraints(nativeView);
+			InitializeContentConstraints(nativeView);
 
-            renderer.Element.MeasureInvalidated += MeasureInvalidated;
-        }
+			renderer.Element.MeasureInvalidated += MeasureInvalidated;
+		}
 
-        protected void Layout(CGSize constraints)
-        {
-            var nativeView = VisualElementRenderer.NativeView;
+		protected void Layout(CGSize constraints)
+		{
+			var nativeView = VisualElementRenderer.NativeView;
 
-            var width = constraints.Width;
-            var height = constraints.Height;
+			var width = constraints.Width;
+			var height = constraints.Height;
 
-            VisualElementRenderer.Element.Measure(width, height, MeasureFlags.IncludeMargins);
+			VisualElementRenderer.Element.Measure(width, height, MeasureFlags.IncludeMargins);
 
-            nativeView.Frame = new CGRect(0, 0, width, height);
+			nativeView.Frame = new CGRect(0, 0, width, height);
 
-            VisualElementRenderer.Element.Layout(nativeView.Frame.ToRectangle());
-        }
+			VisualElementRenderer.Element.Layout(nativeView.Frame.ToRectangle());
+		}
 
-        void ClearSubviews()
-        {
-            for (int n = ContentView.Subviews.Length - 1; n >= 0; n--)
-            {
-                ContentView.Subviews[n].RemoveFromSuperview();
-            }
-        }
+		void ClearSubviews()
+		{
+			for (int n = ContentView.Subviews.Length - 1; n >= 0; n--)
+			{
+				ContentView.Subviews[n].RemoveFromSuperview();
+			}
+		}
 
-		bool IsUsingVSMForSelectionColor(View view) 
+		bool IsUsingVSMForSelectionColor(View view)
 		{
 			var groups = VisualStateManager.GetVisualStateGroups(view);
 			for (var groupIndex = 0; groupIndex < groups.Count; groupIndex++)
@@ -185,45 +185,45 @@ namespace Xamarin.Forms.Platform.iOS
 			return false;
 		}
 
-        public override bool Selected
-        {
-            get => base.Selected;
-            set
-            {
-                base.Selected = value;
+		public override bool Selected
+		{
+			get => base.Selected;
+			set
+			{
+				base.Selected = value;
 
-                var element = VisualElementRenderer?.Element;
+				var element = VisualElementRenderer?.Element;
 
-                if (element != null)
-                {
-                    VisualStateManager.GoToState(element, value
-                        ? VisualStateManager.CommonStates.Selected
-                        : VisualStateManager.CommonStates.Normal);
-                }
-            }
-        }
+				if (element != null)
+				{
+					VisualStateManager.GoToState(element, value
+						? VisualStateManager.CommonStates.Selected
+						: VisualStateManager.CommonStates.Normal);
+				}
+			}
+		}
 
-        protected abstract (bool, Size) NeedsContentSizeUpdate(Size currentSize);
+		protected abstract (bool, Size) NeedsContentSizeUpdate(Size currentSize);
 
-        void MeasureInvalidated(object sender, EventArgs args)
-        {
-            var (needsUpdate, toSize) = NeedsContentSizeUpdate(_size);
+		void MeasureInvalidated(object sender, EventArgs args)
+		{
+			var (needsUpdate, toSize) = NeedsContentSizeUpdate(_size);
 
-            if (!needsUpdate)
-            {
-                return;
-            }
+			if (!needsUpdate)
+			{
+				return;
+			}
 
-            // Cache the size for next time
-            _size = toSize;
+			// Cache the size for next time
+			_size = toSize;
 
-            // Let the controller know that things need to be laid out again
-            OnContentSizeChanged();
-        }
+			// Let the controller know that things need to be laid out again
+			OnContentSizeChanged();
+		}
 
-        protected void OnContentSizeChanged()
-        {
-            ContentSizeChanged?.Invoke(this, EventArgs.Empty);
-        }
-    }
+		protected void OnContentSizeChanged()
+		{
+			ContentSizeChanged?.Invoke(this, EventArgs.Empty);
+		}
+	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -91,7 +91,9 @@ namespace Xamarin.Forms.Platform.iOS
                 var view = itemTemplate.CreateContent() as View;
 
                 // Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
-                if (IsUsingCustomSelectionColor(view) && SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray)
+				// First we check whether the cell has the default selected background color; if it does, then we should check
+				// to see if the cell content is the VSM to set a selected color 
+                if (SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray && IsUsingVSMForSelectionColor(view))
                 {
                     SelectedBackgroundView = new UIView
                     {
@@ -155,21 +157,24 @@ namespace Xamarin.Forms.Platform.iOS
             }
         }
 
-		bool IsUsingCustomSelectionColor(View view) 
+		bool IsUsingVSMForSelectionColor(View view) 
 		{
 			var groups = VisualStateManager.GetVisualStateGroups(view);
-			foreach (var group in groups)
+			for (var groupIndex = 0; groupIndex < groups.Count; groupIndex++)
 			{
-				foreach (var state in group.States)
+				var group = groups[groupIndex];
+				for (var stateIndex = 0; stateIndex < group.States.Count; stateIndex++)
 				{
+					var state = group.States[stateIndex];
 					if (state.Name != VisualStateManager.CommonStates.Selected)
 					{
 						continue;
 					}
 
-					foreach (var setter in state.Setters)
+					for (var setterIndex = 0; setterIndex < state.Setters.Count; setterIndex++)
 					{
-						if (setter.Property.PropertyName == View.BackgroundColorProperty.PropertyName)
+						var setter = state.Setters[setterIndex];
+						if (setter.Property.PropertyName == VisualElement.BackgroundColorProperty.PropertyName)
 						{
 							return true;
 						}
@@ -179,58 +184,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return false;
 		}
-
-        //bool UseDefaultsSelectionColor(ItemsView itemsView, View view)
-        //{
-        //    // Walks through the resource dictionary to know
-        //    // if there is a resource dictionary that have VisualStateGroups
-        //    // with Selected State overrides the selection
-        //    // background color
-
-        //    if (_useDefaultSelectionColors.HasValue)
-        //    {
-        //        return _useDefaultSelectionColors.Value;
-        //    }
-
-        //    if (itemsView.FindParentOfType<Page>() is Page page)
-        //    {
-        //        foreach (var resourceDictionary in page.Resources)
-        //        {
-        //            if (resourceDictionary.Value is Style style
-        //                && style.TargetType.IsAssignableFrom(view.GetType()))
-        //            {
-        //                foreach (var setter in style.Setters)
-        //                {
-        //                    if (setter.Property == VisualStateManager.VisualStateGroupsProperty
-        //                        && setter.Value is VisualStateGroupList visualStateGroups)
-        //                    {
-        //                        foreach (var group in visualStateGroups)
-        //                        {
-        //                            foreach (var state in group.States)
-        //                            {
-        //                                if (state.Name == "Selected")
-        //                                {
-        //                                    foreach (var visualStateSetter in state.Setters)
-        //                                    {
-        //                                        if (visualStateSetter.Property == VisualElement.BackgroundColorProperty)
-        //                                        {
-        //                                            _useDefaultSelectionColors = false;
-        //                                            return false;
-        //                                        }
-        //                                    }
-        //                                }
-        //                            }
-        //                        }
-        //                    }
-        //                }
-        //            }
-
-        //        }
-        //    }
-
-        //    _useDefaultSelectionColors = true;
-        //    return true;
-        //}
 
         public override bool Selected
         {


### PR DESCRIPTION
NOTE: This was orginally https://github.com/xamarin/Xamarin.Forms/pull/11604 from @ronymesquita. We had to re-create the PR due to some CI and merging issues. 

### Description of Change ###

The key idea is to resolve the problem of CollectionView with selected item color on Android and iOS.

### Issues Resolved ### 

- fixes #7790
- fixes #9590
- fixes #11421

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

The platform will check if exists a `Visual State` with `Selected` and not use the default color. In this manner, the background color of the `Visual State` will not be overridden by Android. On iOS, the background color is cleaned when the `Selected` state exists. 
The default behavior still works.

### Before/After Screenshots ### 

#### After (Android)
![android](https://user-images.githubusercontent.com/41541500/88905863-29827c00-d22d-11ea-9522-0e4bf0405053.gif)

#### After (iOS)
![ios](https://user-images.githubusercontent.com/41541500/88905900-343d1100-d22d-11ea-9d93-4ceb66e0f131.gif)

### Testing Procedure ###
The test was manual.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
