### PR TITLE
[iOS] Fix CollectionView EmptyView RTL issue

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewGallery.cs
@@ -28,6 +28,8 @@
 							new EmptyViewSwapGallery(), Navigation),
 						GalleryBuilder.NavButton("EmptyView (load simulation)", () =>
 							new EmptyViewLoadSimulateGallery(), Navigation),
+						GalleryBuilder.NavButton("EmptyView RTL", () =>
+							new EmptyViewRTLGallery(), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewRTLGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewRTLGallery.xaml
@@ -1,0 +1,57 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries.EmptyViewRTLGallery"
+    Title="EmptyView RTL Gallery"
+    x:Name="EmptyViewRTLPage">
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+            <StackLayout>
+                <Picker
+                    x:Name="Picker"
+                    Title="FlowDirection"
+                    SelectedIndexChanged="OnPickerSelectedIndexChanged">
+                    <Picker.ItemsSource>
+                        <x:Array Type="{x:Type x:String}">
+                          <x:String>Left to Right</x:String>
+                          <x:String>Right to Left</x:String>
+                        </x:Array>
+                  </Picker.ItemsSource>
+                </Picker>
+                <SearchBar
+                    x:Name="SearchBar"
+                    Placeholder="Filter" />
+            </StackLayout>
+            <CollectionView
+				x:Name="CollectionView"
+				Grid.Row="1">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout
+						Span="3"
+						Orientation="Vertical" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.EmptyView>
+                    <StackLayout>
+                        <Label
+							FontAttributes="Bold"
+							FontSize="18" Margin="10,25,10,10"
+							HorizontalOptions="Fill"
+                            HorizontalTextAlignment="Start" 
+							Text="No results matched your filter." />
+                        <Label
+							FontAttributes="Italic"
+							FontSize="12" 
+							HorizontalOptions="Fill"
+							HorizontalTextAlignment="End"
+							Text="Maybe try a broader filter?" />
+                    </StackLayout>
+                </CollectionView.EmptyView>
+            </CollectionView>
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewRTLGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/EmptyViewGalleries/EmptyViewRTLGallery.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.EmptyViewGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class EmptyViewRTLGallery : ContentPage
+	{
+		readonly DemoFilteredItemSource _demoFilteredItemSource = new DemoFilteredItemSource();
+
+		public EmptyViewRTLGallery()
+		{
+			InitializeComponent();
+
+			Picker.SelectedIndex = 0;
+
+			CollectionView.ItemTemplate = ExampleTemplates.PhotoTemplate();
+
+			CollectionView.ItemsSource = _demoFilteredItemSource.Items;
+
+			SearchBar.SearchCommand = new Command(() => _demoFilteredItemSource.FilterItems(SearchBar.Text));
+		}
+
+		void OnPickerSelectedIndexChanged(object sender, EventArgs e)
+		{
+			switch (Picker.SelectedIndex)
+			{
+				default:
+				case 0:
+					EmptyViewRTLPage.FlowDirection = FlowDirection.LeftToRight;
+					break;
+				case 1:
+					EmptyViewRTLPage.FlowDirection = FlowDirection.RightToLeft;
+					break;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -206,6 +206,16 @@ namespace Xamarin.Forms.Platform.iOS
 			CollectionView.CollectionViewLayout.InvalidateLayout();
 		}
 
+		public virtual void UpdateFlowDirection()
+		{
+			CollectionView.UpdateFlowDirection(ItemsView);
+
+			if (ItemsSource?.ItemCount == 0)
+				_emptyUIView?.UpdateFlowDirection(_emptyViewFormsElement);
+
+			Layout.InvalidateLayout();
+		}
+
 		public override nint NumberOfSections(UICollectionView collectionView)
 		{
 			if(!_initialized)
@@ -399,7 +409,10 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				_emptyUIView.Tag = EmptyTag;
-				CollectionView.AddSubview(_emptyUIView);
+
+				var collectionViewContainer = CollectionView.Superview;
+				collectionViewContainer.AddSubview(_emptyUIView);
+
 				LayoutEmptyView();
 
 				if (_emptyViewFormsElement != null)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -133,8 +133,7 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-			Controller.CollectionView.UpdateFlowDirection(Element);
-			Controller.Layout.InvalidateLayout();
+			Controller.UpdateFlowDirection();
 		}
 
 		protected virtual void UpdateItemsSource()


### PR DESCRIPTION
### Description of Change ###

The EmptyView using RightToLeft was flipped and does not update the position of the views. This PR include changes to fix the issue.

### Issues Resolved ### 

- fixes #12892 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![cv-emptyview-rtl](https://user-images.githubusercontent.com/6755973/99665374-dcd7e080-2a69-11eb-8313-faa184cc8ac4.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the CollectionView Galleries. Select the EmptyView RTL sample and check that the EmptyView looks correctly both LeftToRight and RightToLeft.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
