### PR TITLE
[iOS] Fixed flickering NavBar color issue on iOS 13 or higher

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -669,19 +669,17 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				var navigationBarAppearance = NavigationBar.StandardAppearance;
 
+				navigationBarAppearance.ConfigureWithOpaqueBackground();
+
 				if (barBackgroundColor == Color.Default)
 				{
-					navigationBarAppearance.ConfigureWithDefaultBackground();
-					navigationBarAppearance.BackgroundColor = null;
+					navigationBarAppearance.BackgroundColor = ColorExtensions.BackgroundColor;
 
 					var parentingViewController = GetParentingViewController();
 					parentingViewController?.SetupDefaultNavigationBarAppearance();
 				}
 				else
-				{
-					navigationBarAppearance.ConfigureWithOpaqueBackground();
 					navigationBarAppearance.BackgroundColor = barBackgroundColor.ToUIColor();
-				}
 
 				var barBackgroundBrush = NavPage.BarBackground;
 				var backgroundImage = NavigationBar.GetBackgroundImage(barBackgroundBrush);


### PR DESCRIPTION
### Description of Change ###

 Fixed flickering NavBar color issue on iOS 13 or higher. 

In iOS 13 important changes were introduced in the management of the `UINavigationBar` (appareaances, etc).

The behavior in iOS 12 in different versions of Xamarin.Forms 4.x and 5.0 is as follows:

![navbar-ios12](https://user-images.githubusercontent.com/6755973/99068738-5cb70400-25ad-11eb-8546-13dca8e0e4a4.gif)

Using  iOS 13, without setting `BarBackgroundColor`, the default color changed from white (or black in DarkTheme) to gray (`ConfigureWithDefaultBackground`) and the problem was the noticeable flickering when navigating:

![](https://user-images.githubusercontent.com/904737/76489403-5dc2ef00-647c-11ea-964f-e88b98c50208.gif)

This PR include changes to apply in iOS 13 or higher the same behavior we have in iOS 12:

![navbar-ios13-light](https://user-images.githubusercontent.com/6755973/99069034-dea72d00-25ad-11eb-826a-719230937439.gif)
![ios13-dark](https://user-images.githubusercontent.com/6755973/99069036-df3fc380-25ad-11eb-8c3e-d2991cf4aaf6.gif)

### Issues Resolved ### 

- fixes #9943 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery, and navigate anywhere. Pay attention to the navigation bar, for a very brief moment the background flicker.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
