### PR TITLE
Fix BL.SetEmptyViewTemplate to use correct Bindable Property

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
@@ -337,6 +337,53 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
 		}
 
+
+		[Test]
+		public void ValidateBindableProperties()
+		{
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			// EmptyView
+			object emptyView = new object();
+			BindableLayout.SetEmptyView(layout, emptyView);
+
+			Assert.AreEqual(emptyView, BindableLayout.GetEmptyView(layout));
+			Assert.AreEqual(emptyView, layout.GetValue(BindableLayout.EmptyViewProperty));
+
+			// EmptyViewTemplateProperty
+			DataTemplate emptyViewTemplate = new DataTemplate(typeof(Label));
+			BindableLayout.SetEmptyViewTemplate(layout, emptyViewTemplate);
+
+			Assert.AreEqual(emptyViewTemplate, BindableLayout.GetEmptyViewTemplate(layout));
+			Assert.AreEqual(emptyViewTemplate, layout.GetValue(BindableLayout.EmptyViewTemplateProperty));
+
+
+			// ItemsSourceProperty
+			IEnumerable itemsSource = new object[0];
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			Assert.AreEqual(itemsSource, BindableLayout.GetItemsSource(layout));
+			Assert.AreEqual(itemsSource, layout.GetValue(BindableLayout.ItemsSourceProperty));
+
+			// ItemTemplateProperty
+			DataTemplate itemTemplate = new DataTemplate(typeof(Label));
+			BindableLayout.SetItemTemplate(layout, itemTemplate);
+
+			Assert.AreEqual(itemTemplate, BindableLayout.GetItemTemplate(layout));
+			Assert.AreEqual(itemTemplate, layout.GetValue(BindableLayout.ItemTemplateProperty));
+
+
+			// ItemTemplateSelectorProperty
+			var itemTemplateSelector = new DataTemplateSelectorFrame();
+			BindableLayout.SetItemTemplateSelector(layout, itemTemplateSelector);
+
+			Assert.AreEqual(itemTemplateSelector, BindableLayout.GetItemTemplateSelector(layout));
+			Assert.AreEqual(itemTemplateSelector, layout.GetValue(BindableLayout.ItemTemplateSelectorProperty));
+		}
+
 		// Checks if for every item in the items source there's a corresponding view
 		static bool IsLayoutWithItemsSource(IEnumerable itemsSource, Layout layout)
 		{

--- a/Xamarin.Forms.Core/BindableLayout.cs
+++ b/Xamarin.Forms.Core/BindableLayout.cs
@@ -77,7 +77,7 @@ namespace Xamarin.Forms
 
 		public static void SetEmptyViewTemplate(BindableObject b, DataTemplate value)
 		{
-			b.SetValue(EmptyViewProperty, value);
+			b.SetValue(EmptyViewTemplateProperty, value);
 		}
 
 		static BindableLayoutController GetBindableLayoutController(BindableObject b)


### PR DESCRIPTION
### Description of Change ###

Wrong BindableProperty being set inside of BindableLayout.SetEmptyViewTemplate 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #12683
- fixes #9905


### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- Unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
