### PR TITLE
[Android / iOS] SwipeItem positioning issues fixes 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10086.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10086.xaml
@@ -1,0 +1,113 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 10086" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue10086">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Modifying the Threshold value, must affect the size of the SwipeItem using Execute mode."/>
+        <Label
+            Text="Default Threshold"/>
+        <CollectionView
+            ItemsSource="{Binding Items}"
+            HeightRequest="200">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <SwipeView>
+                        <SwipeView.RightItems>
+                            <SwipeItems
+                                Mode="Execute">
+                                <SwipeItemView
+                                    WidthRequest="100"
+                                    BackgroundColor="#2e2140">
+                                    <Grid>
+                                        <Label
+                                            HorizontalOptions="End"
+                                            VerticalOptions="Center"
+                                            TextColor="White"
+                                            Text="Delete"
+                                            Margin="24, 0"/>
+                                    </Grid>
+                                </SwipeItemView>
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                        <StackLayout
+                            BackgroundColor="PaleGreen">
+                            <StackLayout
+                                Orientation="Horizontal">
+                                <Label
+                                    Text="Swipe to Left"
+                                    FontSize="Subtitle"
+                                    LineBreakMode="WordWrap" />
+                            </StackLayout>
+                            <Label
+                                Text="{Binding Title}"
+                                FontSize="Micro" />
+                            <Label
+                                Text="{Binding SubTitle}"
+                                FontSize="Micro" />
+                        </StackLayout>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Label
+            Text="Custom Threshold"/>
+        <Slider
+            x:Name="ThresholdRevealSlider"
+            Maximum="300"
+            Minimum="50"
+            Value="250"/>
+        <CollectionView
+            ItemsSource="{Binding Items}"
+            HeightRequest="200">
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <SwipeView
+                        Threshold="{Binding Source={x:Reference ThresholdRevealSlider}, Path=Value}">
+                        <SwipeView.RightItems>
+                            <SwipeItems
+                                Mode="Execute">
+                                <SwipeItemView
+                                    WidthRequest="100"
+                                    BackgroundColor="#2e2140">
+                                    <Grid>
+                                        <Label
+                                            HorizontalOptions="End"
+                                            VerticalOptions="Center"
+                                            TextColor="White"
+                                            Text="Delete"
+                                            Margin="24, 0"/>
+                                    </Grid>
+                                </SwipeItemView>
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                        <StackLayout
+                            BackgroundColor="PaleGreen">
+                            <StackLayout
+                                Orientation="Horizontal">
+                                <Label
+                                    Text="Swipe to Left"
+                                    FontSize="Subtitle"
+                                    LineBreakMode="WordWrap" />
+                            </StackLayout>
+                            <Label
+                                Text="{Binding Title}"
+                                FontSize="Micro" />
+                            <Label
+                                Text="{Binding SubTitle}"
+                                FontSize="Micro" />
+                        </StackLayout>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10086.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10086.xaml.cs
@@ -1,0 +1,62 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10086,
+		"[Bug] SwipeView.RightItems Label is Missing/Hidden Due to Bad Alignment",
+		PlatformAffected.Android | PlatformAffected.iOS)]
+	public partial class Issue10086 : TestContentPage
+	{
+		public Issue10086()
+		{
+#if APP
+			InitializeComponent();
+			BindingContext = new Issue10086ViewModel();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10086Model
+	{
+		public string Title { get; set; }
+		public string SubTitle { get; set; }
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10086ViewModel : BindableObject
+	{
+		public Issue10086ViewModel()
+		{
+			Items = new List<Issue10086Model>();
+			LoadItems();
+		}
+
+		public List<Issue10086Model> Items { get; set; }
+
+		void LoadItems()
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				Items.Add(new Issue10086Model
+				{
+					Title = $"Title {i + 1}",
+					SubTitle = $"SubTitle {i + 1}",
+				});
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8833.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8833.xaml
@@ -1,0 +1,110 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8833"
+    Title="Issue 8833">
+    <Grid RowDefinitions="Auto,*">
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Swipe up or down, if the size of each SwipeItem is 100, the test has passed."/>
+        <CarouselView
+            Grid.Row="1"
+            x:Name="carouselView"
+            ItemsSource="{Binding Monkeys}">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <SwipeView>
+                        <SwipeView.TopItems>
+                            <SwipeItems>
+                                <SwipeItemView
+                                    Command="{Binding Source={x:Reference carouselView}, Path=BindingContext.FavoriteCommand}"
+                                    CommandParameter="{Binding}">
+                                    <Grid
+                                        HeightRequest="100"
+                                        BackgroundColor="LightGreen">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Image
+                                            Source="coffee.png"/>
+                                        <Label
+                                            Grid.Row="1"
+                                            HorizontalOptions="Center"
+                                            TextColor="White"
+                                            Text="Favorite"/>
+                                    </Grid>
+                                </SwipeItemView>
+                            </SwipeItems>
+                        </SwipeView.TopItems>
+                        <SwipeView.BottomItems>
+                            <SwipeItems>
+                                <SwipeItemView
+                                    Command="{Binding Source={x:Reference carouselView}, Path=BindingContext.DeleteCommand}"
+                                    CommandParameter="{Binding}">
+                                    <Grid
+                                        HeightRequest="100"
+                                        BackgroundColor="LightPink">
+                                        <Grid.RowDefinitions>
+                                            <RowDefinition Height="*" />
+                                            <RowDefinition Height="Auto" />
+                                        </Grid.RowDefinitions>
+                                        <Image
+                                            Source="coffee.png"/>
+                                        <Label
+                                            Grid.Row="1"
+                                            HorizontalOptions="Center"
+                                            TextColor="White"
+                                            Text="Delete"/>
+                                    </Grid>
+                                </SwipeItemView>
+                            </SwipeItems>
+                        </SwipeView.BottomItems>
+                        <StackLayout
+                            BackgroundColor="LightGray">
+                            <Frame
+                                HasShadow="True"
+                                BorderColor="DarkGray"
+                                CornerRadius="5"
+                                Margin="20"
+                                HeightRequest="300"
+                                HorizontalOptions="Center"
+                                VerticalOptions="CenterAndExpand">
+                                <StackLayout>
+                                    <Label
+                                        Text="{Binding Name}" 
+                                        FontAttributes="Bold"
+                                        FontSize="Large"
+                                        HorizontalOptions="Center"
+                                        VerticalOptions="Center" />
+                                    <Image
+                                        Source="{Binding ImageUrl}" 
+                                        Aspect="AspectFill"
+                                        HeightRequest="150"
+                                        WidthRequest="150"
+                                        HorizontalOptions="Center" />
+                                    <Label
+                                        Text="{Binding Location}"
+                                        HorizontalOptions="Center" />
+                                    <Label
+                                        Text="{Binding Details}"
+                                        FontAttributes="Italic"
+                                        HorizontalOptions="Center"
+                                        MaxLines="5"
+                                        LineBreakMode="TailTruncation" />
+                                </StackLayout>
+                            </Frame>
+                        </StackLayout>
+                    </SwipeView>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8833.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8833.xaml.cs
@@ -1,0 +1,281 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.ComponentModel;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows.Input;
+using System.Runtime.CompilerServices;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.SwipeView)]
+#endif
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 8833, "[Bug][iOS][Android] SwipeItems selection on CarouselView incorrect",
+        PlatformAffected.All)]
+    public partial class Issue8833 : TestContentPage
+    {
+        public Issue8833()
+        {
+#if APP
+            InitializeComponent();
+            BindingContext = new Issue8833ViewModel();
+
+#endif
+        }
+
+        protected override void Init()
+        {
+
+        }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class Issue8833Model
+    {
+        public string Name { get; set; }
+        public string Location { get; set; }
+        public string Details { get; set; }
+        public string ImageUrl { get; set; }
+        public bool IsFavorite { get; set; }
+    }
+
+    [Preserve(AllMembers = true)]
+    public class Issue8833ViewModel : INotifyPropertyChanged
+    {
+        readonly IList<Issue8833Model> _source;
+
+        public ObservableCollection<Issue8833Model> Monkeys { get; private set; }
+        public IList<Issue8833Model> EmptyMonkeys { get; private set; }
+
+        public Issue8833Model PreviousMonkey { get; set; }
+        public Issue8833Model CurrentMonkey { get; set; }
+        public Issue8833Model CurrentItem { get; set; }
+        public int PreviousPosition { get; set; }
+        public int CurrentPosition { get; set; }
+        public int Position { get; set; }
+
+        public ICommand FilterCommand => new Command<string>(FilterItems);
+        public ICommand ItemChangedCommand => new Command<Issue8833Model>(ItemChanged);
+        public ICommand PositionChangedCommand => new Command<int>(PositionChanged);
+        public ICommand DeleteCommand => new Command<Issue8833Model>(RemoveMonkey);
+        public ICommand FavoriteCommand => new Command<Issue8833Model>(FavoriteMonkey);
+
+        public Issue8833ViewModel()
+        {
+            _source = new List<Issue8833Model>();
+            CreateMonkeyCollection();
+
+            CurrentItem = Monkeys.Skip(3).FirstOrDefault();
+            OnPropertyChanged("CurrentItem");
+            Position = 3;
+            OnPropertyChanged("Position");
+        }
+
+        void CreateMonkeyCollection()
+        {
+            _source.Add(new Issue8833Model
+            {
+                Name = "Baboon",
+                Location = "Africa & Asia",
+                Details = "Baboons are African and Arabian Old World monkeys belonging to the genus Papio, part of the subfamily Cercopithecinae.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/f/fc/Papio_anubis_%28Serengeti%2C_2009%29.jpg/200px-Papio_anubis_%28Serengeti%2C_2009%29.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Capuchin Monkey",
+                Location = "Central & South America",
+                Details = "The capuchin monkeys are New World monkeys of the subfamily Cebinae. Prior to 2011, the subfamily contained only a single genus, Cebus.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/4/40/Capuchin_Costa_Rica.jpg/200px-Capuchin_Costa_Rica.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Blue Monkey",
+                Location = "Central and East Africa",
+                Details = "The blue monkey or diademed monkey is a species of Old World monkey native to Central and East Africa, ranging from the upper Congo River basin east to the East African Rift and south to northern Angola and Zambia",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Squirrel Monkey",
+                Location = "Central & South America",
+                Details = "The squirrel monkeys are the New World monkeys of the genus Saimiri. They are the only genus in the subfamily Saimirinae. The name of the genus Saimiri is of Tupi origin, and was also used as an English name by early researchers.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/2/20/Saimiri_sciureus-1_Luc_Viatour.jpg/220px-Saimiri_sciureus-1_Luc_Viatour.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Golden Lion Tamarin",
+                Location = "Brazil",
+                Details = "The golden lion tamarin also known as the golden marmoset, is a small New World monkey of the family Callitrichidae.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/8/87/Golden_lion_tamarin_portrait3.jpg/220px-Golden_lion_tamarin_portrait3.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Howler Monkey",
+                Location = "South America",
+                Details = "Howler monkeys are among the largest of the New World monkeys. Fifteen species are currently recognised. Previously classified in the family Cebidae, they are now placed in the family Atelidae.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/0/0d/Alouatta_guariba.jpg/200px-Alouatta_guariba.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Japanese Macaque",
+                Location = "Japan",
+                Details = "The Japanese macaque, is a terrestrial Old World monkey species native to Japan. They are also sometimes known as the snow monkey because they live in areas where snow covers the ground for months each year.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/c/c1/Macaca_fuscata_fuscata1.jpg/220px-Macaca_fuscata_fuscata1.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Mandrill",
+                Location = "Southern Cameroon, Gabon, and Congo",
+                Details = "The mandrill is a primate of the Old World monkey family, closely related to the baboons and even more closely to the drill. It is found in southern Cameroon, Gabon, Equatorial Guinea, and Congo.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/7/75/Mandrill_at_san_francisco_zoo.jpg/220px-Mandrill_at_san_francisco_zoo.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Proboscis Monkey",
+                Location = "Borneo",
+                Details = "The proboscis monkey or long-nosed monkey, known as the bekantan in Malay, is a reddish-brown arboreal Old World monkey that is endemic to the south-east Asian island of Borneo.",
+                ImageUrl = "http://upload.wikimedia.org/wikipedia/commons/thumb/e/e5/Proboscis_Monkey_in_Borneo.jpg/250px-Proboscis_Monkey_in_Borneo.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Red-shanked Douc",
+                Location = "Vietnam, Laos",
+                Details = "The red-shanked douc is a species of Old World monkey, among the most colourful of all primates. This monkey is sometimes called the \"costumed ape\" for its extravagant appearance. From its knees to its ankles it sports maroon-red \"stockings\", and it appears to wear white forearm length gloves. Its attire is finished with black hands and feet. The golden face is framed by a white ruff, which is considerably fluffier in males. The eyelids are a soft powder blue. The tail is white with a triangle of white hair at the base. Males of all ages have a white spot on both sides of the corners of the rump patch, and red and white genitals.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9f/Portrait_of_a_Douc.jpg/159px-Portrait_of_a_Douc.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Gray-shanked Douc",
+                Location = "Vietnam",
+                Details = "The gray-shanked douc langur is a douc species native to the Vietnamese provinces of Quảng Nam, Quảng Ngãi, Bình Định, Kon Tum, and Gia Lai. The total population is estimated at 550 to 700 individuals. In 2016, Dr Benjamin Rawson, Country Director of Fauna & Flora International - Vietnam Programme, announced a discovery of an additional population of more than 500 individuals found in Central Vietnam, bringing the total population up to approximately 1000 individuals.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/0b/Cuc.Phuong.Primate.Rehab.center.jpg/320px-Cuc.Phuong.Primate.Rehab.center.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Golden Snub-nosed Monkey",
+                Location = "China",
+                Details = "The golden snub-nosed monkey is an Old World monkey in the Colobinae subfamily. It is endemic to a small area in temperate, mountainous forests of central and Southwest China. They inhabit these mountainous forests of Southwestern China at elevations of 1,500-3,400 m above sea level. The Chinese name is Sichuan golden hair monkey. It is also widely referred to as the Sichuan snub-nosed monkey. Of the three species of snub-nosed monkeys in China, the golden snub-nosed monkey is the most widely distributed throughout China.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg/165px-Golden_Snub-nosed_Monkeys%2C_Qinling_Mountains_-_China.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Black Snub-nosed Monkey",
+                Location = "China",
+                Details = "The black snub-nosed monkey, also known as the Yunnan snub-nosed monkey, is an endangered species of primate in the family Cercopithecidae. It is endemic to China, where it is known to the locals as the Yunnan golden hair monkey and the black golden hair monkey. It is threatened by habitat loss. It was named after Bishop Félix Biet.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/5/59/RhinopitecusBieti.jpg/320px-RhinopitecusBieti.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Tonkin Snub-nosed Monkey",
+                Location = "Vietnam",
+                Details = "The Tonkin snub-nosed monkey or Dollman's snub-nosed monkey is a slender-bodied arboreal Old World monkey, endemic to northern Vietnam. It is a black and white monkey with a pink nose and lips and blue patches round the eyes. It is found at altitudes of 200 to 1,200 m (700 to 3,900 ft) on fragmentary patches of forest on craggy limestone areas. First described in 1912, the monkey was rediscovered in 1990 but is exceedingly rare. In 2008, fewer than 250 individuals were thought to exist, and the species was the subject of intense conservation effort. The main threats faced by these monkeys is habitat loss and hunting, and the International Union for Conservation of Nature has rated the species as \"critically endangered\".",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/9/9c/Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg/320px-Tonkin_snub-nosed_monkeys_%28Rhinopithecus_avunculus%29.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Thomas's Langur",
+                Location = "Indonesia",
+                Details = "Thomas's langur is a species of primate in the family Cercopithecidae. It is endemic to North Sumatra, Indonesia. Its natural habitat is subtropical or tropical dry forests. It is threatened by habitat loss. Its native names are reungkah in Acehnese and kedih in Alas.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/3/31/Thomas%27s_langur_Presbytis_thomasi.jpg/142px-Thomas%27s_langur_Presbytis_thomasi.jpg"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Purple-faced Langur",
+                Location = "Sri Lanka",
+                Details = "The purple-faced langur, also known as the purple-faced leaf monkey, is a species of Old World monkey that is endemic to Sri Lanka. The animal is a long-tailed arboreal species, identified by a mostly brown appearance, dark face (with paler lower face) and a very shy nature. The species was once highly prevalent, found in suburban Colombo and the \"wet zone\" villages (areas with high temperatures and high humidity throughout the year, whilst rain deluges occur during the monsoon seasons), but rapid urbanization has led to a significant decrease in the population level of the monkeys.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/0/02/Semnopithèque_blanchâtre_mâle.JPG/192px-Semnopithèque_blanchâtre_mâle.JPG"
+            });
+
+            _source.Add(new Issue8833Model
+            {
+                Name = "Gelada",
+                Location = "Ethiopia",
+                Details = "The gelada, sometimes called the bleeding-heart monkey or the gelada baboon, is a species of Old World monkey found only in the Ethiopian Highlands, with large populations in the Semien Mountains. Theropithecus is derived from the Greek root words for \"beast-ape.\" Like its close relatives the baboons, it is largely terrestrial, spending much of its time foraging in grasslands.",
+                ImageUrl = "https://upload.wikimedia.org/wikipedia/commons/thumb/1/13/Gelada-Pavian.jpg/320px-Gelada-Pavian.jpg"
+            });
+
+            Monkeys = new ObservableCollection<Issue8833Model>(_source);
+        }
+
+        void FilterItems(string filter)
+        {
+            var filteredItems = _source.Where(monkey => monkey.Name.ToLower().Contains(filter.ToLower())).ToList();
+            foreach (var monkey in _source)
+            {
+                if (!filteredItems.Contains(monkey))
+                {
+                    Monkeys.Remove(monkey);
+                }
+                else
+                {
+                    if (!Monkeys.Contains(monkey))
+                    {
+                        Monkeys.Add(monkey);
+                    }
+                }
+            }
+        }
+
+        void ItemChanged(Issue8833Model item)
+        {
+            PreviousMonkey = CurrentMonkey;
+            CurrentMonkey = item;
+            OnPropertyChanged("PreviousMonkey");
+            OnPropertyChanged("CurrentMonkey");
+        }
+
+        void PositionChanged(int position)
+        {
+            PreviousPosition = CurrentPosition;
+            CurrentPosition = position;
+            OnPropertyChanged("PreviousPosition");
+            OnPropertyChanged("CurrentPosition");
+        }
+
+        void RemoveMonkey(Issue8833Model monkey)
+        {
+            if (Monkeys.Contains(monkey))
+            {
+                Monkeys.Remove(monkey);
+            }
+        }
+
+        void FavoriteMonkey(Issue8833Model monkey)
+        {
+            monkey.IsFavorite = !monkey.IsFavorite;
+        }
+
+        #region INotifyPropertyChanged
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        void OnPropertyChanged([CallerMemberName] string propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+        #endregion
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1667,6 +1667,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12512.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12685.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12642.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8833.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10086.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2025,6 +2027,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12084.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10086.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8833.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/PositionGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/PositionGallery.cs
@@ -1,0 +1,21 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	[Preserve(AllMembers = true)]
+	public class PositionGallery : ContentPage
+	{
+		public PositionGallery()
+		{
+			Title = "Position Galleries";
+			Content = new StackLayout
+			{
+				Children =
+				{
+					GalleryBuilder.NavButton("SwipeItem Position Gallery", () => new SwipeItemPositionGallery(), Navigation),
+					GalleryBuilder.NavButton("SwipeItemView Position Gallery", () => new SwipeItemViewPositionGallery(), Navigation)
+				}
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemPositionGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemPositionGallery.xaml
@@ -1,0 +1,81 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.SwipeItemPositionGallery"
+    Title="SwipeItem Position Gallery">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Picker
+                x:Name="ModePicker"
+                Title="Select a Mode"
+                SelectedIndexChanged="OnModePickerSelectedIndexChanged">
+                <Picker.ItemsSource>
+                    <x:Array Type="{x:Type x:String}">
+                        <x:String>Reveal</x:String>
+                        <x:String>Execute</x:String>
+                    </x:Array>
+                </Picker.ItemsSource>
+            </Picker>
+            <SwipeView
+                Grid.Row="1">
+                <SwipeView.LeftItems>
+                    <SwipeItems
+                        x:Name="LeftSwipeItems">
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            Text="Left Item 1" />
+                        <SwipeItem
+                            BackgroundColor="IndianRed"
+                            Text="Left Item 2" />
+                    </SwipeItems>
+                </SwipeView.LeftItems>
+                <SwipeView.TopItems>
+                    <SwipeItems
+                        x:Name="TopSwipeItems">
+                        <SwipeItem
+                            BackgroundColor="Blue"
+                            Text="Top Item 1" />
+                        <SwipeItem
+                            BackgroundColor="DarkBlue"
+                            Text="Right Item 2" />
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        x:Name="RightSwipeItems">
+                        <SwipeItem
+                            BackgroundColor="Orange"
+                            Text="Right Item 1" />
+                        <SwipeItem
+                            BackgroundColor="DarkOrange"
+                            Text="Right Item 2" />
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.BottomItems>
+                    <SwipeItems
+                        x:Name="BottomSwipeItems">
+                        <SwipeItem
+                            BackgroundColor="DarkGreen"
+                            Text="Bottom Item 1" />
+                        <SwipeItem
+                            BackgroundColor="LawnGreen"
+                            Text="Bottom Item 2" />
+                    </SwipeItems>
+                </SwipeView.BottomItems>
+                <Grid
+                    Opacity="0.75"
+                    BackgroundColor="White">
+                    <Label
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"
+                        Text="Swipe in any direction"/>
+                </Grid>
+            </SwipeView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemPositionGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemPositionGallery.xaml.cs
@@ -1,0 +1,19 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class SwipeItemPositionGallery : ContentPage
+	{
+		public SwipeItemPositionGallery()
+		{
+			InitializeComponent();
+
+			ModePicker.SelectedIndex = 0;
+		}
+
+		void OnModePickerSelectedIndexChanged(object sender, EventArgs e)
+		{
+			LeftSwipeItems.Mode = TopSwipeItems.Mode = RightSwipeItems.Mode = BottomSwipeItems.Mode = ModePicker.SelectedIndex == 0 ? SwipeMode.Reveal : SwipeMode.Execute;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemViewPositionGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemViewPositionGallery.xaml
@@ -1,0 +1,97 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.SwipeItemViewPositionGallery"
+    Title="SwipeItemView Position Gallery">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <Picker
+                x:Name="ModePicker"
+                Title="Select a Mode"
+                SelectedIndexChanged="OnModePickerSelectedIndexChanged">
+                <Picker.ItemsSource>
+                    <x:Array Type="{x:Type x:String}">
+                        <x:String>Reveal</x:String>
+                        <x:String>Execute</x:String>
+                    </x:Array>
+                </Picker.ItemsSource>
+            </Picker>
+            <SwipeView
+                Grid.Row="1">
+                <SwipeView.LeftItems>
+                    <SwipeItems
+                        x:Name="LeftSwipeItems">
+                        <SwipeItemView>
+                            <Grid
+                                WidthRequest="100"
+                                BackgroundColor="Red">
+                                <Label
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    Text="LeftItem"/>
+                            </Grid>
+                        </SwipeItemView>
+                    </SwipeItems>
+                </SwipeView.LeftItems>
+                <SwipeView.TopItems>
+                    <SwipeItems
+                        x:Name="TopSwipeItems">
+                        <SwipeItemView>
+                            <Grid
+                                HeightRequest="200"
+                                BackgroundColor="Blue">
+                                <Label
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    Text="TopItem"/>
+                            </Grid>
+                        </SwipeItemView>
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.RightItems>
+                    <SwipeItems
+                        x:Name="RightSwipeItems">
+                        <SwipeItemView>
+                            <Grid
+                                WidthRequest="150"
+                                BackgroundColor="Orange">
+                                <Label
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    Text="RightItem"/>
+                            </Grid>
+                        </SwipeItemView>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.BottomItems>
+                    <SwipeItems
+                        x:Name="BottomSwipeItems">
+                        <SwipeItemView>
+                            <Grid
+                                HeightRequest="100"
+                                BackgroundColor="Green">
+                                <Label
+                                    HorizontalOptions="Center"
+                                    VerticalOptions="Center"
+                                    Text="BottomItem"/>
+                            </Grid>
+                        </SwipeItemView>
+                    </SwipeItems>
+                </SwipeView.BottomItems>
+                <Grid
+                    Opacity="0.75"
+                    BackgroundColor="White">
+                    <Label
+                        HorizontalOptions="Center"
+                        VerticalOptions="Center"
+                        Text="Swipe in any direction"/>
+                </Grid>
+            </SwipeView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemViewPositionGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeItemViewPositionGallery.xaml.cs
@@ -1,0 +1,18 @@
+﻿using System;
+
+namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class SwipeItemViewPositionGallery : ContentPage
+	{
+		public SwipeItemViewPositionGallery()
+		{
+			InitializeComponent();
+			ModePicker.SelectedIndex = 0;
+		}
+
+		void OnModePickerSelectedIndexChanged(object sender, EventArgs e)
+		{
+			LeftSwipeItems.Mode = TopSwipeItems.Mode = RightSwipeItems.Mode = BottomSwipeItems.Mode = ModePicker.SelectedIndex == 0 ? SwipeMode.Reveal : SwipeMode.Execute;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewGallery.cs
@@ -27,6 +27,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
 						GalleryBuilder.NavButton("Custom SwipeItem Galleries", () => new CustomSwipeItemGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeView BindingContext Gallery", () => new SwipeViewBindingContextGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItem Icon Gallery", () => new SwipeItemIconGallery(), Navigation),
+						GalleryBuilder.NavButton("SwipeItem Position Gallery", () => new PositionGallery(), Navigation),
+ 						GalleryBuilder.NavButton("SwipeView Margin Gallery", () => new SwipeViewMarginGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItem Size Gallery", () => new SwipeItemSizeGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItem IsEnabled Gallery", () => new SwipeItemIsEnabledGallery(), Navigation),
 						GalleryBuilder.NavButton("SwipeItemView IsEnabled Gallery", () => new SwipeItemViewIsEnabledGallery(), Navigation),

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewMarginGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewMarginGallery.xaml
@@ -1,0 +1,94 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries.SwipeViewMarginGallery"
+    Title="SwipeView Margin Gallery">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label
+                Padding="12"
+                BackgroundColor="Black"
+                TextColor="White"
+                Text="Modify the SwipeView Margin and Padding values, and verify when opening that the positioning of the SwipeItems is correct."/>
+            <Label
+                Text="SwipeView Content Margin"/>
+            <Slider
+                x:Name="MarginSlider"
+                MinimumTrackColor="LightGray"
+                Minimum="0"
+                MaximumTrackColor="Gray"
+                Maximum="48"
+                ThumbColor="DarkGray"
+                Value="12"/>
+            <Label
+                Text="SwipeView Content Padding"/>
+            <Slider
+                x:Name="PaddingSlider"
+                MinimumTrackColor="LightGray"
+                Minimum="0"
+                MaximumTrackColor="Gray"
+                Maximum="48"
+                ThumbColor="DarkGray"
+                Value="12"/>
+            <SwipeView
+                BackgroundColor="LightGray">
+                <SwipeView.LeftItems>
+                    <SwipeItems>
+                        <SwipeItem
+                            BackgroundColor="Green"
+                            Text="Favourite"/>
+                    </SwipeItems>
+                </SwipeView.LeftItems>
+                <SwipeView.RightItems>
+                    <SwipeItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            Text="Delete"/>
+                    </SwipeItems>
+                </SwipeView.RightItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="Gray"
+                        HeightRequest="100"
+                        Padding="{Binding Source={x:Reference PaddingSlider}, Path=Value}"
+                        Margin="{Binding Source={x:Reference MarginSlider}, Path=Value}">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Horizontal SwipeItems"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+            <SwipeView
+                BackgroundColor="LightGray">
+                <SwipeView.TopItems>
+                    <SwipeItems>
+                        <SwipeItem
+                            BackgroundColor="Green"
+                            Text="Favourite"/>
+                    </SwipeItems>
+                </SwipeView.TopItems>
+                <SwipeView.BottomItems>
+                    <SwipeItems>
+                        <SwipeItem
+                            BackgroundColor="Red"
+                            Text="Delete"/>
+                    </SwipeItems>
+                </SwipeView.BottomItems>
+                <SwipeView.Content>
+                    <Grid
+                        BackgroundColor="Gray"
+                        HeightRequest="100"
+                        Padding="{Binding Source={x:Reference PaddingSlider}, Path=Value}"
+                        Margin="{Binding Source={x:Reference MarginSlider}, Path=Value}">
+                        <Label
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"
+                            Text="Vertical SwipeItems"/>
+                    </Grid>
+                </SwipeView.Content>
+            </SwipeView>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewMarginGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/SwipeViewGalleries/SwipeViewMarginGallery.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.SwipeViewGalleries
+{
+	public partial class SwipeViewMarginGallery : ContentPage
+	{
+		public SwipeViewMarginGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

The problem that 10086 describes is due to the default behavior applied when using Execute Mode.
The SwipeItem size is different based on the Mode.

- Reveal: A default width is applied to the SwipeItem, and in the case of SwipeItemView the same happens unless a WidthRequest is set.
- Execute: The width of the SwipeItem is the width of the SwipeView. If there are multiple elements, each element takes the proportional width.

However, using the **Threshold** property, this behavior can be modified.
This PR only include a new sample to validate that the issue could be fixed using the Threshold property, but not includes any changes.

### Issues Resolved ### 

- fixes #10086
- fixes #8833

### API Changes ###
 
 None

### Platforms Affected ### 

- None

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![issue10086](https://user-images.githubusercontent.com/6755973/98118417-7a98b080-1eab-11eb-9eb3-7d164886f42e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10086.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
