### PR TITLE
[Tizen] Modify NavigationDrawer to fix Entry issue

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Shell/NavigationDrawer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/NavigationDrawer.cs
@@ -49,73 +49,88 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 			set
 			{
-				if (!_drawer.IsOpen && value)
-				{
-					_drawer.SetScrollableArea(_navigationViewRatio);
-				}
+				if (value)
+					ShowDrawer();
 
 				_drawer.IsOpen = value;
-
-				if (!_drawer.IsOpen)
-				{
-					_drawer.SetScrollableArea(0);
-				}
 			}
 		}
 
 		void Initialize(EvasObject parent)
 		{
-			/**
-			 *  /----------------/
-			 *  /     drawer     /
-			 *  / /------------/ /
-			 *  / /   content  / /
-			 *  / /------------/ /
-			 *  /----------------/
-			 *  /----------------/
-			 *  /     dim        /
-			 *  /----------------/
-			 *  /----------------/
-			 *  /      main      /
-			 *  /-------------- -/
-			 * 
-			 */
-
 			SetLayoutCallback(OnLayout);
 
 			_mainContainer = new EBox(parent);
 			_mainContainer.Show();
-			PackEnd(_mainContainer);
 
 			_dimArea = new EBox(parent)
 			{
 				BackgroundColor = ThemeConstants.Shell.ColorClass.DefaultDrawerDimBackgroundColor
 			};
-			PackEnd(_dimArea);
 
 			_drawer = new Panel(parent);
 
 			_drawer.SetScrollable(true);
-			_drawer.SetScrollableArea(0);
+			_drawer.SetScrollableArea(_navigationViewRatio);
 			_drawer.Direction = PanelDirection.Left;
 
 			_drawer.Toggled += (s, e) =>
 			{
-				UpdateDimArea();
-				Toggled?.Invoke(this, e);
 				if (!_drawer.IsOpen)
 				{
-					Device.StartTimer(TimeSpan.FromSeconds(1), () =>
-					{
-						if (!_drawer.IsOpen)
-							_drawer.SetScrollableArea(0);
-						return false;
-					});
+					HideDrawer();
 				}
+				Toggled?.Invoke(this, e);
 			};
 			_drawer.IsOpen = false;
 			_drawer.Show();
+
+			PackEnd(_dimArea);
 			PackEnd(_drawer);
+			PackEnd(_mainContainer);
+		}
+
+		void HideDrawer()
+		{
+			/**
+			*  /----------------/
+			*  /     main       /
+			*  /----------------/
+			*  /----------------/
+			*  /     drawer     /
+			*  / /------------/ /
+			*  / /   content  / /
+			*  / /------------/ /
+			*  /----------------/
+			*  /----------------/
+			*  /      dim       /
+			*  /----------------/
+			*/
+			_dimArea.Hide();
+			_drawer.Hide();
+			_mainContainer.RaiseTop();
+		}
+
+		void ShowDrawer()
+		{
+			/**
+			*  /----------------/
+			*  /     drawer     /
+			*  / /------------/ /
+			*  / /   content  / /
+			*  / /------------/ /
+			*  /----------------/
+			*  /----------------/
+			*  /      dim       /
+			*  /----------------/
+			*  /----------------/
+			*  /     main       /
+			*  /----------------/
+			*/
+			_dimArea.RaiseTop();
+			_dimArea.Show();
+			_drawer.RaiseTop();
+			_drawer.Show();
 		}
 
 		void UpdateNavigationView(EvasObject navigationView)
@@ -148,18 +163,6 @@ namespace Xamarin.Forms.Platform.Tizen
 				_main.SetWeight(1, 1);
 				_main.Show();
 				_mainContainer.PackEnd(_main);
-			}
-		}
-
-		void UpdateDimArea()
-		{
-			if (_drawer.IsOpen)
-			{
-				_dimArea.Show();
-			}
-			else
-			{
-				_dimArea.Hide();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###
This PR is to modify orders of elements of `NaviagitonDrawer`.
This change is to solve entry selection issue caused from `NavigationDrawer` by putting the navigation drawer(Panel) below the main container(Box).

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Before/After Screenshots ### 
| Before | After |
|--|--|
| <img width="300" src="https://user-images.githubusercontent.com/20968023/97840245-092ff500-1d27-11eb-8689-490bccda16ee.gif" /> |  <img width="300" src="https://user-images.githubusercontent.com/20968023/97840213-f74e5200-1d26-11eb-9bb4-b883c710edc3.gif" /> |


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
