### PR TITLE
Fix cast of non appcompat renderer to DrawerLayout

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -13,6 +13,7 @@ using Android.OS;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using AndroidX.DrawerLayout.Widget;
 using AndroidX.Legacy.App;
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Platform.Android.AppCompat;
@@ -793,7 +794,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		void GetNewFlyoutPageToggle()
 		{
-			var drawer = GetRenderer(CurrentFlyoutPage) as FlyoutPageRenderer;
+			var drawer = GetRenderer(CurrentFlyoutPage) as DrawerLayout;
 			if (drawer == null)
 				return;
 


### PR DESCRIPTION
### Description of Change ###

The NonAppCompat version of MDP was trying to cast its renderer to FlyoutPageRenderer but that's not a valid renderer for the Non AppCompat version of MDP. This changes the cast to be to a DrawerLayout which is the actual type trying to be achieved


### Platforms Affected ### 
- Android

### Testing Procedure ###
Here's the code from the gallery I was using to test this code

```C#
SetMainPage(new MasterDetailPage()
			{
				IconImageSource = "coffee.png",
				Master = new NavigationPage(new ContentPage()
				{
					Title = "test",
					Content = new Button()
					{
						Text = "hello",
						Command = new Command(() =>
						{
							(Application.Current.MainPage as MasterDetailPage)
							.Detail = new NavigationPage(new ContentPage() { Title = "test" });
						}
						)
					}
				})
				{
					IconImageSource = "coffee.png",
					Title = "Master Page"
				},
				Detail = new ContentPage() { Title = "test" },
			});
```

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
