### PR TITLE
[Housekeeping] Added more shapes samples to CoreGallery

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapeAppThemeGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapeAppThemeGallery.xaml
@@ -1,0 +1,36 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.ShapesGalleries.ShapeAppThemeGallery"
+    Title="Shapes AppTheme Gallery">
+    <ContentPage.Resources>
+
+        <Style x:Key="LayoutAppThemeStyle" TargetType="StackLayout">
+            <Setter Property="BackgroundColor" Value="{AppThemeBinding White, Light=White, Dark=Black}" />
+            <Setter Property="Padding" Value="12" />
+        </Style>
+
+        <Style x:Key="LabelAppThemeStyle" TargetType="Label">
+            <Setter Property="TextColor" Value="{AppThemeBinding Black, Light=Green, Dark=Red}" />
+        </Style>
+
+        <Style x:Key="ShapeAppThemeStyle" TargetType="Rectangle">
+            <Setter Property="Stroke" Value="{AppThemeBinding Black, Light=Green, Dark=Red}" />
+            <Setter Property="Fill" Value="{AppThemeBinding Black, Light=Green, Dark=Red}" />
+        </Style>
+
+    </ContentPage.Resources>
+    <ContentPage.Content>
+        <StackLayout
+            Style="{DynamicResource LayoutAppThemeStyle}">
+            <Label
+                Style="{DynamicResource LabelAppThemeStyle}">Shape using AppTheme</Label>
+            <Rectangle
+                HorizontalOptions="Start"
+                HeightRequest="80"
+                WidthRequest="200"
+                Style="{DynamicResource ShapeAppThemeStyle}"/>
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapeAppThemeGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapeAppThemeGallery.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
+{
+	public partial class ShapeAppThemeGallery : ContentPage
+	{
+		public ShapeAppThemeGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapesGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/ShapesGalleries/ShapesGallery.cs
@@ -9,20 +9,12 @@ namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
 		{
 			Title = "Shapes Gallery";
 
-			var button = new Button
-			{
-				Text = "Enable Shapes",
-				AutomationId = "EnableShapes"
-			};
-			button.Clicked += ButtonClicked;
-
 			Content = new ScrollView
 			{
 				Content = new StackLayout
 				{
 					Children =
 					{
-						button,
 						GalleryBuilder.NavButton("Ellipse Gallery", () => new EllipseGallery(), Navigation),
 						GalleryBuilder.NavButton("Line Gallery", () => new LineGallery(), Navigation),
 						GalleryBuilder.NavButton("Polygon Gallery", () => new PolygonGallery(), Navigation),
@@ -37,6 +29,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
 						GalleryBuilder.NavButton("Transform Playground", () => new TransformPlaygroundGallery(), Navigation),
 						GalleryBuilder.NavButton("Path Transform using string (TypeConverter) Gallery", () => new PathTransformStringGallery(), Navigation),
 						GalleryBuilder.NavButton("Animate Shape Gallery", () => new AnimateShapeGallery(), Navigation),
+						GalleryBuilder.NavButton("Shape AppThemes Gallery", () => new ShapeAppThemeGallery(), Navigation),
 						GalleryBuilder.NavButton("Clip Gallery", () => new ClipGallery(), Navigation),
 						GalleryBuilder.NavButton("Clip CornerRadius Gallery", () => new ClipCornerRadiusGallery(), Navigation),
 						GalleryBuilder.NavButton("Clip Views Gallery", () => new ClipViewsGallery(), Navigation),
@@ -45,15 +38,6 @@ namespace Xamarin.Forms.Controls.GalleryPages.ShapesGalleries
 					}
 				}
 			};
-		}
-
-		void ButtonClicked(object sender, System.EventArgs e)
-		{
-			var button = sender as Button;
-
-			button.Text = "Shapes Enabled!";
-			button.TextColor = Color.Black;
-			button.IsEnabled = false;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

To verify issue #13093,  I have added more Shapes examples in the Core Gallery. The button to add the experimental flag no longer necessary is also removed.

### API Changes ###

 None

### Platforms Affected ### 

- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![issue13093](https://user-images.githubusercontent.com/6755973/101756944-da9bfb80-3ad6-11eb-866f-fb8b6ff16a03.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the Shapes samples.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
