### PR TITLE
[iOS] Fix when removing current last Item on CarouselView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms.Controls.Issues
 			Grid.SetRow(btn, 1);
 			Grid.SetColumn(btn, 0);
 
-			btnAdd.Clicked += OnAddlicked;
+			btnAdd.Clicked += OnAddClicked;
 			Grid.SetRow(btnAdd, 1);
 			Grid.SetColumn(btnAdd, 1);
 
@@ -139,7 +139,7 @@ namespace Xamarin.Forms.Controls.Issues
 			await Navigation.PushModalAsync(new ModalPage());
 		}
 
-		void OnAddlicked(object sender, EventArgs e)
+		void OnAddClicked(object sender, EventArgs e)
 		{
 			Items.Insert(0, new ModelIssue10300("0", Color.PaleGreen));
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10300.cs
@@ -129,6 +129,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var index = Items.IndexOf(carousel.CurrentItem as ModelIssue10300);
 			System.Diagnostics.Debug.WriteLine($"Delete {index}");
 			Items.RemoveAt(index);
+			MessagingCenter.Instance.Unsubscribe<Page>(this, "Delete");
 		}
 
 		public ObservableCollection<ModelIssue10300> Items { get; set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
@@ -102,7 +102,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("1 item");
 
 			rightX = rect.X + rect.Width - 1;
-			RunningApp.DragCoordinates(centerX, rect.CenterY, rightX, rect.CenterY);
+			RunningApp.DragCoordinates(rect.X, rect.CenterY, rightX, rect.CenterY);
 
 			RunningApp.WaitForElement("0 item");
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
@@ -121,11 +121,12 @@ namespace Xamarin.Forms.Controls.Issues
 			Title = "CarouselView Looping";
 			Items = new ObservableCollection<ModelIssue12574>();
 			LoadItemsCommand = new Command(() => ExecuteLoadItemsCommand());
-			RemoveItemsCommand = new Command(() => ExecuteRemoveItemsCommand());
+			RemoveItemsCommand = new Command(() => ExecuteRemoveItemsCommand(), () => Items.Count > 0);
 		}
 		void ExecuteRemoveItemsCommand()
 		{
 			Items.Remove(Items.Last());
+			RemoveItemsCommand.ChangeCanExecute();
 		}
 		void ExecuteLoadItemsCommand()
 		{
@@ -146,6 +147,7 @@ namespace Xamarin.Forms.Controls.Issues
 			finally
 			{
 				IsBusy = false;
+				RemoveItemsCommand.ChangeCanExecute();
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
@@ -81,7 +81,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		[Ignore("Ignore while fix is not ready")]
 		public void Issue12574Test()
 		{
 			RunningApp.WaitForElement("0 item");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
@@ -25,8 +25,10 @@ namespace Xamarin.Forms.Controls.Issues
 		ViewModelIssue12574 viewModel;
 		CarouselView _carouselView;
 		Button _btn;
+		Button _btn2;
 		string carouselAutomationId = "carouselView";
 		string btnRemoveAutomationId = "btnRemove";
+		string btnRemoveAllAutomationId = "btnRemoveAll";
 
 		protected override void Init()
 		{
@@ -35,8 +37,15 @@ namespace Xamarin.Forms.Controls.Issues
 				Text = "Remove Last",
 				AutomationId = btnRemoveAutomationId
 			};
-			_btn.SetBinding(Button.CommandProperty, "RemoveItemsCommand");
-			// Initialize ui here instead of ctor
+			_btn.SetBinding(Button.CommandProperty, "RemoveLastItemCommand");
+
+			_btn2 = new Button
+			{
+				Text = "Remove All",
+				AutomationId = btnRemoveAllAutomationId
+			};
+			_btn2.SetBinding(Button.CommandProperty, "RemoveAllItemsCommand");
+
 			_carouselView = new CarouselView
 			{
 				AutomationId = carouselAutomationId,
@@ -64,9 +73,12 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var layout = new Grid();
 			layout.RowDefinitions.Add(new RowDefinition { Height = 100 });
+			layout.RowDefinitions.Add(new RowDefinition { Height = 100 });
 			layout.RowDefinitions.Add(new RowDefinition());
-			Grid.SetRow(_carouselView, 1);
+			Grid.SetRow(_btn2, 1);
+			Grid.SetRow(_carouselView, 2);
 			layout.Children.Add(_btn);
+			layout.Children.Add(_btn2);
 			layout.Children.Add(_carouselView);
 
 			BindingContext = viewModel = new ViewModelIssue12574();
@@ -105,28 +117,54 @@ namespace Xamarin.Forms.Controls.Issues
 
 			RunningApp.WaitForElement("0 item");
 		}
+
+		[Test]
+		public void RemoveItemsQuickly()
+		{
+			RunningApp.WaitForElement("0 item");
+			RunningApp.Tap(btnRemoveAllAutomationId);
+
+			// If we haven't crashed, then the other button should be here
+			RunningApp.WaitForElement(btnRemoveAutomationId);
+		}
 #endif
 	}
 
-	[Preserve(AllMembers = true)]
 	class ViewModelIssue12574 : BaseViewModel1
 	{
 		public ObservableCollection<ModelIssue12574> Items { get; set; }
 		public Command LoadItemsCommand { get; set; }
-		public Command RemoveItemsCommand { get; set; }
+		public Command RemoveAllItemsCommand { get; set; }
+		public Command RemoveLastItemCommand { get; set; }
 
 		public ViewModelIssue12574()
 		{
 			Title = "CarouselView Looping";
 			Items = new ObservableCollection<ModelIssue12574>();
 			LoadItemsCommand = new Command(() => ExecuteLoadItemsCommand());
-			RemoveItemsCommand = new Command(() => ExecuteRemoveItemsCommand(), () => Items.Count > 0);
+			RemoveAllItemsCommand = new Command(() => ExecuteRemoveItemsCommand(), () => Items.Count > 0);
+			RemoveLastItemCommand = new Command(() => ExecuteRemoveLastItemCommand(), () => Items.Count > 0);
 		}
+		
 		void ExecuteRemoveItemsCommand()
 		{
-			Items.Remove(Items.Last());
-			RemoveItemsCommand.ChangeCanExecute();
+			while (Items.Count > 0)
+			{
+				Items.Remove(Items.Last());
+				Items.Remove(Items.Last());
+				Items.Remove(Items.Last());
+			}
+			RemoveAllItemsCommand.ChangeCanExecute();
+			RemoveLastItemCommand.ChangeCanExecute();
 		}
+
+		void ExecuteRemoveLastItemCommand()
+		{
+			Items.Remove(Items.Last());
+			RemoveAllItemsCommand.ChangeCanExecute();
+			RemoveLastItemCommand.ChangeCanExecute();
+		}
+
 		void ExecuteLoadItemsCommand()
 		{
 			IsBusy = true;
@@ -146,7 +184,8 @@ namespace Xamarin.Forms.Controls.Issues
 			finally
 			{
 				IsBusy = false;
-				RemoveItemsCommand.ChangeCanExecute();
+				RemoveAllItemsCommand.ChangeCanExecute();
+				RemoveLastItemCommand.ChangeCanExecute();
 			}
 		}
 
@@ -157,7 +196,6 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 	}
 
-	[Preserve(AllMembers = true)]
 	class ModelIssue12574
 	{
 		public string Id { get; set; }

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -33,25 +33,24 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
-			CheckPositionValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
+			CheckLabelValue("lblSelected", "0");
 
 			SwipeRightToLeft();
 
-			CheckPositionValue("lblPosition", "1");
-			CheckPositionValue("lblCurrentItem", "1");
-			CheckPositionValue("lblSelected", "1");
+			CheckLabelValue("lblPosition", "1");
+			CheckLabelValue("lblCurrentItem", "1");
+			CheckLabelValue("lblSelected", "1");
 
 			App.Tap(x => x.Marked("btnRemove"));
 
-			CheckPositionValue("lblPosition", "1");
-			CheckPositionValue("lblCurrentItem", "2");
-			CheckPositionValue("lblSelected", "2");
+			CheckLabelValue("lblPosition", "1");
+			CheckLabelValue("lblCurrentItem", "2");
+			CheckLabelValue("lblSelected", "2");
 
 			App.Back();
 		}
-
 
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		[TestCase("CarouselView (XAML, Horizontal, Loop)")]
@@ -59,12 +58,12 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
 			App.Tap(x => x.Marked("btnRemove"));
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "1");
-			CheckPositionValue("lblSelected", "1");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "1");
+			CheckLabelValue("lblSelected", "1");
 
 			App.Back();
 		}
@@ -75,20 +74,19 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
 			App.Tap(x => x.Marked("btnNext"));
-			CheckPositionValue("lblPosition", "1");
-			CheckPositionValue("lblCurrentItem", "1");
-			CheckPositionValue("lblSelected", "1");
+			CheckLabelValue("lblPosition", "1");
+			CheckLabelValue("lblCurrentItem", "1");
+			CheckLabelValue("lblSelected", "1");
 			App.Tap(x => x.Marked("btnPrev"));
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
-			CheckPositionValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
+			CheckLabelValue("lblSelected", "0");
 
 			App.Back();
 		}
-
 
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		[TestCase("CarouselView (XAML, Horizontal, Loop)")]
@@ -96,21 +94,21 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
-			CheckPositionValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
+			CheckLabelValue("lblSelected", "0");
 
 			SwipeRightToLeft(4);
 
-			CheckPositionValue("lblPosition", "4");
-			CheckPositionValue("lblCurrentItem", "4");
-			CheckPositionValue("lblSelected", "4");
+			CheckLabelValue("lblPosition", "4");
+			CheckLabelValue("lblCurrentItem", "4");
+			CheckLabelValue("lblSelected", "4");
 
 			App.Tap(x => x.Marked("btnRemove"));
 
-			CheckPositionValue("lblPosition", "3");
-			CheckPositionValue("lblCurrentItem", "3");
-			CheckPositionValue("lblSelected", "3");
+			CheckLabelValue("lblPosition", "3");
+			CheckLabelValue("lblCurrentItem", "3");
+			CheckLabelValue("lblSelected", "3");
 
 			App.Back();
 		}
@@ -120,15 +118,15 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
-			CheckPositionValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
+			CheckLabelValue("lblSelected", "0");
 
 			SwipeRightToLeft(5);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
-			CheckPositionValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
+			CheckLabelValue("lblSelected", "0");
 
 			App.Back();
 		}
@@ -138,18 +136,18 @@ namespace Xamarin.Forms.Core.UITests
 		{
 			VisitSubGallery(subgallery);
 
-			CheckPositionValue("lblPosition", "0");
-			CheckPositionValue("lblCurrentItem", "0");
-			CheckPositionValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", "0");
+			CheckLabelValue("lblCurrentItem", "0");
+			CheckLabelValue("lblSelected", "0");
 
 			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
 			var centerX = rect.CenterX;
 			var rightX = rect.X - 5;
 			App.DragCoordinates(centerX - 50, rect.CenterY, centerX + rect.Width / 2 - 10, rect.CenterY);
 
-			CheckPositionValue("lblPosition", "4");
-			CheckPositionValue("lblCurrentItem", "4");
-			CheckPositionValue("lblSelected", "4");
+			CheckLabelValue("lblPosition", "4");
+			CheckLabelValue("lblCurrentItem", "4");
+			CheckLabelValue("lblSelected", "4");
 
 			App.Back();
 		}
@@ -306,17 +304,16 @@ namespace Xamarin.Forms.Core.UITests
 			App.Tap(t => t.Marked(galleryName));
 		}
 
-		static void CheckPositionValue(string marked, string value)
+		static void CheckLabelValue(string marked, string value)
 		{
 			var positionAfter = App.QueryUntilPresent(() =>
 			{
-				var positionLabel = App.WaitForElement(x => x.Marked(marked));
-				if (positionLabel.First().Text == value)
-					return positionLabel;
+				var label = App.WaitForElement(x => x.Marked(marked));
+				if (label.First().Text == value)
+					return label;
 				return null;
 			}, delayInMs: 1000);
 			Assert.IsTrue(positionAfter[0].Text == value);
 		}
-
 	}
 }

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -13,6 +13,20 @@ namespace Xamarin.Forms.Core.UITests
 			App.NavigateToGallery(GalleryQueries.CarouselViewGallery);
 		}
 
+		void SwipeRightToLeft(int swipes = 1) 
+		{
+			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
+			var fromX = rect.CenterX + 40;
+			var toX = rect.X - 5;
+			var fromY = rect.CenterY;
+			var toY = fromY;
+
+			for (int n = 0; n < swipes; n++)
+			{
+				App.DragCoordinates(fromX, fromY, toX, toY);
+			}
+		}
+
 		[TestCase("CarouselView (XAML, Horizontal)")]
 		[TestCase("CarouselView (XAML, Horizontal, Loop)")]
 		public void CarouselViewRemoveAndUpdateCurrentItem(string subgallery)
@@ -23,10 +37,7 @@ namespace Xamarin.Forms.Core.UITests
 			CheckPositionValue("lblCurrentItem", "0");
 			CheckPositionValue("lblSelected", "0");
 
-			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
-			var centerX = rect.CenterX;
-			var rightX = rect.X - 5;
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			SwipeRightToLeft();
 
 			CheckPositionValue("lblPosition", "1");
 			CheckPositionValue("lblCurrentItem", "1");
@@ -89,13 +100,7 @@ namespace Xamarin.Forms.Core.UITests
 			CheckPositionValue("lblCurrentItem", "0");
 			CheckPositionValue("lblSelected", "0");
 
-			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
-			var centerX = rect.CenterX;
-			var rightX = rect.X - 5;
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			SwipeRightToLeft(4);
 
 			CheckPositionValue("lblPosition", "4");
 			CheckPositionValue("lblCurrentItem", "4");
@@ -119,14 +124,7 @@ namespace Xamarin.Forms.Core.UITests
 			CheckPositionValue("lblCurrentItem", "0");
 			CheckPositionValue("lblSelected", "0");
 
-			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
-			var centerX = rect.CenterX;
-			var rightX = rect.X - 5;
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			SwipeRightToLeft(5);
 
 			CheckPositionValue("lblPosition", "0");
 			CheckPositionValue("lblCurrentItem", "0");
@@ -274,16 +272,18 @@ namespace Xamarin.Forms.Core.UITests
 			Assert.AreEqual("0", App.Query(c => c.Marked("lblPosition")).First().Text);
 			App.Tap("btnNewObservable");
 			Assert.AreEqual("0", App.Query(c => c.Marked("lblPosition")).First().Text);
-			var rect = App.Query(c => c.Marked("TheCarouselView")).First().Rect;
-			var centerX = rect.CenterX;
-			var rightX = rect.X - 5;
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+
+			SwipeRightToLeft();
+			
 			App.Tap("btnAddObservable");
 			Assert.AreEqual("0", App.Query(c => c.Marked("lblPosition")).First().Text);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+			
+			SwipeRightToLeft();
 			Assert.AreEqual("1", App.Query(c => c.Marked("lblPosition")).First().Text);
-			App.DragCoordinates(centerX + 40, rect.CenterY, rightX, rect.CenterY);
+
+			SwipeRightToLeft();
 			Assert.AreEqual("2", App.Query(c => c.Marked("lblPosition")).First().Text);
+			
 			App.Back();
 		}
 

--- a/Xamarin.Forms.Platform.iOS.UnitTests/ObservableItemsSourceTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/ObservableItemsSourceTests.cs
@@ -1,0 +1,62 @@
+﻿using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture(Category = "CollectionView")]
+	public class IndexPathTests
+	{
+		[Test]
+		public void GenerateIndexPathRange() 
+		{
+			var result = IndexPathHelpers.GenerateIndexPathRange(0, 0, 5);
+
+			Assert.That(result.Length, Is.EqualTo(5));
+			Assert.That(result[0].Section, Is.EqualTo(0));
+			Assert.That((int)result[0].Item, Is.EqualTo(0));
+
+			Assert.That(result[4].Section, Is.EqualTo(0));
+			Assert.That((int)result[4].Item, Is.EqualTo(4));
+		}
+
+		[Test]
+		public void GenerateIndexPathRangeForLoop()
+		{
+			// Section 0
+			// 5 items, looped 3 times
+			// Looking for all the items corresponding to indexes 2, 3, and 4
+
+			var result = IndexPathHelpers.GenerateLoopedIndexPathRange(0, 15, 3, 2, 3);
+
+			// Source:
+			// 0, 1, 2, 3, 4, 0, 1, 2, 3, 4,  0,  1,  2,  3,  4
+			// 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14
+
+
+			// Result:
+			// 2, 3, 4, 2, 3, 4,  2,  3,  4
+			// 2, 3, 4, 7, 8, 9, 12, 13, 14
+
+			Assert.That(result.Length, Is.EqualTo(9));
+			
+			Assert.That(result[0].Section, Is.EqualTo(0));
+			Assert.That(result[1].Section, Is.EqualTo(0));
+			Assert.That(result[2].Section, Is.EqualTo(0));
+			Assert.That(result[3].Section, Is.EqualTo(0));
+			Assert.That(result[4].Section, Is.EqualTo(0));
+			Assert.That(result[5].Section, Is.EqualTo(0));
+			Assert.That(result[6].Section, Is.EqualTo(0));
+			Assert.That(result[7].Section, Is.EqualTo(0));
+			Assert.That(result[8].Section, Is.EqualTo(0));
+
+			Assert.That((int)result[0].Item, Is.EqualTo(2));
+			Assert.That((int)result[1].Item, Is.EqualTo(3));
+			Assert.That((int)result[2].Item, Is.EqualTo(4));
+			Assert.That((int)result[3].Item, Is.EqualTo(7));
+			Assert.That((int)result[4].Item, Is.EqualTo(8));
+			Assert.That((int)result[5].Item, Is.EqualTo(9));
+			Assert.That((int)result[6].Item, Is.EqualTo(12));
+			Assert.That((int)result[7].Item, Is.EqualTo(13));
+			Assert.That((int)result[8].Item, Is.EqualTo(14));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -58,6 +58,7 @@
     <Compile Include="IsEnabledTests.cs" />
     <Compile Include="IsVisibleTests.cs" />
     <Compile Include="NavigationTests.cs" />
+    <Compile Include="ObservableItemsSourceTests.cs" />
     <Compile Include="OpacityTests.cs" />
     <Compile Include="PlatformTestFixture.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -218,11 +218,16 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 
 			if (removingCurrentElement)
+			{
+				// we are reloading the VisibleItems so we need to wait for the UICollectionView to reload
+				// and then scroll to the correct position
 				CollectionView.ReloadItems(CollectionView.IndexPathsForVisibleItems);
-
-			// we migh be reloading the VisibleItems so we need to wait for the UICollectionView to reload
-			// and then scroll to the correct position
-			CollectionView.PerformBatchUpdates(() => { }, (_) => ScrollToPosition(newPosition, Carousel.Position, false, removingCurrentElement));
+				CollectionView.PerformBatchUpdates(() => { }, (_) => ScrollToPosition(newPosition, Carousel.Position, false, removingCurrentElement));
+			}
+			else
+			{
+				ScrollToPosition(newPosition, Carousel.Position, false, removingCurrentElement);
+			}
 		}
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -202,7 +202,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_gotoPosition = -1;
 
-			ScrollToPositionIfNeeded(newPosition, count, currentItemPosition == -1);
+			bool removingCurrentItem = e.Action == NotifyCollectionChangedAction.Remove &&
+									currentItemPosition == -1;
+
+			ScrollToPositionIfNeeded(newPosition, count, removingCurrentItem);
 
 			SetCurrentItem(newPosition);
 			SetPosition(newPosition);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -205,17 +205,20 @@ namespace Xamarin.Forms.Platform.iOS
 			bool removingCurrentItem = e.Action == NotifyCollectionChangedAction.Remove &&
 									currentItemPosition == -1;
 
-			ScrollToPositionIfNeeded(newPosition, count, removingCurrentItem);
+			ReloadAndScrollToPositionIfNeeded(newPosition, count, removingCurrentItem);
 
 			SetCurrentItem(newPosition);
 			SetPosition(newPosition);
 		}
 
-		void ScrollToPositionIfNeeded(int newPosition, int count, bool removingCurrentElement)
-		{
-			// if we don't have items no need to scroll
+		void ReloadAndScrollToPositionIfNeeded(int newPosition, int count, bool removingCurrentElement)
+		{		
+			// if we don't have items no need to scroll or reload
 			if (count <= 0)
 				return;
+
+			if (removingCurrentElement)
+				CollectionView.ReloadItems(CollectionView.IndexPathsForVisibleItems);
 
 			// we migh be reloading the VisibleItems so we need to wait for the UICollectionView to reload
 			// and then scroll to the correct position
@@ -253,9 +256,6 @@ namespace Xamarin.Forms.Platform.iOS
 				//If we are not removing the current element set position to the CurrentItem
 				carouselPosition = currentItemPosition;
 			}
-
-			if (removingCurrentElement)
-				CollectionView.ReloadItems(CollectionView.IndexPathsForVisibleItems);
 
 			return carouselPosition;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -211,29 +211,15 @@ namespace Xamarin.Forms.Platform.iOS
 			SetPosition(newPosition);
 		}
 
-		void ScrollToPositionIfNeeded(int newPosition, int count, bool removingCurrentItem)
+		void ScrollToPositionIfNeeded(int newPosition, int count, bool removingCurrentElement)
 		{
 			// if we don't have items no need to scroll
 			if (count <= 0)
 				return;
 
-			if (!removingCurrentItem)
-			{
-				ScrollToPosition(newPosition, Carousel.Position, false);
-			}
-			else
-			{
-				// we will Reloadthe VisibleItems so we need delay a bit for the collectionView to reload
-				// and then scroll to the correct position
-				Device.StartTimer(TimeSpan.FromMilliseconds(50), () =>
-				{
-					// reset _goToPosition since we are reloading 
-					// but a ScrollTo could be happening
-					_gotoPosition = -1;
-					ScrollToPosition(newPosition, Carousel.Position, false, removingCurrentItem);
-					return false;
-				});
-			}
+			// we migh be reloading the VisibleItems so we need to wait for the UICollectionView to reload
+			// and then scroll to the correct position
+			CollectionView.PerformBatchUpdates(() => { }, (_) => ScrollToPosition(newPosition, Carousel.Position, false, removingCurrentElement));
 		}
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -202,11 +202,35 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_gotoPosition = -1;
 
-			if (count > 0)
-				ScrollToPosition(newPosition, carouselPosition, false);
+			ScrollToPositionIfNeeded(newPosition, count, currentItemPosition == -1);
 
 			SetCurrentItem(newPosition);
 			SetPosition(newPosition);
+		}
+
+		void ScrollToPositionIfNeeded(int newPosition, int count, bool removingCurrentItem)
+		{
+			// if we don't have items no need to scroll
+			if (count <= 0)
+				return;
+
+			if (!removingCurrentItem)
+			{
+				ScrollToPosition(newPosition, Carousel.Position, false);
+			}
+			else
+			{
+				// we will Reloadthe VisibleItems so we need delay a bit for the collectionView to reload
+				// and then scroll to the correct position
+				Device.StartTimer(TimeSpan.FromMilliseconds(50), () =>
+				{
+					// reset _goToPosition since we are reloading 
+					// but a ScrollTo could be happening
+					_gotoPosition = -1;
+					ScrollToPosition(newPosition, Carousel.Position, false, removingCurrentItem);
+					return false;
+				});
+			}
 		}
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -215,7 +215,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var targetPosition = _positionAfterUpdate;
 			_positionAfterUpdate = -1;
 
-			SetPosition(targetPosition);
+			ScrollToPosition(targetPosition, Carousel.Position, false);
 		}
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -119,6 +119,10 @@ namespace Xamarin.Forms.Platform.iOS
 			base.UpdateItemsSource();
 			//we don't need to Subscribe because base calls CreateItemsViewSource
 			_carouselViewLoopManager?.SetItemsSource(LoopItemsSource);
+
+			Carousel.SetValueFromRenderer(CarouselView.CurrentItemProperty, null);
+			Carousel.SetValueFromRenderer(CarouselView.PositionProperty, 0);
+
 			_initialPositionSet = false;
 			UpdateInitialPosition();
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -86,12 +86,14 @@ namespace Xamarin.Forms.Platform.iOS
 				_updatingScrollOffset = false;
 			}
 
-			UpdateInitialPosition();
-
 			if (CollectionView.Bounds.Size != _size)
 			{
 				_size = CollectionView.Bounds.Size;
 				BoundsSizeChanged();
+			}
+			else
+			{
+				UpdateInitialPosition();
 			}
 		}
 
@@ -188,6 +190,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionViewUpdating(object sender, NotifyCollectionChangedEventArgs e)
 		{
+			if (e.Action == NotifyCollectionChangedAction.Reset)
+			{
+				return;
+			}
+
 			int carouselPosition = Carousel.Position;
 			_positionAfterUpdate = carouselPosition;
 			var currentItemPosition = ItemsSource.GetIndexForItem(Carousel.CurrentItem).Row;
@@ -205,7 +212,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionViewUpdated(object sender, NotifyCollectionChangedEventArgs e)
 		{
-			if (_positionAfterUpdate == -1)
+			if (e.Action == NotifyCollectionChangedAction.Reset || _positionAfterUpdate == -1)
 			{
 				return;
 			}
@@ -215,7 +222,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var targetPosition = _positionAfterUpdate;
 			_positionAfterUpdate = -1;
 
-			ScrollToPosition(targetPosition, Carousel.Position, false);
+			Carousel.ScrollTo(targetPosition, position: Xamarin.Forms.ScrollToPosition.Center, animate: false);
 		}
 
 		int GetPositionWhenAddingItems(int carouselPosition, int currentItemPosition)
@@ -337,7 +344,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateFromCurrentItem()
 		{
-			if (Carousel?.CurrentItem == null || ItemsSource?.ItemCount == 0)
+			if (Carousel?.CurrentItem == null || ItemsSource == null || ItemsSource.ItemCount == 0)
 				return;
 
 			var currentItemPosition = GetIndexForItem(Carousel.CurrentItem).Row;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathHelpers.cs
@@ -1,0 +1,36 @@
+﻿using Foundation;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	public static class IndexPathHelpers
+	{
+		public static NSIndexPath[] GenerateIndexPathRange(int section, int startIndex, int count) 
+		{
+			var result = new NSIndexPath[count];
+
+			for (int n = 0; n < count; n++)
+			{
+				result[n] = NSIndexPath.Create(section, startIndex + n);
+			}
+
+			return result;
+		}
+
+		public static NSIndexPath[] GenerateLoopedIndexPathRange(int section, int sectionCount, int iterations, int startIndex, int count)
+		{
+			var result = new NSIndexPath[iterations * count];
+			var step = sectionCount / iterations;
+
+			for (int r = 0; r < iterations; r++)
+			{
+				for (int n = 0; n < count; n++)
+				{
+					var index = startIndex + (r * step) + n;
+					result[(r * count) + n] = NSIndexPath.Create(section, index);
+				}
+			}
+
+			return result;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -305,7 +305,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var indexPath = NSIndexPath.Create(group, 0);
 
-			return GetCell(CollectionView, indexPath);
+			return CreateMeasurementCell(indexPath);
 		}
 
 		protected virtual void RegisterViewTypes()
@@ -443,6 +443,32 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_emptyViewDisplayed = false;
 			}
+		}
+
+		TemplatedCell CreateAppropriateCellForLayout()
+		{
+			var frame = new CGRect(0, 0, ItemsViewLayout.EstimatedItemSize.Width, ItemsViewLayout.EstimatedItemSize.Height);
+
+			if (ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+			{
+				return new HorizontalCell(frame);
+			}
+
+			return new VerticalCell(frame);
+		}
+
+		public TemplatedCell CreateMeasurementCell(NSIndexPath indexPath)
+		{
+			if (ItemsView.ItemTemplate == null)
+			{
+				return null;
+			}
+
+			TemplatedCell templatedCell = CreateAppropriateCellForLayout();
+
+			UpdateTemplatedCell(templatedCell, indexPath);
+
+			return templatedCell;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -527,7 +527,14 @@ namespace Xamarin.Forms.Platform.iOS
 				return base.ShouldInvalidateLayoutForBoundsChange(newBounds);
 			}
 
-			UpdateConstraints(CollectionView.AdjustedContentInset.InsetRect(newBounds).Size);
+			if (Forms.IsiOS11OrNewer)
+			{
+				UpdateConstraints(CollectionView.AdjustedContentInset.InsetRect(newBounds).Size);
+			}
+			else
+			{
+				UpdateConstraints(CollectionView.Bounds.Size);
+			}
 
 			return true;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/LoopObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/LoopObservableItemsSource.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using Foundation;
 using UIKit;
 
@@ -20,22 +19,13 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override NSIndexPath[] CreateIndexesFrom(int startIndex, int count)
 		{
-			if (Loop)
-				count *= LoopBy;
-
-			var result = new NSIndexPath[count];
-
-			for (int n = 0; n < count; n++)
+			if (!Loop)
 			{
-				var index = startIndex + n;
-				if (Loop)
-				{
-					index = startIndex + n * Count;
-				}
-				result[n] = NSIndexPath.Create(Section, index);
+				return base.CreateIndexesFrom(startIndex, count);
 			}
 
-			return result;
+			return IndexPathHelpers.GenerateLoopedIndexPathRange(Section,
+				(int)CollectionView.NumberOfItemsInSection(Section), LoopBy, startIndex, count);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -2,7 +2,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Collections.Specialized;
-using System.Threading.Tasks;
 using Foundation;
 using UIKit;
 
@@ -128,55 +127,49 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		async void CollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
+		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
 			if (Device.IsInvokeRequired)
 			{
-				await Device.InvokeOnMainThreadAsync(async () => await CollectionChanged(args));
+				Device.BeginInvokeOnMainThread(() => CollectionChanged(args));
 			}
 			else
 			{
-				await CollectionChanged(args);
+				CollectionChanged(args);
 			}
 		}
 
-		async Task CollectionChanged(NotifyCollectionChangedEventArgs args)
+		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
 			switch (args.Action)
 
 			{
 				case NotifyCollectionChangedAction.Add:
-					await Add(args);
+					Add(args);
 					break;
 				case NotifyCollectionChangedAction.Remove:
-					await Remove(args);
+					Remove(args);
 					break;
 				case NotifyCollectionChangedAction.Replace:
-					await Replace(args);
+					Replace(args);
 					break;
 				case NotifyCollectionChangedAction.Move:
 					Move(args);
 					break;
 				case NotifyCollectionChangedAction.Reset:
-					await Reload();
+					Reload();
 					break;
 				default:
 					throw new ArgumentOutOfRangeException();
 			}
 		}
 
-		async Task Reload()
+		void Reload()
 		{
-			await Task.Delay(1);
-
 			ResetGroupTracking();
-
-			//await _batchUpdating.WaitAsync();
 
 			_collectionView.ReloadData();
 			_collectionView.CollectionViewLayout.InvalidateLayout();
-
-			//_batchUpdating.Release();
 		}
 
 		NSIndexSet CreateIndexSetFrom(int startIndex, int count)
@@ -191,11 +184,11 @@ namespace Xamarin.Forms.Platform.iOS
 			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
 		}
 
-		async Task Add(NotifyCollectionChangedEventArgs args)
+		void Add(NotifyCollectionChangedEventArgs args)
 		{
 			if (ReloadRequired())
 			{
-				await Reload();
+				Reload();
 				return;
 			}
 
@@ -210,7 +203,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_collectionView.InsertSections(CreateIndexSetFrom(startIndex, count));
 		}
 
-		async Task Remove(NotifyCollectionChangedEventArgs args)
+		void Remove(NotifyCollectionChangedEventArgs args)
 		{
 			var startIndex = args.OldStartingIndex;
 
@@ -218,13 +211,13 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				// INCC implementation isn't giving us enough information to know where the removed items were in the
 				// collection. So the best we can do is a complete reload
-				await Reload();
+				Reload();
 				return;
 			}
 
 			if (ReloadRequired())
 			{
-				await Reload();
+				Reload();
 				return;
 			}
 
@@ -239,7 +232,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count));
 		}
 
-		async Task Replace(NotifyCollectionChangedEventArgs args)
+		void Replace(NotifyCollectionChangedEventArgs args)
 		{
 			var newCount = args.NewItems.Count;
 
@@ -256,7 +249,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// The original and replacement sets are of unequal size; this means that everything currently in view will 
 			// have to be updated. So we just have to use ReloadData and let the UICollectionView update everything
-			await Reload();
+			Reload();
 		}
 
 		void Move(NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -342,8 +342,7 @@ namespace Xamarin.Forms.Platform.iOS
 			// hard. We'll need to reload the data instead.
 
 			return NotLoadedYet()
-				|| _collectionView.NumberOfSections() == 0
-				|| _collectionView.VisibleCells.Length == 0;
+				|| _collectionView.NumberOfSections() == 0;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -137,11 +137,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
 
+			Count = ItemsCount();
+
 			OnCollectionViewUpdating(args);
 
 			CollectionView.ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
-			Count = ItemsCount();
 
 			OnCollectionViewUpdated(args);
 		}
@@ -288,22 +289,24 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool ReloadRequired()
 		{
-			if (NotLoadedYet())
-			{
-				return true;
-			}
+			return false;
 
-			// UICollectionView doesn't like when we insert items into a completely empty un-grouped CV,
-			// and it doesn't like when we insert items into a grouped CV with no actual cells (just empty groups)
-			// In those circumstances, we just need to ask it to reload the data so it can get its internal
-			// accounting in order
+			//if (NotLoadedYet())
+			//{
+			//	return true;
+			//}
 
-			if (!_grouped && CollectionView.NumberOfItemsInSection(_section) == 0)
-			{
-				return true;
-			}
+			//// UICollectionView doesn't like when we insert items into a completely empty un-grouped CV,
+			//// and it doesn't like when we insert items into a grouped CV with no actual cells (just empty groups)
+			//// In those circumstances, we just need to ask it to reload the data so it can get its internal
+			//// accounting in order
 
-			return CollectionView.VisibleCells.Length == 0;
+			//if (!_grouped && CollectionView.NumberOfItemsInSection(_section) == 0)
+			//{
+			//	return true;
+			//}
+
+			//return CollectionView.VisibleCells.Length == 0;
 		}
 
 		void Update(Action update, NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -154,12 +154,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Add(NotifyCollectionChangedEventArgs args)
 		{
-			if (ReloadRequired())
-			{
-				Reload();
-				return;
-			}
-
 			var count = args.NewItems.Count;
 			Count += count;
 			var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
@@ -176,12 +170,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				// INCC implementation isn't giving us enough information to know where the removed items were in the
 				// collection. So the best we can do is a ReloadData()
-				Reload();
-				return;
-			}
-
-			if (ReloadRequired())
-			{
 				Reload();
 				return;
 			}
@@ -278,35 +266,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return -1;
-		}
-
-		bool NotLoadedYet()
-		{
-			// If the UICollectionView hasn't actually been loaded, then calling InsertItems or DeleteItems is 
-			// going to crash or get in an unusable state; instead, ReloadData should be used
-			return !_collectionViewController.IsViewLoaded || _collectionViewController.View.Window == null;
-		}
-
-		bool ReloadRequired()
-		{
-			return false;
-
-			//if (NotLoadedYet())
-			//{
-			//	return true;
-			//}
-
-			//// UICollectionView doesn't like when we insert items into a completely empty un-grouped CV,
-			//// and it doesn't like when we insert items into a grouped CV with no actual cells (just empty groups)
-			//// In those circumstances, we just need to ask it to reload the data so it can get its internal
-			//// accounting in order
-
-			//if (!_grouped && CollectionView.NumberOfItemsInSection(_section) == 0)
-			//{
-			//	return true;
-			//}
-
-			//return CollectionView.VisibleCells.Length == 0;
 		}
 
 		void Update(Action update, NotifyCollectionChangedEventArgs args)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -111,6 +111,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
+			if (CollectionView.NumberOfSections() == 0)
+			{
+				// The CollectionView isn't fully initialized yet
+				return;
+			}
+
+			// Force UICollectionView to get the internal accounting straight 
+			CollectionView.NumberOfItemsInSection(_section);
+
 			switch (args.Action)
 			{
 				case NotifyCollectionChangedAction.Add:

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -127,6 +127,7 @@
     <Compile Include="CollectionView\HorizontalTemplatedHeaderView.cs" />
     <Compile Include="CollectionView\IItemsViewSource.cs" />
     <Compile Include="CollectionView\IndexPathExtensions.cs" />
+    <Compile Include="CollectionView\IndexPathHelpers.cs" />
     <Compile Include="CollectionView\ItemsSourceFactory.cs" />
     <Compile Include="CollectionView\ItemsViewCell.cs" />
     <Compile Include="CollectionView\ItemsViewRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###

When adding test for #12574 I saw that when we are removing the current last item sometimes the scroll to the previous position wasn't happening, this was related to ReloadingVisibleItems that is need when using the Loop feature, so we can update the UI when cell is removed. Adding a small delay will make the collection reload and then set the CollectionView to the correct position

### Issues Resolved ### 


### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

Remove the last item should then show the previous item

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Issue12574 should pass on iOS

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
