### PR TITLE
Add Shell Resource file explicitly

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -28,7 +28,7 @@
       </group>
       <group targetFramework="uap10.0.16299">
         <dependency id="Win2D.uwp" version="1.20.0" />
-        <dependency id="Microsoft.UI.Xaml" version="2.4.2" />
+        <dependency id="Microsoft.UI.Xaml" version="2.4.3" />
       </group>
       <group targetFramework="tizen40">
         <dependency id="Tizen.NET" version="4.0.0"/>

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -256,7 +256,7 @@
       <Version>6.2.10</Version>
     </PackageReference>
     <PackageReference Include="Microsoft.UI.Xaml">
-      <Version>2.4.2</Version>
+      <Version>2.4.3</Version>
     </PackageReference>
     <PackageReference Include="Newtonsoft.Json">
       <Version>12.0.3</Version>

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -41,6 +41,13 @@ namespace Xamarin.Forms
 			try
 			{
 				Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(new Microsoft.UI.Xaml.Controls.XamlControlsResources());
+#if UWP_16299
+				Windows.UI.Xaml.Application.Current.Resources.MergedDictionaries.Add(
+					new Windows.UI.Xaml.ResourceDictionary
+					{
+						Source = new Uri("ms-appx:///Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xbf")
+					});
+#endif
 			}
 			catch
 			{

--- a/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
+++ b/Xamarin.Forms.Platform.UAP/Xamarin.Forms.Platform.UAP.csproj
@@ -125,7 +125,7 @@
     <!-- Conditions duplicated on PackageReference to make VS Mac happy -->
     <PackageReference Include="Microsoft.UI.Xaml" Condition="'$(OS)' == 'Windows_NT' AND $(TargetPlatformMinVersion) &lt; '10.0.16299.0'" Version="2.1.190606001">
     </PackageReference>
-    <PackageReference Include="Microsoft.UI.Xaml" Condition="'$(OS)' == 'Windows_NT' AND $(TargetPlatformMinVersion) &gt;= '10.0.16299.0'" Version="2.4.2">
+    <PackageReference Include="Microsoft.UI.Xaml" Condition="'$(OS)' == 'Windows_NT' AND $(TargetPlatformMinVersion) &gt;= '10.0.16299.0'" Version="2.4.3">
     </PackageReference>
     <PackageReference Include="Win2D.uwp" Condition="'$(OS)' == 'Windows_NT'" Version="1.20.0">
     </PackageReference>


### PR DESCRIPTION
### Description of Change ###

With the addition of 14393 we setup the ShellStyles resource file to only get included when Min Target is 16299 and removed the reference from the Resources.xaml file. This appears to work fine if you have target framework set to >= 18632 but if you have it set to 17763 or 16299 then it fails to load the resource.

### Issues Resolved ### 
- fixes #11505

### Platforms Affected ### 
- UWP


### Testing Procedure ###
- Pull down the project on the related issue and test the included nuget

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
