### PR TITLE
Extra restore to fix 16.8 builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,8 +3,6 @@ variables:
   value: 'any cpu'
 - name: ApkName
   value: AndroidControlGallery.AndroidControlGallery.apk
-- name: SolutionFile
-  value: Xamarin.Forms.sln
 - name: BuildVersion
   value: $[counter('nuget-counter', 126)]
 - name: BuildVersion42
@@ -101,7 +99,6 @@ stages:
         steps:
           - template: build/steps/build-windows.yml
             parameters:
-              slnPath: build/Xamarin.Forms.Pages.sln
               includeUwp: false
               includeAndroid: false
               includeNonUwpAndNonAndroid: false
@@ -168,7 +165,6 @@ stages:
         steps:
           - template: build/steps/build-windows.yml
             parameters:
-              slnPath: build/Xamarin.Forms.Pages.sln
               includeUwp: false
               includeAndroid: false
               includeNonUwpAndNonAndroid: false
@@ -271,7 +267,6 @@ stages:
         variables:
           provisionator.osxPath : 'build/provisioning/provisioning.csx'
           buildConfiguration: $(DefaultBuildConfiguration)
-          slnPath: $(SolutionFile)
           iOSCertSecureFileName: 'Xamarin Forms iOS Certificate.p12'
           iOSProvisioningSecureFileName: 'Xamarin Forms iOS Provisioning.mobileprovision'
           buildForVS2017: 'true'

--- a/build.cake
+++ b/build.cake
@@ -866,7 +866,7 @@ Task("BuildPages")
 
         msbuildSettings.BinaryLogger = binaryLogger;
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-pages-{configuration}.binlog";
-        MSBuild("./Xamarin.Forms.Pages.sln", msbuildSettings.WithRestore());
+        MSBuild("./build/Xamarin.Forms.Pages.sln", msbuildSettings.WithRestore());
 
     }
     catch(Exception)

--- a/build.cake
+++ b/build.cake
@@ -728,7 +728,7 @@ Task("BuildForNuget")
 
         msbuildSettings.BinaryLogger = binaryLogger;
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}.binlog";
-        MSBuild("./Xamarin.Forms.sln", msbuildSettings);
+        MSBuild("./Xamarin.Forms.sln", msbuildSettings.WithRestore());
         
         // // This currently fails on CI will revisit later
         // if(isCIBuild)
@@ -1108,6 +1108,11 @@ MSBuildSettings GetMSBuildSettings(PlatformTarget? platformTarget = PlatformTarg
     if(!String.IsNullOrWhiteSpace(XamarinFormsVersion))
     {
         buildSettings = buildSettings.WithProperty("XamarinFormsVersion", XamarinFormsVersion);
+    }
+    
+    if(isCIBuild)
+    {
+        buildSettings = buildSettings.WithProperty("RestoreConfigFile", $"DevopsNuget.config");
     }
     
     buildSettings.ArgumentCustomization = args => args.Append($"/nowarn:VSX1000 {MSBuildArguments}");

--- a/build.cake
+++ b/build.cake
@@ -852,6 +852,30 @@ Task("BuildForNuget")
     }
 });
 
+Task("BuildPages")
+    .IsDependentOn("BuildTasks")
+    .Description("Build Xamarin.Forms.Pages")
+    .Does(() =>
+{
+    try
+    {
+        var msbuildSettings = GetMSBuildSettings();
+        var binaryLogger = new MSBuildBinaryLogSettings {
+            Enabled  = isCIBuild
+        };
+
+        msbuildSettings.BinaryLogger = binaryLogger;
+        binaryLogger.FileName = $"{artifactStagingDirectory}/win-pages-{configuration}.binlog";
+        MSBuild("./Xamarin.Forms.Pages.sln", msbuildSettings.WithRestore());
+
+    }
+    catch(Exception)
+    {
+        if(IsRunningOnWindows())
+            throw;
+    }
+});
+
 Task("BuildTasks")
     .Description("Build Xamarin.Forms.Build.Tasks/Xamarin.Forms.Build.Tasks.csproj")
     .Does(() =>

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -9,7 +9,6 @@ parameters:
   includeNonUwpAndNonAndroid: 'true'
   includePages: 'false'
 
-
 steps:
   - checkout: self
     clean: true
@@ -37,6 +36,14 @@ steps:
     condition: ne(variables['NUGET_VERSION'], '')
     inputs:
       versionSpec: $(NUGET_VERSION)
+
+  - task: NuGetCommand@2
+    displayName: 'NuGet restore ${{ parameters.slnPath }}'
+    condition: eq(${{ parameters.includePages }}, 'true')
+    inputs:
+      restoreSolution: ${{ parameters.slnPath }}
+      feedsToUse: config
+      nugetConfigPath: 'DevopsNuget.config'
 
   - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winbuild

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -1,5 +1,4 @@
 parameters:
-  slnPath : 'Xamarin.Forms.sln'
   msbuildExtraArguments : ''
   artifactsTargetFolder: '$(build.artifactstagingdirectory)'
   artifactsName: 'win_build'
@@ -31,33 +30,15 @@ steps:
   #     version: $(DOTNET_VERSION)
   #     packageType: 'sdk'
 
-  - task: NuGetToolInstaller@1
-    displayName: 'Use NuGet $(NUGET_VERSION)'
-    condition: ne(variables['NUGET_VERSION'], '')
-    inputs:
-      versionSpec: $(NUGET_VERSION)
-
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore ${{ parameters.slnPath }}'
-    condition: eq(${{ parameters.includePages }}, 'true')
-    inputs:
-      restoreSolution: ${{ parameters.slnPath }}
-      feedsToUse: config
-      nugetConfigPath: 'DevopsNuget.config'
-
   - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winbuild
     displayName: 'Build Projects For Nuget'
     condition: ne(${{ parameters.includePages }}, 'true')
 
-  - task: MSBuild@1
-    displayName: 'Build solution ${{ parameters.slnPath }}'
+  - script: build.cmd -Target BuildPages -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winslnbuild
+    displayName: 'Build solution Xamarin.Forms.Pages.sln'
     condition: eq(${{ parameters.includePages }}, 'true')
-    inputs:
-      solution: ${{ parameters.slnPath }}
-      configuration: '$(BuildConfiguration)'
-      msbuildArguments: ${{ parameters.msbuildExtraArguments }} /bl:$(Build.ArtifactStagingDirectory)\win-$(BuildConfiguration).binlog
 
   - task: VSTest@2
     displayName: 'Unit Tests'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -38,13 +38,6 @@ steps:
     inputs:
       versionSpec: $(NUGET_VERSION)
 
-  - task: NuGetCommand@2
-    displayName: 'NuGet restore ${{ parameters.slnPath }}'
-    inputs:
-      restoreSolution: ${{ parameters.slnPath }}
-      feedsToUse: config
-      nugetConfigPath: 'DevopsNuget.config'
-
   - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winbuild
     displayName: 'Build Projects For Nuget'


### PR DESCRIPTION
### Description of Change ###

16.8.1 seems to require an additional restore operation against the SLN file. I've also removed the nuget restore inside the YAML we'll see if that survives the CI :-) 

### Testing Procedure ###
- make sure builds work on public/private CI

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
