### PR TITLE
Fix multiple events on toolbar items

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7181.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue7181.cs
@@ -31,9 +31,11 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			var page = CreateContentPage("Test page");
 
-			_toolbarItem = new ToolbarItem(DefaultToolbarItemText, string.Empty, OnToolbarClicked)
+			_toolbarItem = new ToolbarItem()
 			{
-				AutomationId = ToolbarBtn
+				Text = DefaultToolbarItemText,
+				AutomationId = ToolbarBtn,
+				Command = new Command(OnToolbarClicked)
 			};
 
 			page.ToolbarItems.Add(_toolbarItem);
@@ -58,20 +60,20 @@ namespace Xamarin.Forms.Controls.Issues
 		private void OnToolbarClicked() =>
 			_toolbarItem.Text = $"{AfterClickToolbarItemText} {_clicks++}";
 
-#if UITEST && __ANDROID__
+#if UITEST && (__ANDROID__ || __WINDOWS__)
 		[Test]
 		public void ShellToolbarItemTests()
 		{
 			var count = 0;
 			var toolbarButton = RunningApp.WaitForElement(ToolbarBtn);
-			Assert.AreEqual(toolbarButton[0].Text, DefaultToolbarItemText);
+			Assert.AreEqual(DefaultToolbarItemText, toolbarButton[0].ReadText());
 
 			for (int i = 0; i < 5; i++)
 			{
 				RunningApp.Tap(ToolbarBtn);
 
 				toolbarButton = RunningApp.WaitForElement(ToolbarBtn);
-				Assert.AreEqual($"{AfterClickToolbarItemText} {count++}", toolbarButton[0].Text);
+				Assert.AreEqual($"{AfterClickToolbarItemText} {count++}", toolbarButton[0].ReadText());
 			}
 
 			RunningApp.Tap(SetToolbarIconBtn);

--- a/Xamarin.Forms.Platform.UAP/AccessibilityExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/AccessibilityExtensions.cs
@@ -123,5 +123,16 @@ namespace Xamarin.Forms.Platform.UWP
 
 		}
 
+		internal static void SetAutomationProperties(
+			this FrameworkElement frameworkElement, 
+			Element element,
+			string defaultName = null)
+		{
+			frameworkElement.SetAutomationPropertiesAutomationId(element?.AutomationId);
+			 frameworkElement.SetAutomationPropertiesName(element, defaultName);
+			frameworkElement.SetAutomationPropertiesHelpText(element);
+			frameworkElement.SetAutomationPropertiesLabeledBy(element);
+			frameworkElement.SetAutomationPropertiesAccessibilityView(element);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
@@ -28,8 +28,7 @@
         <StackPanel Orientation="Horizontal" />
     </ItemsPanelTemplate>
     <DataTemplate x:Key="ShellToolbarItemTemplate">
-        <xf:ShellToolbarItemRenderer ToolbarItem="{Binding}" Margin="0" Background="Transparent" BorderThickness="1"
-                      IsEnabled="{Binding IsEnabled}" Command="{Binding Command}" CommandParameter="{Binding CommandParameter}">
+        <xf:ShellToolbarItemRenderer  ToolbarItem="{Binding}" Margin="0" Background="Transparent" BorderThickness="1" IsEnabled="{Binding IsEnabled}">
             <Grid>
                 <Grid.ColumnDefinitions>
                     <ColumnDefinition Width="Auto"></ColumnDefinition>

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellToolbarItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellToolbarItemRenderer.cs
@@ -10,6 +10,16 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public class ShellToolbarItemRenderer : Windows.UI.Xaml.Controls.Button
 	{
+
+		public static readonly DependencyProperty ToolbarItemProperty =
+			DependencyProperty.Register("ToolbarItem", typeof(ToolbarItem), typeof(ShellToolbarItemRenderer), new PropertyMetadata(null, OnToolbarItemChanged));
+
+		static void OnToolbarItemChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)
+		{
+			((ShellToolbarItemRenderer)d)
+				.ToolbarItemChanged(e.OldValue as ToolbarItem, e.NewValue as ToolbarItem);
+		}
+
 		public ShellToolbarItemRenderer()
 		{
 			Xamarin.Forms.Shell.VerifyShellUWPFlagEnabled(nameof(ShellToolbarItemRenderer));
@@ -28,7 +38,20 @@ namespace Xamarin.Forms.Platform.UWP
 			set { SetValue(ToolbarItemProperty, value); }
 		}
 
-		public static readonly DependencyProperty ToolbarItemProperty =
-			DependencyProperty.Register("ToolbarItem", typeof(ToolbarItem), typeof(ShellToolbarItemRenderer), new PropertyMetadata(null));
+		void ToolbarItemChanged(ToolbarItem oldItem, ToolbarItem newItem)
+		{
+			if(oldItem != null)
+				oldItem.PropertyChanged -= ToolbarItemPropertyChanged;
+
+			this.SetAutomationProperties(newItem, defaultName: newItem?.Text);
+
+			if (newItem != null)
+				newItem.PropertyChanged += ToolbarItemPropertyChanged;
+
+			void ToolbarItemPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
+			{
+				this.SetAutomationProperties(newItem, defaultName: newItem?.Text);
+			}
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Toolbar Items in UWP shell are bound to the commands and firing the click events from code behind which is causing the Command bound to ToolbarItem to fire multiple times. This PR removes the command binding since the Click event in the code behind handles the firing of the Command.

### Platforms Affected ### 
- UWP

### Testing Procedure ###
- UI Tests included
- This was originally found on the Shell templates for Visual Studio. When clicking "Add new item" two pages were being pushed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
