### PR TITLE
Prevent FocusSearch from focusing disabled element

### DIFF
--- a/Xamarin.Forms.Core/Element.cs
+++ b/Xamarin.Forms.Core/Element.cs
@@ -497,6 +497,25 @@ namespace Xamarin.Forms
 				}
 			}
 		}
+		
+		internal IEnumerable<Element> VisibleEnabledDescendants()
+		{
+			var queue = new Queue<Element>(16);
+			queue.Enqueue(this);
+
+			while (queue.Count > 0)
+			{
+				ReadOnlyCollection<Element> children = queue.Dequeue().LogicalChildrenInternal;
+				for (var i = 0; i < children.Count; i++)
+				{
+					var child = children[i] as VisualElement;
+					if (child == null || !child.IsVisible || !child.IsEnabled)
+						continue;
+					yield return child;
+					queue.Enqueue(child);
+				}
+			}
+		}		
 
 		void AttachEffect(Effect effect)
 		{

--- a/Xamarin.Forms.Core/TabIndexExtensions.cs
+++ b/Xamarin.Forms.Core/TabIndexExtensions.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms
 			while (parentPage != null && !(parentPage is Page))
 				parentPage = parentPage.Parent;
 
-			var descendantsOnPage = parentPage?.VisibleDescendants();
+			var descendantsOnPage = parentPage?.VisibleEnabledDescendants();
 
 			if (parentPage is IShellController shell)
 				descendantsOnPage = shell.GetItems();


### PR DESCRIPTION
### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

Prevent FocusSearch from focusing disabled element when pressing Tab key.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
