### PR TITLE
[Core] Propagate BindingContext to Path Transforms

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/PathTransformBindingContextGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/PathTransformBindingContextGallery.xaml
@@ -1,0 +1,183 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:vm="clr-namespace:Xamarin.Forms.Controls.GalleryPages.ShapesGalleries"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.ShapesGalleries.PathTransformBindingContextGallery"
+    Title="Path Transform BindingContext Gallery">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+
+            <Style x:Key="PathContainerStyle" TargetType="Grid">
+                <Setter Property="HeightRequest" Value="200" />
+                <Setter Property="WidthRequest" Value="200" />
+                <Setter Property="BackgroundColor" Value="#e5e5e5" />
+                <Setter Property="HorizontalOptions" Value="Start" />
+                <Setter Property="VerticalOptions" Value="Start" />
+            </Style>
+
+            <Style x:Key="PathStyle" TargetType="Path">
+                <Setter Property="HeightRequest" Value="200" />
+                <Setter Property="WidthRequest" Value="200" />
+                <Setter Property="Fill" Value="Red" />
+                <Setter Property="Stroke" Value="Blue" />
+                <Setter Property="StrokeThickness" Value="4" />
+            </Style>
+
+            <Style x:Key="HeaderStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="14" />
+                <Setter Property="Margin" Value="6, 12, 0, 0" />
+            </Style>
+
+            <Style x:Key="ValueStyle" TargetType="Label">
+                <Setter Property="FontSize" Value="10" />
+                <Setter Property="Margin" Value="12, 0" />
+            </Style>
+
+            <Style TargetType="Slider">
+                <Setter Property="ThumbColor" Value="Black" />
+                <Setter Property="MinimumTrackColor" Value="LightGray" />
+                <Setter Property="MaximumTrackColor" Value="Gray" />
+            </Style>
+
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <ContentPage.BindingContext>
+        <vm:PathTransformBindingContextViewModel />
+    </ContentPage.BindingContext>
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+            </Grid.RowDefinitions>
+            <!-- PATH -->
+            <Grid
+                Style="{StaticResource PathContainerStyle}">
+                <Path
+                    Style="{StaticResource PathStyle}">
+                    <Path.Data>
+                        <RectangleGeometry
+                            Rect="0, 0, 50, 50" />
+                    </Path.Data>
+                    <Path.RenderTransform>
+                        <TransformGroup>
+                            <RotateTransform
+                                Angle="{Binding Rotation}"
+                                CenterX="{Binding CenterX}"
+                                CenterY="{Binding CenterY}" />
+                            <ScaleTransform
+                                ScaleX="{Binding ScaleX}"
+                                ScaleY="{Binding ScaleY}"
+                                CenterX="{Binding CenterX}"   
+                                CenterY="{Binding CenterY}" />
+                            <SkewTransform
+                                AngleX="{Binding SkewX}"
+                                AngleY="{Binding SkewY}"
+                                CenterX="{Binding CenterX}"
+                                CenterY="{Binding CenterY}" />
+                            <TranslateTransform
+                                X="{Binding TranslateX}"
+                                Y="{Binding TranslateY}"/>
+                        </TransformGroup>
+                    </Path.RenderTransform>
+                </Path>
+            </Grid>
+            <!-- TRANSFORMS -->
+            <ScrollView
+                Grid.Row="1"
+                Padding="12">
+                <StackLayout>
+                    <!-- ROTATE -->
+                    <Label
+                        Text="RotateTransform"
+                        Style="{StaticResource HeaderStyle}"/>
+                    <Label
+                        Text="{Binding Rotation, StringFormat='Rotation: {0:F0}'}"
+                        Style="{StaticResource ValueStyle}"/>
+                    <Slider
+                        x:Name="Rotation"
+                        Minimum="0"
+                        Maximum="200"
+                        Value="{Binding Rotation, Mode=TwoWay}"/>
+                    <Label
+                        Text="{Binding CenterX, StringFormat='CenterX: {0:F0}'}"
+                        Style="{StaticResource ValueStyle}"/>
+                    <Slider
+                        x:Name="CenterX"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="{Binding CenterX}"/>
+                    <Label
+                        Text="{Binding  CenterY, StringFormat='CenterY: {0:F0}'}"
+                        Style="{StaticResource ValueStyle}"/>
+                    <Slider
+                        x:Name="CenterY"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="{Binding CenterY}"/>
+                    <!-- SCALE -->
+                    <Label
+                        Text="ScaleTransform"
+                        Style="{StaticResource HeaderStyle}"/>
+                    <Label
+                        Text="{Binding ScaleX, StringFormat='ScaleX: {0:F2}'}"
+                        Style="{StaticResource ValueStyle}" />
+                    <Slider
+                        x:Name="ScaleX"
+                        Minimum="0.5"
+                        Maximum="2"
+                        Value="{Binding ScaleX}" />
+                    <Label
+                        Text="{Binding ScaleY, StringFormat='ScaleY: {0:F2}'}"
+                        Style="{StaticResource ValueStyle}" />
+                    <Slider
+                        x:Name="ScaleY"
+                        Minimum="0.5"
+                        Maximum="2"
+                        Value="{Binding ScaleY}" />
+                    <!-- SKEW -->
+                    <Label
+                        Text="SkewTransform"
+                        Style="{StaticResource HeaderStyle}"/>
+                    <Label
+                        Text="{Binding SkewX, StringFormat='SkewX: {0:F0}'}"
+                        Style="{StaticResource ValueStyle}" />
+                    <Slider
+                        x:Name="SkewX"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="{Binding SkewX}"/>
+                    <Label
+                        Text="{Binding SkewY, StringFormat='SkewY: = {0:F0}'}"
+                        Style="{StaticResource ValueStyle}"/>
+                    <Slider
+                        x:Name="SkewY"
+                        Minimum="0"
+                        Maximum="100"
+                        Value="{Binding SkewY}" />
+                    <!-- TRANSLATE -->
+                    <Label
+                        Text="TranslateTransform"
+                        Style="{StaticResource HeaderStyle}"/>
+                    <Label
+                        Text="{Binding TranslateX, StringFormat='X: {0:F0}'}"
+                        Style="{StaticResource ValueStyle}"/>
+                    <Slider
+                        x:Name="TranslateX"
+                        Minimum="0"
+                        Maximum="200"
+                        Value="{Binding TranslateX}"/>
+                    <Label
+                        Text="{Binding TranslateY, StringFormat='Y: {0:F0}'}"
+                        Style="{StaticResource ValueStyle}"/>
+                    <Slider
+                        x:Name="TranslateY"
+                        Minimum="0"
+                        Maximum="200"
+                        Value="{Binding TranslateY}"/>
+                </StackLayout>
+            </ScrollView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/PathTransformBindingContextGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/PathTransformBindingContextGallery.xaml.cs
@@ -1,0 +1,128 @@
+﻿using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
+{
+	[Preserve(AllMembers = true)]
+	public partial class PathTransformBindingContextGallery : ContentPage
+	{
+		public PathTransformBindingContextGallery()
+		{
+			InitializeComponent();
+		}
+	}
+
+	public class PathTransformBindingContextViewModel : BindableObject
+	{
+		double _rotation;
+		double _centerX;
+		double _centerY;
+		double _scaleX;
+		double _scaleY;
+		double _skewX;
+		double _skewY;
+		double _translateX;
+		double _translateY;
+
+		public PathTransformBindingContextViewModel()
+		{
+			Rotation = 0;
+			CenterX = 0;
+			CenterY = 0;
+			ScaleX = 1;
+			ScaleY = 1;
+			SkewX = 0;
+			SkewY = 0;
+			TranslateX = 0;
+			TranslateY = 0;
+		}
+
+		public double Rotation
+		{
+			get { return _rotation; }
+			set
+			{
+				_rotation = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double CenterX
+		{
+			get { return _centerX; }
+			set
+			{
+				_centerX = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double CenterY
+		{
+			get { return _centerY; }
+			set
+			{
+				_centerY = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double ScaleX
+		{
+			get { return _scaleX; }
+			set
+			{
+				_scaleX = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double ScaleY
+		{
+			get { return _scaleY; }
+			set
+			{
+				_scaleY = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double SkewX
+		{
+			get { return _skewX; }
+			set
+			{
+				_skewX = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double SkewY
+		{
+			get { return _skewY; }
+			set
+			{
+				_skewY = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public double TranslateX
+		{
+			get { return _translateX; }
+			set
+			{
+				_translateX = value;
+				OnPropertyChanged();
+			}
+		}
+		public double TranslateY
+		{
+			get { return _translateY; }
+			set
+			{
+				_translateY = value;
+				OnPropertyChanged();
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/PathTransformStringGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/PathTransformStringGallery.xaml
@@ -22,8 +22,7 @@
                 Padding="12">
                 <Label
                     Text="Without RenderTransform"/>
-                <Path
-                    RenderTransform="0.75 0 0 0.75 0 0">
+                <Path>
                     <Path.Data>
                       <PathGeometry>
                         <PathGeometry.Figures>
@@ -59,7 +58,8 @@
                 </Path>
                 <Label
                     Text="With RenderTransform"/>
-                <Path>
+                <Path
+                    RenderTransform="0 1 1 0 0 0">
                     <Path.Data>
                       <PathGeometry>
                         <PathGeometry.Figures>

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapesGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapesGallery.cs
@@ -35,6 +35,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
 						GalleryBuilder.NavButton("Path Aspect Gallery", () => new PathAspectGallery(), Navigation),
 						GalleryBuilder.NavButton("Path LayoutOptions Gallery", () => new PathLayoutOptionsGallery(), Navigation),
 						GalleryBuilder.NavButton("Transform Playground", () => new TransformPlaygroundGallery(), Navigation),
+						GalleryBuilder.NavButton("Path Transform BindingContext Gallery", () => new PathTransformBindingContextGallery(), Navigation),
 						GalleryBuilder.NavButton("Path Transform using string (TypeConverter) Gallery", () => new PathTransformStringGallery(), Navigation),
 						GalleryBuilder.NavButton("Animate Shape Gallery", () => new AnimateShapeGallery(), Navigation),
 						GalleryBuilder.NavButton("Clip Gallery", () => new ClipGallery(), Navigation),

--- a/Xamarin.Forms.Core/Shapes/Path.cs
+++ b/Xamarin.Forms.Core/Shapes/Path.cs
@@ -53,6 +53,13 @@ namespace Xamarin.Forms.Shapes
 			}
 		}
 
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			SetInheritedBindingContext(RenderTransform, BindingContext);
+		}
+
 		void OnGeometryPropertyChanged(object sender, PropertyChangedEventArgs args)
 		{
 			OnPropertyChanged(nameof(Geometry));

--- a/Xamarin.Forms.Core/Shapes/TransformGroup.cs
+++ b/Xamarin.Forms.Core/Shapes/TransformGroup.cs
@@ -36,6 +36,14 @@ namespace Xamarin.Forms.Shapes
 			(bindable as TransformGroup).UpdateTransformMatrix();
 		}
 
+		protected override void OnBindingContextChanged()
+		{
+			base.OnBindingContextChanged();
+
+			foreach(var children in Children)
+				SetInheritedBindingContext(children, BindingContext);
+		}
+
 		void OnChildrenCollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
 			if (args.NewItems != null)


### PR DESCRIPTION
### Description of Change ###

Correctly propagate the BC from the Path to the Path RenderTransforms.

### Issues Resolved ### 
There really is no issue registered, David has notified me detecting the issue creating https://github.com/davidortinau/easings

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix-pbc-transform](https://user-images.githubusercontent.com/6755973/99290470-a10d0300-283e-11eb-85fe-ce258a97176b.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Shapes galleries. Select the new "Path Transform BindingContext Gallery" and modify the Sliders. If changing the Sliders transform the Path, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
