### PR TITLE
[iOS] CollectionView EmptyView issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12275.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12275.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12275, "[Regression] On iOS, CollectionView.EmptyView Does Not Appear in Xamarin.Forms v5.0.0.1487-pre1", PlatformAffected.iOS)]
+	public class Issue12275 : TestContentPage
+	{
+		public Issue12275()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If an image appears below (CollectionView EmptyView), the test has passed."
+			};
+
+			var collectionView = new CollectionView
+			{
+				EmptyView = new Image
+				{
+					Source = "https://img-prod-cms-rt-microsoft-com.akamaized.net/cms/api/am/imageFileData/RE2r0Th?ver=5b7d"
+				}
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(collectionView);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+		
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1646,6 +1646,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8988.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12084.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12512.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12275.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">


### PR DESCRIPTION
### Description of Change ###

I can reproduce the issue in Xamarin.Forms 5.0-pre4 but not in the 5.0.0 branch. @hartez  I know you have made some recent CollectionView fixes, do you know if you made changes related with the EmptyView?

### Issues Resolved ### 

- fixes #12275 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="388" alt="issue12275" src="https://user-images.githubusercontent.com/6755973/100628657-bdbe3600-3328-11eb-9128-2b307255a5f4.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12275.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
