### PR TITLE
[Core] Brushes working with DynamicResource

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11691.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11691.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11691"
+    Title="Issue 11691">
+    <controls:TestContentPage.Resources>
+        <ResourceDictionary>
+
+            <Color x:Key="PrimaryColor">#0099ff</Color>
+
+            <SolidColorBrush x:Key="PrimaryColorBrush" Color="{DynamicResource PrimaryColor}" />
+
+        </ResourceDictionary>
+    </controls:TestContentPage.Resources>
+    <controls:TestContentPage.Content>
+        <StackLayout>
+            <Label
+                Padding="12"
+                BackgroundColor="Black"
+                TextColor="White"
+                Text="If both polygons are visible, the test has passed."/>
+            <Label
+                Text="Polygon with fixed color" />
+            <Polygon
+                Fill="Blue"
+                Points="10,10 100,20 150,45 70,50" />
+            <Label
+                Text="Polygon with dynamic color" />
+            <Polygon
+                Fill="{DynamicResource PrimaryColorBrush}"
+                Points="10,10 100,20 150,45 70,50" />
+        </StackLayout>
+    </controls:TestContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11691.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11691.xaml.cs
@@ -1,0 +1,33 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shape)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11691,
+		"Polygon Shape doesn't work with DynamicResource color binding",
+		PlatformAffected.All)]
+	public partial class Issue11691 : TestContentPage
+	{
+		public Issue11691()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11911.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11911.xaml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+  xmlns="http://xamarin.com/schemas/2014/forms" 
+  xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+  x:Class="Xamarin.Forms.Controls.Issues.Issue11911"
+    Title="Issue 11911">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Color x:Key="DynamicColor">Red</Color>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the gradient use Green and Red colors, the test has passed."/>
+        <BoxView
+            HorizontalOptions="FillAndExpand"
+            VerticalOptions="FillAndExpand">
+            <BoxView.Background>
+	            <LinearGradientBrush
+		            StartPoint="0.5, 0" EndPoint="0.5, 1">
+		            <GradientStop Color="Green" Offset="0.0" />
+		            <GradientStop Color="{DynamicResource DynamicColor}" Offset="1.0" />
+	            </LinearGradientBrush>
+            </BoxView.Background>
+        </BoxView>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11911.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11911.xaml.cs
@@ -1,0 +1,18 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11911, "[Bug] Brushes can't use DynamicResource", PlatformAffected.All)]
+	public partial class Issue11911 : ContentPage
+	{
+		public Issue11911()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1624,6 +1624,7 @@
       <DependentUpon>Issue11081.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue12222.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11911.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1949,6 +1950,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11081.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11911.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1625,6 +1625,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue12222.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11911.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11691.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1953,6 +1954,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11911.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11691.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Core.UnitTests/BrushUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BrushUnitTests.cs
@@ -55,5 +55,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.True(_converter.CanConvertFrom(typeof(string)));
 			Assert.NotNull(_converter.ConvertFromInvariantString(brush));
 		}
+
+		[Test]
+		public void TestBindingContextPropagation()
+		{
+			var context = new object();
+			var linearGradientBrush = new LinearGradientBrush();
+
+			var firstStop = new GradientStop { Offset = 0.1f, Color = Color.Red };
+			var secondStop = new GradientStop { Offset = 1.0f, Color = Color.Blue };
+
+			linearGradientBrush.GradientStops.Add(firstStop);
+			linearGradientBrush.GradientStops.Add(secondStop);
+
+			linearGradientBrush.BindingContext = context;
+
+			Assert.AreSame(context, firstStop.BindingContext);
+			Assert.AreSame(context, secondStop.BindingContext);
+		}
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/BrushUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BrushUnitTests.cs
@@ -73,5 +73,29 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreSame(context, firstStop.BindingContext);
 			Assert.AreSame(context, secondStop.BindingContext);
 		}
+
+		[Test]
+		public void TestBrushParent()
+		{
+			var context = new object();
+
+			var parent = new Grid
+			{
+				BindingContext = context
+			};
+
+			var linearGradientBrush = new LinearGradientBrush();
+
+			var firstStop = new GradientStop { Offset = 0.1f, Color = Color.Red };
+			var secondStop = new GradientStop { Offset = 1.0f, Color = Color.Blue };
+
+			linearGradientBrush.GradientStops.Add(firstStop);
+			linearGradientBrush.GradientStops.Add(secondStop);
+
+			parent.Background = linearGradientBrush;
+
+			Assert.AreSame(parent, parent.Background.Parent);
+			Assert.AreSame(context, parent.Background.BindingContext);
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Brush.cs
+++ b/Xamarin.Forms.Core/Brush.cs
@@ -1,7 +1,7 @@
 ﻿namespace Xamarin.Forms
 {
 	[TypeConverter(typeof(BrushTypeConverter))]
-	public abstract class Brush : BindableObject
+	public abstract class Brush : Element
 	{
 		public static Brush Default
 		{

--- a/Xamarin.Forms.Core/GradientBrush.cs
+++ b/Xamarin.Forms.Core/GradientBrush.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Specialized;
 using System.ComponentModel;
-using System.Runtime.CompilerServices;
 
 namespace Xamarin.Forms
 {
@@ -28,6 +27,14 @@ namespace Xamarin.Forms
 		static void OnGradientStopsChanged(BindableObject bindable, object oldValue, object newValue)
 		{
 			(bindable as GradientBrush)?.UpdateGradientStops(oldValue as GradientStopCollection, newValue as GradientStopCollection);
+		}
+
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			foreach (var item in GradientStops)
+				SetInheritedBindingContext(item, BindingContext);
 		}
 
 		void UpdateGradientStops(GradientStopCollection oldCollection, GradientStopCollection newCollection)

--- a/Xamarin.Forms.Core/GradientBrush.cs
+++ b/Xamarin.Forms.Core/GradientBrush.cs
@@ -33,8 +33,8 @@ namespace Xamarin.Forms
 		{
 			base.OnBindingContextChanged();
 
-			foreach (var item in GradientStops)
-				SetInheritedBindingContext(item, BindingContext);
+			foreach (var gradientStop in GradientStops)
+				SetInheritedBindingContext(gradientStop, BindingContext);
 		}
 
 		void UpdateGradientStops(GradientStopCollection oldCollection, GradientStopCollection newCollection)
@@ -45,6 +45,7 @@ namespace Xamarin.Forms
 
 				foreach (var oldStop in oldCollection)
 				{
+					oldStop.Parent = null;
 					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
 				}
 			}
@@ -56,6 +57,7 @@ namespace Xamarin.Forms
 
 			foreach (var newStop in newCollection)
 			{
+				newStop.Parent = this;
 				newStop.PropertyChanged += OnGradientStopPropertyChanged;
 			}
 		}
@@ -69,6 +71,7 @@ namespace Xamarin.Forms
 					if (!(oldItem is GradientStop oldStop))
 						continue;
 
+					oldStop.Parent = null;
 					oldStop.PropertyChanged -= OnGradientStopPropertyChanged;
 				}
 			}
@@ -80,6 +83,7 @@ namespace Xamarin.Forms
 					if (!(newItem is GradientStop newStop))
 						continue;
 
+					newStop.Parent = this;
 					newStop.PropertyChanged += OnGradientStopPropertyChanged;
 				}
 			}

--- a/Xamarin.Forms.Core/GradientStop.cs
+++ b/Xamarin.Forms.Core/GradientStop.cs
@@ -1,6 +1,6 @@
 ﻿namespace Xamarin.Forms
 {
-	public class GradientStop : BindableObject
+	public class GradientStop : Element
 	{
 		public static readonly BindableProperty ColorProperty = BindableProperty.Create(
 			nameof(Color), typeof(Color), typeof(GradientStop), Color.Default);

--- a/Xamarin.Forms.Core/Shapes/Shape.cs
+++ b/Xamarin.Forms.Core/Shapes/Shape.cs
@@ -7,10 +7,12 @@
 		}
 
 		public static readonly BindableProperty FillProperty =
-			BindableProperty.Create(nameof(Fill), typeof(Brush), typeof(Shape), null);
+			BindableProperty.Create(nameof(Fill), typeof(Brush), typeof(Shape), null,
+				propertyChanged: OnBrushChanged);
 
 		public static readonly BindableProperty StrokeProperty =
-			BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(Shape), null);
+			BindableProperty.Create(nameof(Stroke), typeof(Brush), typeof(Shape), null,
+				propertyChanged: OnBrushChanged);
 
 		public static readonly BindableProperty StrokeThicknessProperty =
 			BindableProperty.Create(nameof(StrokeThickness), typeof(double), typeof(Shape), 1.0);
@@ -87,5 +89,12 @@
 			set { SetValue(AspectProperty, value); }
 			get { return (Stretch)GetValue(AspectProperty); }
 		}
+
+		static void OnBrushChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((Shape)bindable).UpdateBrushParent((Brush)newValue);
+		}
+
+		void UpdateBrushParent(Brush brush) => brush.Parent = this;
 	}
 }

--- a/Xamarin.Forms.Core/Shapes/Shape.cs
+++ b/Xamarin.Forms.Core/Shapes/Shape.cs
@@ -95,6 +95,10 @@
 			((Shape)bindable).UpdateBrushParent((Brush)newValue);
 		}
 
-		void UpdateBrushParent(Brush brush) => brush.Parent = this;
+		void UpdateBrushParent(Brush brush)
+		{
+			if (brush != null)
+				brush.Parent = this;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -821,7 +821,6 @@ namespace Xamarin.Forms
 		protected override void OnBindingContextChanged()
 		{
 			PropagateBindingContextToStateTriggers();
-			PropagateBindingContextToBrush();
 
 			base.OnBindingContextChanged();
 		}
@@ -984,21 +983,6 @@ namespace Xamarin.Forms
 				foreach (var state in group.States)
 					foreach (var stateTrigger in state.StateTriggers)
 						SetInheritedBindingContext(stateTrigger, BindingContext);
-		}
-
-		void PropagateBindingContextToBrush()
-		{
-			var brush = (Brush)GetValue(BackgroundProperty);
-
-			if (brush != null)
-			{
-				if (brush is SolidColorBrush solidColorBrush)
-					SetInheritedBindingContext(solidColorBrush, BindingContext);
-
-				if (brush is GradientBrush gradientBrush)
-					foreach (var item in gradientBrush.GradientStops)
-						SetInheritedBindingContext(item, BindingContext);
-			}
 		}
 		
 		void OnFocused() => Focused?.Invoke(this, new FocusEventArgs(this, true));

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -821,6 +821,8 @@ namespace Xamarin.Forms
 		protected override void OnBindingContextChanged()
 		{
 			PropagateBindingContextToStateTriggers();
+			PropagateBindingContextToBrush();
+
 			base.OnBindingContextChanged();
 		}
 
@@ -984,6 +986,21 @@ namespace Xamarin.Forms
 						SetInheritedBindingContext(stateTrigger, BindingContext);
 		}
 
+		void PropagateBindingContextToBrush()
+		{
+			var brush = (Brush)GetValue(BackgroundProperty);
+
+			if (brush != null)
+			{
+				if (brush is SolidColorBrush solidColorBrush)
+					SetInheritedBindingContext(solidColorBrush, BindingContext);
+
+				if (brush is GradientBrush gradientBrush)
+					foreach (var item in gradientBrush.GradientStops)
+						SetInheritedBindingContext(item, BindingContext);
+			}
+		}
+		
 		void OnFocused() => Focused?.Invoke(this, new FocusEventArgs(this, true));
 
 		internal void ChangeVisualStateInternal() => ChangeVisualState();

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -216,6 +216,7 @@ namespace Xamarin.Forms
 		{
 			if (Background != null)
 			{
+				Background.Parent = this;
 				Background.PropertyChanged += OnBackgroundChanged;
 
 				if (Background is GradientBrush gradientBrush)
@@ -227,6 +228,7 @@ namespace Xamarin.Forms
 		{
 			if (Background != null)
 			{
+				Background.Parent = null;
 				Background.PropertyChanged -= OnBackgroundChanged;
 
 				if (Background is GradientBrush gradientBrush)


### PR DESCRIPTION
### Description of Change ###

Changed Brush and GradientStop from BindableProperty to Element and propagate correctly the Parent.

### Issues Resolved ### 

- fixes #11907
- fixes #11911
- fixes #11691

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="507" alt="issue11696" src="https://user-images.githubusercontent.com/6755973/98389542-7c51a800-2054-11eb-9dae-39741cfc00a7.png">
<img width="505" alt="issue11911" src="https://user-images.githubusercontent.com/6755973/98389545-7e1b6b80-2054-11eb-8a1a-5007eabeb426.png">

### Testing Procedure ###

Launch Core Gallery and navigate to the issues 11696 and 11911. Verify that the expected colors are rendered (read issue instructions).

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
