### PR TITLE
[Android/iOS] Changes using SwipeTransitionMode in SwipeView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12614.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12614.xaml
@@ -1,0 +1,129 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue12614"
+    BackgroundColor="White"
+    Title="Issue 12614"
+    xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core">
+    <StackLayout>
+        <Label
+            Text="Using Drag SwipeTransitionMode with Reveal Mode"/>
+        <CollectionView
+            HeightRequest="120">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Hi</x:String>
+                    <x:String>This is just a test to validate an Issue</x:String>
+                    <x:String>Using SwipeView</x:String>
+                    <x:String>and Drag SwipeTransitionMode</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid
+                        BackgroundColor="White"
+                        VerticalOptions="Center">
+                        <SwipeView
+                            android:SwipeView.SwipeTransitionMode="Drag"
+                            ios:SwipeView.SwipeTransitionMode="Drag"
+                            Margin="6, 6, 6, 0">
+                            <Frame
+                                BackgroundColor="WhiteSmoke"
+                                CornerRadius="24"
+                                HasShadow="False"
+                                Padding="6">
+                                <Label
+                                    Text="{Binding .}"
+                                    HorizontalOptions="End"
+                                    Margin="6"
+                                    VerticalOptions="Center"/>
+                            </Frame>
+                            <SwipeView.RightItems>
+                                <SwipeItems
+                                    Mode="Reveal">
+                                    <SwipeItemView>
+                                        <Frame
+                                            HasShadow="False"
+                                            BackgroundColor="Red"
+                                            CornerRadius="24"
+                                            Padding="6">
+                                            <Label
+                                                Text="Delete"
+                                                TextColor="White"
+                                                FontAttributes="Bold"
+                                                HorizontalOptions="Center"
+                                                VerticalOptions="Center"/>
+                                        </Frame>
+                                    </SwipeItemView>
+                                </SwipeItems>
+                            </SwipeView.RightItems>
+                        </SwipeView>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Label
+            Text="Using Drag SwipeTransitionMode with Execute Mode"/>
+        <CollectionView
+            HeightRequest="120">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Hi</x:String>
+                    <x:String>This is just a test to validate an Issue</x:String>
+                    <x:String>Using SwipeView</x:String>
+                    <x:String>and Drag SwipeTransitionMode</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid
+                        BackgroundColor="White"
+                        VerticalOptions="Center">
+                        <SwipeView
+                            android:SwipeView.SwipeTransitionMode="Drag"
+                            ios:SwipeView.SwipeTransitionMode="Drag"
+                            Margin="6, 6, 6, 0">
+                            <Frame
+                                BackgroundColor="WhiteSmoke"
+                                CornerRadius="24"
+                                HasShadow="False"
+                                Padding="6">
+                                <Label
+                                    Text="{Binding .}"
+                                    HorizontalOptions="End"
+                                    Margin="6"
+                                    VerticalOptions="Center"/>
+                            </Frame>
+                            <SwipeView.RightItems>
+                                <SwipeItems
+                                    Mode="Execute">
+                                    <SwipeItemView
+                                        WidthRequest="100">
+                                        <Frame
+                                            HasShadow="False"
+                                            BackgroundColor="Red"
+                                            CornerRadius="24"
+                                            Padding="6">
+                                            <Label
+                                                Text="Delete"
+                                                TextColor="White"
+                                                FontAttributes="Bold"
+                                                HorizontalOptions="Center"
+                                                VerticalOptions="Center"/>
+                                        </Frame>
+                                    </SwipeItemView>
+                                </SwipeItems>
+                            </SwipeView.RightItems>
+                        </SwipeView>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12614.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12614.xaml.cs
@@ -1,0 +1,36 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.SwipeView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12614, "[Bug] SwipeView with transparent bg in element", PlatformAffected.Android | PlatformAffected.iOS)]
+	public partial class Issue12614 : TestContentPage
+	{
+		public Issue12614()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1667,6 +1667,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12512.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12685.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12642.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12614.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2025,6 +2026,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12084.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12614.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Changes:
- Fixed wrong SwipeViewItem size calc.
- Implemented the Drag swipe animation closing the SwipeView.

### Issues Resolved ### 

- fixes #12614
- fixes #13496

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix12614-small](https://user-images.githubusercontent.com/6755973/98023162-d0674d00-1e06-11eb-9f63-b69063e8034b.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12614. There are two collections, in both cases using SwipeViews with Drag mode. Verify that both the opening and closing animations are correct.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
