### PR TITLE
Remove WRITE_EXTERNAL_STORAGE from maps

### DIFF
--- a/Xamarin.Forms.Maps.Android/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Maps.Android/Properties/AssemblyInfo.cs
@@ -10,6 +10,11 @@ using Xamarin.Forms.Maps.Android;
 [assembly: ComVisible(false)]
 
 [assembly: UsesPermission(Manifest.Permission.Internet)]
+
+// For debug purposes. Probably won't be needed once we get to 16-9
+// https://github.com/xamarin/xamarin-android/issues/5247#issuecomment-719481786
+#if DEBUG
 [assembly: UsesPermission(Manifest.Permission.WriteExternalStorage)]
+#endif
 [assembly: ExportRenderer(typeof(Map), typeof(MapRenderer))]
 [assembly: Preserve]


### PR DESCRIPTION
### Description of Change ###
Write_External_storage is no longer needed if you are targeting 23+ 

https://developers.google.com/maps/documentation/android-sdk/config#external-storage-permission

You're required to target API 29 to release to the play store. If for some reason a user needs to target lower than 23 they can just add the permission in themselves

### Issues Resolved ### 
- fixes #12680 

### Platforms Affected ### 
- Android

### Testing Procedure ###
- Ensure that the release nuget package loads maps correctly without having to set the WRITE_EXTERNAL_STORAGE permission

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
