### PR TITLE
Build 14393 targets separately

### DIFF
--- a/UWP.Build.props
+++ b/UWP.Build.props
@@ -3,8 +3,7 @@
     <TargetFrameworks>$(UwpMinTargetFrameworks)</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(UwpMinTargetFrameworks)' == '' ">
-    <TargetFrameworks Condition=" '$(BuildingInsideVisualStudio)' == 'true' AND '$(OS)' == 'Windows_NT' ">uap10.0.16299</TargetFrameworks>
-    <TargetFrameworks Condition=" '$(BuildingInsideVisualStudio)' != 'true' AND '$(OS)' == 'Windows_NT' ">uap10.0.14393;uap10.0.16299</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' == 'Windows_NT' ">uap10.0.16299</TargetFrameworks>
     <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netstandard2.0</TargetFrameworks>
   </PropertyGroup>
   <PropertyGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4597.cs
@@ -1,11 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 using System.Text;
+using System.Threading;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-using System.Linq;
-using System.Threading;
 
 #if UITEST
 using Xamarin.UITest;
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 				IsToggled = false,
 				HeightRequest = 60
 			};
-			var sourceLabel = new Label { Text = _imageFromFile };
+			var sourceLabel = new Label { Text = _imageFromFile, AutomationId = "SourceLabel" };
 
 			switchToUri.Toggled += (_, e) =>
 			{
@@ -176,42 +176,42 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void ImageFromFileSourceAppearsAndDisappearsCorrectly()
 		{
-			RunTest(nameof(Image), false);
+			RunTest(nameof(Image), true);
 		}
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ImageFromUriSourceAppearsAndDisappearsCorrectly()
 		{
-			RunTest(nameof(Image), true);
+			RunTest(nameof(Image), false);
 		}
 
 
 		[Test]
 		public void ButtonFromFileSourceAppearsAndDisappearsCorrectly()
 		{
-			RunTest(nameof(Button), false);
+			RunTest(nameof(Button), true);
 		}
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ButtonFromUriSourceAppearsAndDisappearsCorrectly()
 		{
-			RunTest(nameof(Button), true);
+			RunTest(nameof(Button), false);
 		}
 
 
 		[Test]
 		public void ImageButtonFromFileSourceAppearsAndDisappearsCorrectly()
 		{
-			RunTest(nameof(ImageButton), false);
+			RunTest(nameof(ImageButton), true);
 		}
 
 		[Test]
 		[NUnit.Framework.Category(UITestCategories.RequiresInternetConnection)]
 		public void ImageButtonFromUriSourceAppearsAndDisappearsCorrectly()
 		{
-			RunTest(nameof(ImageButton), true);
+			RunTest(nameof(ImageButton), false);
 		}
 
 		[Test]
@@ -306,9 +306,10 @@ namespace Xamarin.Forms.Controls.Issues
 				RunningApp.WaitForNoElement(activeTest);
 			}
 
-			if (fileSource && RunningApp.Query(_imageFromFile).Length == 0)
+			string sourceLabel = RunningApp.WaitForFirstElement("SourceLabel").ReadText();
+			if (fileSource && sourceLabel != _imageFromFile)
 				RunningApp.Tap(_switchUriId);
-			else if (!fileSource && RunningApp.Query(_imageFromUri).Length == 0)
+			else if (!fileSource && sourceLabel != _imageFromUri)
 				RunningApp.Tap(_switchUriId);
 		}
 #endif

--- a/build.cake
+++ b/build.cake
@@ -808,7 +808,7 @@ Task("BuildForNuget")
 
         msbuildSettings = GetMSBuildSettings();
         msbuildSettings.BinaryLogger = binaryLogger;
-        binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}-csproj.binlog";
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-16299-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
                     msbuildSettings
                         .WithRestore()
@@ -819,7 +819,7 @@ Task("BuildForNuget")
 
         msbuildSettings = GetMSBuildSettings();
         msbuildSettings.BinaryLogger = binaryLogger;
-        binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}-csproj.binlog";
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-14393-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
                     msbuildSettings
                         .WithRestore()

--- a/build.cake
+++ b/build.cake
@@ -800,12 +800,22 @@ Task("BuildForNuget")
 
         msbuildSettings = GetMSBuildSettings();
         msbuildSettings.BinaryLogger = binaryLogger;
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-maps-{configuration}-csproj.binlog";
+        MSBuild("./Xamarin.Forms.Maps.UWP/Xamarin.Forms.Maps.UWP.csproj",
+                    msbuildSettings
+                        .WithProperty("UwpMinTargetFrameworks", "uap10.0.14393")
+                        .WithRestore());
+
+        msbuildSettings = GetMSBuildSettings();
+        msbuildSettings.BinaryLogger = binaryLogger;
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}-csproj.binlog";
         MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
                     msbuildSettings
+                        .WithRestore()
                         .WithTarget("rebuild")
                         .WithProperty("DisableEmbeddedXbf", "false")
-                        .WithProperty("EnableTypeInfoReflection", "false"));
+                        .WithProperty("EnableTypeInfoReflection", "false")
+                        .WithProperty("UwpMinTargetFrameworks", "uap10.0.14393;uap10.0.16299"));
 
         msbuildSettings = GetMSBuildSettings();
         msbuildSettings.BinaryLogger = binaryLogger;

--- a/build.cake
+++ b/build.cake
@@ -815,7 +815,18 @@ Task("BuildForNuget")
                         .WithTarget("rebuild")
                         .WithProperty("DisableEmbeddedXbf", "false")
                         .WithProperty("EnableTypeInfoReflection", "false")
-                        .WithProperty("UwpMinTargetFrameworks", "uap10.0.14393;uap10.0.16299"));
+                        .WithProperty("UwpMinTargetFrameworks", "uap10.0.16299"));
+
+        msbuildSettings = GetMSBuildSettings();
+        msbuildSettings.BinaryLogger = binaryLogger;
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}-csproj.binlog";
+        MSBuild("./Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj",
+                    msbuildSettings
+                        .WithRestore()
+                        .WithTarget("rebuild")
+                        .WithProperty("DisableEmbeddedXbf", "false")
+                        .WithProperty("EnableTypeInfoReflection", "false")
+                        .WithProperty("UwpMinTargetFrameworks", "uap10.0.14393"));
 
         msbuildSettings = GetMSBuildSettings();
         msbuildSettings.BinaryLogger = binaryLogger;


### PR DESCRIPTION
### Description of Change ###

This completely removes the 14393 targets from our csproj files and only builds them as part of our nuget build process. The command line build was also having the same issue building 14393 together with 16299 so this PR just removes the multi targeting completely

### Platforms Affected ### 
- UWP

### Testing Procedure ###
- Run the build.cmd and ensure that it builds all the nugets

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
