### PR TITLE
[Actions] Add stale issue/pr workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,24 @@
+name: Mark stale issues and pull requests
+
+on:
+  schedule:
+  - cron: "0 0/3 * * *"
+
+jobs:
+  stale:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/stale@v3
+      with:
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        stale-issue-message: 'This issue is stale because it has been open for 180 days with no activity. Remove the stale label or comment on the issue otherwise this will be closed in 5 days'
+        stale-pr-message: 'This PR is stale because it has been open for 180 days with no activity. Remove the stale label or comment on the PR otherwise this will be closed in 5 days'
+        stale-issue-label: 'stale'
+        stale-pr-label: 'stale'
+        days-before-stale: 180
+        days-before-close: 5
+        operations-per-run: 100
+        exempt-issue-labels: 'backlog'
+        remove-stale-when-updated: true


### PR DESCRIPTION
### Description of Change ###

Add workflow to handle stale issues and prs.

This action will mark with a stale label a issue or pr after 180 days of no activity, if the the label is not removed after 5 days it will close the issue.
It will ignore issues/pr's with backlog label.

### Issues Resolved ### 

none

### API Changes ###
 
 None

### Platforms Affected ### 

- None

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
 None

Not applicable

### Testing Procedure ###


### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
