### PR TITLE
[UWP] Fix 12731 The ClearButton is no longer displayed in the entry

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8836.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8836.cs
@@ -14,12 +14,25 @@ namespace Xamarin.Forms.Controls.Issues
 			stack.Children.Add(new Label {Text = "Click the button to toggle the clear button visibility."});
 			stack.Children.Add(new Label { Text = "The default state when this page loaded is NEVER.  The clear button should not be visible until you click toggle." });
 
-			Entry = new Entry
+			EntryToggle = new Entry
 			{
-				Text = "Clear Button: Never",
+				Text = "Clear Button: Never (toggles)",
 				ClearButtonVisibility = ClearButtonVisibility.Never
 			};
-			stack.Children.Add(Entry);
+			stack.Children.Add(EntryToggle);
+
+			EntryNever = new Entry
+			{
+				Text = "Clear Button: Never (Default Entry ClearButtonVisibility)"
+			};
+			stack.Children.Add(EntryNever);
+
+			EntryAlways = new Entry
+			{
+				Text = "Clear Button: Always (Set before load)",
+				ClearButtonVisibility = ClearButtonVisibility.WhileEditing
+			};
+			stack.Children.Add(EntryAlways);
 
 			var button = new Button { Text = "Toggle Clear Button State" };
 			button.Clicked += Button_Clicked;
@@ -28,22 +41,24 @@ namespace Xamarin.Forms.Controls.Issues
 			Content = stack;
 		}
 
-		private void Button_Clicked(object sender, System.EventArgs e)
+		void Button_Clicked(object sender, System.EventArgs e)
 		{
-			if (Entry.ClearButtonVisibility == ClearButtonVisibility.Never)
+			if (EntryToggle.ClearButtonVisibility == ClearButtonVisibility.Never)
 			{
-				Entry.ClearButtonVisibility = ClearButtonVisibility.WhileEditing;
-				Entry.Text = "Clear Button: While Editing";
+				EntryToggle.ClearButtonVisibility = ClearButtonVisibility.WhileEditing;
+				EntryToggle.Text = "Clear Button: While Editing (toggles)";
 			}
 			else
 			{
-				Entry.ClearButtonVisibility = ClearButtonVisibility.Never;
-				Entry.Text = "Clear Button: Never";
+				EntryToggle.ClearButtonVisibility = ClearButtonVisibility.Never;
+				EntryToggle.Text = "Clear Button: Never (toggles)";
 			}
-			Entry.Focus();
+			EntryToggle.Focus();
 		}
 
-		public Entry Entry { get; set; }
+		public Entry EntryToggle { get; set; }
+		public Entry EntryAlways { get; set; }
+		public Entry EntryNever { get; set; }
 
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBox.cs
@@ -397,7 +397,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				if (ClearButtonVisible && !states.Contains(visibleState))
 					states.Add(visibleState);
-				else
+				else if(!ClearButtonVisible)
 					states.Remove(visibleState);
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

UWP Entry ClearButtonVisiblity was not being honored when set to WhileEditing prior to loading.

### Issues Resolved ### 

- fixes #12731 

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Open the 8836 issue page and make sure the clear buttons work as expected.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
