### PR TITLE
Remove unnecessary UpdateConstraints calls when rotating

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12193.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12193.cs
@@ -1,0 +1,93 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CarouselView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12193, "[Bug] CarouselView content disappears after 2 rotations if TextType=Html is used",
+		PlatformAffected.iOS)]
+	public class Issue12193 : TestContentPage
+	{
+		public const string HTML = "HTML";
+
+		protected override void Init()
+		{
+#if APP
+			Title = "CarouselView HTML Label";
+
+			var instructions = new Label { Text = $"Rotate the device, then rotate it back 3 times. If the label \"{HTML}\" disappears, this test has failed." };
+
+			var source = new List<string>();
+			for (int n = 0; n < 10; n++)
+			{
+				source.Add($"Item: {n}");
+			}
+
+			var template = new DataTemplate(() =>
+			{
+				var label = new Label
+				{
+					TextType = TextType.Html,
+					Text = $"<p style='background-color:red;'>{HTML}</p>",
+					AutomationId = HTML
+				};
+
+				return label;
+			});
+
+			var cv = new CarouselView()
+			{
+				ItemsSource = source,
+				ItemTemplate = template,
+				Loop = false
+			};
+
+			var layout = new StackLayout();
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(cv);
+
+			Content = layout;
+#endif
+		}
+
+
+#if UITEST
+		[Test]
+		public async Task RotatingCarouselViewHTMLShouldNotDisappear()
+		{
+			int delay = 3000;
+
+			RunningApp.SetOrientationPortrait();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationLandscape();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationPortrait();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationLandscape();
+			await Task.Delay(delay);
+
+			RunningApp.SetOrientationPortrait();
+			await Task.Delay(delay);
+
+			RunningApp.WaitForElement(HTML);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10897.xaml.cs">
       <DependentUpon>Issue10897.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12193.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12320.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12153.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10324.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselTemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselTemplatedCell.cs
@@ -7,26 +7,28 @@ namespace Xamarin.Forms.Platform.iOS
 	public class CarouselTemplatedCell : TemplatedCell
 	{
 		public static NSString ReuseId = new NSString("Xamarin.Forms.Platform.iOS.CarouselTemplatedCell");
+		CGSize _constraint;
 
 		[Export("initWithFrame:")]
 		[Internals.Preserve(Conditional = true)]
 		protected CarouselTemplatedCell(CGRect frame) : base(frame)
-		{ }
+		{ 
+		}
 
 		public override void ConstrainTo(nfloat constant)
 		{
-			
 		}
-		CGSize _constrain;
+		
 		public override void ConstrainTo(CGSize constraint)
 		{
-			_constrain = constraint;
-			Layout(constraint);
+			ClearConstraints();
+
+			_constraint = constraint;
 		}
 
 		public override CGSize Measure()
 		{
-			return new CGSize(_constrain.Width,_constrain.Height);
+			return new CGSize(_constraint.Width, _constraint.Height);
 		}
 
 		protected override (bool, Size) NeedsContentSizeUpdate(Size currentSize)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -15,11 +15,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		CarouselViewLoopManager _carouselViewLoopManager;
 		bool _initialPositionSet;
-		bool _viewInitialized;
 		bool _updatingScrollOffset;
 		List<View> _oldViews;
 		int _gotoPosition = -1;
-		CGSize _size;
 		ILoopItemsViewSource LoopItemsSource => ItemsSource as ILoopItemsViewSource;
 
 		public CarouselViewController(CarouselView itemsView, ItemsViewLayout layout) : base(itemsView, layout)
@@ -64,23 +62,12 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewWillLayoutSubviews()
 		{
 			base.ViewWillLayoutSubviews();
-			if (!_viewInitialized)
-			{
-				_viewInitialized = true;
-				_size = CollectionView.Bounds.Size;
-			}
-
 			UpdateVisualStates();
 		}
 
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
-			if (CollectionView.Bounds.Size != _size)
-			{
-				_size = CollectionView.Bounds.Size;
-				BoundsSizeChanged();
-			}
 
 			if (Carousel?.Loop == true && _carouselViewLoopManager != null)
 			{
@@ -88,6 +75,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_carouselViewLoopManager.CenterIfNeeded(CollectionView, IsHorizontal);
 				_updatingScrollOffset = false;
 			}
+
 			UpdateInitialPosition();
 		}
 
@@ -105,7 +93,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			UnsubscribeCollectionItemsSourceChanged(ItemsSource);
 			base.UpdateItemsSource();
-			//we don't need to Subscribe becasse base calls CreateItemsViewSource
+			//we don't need to Subscribe because base calls CreateItemsViewSource
 			_carouselViewLoopManager?.SetItemsSource(LoopItemsSource);
 			_initialPositionSet = false;
 			UpdateInitialPosition();
@@ -135,18 +123,6 @@ namespace Xamarin.Forms.Platform.iOS
 			_carouselViewLoopManager?.SetItemsSource(itemsSource);
 			SubscribeCollectionItemsSourceChanged(itemsSource);
 			return itemsSource;
-		}
-
-		protected void BoundsSizeChanged()
-		{
-			//we might be rotating our phone
-			ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
-
-			//We call ReloadData so our VisibleCells also update their size
-			CollectionView.ReloadData();
-
-			//if the size changed center the item
-			Carousel.ScrollTo(Carousel.Position, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 		}
 
 		internal void TearDown()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -2,6 +2,7 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
+using System.Linq;
 using System.Threading.Tasks;
 using CoreGraphics;
 using Foundation;
@@ -77,6 +78,9 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			UpdateInitialPosition();
+
+			//if the size changed center the item	
+			Carousel.ScrollTo(Carousel.Position, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 		}
 
 		public override void DraggingStarted(UIScrollView scrollView)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _updatingScrollOffset;
 		List<View> _oldViews;
 		int _gotoPosition = -1;
+		CGSize _size;
 		ILoopItemsViewSource LoopItemsSource => ItemsSource as ILoopItemsViewSource;
 
 		public CarouselViewController(CarouselView itemsView, ItemsViewLayout layout) : base(itemsView, layout)
@@ -79,6 +80,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UpdateInitialPosition();
 
+			if (CollectionView.Bounds.Size != _size)
+			{
+				_size = CollectionView.Bounds.Size;
+				BoundsSizeChanged();
+			}
+		}
+
+		void BoundsSizeChanged() 
+		{
 			//if the size changed center the item	
 			Carousel.ScrollTo(Carousel.Position, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
@@ -24,7 +24,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (ScrollDirection == UICollectionViewScrollDirection.Horizontal)
 			{
-				ItemSize = new CGSize(width, height);
+				ItemSize = new CGSize(width, size.Height);
 			}
 			else
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewLayout.cs
@@ -16,11 +16,6 @@ namespace Xamarin.Forms.Platform.iOS
 			_itemsLayout = itemsLayout;
 		}
 
-		public override bool ShouldInvalidateLayoutForBoundsChange(CGRect newBounds)
-		{
-			return false;
-		}
-
 		public override void ConstrainTo(CGSize size)
 		{
 			//TODO: Should we scale the items 
@@ -29,18 +24,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (ScrollDirection == UICollectionViewScrollDirection.Horizontal)
 			{
-				ItemSize = new CGSize(width, size.Height);
+				ItemSize = new CGSize(width, height);
 			}
 			else
 			{
 				ItemSize = new CGSize(size.Width, height);
 			}
-		}
-
-		internal override void UpdateConstraints(CGSize size)
-		{
-			ConstrainTo(size);
-			UpdateCellConstraints();
 		}
 
 		public override nfloat GetMinimumInteritemSpacingForSection(UICollectionView collectionView, UICollectionViewLayout layout, nint section)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewRenderer.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (Carousel?.Loop == true)
 			{
 				var goToIndexPath = Controller.GetScrollToIndexPath(args.Index);
+
+				if (!IsIndexPathValid(goToIndexPath))
+				{
+					return;
+				}
+
 				Controller.CollectionView.ScrollToItem(goToIndexPath,
 					args.ScrollToPosition.ToCollectionViewScrollPosition(_layout.ScrollDirection),
 					args.IsAnimated);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -393,6 +393,5 @@ namespace Xamarin.Forms.Platform.iOS
 				_emptyViewDisplayed = false;
 			}
 		}
-		
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -527,15 +527,9 @@ namespace Xamarin.Forms.Platform.iOS
 				return base.ShouldInvalidateLayoutForBoundsChange(newBounds);
 			}
 
-			return true;
-		}
+			UpdateConstraints(CollectionView.AdjustedContentInset.InsetRect(newBounds).Size);
 
-		public override void InvalidateLayout()
-		{
-			if (CollectionView != null && CollectionView.Frame != null) {
-				UpdateConstraints(CollectionView.Frame.Size);
-			}
-			base.InvalidateLayout();
+			return true;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -233,7 +233,7 @@ namespace Xamarin.Forms.Platform.iOS
 			base.Dispose(disposing);
 		}
 
-		bool IsIndexPathValid(NSIndexPath indexPath)
+		protected bool IsIndexPathValid(NSIndexPath indexPath)
 		{
 			if (indexPath.Item < 0 || indexPath.Section < 0)
 			{


### PR DESCRIPTION
### Description of Change ###

Removes unnecessary constraints update calls during InvalidateLayout which were causing auto-layout errors for CarouselView (and making HTML Labels occasionally disappear). 

Also removes some unecessary overrides from CarouselView Layout/Controller (deferring to ItemsView Layout/Controller). 

### Issues Resolved ### 

- fixes #12193

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
