### PR TITLE
[Android] Add missing unsubscribe on activity destroy

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -327,7 +327,10 @@ namespace Xamarin.Forms.Platform.Android
 			PreviousActivityDestroying.Reset();
 
 			if (_application != null)
+			{
+				_application.PropertyChanging -= AppOnPropertyChanging;
 				_application.PropertyChanged -= AppOnPropertyChanged;
+			}
 
 			PopupManager.Unsubscribe(this);
 


### PR DESCRIPTION
### Description of Change ###
When the activity is destroyed an event remain attached, if the application is a singleton this cause a memory leak of the activity.

### Issues Resolved ### 
Memory leak

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
None

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
