### PR TITLE
[iOS] Fixed RequestedThemeChanged raised twice issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12512.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12512.cs
@@ -1,0 +1,70 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Diagnostics;
+using System;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12512, "[Bug] Application.RequestedThemeChanged raised twice on iOS when switching to home screen and back", PlatformAffected.Default)]
+	public class Issue12512 : TestContentPage
+	{
+		int _count;
+		readonly Label _themes;
+
+		public Issue12512()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Go to system settings and change the theme. Go back to the App to see that only one theme has been registered. Repeat the process again. When you return to the App you must have registered two theme changes."
+			};
+
+			_themes = new Label();
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(_themes);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+			Application.Current.RequestedThemeChanged += OnRequestedThemeChanged;
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+			Application.Current.RequestedThemeChanged -= OnRequestedThemeChanged;
+		}
+
+		void OnRequestedThemeChanged(object sender, AppThemeChangedEventArgs e)
+		{
+			string requestedTheme = $"{_count}: {e.RequestedTheme}";
+			Debug.WriteLine(requestedTheme);
+
+			_themes.Text += requestedTheme + Environment.NewLine;
+			_count++;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1636,6 +1636,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12777.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11911.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11691.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12512.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/PageRenderer.cs
@@ -364,7 +364,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.TraitCollectionDidChange(previousTraitCollection);
 
-			if (Forms.IsiOS13OrNewer && previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle)
+			if (Forms.IsiOS13OrNewer &&
+				previousTraitCollection.UserInterfaceStyle != TraitCollection.UserInterfaceStyle &&
+				UIApplication.SharedApplication.ApplicationState != UIApplicationState.Background)
 				Application.Current?.TriggerThemeChanged(new AppThemeChangedEventArgs(Application.Current.RequestedTheme));
 		}
 


### PR DESCRIPTION
### Description of Change ###

The issue is in fact an iOS feature. Is doing multiple snapshots of the app's UI that will be presented in the App Switcher. And since the user could change to Dark Mode while your app is in the background, iOS does snapshots in both interface styles to always show the correct one.

Happens something like: The system takes a screenshot of your Light UI, switches to Dark (first trigger), takes a screenshot (off-screen), and switches back to Light (second trigger). And we have raised twice `RequestedThemeChanged`.

This PR include changes to only raise `RequestedThemeChanged` if the App is not in Background. Why?. To avoid raise the event  while app snapshots are being taken when going to background. In that way, the App raise the event just 1 time when pass from background to foreground.

### Issues Resolved ### 

- fixes #12512.

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12512. Then, follow the instructions.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
