### PR TITLE
Handle selected background color updates after cell is added as child of CollectionView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SelectionGalleries/SingleBoundSelection.xaml
@@ -4,50 +4,40 @@
 	xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
 	x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.SelectionGalleries.SingleBoundSelection">
 
-	<ContentPage.Content>
-		<StackLayout
+    <ContentPage.Content>
+        <StackLayout
 			Spacing="5">
 
-			<Label
+            <Label
 				Text="The selected item in the CollectionView should match the 'Selected' Label below. If it does not, this test has failed."
 				VerticalOptions="CenterAndExpand"
 				HorizontalOptions="CenterAndExpand" />
 
-			<Label
+            <Label
 				Text="{Binding SelectedItem, StringFormat='{}Selected: {0}'}"
 				VerticalOptions="CenterAndExpand"
 				HorizontalOptions="CenterAndExpand" />
 
-			<Button
+            <Button
 				AutomationId="Reset"
 				Text="Reset Selection to Item 0"
 				Clicked="ResetClicked" />
 
-			<Button
+            <Button
 				AutomationId="Clear"
 				Text="Clear Selection"
 				Clicked="ClearClicked" />
 
-			<CollectionView
+            <CollectionView
 				ItemsSource="{Binding Items}"
 				SelectionMode="Single"
 				SelectedItem="{Binding SelectedItem}">
-				<CollectionView.ItemTemplate>
-					<DataTemplate>
-						<Frame
-							HasShadow="False"
-							Margin="10"
-							BackgroundColor="LightBlue"
-							CornerRadius="20">
-							<StackLayout>
-								<Image
-									Source="{Binding Image}"
-									HeightRequest="50" />
-								<Label
-									Text="{Binding Caption}"></Label>
-							</StackLayout>
 
-							<VisualStateManager.VisualStateGroups>
+                <CollectionView.Resources>
+                    <ResourceDictionary>
+                        <Style TargetType="Frame">
+                            <Setter Property="VisualStateManager.VisualStateGroups">
+
 								<VisualStateGroupList>
 									<VisualStateGroup x:Name="CommonStates">
 										<VisualState x:Name="Normal" />
@@ -63,13 +53,51 @@
 										</VisualState>
 									</VisualStateGroup>
 								</VisualStateGroupList>
-							</VisualStateManager.VisualStateGroups>
 
-						</Frame>
-					</DataTemplate>
-				</CollectionView.ItemTemplate>
-			</CollectionView>
+                            </Setter>
+                        </Style>
+                    </ResourceDictionary>
 
-		</StackLayout>
-	</ContentPage.Content>
+                </CollectionView.Resources>
+
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Frame
+							HasShadow="False"
+							Margin="10"
+							BackgroundColor="LightBlue"
+							CornerRadius="20">
+                            <StackLayout>
+                                <Image
+									Source="{Binding Image}"
+									HeightRequest="50" />
+                                <Label
+									Text="{Binding Caption}"></Label>
+                            </StackLayout>
+
+                            <!--<VisualStateManager.VisualStateGroups>
+								<VisualStateGroupList>
+									<VisualStateGroup x:Name="CommonStates">
+										<VisualState x:Name="Normal" />
+										<VisualState x:Name="Selected">
+											<VisualState.Setters>
+												<Setter
+													Property="BackgroundColor"
+													Value="RoyalBlue" />
+												<Setter
+													Property="Scale"
+													Value="0.9" />
+											</VisualState.Setters>
+										</VisualState>
+									</VisualStateGroup>
+								</VisualStateGroupList>
+							</VisualStateManager.VisualStateGroups>-->
+
+                        </Frame>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+
+        </StackLayout>
+    </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -90,17 +90,6 @@ namespace Xamarin.Forms.Platform.iOS
 				// Create the content and renderer for the view 
 				var view = itemTemplate.CreateContent() as View;
 
-				// Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
-				// First we check whether the cell has the default selected background color; if it does, then we should check
-				// to see if the cell content is the VSM to set a selected color 
-				if (SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray && IsUsingVSMForSelectionColor(view))
-				{
-					SelectedBackgroundView = new UIView
-					{
-						BackgroundColor = UIColor.Clear
-					};
-				}
-
 				// Set the binding context _before_ we create the renderer; that way, it's available during OnElementChanged
 				view.BindingContext = bindingContext;
 
@@ -112,6 +101,17 @@ namespace Xamarin.Forms.Platform.iOS
 				// if we do it before, the element briefly inherits the ItemsView's bindingcontext and we 
 				// emit a bunch of needless binding errors
 				itemsView.AddLogicalChild(view);
+
+				// Prevents the use of default color when there are VisualStateManager with Selected state setting the background color
+				// First we check whether the cell has the default selected background color; if it does, then we should check
+				// to see if the cell content is the VSM to set a selected color 
+				if (SelectedBackgroundView.BackgroundColor == ColorExtensions.Gray && IsUsingVSMForSelectionColor(view))
+				{
+					SelectedBackgroundView = new UIView
+					{
+						BackgroundColor = UIColor.Clear
+					};
+				}
 			}
 			else
 			{


### PR DESCRIPTION
### Description of Change ###

#12561 fixed selected item background colors when the selected background is set by the VisualStateManager for most cases. However, if the visual state information is provided as a resource on the CollectionView itself, that information does not propagate to the cells on iOS until the cells are added as logical children of the CollectionView. This results in a situation where background color is decided too early, and the default native selection color remains. 

This change moves that decision after the cell has been added as a logical child; that way, the cell has enough VSM information to correctly make the background color decision.

### Issues Resolved ### 

- fixes #9282

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery -> Selection Gallery -> Single Selection Bound

The selected item background should not be the default Gray.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
