### PR TITLE
Add GetThreadId extension method for IDispatcher

### DIFF
--- a/Xamarin.Forms.Core/DispatcherExtensions.cs
+++ b/Xamarin.Forms.Core/DispatcherExtensions.cs
@@ -1,8 +1,11 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+using System.Threading;
+using System.Threading.Tasks;
 
 namespace Xamarin.Forms
 {
-	internal static class DispatcherExtensions
+	public static class DispatcherExtensions
 	{
 		static IDispatcherProvider s_current;
 		static IDispatcher s_default;
@@ -29,7 +32,7 @@ namespace Xamarin.Forms
 			return s_current.GetDispatcher(bindableObject) ?? new FallbackDispatcher();
 		}
 
-		public static void Dispatch(this IDispatcher dispatcher, Action action)
+		internal static void Dispatch(this IDispatcher dispatcher, Action action)
 		{
 			if (dispatcher != null)
 			{
@@ -53,6 +56,57 @@ namespace Xamarin.Forms
 					action();
 				}
 			}
+		}
+
+		internal static Task<int> GetThreadIdAsync(this IDispatcher dispatcher)
+		{
+			var tcs = new TaskCompletionSource<int>();
+
+			if (!dispatcher.IsInvokeRequired)
+			{
+#if NETSTANDARD2_0
+				tcs.SetResult(Thread.CurrentThread.ManagedThreadId);
+#else
+				tcs.SetResult(0);
+#endif
+				return tcs.Task;
+			}
+
+			dispatcher.BeginInvokeOnMainThread(() =>
+			{
+				try
+				{
+
+#if NETSTANDARD2_0
+					tcs.SetResult(Thread.CurrentThread.ManagedThreadId);
+#else
+					tcs.SetResult(0);
+#endif
+				}
+				catch (Exception ex)
+				{
+					tcs.SetException(ex);
+				}
+			});
+
+			return tcs.Task;
+		}
+
+		static ConditionalWeakTable<IDispatcher, object> ThreadIds = new ConditionalWeakTable<IDispatcher, object>();
+
+		public static int GetThreadId(this IDispatcher dispatcher)
+		{
+			if (ThreadIds.TryGetValue(dispatcher, out object threadId))
+			{
+				return (int)threadId;
+			}
+
+			var t = dispatcher.GetThreadIdAsync();
+			var result = t.ConfigureAwait(false).GetAwaiter().GetResult();
+
+			ThreadIds.Add(dispatcher, result);
+
+			return result;
 		}
 	}
 

--- a/Xamarin.Forms.Platform.Android.UnitTests/DispatcherTests.cs
+++ b/Xamarin.Forms.Platform.Android.UnitTests/DispatcherTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.Android.UnitTests
+{
+	[TestFixture]
+	public class DispatcherTests : PlatformTestFixture
+	{
+		[Test]
+		[Description("Can retrieve the thread ID of an IDispatcher")]
+		public async Task CanGetDispatcherThreadId()
+		{
+			var label = new Label { Text = "foo" };
+
+			await Device.InvokeOnMainThreadAsync(() => {
+				GetRenderer(label);
+			});
+
+			Assert.That(label.Dispatcher.GetThreadId(), Is.GreaterThan(0));
+		}
+
+		[Test]
+		[Description("Dispatcher thread Ids match")]
+		public async Task DispatcherThreadIdsMatch()
+		{
+			var label = new Label { Text = "foo" };
+
+			var a = label.Dispatcher;
+
+			Assert.That(a.GetThreadId(), Is.GreaterThan(0));
+
+			await Device.InvokeOnMainThreadAsync(() => {
+				GetRenderer(label);
+			});
+
+			var b = label.Dispatcher;
+
+			Assert.That(b.GetThreadId(), Is.GreaterThan(0));
+
+			Assert.That(a.GetThreadId(), Is.EqualTo(b.GetThreadId()));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="BackgroundColorTests.cs" />
     <Compile Include="CollectionViewTests.cs" />
     <Compile Include="CornerRadiusTests.cs" />
+    <Compile Include="DispatcherTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="IsEnabledTests.cs" />
     <Compile Include="Issues.cs" />

--- a/Xamarin.Forms.Platform.UAP.UnitTests/DispatcherTests.cs
+++ b/Xamarin.Forms.Platform.UAP.UnitTests/DispatcherTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.UAP.UnitTests
+{
+	[TestFixture]
+	public class DispatcherTests : PlatformTestFixture
+	{
+		[Test]
+		[Description("Can retrieve the thread ID of an IDispatcher")]
+		public async Task CanGetDispatcherThreadId()
+		{
+			var label = new Label { Text = "foo" };
+
+			await Device.InvokeOnMainThreadAsync(() => {
+				GetRenderer(label);
+			});
+
+			Assert.That(label.Dispatcher.GetThreadId(), Is.GreaterThan(0));
+		}
+
+		[Test]
+		[Description("Dispatcher thread Ids match")]
+		public async Task DispatcherThreadIdsMatch()
+		{
+			var label = new Label { Text = "foo" };
+
+			var a = label.Dispatcher;
+
+			Assert.That(a.GetThreadId(), Is.GreaterThan(0));
+
+			await Device.InvokeOnMainThreadAsync(() => {
+				GetRenderer(label);
+			});
+
+			var b = label.Dispatcher;
+
+			Assert.That(b.GetThreadId(), Is.GreaterThan(0));
+
+			Assert.That(a.GetThreadId(), Is.EqualTo(b.GetThreadId()));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP.UnitTests/Xamarin.Forms.Platform.UAP.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.UAP.UnitTests/Xamarin.Forms.Platform.UAP.UnitTests.csproj
@@ -122,6 +122,7 @@
   <ItemGroup>
     <Compile Include="BackgroundColorTests.cs" />
     <Compile Include="ColorTests.cs" />
+    <Compile Include="DispatcherTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="IsEnabledTests.cs" />

--- a/Xamarin.Forms.Platform.UAP/Dispatcher.cs
+++ b/Xamarin.Forms.Platform.UAP/Dispatcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Windows.ApplicationModel.Core;
 using Windows.UI.Core;
 using Xamarin.Forms;
@@ -25,6 +26,6 @@ namespace Xamarin.Forms.Platform.UWP
 			_coreDispatcher = coreDispatcher;
 		}
 
-		bool IDispatcher.IsInvokeRequired => Device.IsInvokeRequired;
+		bool IDispatcher.IsInvokeRequired => !_coreDispatcher.HasThreadAccess;
 	}
 }

--- a/Xamarin.Forms.Platform.iOS.UnitTests/DispatcherTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/DispatcherTests.cs
@@ -1,0 +1,43 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture]
+	public class DispatcherTests : PlatformTestFixture
+	{
+		[Test]
+		[Description("Can retrieve the thread ID of an IDispatcher")]
+		public async Task CanGetDispatcherThreadId()
+		{
+			var label = new Label { Text = "foo" };
+
+			await Device.InvokeOnMainThreadAsync(() => {
+				GetRenderer(label);
+			});
+
+			Assert.That(label.Dispatcher.GetThreadId(), Is.GreaterThan(0));
+		}
+
+		[Test]
+		[Description("Dispatcher thread Ids match")]
+		public async Task DispatcherThreadIdsMatch()
+		{
+			var label = new Label { Text = "foo" };
+
+			var a = label.Dispatcher;
+
+			Assert.That(a.GetThreadId(), Is.GreaterThan(0));
+
+			await Device.InvokeOnMainThreadAsync(() => {
+				GetRenderer(label);
+			});
+
+			var b = label.Dispatcher;
+
+			Assert.That(b.GetThreadId(), Is.GreaterThan(0));
+
+			Assert.That(a.GetThreadId(), Is.EqualTo(b.GetThreadId()));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="BackgroundColorTests.cs" />
     <Compile Include="ColorComparison.cs" />
     <Compile Include="CornerRadiusTests.cs" />
+    <Compile Include="DispatcherTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="FrameTests.cs" />


### PR DESCRIPTION
### Description of Change ###

Adds GetThreadId extension method for IDispatcher objects.

### Issues Resolved ### 

- fixes #12729

### API Changes ###

Added:
 - int DispatcherExtensions.GetThreadId(this IDispatcher dispatcher);

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated platform tests

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
