### PR TITLE
Convert ShellContent transitions to use animators and be smarter about selecting visible content

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12642.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12642.cs
@@ -1,0 +1,73 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12642, "[iOS] Rapid ShellContent Navigation Causes Blank Screens",
+		PlatformAffected.iOS)]
+#if UITEST
+	[Category(Core.UITests.UITestCategories.Github10000)]
+	[Category(UITestCategories.Shell)]
+#endif
+	public class Issue12642 : TestShell
+	{
+		protected override void Init()
+		{
+			var page = AddTopTab("Tab 1");
+			var page2 = AddTopTab("Tab 2");
+
+			page.Content = CreateContent();
+			page2.Content = CreateContent();
+
+			StackLayout CreateContent()
+			{
+				return new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Click quickly between the tabs. If you stop clicking and the content is blank then the test has failed.",
+							AutomationId = "Success"
+						},
+						new Button()
+						{
+							Text = "Run Test Automated",
+							AutomationId = "AutomatedRun",
+							Command = new Command(async () =>
+							{
+								for(int i = 0; i < 20; i++)
+								{
+									this.CurrentItem = Items[0].Items[0].Items[0];
+									await Task.Delay(10);
+									this.CurrentItem = Items[0].Items[0].Items[1];
+									await Task.Delay(10);
+								}
+							})
+						}
+					}
+				};
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void ClickingQuicklyBetweenTopTabsBreaksContent()
+		{
+			RunningApp.Tap("AutomatedRun");
+			RunningApp.Tap("Success");
+			RunningApp.Tap("AutomatedRun");
+			RunningApp.Tap("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1646,6 +1646,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8988.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12084.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12512.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12642.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -184,7 +184,12 @@ namespace Xamarin.Forms
 		{
 			if (shellSection.Parent != null)
 			{
-				return (ShellItem)shellSection.Parent;
+				var current = (ShellItem)shellSection.Parent;
+
+				if(current.Items.Contains(shellSection))
+					current.CurrentItem = shellSection;
+
+				return current;
 			}
 
 			ShellItem result = null;

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -275,7 +275,12 @@ namespace Xamarin.Forms
 		{
 			if (shellContent.Parent != null)
 			{
-				return (ShellSection)shellContent.Parent;
+				var current = (ShellSection)shellContent.Parent;
+
+				if (current.Items.Contains(shellContent))
+					current.CurrentItem = shellContent;
+
+				return current;
 			}
 
 			var shellSection = new ShellSection();

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -154,9 +154,9 @@ namespace Xamarin.Forms.Platform.iOS
 				if (oldPage == null)
 					((IShellController)_context.Shell).AddFlyoutBehaviorObserver(this);
 			}
-			else if(newPage == null)
+			else if(newPage == null && _context?.Shell is IShellController shellController)
 			{
-				((IShellController)_context.Shell).RemoveFlyoutBehaviorObserver(this);
+				shellController.RemoveFlyoutBehaviorObserver(this);
 			}
 
 			if (newPage != null)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -150,10 +150,14 @@ namespace Xamarin.Forms.Platform.iOS
 				UpdateTitleView();
 				UpdateTitle();
 				UpdateTabBarVisible();
-			}
 
-			if (oldPage == null)
-				((IShellController)_context.Shell).AddFlyoutBehaviorObserver(this);
+				if (oldPage == null)
+					((IShellController)_context.Shell).AddFlyoutBehaviorObserver(this);
+			}
+			else if(newPage == null)
+			{
+				((IShellController)_context.Shell).RemoveFlyoutBehaviorObserver(this);
+			}
 
 			if (newPage != null)
 			{
@@ -208,6 +212,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected virtual async Task UpdateToolbarItems()
 		{
+			if (NavigationItem == null)
+				return;
+
 			if (NavigationItem.RightBarButtonItems != null)
 			{
 				for (var i = 0; i < NavigationItem.RightBarButtonItems.Length; i++)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -1,4 +1,6 @@
-﻿using CoreGraphics;
+﻿using CoreAnimation;
+using CoreGraphics;
+using Foundation;
 using System;
 using System.Collections.Generic;
 using System.Collections.Specialized;
@@ -31,6 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 		int _lastTabThickness = Int32.MinValue;
 		Thickness _lastInset;
 		bool _isDisposed;
+		private UIViewPropertyAnimator _pageAnimation;
 
 		ShellSection ShellSection
 		{
@@ -121,6 +124,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void IDisconnectable.Disconnect()
 		{
+			_pageAnimation?.StopAnimation(true);
+			_pageAnimation = null;
 			if (ShellSection != null)
 				ShellSection.PropertyChanged -= OnShellSectionPropertyChanged;
 
@@ -296,40 +301,83 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				var currentRenderer = _renderers[newContent];
-
-				// -1 == slide left, 1 ==  slide right
-				int motionDirection = newIndex > oldIndex ? -1 : 1;
-
-				_containerArea.AddSubview(currentRenderer.NativeView);
-
 				_isAnimatingOut = oldRenderer;
+				_pageAnimation?.StopAnimation(true);
+				_pageAnimation = null;
+				_pageAnimation = CreateContentAnimator(oldRenderer, currentRenderer, oldIndex, newIndex, _containerArea);
 
-				currentRenderer.NativeView.Frame = new CGRect(-motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
-
-				if(oldRenderer.NativeView != null)
-					oldRenderer.NativeView.Frame = _containerArea.Bounds;
-
-				UIView.Animate(.25, 0, UIViewAnimationOptions.CurveEaseOut, () =>
+				if (_pageAnimation != null)
 				{
-					currentRenderer.NativeView.Frame = _containerArea.Bounds;
-
-					if (oldRenderer.NativeView != null)
-						oldRenderer.NativeView.Frame = new CGRect(motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
-				},
-				() =>
-				{
-					if (_isDisposed)
-						return;
-
-					if(oldRenderer.NativeView != null && _renderers.ContainsKey(oldContent))
-						oldRenderer.NativeView.RemoveFromSuperview();
-
-					_isAnimatingOut = null;
-					_tracker.Page = ((IShellContentController)newContent).Page;
-
-					if (!ShellSectionController.GetItems().Contains(oldContent) && _renderers.ContainsKey(oldContent))
+					_pageAnimation.AddCompletion((p) =>
 					{
-						_renderers.Remove(oldContent);
+						if (_isDisposed)
+							return;
+
+						if (p == UIViewAnimatingPosition.End)
+						{
+							RemoveNonVisibleRenderers();
+						}
+					});
+
+					_pageAnimation.StartAnimation();
+				}
+				else
+				{
+					RemoveNonVisibleRenderers();
+				}
+			}
+		}
+
+		UIViewPropertyAnimator CreateContentAnimator(
+			IVisualElementRenderer oldRenderer,
+			IVisualElementRenderer newRenderer,
+			int oldIndex,
+			int newIndex,
+			UIView containerView)
+		{
+			containerView.AddSubview(newRenderer.NativeView);
+			// -1 == slide left, 1 ==  slide right
+			int motionDirection = newIndex > oldIndex ? -1 : 1;
+
+			newRenderer.NativeView.Frame = new CGRect(-motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
+
+			if (oldRenderer.NativeView != null)
+				oldRenderer.NativeView.Frame = containerView.Bounds;
+
+			return new UIViewPropertyAnimator(0.25, UIViewAnimationCurve.EaseOut, () =>
+			{
+				newRenderer.NativeView.Frame = containerView.Bounds;
+
+				if (oldRenderer.NativeView != null)
+					oldRenderer.NativeView.Frame = new CGRect(motionDirection * View.Bounds.Width, 0, View.Bounds.Width, View.Bounds.Height);
+
+			});
+		}
+
+		void RemoveNonVisibleRenderers()
+		{
+			IVisualElementRenderer activeRenderer = null;
+			var activeItem = ShellSection?.CurrentItem;
+
+			if (activeItem is IShellContentController scc &&
+				_renderers.TryGetValue(activeItem, out activeRenderer))
+			{
+				var sectionItems = ShellSectionController.GetItems();
+				List<ShellContent> removeMe = null;
+				foreach (var r in _renderers)
+				{
+					if (r.Value == activeRenderer)
+						continue;
+
+					var oldContent = r.Key;
+					var oldRenderer = r.Value;
+
+					r.Value.NativeView.RemoveFromSuperview();
+
+					if (!sectionItems.Contains(oldContent) && _renderers.ContainsKey(oldContent))
+					{
+						removeMe = removeMe ?? new List<ShellContent>();
+						removeMe.Add(oldContent);
 
 						if (oldRenderer.NativeView != null)
 						{
@@ -337,8 +385,18 @@ namespace Xamarin.Forms.Platform.iOS
 							oldRenderer.Dispose();
 						}
 					}
-				});
+				}
+
+				if(removeMe != null)
+				{
+					foreach (var remove in removeMe)
+						_renderers.Remove(remove);
+				}
+
+				_tracker.Page = scc.Page;
 			}
+
+			_isAnimatingOut = null;
 		}
 
 		protected virtual IShellSectionRootHeader CreateShellSectionRootHeader(IShellContext shellContext)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 		int _lastTabThickness = Int32.MinValue;
 		Thickness _lastInset;
 		bool _isDisposed;
-		private UIViewPropertyAnimator _pageAnimation;
+		UIViewPropertyAnimator _pageAnimation;
 
 		ShellSection ShellSection
 		{


### PR DESCRIPTION
### Description of Change ###

On iOS when transitioning really quickly the animations would start to overlap which would cause all the UIViews to become removed once the animations resolved. I converted over to using a UIViewPropertyAnimator so that I can cancel the animation if the user clicks quickly enough that it has resolved.

Once the animation concludes the code now just figures out who should be visible instead of using messy closures from whoever started the animation. 

### Issues Resolved ### 
- fixes #12642


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
