### PR TITLE
[iOS] Fixed IndicatorView rendering issue on iOS 14

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/IndicatorViewRenderer.cs
@@ -37,6 +37,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (UIPager != null)
 			{
+				if (Forms.IsiOS14OrNewer)
+				{
+					UIPager.AllowsContinuousInteraction = false;
+					UIPager.BackgroundStyle = UIPageControlBackgroundStyle.Minimal;
+				}
+
 				UpdatePagesIndicatorTintColor();
 				UpdateCurrentPagesIndicatorTintColor();
 				UpdatePages();


### PR DESCRIPTION
### Description of Change ###

Fixed IndicatorView rendering issue on iOS 14.

In iOS 14, We have a new styling option for a UIPageControl called `BackgroundStyle`. This is an enum with three values:
- Automatic: The default background style that adapts based on the current interaction state.
- Prominent: The background style that shows a full background regardless of the interaction
- Minimal :The background style that shows a minimal background regardless of the interaction

Apple also has provided a new way to manage the interaction for the UIPageControl in iOS14 called InteractionState. `AllowsContinuousInteraction` allow us in a. simple way to manage if we want continuous interaction or not.

To maintain the IndicatorView behavior, this PR introduce changes using the previous properties only in iOS 14.

### Issues Resolved ### 

- fixes #12028 
- fixes #12318

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix12028](https://user-images.githubusercontent.com/6755973/97564673-34dc7380-19e5-11eb-9127-c916fc8b429f.gif)

### Testing Procedure ###
Launch Core Gallery on iOS 14 and navigate to the IndicatorView Gallery. Verify that the IndicatorView renders as expected.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
