### PR TITLE
Allow CollectionView on UWP to layout even if items are not loaded 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8814.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8814.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shell)]
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Issue(IssueTracker.Github, 8814,
+		"[Bug] UWP Shell cannot host CollectionView/CarouselView",
+		PlatformAffected.UWP)]
+	public class Issue8814 : TestShell
+	{
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var cv = new CollectionView();
+			var items = new List<string>() { Success, "two", "three" };
+			cv.ItemTemplate = new DataTemplate(() => {
+
+				var layout = new StackLayout();
+
+				var label = new Label();
+				label.SetBinding(Label.TextProperty, new Binding("."));
+
+				layout.Children.Add(label);
+				
+				return layout;
+			});
+
+			cv.ItemsSource = items;
+
+			var page = CreateContentPage<FlyoutItem>("CollectionView");
+
+			var instructions = new Label { Text = "The should be a CollectionView visible below. If not, this test has failed. Unfortunately, without the fix for this bug, these instructions also won't be visible. 🤔" };
+
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					instructions,
+					cv
+				}
+			};
+		}
+
+#if UITEST 
+		[Test]
+		public void CollectionViewInShellShouldBeVisible()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -59,6 +59,8 @@
       <DependentUpon>Issue2448.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8814.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7606.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -59,7 +59,6 @@
       <DependentUpon>Issue2448.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8814.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />


### PR DESCRIPTION
### Description of Change ###

Hosting a CollectionView in Shell on UWP could result in a race condition where the items in the CollectionView were not fully loaded (in the UWP Loaded event sense) before a containing layout needed to measure the CollectionView (because items inside a ListViewBase can load asynchronously). This meant that the descendant controls might have IsNativeStateConsistent set to `false`, which then meant that the layout was skipped. This would result in a blank Layout, and could only be corrected by forcing another full layout pass (e.g., by resizing the window). 

This change forces the IsNativeStateConsistent flag to `true` for the contents of an ItemContentControl inside of a CollectionView, so that the layout step can complete. 

### Issues Resolved ### 

- fixes #8814

### API Changes ###
 
None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test (Issue 8814)


### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
