### PR TITLE
[Tizen] Allow Tap gesture using remote control on TV

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
+++ b/Xamarin.Forms.Platform.Tizen/GestureDetector.cs
@@ -65,6 +65,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				}
 			}
 			_handlerCache.Clear();
+
+			if (Device.Idiom == TargetIdiom.TV)
+			{
+				_renderer.NativeView.KeyDown -= OnKeyDown;
+			}
 		}
 
 		public void AddGestures(IEnumerable<IGestureRecognizer> recognizers)
@@ -94,6 +99,11 @@ namespace Xamarin.Forms.Platform.Tizen
 				Clear();
 			};
 			UpdateGestureLayerEnabled();
+
+			if (Device.Idiom == TargetIdiom.TV)
+			{
+				_renderer.NativeView.KeyDown += OnKeyDown;
+			}
 		}
 
 		void UpdateGestureLayerEnabled()
@@ -547,6 +557,22 @@ namespace Xamarin.Forms.Platform.Tizen
 
 					default:
 						break;
+				}
+			}
+		}
+
+		void OnKeyDown(object sender, EvasKeyEventArgs e)
+		{
+			if (e.KeyName == "Return" && _gestureLayer.IsEnabled)
+			{
+				var cache = _handlerCache;
+				if (cache.ContainsKey(EGestureType.Tap))
+				{
+					foreach (var handler in cache[EGestureType.Tap])
+					{
+						(handler as IGestureController)?.SendStarted(View, null);
+						(handler as IGestureController)?.SendCompleted(View, null);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###
In modern Xamarin.Forms mobile app development, `TapGestures` are used very frequently. However, `Tapped` event couldn't be used in non-touch-based products such as TV.
This PR allows the `TapGestureRecognizer.Tapped` event to be activated even through the remote control keystroke (e.g.,`OK` or `Enter` Key) on the TV devices.

![TapOnTV](https://user-images.githubusercontent.com/1029134/98617342-2a559e80-2342-11eb-857e-b819269cf94e.gif)

### Issues Resolved ### 
- None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
`Tapped` event occurs through not only touch gesture, but also through remote controller on the TV devices.(`TargetIdiom.TV`)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
