### PR TITLE
EventArgs for BindingFailed must match Log.Warning

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -14,6 +14,8 @@ namespace Xamarin.Forms
 	internal class BindingExpression
 	{
 		internal const string PropertyNotFoundErrorMessage = "'{0}' property not found on '{1}', target property: '{2}.{3}'";
+		internal const string CannotConvertTypeErrorMessage = "'{0}' cannot be converted to type '{1}'";
+		internal const string ParseIndexErrorMessage = "'{0}' could not be parsed as an index for a '{1}'";
 		static readonly char[] ExpressionSplit = new[] { '.' };
 
 		readonly List<BindingExpressionPart> _parts = new List<BindingExpressionPart>();
@@ -129,8 +131,7 @@ namespace Xamarin.Forms
 					&& ((needsGetter && part.LastGetter == null)
 						|| (needsSetter && part.NextPart == null && part.LastSetter == null)))
 				{
-					Log.Warning("Binding", PropertyNotFoundErrorMessage, part.Content, current, target.GetType(), property.PropertyName);
-					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, PropertyNotFoundErrorMessage, new[] { part.Content, current, target.GetType(), property.PropertyName });
+					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, "Binding", PropertyNotFoundErrorMessage, part.Content, current, target.GetType(), property.PropertyName);
 					break;
 				}
 
@@ -152,8 +153,7 @@ namespace Xamarin.Forms
 
 				if (!TryConvert(ref value, property, property.ReturnType, true))
 				{
-					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, property.ReturnType);
-					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, property.ReturnType });
+					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, "Binding", CannotConvertTypeErrorMessage, value, property.ReturnType);
 					return;
 				}
 
@@ -165,8 +165,7 @@ namespace Xamarin.Forms
 
 				if (!TryConvert(ref value, property, part.SetterType, false))
 				{
-					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, part.SetterType);
-					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, part.SetterType });
+					BindingDiagnostics.SendBindingFailure(Binding, current, target, property, "Binding", CannotConvertTypeErrorMessage, value, part.SetterType);
 					return;
 				}
 
@@ -313,8 +312,7 @@ namespace Xamarin.Forms
 				{
 					if (!int.TryParse(part.Content, out var index))
 					{
-						Log.Warning("Binding", "{0} could not be parsed as an index for a {1}", part.Content, sourceType);
-						BindingDiagnostics.SendBindingFailure(Binding, null, "{0} could not be parsed as an index for a {1}", new object[] { part.Content, sourceType });
+						BindingDiagnostics.SendBindingFailure(Binding, "Binding", ParseIndexErrorMessage, part.Content, sourceType);
 					}
 					else
 						part.Arguments = new object[] { index };

--- a/Xamarin.Forms.Core/MultiBinding.cs
+++ b/Xamarin.Forms.Core/MultiBinding.cs
@@ -90,8 +90,7 @@ namespace Xamarin.Forms
 					_applying = true;
 					if (!BindingExpression.TryConvert(ref value, _targetProperty, _targetProperty.ReturnType, true))
 					{
-						Log.Warning("MultiBinding", "'{0}' cannot be converted to type '{1}'.", value, _targetProperty.ReturnType);
-						BindingDiagnostics.SendBindingFailure(this, null, _targetObject, _targetProperty, null, "{0} cannot be converted to type '{1}'", new[] { value, _targetProperty.ReturnType });
+						BindingDiagnostics.SendBindingFailure(this, null, _targetObject, _targetProperty, "MultiBinding", BindingExpression.CannotConvertTypeErrorMessage, value, _targetProperty.ReturnType);
 						return;
 					}
 					_targetObject.SetValueCore(_targetProperty, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
@@ -164,8 +163,7 @@ namespace Xamarin.Forms
 				_applying = true;
 				if (!BindingExpression.TryConvert(ref value, _targetProperty, _targetProperty.ReturnType, true))
 				{
-					Log.Warning("MultiBinding", "'{0}' cannot be converted to type '{1}'.", value, _targetProperty.ReturnType);
-					BindingDiagnostics.SendBindingFailure(this, context, _targetObject, _targetProperty, null, "{0} cannot be converted to type '{1}'", new[] { value, _targetProperty.ReturnType });
+					BindingDiagnostics.SendBindingFailure(this, context, _targetObject, _targetProperty, "MultiBinding", BindingExpression.CannotConvertTypeErrorMessage, value, _targetProperty.ReturnType);
 					return;
 				}
 				_targetObject.SetValueCore(_targetProperty, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);

--- a/Xamarin.Forms.Core/TypedBinding.cs
+++ b/Xamarin.Forms.Core/TypedBinding.cs
@@ -4,8 +4,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Globalization;
-using System.Reflection;
-using Xamarin.Forms.Internals;
 using Xamarin.Forms.Xaml.Diagnostics;
 
 namespace Xamarin.Forms.Internals
@@ -229,8 +227,7 @@ namespace Xamarin.Forms.Internals
 				}
 				if (!BindingExpression.TryConvert(ref value, property, property.ReturnType, true))
 				{
-					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, property.ReturnType);
-					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, property.ReturnType });
+					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, "Binding", BindingExpression.CannotConvertTypeErrorMessage, value, property.ReturnType);
 					return;
 				}
 				target.SetValueCore(property, value, SetValueFlags.ClearDynamicResource, BindableObject.SetValuePrivateFlags.Default | BindableObject.SetValuePrivateFlags.Converted);
@@ -243,8 +240,7 @@ namespace Xamarin.Forms.Internals
 				var value = GetTargetValue(target.GetValue(property), typeof(TProperty));
 				if (!BindingExpression.TryConvert(ref value, property, typeof(TProperty), false))
 				{
-					Log.Warning("Binding", "'{0}' cannot be converted to type '{1}'.", value, typeof(TProperty));
-					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, null, "{0} cannot be converted to type '{1}'", new[] { value, property.ReturnType });
+					BindingDiagnostics.SendBindingFailure(this, sourceObject, target, property, "Binding", BindingExpression.CannotConvertTypeErrorMessage, value, typeof(TProperty));
 					return;
 				}
 				_setter((TSource)sourceObject, (TProperty)value);

--- a/Xamarin.Forms.Core/Xaml/Diagnostics/BindingDiagnostics.cs
+++ b/Xamarin.Forms.Core/Xaml/Diagnostics/BindingDiagnostics.cs
@@ -2,17 +2,24 @@
 // Licensed under the MIT License.
 
 using System;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Xaml.Diagnostics
 {
 	public class BindingDiagnostics
 	{
-		internal static void SendBindingFailure(BindingBase binding, string errorCode, string message, object[] messageArgs) =>
-			BindingFailed?.Invoke(binding, new BindingBaseErrorEventArgs(VisualDiagnostics.GetXamlSourceInfo(binding), binding, errorCode, message, messageArgs));
-
-		internal static void SendBindingFailure(BindingBase binding, object source, BindableObject bo, BindableProperty bp, string errorCode, string message, object[] messageArgs) =>
-			BindingFailed?.Invoke(binding, new BindingErrorEventArgs(VisualDiagnostics.GetXamlSourceInfo(binding), binding, source, bo, bp, errorCode, message, messageArgs));
-
 		public static event EventHandler<BindingBaseErrorEventArgs> BindingFailed;
+
+		internal static void SendBindingFailure(BindingBase binding, string errorCode, string message, params object[] messageArgs)
+		{
+			Log.Warning(errorCode, message, messageArgs);
+			BindingFailed?.Invoke(null, new BindingBaseErrorEventArgs(binding, errorCode, message, messageArgs));
+		}
+
+		internal static void SendBindingFailure(BindingBase binding, object source, BindableObject bo, BindableProperty bp, string errorCode, string message, params object[] messageArgs)
+		{
+			Log.Warning(errorCode, message, messageArgs);
+			BindingFailed?.Invoke(null, new BindingErrorEventArgs(binding, source, bo, bp, errorCode, message, messageArgs));
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Xaml/Diagnostics/BindingDiagnostics.cs
+++ b/Xamarin.Forms.Core/Xaml/Diagnostics/BindingDiagnostics.cs
@@ -13,13 +13,13 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 		internal static void SendBindingFailure(BindingBase binding, string errorCode, string message, params object[] messageArgs)
 		{
 			Log.Warning(errorCode, message, messageArgs);
-			BindingFailed?.Invoke(null, new BindingBaseErrorEventArgs(binding, errorCode, message, messageArgs));
+			BindingFailed?.Invoke(null, new BindingBaseErrorEventArgs(VisualDiagnostics.GetXamlSourceInfo(binding), binding, errorCode, message, messageArgs));
 		}
 
 		internal static void SendBindingFailure(BindingBase binding, object source, BindableObject bo, BindableProperty bp, string errorCode, string message, params object[] messageArgs)
 		{
 			Log.Warning(errorCode, message, messageArgs);
-			BindingFailed?.Invoke(null, new BindingErrorEventArgs(binding, source, bo, bp, errorCode, message, messageArgs));
+			BindingFailed?.Invoke(null, new BindingErrorEventArgs(VisualDiagnostics.GetXamlSourceInfo(binding), binding, source, bo, bp, errorCode, message, messageArgs));
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Xaml/Diagnostics/BindingErrorEventArgs.cs
+++ b/Xamarin.Forms.Core/Xaml/Diagnostics/BindingErrorEventArgs.cs
@@ -7,9 +7,8 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 {
 	public class BindingBaseErrorEventArgs : EventArgs
 	{
-		internal BindingBaseErrorEventArgs(XamlSourceInfo xamlSourceInfo, BindingBase binding, string errorCode, string message, object[] messageArgs)
+		internal BindingBaseErrorEventArgs(BindingBase binding, string errorCode, string message, object[] messageArgs)
 		{
-			XamlSourceInfo = xamlSourceInfo;
 			Binding = binding;
 			ErrorCode = errorCode;
 			Message = message;
@@ -26,13 +25,13 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 	public class BindingErrorEventArgs : BindingBaseErrorEventArgs
 	{
 		internal BindingErrorEventArgs(
-			XamlSourceInfo xamlSourceInfo,
 			BindingBase binding,
 			object bindingsource,
 			BindableObject target,
 			BindableProperty property,
 			string errorCode,
-			string message, object[] messageArgs) : base(xamlSourceInfo, binding, errorCode, message, messageArgs)
+			string message,
+			object[] messageArgs) : base(binding, errorCode, message, messageArgs)
 		{
 			Source = bindingsource;
 			Target = target;

--- a/Xamarin.Forms.Core/Xaml/Diagnostics/BindingErrorEventArgs.cs
+++ b/Xamarin.Forms.Core/Xaml/Diagnostics/BindingErrorEventArgs.cs
@@ -7,8 +7,9 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 {
 	public class BindingBaseErrorEventArgs : EventArgs
 	{
-		internal BindingBaseErrorEventArgs(BindingBase binding, string errorCode, string message, object[] messageArgs)
+		internal BindingBaseErrorEventArgs(XamlSourceInfo xamlSourceInfo, BindingBase binding, string errorCode, string message, object[] messageArgs)
 		{
+			XamlSourceInfo = xamlSourceInfo;
 			Binding = binding;
 			ErrorCode = errorCode;
 			Message = message;
@@ -25,13 +26,14 @@ namespace Xamarin.Forms.Xaml.Diagnostics
 	public class BindingErrorEventArgs : BindingBaseErrorEventArgs
 	{
 		internal BindingErrorEventArgs(
+			XamlSourceInfo xamlSourceInfo,
 			BindingBase binding,
 			object bindingsource,
 			BindableObject target,
 			BindableProperty property,
 			string errorCode,
 			string message,
-			object[] messageArgs) : base(binding, errorCode, message, messageArgs)
+			object[] messageArgs) : base(xamlSourceInfo, binding, errorCode, message, messageArgs)
 		{
 			Source = bindingsource;
 			Target = target;


### PR DESCRIPTION
### Description of Change ###

This is the follow-up for the initial XAML BindingDiagnostics PR by @StephaneDelcroix:
#10523 

See the bug I logged:
#12645 

The change I'm making allows binding failures to show up properly in VS's binding failures pane:
* The Message string didn't always exactly match the debug output for the binding failure
* In order to de-dupe the BindingFailed event against debug output, I need the failure messages to _exactly_ match. This change ensures that the messages must match

### Issues Resolved ### 
- fixes #12645

### API Changes ###
Changed:
- BindingBaseErrorEventArgs.ErrorCode gets a value of "Binding" or "MultiBinding" depending on what gets written to debug output (instead of not ever having a value). VS will need to know that in order to reconstruct the failure message and de-dupe against debug output.

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Made all necessary changes in VS to handle the BindingFailed event from Xamarin. Manually made sure that Android and UWP debugging shows binding failures in the new XAML Binding Failures pane. Tested that double click will "go to code".

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
