### PR TITLE
[Tizen] Fix the FrameRender

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/FrameRenderer.cs
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
 			var canvas = e.Surface.Canvas;
 			var bound = e.Info.Rect;
 			canvas.Clear();
-			var bgColor = Element.BackgroundColor == Color.Default ? SKColors.White : SKColor.Parse(Element.BackgroundColor.ToHex());
+			var bgColor = Element.BackgroundColor == Color.Default ? s_defaultColor : SKColor.Parse(Element.BackgroundColor.ToHex());
 			var borderColor = Element.BorderColor == Color.Default ? s_defaultColor : SKColor.Parse(Element.BorderColor.ToHex());
 			var roundRect = CreateRoundRect(bound);
 
@@ -105,14 +105,13 @@ namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
 			var bound = e.Info.Rect;
 			canvas.Clear();
 
-			var bgColor = Element.BackgroundColor == Color.Default ? SKColors.White : SKColor.Parse(Element.BackgroundColor.ToHex());
 			var roundRect = CreateRoundRect(bound);
 
 			using (var paint = new SKPaint
 			{
 				IsAntialias = true,
 				Style = SKPaintStyle.Fill,
-				Color = bgColor,
+				Color = SKColors.White,
 			})
 			{
 				canvas.DrawRoundRect(roundRect, paint);


### PR DESCRIPTION
### Description of Change ###
Changes the default background color of Frame to `Transparent`. Plus, fix the clipper correctly.

### Issues Resolved ### 
None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
