### PR TITLE
Enable Shell tests on UWP and fix a few bugs

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11244.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11244.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 
-#if UITEST
+#if UITEST && __SHELL__
 		[Test]
 		public void LeftToolbarItemTextDisplaysWhenFlyoutIsDisabled()
 		{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue6878.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap(ClearShellItems);
 
 			var label = RunningApp.WaitForElement(StatusLabel)[0];
-			Assert.AreEqual(label.Text, StatusLabelText);
+			Assert.AreEqual(StatusLabelText, label.ReadText());
 			RunningApp.Tap(PostClearTopTab);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -575,7 +575,7 @@ namespace Xamarin.Forms.Controls
 	public abstract class TestShell : Shell
 	{
 		protected const string FlyoutIconAutomationId = "OK";
-#if __IOS__
+#if __IOS__ || __WINDOWS__
 		protected const string BackButtonAutomationId = "Back";
 #else
 		protected const string BackButtonAutomationId = "OK";

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -5,6 +5,7 @@ using NUnit.Framework.Interfaces;
 using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.CustomAttributes;
 using IOPath = System.IO.Path;
+using System.Collections.Generic;
 
 #if UITEST
 using Xamarin.Forms.Core.UITests;
@@ -605,6 +606,7 @@ namespace Xamarin.Forms.Controls
 
 		protected TestShell() : base()
 		{
+			Device.SetFlags(new List<string> { ExperimentalFlags.ShellUWPExperimental });
 			Routing.Clear();
 #if APP
 			Init();

--- a/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
+++ b/Xamarin.Forms.Controls/XamStore/StoreShell.xaml.cs
@@ -12,8 +12,6 @@ namespace Xamarin.Forms.Controls.XamStore
 		{
 			InitializeComponent();
 
-			Device.SetFlags(new List<string> { ExperimentalFlags.ShellUWPExperimental });
-
 			CurrentItem = _storeItem;
 		}
 

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellRenderer.cs
@@ -52,6 +52,8 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				Internals.Log.Warning(nameof(Shell), $"Failed to Navigate Back: {exc}");
 			}
+
+			UpdateToolBar();
 		}
 
 		public WBrush FlyoutBackgroundColor
@@ -328,8 +330,8 @@ namespace Xamarin.Forms.Platform.UWP
 			switch (_flyoutBehavior)
 			{
 				case FlyoutBehavior.Disabled:
-					IsPaneToggleButtonVisible = false;
-					IsPaneVisible = false;
+					IsPaneVisible = IsBackEnabled;
+					IsPaneToggleButtonVisible = !IsBackEnabled;
 					PaneDisplayMode = Microsoft.UI.Xaml.Controls.NavigationViewPaneDisplayMode.LeftMinimal;
 					IsPaneOpen = false;
 					break;

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellSectionRenderer.cs
@@ -106,8 +106,22 @@ namespace Xamarin.Forms.Platform.UWP
 			Page nextPage = (ShellSection as IShellSectionController)
 					.PresentedPage ?? ((IShellContentController)shellContent)?.GetOrCreateContent();
 
-			OnShellSectionChanged();
+			int currentIndex = Frame.BackStackDepth;
+
+			// Build up current stack
+			Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(ShellNavigationSource.ShellSectionChanged));
+
+			for (int i = 0; i < ShellSection.Stack.Count - 1; i++)
+				Frame.Navigate(typeof(ShellPageWrapper));
+
+			// remove old stack
+			for (int i = currentIndex - 1; i >= 0; i--)
+			{
+				Frame.BackStack.RemoveAt(i);
+			}
+
 			NavigateToContent(new NavigationRequestedEventArgs(nextPage, true), ShellSection);
+			OnShellSectionChanged();
 		}
 
 		void SyncMenuItems()
@@ -127,6 +141,8 @@ namespace Xamarin.Forms.Platform.UWP
 				if (!newItems.Contains(item))
 					ShellContentMenuItems.RemoveAt(i);
 			}
+
+			IsPaneVisible = ShellSectionController.GetItems().Count > 1;
 		}
 
 		void OnShellSectionRendererCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
@@ -240,7 +256,6 @@ namespace Xamarin.Forms.Platform.UWP
 
 		protected virtual void OnShellSectionChanged()
 		{
-			Frame.Navigate(typeof(ShellPageWrapper), GetTransitionInfo(ShellNavigationSource.ShellSectionChanged));
 		}
 
 		protected virtual NavigationTransitionInfo GetTransitionInfo(NavigationRequestedEventArgs e)

--- a/build.cake
+++ b/build.cake
@@ -70,7 +70,7 @@ bool isHostedAgent = agentName.StartsWith("Azure Pipelines") || agentName.Starts
 string defaultUnitTestWhere = "";
 
 if(target.ToLower().Contains("uwp"))
-    defaultUnitTestWhere = "cat != Shell && cat != UwpIgnore";
+    defaultUnitTestWhere = "cat != UwpIgnore";
 
 var NUNIT_TEST_WHERE = Argument("NUNIT_TEST_WHERE", defaultUnitTestWhere);
 var ExcludeCategory = GetBuildVariable("ExcludeCategory", "")?.Replace("\"", "");


### PR DESCRIPTION
### Description of Change ###

- Removed shell filter from UWP UI tests
- When the FlyoutBehavior is set to disabled make sure to still show backbutton
- When switching shell sections synchronize frame to current navigation stack 
- Fix Top Tabs so they hide and show correctly as top tabs are removed and shown

### Platforms Affected ### 
- UWP

### Testing Procedure ###
- UWP tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
