### PR TITLE
[macOS] Fix InvalidCastException tapped RadioButton

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
@@ -27,9 +27,6 @@ namespace Xamarin.Forms.Platform.MacOS
 
 		protected override void Dispose(bool disposing)
 		{
-			if (Control != null)
-				Control.Activated -= OnButtonActivated;
-
 			ObserveStateChange(false);
 
 			base.Dispose(disposing);
@@ -47,8 +44,6 @@ namespace Xamarin.Forms.Platform.MacOS
 					btn.SetButtonType(NSButtonType.Radio);
 					SetNativeControl(btn);
 					ObserveStateChange(true);
-
-					Control.Activated += OnButtonActivated;
 				}
 
 				UpdateContent();
@@ -75,11 +70,6 @@ namespace Xamarin.Forms.Platform.MacOS
 				UpdateBackgroundVisibility();
 			else if (e.PropertyName == RadioButton.IsCheckedProperty.PropertyName)
 				UpdateCheck();
-		}
-
-		void OnButtonActivated(object sender, EventArgs eventArgs)
-		{
-			((IButtonController)Element)?.SendClicked();
 		}
 
 		void UpdateBackgroundVisibility()


### PR DESCRIPTION
### Description of Change ###

Removed unnecessary SendClicked logic in macOS RadioButtonRenderer

### Issues Resolved ### 

- fixes #12880 

### API Changes ###

 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery on macOS and navigate to the RadioButton Gallery. Then, tap any RadioButton. Without exceptions, the test has passed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
