### PR TITLE
[iOS] Cannot access a disposed object using CollectionView EmptyView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml
@@ -1,0 +1,51 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue12910"
+    Title="Issue 12910">
+    <ContentPage.Content>
+        <StackLayout>
+            <CollectionView
+                HeightRequest="200">
+                <CollectionView.ItemsSource>
+                    <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                    <x:String>Item 3</x:String>
+                    <x:String>Item 4</x:String>
+                    <x:String>Item 5</x:String>
+                    <x:String>Item 6</x:String>
+                    <x:String>Item 7</x:String>
+                    <x:String>Item 8</x:String>
+                    <x:String>Item 9</x:String>
+                    <x:String>Item 10</x:String>
+                    </x:Array>
+                </CollectionView.ItemsSource>
+                <CollectionView.EmptyView>
+                        <StackLayout
+                            BackgroundColor="Red">
+                            <Label
+                                HorizontalOptions="CenterAndExpand"
+                                VerticalOptions="CenterAndExpand"
+                                TextColor="White"
+                                Text="EmptyView"
+                                FontAttributes="Bold"/>
+                        </StackLayout>
+                </CollectionView.EmptyView>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid
+                            Padding="12">
+                            <Label
+                                HorizontalOptions="Center"
+                                VerticalOptions="Center"
+                                Text="{Binding}"/>
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml
@@ -4,12 +4,12 @@
     xmlns="http://xamarin.com/schemas/2014/forms"
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Controls.Issues.Issue12910"
+    xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"  
     Title="Issue 12910">
     <ContentPage.Content>
         <Grid
             RowSpacing="0">
             <Grid.RowDefinitions>
-                <RowDefinition Height="Auto" />
                 <RowDefinition Height="*" />
                 <RowDefinition Height="Auto" />
             </Grid.RowDefinitions>
@@ -17,37 +17,89 @@
                 Padding="12"
                 BackgroundColor="Black"
                 TextColor="White"
-                Text="Tap the Button. Without exceptions, the test has passed."/>
-            <CollectionView
+                Text="Pull to Refresh. Without exceptions, the test has passed."/>
+            <RefreshView
                 Grid.Row="1"
-                ItemsSource="{Binding Items}">
-                <CollectionView.EmptyView>
-                        <StackLayout
-                            BackgroundColor="Red">
+				x:DataType="local:Issue12910ViewModel"
+				Command="{Binding LoadItemsCommand}"
+				IsRefreshing="{Binding IsBusy, Mode=TwoWay}">
+                <CollectionView
+                    x:Name="ItemsListView"
+                    ItemsSource="{Binding Items}"
+                    SelectionMode="None">
+                    <CollectionView.ItemsLayout>
+                        <GridItemsLayout
+							Orientation="Vertical"
+							HorizontalItemSpacing="10"
+							VerticalItemSpacing="10">
+                            <GridItemsLayout.Span>
+                                <OnIdiom
+								x:TypeArguments="x:Int32"
+								Default="2"
+								Tablet="4"
+								Desktop="6"/>
+                            </GridItemsLayout.Span>
+                        </GridItemsLayout>
+                    </CollectionView.ItemsLayout>
+                    <CollectionView.Header>
+                        <ScrollView
+						    Orientation="Horizontal"
+						    HorizontalScrollBarVisibility="Never">
+                            <StackLayout
+						        Orientation="Horizontal"
+						        Spacing="0"
+						        BindableLayout.ItemsSource="{Binding Items}">
+                                <BindableLayout.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button
+										    Text="{Binding Text}"
+										    BackgroundColor="#555555"
+										    Command="{Binding Source={RelativeSource AncestorType={x:Type local:Issue12910ViewModel}}, Path=ItemTapped}"
+										    CommandParameter="{Binding .}"/>
+                                    </DataTemplate>
+                                </BindableLayout.ItemTemplate>
+                            </StackLayout>
+                        </ScrollView>
+                    </CollectionView.Header>
+                    <CollectionView.EmptyView>
+                        <StackLayout>
                             <Label
-                                HorizontalOptions="CenterAndExpand"
-                                VerticalOptions="CenterAndExpand"
-                                TextColor="White"
-                                Text="EmptyView"
-                                FontAttributes="Bold"/>
+								HorizontalOptions="CenterAndExpand"
+								Text="Empty list"
+								VerticalOptions="EndAndExpand" />
+                            <Button
+								Command="{Binding LoadItemsCommand}"
+								HorizontalOptions="CenterAndExpand"
+								Text="Refresh"
+								VerticalOptions="StartAndExpand" />
                         </StackLayout>
-                </CollectionView.EmptyView>
-                <CollectionView.ItemTemplate>
-                    <DataTemplate>
-                        <Grid
-                            Padding="12">
-                            <Label
-                                HorizontalOptions="Center"
-                                VerticalOptions="Center"
-                                Text="{Binding}"/>
-                        </Grid>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-            <Button
-                Grid.Row="2"
-                Text="Remove Items"
-                Command="{Binding RemoveItemsCommand}"/>
+                    </CollectionView.EmptyView>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate>
+                            <Frame
+							    CornerRadius="15" 
+					            Padding="15"
+							    x:DataType="model:Item">
+                                <StackLayout>
+                                    <Label
+									    Text="{Binding Text}" 
+									    LineBreakMode="TailTruncation" />
+                                    <Label
+									    Text="{Binding Description}" 
+									    LineBreakMode="TailTruncation" />
+                                </StackLayout>
+                                <Frame.GestureRecognizers>
+                                    <TapGestureRecognizer 
+									    NumberOfTapsRequired="1"
+									    Command="{Binding Source={RelativeSource AncestorType={x:Type local:Issue12910ViewModel}}, Path=ItemTapped}"		
+									    CommandParameter="{Binding .}">
+                                    </TapGestureRecognizer>
+                                </Frame.GestureRecognizers>
+                            </Frame>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </RefreshView>
         </Grid>
     </ContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml
@@ -6,23 +6,21 @@
     x:Class="Xamarin.Forms.Controls.Issues.Issue12910"
     Title="Issue 12910">
     <ContentPage.Content>
-        <StackLayout>
+        <Grid
+            RowSpacing="0">
+            <Grid.RowDefinitions>
+                <RowDefinition Height="Auto" />
+                <RowDefinition Height="*" />
+                <RowDefinition Height="Auto" />
+            </Grid.RowDefinitions>
+            <Label
+                Padding="12"
+                BackgroundColor="Black"
+                TextColor="White"
+                Text="Tap the Button. Without exceptions, the test has passed."/>
             <CollectionView
-                HeightRequest="200">
-                <CollectionView.ItemsSource>
-                    <x:Array Type="{x:Type x:String}">
-                    <x:String>Item 1</x:String>
-                    <x:String>Item 2</x:String>
-                    <x:String>Item 3</x:String>
-                    <x:String>Item 4</x:String>
-                    <x:String>Item 5</x:String>
-                    <x:String>Item 6</x:String>
-                    <x:String>Item 7</x:String>
-                    <x:String>Item 8</x:String>
-                    <x:String>Item 9</x:String>
-                    <x:String>Item 10</x:String>
-                    </x:Array>
-                </CollectionView.ItemsSource>
+                Grid.Row="1"
+                ItemsSource="{Binding Items}">
                 <CollectionView.EmptyView>
                         <StackLayout
                             BackgroundColor="Red">
@@ -46,6 +44,10 @@
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
-        </StackLayout>
+            <Button
+                Grid.Row="2"
+                Text="Remove Items"
+                Command="{Binding RemoveItemsCommand}"/>
+        </Grid>
     </ContentPage.Content>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
@@ -1,5 +1,8 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
 
 #if UITEST
 using Xamarin.UITest;
@@ -22,12 +25,57 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 #if APP
 			InitializeComponent();
+			BindingContext = new Issue12910ViewModel();
 #endif
 		}
 
 		protected override void Init()
 		{
 
+		}
+	}
+
+	public class Issue12910ViewModel : BindableObject
+	{
+		ObservableCollection<string> _items;
+
+		public Issue12910ViewModel()
+		{
+			LoadItems();
+		}
+
+		public ObservableCollection<string> Items
+		{
+			get { return _items; }
+			set
+			{
+				_items = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ICommand RemoveItemsCommand => new Command(ExecuteRemoveItems);
+
+		void LoadItems()
+		{
+			Items = new ObservableCollection<string>
+			{
+				"Item 1",
+				"Item 2",
+				"Item 3",
+				"Item 4",
+				"Item 5",
+				"Item 6",
+				"Item 7",
+				"Item 8",
+				"Item 9",
+				"Item 10"
+			};
+		}
+
+		void ExecuteRemoveItems()
+		{
+			Items.Clear();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
@@ -1,0 +1,33 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12910,
+		"[Bug] 'Cannot access a disposed object. Object name: 'DefaultRenderer' - on ios with CollectionView and EmptyView",
+		PlatformAffected.iOS)]
+	public partial class Issue12910 : TestContentPage
+	{
+		public Issue12910()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
@@ -23,13 +23,14 @@ namespace Xamarin.Forms.Controls.Issues
         PlatformAffected.iOS)]
     public partial class Issue12910 : TestContentPage
     {
-        Issue12910ViewModel _viewModel;
+		readonly Issue12910ViewModel _viewModel;
 
         public Issue12910()
         {
+            _viewModel = new Issue12910ViewModel();
 #if APP
             InitializeComponent();
-            BindingContext = _viewModel = new Issue12910ViewModel();
+            BindingContext = _viewModel;
 #endif
         }
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12910.xaml.cs
@@ -3,6 +3,8 @@ using Xamarin.Forms.Internals;
 using System;
 using System.Collections.ObjectModel;
 using System.Windows.Input;
+using System.Threading.Tasks;
+using System.Diagnostics;
 
 #if UITEST
 using Xamarin.UITest;
@@ -15,67 +17,117 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[Category(UITestCategories.CollectionView)]
 #endif
-	[Preserve(AllMembers = true)]
-	[Issue(IssueTracker.Github, 12910,
-		"[Bug] 'Cannot access a disposed object. Object name: 'DefaultRenderer' - on ios with CollectionView and EmptyView",
-		PlatformAffected.iOS)]
-	public partial class Issue12910 : TestContentPage
-	{
-		public Issue12910()
-		{
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 12910,
+        "[Bug] 'Cannot access a disposed object. Object name: 'DefaultRenderer' - on ios with CollectionView and EmptyView",
+        PlatformAffected.iOS)]
+    public partial class Issue12910 : TestContentPage
+    {
+        Issue12910ViewModel _viewModel;
+
+        public Issue12910()
+        {
 #if APP
-			InitializeComponent();
-			BindingContext = new Issue12910ViewModel();
+            InitializeComponent();
+            BindingContext = _viewModel = new Issue12910ViewModel();
 #endif
-		}
+        }
 
-		protected override void Init()
-		{
+        protected override void Init()
+        {
 
-		}
-	}
+        }
 
-	public class Issue12910ViewModel : BindableObject
-	{
-		ObservableCollection<string> _items;
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            _viewModel.OnAppearing();
+        }
+    }
 
-		public Issue12910ViewModel()
-		{
-			LoadItems();
-		}
+    public class Issue12910Model
+    {
+        public string Id { get; set; }
+        public string Text { get; set; }
+        public string Description { get; set; }
+    }
 
-		public ObservableCollection<string> Items
-		{
-			get { return _items; }
-			set
-			{
-				_items = value;
-				OnPropertyChanged();
-			}
-		}
+    public class Issue12910ViewModel : BindableObject
+    {
+        bool _isBusy;
+        Issue12910Model _selectedItem;
 
-		public ICommand RemoveItemsCommand => new Command(ExecuteRemoveItems);
+        public ObservableCollection<Issue12910Model> Items { get; }
+        public Command LoadItemsCommand { get; }
+        public Command AddItemCommand { get; }
+        public Command<Issue12910Model> ItemTapped { get; }
 
-		void LoadItems()
-		{
-			Items = new ObservableCollection<string>
-			{
-				"Item 1",
-				"Item 2",
-				"Item 3",
-				"Item 4",
-				"Item 5",
-				"Item 6",
-				"Item 7",
-				"Item 8",
-				"Item 9",
-				"Item 10"
-			};
-		}
+        public Issue12910ViewModel()
+        {
+            Items = new ObservableCollection<Issue12910Model>();
+            LoadItemsCommand = new Command(async () => await ExecuteLoadItemsCommand());
+            ItemTapped = new Command<Issue12910Model>(OnItemSelected);
+            AddItemCommand = new Command(OnAddItem);
+        }
 
-		void ExecuteRemoveItems()
-		{
-			Items.Clear();
-		}
-	}
+        async Task ExecuteLoadItemsCommand()
+        {
+            IsBusy = true;
+
+            try
+            {
+                Items.Clear();
+
+                await Task.Delay(500);
+
+                Items.Add(new Issue12910Model { Id = "1", Text = "Text 1", Description = "Description 1" });
+                Items.Add(new Issue12910Model { Id = "2", Text = "Text 2", Description = "Description 2" });
+                Items.Add(new Issue12910Model { Id = "3", Text = "Text 3", Description = "Description 3" });
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine(ex);
+            }
+            finally
+            {
+                IsBusy = false;
+            }
+        }
+
+        public void OnAppearing()
+        {
+            IsBusy = true;
+            SelectedItem = null;
+        }
+
+        public bool IsBusy
+        {
+            get => _isBusy;
+            set
+            {
+                _isBusy = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public Issue12910Model SelectedItem
+        {
+            get => _selectedItem;
+            set
+            {
+                _selectedItem = value;
+                OnPropertyChanged();
+            }
+        }
+
+        void OnAddItem(object obj)
+        {
+
+        }
+
+        void OnItemSelected(Issue12910Model item)
+        {
+
+        }
+    }
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1639,6 +1639,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12777.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11911.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11691.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12910.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -1976,6 +1977,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11691.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12910.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			get
 			{
-				if (Element.IsSet(PlatformConfiguration.iOSSpecific.VisualElement.CanBecomeFirstResponderProperty))
+				if (Element != null && Element.IsSet(PlatformConfiguration.iOSSpecific.VisualElement.CanBecomeFirstResponderProperty))
 					return PlatformConfiguration.iOSSpecific.VisualElement.GetCanBecomeFirstResponder(Element);
 
 				return base.CanBecomeFirstResponder;


### PR DESCRIPTION
### Description of Change ###

Cannot access a disposed object exception using CollectionView EmptyView.

I cannot reproduce the issue neither in the repro sample created, nor using the 5.0.0 branch with the example attached in #12776 (see attached gif). Using Xamarin.Forms 5.0-pre4 can reproduce the issue.@hartez has submitted a few CollectionView fixes recently, but I cannot associate a direct change related to EmptyView that may have fixed the issue. For now, I created this PR as a draft to investigate more.

### Issues Resolved ### 

- fixes #12910 
- fixes #12894 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix12910](https://user-images.githubusercontent.com/6755973/99784803-9db69780-2b1c-11eb-8bc5-cf78ce03bb75.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12910. Pull to Refresh. Without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
