### PR TITLE
[macOS] Fix ScrollTo on NSScrollView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1580,7 +1580,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11572.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11571.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11715.xaml.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11875.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11875.xaml.cs">
       <DependentUpon>Issue11875.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11737.xaml.cs">
@@ -2444,7 +2444,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10897.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -14,33 +14,6 @@ using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Controls
 {
-	public class Bible : ContentPage
-	{
-		ScrollView scrollview;
-
-		public Bible()
-		{
-			scrollview = new ScrollView();
-			var layut = new StackLayout();
-			var label = new Label();
-			label.Text = "Adapted from \"The Colors of Animals\" by Sir John Lubbock in A Book of Natural History (1902, ed. David Starr Jordan)  The color of animals is by no means a matter of chance; it depends on many considerations, but in the majority of cases tends to protect the animal from danger by rendering it less conspicuous. Perhaps it may be said that if coloring is mainly protective, there ought to be but few brightly colored animals.There are, however, not a few cases in which vivid colors are themselves protective. The kingfisher itself, though so brightly colored, is by no means easy to see. The blue harmonizes with the water, and the bird as it darts along the stream looks almost like a flash of sunlight.  Desert animals are generally the color of the desert.Thus, for instance, the lion, the antelope, and the wild donkey are all sand - colored. “Indeed,” says Canon Tristram, “in the desert, where neither trees, brushwood, nor even undulation of the surface afford the slightest protection to its foes, a modification of color assimilated to that of the surrounding country is absolutely necessary. Hence, without exception, the upper plumage of every bird, and also the fur of all the smaller mammals and the skin of all the snakes and lizards, is of one uniform sand color.”  The next point is the color of the mature caterpillars, some of which are brown.This probably makes the caterpillar even more conspicuous among the green leaves than would otherwise be the case. Let us see, then, whether the habits of the insect will throw any light upon the riddle.What would you do if you were a big caterpillar? Why, like most other defenseless creatures, you would feed by night, and lie concealed by day. So do these caterpillars. When the morning light comes, they creep down the stem of the food plant, and lie concealed among the thick herbage and dry sticks and leaves, near the ground, and it is obvious that under such circumstances the brown color really becomes a protection. It might indeed be argued that the caterpillars, having become brown, concealed themselves on the ground, and that we were reversing the state of things. But this is not so, because, while we may say as a general rule that large caterpillars feed by night and lie concealed by day, it is by no means always the case that they are brown; some of them still retaining the green color. We may then conclude that the habit of concealing themselves by day came first, and that the brown color is a later adaptation.  The example of the mature caterpillar in the third paragraph is primarily intended to demonstrate _____________.";
-
-			var button = new Button
-			{	
-				Text = "Click me"
-			};
-			button.Clicked += Button_Clicked;
-			layut.Children.Add(label);
-			layut.Children.Add(button);
-			scrollview.Content = layut;
-			Content = scrollview;
-		}
-
-		private void Button_Clicked(object sender, EventArgs e)
-		{
-			scrollview.ScrollToAsync(0, 0, false);
-		}
-	}
 	public class App : Application
 	{
 		public const string AppName = "XamarinFormsControls";
@@ -60,7 +33,6 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 
-			var bible = new Bible();
 			SetMainPage(CreateDefaultMainPage());
 
 			//TestMainPageSwitches();

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -14,7 +14,33 @@ using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
 
 namespace Xamarin.Forms.Controls
 {
+	public class Bible : ContentPage
+	{
+		ScrollView scrollview;
 
+		public Bible()
+		{
+			scrollview = new ScrollView();
+			var layut = new StackLayout();
+			var label = new Label();
+			label.Text = "Adapted from \"The Colors of Animals\" by Sir John Lubbock in A Book of Natural History (1902, ed. David Starr Jordan)  The color of animals is by no means a matter of chance; it depends on many considerations, but in the majority of cases tends to protect the animal from danger by rendering it less conspicuous. Perhaps it may be said that if coloring is mainly protective, there ought to be but few brightly colored animals.There are, however, not a few cases in which vivid colors are themselves protective. The kingfisher itself, though so brightly colored, is by no means easy to see. The blue harmonizes with the water, and the bird as it darts along the stream looks almost like a flash of sunlight.  Desert animals are generally the color of the desert.Thus, for instance, the lion, the antelope, and the wild donkey are all sand - colored. “Indeed,” says Canon Tristram, “in the desert, where neither trees, brushwood, nor even undulation of the surface afford the slightest protection to its foes, a modification of color assimilated to that of the surrounding country is absolutely necessary. Hence, without exception, the upper plumage of every bird, and also the fur of all the smaller mammals and the skin of all the snakes and lizards, is of one uniform sand color.”  The next point is the color of the mature caterpillars, some of which are brown.This probably makes the caterpillar even more conspicuous among the green leaves than would otherwise be the case. Let us see, then, whether the habits of the insect will throw any light upon the riddle.What would you do if you were a big caterpillar? Why, like most other defenseless creatures, you would feed by night, and lie concealed by day. So do these caterpillars. When the morning light comes, they creep down the stem of the food plant, and lie concealed among the thick herbage and dry sticks and leaves, near the ground, and it is obvious that under such circumstances the brown color really becomes a protection. It might indeed be argued that the caterpillars, having become brown, concealed themselves on the ground, and that we were reversing the state of things. But this is not so, because, while we may say as a general rule that large caterpillars feed by night and lie concealed by day, it is by no means always the case that they are brown; some of them still retaining the green color. We may then conclude that the habit of concealing themselves by day came first, and that the brown color is a later adaptation.  The example of the mature caterpillar in the third paragraph is primarily intended to demonstrate _____________.";
+
+			var button = new Button
+			{	
+				Text = "Click me"
+			};
+			button.Clicked += Button_Clicked;
+			layut.Children.Add(label);
+			layut.Children.Add(button);
+			scrollview.Content = layut;
+			Content = scrollview;
+		}
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			scrollview.ScrollToAsync(0, 0, false);
+		}
+	}
 	public class App : Application
 	{
 		public const string AppName = "XamarinFormsControls";
@@ -34,6 +60,7 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 
+			var bible = new Bible();
 			SetMainPage(CreateDefaultMainPage());
 
 			//TestMainPageSwitches();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/ScrollViewRenderer.cs
@@ -209,7 +209,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 
 			Point scrollPoint = (e.Mode == ScrollToMode.Position)
-				? new Point(e.ScrollX, Element.Height - e.ScrollY)
+				? new Point(e.ScrollX, e.ScrollY)
 				: ScrollView.GetScrollPositionForElement(e.Element as VisualElement, e.Position);
 
 			ContentView.ScrollToPoint(scrollPoint.ToPointF());


### PR DESCRIPTION
### Description of Change ###

Since ScrolViewRenderer on macOS uses a FlipClippedView we don't need to invert the coordinates. 

### Issues Resolved ### 

- fixes #12543

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

Should scroll to the correct position 

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

use the scrollview gallery , check ScrollTo 100 works.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
