### PR TITLE
[UWP,iOS] Fix focus on WebViewRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12497.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12497.cs
@@ -1,0 +1,117 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12497, "Calling Focus() on a WebView on UWP does not move the focus to the WebView", PlatformAffected.UWP)]
+	public class Issue12497 : TestContentPage // or TestFlyoutPage, etc ...
+	{
+		bool _firstTimeOnAppearing = true;
+		Button _button1;
+		Button _button2;
+		Button _button3;
+		WebView _webView;
+
+		protected override void Init()
+		{
+			PopulatePage();
+		}
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			if (_firstTimeOnAppearing)
+			{
+				_firstTimeOnAppearing = false;
+
+				//PopulatePage();
+
+				// The following is just here as a convenience.
+				// It's a nasty, hacky way of setting the initial focus, 
+				// that introduces a race condition. Good enough for
+				// this repro sample though.
+				Task.Run(async () =>
+				{
+					await Task.Delay(1000);
+					if (_button1 != null)
+						_button1.Focus();
+
+				});
+			}
+		}
+
+		void PopulatePage()
+		{
+			int defaultTabIndex = Int32.MaxValue; // UWP says this should be the max int. Xamarin.Forms docs say it should be 0;
+
+			_button1 = new Button
+			{
+				Text = "Button 1 (should be first in tab order)",
+				TextColor = Color.Black,
+				BackgroundColor = Color.White,
+				TabIndex = defaultTabIndex,
+				VerticalOptions = LayoutOptions.Start
+			};
+
+			_webView = new WebView
+			{
+				BackgroundColor = Color.White,
+				HorizontalOptions = LayoutOptions.Fill,
+				TabIndex = defaultTabIndex,
+				VerticalOptions = LayoutOptions.FillAndExpand,
+				Source = new HtmlWebViewSource
+				{
+					Html = "<html><body>Hello (should be second in tab order)<br>1<br>2<br>3<br>4<br>5<br>6<br>7<br>8<br>9<br>10<br>11<br>12<br>13<br>14<br>15<br>16<br>17<br>18<br>19<br>20<br>21<br>22<br>23<br>24<br>25<br>26<br>27<br>28<br>29</body></html>"
+				}
+			};
+
+			_button2 = new Button
+			{
+				Text = "Button 2 (should be third in tab order)",
+				TextColor = Color.Black,
+				BackgroundColor = Color.White,
+				TabIndex = defaultTabIndex,
+				VerticalOptions = LayoutOptions.End
+			};
+
+			_button3 = new Button
+			{
+				Text = "Button 3 (press to set focus to WebView)",
+				TextColor = Color.Black,
+				BackgroundColor = Color.White,
+				TabIndex = defaultTabIndex,
+				VerticalOptions = LayoutOptions.End,
+				Command = new Command(() =>
+				{
+					_webView.Focus(); // _button1.Focus();
+				})
+			};
+
+			Content = new StackLayout
+			{
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill,
+				BackgroundColor = Color.Pink,
+				Children =
+			{
+				_button1,
+				_webView,
+				_button2,
+				_button3
+			}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12497.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12497.cs
@@ -16,13 +16,18 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 12497, "Calling Focus() on a WebView on UWP does not move the focus to the WebView", PlatformAffected.UWP)]
-	public class Issue12497 : TestContentPage // or TestFlyoutPage, etc ...
+	public class Issue12497 : TestContentPage
 	{
 		bool _firstTimeOnAppearing = true;
 		Button _button1;
 		Button _button2;
 		Button _button3;
 		WebView _webView;
+		Label _label;
+
+		const string FAIL = "Fail";
+		const string SUCCESS = "Success";
+		const string btnAutomationId = "btn3";
 
 		protected override void Init()
 		{
@@ -56,6 +61,11 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			int defaultTabIndex = Int32.MaxValue; // UWP says this should be the max int. Xamarin.Forms docs say it should be 0;
 
+			_label = new Label
+			{
+				Text = FAIL
+			};
+
 			_button1 = new Button
 			{
 				Text = "Button 1 (should be first in tab order)",
@@ -77,6 +87,11 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 
+			_webView.Focused += (s, e) =>
+			{
+				_label.Text = SUCCESS;
+			};
+
 			_button2 = new Button
 			{
 				Text = "Button 2 (should be third in tab order)",
@@ -88,6 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			_button3 = new Button
 			{
+				AutomationId = btnAutomationId,
 				Text = "Button 3 (press to set focus to WebView)",
 				TextColor = Color.Black,
 				BackgroundColor = Color.White,
@@ -105,13 +121,23 @@ namespace Xamarin.Forms.Controls.Issues
 				VerticalOptions = LayoutOptions.Fill,
 				BackgroundColor = Color.Pink,
 				Children =
-			{
-				_button1,
-				_webView,
-				_button2,
-				_button3
-			}
+				{
+					_button1,
+					_webView,
+					_button2,
+					_button3,
+					_label
+				}
 			};
 		}
+
+#if UITEST
+		[Test]
+		public void Issue12497Test()
+		{
+			RunningApp.Tap(btnAutomationId);
+			RunningApp.WaitForElement(SUCCESS);
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12497.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12497.cs
@@ -12,7 +12,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	[Category(UITestCategories.ManualReview)]
+	[Category(UITestCategories.WebView)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 12497, "Calling Focus() on a WebView on UWP does not move the focus to the WebView", PlatformAffected.UWP)]
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void Issue12497Test()
+		public void WebviewFocusIsFiring()
 		{
 			RunningApp.Tap(btnAutomationId);
 			RunningApp.WaitForElement(SUCCESS);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -871,6 +871,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10699.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11185.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10307.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12497.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -302,6 +302,9 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Shapes\ShapeRenderer.cs">
       <Link>Shapes\ShapeRenderer.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\TabIndexManager.cs">
+      <Link>TabIndexManager.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -595,6 +595,11 @@ namespace Xamarin.Forms.Platform.UWP
 			if (control == null || !control.IsEnabled || !control.IsTabStop)
 				return;
 
+			UnfocusOnContainingPage(control);
+		}
+
+		internal void UnfocusOnContainingPage(FrameworkElement control)
+		{
 			// "Unfocusing" doesn't really make sense on Windows; for accessibility reasons,
 			// something always has focus. So forcing the unfocusing of a control would normally 
 			// just move focus to the next control, or leave it on the current control if no other
@@ -605,7 +610,7 @@ namespace Xamarin.Forms.Platform.UWP
 			if (_containingPage == null)
 			{
 				// Work our way up the tree to find the containing Page
-				DependencyObject parent = _control;
+				DependencyObject parent = control;
 				while (parent != null && !(parent is Windows.UI.Xaml.Controls.Page))
 				{
 					parent = VisualTreeHelper.GetParent(parent);

--- a/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/WebViewRenderer.cs
@@ -10,6 +10,7 @@ using System.Net;
 using Windows.Web.Http;
 using System.Collections.Generic;
 using System.Linq;
+using Windows.UI.Xaml;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -152,6 +153,25 @@ if(bases.length == 0){
 
 				Load();
 			}
+		}
+
+		internal override void OnElementFocusChangeRequested(object sender, VisualElement.FocusRequestArgs args)
+		{
+			base.OnElementFocusChangeRequested(sender, args);
+			if (args.Focus)
+				args.Result = Control.Focus(FocusState.Programmatic);
+			else
+			{
+				UnfocusControl(Control);
+				args.Result = true;
+			}
+		}
+
+		internal void UnfocusControl(Windows.UI.Xaml.Controls.WebView control)
+		{
+			if (control == null)
+				return;
+			UnfocusOnContainingPage(control);
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.iOS/TabIndexManager.cs
+++ b/Xamarin.Forms.Platform.iOS/TabIndexManager.cs
@@ -1,0 +1,168 @@
+﻿using System;
+
+#if __MOBILE__
+using UIKit;
+using NativeView = UIKit.UIView;
+
+namespace Xamarin.Forms.Platform.iOS
+#else
+using NativeView = AppKit.NSView;
+
+namespace Xamarin.Forms.Platform.MacOS
+#endif
+{
+	internal class TabIndexManager : IDisposable
+	{
+		VisualElement _element;
+		bool _disposed;
+		IVisualElementRenderer _renderer;
+
+#if __MOBILE__
+		public UIKeyCommand[] TabCommands = {
+			UIKeyCommand.Create ((Foundation.NSString)"\t", 0, new ObjCRuntime.Selector ("tabForward:")),
+			UIKeyCommand.Create ((Foundation.NSString)"\t", UIKeyModifierFlags.Shift, new ObjCRuntime.Selector ("tabBackward:"))
+		};
+#endif
+
+		public TabIndexManager(IVisualElementRenderer renderer)
+		{
+			_renderer = renderer;
+			_renderer.ElementChanged += RendererElementChanged;
+
+			RendererElementChanged(this, new VisualElementChangedEventArgs(null, _renderer.Element));
+		}
+
+		public void UpdateParentPageAccessibilityElements()
+		{
+#if __MOBILE__
+			var parentRenderer = _renderer.NativeView.Superview;
+			while (parentRenderer != null)
+			{
+				if (parentRenderer is PageContainer container)
+				{
+					container.ClearAccessibilityElements();
+					break;
+				}
+
+				parentRenderer = parentRenderer.Superview;
+			}
+#endif
+		}
+
+		public NativeView FocusSearch(bool forwardDirection)
+		{
+			int maxAttempts = 0;
+			var tabIndexes = _element?.GetTabIndexesOnParentPage(out maxAttempts);
+			if (tabIndexes == null)
+				return null;
+
+			int tabIndex = _element.TabIndex;
+			int attempt = 0;
+
+			do
+			{
+				_element = _element.FindNextElement(forwardDirection, tabIndexes, ref tabIndex) as VisualElement;
+				if (_element == null)
+					break;
+
+#if __MACOS__
+				var renderer = Platform.GetRenderer(_element);
+				var control = (renderer as ITabStop)?.TabStop;
+				if (control != null && control.AcceptsFirstResponder())
+					return control;
+#endif
+				_element.Focus();
+			} while (!(_element.IsFocused || ++attempt >= maxAttempts));
+			return null;
+		}
+
+		public void UpdateTabStopAndIndex()
+		{
+			UpdateTabStop();
+			UpdateTabIndex();
+		}
+
+		protected int TabIndex { get; set; } = 0;
+
+		protected bool TabStop { get; set; } = true;
+		
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (!disposing)
+				return;
+
+			if (_renderer != null)
+				_renderer.ElementChanged -= RendererElementChanged;
+
+			if (_element != null)
+			{
+				_element.FocusChangeRequested -= ViewOnFocusChangeRequested;
+				_element.PropertyChanged -= ElementPropertyChanged;
+			}
+
+			_element = null;
+			_renderer = null;
+		}
+
+		void UpdateTabStop()
+		{
+			if (_element == null)
+				return;
+
+			TabStop = _element.IsTabStop;
+			UpdateParentPageAccessibilityElements();
+		}
+
+		void UpdateTabIndex()
+		{
+			if (_element == null)
+				return;
+
+			TabIndex = _element.TabIndex;
+			UpdateParentPageAccessibilityElements();
+		}
+
+
+		void RendererElementChanged(object sender, VisualElementChangedEventArgs e)
+		{
+			if (_element != null)
+			{
+				_element.FocusChangeRequested -= ViewOnFocusChangeRequested;
+				_element.PropertyChanged += ElementPropertyChanged;
+			}
+
+			if (e.NewElement != null)
+			{
+				_element = e.NewElement;
+				_element.FocusChangeRequested += ViewOnFocusChangeRequested;
+				_element.PropertyChanged += ElementPropertyChanged;
+			}
+
+			UpdateTabStopAndIndex();
+		}
+
+		void ElementPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == VisualElement.IsTabStopProperty.PropertyName)
+				UpdateTabStop();
+			else if (e.PropertyName == VisualElement.TabIndexProperty.PropertyName)
+				UpdateTabIndex();
+		}
+
+		void ViewOnFocusChangeRequested(object sender, VisualElement.FocusRequestArgs focusRequestArgs)
+		{
+			focusRequestArgs.Result = focusRequestArgs.Focus ? _renderer.NativeView.BecomeFirstResponder() : _renderer.NativeView.ResignFirstResponder();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -274,6 +274,7 @@
     <Compile Include="CollectionView\LoopListSource.cs" />
     <Compile Include="CollectionView\ILoopItemsViewSource.cs" />
     <Compile Include="Renderers\IDisconnectable.cs" />
+    <Compile Include="TabIndexManager.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />


### PR DESCRIPTION
### Description of Change ###

The WebView on UWP is not a `Control` so the logic on VisualElementRenderer to handle the focus request is not working.
We need to override and implement the same logic but for the WebView in specific.

Fix iOS WKWebviewRenderer to also handle focus.

Refactor TabIndex logic to TabIndexManager to be used by other renderers

- fixes #12497 

### API Changes ###

 None

### Platforms Affected ### 

- UWP
-iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

Go to issue `Issue12497` click `Button 3`to focus the webview , press tab and see the next focus element is `Button 2`

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
