### PR TITLE
[C] Keep the Style value as backup

### DIFF
--- a/Xamarin.Forms.Core/Setter.cs
+++ b/Xamarin.Forms.Core/Setter.cs
@@ -25,29 +25,28 @@ namespace Xamarin.Forms
 				throw new XamlParseException("Property not set", serviceProvider);
 			var valueconverter = serviceProvider.GetService(typeof(IValueConverterProvider)) as IValueConverterProvider;
 
-			Func<MemberInfo> minforetriever =
-				() =>
+			MemberInfo minforetriever()
+			{
+				MemberInfo minfo = null;
+				try
 				{
-					MemberInfo minfo = null;
-					try
-					{
-						minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
-					}
-					catch (AmbiguousMatchException e)
-					{
-						throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", serviceProvider, innerException: e);
-					}
-					if (minfo != null)
-						return minfo;
-					try
-					{
-						return Property.DeclaringType.GetRuntimeMethod("Get" + Property.PropertyName, new[] { typeof(BindableObject) });
-					}
-					catch (AmbiguousMatchException e)
-					{
-						throw new XamlParseException($"Multiple methods with name '{Property.DeclaringType}.Get{Property.PropertyName}' found.", serviceProvider, innerException: e);
-					}
-				};
+					minfo = Property.DeclaringType.GetRuntimeProperty(Property.PropertyName);
+				}
+				catch (AmbiguousMatchException e)
+				{
+					throw new XamlParseException($"Multiple properties with name '{Property.DeclaringType}.{Property.PropertyName}' found.", serviceProvider, innerException: e);
+				}
+				if (minfo != null)
+					return minfo;
+				try
+				{
+					return Property.DeclaringType.GetRuntimeMethod("Get" + Property.PropertyName, new[] { typeof(BindableObject) });
+				}
+				catch (AmbiguousMatchException e)
+				{
+					throw new XamlParseException($"Multiple methods with name '{Property.DeclaringType}.Get{Property.PropertyName}' found.", serviceProvider, innerException: e);
+				}
+			}
 
 			object value = valueconverter.Convert(Value, Property.ReturnType, minforetriever, serviceProvider);
 			Value = value;
@@ -74,10 +73,9 @@ namespace Xamarin.Forms
 				_originalValues.Add(targetObject, originalValue);
 			}
 
-			var dynamicResource = Value as DynamicResource;
 			if (Value is BindingBase binding)
 				targetObject.SetBinding(Property, binding.Clone(), fromStyle);
-			else if (dynamicResource != null)
+			else if (Value is DynamicResource dynamicResource)
 				targetObject.SetDynamicResource(Property, dynamicResource.Key, fromStyle);
 			else
 			{
@@ -116,7 +114,7 @@ namespace Xamarin.Forms
 				_originalValues.Remove(targetObject);
 			}
 			else
-				targetObject.ClearValue(Property);
+				targetObject.ClearValue(Property, fromStyle);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Style.cs
+++ b/Xamarin.Forms.Core/Style.cs
@@ -62,8 +62,7 @@ namespace Xamarin.Forms
 				//update all DynamicResources
 				foreach (WeakReference<BindableObject> bindableWr in _targets)
 				{
-					BindableObject target;
-					if (!bindableWr.TryGetTarget(out target))
+					if (!bindableWr.TryGetTarget(out BindableObject target))
 						continue;
 					target.RemoveDynamicResource(_basedOnResourceProperty);
 					if (value != null)
@@ -74,10 +73,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		public IList<Behavior> Behaviors
-		{
-			get { return _behaviors ?? (_behaviors = new AttachedCollection<Behavior>()); }
-		}
+		public IList<Behavior> Behaviors => _behaviors ??= new AttachedCollection<Behavior>();
 
 		public bool CanCascade { get; set; }
 
@@ -85,10 +81,7 @@ namespace Xamarin.Forms
 
 		public IList<Setter> Setters { get; }
 
-		public IList<TriggerBase> Triggers
-		{
-			get { return _triggers ?? (_triggers = new AttachedCollection<TriggerBase>()); }
-		}
+		public IList<TriggerBase> Triggers => _triggers ??= new AttachedCollection<TriggerBase>();
 
 		void IStyle.Apply(BindableObject bindable)
 		{
@@ -108,11 +101,7 @@ namespace Xamarin.Forms
 			bindable.RemoveDynamicResource(_basedOnResourceProperty);
 			lock (_targets)
 			{
-				_targets.RemoveAll(wr =>
-				{
-					BindableObject target;
-					return wr != null && wr.TryGetTarget(out target) && target == bindable;
-				});
+				_targets.RemoveAll(wr => wr != null && wr.TryGetTarget(out BindableObject target) && target == bindable);
 			}
 		}
 
@@ -146,8 +135,7 @@ namespace Xamarin.Forms
 		{
 			foreach (WeakReference<BindableObject> bindableRef in _targets)
 			{
-				BindableObject bindable;
-				if (!bindableRef.TryGetTarget(out bindable))
+				if (!bindableRef.TryGetTarget(out BindableObject bindable))
 					continue;
 
 				UnApplyCore(bindable, oldValue);
@@ -155,10 +143,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		Style GetBasedOnResource(BindableObject bindable)
-		{
-			return (Style)bindable.GetValue(_basedOnResourceProperty);
-		}
+		Style GetBasedOnResource(BindableObject bindable) => (Style)bindable.GetValue(_basedOnResourceProperty);
 
 		static void OnBasedOnResourceChanged(BindableObject bindable, object oldValue, object newValue)
 		{
@@ -190,9 +175,7 @@ namespace Xamarin.Forms
 		void CleanUpWeakReferences()
 		{
 			if (_targets.Count < _cleanupThreshold)
-			{
 				return;
-			}
 
 			lock (_targets)
 			{

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12874.xaml
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12874.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Xaml.UnitTests.Gh12874">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+            <Style x:Key="S0" TargetType="Label">
+                <Setter Property="FontSize" Value="40" />
+                <Setter Property="TextColor" Value="Blue" />
+                <Setter Property="HorizontalOptions" Value="Center" />
+            </Style>
+        </ResourceDictionary>
+    </ContentPage.Resources>
+    <StackLayout>
+        <Grid>
+            <Grid.Resources>
+                <ResourceDictionary>
+                    <Style x:Key="S1" TargetType="Label">
+                        <Setter Property="FontSize" Value="40" />
+                        <Setter Property="TextColor" Value="Blue" />
+                        <Setter Property="HorizontalOptions" Value="Center" />
+                    </Style>
+                </ResourceDictionary>
+            </Grid.Resources>
+            <Label x:Name='label0' FontSize='40'
+                   Style='{StaticResource S0}'
+                   HorizontalOptions='Start'/>
+            <Label x:Name='label1' FontSize='40'
+                   Style='{StaticResource S1}'
+                   HorizontalOptions='Start'/>
+        </Grid>
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12874.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/Gh12874.xaml.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using NUnit.Framework;
+using Xamarin.Forms;
+using Xamarin.Forms.Core.UnitTests;
+
+namespace Xamarin.Forms.Xaml.UnitTests
+{
+	public partial class Gh12874 : ContentPage
+	{
+		public Gh12874() => InitializeComponent();
+		public Gh12874(bool useCompiledXaml)
+		{
+			//this stub will be replaced at compile time
+		}
+
+		[TestFixture]
+		class Tests
+		{
+			[SetUp] public void Setup() => Device.PlatformServices = new MockPlatformServices();
+			[TearDown] public void TearDown() => Device.PlatformServices = null;
+
+			[Test]
+			public void RevertToStyleValue([Values(false, true)] bool useCompiledXaml)
+			{
+				var layout = new Gh12874(useCompiledXaml);
+				Assert.That(layout.label0.HorizontalOptions, Is.EqualTo(LayoutOptions.Start));
+				Assert.That(layout.label1.HorizontalOptions, Is.EqualTo(LayoutOptions.Start));
+				layout.label0.ClearValue(Label.HorizontalOptionsProperty);
+				layout.label1.ClearValue(Label.HorizontalOptionsProperty);
+				Assert.That(layout.label0.HorizontalOptions, Is.EqualTo(LayoutOptions.Center));
+				Assert.That(layout.label1.HorizontalOptions, Is.EqualTo(LayoutOptions.Center));
+			}
+		}
+	}
+}


### PR DESCRIPTION


### Description of Change ###

When a BP is cleared, (re)apply the style value

### Issues Resolved ### 

- fixes #12874

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Before
![IMG_9101](https://user-images.githubusercontent.com/313003/99799031-49b6ad80-2b32-11eb-9069-4ec665a38cc6.png)

After
![IMG_9102](https://user-images.githubusercontent.com/313003/99799073-5d621400-2b32-11eb-9583-31177cecbd52.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
