### PR TITLE
[iOS] Path is not displayed correctly

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12672.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12672.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue12672"
+    Title="Issue 12672">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the Path is rendered in the same way on Android and iOS, the test has passed."/>
+        <Grid
+            BackgroundColor="Red"
+            VerticalOptions="Start">
+            <Path Data="M0,37 V0 H193.86 L179.575,26.261 A19.5,19.5,0,0,1,162.148,37 Z"
+                  Fill="Yellow"
+                  Stroke="Green"
+                  StrokeDashArray="1 1">
+                <!--<Path.Fill>
+                    <LinearGradientBrush>
+                        <GradientStop Offset="0" Color="White" />
+                        <GradientStop Offset="1" Color="Orange" />
+                    </LinearGradientBrush>
+                </Path.Fill>-->
+            </Path>
+        </Grid>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12672.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12672.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12672, "[iOS] Path is not displayed correctly",
+		PlatformAffected.iOS)]
+	public partial class Issue12672 : TestContentPage
+	{
+		public Issue12672()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1636,6 +1636,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12777.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11911.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11691.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12672.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1970,6 +1971,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11691.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12672.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Extensions/GeometryExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/GeometryExtensions.cs
@@ -92,9 +92,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
                             lastPoint = points[points.Count - 1];
                         }
-
                         // BezierSegment
-                        if (pathSegment is BezierSegment)
+                        else if (pathSegment is BezierSegment)
                         {
                             BezierSegment bezierSegment = pathSegment as BezierSegment;
 
@@ -126,9 +125,8 @@ namespace Xamarin.Forms.Platform.MacOS
 
                             lastPoint = points[points.Count - 1];
                         }
-
                         // QuadraticBezierSegment
-                        if (pathSegment is QuadraticBezierSegment)
+                        else if (pathSegment is QuadraticBezierSegment)
                         {
                             QuadraticBezierSegment bezierSegment = pathSegment as QuadraticBezierSegment;
 
@@ -180,14 +178,15 @@ namespace Xamarin.Forms.Platform.MacOS
                                 arcSegment.SweepDirection == SweepDirection.CounterClockwise,
                                 1);
 
-                            CGPoint[] cgpoints = new CGPoint[points.Count];
-
                             for (int i = 0; i < points.Count; i++)
-                                cgpoints[i] = transform.TransformPoint(points[i].ToPointF());
+                            {
+                                pathData.Data.AddLineToPoint(
+                                    (nfloat)points[i].X,
+                                    (nfloat)points[i].Y);
+                            }
 
-                            pathData.Data.AddLines(cgpoints);
-
-                            lastPoint = points.Count > 0 ? points[points.Count - 1] : Point.Zero;
+                            if (points.Count > 0)
+                                lastPoint = points[points.Count - 1];
                         }
                     }
 


### PR DESCRIPTION
### Description of Change ###

Fixed issue in iOS drawing an ArcSegment after flatten the arc.

### Issues Resolved ### 

- fixes #12672 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="373" alt="issue12672" src="https://user-images.githubusercontent.com/6755973/99399174-9b1e2d00-28e5-11eb-9087-b5b2228f7609.png">

### Testing Procedure ###
Launch Core Gallery in Android and iOS. Compare the issue 12672 on Android and iOS. If the Path is rendered in the same way, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
