### PR TITLE
Prevent layout hang on iOS when CollectionView is initially invisible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12714.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12714.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Issue(IssueTracker.Github, 12714, 
+		"[Bug] iOS application suspended at UICollectionViewFlowLayout.PrepareLayout() when using IsVisible = false", 
+		PlatformAffected.iOS)]
+	public class Issue12714 : TestContentPage
+	{
+		const string Success = "Success";
+		const string Show = "Show";
+
+		protected override void Init()
+		{
+			var items = new List<string>() { "uno", "dos", "tres", Success };
+			var cv = new CollectionView
+			{
+				ItemsSource = items,
+				IsVisible = false,
+				ItemsLayout = new GridItemsLayout(2, ItemsLayoutOrientation.Vertical)
+			};
+
+			var layout = new StackLayout() { Margin = 40 };
+
+			var button = new Button { Text = Show };
+			button.Clicked += (sender, args) => { cv.IsVisible = !cv.IsVisible; };
+
+			layout.Children.Add(button);
+			layout.Children.Add(cv);
+
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void InitiallyInvisbleCollectionViewSurvivesiOSLayoutNonsense()
+		{
+			RunningApp.WaitForElement(Show);
+			RunningApp.Tap(Show);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -46,6 +46,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue12246.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12652.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12714.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public IItemsViewSource ItemsSource { get; protected set; }
 		public TItemsView ItemsView { get; }
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
-		bool _initialConstraintsSet;
+		bool _initialized;
 		bool _isEmpty;
 		bool _emptyViewDisplayed;
 		bool _disposed;
@@ -36,18 +36,16 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			ItemsViewLayout = newLayout;
-			ItemsViewLayout.GetPrototype = GetPrototype;
 
-            Delegator = CreateDelegator();
-			CollectionView.Delegate = Delegator;
+			_initialized = false;
 
-			// Make sure the new layout is sized properly
-			ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
+			EnsureLayoutInitialized();
 
-			CollectionView.SetCollectionViewLayout(ItemsViewLayout, false);
-
-			// Reload the data so the currently visible cells get laid out according to the new layout
-			CollectionView.ReloadData();
+			if (_initialized)
+			{
+				// Reload the data so the currently visible cells get laid out according to the new layout
+				CollectionView.ReloadData();
+			}
 		}
 
 		protected override void Dispose(bool disposing)
@@ -95,6 +93,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override nint GetItemsCount(UICollectionView collectionView, nint section)
 		{
+			if (!_initialized)
+			{
+				return 0;
+			}
+
 			CheckForEmptySource();
 
 			return ItemsSource.ItemCountInGroup(section);
@@ -125,10 +128,6 @@ namespace Xamarin.Forms.Platform.iOS
 			base.ViewDidLoad();
 
 			ItemsSource = CreateItemsViewSource();
-			ItemsViewLayout.GetPrototype = GetPrototype;
-
-			Delegator = CreateDelegator();
-			CollectionView.Delegate = Delegator;
 
 			if (!Forms.IsiOS11OrNewer)
 				AutomaticallyAdjustsScrollViewInsets = false;
@@ -148,20 +147,46 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewWillLayoutSubviews();
 
-			// We can't set this constraint up on ViewDidLoad, because Forms does other stuff that resizes the view
+			if (!_initialized)
+			{
+				UpdateEmptyView();
+			}
+
+			// We can't set this up during ViewDidLoad, because Forms does other stuff that resizes the view
 			// and we end up with massive layout errors. And View[Will/Did]Appear do not fire for this controller
 			// reliably. So until one of those options is cleared up, we set this flag so that the initial constraints
 			// are set up the first time this method is called.
-			if (!_initialConstraintsSet)
-			{
-				ItemsViewLayout.SetInitialConstraints(CollectionView.Bounds.Size);
-				UpdateEmptyView();
-				_initialConstraintsSet = true;
-			}
-			else
+			EnsureLayoutInitialized();
+						
+			if(_initialized)
 			{
 				LayoutEmptyView();
 			}
+		}
+
+		void EnsureLayoutInitialized() 
+		{
+			if (_initialized)
+			{
+				return;
+			}
+
+			if (!ItemsView.IsVisible)
+			{
+				// If the CollectionView starts out invisible, we'll get a layout pass with a size of 1,1 and everything will
+				// go pear-shaped. So until the first time this CollectionView is visible, we do nothing.
+				return;
+			}
+
+			_initialized = true;
+
+			ItemsViewLayout.GetPrototype = GetPrototype;
+
+			Delegator = CreateDelegator();
+			CollectionView.Delegate = Delegator;
+
+			ItemsViewLayout.SetInitialConstraints(CollectionView.Bounds.Size);
+			CollectionView.SetCollectionViewLayout(ItemsViewLayout, false);
 		}
 
 		protected virtual UICollectionViewDelegateFlowLayout CreateDelegator()
@@ -183,6 +208,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override nint NumberOfSections(UICollectionView collectionView)
 		{
+			if(!_initialized)
+			{
+				return 0;
+			}
+
 			CheckForEmptySource();
 			return ItemsSource.GroupCount;
 		}


### PR DESCRIPTION
### Description of Change ###

An initially invisible CollectionView on iOS attempts to layout at a tiny size, which causes autolayout errors and other assorted mayhem, hanging the application.

These changes prevent the intial layout from occurring until the CollectionView is actually visible, avoiding the problem.

### Issues Resolved ### 

- fixes #12714

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test 12714

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
