### PR TITLE
Build AppX packages before doing Solution Restore to fix UWP UI tests

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -728,7 +728,7 @@ Task("BuildForNuget")
 
         msbuildSettings.BinaryLogger = binaryLogger;
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}.binlog";
-        MSBuild("./Xamarin.Forms.sln", msbuildSettings.WithRestore());
+        MSBuild("./Xamarin.Forms.sln", msbuildSettings);
         
         // // This currently fails on CI will revisit later
         // if(isCIBuild)

--- a/build.cake
+++ b/build.cake
@@ -728,7 +728,7 @@ Task("BuildForNuget")
 
         msbuildSettings.BinaryLogger = binaryLogger;
         binaryLogger.FileName = $"{artifactStagingDirectory}/win-{configuration}.binlog";
-        MSBuild("./Xamarin.Forms.sln", msbuildSettings);
+        MSBuild("./Xamarin.Forms.sln", msbuildSettings.WithRestore());
         
         // // This currently fails on CI will revisit later
         // if(isCIBuild)

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -29,24 +29,22 @@ steps:
   #   inputs:
   #     version: $(DOTNET_VERSION)
   #     packageType: 'sdk'
-  
-  - task: NuGetToolInstaller@1	
-    displayName: 'Use NuGet $(NUGET_VERSION)'	
-    condition: ne(variables['NUGET_VERSION'], '')	
-    inputs:	
-      versionSpec: $(NUGET_VERSION)
-
-  - task: NuGetCommand@2	
-    displayName: 'NuGet restore Xamarin.Forms.sln'	
-    inputs:	
-      restoreSolution: 'Xamarin.Forms.sln'
-      feedsToUse: config	
-      nugetConfigPath: 'DevopsNuget.config'
 
   - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winbuild
     displayName: 'Build Projects For Nuget'
     condition: ne(${{ parameters.includePages }}, 'true')
+
+  - task: CopyFiles@2
+    displayName: 'Copy Appx Packages Dependencies'
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
+    inputs:
+      Contents: |
+        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/*
+        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/Add-AppDevPackage.resources/**
+        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/TelemetryDependencies/**
+        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/Dependencies/x86/**
+      TargetFolder: '$(build.artifactstagingdirectory)'
 
   - script: build.cmd -Target BuildPages -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winslnbuild
@@ -202,6 +200,7 @@ steps:
       TargetFolder: '$(build.artifactstagingdirectory)'
       CleanTargetFolder: false
       flattenFolders: false
+      overWrite: true
 
   - task: CopyFiles@2
     displayName: 'Copy Cake File'

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -29,6 +29,19 @@ steps:
   #   inputs:
   #     version: $(DOTNET_VERSION)
   #     packageType: 'sdk'
+  
+  - task: NuGetToolInstaller@1	
+    displayName: 'Use NuGet $(NUGET_VERSION)'	
+    condition: ne(variables['NUGET_VERSION'], '')	
+    inputs:	
+      versionSpec: $(NUGET_VERSION)
+
+  - task: NuGetCommand@2	
+    displayName: 'NuGet restore Xamarin.Forms.sln'	
+    inputs:	
+      restoreSolution: 'Xamarin.Forms.sln'
+      feedsToUse: config	
+      nugetConfigPath: 'DevopsNuget.config'
 
   - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winbuild

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -30,13 +30,13 @@ steps:
   #     version: $(DOTNET_VERSION)
   #     packageType: 'sdk'
 
-  - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
-    name: winbuild
-    displayName: 'Build Projects For Nuget'
-    condition: ne(${{ parameters.includePages }}, 'true')
+  
+  - script: build.cmd -Target cg-uwp-build-tests  -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"'
+    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
+    displayName: 'Build Tests and APPX'
 
   - task: CopyFiles@2
-    displayName: 'Copy Appx Packages Dependencies'
+    displayName: 'Copy Appx Packages'
     condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
     inputs:
       Contents: |
@@ -45,6 +45,11 @@ steps:
         Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/TelemetryDependencies/**
         Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/Dependencies/x86/**
       TargetFolder: '$(build.artifactstagingdirectory)'
+
+  - script: build.cmd -Target BuildForNuget -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
+    name: winbuild
+    displayName: 'Build Projects For Nuget'
+    condition: ne(${{ parameters.includePages }}, 'true')
 
   - script: build.cmd -Target BuildPages -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"','-Build_ArtifactStagingDirectory="$(Build.ArtifactStagingDirectory)"'
     name: winslnbuild
@@ -183,24 +188,6 @@ steps:
         **/*.binlog
 
       TargetFolder: ${{ parameters.artifactsTargetFolder }}
-  
-  - script: build.cmd -Target cg-uwp-build-tests  -ScriptArgs '-BUILD_CONFIGURATION="$(BuildConfiguration)"'
-    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
-    displayName: 'Build Tests and APPX'
-
-  - task: CopyFiles@2
-    displayName: 'Copy Appx Packages'
-    condition: and(eq(variables['BuildConfiguration'], 'Release'), ne('${{ parameters.includePages }}', true))
-    inputs:
-      Contents: |
-        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/*
-        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/Add-AppDevPackage.resources/**
-        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/TelemetryDependencies/**
-        Xamarin.Forms.ControlGallery.WindowsUniversal/AppPackages/*/Dependencies/x86/**
-      TargetFolder: '$(build.artifactstagingdirectory)'
-      CleanTargetFolder: false
-      flattenFolders: false
-      overWrite: true
 
   - task: CopyFiles@2
     displayName: 'Copy Cake File'


### PR DESCRIPTION
### Description of Change ###

For 16.8.* we had to add a "/restore" call to the msbuild operation we use to build the nugets. This seems to put the ControlGallery appx files into a weird state where they can't be deployed because of some dependency confusion.

This PR moves the APPX build part to happen before the nugets are packaged which seems to work

### Testing Procedure ###
- ensure UWP UI Tests run

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
