### PR TITLE
[Tizen] CollectionView optimize for TV profile

### DIFF
--- a/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/ItemsView.cs
+++ b/Xamarin.Forms.Core/PlatformConfiguration/TizenSpecific/ItemsView.cs
@@ -1,0 +1,31 @@
+namespace Xamarin.Forms.PlatformConfiguration.TizenSpecific
+{
+	using FormsElement = Forms.ItemsView;
+
+	public static class ItemsView
+	{
+		public static readonly BindableProperty FocusedItemScrollPositionProperty = BindableProperty.Create("FocusedItemScrollPosition", typeof(ScrollToPosition), typeof(FormsElement), ScrollToPosition.MakeVisible);
+
+
+		public static ScrollToPosition GetFocusedItemScrollPosition(BindableObject element)
+		{
+			return (ScrollToPosition)element.GetValue(FocusedItemScrollPositionProperty);
+		}
+
+		public static void SetFocusedItemScrollPosition(BindableObject element, ScrollToPosition position)
+		{
+			element.SetValue(FocusedItemScrollPositionProperty, position);
+		}
+
+		public static ScrollToPosition GetFocusedItemScrollPosition(this IPlatformElementConfiguration<Tizen, FormsElement> config)
+		{
+			return GetFocusedItemScrollPosition(config.Element);
+		}
+
+		public static IPlatformElementConfiguration<Tizen, FormsElement> SetFocusedItemScrollPosition(this IPlatformElementConfiguration<Tizen, FormsElement> config, ScrollToPosition position)
+		{
+			SetFocusedItemScrollPosition(config.Element, position);
+			return config;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/GridLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/GridLayoutManager.cs
@@ -401,9 +401,17 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			if (_scrollCanvasSize.Width < x || _scrollCanvasSize.Height < y)
 				return CollectionView.Count - 1;
 
-			int first = (IsHorizontal ? x : y) / (BaseItemSize + ItemSpacing);
-			if (_hasUnevenRows)
+			int first = 0;
+			if (!_hasUnevenRows)
+			{
+				first = Math.Min(Math.Max(0, ((IsHorizontal ? x : y) - ItemStartPoint) / (BaseItemSize + ItemSpacing)), ((CollectionView.Count - 1) / Span));
+			}
+			else
+			{
 				first = _accumulatedItemSizes.FindIndex(current => (IsHorizontal ? x : y) <= current);
+				if (first == -1)
+					first = (CollectionView.Count - 1) / Span;
+			}
 
 			int second = (IsHorizontal ? y : x) / (ColumnSize + ColumnSpacing);
 			if (second == Span)

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ItemTemplateAdaptor.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ItemTemplateAdaptor.cs
@@ -134,7 +134,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			{
 				_footerCache.Parent = _itemsView;
 				var renderer = Platform.GetOrCreateRenderer(_footerCache);
-				(renderer as LayoutRenderer).RegisterOnLayoutUpdated();
+				(renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
 				return renderer.NativeView;
 			}
 			return null;

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
@@ -344,9 +344,16 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				return CollectionView.Count - 1;
 
 			if (!_hasUnevenRows)
-				return coordinate / (BaseItemSize + ItemSpacing);
+			{
+				return Math.Min(Math.Max(0, (coordinate - ItemStartPoint) / (BaseItemSize + ItemSpacing)), CollectionView.Count - 1);
+			}
 			else
-				return _accumulatedItemSizes.FindIndex(current => coordinate <= current);
+			{
+				var index =  _accumulatedItemSizes.FindIndex(current => coordinate <= current);
+				if (index == -1)
+					index = CollectionView.Count - 1;
+				return index;
+			}
 		}
 
 		public int GetScrollBlockSize()

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ViewHolder.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ViewHolder.cs
@@ -1,8 +1,6 @@
 using System;
 using ElmSharp;
 using EColor = ElmSharp.Color;
-using ERectangle = ElmSharp.Rectangle;
-
 
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
@@ -125,10 +123,11 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				_isSelected = true;
 			else if (State == ViewHolderState.Normal)
 				_isSelected = false;
+			else if (State == ViewHolderState.Focused)
+				RaiseTop();
 
 			StateUpdated?.Invoke(this, EventArgs.Empty);
 		}
-
 
 		void OnKeyUp(object sender, EvasKeyEventArgs e)
 		{

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
@@ -3,6 +3,8 @@ using System.Linq;
 
 using Xamarin.Forms.Platform.Tizen.Native;
 
+using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.ItemsView;
+
 namespace Xamarin.Forms.Platform.Tizen
 {
 	public abstract class ItemsViewRenderer<TItemsView, TNative> : ViewRenderer<TItemsView, TNative>
@@ -19,6 +21,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(ItemsView.ItemTemplateProperty, UpdateAdaptor);
 			RegisterPropertyHandler(ItemsView.HorizontalScrollBarVisibilityProperty, UpdateHorizontalScrollBarVisibility);
 			RegisterPropertyHandler(ItemsView.VerticalScrollBarVisibilityProperty, UpdateVerticalScrollBarVisibility);
+			RegisterPropertyHandler(Specific.FocusedItemScrollPositionProperty, UpdateFocusedItemScrollPosition);
 		}
 
 		protected abstract TNative CreateNativeControl(ElmSharp.EvasObject parent);
@@ -175,6 +178,13 @@ namespace Xamarin.Forms.Platform.Tizen
 		protected virtual void UpdateVerticalScrollBarVisibility()
 		{
 			Control.VerticalScrollBarVisiblePolicy = Element.VerticalScrollBarVisibility.ToNative();
+		}
+
+		void UpdateFocusedItemScrollPosition(bool init)
+		{
+			if (init && Specific.GetFocusedItemScrollPosition(Element) == ScrollToPosition.MakeVisible)
+				return;
+			Control.FocusedItemScrollPosition = Specific.GetFocusedItemScrollPosition(Element);
 		}
 	}
 


### PR DESCRIPTION
<!-- WAIT! 

After July 15, 2020, feature related pull requests cannot be guaranteed to merge by Xamarin.Forms 5.0. They will be labeled "maui" for transition to dotnet/maui. See the [transition to .NET MAUI](https://github.com/xamarin/Xamarin.Forms/wiki/Feature-Roadmap#transition-to-net-maui) for more information.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/main/.github/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###
 * This PR optimize `CollectionView` for TV profile
   - ScrollStep of CollectionView was increased to item size, it improve scrolling of items
   - Focused items was raised to the top, it fix focus effect issue on some apps
   - VisibleItemIndex on Scrolled event was not correct with header/footer, it was fixed
   - Add FocusedItemScrollPosition property in ItemsView as TizenSpecific, useful for controlling with focus.

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 Added:
``` c#
public static void Xamarin.Forms.PlatformConfiguration.TizenSpecific.ItemsView.SetFocusedItemScrollPosition(BindableObject element, ScrollToPosition position)
public static ScrollToPosition Xamarin.Forms.PlatformConfiguration.TizenSpecific.ItemsView.GetFocusedItemScrollPosition(BindableObject element)
```

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->
- Tizen

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->
 * FocusedItemScrollPosition
![focusItemPosition](https://user-images.githubusercontent.com/1029155/98492768-3414ce80-227c-11eb-9a6f-fb184ae01d48.gif)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)