### PR TITLE
Ignore Locale tests and one CV test on UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/DateTimePickerLocalizationTests.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/DateTimePickerLocalizationTests.cs
@@ -54,6 +54,8 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		// Tests runs locally without issues but doesn't run successfully in a hosted agent yet
+		[Category(UITestCategories.UwpIgnore)]
 		public void TimePicker24H()
 		{
 			RunningApp.Tap(x => x.Marked("TimePicker"));
@@ -92,6 +94,8 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 
 		[Test]
+		// Tests runs locally without issues but doesn't run successfully in a hosted agent yet
+		[Category(UITestCategories.UwpIgnore)]
 		public void DatePickerDMY()
 		{
 			RunningApp.Tap(x => x.Marked("DatePicker"));
@@ -109,6 +113,8 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 		[Test]
+		// Tests runs locally without issues but doesn't run successfully in a hosted agent yet
+		[Category(UITestCategories.UwpIgnore)]
 		public void DatePickerMissing()
 		{
 			RunningApp.Tap(x => x.Marked("DatePicker"));

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12574.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.CarouselView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 12574, "CarouselView Loop=True default freezes iOS app", PlatformAffected.Default)]


### PR DESCRIPTION
### Description of Change ###

It appears that when running UWP tests on the hosted agent that the selectors don't popup after being interacted with.
For now we'll ignore these tests when they are being ran on the CI


### Testing Procedure ###
- make sure UWP tests are all passing

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
