### PR TITLE
fix-8284 - [Bug] [Android] Cannot add/remove menuitems at runtime to contextActions of a ViewCell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8284.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8284.cs
@@ -1,0 +1,116 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8284, "Cannot add/remove menuitems at runtime to contextActions of a ViewCell", PlatformAffected.Android)]
+	public class Issue8284 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			var contentPage = new ContentPage();
+
+			var retainElementButton = new Button() { Text = $"{nameof(ListViewCachingStrategy.RetainElement)}" };
+			retainElementButton.Clicked += CreateHandler(GetListViewPage(ListViewCachingStrategy.RetainElement));
+
+			var recycleElementButton = new Button() { Text = $"{nameof(ListViewCachingStrategy.RecycleElement)}" };
+			recycleElementButton.Clicked += CreateHandler(GetListViewPage(ListViewCachingStrategy.RecycleElement));
+
+			var recycleElementAndDataTemplateButton = new Button() { Text = $"{nameof(ListViewCachingStrategy.RecycleElementAndDataTemplate)}" };
+			recycleElementAndDataTemplateButton.Clicked += CreateHandler(GetListViewPage(ListViewCachingStrategy.RecycleElementAndDataTemplate));
+
+			contentPage.Content = new StackLayout
+			{
+				Children = {
+					new Label { Text = $"All three buttons create a listview with a different {nameof(ListViewCachingStrategy)}" +
+									   $"Click all Buttons and verify that you can add/remove ContextActions",
+						TextColor = Color.Red
+					},
+					retainElementButton,
+					recycleElementButton,
+					recycleElementAndDataTemplateButton,
+
+				}
+			};
+
+			Navigation.PushAsync(contentPage);
+		}
+
+		EventHandler CreateHandler(ContentPage contentPage)
+		{
+			return async (sender, args) =>
+			{
+				try
+				{
+					await Navigation.PushAsync(contentPage);
+				}
+				catch (Exception e)
+				{
+					Console.WriteLine(e);
+					throw;
+				}
+			};
+		}
+
+		static ContentPage GetListViewPage(ListViewCachingStrategy strategy)
+		{
+			var listView = new ListView(strategy);
+			listView.ItemTemplate = new DataTemplate(typeof(CustomViewCell));
+
+			var source = new ObservableCollection<string>();
+			listView.ItemsSource = source;
+			Array.ForEach(Enumerable.Range(0, 3).Select(i => i.ToString()).ToArray(), item => source.Add(item));
+
+			var contentPage = new ContentPage();
+
+			contentPage.Content = new StackLayout
+			{
+				Children = {
+					new Label{Text=$"ListViewCachingStrategy is {strategy}", TextColor = Color.Red },
+					new Label { Text = $"Press 'Add' or 'Remove' and check if the 'ContextActions' are being added." +
+									   $"Verify that by long-pressing an item in the {nameof(ListView)}" +
+									   $"The {nameof(ListView)} uses {nameof(ListViewCachingStrategy.RecycleElement)}"},
+					listView
+				}
+			};
+
+			return contentPage;
+		}
+
+		class CustomViewCell : ViewCell
+		{
+			public CustomViewCell()
+			{
+				var view = new StackLayout();
+				View = view;
+				view.Orientation = StackOrientation.Horizontal;
+				view.Children.Add(new Label() { Text = "Add or remove!" });
+
+				var menuItem = new MenuItem() { Text = "Item" };
+
+				var addButton = new Button { Text = "Add" };
+				addButton.Clicked += (sender, args) =>
+				{
+					ContextActions.Add(menuItem);
+				};
+
+				var removeButton = new Button { Text = "Remove" };
+				removeButton.Clicked += (sender, args) =>
+				{
+					if (ContextActions.Count != 0)
+						ContextActions.RemoveAt(0);
+				};
+
+				view.Children.Add(addButton);
+				view.Children.Add(removeButton);
+
+				ContextActions.Add(menuItem);
+			}
+		}
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -51,6 +51,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12246.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12652.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12714.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8284.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -15,6 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 	public abstract class CellAdapter : BaseAdapter<object>, AdapterView.IOnItemLongClickListener, ActionMode.ICallback, AdapterView.IOnItemClickListener, AActionMode.ICallback
 	{
 		readonly Context _context;
+		readonly ListViewCachingStrategy? _cachingStrategy;
 		ActionMode _actionMode;
 		Cell _actionModeContext;
 
@@ -28,6 +29,15 @@ namespace Xamarin.Forms.Platform.Android
 				throw new ArgumentNullException("context");
 
 			_context = context;
+		}
+
+		protected CellAdapter(Context context, ListViewCachingStrategy cachingStrategy)
+		{
+			if (context == null)
+				throw new ArgumentNullException("context");
+
+			_context = context;
+			_cachingStrategy = cachingStrategy;
 		}
 
 		internal Cell ActionModeContext
@@ -145,6 +155,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		public bool OnItemLongClick(AdapterView parent, AView view, int position, long id)
 		{
+			if (_cachingStrategy != null && _cachingStrategy != ListViewCachingStrategy.RecycleElement)
+				return true;
+
 			var listView = parent as AListView;
 			if (listView != null)
 				position -= listView.HeaderViewsCount;
@@ -212,6 +225,17 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
+		internal bool HandleCachedContextMode(AView view, Cell cell)
+		{
+			if (view is EditText || view is TextView || view is SearchView)
+				return false;
+
+			if (cell == null)
+				return false;
+
+			return HandleContextModeImpl(view, cell);
+		}
+
 		bool HandleContextMode(AView view, int position)
 		{
 			if (view is EditText || view is TextView || view is SearchView)
@@ -219,6 +243,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			Cell cell = GetCellForPosition(position);
 
+			return HandleContextModeImpl(view, cell);
+		}
+
+		bool HandleContextModeImpl(AView view, Cell cell)
+		{
 			if (cell == null)
 				return false;
 

--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -300,7 +300,7 @@ namespace Xamarin.Forms.Platform.Android
 				// LongClick handling from happening. So we need to watch locally for LongPress and if we see it,
 				// trigger the LongClick manually.
 				_watchForLongPress = _viewCell.ContextActions.Count > 0
-					&& HasTapGestureRecognizers(vw);
+									 || HasTapGestureRecognizers(vw);
 			}
 
 			static bool HasTapGestureRecognizers(View view)
@@ -316,7 +316,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			void TriggerLongClick()
 			{
-				ListViewRenderer?.LongClickOn(this);
+				ListViewRenderer._adapter.HandleCachedContextMode(this, _viewCell);
 			}
 
 			internal class TapGestureListener : Java.Lang.Object, GestureDetector.IOnGestureListener

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.Android
 		IListViewController Controller => _listView;
 		protected ITemplatedItemsView<Cell> TemplatedItemsView => _listView;
 
-		public ListViewAdapter(Context context, AListView realListView, ListView listView) : base(context)
+		public ListViewAdapter(Context context, AListView realListView, ListView listView) : base(context, listView.CachingStrategy)
 		{
 			_context = context;
 			_realListView = realListView;
@@ -550,7 +550,8 @@ namespace Xamarin.Forms.Platform.Android
 					if (position + x >= templatedItemsCount)
 						return cells;
 
-					cells.Add(templatedItems[x + position]);
+					var item = templatedItems[x + position];
+					cells.Add(item);
 				}
 
 				return cells;

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -15,7 +15,7 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public class ListViewRenderer : ViewRenderer<ListView, AListView>, SwipeRefreshLayout.IOnRefreshListener
 	{
-		ListViewAdapter _adapter;
+		internal ListViewAdapter _adapter;
 		bool _disposed;
 		IVisualElementRenderer _headerRenderer;
 		IVisualElementRenderer _footerRenderer;


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

When the `ListView` uses a `ListViewCachingStrategy.RecycleElement` then it was not able to add or remove contextations during runtime.

When using this CachingStrategy the ViewCells are not cached in `Xamarin.Forms.TemplatedItemsList`.
The android ContextActionMenu is created when long pressing a ViewCell.
During this process we try to get the ViewCell from the `TemplatedItemsList` but when the ViewCell is not cached it is created using reflection (`Activator.CreateInstance`).

The ContextActions of the activated ViewCell are used for the MenuItems when the Android ContextActionMenu is created.
Which means that the initial ContextActions are used and not the runtime changed context actions.

I tried to code as defensive as possible.
This solution could include some design smells.
However, I want to ask for a feedback before changing too much of the codebase.

### Issues Resolved ### 
- fixes #8284

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

It's possible to add ContextActions to the ViewCell/ListView during runtime on Android.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before: (this is the gif from the Issue)
![image](https://user-images.githubusercontent.com/35541212/67760752-2b22d780-fa42-11e9-986a-f8aef8404092.gif)

After:
![8284](https://user-images.githubusercontent.com/35541212/98325162-6f01d280-1fee-11eb-9703-ed800e483ce0.gif)


### Testing Procedure ###
1.) switch to my branch
2.) start the android control galery
3.) go to issues
4.) search for 8284

5.) open all 3 pages (all pages use a different ListViewCachingStrategy)
6.) try to add and remove contextactions 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
