### PR TITLE
[iOS] Clip using a GeometryGroup

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11514.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11514.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+	xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+	xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue11514"
+    Title="Issue 11514">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the image is clipped, the test has passed." />
+        <Image
+            Source="http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg">
+            <Image.Clip>
+                <GeometryGroup>
+                    <GeometryGroup 
+                        FillRule="EvenOdd">
+                        <EllipseGeometry Center="150, 150" RadiusX="100" RadiusY="100" />
+                        <EllipseGeometry Center="250, 150" RadiusX="100" RadiusY="100" />
+                        <EllipseGeometry Center="150, 250" RadiusX="100" RadiusY="100" />
+                        <EllipseGeometry Center="250, 250" RadiusX="100" RadiusY="100" />
+                    </GeometryGroup>
+                </GeometryGroup>
+            </Image.Clip>
+        </Image>
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11514.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11514.xaml
@@ -12,16 +12,20 @@
             TextColor="White"
             Text="If the image is clipped, the test has passed." />
         <Image
+            Aspect="AspectFill"
+            HeightRequest="144"
+            WidthRequest="144"
+            HorizontalOptions="Center"
+            BackgroundColor="LightGray"
             Source="http://upload.wikimedia.org/wikipedia/commons/thumb/8/83/BlueMonkey.jpg/220px-BlueMonkey.jpg">
             <Image.Clip>
-                <GeometryGroup>
-                    <GeometryGroup 
-                        FillRule="EvenOdd">
-                        <EllipseGeometry Center="150, 150" RadiusX="100" RadiusY="100" />
-                        <EllipseGeometry Center="250, 150" RadiusX="100" RadiusY="100" />
-                        <EllipseGeometry Center="150, 250" RadiusX="100" RadiusY="100" />
-                        <EllipseGeometry Center="250, 250" RadiusX="100" RadiusY="100" />
-                    </GeometryGroup>
+                <GeometryGroup FillRule="Nonzero">
+                    <EllipseGeometry RadiusX="8" RadiusY="8" Center="8,8" />
+                    <EllipseGeometry RadiusX="8" RadiusY="8" Center="8,136" />
+                    <EllipseGeometry RadiusX="8" RadiusY="8" Center="136,8" />
+                    <EllipseGeometry RadiusX="8" RadiusY="8" Center="136,136" />
+                    <RectangleGeometry Rect="8,0,128,144"/>
+                    <RectangleGeometry Rect="0,8,144,128"/>
                 </GeometryGroup>
             </Image.Clip>
         </Image>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11514.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11514.xaml.cs
@@ -1,0 +1,22 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11514, "[Bug] iOS crashes when clipping with GeometryGroup", PlatformAffected.iOS)]
+	public partial class Issue11514 : TestContentPage
+	{
+		public Issue11514()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1878,6 +1878,7 @@
       <DependentUpon>Issue15100.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue13790.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11514.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2438,6 +2439,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13790.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11514.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

The crash does not happen in 5.0.0 branch and also everything works as expected. For that reason, this PR only includes the sample.

### Issues Resolved ### 

- fixes #11514 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="383" alt="Captura de pantalla 2020-12-01 a las 10 09 17" src="https://user-images.githubusercontent.com/6755973/100720633-95811680-33be-11eb-82ea-aebeb8961d47.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 11514. If the image is clipped, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
