### PR TITLE
Check for Internet Connection before running tests that Require an Internet Connection

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -11,6 +11,8 @@ using Xamarin.Forms.Platform.Android;
 using Xamarin.Forms.Platform.Android.AppLinks;
 using System.Linq;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+using System.Net.Http;
 
 namespace Xamarin.Forms.ControlGallery.Android
 {
@@ -114,6 +116,27 @@ namespace Xamarin.Forms.ControlGallery.Android
 		{
 			base.OnResume();
 			Profile.Stop();
+		}
+
+		[Export("hasInternetAccess")]
+		public bool HasInternetAccess()
+		{
+			try
+			{
+				using (var httpClient = new HttpClient())
+				using (var httpResponse = httpClient.GetAsync(@"https://www.github.com"))
+				{
+					httpResponse.Wait();
+					if (httpResponse.Result.StatusCode == System.Net.HttpStatusCode.OK)
+						return true;
+					else
+						return false;
+				}
+			}
+			catch
+			{
+				return false;
+			}
 		}
 
 		[Export("IsPreAppCompat")]

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -59,7 +59,6 @@
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -59,6 +59,7 @@
     <Debugger>Xamarin</Debugger>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
+    <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <Optimize>true</Optimize>

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -410,7 +410,7 @@ namespace Xamarin.Forms.ControlGallery.iOS
 			return App.IOSVersion;
 		}
 
-		[Export("hasInternetAccess:")]
+		[Export("hasInternetAccess")]
 		public bool HasInternetAccess()
 		{
 			try

--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -2,6 +2,8 @@
 using System.Drawing;
 using System.Globalization;
 using System.IO;
+using System.Net.Http;
+using System.Threading.Tasks;
 using CoreGraphics;
 using Foundation;
 using UIKit;
@@ -406,6 +408,27 @@ namespace Xamarin.Forms.ControlGallery.iOS
 		public int iOSVersion()
 		{
 			return App.IOSVersion;
+		}
+
+		[Export("hasInternetAccess:")]
+		public bool HasInternetAccess()
+		{
+			try
+			{
+				using (var httpClient = new HttpClient())
+				using (var httpResponse = httpClient.GetAsync(@"https://www.github.com"))
+				{
+					httpResponse.Wait();
+					if (httpResponse.Result.StatusCode == System.Net.HttpStatusCode.OK)
+						return true;
+					else
+						return false;
+				}
+			}
+			catch
+			{
+				return false;
+			}
 		}
 	}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10744.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10744.cs
@@ -66,6 +66,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 		[Test]
 		[NUnit.Framework.Category(Core.UITests.UITestCategories.UwpIgnore)]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void WebViewEvalCrashesOnAndroidWithLongString()
 		{
 			RunningApp.WaitForElement("navigatedLabel");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12134.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12134.cs
@@ -113,6 +113,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void CookiesCorrectlyLoadWithMultipleWebViews()
 		{
 			for (int i = 0; i < 10; i++)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
@@ -17,6 +17,7 @@ namespace Xamarin.Forms.Controls.Issues
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Image)]
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.ListView)]
+	[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2354, "ListView, ImageCell and disabled source cache and same image url", PlatformAffected.iOS | PlatformAffected.Android)]
@@ -124,7 +125,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void TestDoesntCrashWithCachingDisable()
 		{
 			RunningApp.WaitForElement("ImageLoaded");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2354.cs
@@ -8,12 +8,15 @@ using Xamarin.Forms.Internals;
 #if UITEST
 using NUnit.Framework;
 using Xamarin.UITest;
+using Xamarin.Forms.Core.UITests;
 #endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Image)]
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.ListView)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 2354, "ListView, ImageCell and disabled source cache and same image url", PlatformAffected.iOS | PlatformAffected.Android)]
@@ -22,10 +25,17 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 			var presidents = new List<President>();
-			for (int i = 0; i < 10; i++)
-			{
-				presidents.Add(new President($"Presidente {44 - i}", 1, $"http://static.c-span.org/assets/images/series/americanPresidents/{43 - i}_400.png"));
-			}
+
+			presidents.Add(new President($"Presidente 44", 1, $"https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/Fruits.jpg?raw=true"));
+			presidents.Add(new President($"Presidente 43", 2, $"https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.ControlGallery.Android/Resources/drawable/person.png?raw=true"));
+			presidents.Add(new President($"Presidente 42", 3, $"https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.ControlGallery.Android/Resources/drawable/photo.jpg?raw=true"));
+			presidents.Add(new President($"Presidente 41", 4, $"https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/FlowerBuds.jpg?raw=true"));
+			presidents.Add(new President($"Presidente 40", 5, $"https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/games.png?raw=true"));
+			presidents.Add(new President($"Presidente 39", 6, $"https://github.com/xamarin/Xamarin.Forms/blob/17881ec93d6b3fb0ee5e1a2be46d7eeadef23529/Xamarin.Forms.ControlGallery.Android/Resources/drawable/gear.png?raw=true"));
+			presidents.Add(new President($"Presidente 38", 7, $"https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.ControlGallery.Android/Resources/drawable/xamarinlogo.png?raw=true"));
+			presidents.Add(new President($"Presidente 37", 8, $"https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.ControlGallery.Android/Resources/drawable/xamarinstore.jpg?raw=true"));
+			presidents.Add(new President($"Presidente 36", 9, $"https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.ControlGallery.Android/Resources/drawable/oasis.jpg?raw=true"));
+			presidents.Add(new President($"Presidente 35", 10, $"https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.ControlGallery.Android/Resources/drawable/Vegetables.jpg?raw=true"));
 
 			var header = new Label
 			{
@@ -114,6 +124,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void TestDoesntCrashWithCachingDisable()
 		{
 			RunningApp.WaitForElement("ImageLoaded");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -306,9 +306,9 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.WaitForNoElement(activeTest);
 			}
 
-			if (fileSource && RunningApp.Query(_imageFromUri).Length == 0)
+			if (fileSource && RunningApp.Query(_imageFromFile).Length == 0)
 				RunningApp.Tap(_switchUriId);
-			else if (!fileSource && RunningApp.Query(_imageFromFile).Length == 0)
+			else if (!fileSource && RunningApp.Query(_imageFromUri).Length == 0)
 				RunningApp.Tap(_switchUriId);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -180,6 +180,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ImageFromUriSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(Image), true);
@@ -193,6 +194,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ButtonFromUriSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(Button), true);
@@ -206,6 +208,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ImageButtonFromUriSourceAppearsAndDisappearsCorrectly()
 		{
 			RunTest(nameof(ImageButton), true);
@@ -218,6 +221,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ImageCellFromUriSourceAppearsAndDisappearsCorrectly()
 		{
 			ImageCellTest(false);
@@ -235,6 +239,7 @@ namespace Xamarin.Forms.Controls.Issues
 			SetImageSourceToNull();
 
 			imageVisible = GetImage();
+			Assert.AreEqual(0, imageVisible.Length);
 
 			UITest.Queries.AppResult[] GetImage()
 			{
@@ -300,8 +305,6 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.Tap(_nextTestId);
 				RunningApp.WaitForNoElement(activeTest);
 			}
-
-			var currentSetting = RunningApp.WaitForElement(_switchUriId)[0].ReadText();
 
 			if (fileSource && RunningApp.Query(_imageFromUri).Length == 0)
 				RunningApp.Tap(_switchUriId);

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9682.xaml.cs
@@ -40,6 +40,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test, NUnit.Framework.Category(UITestCategories.Image)]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void MonkiesShouldLoad()
 		{
 			RunningApp.WaitForElement("MonkeyLoadButton");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -476,6 +476,18 @@ namespace Xamarin.Forms.Controls
 		public void TestSetup(Type testType, bool isolate)
 		{
 
+			if (TestContext.CurrentContext.Test.Properties["Category"].Contains(UITestCategories.RequiresInternetConnection))
+			{
+				var hasInternetAccess = $"{_app.Invoke("hasInternetAccess")}";
+				bool checkInternet;
+
+				if (bool.TryParse(hasInternetAccess, out checkInternet))
+				{
+					if (!checkInternet)
+						Assert.Inconclusive("Device Has No Internet Connection");
+				}
+			}
+
 #if __WINDOWS__
 			RestartIfAppIsClosed();
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/ScreenshotConditionalApp.cs
@@ -473,10 +473,27 @@ namespace Xamarin.Forms.Controls
 		}
 #endif
 
+		string[] GetTestCategories()
+		{
+			var testClassName = TestContext.CurrentContext.Test.ClassName;
+
+			// TestContext.CurrentContext.Test.Properties["Category"]
+			// Only gives you the categories on the test itself
+			// There isn't a property I could find that gives you the Categories
+			// on the Test Class
+			return GetType()
+						.Assembly
+						.GetType(testClassName)
+						.GetCustomAttributes(typeof(NUnit.Framework.CategoryAttribute), true)
+						.OfType<NUnit.Framework.CategoryAttribute>()
+						.Select(x => x.Name)
+						.Union(TestContext.CurrentContext.Test.Properties["Category"].OfType<string>())
+						.ToArray();
+		}
+
 		public void TestSetup(Type testType, bool isolate)
 		{
-
-			if (TestContext.CurrentContext.Test.Properties["Category"].Contains(UITestCategories.RequiresInternetConnection))
+			if (GetTestCategories().Contains(UITestCategories.RequiresInternetConnection))
 			{
 				var hasInternetAccess = $"{_app.Invoke("hasInternetAccess")}";
 				bool checkInternet;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Xamarin.Forms.CustomAttributes;
 using IOPath = System.IO.Path;
+using System.Linq;
 using NUnit.Framework.Interfaces;
 using Xamarin.Forms.Controls.Issues;
 
@@ -414,6 +415,18 @@ namespace Xamarin.Forms.Controls
 		public void Setup()
 		{
 			(RunningApp as ScreenshotConditionalApp).TestSetup(GetType(), Isolate);
+
+			if(TestContext.CurrentContext.Test.Properties["Category"].Contains(UITestCategories.RequiresInternetConnection))
+			{
+				var hasInternetAccess = $"{RunningApp.Invoke("hasInternetAccess")}";
+				bool checkInternet;
+
+				if(bool.TryParse(hasInternetAccess, out checkInternet))
+				{
+					if (!checkInternet)
+						Assert.Inconclusive("Device Has No Internet Connection");
+				}
+			}
 		}
 
 		[TearDown]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -415,18 +415,6 @@ namespace Xamarin.Forms.Controls
 		public void Setup()
 		{
 			(RunningApp as ScreenshotConditionalApp).TestSetup(GetType(), Isolate);
-
-			if(TestContext.CurrentContext.Test.Properties["Category"].Contains(UITestCategories.RequiresInternetConnection))
-			{
-				var hasInternetAccess = $"{RunningApp.Invoke("hasInternetAccess")}";
-				bool checkInternet;
-
-				if(bool.TryParse(hasInternetAccess, out checkInternet))
-				{
-					if (!checkInternet)
-						Assert.Inconclusive("Device Has No Internet Connection");
-				}
-			}
 		}
 
 		[TearDown]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/issue3262.cs
@@ -15,7 +15,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	[Category(UITestCategories.ManualReview)]
+	[Category(UITestCategories.WebView)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 3262, "Adding Cookies ability to a WebView...")]
@@ -300,6 +300,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void LoadingPageWithoutCookiesSpecifiedDoesntCrash()
 		{
 			RunningApp.Tap("PageWithoutCookies");
@@ -307,6 +308,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ChangeDuringNavigating()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -318,6 +320,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void AddAdditionalCookieToWebView()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -329,6 +332,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void SetToOneCookie()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -337,6 +341,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void SetCookieContainerToNullDisablesCookieManagement()
 		{
 			RunningApp.WaitForElement("Loaded");
@@ -348,6 +353,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void RemoveAllTheCookiesIAdded()
 		{
 			RunningApp.WaitForElement("Loaded");

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/Legacy-CellsUITests.cs
@@ -140,6 +140,7 @@ namespace Xamarin.Forms.Core.UITests
 		[Description("ListView with ImageCells, file access problems")]
 		[UiTest(typeof(ListView))]
 		[UiTest(typeof(ImageCell))]
+		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public async Task CellsGalleryImageUrlCellList()
 		{
 			SelectTest("ImageCell Url List");

--- a/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/UITestCategories.cs
@@ -30,6 +30,7 @@
 		public const string MasterDetailPage = "MasterDetailPage";
 		public const string Picker = "Picker";
 		public const string ProgressBar = "ProgressBar";
+		public const string RequiresInternetConnection = "RequiresInternetConnection";
 		public const string RootGallery = "RootGallery";
 		public const string ScrollView = "ScrollView";
 		public const string SearchBar = "SearchBar";

--- a/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
+++ b/Xamarin.Forms.Core.Windows.UITests/WinDriverApp.cs
@@ -203,6 +203,26 @@ namespace Xamarin.Forms.Core.UITests
 				ContextClick(arguments[0].ToString());
 				return null;
 			}
+			
+			if(methodName == "hasInternetAccess")
+			{
+				try
+				{
+					using (var httpClient = new System.Net.Http.HttpClient())
+					using (var httpResponse = httpClient.GetAsync(@"https://www.github.com"))
+					{
+						httpResponse.Wait();
+						if (httpResponse.Result.StatusCode == System.Net.HttpStatusCode.OK)
+							return true;
+						else
+							return false;
+					}
+				}
+				catch
+				{
+					return false;
+				}
+			}
 
 			return null;
 		}


### PR DESCRIPTION
### Description of Change ###

- Categorize tests that require internet access that are currently failing on App Center
- Before these tests run verify if the device has a valid internet connection. If it doesn't then just mark the test as Inconclusive
- For the most part tests inside of AppCenter run without issue but the internet connection on the device seems to fail enough that we need to detect for this and not fail the whole group but just mark a given set inconclusive

### Platforms Affected ### 
- iOS
- Android
- UWP

### Testing Procedure ###
- Make sure UI tests all pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
