### PR TITLE
Only build one UWP target when using IDE

### DIFF
--- a/UWP.Build.props
+++ b/UWP.Build.props
@@ -3,8 +3,8 @@
     <TargetFrameworks>$(UwpMinTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UwpMinTargetFrameworks)' == '' ">
-    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
-    <!--<TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299;uap10.0.18362</TargetFrameworks>-->
+    <TargetFrameworks Condition=" '$(BuildingInsideVisualStudio)' == 'true' AND '$(OS)' == 'Windows_NT' ">uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(BuildingInsideVisualStudio)' != 'true' AND '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>


### PR DESCRIPTION
### Description of Change ###

Visual Studio 16.8 doesn't seem to like having a multi targeted UWP project as much as 16.7 did. This change makes it so both UWP targets are only built when building from the command line and just builds the 16299 target when building in the IDE

### Testing Procedure ###
- Make sure the produced nuget still has both of the UWP targets

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
