### PR TITLE
[iOS] Fix NRE using custom font and Italic attribute

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11720.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11720.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11720"
+    Title="Issue 11720">
+    <StackLayout>
+        <Label
+            FontFamily="Font Awesome 5 Free"
+            FontAttributes="Italic"
+            Text="Without crash, the test has passed." />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11720.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11720.xaml.cs
@@ -1,0 +1,27 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11720, "[Bug] Crash: Value cannot be null. Parameter name: descriptor <-- suddenly started crashing without editing code",
+		PlatformAffected.iOS)]
+	public partial class Issue11720 : ContentPage
+	{
+		public Issue11720()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1759,6 +1759,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12150.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11720.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2192,6 +2193,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13684.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11720.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/FontExtensions.cs
@@ -38,7 +38,12 @@ namespace Xamarin.Forms.Platform.iOS
 								traits = traits | UIFontDescriptorSymbolicTraits.Italic;
 
 							descriptor = descriptor.CreateWithTraits(traits);
+
+							if (descriptor != null)
+								throw new Exception();
+
 							result = UIFont.FromDescriptor(descriptor, size);
+
 							if (result != null)
 								return result;
 						}


### PR DESCRIPTION
### Description of Change ###

The problem is when using _UIFont.FromDescriptor_ with a null UIFontDescriptor. An internal exception occurs in Xamarin.iOS (we are passing a null UIFontDescriptor parameter). This PR include changes to avoid the Xamarin.iOS internal exception. 
However, the behavior is exactly the same. If cannot set a specific font, use the default font.

### Issues Resolved ### 

- fixes #11720 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use the NuGet package generated by this PR. Use the code from the Issue11720. Without any exception, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
