### PR TITLE
Fix double up of YAML tasks

### DIFF
--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -100,7 +100,6 @@ steps:
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
         Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
       TargetFolder: '$(build.artifactstagingdirectory)/ios'
-      CleanTargetFolder: true
       flattenFolders: true
 
   - task: CopyFiles@2
@@ -131,32 +130,8 @@ steps:
     inputs:
       Contents: '**/Xamarin.UITest.*/tools/test-cloud.exe'
       TargetFolder: '$(build.artifactstagingdirectory)/testcloud'
-      CleanTargetFolder: true
       OverWrite: true
       flattenFolders: true
-
-  - task: CopyFiles@2
-    displayName: 'Copy iOS Files for UITest'
-    inputs:
-      Contents: |
-        **/XamarinFormsControlGalleryiOS.ipa
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Newtonsoft.Json.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/nunit.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/NUnit3.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Plugin.*
-        Xamarin.Forms.Core.iOS.UITests/bin/$(BuildConfiguration)/Xamarin.*
-      TargetFolder: '$(build.artifactstagingdirectory)/ios'
-      CleanTargetFolder: true
-      flattenFolders: true
-
-  - task: CopyFiles@2
-    displayName: 'Copy iOS dSYM'
-    inputs:
-      Contents: |
-        **/*.dSYM/**/*.*
-      TargetFolder: '$(build.artifactstagingdirectory)/ios'
-      CleanTargetFolder: false
-      flattenFolders: false
 
   - task: CopyFiles@2
     displayName: 'Copy Android Files for UITest'


### PR DESCRIPTION
### Description of Change ###

It looks like a bad merge doubled up some iOS tasks which is causing the iOS simulator files to get wiped out from the publish directories. These files are needed for deploying to simulator devices


### Testing Procedure ###
- make sure tests are still able to run

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
