### PR TITLE
[iOS] Fix pushing same page as a modal on iOS13 in split mode

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8988.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8988.cs
@@ -1,0 +1,86 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8988, "App freezes on iPadOS 13.3 when in split view mode (multi-tasking) and change between pages", PlatformAffected.iOS)]
+	public class Issue8988 : TestContentPage // or TestFlyoutPage, etc ...
+	{
+		SecondPage secondPage;
+
+		protected override void Init()
+		{
+			secondPage = new SecondPage();
+			var layout = new StackLayout();
+			var label = new Label
+			{
+				Text = "Welcome to Xamarin Forms!",
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+			};
+			var button = new Button
+			{
+				Text = "NextPage",
+				Command = new Command(async () =>
+				{
+					await Navigation.PushModalAsync(secondPage, false);
+				})
+
+			};
+
+			layout.Children.Add(label);
+			layout.Children.Add(button);
+
+			BackgroundColor = Color.YellowGreen;
+			Content = layout;
+		}
+
+#if UITEST
+		[Test]
+		public void Issue8988Test()
+		{
+			RunningApp.WaitForElement("Issue1Label");
+			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
+			RunningApp.Screenshot("I am at Issue1");
+			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));
+			RunningApp.Screenshot("I see the Label");
+		}
+#endif
+	}
+
+	class SecondPage : ContentPage
+	{
+		public SecondPage()
+		{
+			var layout = new StackLayout();
+			var label = new Label
+			{
+				Text = "This is the Second Page!",
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalOptions = LayoutOptions.CenterAndExpand,
+			};
+			var button = new Button
+			{
+				Text = "Go Back to Main Page",
+				Command = new Command(() => Navigation.PopModalAsync(false))
+			};
+
+			layout.Children.Add(label);
+			layout.Children.Add(button);
+
+			BackgroundColor = Color.Yellow;
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8988.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8988.cs
@@ -24,9 +24,10 @@ namespace Xamarin.Forms.Controls.Issues
 			var layout = new StackLayout();
 			var label = new Label
 			{
-				Text = "Welcome to Xamarin Forms!",
+				Text = "Click Next to push a modal, pop it, and push it again, you should see the second page a 2nd time without glitches.",
 				VerticalOptions = LayoutOptions.CenterAndExpand,
 				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalTextAlignment = TextAlignment.Center
 			};
 			var button = new Button
 			{
@@ -44,18 +45,6 @@ namespace Xamarin.Forms.Controls.Issues
 			BackgroundColor = Color.YellowGreen;
 			Content = layout;
 		}
-
-#if UITEST
-		[Test]
-		public void Issue8988Test()
-		{
-			RunningApp.WaitForElement("Issue1Label");
-			// Delete this and all other UITEST sections if there is no way to automate the test. Otherwise, be sure to rename the test and update the Category attribute on the class. Note that you can add multiple categories.
-			RunningApp.Screenshot("I am at Issue1");
-			RunningApp.WaitForElement(q => q.Marked("Issue1Label"));
-			RunningApp.Screenshot("I see the Label");
-		}
-#endif
 	}
 
 	class SecondPage : ContentPage
@@ -65,9 +54,10 @@ namespace Xamarin.Forms.Controls.Issues
 			var layout = new StackLayout();
 			var label = new Label
 			{
-				Text = "This is the Second Page!",
+				Text = "This is the Second Page! Pop me and push again. I should look the same",
 				VerticalOptions = LayoutOptions.CenterAndExpand,
 				HorizontalOptions = LayoutOptions.CenterAndExpand,
+				HorizontalTextAlignment = TextAlignment.Center
 			};
 			var button = new Button
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8988.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8988.cs
@@ -45,32 +45,43 @@ namespace Xamarin.Forms.Controls.Issues
 			BackgroundColor = Color.YellowGreen;
 			Content = layout;
 		}
-	}
 
-	class SecondPage : ContentPage
-	{
-		public SecondPage()
+		[Preserve(AllMembers = true)]
+		class SecondPage : ContentPage
 		{
-			var layout = new StackLayout();
-			var label = new Label
+			public SecondPage()
 			{
-				Text = "This is the Second Page! Pop me and push again. I should look the same",
-				VerticalOptions = LayoutOptions.CenterAndExpand,
-				HorizontalOptions = LayoutOptions.CenterAndExpand,
-				HorizontalTextAlignment = TextAlignment.Center
-			};
-			var button = new Button
+				var layout = new StackLayout();
+				var label = new Label
+				{
+					Text = "This is the Second Page! Pop me and push again. I should look the same",
+					VerticalOptions = LayoutOptions.CenterAndExpand,
+					HorizontalOptions = LayoutOptions.CenterAndExpand,
+					HorizontalTextAlignment = TextAlignment.Center
+				};
+				var button = new Button
+				{
+					Text = "Go Back to Main Page",
+					Command = new Command(() => Navigation.PopModalAsync(false))
+				};
+
+				layout.Children.Add(label);
+				layout.Children.Add(button);
+
+				BackgroundColor = Color.Yellow;
+
+				Content = layout;
+			}
+
+			protected override void LayoutChildren(double x, double y, double width, double height)
 			{
-				Text = "Go Back to Main Page",
-				Command = new Command(() => Navigation.PopModalAsync(false))
-			};
+				base.LayoutChildren(x, y, width, height);
+			}
 
-			layout.Children.Add(label);
-			layout.Children.Add(button);
-
-			BackgroundColor = Color.Yellow;
-
-			Content = layout;
+			protected override void InvalidateMeasure()
+			{
+				base.InvalidateMeasure();
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1632,6 +1632,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12777.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11911.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11691.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8988.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
@@ -33,14 +33,15 @@ namespace Xamarin.Forms.Platform.MacOS
 #if __MOBILE__
 					if (renderer.ViewController != null)
 					{
-
-						var modalWrapper = renderer.ViewController.ParentViewController as ModalWrapper;
-						if (modalWrapper != null)
+						if (renderer.ViewController.ParentViewController is ModalWrapper modalWrapper)
 							modalWrapper.Dispose();
 					}
 #endif
 					renderer.NativeView.RemoveFromSuperview();
 					renderer.Dispose();
+					//reset layout size so we can re-layout the layer if we are reusing the same page.
+					//fixes a issue on split apps on iPad and iOS13
+					visualElement.Layout(new Rectangle(0, 0, -1, -1));
 				}
 				view.ClearValue(Platform.RendererProperty);
 			}

--- a/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
@@ -39,11 +39,12 @@ namespace Xamarin.Forms.Platform.MacOS
 #endif
 					renderer.NativeView.RemoveFromSuperview();
 					renderer.Dispose();
-					//reset layout size so we can re-layout the layer if we are reusing the same page.
-					//fixes a issue on split apps on iPad and iOS13
-					visualElement.Layout(new Rectangle(0, 0, -1, -1));
 				}
 				view.ClearValue(Platform.RendererProperty);
+				//reset layout size so we can re-layout the layer if we are reusing the same page.
+				//fixes a issue on split apps on iPad and iOS13
+				if (Forms.IsiOS13OrNewer && visualElement is Page)
+					visualElement.Layout(new Rectangle(0, 0, -1, -1));
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
@@ -41,13 +41,6 @@ namespace Xamarin.Forms.Platform.MacOS
 					renderer.Dispose();
 				}
 				view.ClearValue(Platform.RendererProperty);
-#if __MOBILE__
-
-				//reset layout size so we can re-layout the layer if we are reusing the same page.
-				//fixes a issue on split apps on iPad and iOS13
-				if (Forms.IsiOS13OrNewer && visualElement is Page)
-					visualElement.Layout(new Rectangle(0, 0, -1, -1));
-#endif
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/DisposeHelpers.cs
@@ -41,10 +41,13 @@ namespace Xamarin.Forms.Platform.MacOS
 					renderer.Dispose();
 				}
 				view.ClearValue(Platform.RendererProperty);
+#if __MOBILE__
+
 				//reset layout size so we can re-layout the layer if we are reusing the same page.
 				//fixes a issue on split apps on iPad and iOS13
 				if (Forms.IsiOS13OrNewer && visualElement is Page)
 					visualElement.Layout(new Rectangle(0, 0, -1, -1));
+#endif
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -138,7 +138,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_modal?.Element is Page modalPage)
 				{
-					_modal.SetElementSize(new Size(-1, -1));
 					modalPage.PropertyChanged -= OnModalPagePropertyChanged;
 				}
 				_modal = null;

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -21,8 +21,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (elementConfiguration?.On<PlatformConfiguration.iOS>()?.ModalPresentationStyle() is PlatformConfiguration.iOSSpecific.UIModalPresentationStyle style)
 			{
 				var result = style.ToNativeModalPresentationStyle();
-		
-        if (!Forms.IsiOS13OrNewer && result == UIKit.UIModalPresentationStyle.Automatic)
+
+				if (!Forms.IsiOS13OrNewer && result == UIKit.UIModalPresentationStyle.Automatic)
 				{
 					result = UIKit.UIModalPresentationStyle.FullScreen;
 				}
@@ -49,9 +49,6 @@ namespace Xamarin.Forms.Platform.iOS
 				PresentationController.Delegate = this;
 
 			((Page)modal.Element).PropertyChanged += OnModalPagePropertyChanged;
-
-			if (Forms.IsiOS13OrNewer)
-				PresentationController.Delegate = this;
 		}
 
 		[Export("presentationControllerDidDismiss:")]
@@ -119,13 +116,12 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void ViewDidLayoutSubviews()
 		{
 			base.ViewDidLayoutSubviews();
-			if (_modal != null)
-				_modal.SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));
+			_modal?.SetElementSize(new Size(View.Bounds.Width, View.Bounds.Height));
 		}
 
 		public override void ViewWillAppear(bool animated)
 		{
-			if(!_isDisposed)
+			if (!_isDisposed)
 				UpdateBackgroundColor();
 
 			base.ViewWillAppear(animated);
@@ -141,8 +137,10 @@ namespace Xamarin.Forms.Platform.iOS
 			if (disposing)
 			{
 				if (_modal?.Element is Page modalPage)
+				{
+					_modal.SetElementSize(new Size(-1, -1));
 					modalPage.PropertyChanged -= OnModalPagePropertyChanged;
-
+				}
 				_modal = null;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -142,14 +142,25 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public void SetElementSize(Size size)
 		{
+			// In Split Mode the Frame will occasionally get set to the wrong value
+			var rect = new CoreGraphics.CGRect(Element.X, Element.Y, size.Width, size.Height);
+			if (rect != _pageContainer.Frame)
+				_pageContainer.Frame = rect;
+
 			Element.Layout(new Rectangle(Element.X, Element.Y, size.Width, size.Height));
 		}
 
 		public override void LoadView()
 		{
+
 			//by default use the MainScreen Bounds so Effects can access the Container size
 			if (_pageContainer == null)
-				_pageContainer = new PageContainer(this) { Frame = UIScreen.MainScreen.Bounds };
+			{
+				var bounds = UIApplication.SharedApplication?.GetKeyWindow()?.Bounds ??
+					UIScreen.MainScreen.Bounds;
+
+				_pageContainer = new PageContainer(this) { Frame = bounds };
+			}
 
 			View = _pageContainer;
 		}


### PR DESCRIPTION
### Description of Change ###

There's a issue on iOS13  that pushing a modal using your app in split mode, (side by side with other app),  it causes issues rendering the second time. 
The particular issue is also related with retaining the pushed page , it keeps it's bounds, and we need to force the layout.
Workaround could be to just reset is bounds when is popped.

### Issues Resolved ### 

- fixes #8988

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

### Testing Procedure ###

Go to Issue8988 , click Next, check the page loaded, click Go Back, then click again Next and make sure the page loads fine.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
