### PR TITLE
[X] deprecate FontImageExtension

### DIFF
--- a/Xamarin.Forms.Core/FontImageSource.cs
+++ b/Xamarin.Forms.Core/FontImageSource.cs
@@ -1,5 +1,6 @@
 ﻿namespace Xamarin.Forms
 {
+	[ContentProperty(nameof(Glyph))]
 	public class FontImageSource : ImageSource
 	{
 		public override bool IsEmpty => string.IsNullOrEmpty(Glyph);

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12851.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12851.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.Gh12851">
+    <ContentPage.Resources>
+        <Color x:Key="PrimaryColor">HotPink</Color>
+    </ContentPage.Resources>
+    <StackLayout>
+        <Image x:Name="staticImage" Source="{FontImageSource Color={StaticResource PrimaryColor}}"/>
+        <Image x:Name="dynamicWithExtension" Source="{FontImageSource Color={DynamicResource PrimaryColor}}"/>
+        <Image x:Name="dynamicWithElement">
+            <Image.Source>
+                <FontImageSource Color="{DynamicResource PrimaryColor}" />
+            </Image.Source>
+        </Image>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12851.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12851.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh12851 : ContentPage
+	{
+		public Gh12851() => InitializeComponent();
+		public Gh12851(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void FontImageWithDynamicResource([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new Gh12851(useCompiledXaml);
+				Assert.That((layout.staticImage.Source as FontImageSource).Color, Is.EqualTo(Color.HotPink));
+				Assert.That((layout.dynamicWithExtension.Source as FontImageSource).Color, Is.EqualTo(Color.HotPink));
+				Assert.That((layout.dynamicWithElement.Source as FontImageSource).Color, Is.EqualTo(Color.HotPink));
+			}
+
+			[Test]
+			public void FontImageWithDynamicResourceChanged([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new Gh12851(useCompiledXaml);
+				var rd = layout.Resources;
+				rd["PrimaryColor"] = Color.Chartreuse;
+				Assert.That((layout.staticImage.Source as FontImageSource).Color, Is.EqualTo(Color.HotPink));
+				Assert.That((layout.dynamicWithExtension.Source as FontImageSource).Color, Is.EqualTo(Color.Chartreuse));
+				Assert.That((layout.dynamicWithElement.Source as FontImageSource).Color, Is.EqualTo(Color.Chartreuse));
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml/MarkupExtensions/FontImageExtension.cs
+++ b/Xamarin.Forms.Xaml/MarkupExtensions/FontImageExtension.cs
@@ -4,6 +4,7 @@ namespace Xamarin.Forms.Xaml
 {
 	[AcceptEmptyServiceProvider]
 	[ContentProperty(nameof(Glyph))]
+	[Obsolete("This markup extension is deprecated. Use \"{FontImageSource}\" syntax.")]
 	public class FontImageExtension : IMarkupExtension<ImageSource>
 	{
 		public string FontFamily { get; set; }


### PR DESCRIPTION
### Description of Change ###

this markup extension is a pass-through and does nothing, but add some
restricition (can't bind, or set dynamic resource to Color, e.g.). Using
the FontImageSource as a markup, like in `{FontImageSource}`, doesn't
have those restricitions, and reduce the amount of processing and
allocation. It should be used instead

### Issues Resolved ### 

- fixes #12851

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
