### PR TITLE
Dismiss UISearchController when losing focus

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10124.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10124.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10124, "[Bug] Shell SearchHandler - SearchHandler blocks touch to view", PlatformAffected.iOS)]
+	public class Issue10124 : TestShell
+	{
+		protected override void Init()
+		{
+			var cp = CreateContentPage();
+			cp.Content = new Label
+			{
+				Text = "Enter a search query and execute. This content should no longer be obscured by the search controller dimmed background"
+			};
+			Shell.SetSearchHandler(cp, new SearchHandler());
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10124.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12984.xaml.cs">
       <DependentUpon>Issue12984.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -476,6 +476,11 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateSearchVisibility(_searchController);
 			else if (e.PropertyName == SearchHandler.IsSearchEnabledProperty.PropertyName)
 				UpdateSearchIsEnabled(_searchController);
+			else if (e.PropertyName == SearchHandler.IsFocusedProperty.PropertyName)
+			{
+				if (!_searchHandler.IsFocused)
+					_searchController.Active = false;
+			}
 			else if (e.Is(SearchHandler.AutomationIdProperty))
 			{
 				UpdateAutomationId();


### PR DESCRIPTION

### Description of Change ###

Dismiss UISearchController when losing focus

### Issues Resolved ### 
- fixes #10124 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
When a query is confirmed in SearchHandler, the search handler will lose focus and will no longer display a dimmed view on top of the remaining page

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Add a Shell SearchHandler
2. Tap the search bar to focus
3. Notice the main page is dimmed
4. Enter a search term
5. Execute the search
6. Notice the SearchHandler no longer displays a dimmed background and the main content is tappable

![out](https://user-images.githubusercontent.com/4793020/97806883-e10f9b80-1c2b-11eb-8191-aff2b403c826.gif)


### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
