### PR TITLE
Cache cell sizes after resize from estimates

### DIFF
--- a/.Xamarin.Forms.iOS.slnf
+++ b/.Xamarin.Forms.iOS.slnf
@@ -3,8 +3,6 @@
     "path": "Xamarin.Forms.sln",
     "projects": [
       "Stubs\\Xamarin.Forms.Platform.iOS\\Xamarin.Forms.Platform.iOS (Forwarders).csproj",
-      "XFCorePostProcessor.Tasks\\XFCorePostProcessor.Tasks.csproj",
-      "Xamarin.Flex\\Xamarin.Flex.shproj",
       "Xamarin.Forms.Build.Tasks\\Xamarin.Forms.Build.Tasks.csproj",
       "Xamarin.Forms.ControlGallery.iOS\\Xamarin.Forms.ControlGallery.iOS.csproj",
       "Xamarin.Forms.Controls.Issues\\Xamarin.Forms.Controls.Issues.Shared\\Xamarin.Forms.Controls.Issues.Shared.shproj",
@@ -18,8 +16,6 @@
       "Xamarin.Forms.Maps.iOS\\Xamarin.Forms.Maps.iOS.csproj",
       "Xamarin.Forms.Maps\\Xamarin.Forms.Maps.csproj",
       "Xamarin.Forms.Material.iOS\\Xamarin.Forms.Material.iOS.csproj",
-      "Xamarin.Forms.Pages.Azure\\Xamarin.Forms.Pages.Azure.csproj",
-      "Xamarin.Forms.Pages\\Xamarin.Forms.Pages.csproj",
       "Xamarin.Forms.Platform.iOS.UnitTests\\Xamarin.Forms.Platform.iOS.UnitTests.csproj",
       "Xamarin.Forms.Platform.iOS\\Xamarin.Forms.Platform.iOS.csproj",
       "Xamarin.Forms.Platform\\Xamarin.Forms.Platform.csproj",

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateGallery.cs
@@ -1,4 +1,6 @@
-﻿namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
+﻿using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTemplateSelectorGalleries;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
 	internal class DataTemplateGallery : ContentPage
 	{
@@ -26,6 +28,8 @@
 							new TemplateCodeCollectionViewGridGallery (ItemsLayoutOrientation.Horizontal), Navigation),
 						GalleryBuilder.NavButton("DataTemplateSelector", () =>
 							new DataTemplateSelectorGallery(), Navigation),
+						GalleryBuilder.NavButton("Varied Size Data Templates", () =>
+							new VariedSizeDataTemplateSelectorGallery(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml
@@ -1,0 +1,93 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" xmlns:datatemplateselectorgalleries="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTemplateSelectorGalleries"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTemplateSelectorGalleries.VariedSizeDataTemplateSelectorGallery">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="MilkTemplate">
+                <Frame BorderColor="Red" BackgroundColor="Wheat" HeightRequest="100">
+                    <StackLayout HeightRequest="100">
+                        <Label Text="{Binding Name}" />
+                    </StackLayout>
+                </Frame>
+            </DataTemplate>
+
+            <DataTemplate x:Key="CoffeeTemplate">
+                <Frame BorderColor="Red" BackgroundColor="SaddleBrown" HeightRequest="50">
+                    <StackLayout HeightRequest="50">
+                        <Label Text="{Binding Name}" />
+                    </StackLayout>
+                </Frame>
+            </DataTemplate>
+
+            <DataTemplate x:Key="LatteTemplate" x:DataType="datatemplateselectorgalleries:Latte">
+                <Frame BorderColor="Red" BackgroundColor="BurlyWood" >
+                    <StackLayout>
+                        <Label Text="{Binding Name, StringFormat='Drink name is: {0}'}"/>
+                        <Label Text="     The ingredients are: " Margin="0,10,0,0"/>
+                        <StackLayout BindableLayout.ItemsSource="{Binding Ingredients}" >
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate x:DataType="datatemplateselectorgalleries:DrinkBase">
+                                    <Label Text="{Binding Name, StringFormat='    {0}'}" />
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </StackLayout>
+                    </StackLayout>
+                </Frame>
+            </DataTemplate>
+
+            <datatemplateselectorgalleries:DrinkTemplateSelector x:Key="VehicleTemplateSelector"
+                                                            MilkTemplate="{StaticResource MilkTemplate}"
+                                                            CoffeeTemplate="{StaticResource CoffeeTemplate}"
+                                                            LatteTemplate="{StaticResource LatteTemplate}"/>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    
+    <ContentPage.Content>
+            <Grid>
+                <Grid.RowDefinitions>
+                    <RowDefinition Height="*"/>
+                    <RowDefinition Height="Auto"/>
+                </Grid.RowDefinitions>
+
+                <CollectionView ItemsSource="{Binding Items}" 
+                            ItemTemplate="{StaticResource VehicleTemplateSelector}"
+                            VerticalOptions="FillAndExpand"
+                            ItemSizingStrategy="MeasureAllItems" />
+
+                <StackLayout Grid.Row="1">
+
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                            <ColumnDefinition/>
+                        </Grid.ColumnDefinitions>
+                        <Button Grid.Column="0" Text="Insert" Clicked="Insert_OnClicked"/>
+                        <Button Grid.Column="1" Text="Add" Clicked="Add_OnClicked"/>
+                        <Button Grid.Column="2" Text="Remove" Clicked="Remove_OnClicked"/>
+                    </Grid>
+
+                    <StackLayout Orientation="Horizontal">
+                        <Label Text="Index"/>
+                        <Entry Text="{Binding Index}" HorizontalOptions="FillAndExpand"/>
+                    </StackLayout>
+
+                    <Picker x:Name="TemplatePicker"
+                        Title="Select a template"
+                        TitleColor="Red"
+                        SelectedItem="{Binding SelectedTemplate}">
+                        <Picker.ItemsSource>
+                            <x:Array Type="{x:Type x:String}">
+                                <x:String>Coffee</x:String>
+                                <x:String>Milk</x:String>
+                                <x:String>Latte</x:String>
+                            </x:Array>
+                        </Picker.ItemsSource>
+                    </Picker>
+
+                </StackLayout>
+            </Grid>
+        </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
@@ -28,11 +28,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTempla
 			IEnumerable<DrinkBase> CreateDefaultDrinks()
 			{
 				yield return new Coffee("0");
-				//yield return new Milk("1");
-				//yield return new Coffee("2");
-				//yield return new Coffee("3");
-				//yield return new Milk("4");
-				//yield return new Coffee("5");
+				yield return new Milk("1");
+				yield return new Coffee("2");
+				yield return new Coffee("3");
+				yield return new Milk("4");
+				yield return new Coffee("5");
 			}
 		}
 

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/DataTemplateSelectorGalleries/VariedSizeDataTemplateSelectorGallery.xaml.cs
@@ -1,0 +1,183 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.DataTemplateSelectorGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class VariedSizeDataTemplateSelectorGallery : ContentPage
+	{
+		string _index = "1";
+		string _itemsCount = "1";
+		int _counter = 6;
+		string _selectedTemplate = nameof(Latte);
+		bool _shouldTriggerReset;
+
+		public VariedSizeDataTemplateSelectorGallery()
+		{
+			InitializeComponent();
+			BindingContext = this;
+
+			foreach (var vehicle in CreateDefaultDrinks())
+			{
+				Items.Add(vehicle);
+			}
+
+			IEnumerable<DrinkBase> CreateDefaultDrinks()
+			{
+				yield return new Coffee("0");
+				//yield return new Milk("1");
+				//yield return new Coffee("2");
+				//yield return new Coffee("3");
+				//yield return new Milk("4");
+				//yield return new Coffee("5");
+			}
+		}
+
+		public ObservableCollection<DrinkBase> Items { get; set; } =
+			new ObservableCollection<DrinkBase>();
+
+		public string Index
+		{
+			get => _index;
+			set => SetValue(ref _index, value);
+		}
+
+		public string ItemsCount
+		{
+			get => _itemsCount;
+			set => SetValue(ref _itemsCount, value);
+		}
+
+		public string SelectedTemplate
+		{
+			get => _selectedTemplate;
+			set => SetValue(ref _selectedTemplate, value);
+		}
+
+		public bool ShouldTriggerReset
+		{
+			get => _shouldTriggerReset;
+			set => SetValue(ref _shouldTriggerReset, value);
+		}
+
+		void Insert_OnClicked(object sender, EventArgs e)
+		{
+			if (!IsValid(out var index))
+				return;
+
+			Items.Insert(index, CreateDrink());
+		}
+
+		void Add_OnClicked(object sender, EventArgs e)
+		{
+			if (!IsValid(out var _))
+				return;
+
+			Items.Add(CreateDrink());
+		}
+
+		void SetValue<T>(ref T backingField, in T value, [CallerMemberName] string callerName = null)
+		{
+			if (Equals(backingField, value))
+				return;
+			OnPropertyChanging(callerName);
+			backingField = value;
+			OnPropertyChanged(callerName);
+		}
+
+		void Remove_OnClicked(object sender, EventArgs e)
+		{
+			if (!IsValid(out var index))
+				return;
+
+			Items.RemoveAt(index);
+		}
+
+		DrinkBase CreateDrink()
+		{
+			switch (SelectedTemplate)
+			{
+				case nameof(Milk):
+					return new Milk(_counter++.ToString());
+				case nameof(Coffee):
+					return new Coffee(_counter++.ToString());
+				case nameof(Latte):
+					{
+						var latte = new Latte(_counter++.ToString())
+						{
+							Ingredients = new ObservableCollection<DrinkBase>() { new Milk(_counter++.ToString()), new Coffee(_counter++.ToString()) }
+						};
+						return latte;
+					}
+				default:
+					throw new ArgumentException();
+			}
+		}
+
+		bool IsValid(out int index)
+		{
+			index = -1;
+			if (string.IsNullOrWhiteSpace(Index))
+				return false;
+			if (!int.TryParse(Index, out index))
+				return false;
+			if (index > Items.Count || index < 0)
+				return false;
+
+			return true;
+		}
+	}
+
+	class DrinkTemplateSelector : DataTemplateSelector
+	{
+		public DataTemplate CoffeeTemplate { get; set; }
+		public DataTemplate MilkTemplate { get; set; }
+		public DataTemplate LatteTemplate { get; set; }
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			if (item is Coffee)
+				return CoffeeTemplate;
+
+			if (item is Milk)
+				return MilkTemplate;
+
+			if (item is Latte)
+				return LatteTemplate;
+
+			throw new ArgumentOutOfRangeException();
+		}
+	}
+
+	public abstract class DrinkBase
+	{
+		protected DrinkBase(string name) => Name = name;
+
+		public string Name { get; set; }
+
+		public override string ToString()
+		{
+			return Name;
+		}
+	}
+
+	class Coffee : DrinkBase
+	{
+		public Coffee(string name) : base(nameof(Coffee) + name) { }
+	}
+
+	class Milk : DrinkBase
+	{
+		public Milk(string name) : base(nameof(Milk) + name) { }
+	}
+
+	class Latte : DrinkBase
+	{
+		public Latte(string name) : base(nameof(Latte) + name) { }
+
+		public ObservableCollection<DrinkBase> Ingredients { get; set; } = new ObservableCollection<DrinkBase>();
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ChatExample.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ChatExample.xaml
@@ -1,0 +1,68 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:chat="clr-namespace:Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ItemSizeGalleries"
+             x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ItemSizeGalleries.ChatExample">
+
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <DataTemplate x:Key="Local">
+                <Grid>
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                        <ColumnDefinition Width="2*"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <Frame BorderColor="Green" BackgroundColor="LightGreen" CornerRadius="5" Grid.Column="1">
+                        <StackLayout Margin="2">
+                            <Label Text="{Binding Text}" LineBreakMode="WordWrap" FontSize="10" HorizontalTextAlignment="End" />
+                        </StackLayout>
+                    </Frame>
+                </Grid>
+            </DataTemplate>
+
+            <DataTemplate x:Key="Remote">
+                <Grid Padding="5,0,5,0">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="2*"></ColumnDefinition>
+                        <ColumnDefinition Width="*"></ColumnDefinition>
+                    </Grid.ColumnDefinitions>
+                    <Frame BorderColor="Blue" BackgroundColor="LightBlue" CornerRadius="5">
+                        <StackLayout Margin="2">
+                            <Label Text="{Binding Text}" LineBreakMode="WordWrap" FontSize="10" HorizontalTextAlignment="Start" />
+                        </StackLayout>
+                    </Frame>
+                </Grid>
+            </DataTemplate>
+
+            <chat:ChatTemplateSelector x:Key="ChatTemplateSelector"
+                                                            LocalTemplate="{StaticResource Local}"
+                                                            RemoteTemplate="{StaticResource Remote}"/>
+            
+        </ResourceDictionary>
+    </ContentPage.Resources>
+
+    <ContentPage.Content>
+        <Grid>
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="*"/>
+            </Grid.RowDefinitions>
+
+            <StackLayout Orientation="Horizontal">
+                <Button x:Name="AppendRandomSizedItem" Text="Append Random Message" Margin="2" />
+                <Button x:Name="Clear" Text="Clear" Margin="2" />
+                <Button x:Name="Lots" Text="Add 1000 Messages" Margin="2" />
+            </StackLayout>
+
+            <CollectionView ItemsSource="{Binding ChatMessages}" 
+                            ItemTemplate="{StaticResource ChatTemplateSelector}"
+                            ItemSizingStrategy="MeasureAllItems"
+                            Grid.Row="1">
+                <CollectionView.ItemsLayout>
+                    <LinearItemsLayout Orientation="Vertical" ItemSpacing="5"/>
+                </CollectionView.ItemsLayout>
+            </CollectionView>
+
+        </Grid>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ChatExample.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ChatExample.xaml.cs
@@ -1,0 +1,115 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.Xaml;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.ItemSizeGalleries
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class ChatExample : ContentPage
+	{
+		Random _random = new Random(DateTime.Now.Millisecond);
+		ChatExampleViewModel _vm = new ChatExampleViewModel();
+
+		public ChatExample()
+		{
+			InitializeComponent();
+			BindingContext = _vm;
+
+			AppendRandomSizedItem.Clicked += AppendRandomChatMessage;
+			Clear.Clicked += ClearMessages;
+			Lots.Clicked += LotsOfMessages;
+		}
+
+		void AppendRandomChatMessage(object sender, EventArgs e)
+		{
+			_vm.ChatMessages.Add(GenerateRandomMessage());
+		}
+
+		void LotsOfMessages(object sender, EventArgs e)
+		{
+			var newVm = new ChatExampleViewModel(GenerateMessages(1000));
+			_vm = newVm;
+			BindingContext = _vm;
+		}
+
+		void ClearMessages(object sender, EventArgs e)
+		{
+			_vm.ChatMessages.Clear();
+		}
+
+		ChatMessage GenerateRandomMessage() 
+		{
+			const string lorem = "Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut " 
+				+ "labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip " 
+				+ "ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat "
+				+ "nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum.";
+
+			var local = _random.Next(0, 2) == 1;
+
+			var textLength = _random.Next(0, lorem.Length - 1);
+
+			var text = lorem.Substring(0, textLength);
+
+			return new ChatMessage(text, local);
+		}
+
+		IEnumerable<ChatMessage> GenerateMessages(int count)
+		{
+			for (int n = 0; n < count; n++)
+			{
+				yield return GenerateRandomMessage();
+			}
+		}
+	}
+
+	public class ChatExampleViewModel
+	{
+		public ObservableCollection<ChatMessage> ChatMessages { get; }
+
+		public ChatExampleViewModel() 
+		{
+			ChatMessages = new ObservableCollection<ChatMessage>();
+		}
+
+		public ChatExampleViewModel(IEnumerable<ChatMessage> chatMessages) 
+		{ 
+			ChatMessages = new ObservableCollection<ChatMessage>(chatMessages);
+		}
+	}
+
+	public class ChatMessage
+	{
+		public bool IsLocal { get; set; }
+		public string Text { get; set; }
+
+		public ChatMessage(string text) : this(text, true) { }
+
+		public ChatMessage(string text, bool isLocal)
+		{
+			IsLocal = isLocal;
+			Text = text;
+		}
+	}
+
+	class ChatTemplateSelector : DataTemplateSelector
+	{
+		public DataTemplate LocalTemplate { get; set; }
+		public DataTemplate RemoteTemplate { get; set; }
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			if (item is ChatMessage message)
+			{
+				if (message.IsLocal)
+				{
+					return LocalTemplate;
+				}
+
+				return RemoteTemplate;
+			}
+
+			throw new ArgumentOutOfRangeException();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ItemsSizeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/ItemsSizeGallery.cs
@@ -21,7 +21,9 @@
 						GalleryBuilder.NavButton("Expanding Text (Horizontal List)", () =>
 							new DynamicItemSizeGallery(LinearItemsLayout.Horizontal), Navigation),
 						GalleryBuilder.NavButton("ItemSizing Strategy", () =>
-							new VariableSizeTemplateGridGallery (ItemsLayoutOrientation.Horizontal), Navigation)
+							new VariableSizeTemplateGridGallery (ItemsLayoutOrientation.Horizontal), Navigation),
+						GalleryBuilder.NavButton("Chat Example (Randomly Sized Items)", () =>
+							new ChatExample(), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemsSourceGenerator.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemsSourceGenerator.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Collections.Specialized;
+using System.Diagnostics;
 using Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries;
 using Xamarin.Forms.Internals;
 
@@ -95,7 +96,11 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 						$"Item: {n}", _images[n % _images.Length], n));
 				}
 
+				var watch = new Stopwatch();
+				watch.Start();
 				_cv.ItemsSource = items;
+				watch.Stop();
+				System.Diagnostics.Debug.WriteLine($">>>>>> That itemsource update took {watch.ElapsedMilliseconds} ms");
 			}
 		}
 

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -67,6 +67,9 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\DataTemplateSelectorGalleries\VariedSizeDataTemplateSelectorGallery.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\DragAndDropGalleries\DragAndDropBetweenLayouts.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
+++ b/Xamarin.Forms.Controls/Xamarin.Forms.Controls.csproj
@@ -70,6 +70,9 @@
     <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\DataTemplateSelectorGalleries\VariedSizeDataTemplateSelectorGallery.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <EmbeddedResource Update="GalleryPages\CollectionViewGalleries\ItemSizeGalleries\ChatExample.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Update="GalleryPages\DragAndDropGalleries\DragAndDropBetweenLayouts.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
@@ -88,6 +91,9 @@
     <EmbeddedResource Update="GalleryPages\RadioButtonGalleries\RadioButtonGroupGalleryPage.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
+    <Compile Update="GalleryPages\CollectionViewGalleries\ItemSizeGalleries\ChatExample.xaml.cs">
+      <DependentUpon>ChatExample.xaml</DependentUpon>
+    </Compile>
     <Compile Update="GalleryPages\RadioButtonGalleries\RadioButtonGroupGallery.xaml.cs">
       <DependentUpon>RadioButtonGroupGallery.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS.UnitTests/ObservableItemsSourceTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/ObservableItemsSourceTests.cs
@@ -1,4 +1,7 @@
-﻿using NUnit.Framework;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Foundation;
+using NUnit.Framework;
 
 namespace Xamarin.Forms.Platform.iOS.UnitTests
 {
@@ -57,6 +60,27 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			Assert.That((int)result[6].Item, Is.EqualTo(12));
 			Assert.That((int)result[7].Item, Is.EqualTo(13));
 			Assert.That((int)result[8].Item, Is.EqualTo(14));
+		}
+
+		[Test]
+		public void IndexPathValidTest() 
+		{
+			var list = new List<string>
+			{
+				"one",
+				"two",
+				"three"
+			};
+
+			var source = new ListSource(list);
+
+			var valid = NSIndexPath.FromItemSection(2, 0);
+			var invalidItem = NSIndexPath.FromItemSection(7, 0);
+			var invalidSection = NSIndexPath.FromItemSection(1, 9);
+
+			Assert.IsTrue(source.IsIndexPathValid(valid));
+			Assert.IsFalse(source.IsIndexPathValid(invalidItem));
+			Assert.IsFalse(source.IsIndexPathValid(invalidSection));
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselTemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselTemplatedCell.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -34,6 +35,11 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override (bool, Size) NeedsContentSizeUpdate(Size currentSize)
 		{
 			return (false, Size.Zero);
+		}
+
+		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)
+		{
+			return false;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -156,6 +156,12 @@ namespace Xamarin.Forms.Platform.iOS
 			return itemsSource;
 		}
 
+		protected override void CacheCellAttributes(NSIndexPath indexPath, CGSize size)
+		{
+			var itemIndex = GetIndexFromIndexPath(indexPath);
+			base.CacheCellAttributes(NSIndexPath.FromItemSection(itemIndex, 0), size);
+		}
+
 		internal void TearDown()
 		{
 			Carousel.PropertyChanged -= CarouselViewPropertyChanged;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalCell.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -19,6 +20,11 @@ namespace Xamarin.Forms.Platform.iOS
 				ConstrainedDimension, MeasureFlags.IncludeMargins);
 
 			return new CGSize(measure.Request.Width, ConstrainedDimension);
+		}
+
+		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)
+		{
+			return attributes.Frame.Width == ConstrainedDimension;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalTemplatedHeaderView.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/HorizontalTemplatedHeaderView.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -20,13 +21,18 @@ namespace Xamarin.Forms.Platform.iOS
 				return CGSize.Empty;
 			}
 
-			var measure = VisualElementRenderer.Element.Measure(double.PositiveInfinity, 
+			var measure = VisualElementRenderer.Element.Measure(double.PositiveInfinity,
 				ConstrainedDimension, MeasureFlags.IncludeMargins);
 
-			var width = VisualElementRenderer.Element.Width > 0 
+			var width = VisualElementRenderer.Element.Width > 0
 				? VisualElementRenderer.Element.Width : measure.Request.Width;
 
 			return new CGSize(width, ConstrainedDimension);
+		}
+
+		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)
+		{
+			return attributes.Frame.Height == ConstrainedDimension;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathHelpers.cs
@@ -32,5 +32,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return result;
 		}
+
+		public static bool IsIndexPathValid(this IItemsViewSource source, NSIndexPath indexPath) 
+		{
+			if (indexPath.Section >= source.GroupCount)
+			{
+				return false;
+			}
+
+			if (indexPath.Item >= source.ItemCountInGroup(indexPath.Section))
+			{
+				return false;
+			}
+
+			return true;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -119,7 +119,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (wasEmpty != _isEmpty)
 			{
-				UpdateEmptyViewVisibility(_isEmpty);
+				 UpdateEmptyViewVisibility(_isEmpty);
 			}
 			
 			if (wasEmpty && !_isEmpty)
@@ -286,7 +286,21 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_disposed)
 				return;
 
-			Layout?.InvalidateLayout();
+			if (!(sender is TemplatedCell cell))
+			{
+				return;
+			}
+
+			var visibleCells = CollectionView.VisibleCells;
+
+			for (int n = 0; n < visibleCells.Length; n++)
+			{
+				if (cell == visibleCells[n])
+				{
+					Layout?.InvalidateLayout();
+					return;
+				}
+			}
 		}
 
 		void CellLayoutAttributesChanged(object sender, LayoutAttributesChangedEventArgs args)
@@ -296,6 +310,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual void CacheCellAttributes(NSIndexPath indexPath, CGSize size) 
 		{
+			if (!ItemsSource.IsIndexPathValid(indexPath))
+			{
+				// The upate might be coming from a cell that's being removed; don't cache it.
+				return;
+			}
+
 			var item = ItemsSource[indexPath];
 			if (item != null)
 			{
@@ -437,7 +457,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (isEmpty && _emptyUIView != null)
 			{
-				var emptyView = CollectionView.ViewWithTag(EmptyTag);
+				var emptyView = CollectionView.Superview.ViewWithTag(EmptyTag);
 
 				if(emptyView != null)
 				{
@@ -449,7 +469,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				var collectionViewContainer = CollectionView.Superview;
 				collectionViewContainer.AddSubview(_emptyUIView);
-
+				
 				LayoutEmptyView();
 
 				if (_emptyViewFormsElement != null)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -291,10 +291,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CellLayoutAttributesChanged(object sender, LayoutAttributesChangedEventArgs args)
 		{
-			var item = ItemsSource[args.NewAttributes.IndexPath];
+			CacheCellAttributes(args.NewAttributes.IndexPath, args.NewAttributes.Size);
+		}
+
+		protected virtual void CacheCellAttributes(NSIndexPath indexPath, CGSize size) 
+		{
+			var item = ItemsSource[indexPath];
 			if (item != null)
 			{
-				_cellSizeCache[item] = args.NewAttributes.Size;
+				_cellSizeCache[item] = size;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
@@ -165,6 +165,15 @@ namespace Xamarin.Forms.Platform.iOS
 			return centerItemIndex;
 		}
 
+		// Note: we are deliberately avoiding calculating the exact size of every item that the UICollectionViewFlowLayout
+		// requests from us; instead, we use the exact ItemSize (when possible) or the EstimatedItemSize.
+		// UICollectionViewFlowLayout will request the size for _every single item_ in our datasource, even if it's not going
+		// to be on screen yet. For small datasources, realizing the Forms content and measuring it is no problem. 
+		// But for large datasets (hundreds or thousands of items), we'd be realizing a Forms datatemplate and binding it for 
+		// every single item, which defeats virtualization almost entirely. 
+		// So we only create a measurement cell and measure it in this method if we don't already have a cached estimate for 
+		// that item's data template. 
+
 		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
 		{
 			if (ItemsViewLayout.EstimatedItemSize.IsEmpty)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
@@ -1,8 +1,10 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 using CoreGraphics;
 using Foundation;
 using UIKit;
+using Xamarin.Forms.Internals;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -14,6 +16,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public TViewController ViewController { get; }
 
 		protected float PreviousHorizontalOffset, PreviousVerticalOffset;
+		readonly Dictionary<DataTemplate, CGSize> _templateSizeEstimates = new Dictionary<DataTemplate, CGSize>();
 
 		public ItemsViewDelegator(ItemsViewLayout itemsViewLayout, TViewController itemsViewController)
 		{
@@ -160,6 +163,45 @@ namespace Xamarin.Forms.Platform.iOS
 			var centerIndexPath = collectionView.IndexPathForItemAtPoint(centerPoint);
 			centerItemIndex = centerIndexPath ?? firstVisibleItemIndex;
 			return centerItemIndex;
+		}
+
+		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
+		{
+			if (ItemsViewLayout.EstimatedItemSize.IsEmpty)
+			{
+				return ItemsViewLayout.ItemSize;
+			}
+
+			var itemTemplate = ViewController.ItemsView.ItemTemplate;
+
+			if (!(itemTemplate is DataTemplateSelector dataTemplateSelector))
+			{
+				// If the DataTemplate only maps to a single template, then our original size estimate will be fine
+				return ItemsViewLayout.EstimatedItemSize;
+			}
+
+			// Determine the template type for the current item 
+			var targetTemplate = dataTemplateSelector.SelectDataTemplate(ViewController.ItemsSource[indexPath], ViewController.ItemsView);
+
+			if (_templateSizeEstimates.TryGetValue(targetTemplate, out CGSize templateSizeEstimate))
+			{
+				// We've seen this template before; use the cached estimate
+				return templateSizeEstimate;
+			}
+		
+			var measurementCell = ViewController.CreateMeasurementCell(indexPath);
+
+			if (measurementCell == null)
+			{
+				// If we couldn't get a measurement cell for some reason, fall back to the old estimate
+				return ItemsViewLayout.EstimatedItemSize;
+			}
+
+			// Measure the cell and cache the result as our estimate for this template
+			var size = measurementCell.Measure();
+			_templateSizeEstimates[measurementCell.CurrentTemplate] = size;
+
+			return size;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -187,7 +187,10 @@ namespace Xamarin.Forms.Platform.iOS
 			//		an estimate set so that when a cell _does_ become available (i.e., when the items source
 			//		has at least one item), Autolayout will kick in for the first cell and size it correctly
 			// If GetPrototype() _can_ return a cell, this estimate will be updated once that cell is measured
-			EstimatedItemSize = new CGSize(1, 1);
+			if (EstimatedItemSize == CGSize.Empty)
+			{
+				EstimatedItemSize = new CGSize(1, 1);
+			}
 
 			ItemsViewCell prototype = null;
 
@@ -360,11 +363,31 @@ namespace Xamarin.Forms.Platform.iOS
 			if (preferredAttributes.RepresentedElementKind != UICollectionElementKindSectionKey.Header
 				&& preferredAttributes.RepresentedElementKind != UICollectionElementKindSectionKey.Footer)
 			{
-				return base.GetInvalidationContext(preferredAttributes, originalAttributes);
+				if (Forms.IsiOS12OrNewer)
+				{
+					return base.GetInvalidationContext(preferredAttributes, originalAttributes);
+				}
+
+				try
+				{
+					// We only have to do this on older iOS versions; sometimes when removing a cell that's right at the edge
+					// of the viewport we'll run into a race condition where the invalidation context will have the removed
+					// indexpath. And then things crash. So 
+
+					var defaultContext = base.GetInvalidationContext(preferredAttributes, originalAttributes);
+					return defaultContext;
+				}
+				catch (MonoTouchException ex) when (ex.Name == "NSRangeException") 
+				{
+					Log.Warning("ItemsViewLayout", ex.ToString());
+				}
+
+				UICollectionViewFlowLayoutInvalidationContext context = new UICollectionViewFlowLayoutInvalidationContext();
+				return context;
 			}
-			
+
 			// Ensure that if this invalidation was triggered by header/footer changes, the header/footer are being invalidated
-			
+
 			UICollectionViewFlowLayoutInvalidationContext invalidationContext = new UICollectionViewFlowLayoutInvalidationContext();
 			var indexPath = preferredAttributes.IndexPath;
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/LayoutAttributesChangedEventArgs.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/LayoutAttributesChangedEventArgs.cs
@@ -1,0 +1,12 @@
+﻿using System;
+using UIKit;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	public class LayoutAttributesChangedEventArgs : EventArgs
+	{
+		public UICollectionViewLayoutAttributes NewAttributes { get; }
+
+		public LayoutAttributesChangedEventArgs(UICollectionViewLayoutAttributes newAttributes) => NewAttributes = newAttributes;
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -55,14 +55,27 @@ namespace Xamarin.Forms.Platform.iOS
 			var preferredAttributes = base.PreferredLayoutAttributesFittingAttributes(layoutAttributes);
 
 			var preferredSize = preferredAttributes.Frame.Size;
-			var elementSize = VisualElementRenderer.Element.Bounds.Size;
 
-			if (SizesAreSame(preferredSize, elementSize) 
+			if (SizesAreSame(preferredSize, _size)
 				&& AttributesConsistentWithConstrainedDimension(preferredAttributes))
 			{
 				return preferredAttributes;
 			}
 
+			var size = UpdateCellSize();
+
+			// Adjust the preferred attributes to include space for the Forms element
+			preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, size);
+
+			OnLayoutAttributesChanged(preferredAttributes);
+
+			//_isMeasured = true;
+
+			return preferredAttributes;
+		}
+
+		CGSize UpdateCellSize() 
+		{
 			// Measure this cell (including the Forms element) if there is no constrained size
 			var size = ConstrainedSize == default ? Measure() : ConstrainedSize;
 
@@ -75,12 +88,7 @@ namespace Xamarin.Forms.Platform.iOS
 			VisualElementRenderer.Element.Layout(nativeBounds);
 			_size = nativeBounds.Size;
 
-			// Adjust the preferred attributes to include space for the Forms element
-			preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, size);
-
-			OnLayoutAttributesChanged(preferredAttributes);
-
-			return preferredAttributes;
+			return size;
 		}
 
 		public void Bind(DataTemplate template, object bindingContext, ItemsView itemsView)
@@ -142,6 +150,8 @@ namespace Xamarin.Forms.Platform.iOS
 						oldElement.MeasureInvalidated -= MeasureInvalidated;
 						oldElement.BindingContext = bindingContext;
 						oldElement.MeasureInvalidated += MeasureInvalidated;
+
+						UpdateCellSize();
 					}
 				}
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Platform.iOS
 	public abstract class TemplatedCell : ItemsViewCell
 	{
 		public event EventHandler<EventArgs> ContentSizeChanged;
+		public event EventHandler<LayoutAttributesChangedEventArgs> LayoutAttributesChanged;
 
 		protected CGSize ConstrainedSize;
 
@@ -26,9 +27,6 @@ namespace Xamarin.Forms.Platform.iOS
 		[Internals.Preserve(Conditional = true)]
 		protected TemplatedCell(CGRect frame) : base(frame)
 		{
-
-			System.Diagnostics.Debug.WriteLine($">>>>>> TemplatedCell constructor");
-
 		}
 
 		internal IVisualElementRenderer VisualElementRenderer { get; private set; }
@@ -79,6 +77,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			// Adjust the preferred attributes to include space for the Forms element
 			preferredAttributes.Frame = new CGRect(preferredAttributes.Frame.Location, size);
+
+			OnLayoutAttributesChanged(preferredAttributes);
 
 			return preferredAttributes;
 		}
@@ -153,6 +153,9 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			VisualElementRenderer = renderer;
 			var nativeView = VisualElementRenderer.NativeView;
+
+			// Clear out any old views if this cell is being reused
+			ClearSubviews();
 
 			InitializeContentConstraints(nativeView);
 
@@ -260,6 +263,11 @@ namespace Xamarin.Forms.Platform.iOS
 		protected void OnContentSizeChanged()
 		{
 			ContentSizeChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		protected void OnLayoutAttributesChanged(UICollectionViewLayoutAttributes newAttributes)
+		{
+			LayoutAttributesChanged?.Invoke(this, new LayoutAttributesChangedEventArgs(newAttributes));
 		}
 
 		protected abstract bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalCell.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -19,6 +20,11 @@ namespace Xamarin.Forms.Platform.iOS
 				double.PositiveInfinity, MeasureFlags.IncludeMargins);
 
 			return new CGSize(ConstrainedDimension, measure.Request.Height);
+		}
+
+		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)
+		{
+			return attributes.Frame.Width == ConstrainedDimension;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalSupplementaryView.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalSupplementaryView.cs
@@ -1,5 +1,6 @@
 ﻿using CoreGraphics;
 using Foundation;
+using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -27,6 +28,11 @@ namespace Xamarin.Forms.Platform.iOS
 				? VisualElementRenderer.Element.Height : measure.Request.Height;
 
 			return new CGSize(ConstrainedDimension, height);
+		}
+
+		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)
+		{
+			return attributes.Frame.Width == ConstrainedDimension;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -134,6 +134,7 @@
     <Compile Include="CollectionView\DefaultCell.cs" />
     <Compile Include="CollectionView\HorizontalDefaultCell.cs" />
     <Compile Include="CollectionView\ItemsViewController.cs" />
+    <Compile Include="CollectionView\LayoutAttributesChangedEventArgs.cs" />
     <Compile Include="CollectionView\ObservableGroupedSource.cs" />
     <Compile Include="CollectionView\ScrollToPositionExtensions.cs" />
     <Compile Include="CollectionView\SelectableItemsViewController.cs" />


### PR DESCRIPTION
### Description of Change ###

CollectionView on iOS utilizes the UICollectionViewFlowLayout's EstimatedItemSize property to allow virtualization; for items which have not yet been realized, the EstimatedItemSize is used for calculating properties like the UICollectionView's content size (for scrollbars, etc). 

When the layout is invalidated, this size is also used for newly inserted items (which have not yet had their actual sizes determined by a cell) and for any items invalidated by insertion/removal. For single DataTemplate scenarios, this is generally fine, since the estimated size calculated from the first item is likely to be close to or exactly the size of subsequent items. 

These changes now cache the size of each cell as they are updated from the initial estimated size, and reuses the cached values during future operations.

### Issues Resolved ### 

- fixes #10842
- fixes #10625 

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery -> CollectionView Gallery -> DataTemplate Galleries -> Varied Size Data Templates

Add/Insert/Remove items - the animation should be smooth, and no items other than the ones being inserted/removed should change size.

Control Gallery -> CollectionView Gallery -> ItemSize Galleries -> Chat Example

Add items - the animation should be smooth, and items should not jump around

### PR Checklist ###
<!-- To be completed by reviewers --> 

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
