### PR TITLE
[UWP] Fixed crash in CarouselView resizing the Window

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10897.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10897.xaml
@@ -1,0 +1,24 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue10897"
+    Title="Issue 10897">
+    <CarouselView ItemsSource="{Binding CarouselItems}">
+        <CarouselView.ItemTemplate>
+            <DataTemplate>
+                <CollectionView ItemsSource="{Binding Items}">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Label Text="{Binding Text}" />
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </DataTemplate>
+        </CarouselView.ItemTemplate>
+    </CarouselView>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10897.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10897.xaml.cs
@@ -1,0 +1,53 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10897, "[Bug] UWP: CollectionView in CarouselView crashes when resizing the window",
+		PlatformAffected.UWP)]
+	public partial class Issue10897 : TestContentPage
+	{
+		public Issue10897()
+		{
+#if APP
+			InitializeComponent();    
+			
+			Issue10897ViewModel vm = new Issue10897ViewModel();  
+			vm.CarouselItems = new List<Issue10897Items>();
+			vm.CarouselItems.Add(new Issue10897Items() { Items = new List<Issue10897Item>() { new Issue10897Item() { Text = "Item1" }, new Issue10897Item() { Text = "Item2" } } });
+			BindingContext = vm;
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10897Item
+	{
+		public string Text { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10897Items
+	{
+		public List<Issue10897Item> Items { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10897ViewModel
+	{
+		public List<Issue10897Items> CarouselItems { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10897.xaml.cs">
+      <DependentUpon>Issue10897.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue12320.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12153.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10324.cs" />
@@ -2424,6 +2427,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11794.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10897.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/CarouselViewRenderer.cs
@@ -515,7 +515,9 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (e.NewSize.Width > 0 && e.NewSize.Height > 0)
 			{
+				ListViewBase.SizeChanged -= InitialSetup;
 				_scrollViewer.SizeChanged -= InitialSetup;
+
 				UpdateItemsSource();
 				UpdateSnapPointsType();
 				UpdateSnapPointsAlignment();


### PR DESCRIPTION
### Description of Change ###

Fixed crash in CarouselView resizing the Window on UWP.

### Issues Resolved ### 

- fixes #10897 

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10897. Resize several times the App Window. If everything works without any exception, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
