### PR TITLE
[iOS/macOS] Same offsets behavior in GradientBrush between platforms

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientBrushDefaultOffsetGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientBrushDefaultOffsetGallery.xaml
@@ -1,0 +1,56 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.GradientGalleries.GradientBrushDefaultOffsetGallery"
+    Title="GradientBrush default Offset Gallery">
+    <ContentPage.Content>
+        <ScrollView>
+            <StackLayout
+                Padding="12">
+                <Frame
+                    Padding="12"
+                    CornerRadius="0"
+                    HasShadow="False">
+                    <Frame.Background>
+                        <LinearGradientBrush
+                            StartPoint="0, 0"
+                            EndPoint="1, 0">
+                            <LinearGradientBrush.GradientStops>
+                                <GradientStop Color="Red" />
+                                <GradientStop Color="Blue" />
+                            </LinearGradientBrush.GradientStops>
+                        </LinearGradientBrush>
+                    </Frame.Background>
+                    <Label
+                        Text="GradientBrush without set Offsets (2 GradientStops)"
+                        HorizontalTextAlignment="Center"
+                        TextColor="White"
+                        FontSize="24"/>
+                </Frame>
+                <Frame
+                    Padding="12"
+                    CornerRadius="0"
+                    HasShadow="False">
+                    <Frame.Background>
+                        <LinearGradientBrush
+                            StartPoint="0, 0"
+                            EndPoint="1, 0">
+                            <LinearGradientBrush.GradientStops>
+                                <GradientStop Color="GreenYellow" />
+                                <GradientStop Color="LawnGreen" />
+                                <GradientStop Color="Green" />
+                                <GradientStop Color="DarkGreen" />
+                            </LinearGradientBrush.GradientStops>
+                        </LinearGradientBrush>
+                    </Frame.Background>
+                    <Label
+                        Text="GradientBrush without set Offsets (4 GradientStops)"
+                        HorizontalTextAlignment="Center"
+                        TextColor="White"
+                        FontSize="24"/>
+                </Frame>
+            </StackLayout>
+        </ScrollView>
+    </ContentPage.Content>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientBrushDefaultOffsetGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientBrushDefaultOffsetGallery.xaml
@@ -17,6 +17,26 @@
                             StartPoint="0, 0"
                             EndPoint="1, 0">
                             <LinearGradientBrush.GradientStops>
+                                <GradientStop Color="Red" Offset="0"  />
+                                <GradientStop Color="Blue" Offset="0.5" />
+                            </LinearGradientBrush.GradientStops>
+                        </LinearGradientBrush>
+                    </Frame.Background>
+                    <Label
+                        Text="GradientBrush with Offsets (2 GradientStops)"
+                        HorizontalTextAlignment="Center"
+                        TextColor="White"
+                        FontSize="24"/>
+                </Frame>
+                <Frame
+                    Padding="12"
+                    CornerRadius="0"
+                    HasShadow="False">
+                    <Frame.Background>
+                        <LinearGradientBrush
+                            StartPoint="0, 0"
+                            EndPoint="1, 0">
+                            <LinearGradientBrush.GradientStops>
                                 <GradientStop Color="Red" />
                                 <GradientStop Color="Blue" />
                             </LinearGradientBrush.GradientStops>
@@ -24,6 +44,28 @@
                     </Frame.Background>
                     <Label
                         Text="GradientBrush without set Offsets (2 GradientStops)"
+                        HorizontalTextAlignment="Center"
+                        TextColor="White"
+                        FontSize="24"/>
+                </Frame>
+                <Frame
+                    Padding="12"
+                    CornerRadius="0"
+                    HasShadow="False">
+                    <Frame.Background>
+                        <LinearGradientBrush
+                            StartPoint="0, 0"
+                            EndPoint="1, 0">
+                            <LinearGradientBrush.GradientStops>
+                                <GradientStop Color="GreenYellow" Offset="0" />
+                                <GradientStop Color="LawnGreen" Offset="0.25" />
+                                <GradientStop Color="Green" Offset="0.5" />
+                                <GradientStop Color="DarkGreen" Offset="0.75" />
+                            </LinearGradientBrush.GradientStops>
+                        </LinearGradientBrush>
+                    </Frame.Background>
+                    <Label
+                        Text="GradientBrush with Offsets (4 GradientStops)"
                         HorizontalTextAlignment="Center"
                         TextColor="White"
                         FontSize="24"/>

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientBrushDefaultOffsetGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientBrushDefaultOffsetGallery.xaml.cs
@@ -1,0 +1,10 @@
+﻿namespace Xamarin.Forms.Controls.GalleryPages.GradientGalleries
+{
+	public partial class GradientBrushDefaultOffsetGallery : ContentPage
+	{
+		public GradientBrushDefaultOffsetGallery()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientsGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientsGallery.cs
@@ -48,6 +48,8 @@
 						new LinearGradientExplorerGallery(), Navigation),
 					GalleryBuilder.NavButton("RadialGradient Explorer", () =>
 						new RadialGradientExplorerGallery(), Navigation),
+					GalleryBuilder.NavButton("GradientBrush Offset Gallery", () =>
+						new GradientBrushDefaultOffsetGallery(), Navigation),
 					GalleryBuilder.NavButton("Bindable Brush Gallery", () =>
 						new BindableBrushGallery(), Navigation),
 					GalleryBuilder.NavButton("Update Brush Colors Gallery", () =>

--- a/Xamarin.Forms.Platform.MacOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/BrushExtensions.cs
@@ -1,4 +1,5 @@
-﻿using System.Linq;
+﻿using System.Collections.Generic;
+using System.Linq;
 using AppKit;
 using CoreAnimation;
 using CoreGraphics;
@@ -76,7 +77,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					var orderedStops = linearGradientBrush.GradientStops.OrderBy(x => x.Offset).ToList();
 					linearGradientLayer.Colors = orderedStops.Select(x => x.Color.ToCGColor()).ToArray();
-					linearGradientLayer.Locations = orderedStops.Select(x => new NSNumber(x.Offset)).ToArray();
+					linearGradientLayer.Locations = GetCAGradientLayerLocations(orderedStops);
 				}
 
 				return linearGradientLayer;
@@ -103,7 +104,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				{
 					var orderedStops = radialGradientBrush.GradientStops.OrderBy(x => x.Offset).ToList();
 					radialGradientLayer.Colors = orderedStops.Select(x => x.Color.ToCGColor()).ToArray();
-					radialGradientLayer.Locations = orderedStops.Select(x => new NSNumber(x.Offset)).ToArray();
+					radialGradientLayer.Locations = GetCAGradientLayerLocations(orderedStops);
 				}
 
 				return radialGradientLayer;
@@ -195,6 +196,38 @@ namespace Xamarin.Forms.Platform.MacOS
 				y = 1;
 
 			return new CGPoint(x, y);
+		}
+
+		static NSNumber[] GetCAGradientLayerLocations(List<GradientStop> gradientStops)
+		{
+			if (gradientStops == null || gradientStops.Count == 0)
+				return new NSNumber[0];
+
+			if (gradientStops.Count > 1 && gradientStops.Any(gt => gt.Offset != 0))
+				return gradientStops.Select(x => new NSNumber(x.Offset)).ToArray();
+			else
+			{
+				int itemCount = gradientStops.Count;
+				int index = 0;
+				float step = 1.0f / itemCount;
+
+				NSNumber[] locations = new NSNumber[itemCount];
+
+				foreach (var gradientStop in gradientStops)
+				{
+					float location = step * index;
+					bool setLocation = !gradientStops.Any(gt => gt.Offset > location);
+
+					if (gradientStop.Offset == 0 && setLocation)
+						locations[index] = new NSNumber(location);
+					else
+						locations[index] = new NSNumber(gradientStop.Offset);
+
+					index++;
+				}
+
+				return locations;
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/BrushExtensions.cs
@@ -1,13 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using AppKit;
 using CoreAnimation;
 using CoreGraphics;
-using Foundation;
 
 namespace Xamarin.Forms.Platform.MacOS
 {
-	public static class BrushExtensions
+	public static partial class BrushExtensions
 	{
 		const string BackgroundLayer = "BackgroundLayer";
 		const string SolidColorBrushLayer = "SolidColorBrushLayer";
@@ -177,57 +175,6 @@ namespace Xamarin.Forms.Platform.MacOS
 			return false;
 		}
 
-		static CGPoint GetRadialGradientBrushEndPoint(Point startPoint, double radius)
-		{
-			double x = startPoint.X == 1 ? (startPoint.X - radius) : (startPoint.X + radius);
-
-			if (x < 0)
-				x = 0;
-
-			if (x > 1)
-				x = 1;
-
-			double y = startPoint.Y == 1 ? (startPoint.Y - radius) : (startPoint.Y + radius);
-
-			if (y < 0)
-				y = 0;
-
-			if (y > 1)
-				y = 1;
-
-			return new CGPoint(x, y);
-		}
-
-		static NSNumber[] GetCAGradientLayerLocations(List<GradientStop> gradientStops)
-		{
-			if (gradientStops == null || gradientStops.Count == 0)
-				return new NSNumber[0];
-
-			if (gradientStops.Count > 1 && gradientStops.Any(gt => gt.Offset != 0))
-				return gradientStops.Select(x => new NSNumber(x.Offset)).ToArray();
-			else
-			{
-				int itemCount = gradientStops.Count;
-				int index = 0;
-				float step = 1.0f / itemCount;
-
-				NSNumber[] locations = new NSNumber[itemCount];
-
-				foreach (var gradientStop in gradientStops)
-				{
-					float location = step * index;
-					bool setLocation = !gradientStops.Any(gt => gt.Offset > location);
-
-					if (gradientStop.Offset == 0 && setLocation)
-						locations[index] = new NSNumber(location);
-					else
-						locations[index] = new NSNumber(gradientStop.Offset);
-
-					index++;
-				}
-
-				return locations;
-			}
-		}
+	
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
+++ b/Xamarin.Forms.Platform.MacOS/Xamarin.Forms.Platform.macOS.csproj
@@ -302,6 +302,9 @@
     <Compile Include="..\Xamarin.Forms.Platform.iOS\Shapes\ShapeRenderer.cs">
       <Link>Shapes\ShapeRenderer.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Forms.Platform.iOS\Extensions\BrushExtensions.shared.cs">
+      <Link>Extensions\BrushExtensions.shared.cs</Link>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Platform\Xamarin.Forms.Platform.csproj">

--- a/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
@@ -1,13 +1,11 @@
-﻿using System.Collections.Generic;
-using System.Linq;
+﻿using System.Linq;
 using CoreAnimation;
 using CoreGraphics;
-using Foundation;
 using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public static class BrushExtensions
+	public static partial class BrushExtensions
 	{
 		const string BackgroundLayer = "BackgroundLayer";
 
@@ -199,46 +197,6 @@ namespace Xamarin.Forms.Platform.iOS
 				return true;
 
 			return false;
-		}
-
-		static CGPoint GetRadialGradientBrushEndPoint(Point startPoint, double radius)
-		{
-			double x = startPoint.X == 1 ? (startPoint.X - radius) : (startPoint.X + radius);
-			double y = startPoint.Y == 1 ? (startPoint.Y - radius) : (startPoint.Y + radius);
-
-			return new CGPoint(x, y);
-		}
-
-		static NSNumber[] GetCAGradientLayerLocations(List<GradientStop> gradientStops)
-		{
-			if (gradientStops == null || gradientStops.Count == 0)
-				return new NSNumber[0];
-
-			if (gradientStops.Count > 1 && gradientStops.Any(gt => gt.Offset != 0))
-				return gradientStops.Select(x => new NSNumber(x.Offset)).ToArray();
-			else
-			{
-				int itemCount = gradientStops.Count;
-				int index = 0;
-				float step = 1.0f / itemCount;
-
-				NSNumber[] locations = new NSNumber[itemCount];
-
-				foreach (var gradientStop in gradientStops)
-				{
-					float location = step * index;
-					bool setLocation = !gradientStops.Any(gt => gt.Offset > location);
-
-					if (gradientStop.Offset == 0 && setLocation)
-						locations[index] = new NSNumber(location);
-					else
-						locations[index] = new NSNumber(gradientStop.Offset);
-
-					index++;
-				}
-
-				return locations;
-			}
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.shared.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.shared.cs
@@ -1,0 +1,67 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using CoreGraphics;
+using Foundation;
+
+#if __MOBILE__
+namespace Xamarin.Forms.Platform.iOS
+#else
+namespace Xamarin.Forms.Platform.MacOS
+#endif
+{
+	public partial class BrushExtensions
+	{
+		static CGPoint GetRadialGradientBrushEndPoint(Point startPoint, double radius)
+		{
+			double x = startPoint.X == 1 ? (startPoint.X - radius) : (startPoint.X + radius);
+
+			if (x < 0)
+				x = 0;
+
+			if (x > 1)
+				x = 1;
+
+			double y = startPoint.Y == 1 ? (startPoint.Y - radius) : (startPoint.Y + radius);
+
+			if (y < 0)
+				y = 0;
+
+			if (y > 1)
+				y = 1;
+
+			return new CGPoint(x, y);
+		}
+
+		static NSNumber[] GetCAGradientLayerLocations(List<GradientStop> gradientStops)
+		{
+			if (gradientStops == null || gradientStops.Count == 0)
+				return new NSNumber[0];
+
+			if (gradientStops.Count > 1 && gradientStops.Any(gt => gt.Offset != 0))
+				return gradientStops.Select(x => new NSNumber(x.Offset)).ToArray();
+			else
+			{
+				int itemCount = gradientStops.Count;
+				int index = 0;
+				float step = 1.0f / itemCount;
+
+				NSNumber[] locations = new NSNumber[itemCount];
+
+				foreach (var gradientStop in gradientStops)
+				{
+					float location = step * index;
+					bool setLocation = !gradientStops.Any(gt => gt.Offset > location);
+
+					if (gradientStop.Offset == 0 && setLocation)
+						locations[index] = new NSNumber(location);
+					else
+						locations[index] = new NSNumber(gradientStop.Offset);
+
+					index++;
+				}
+
+				return locations;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -275,6 +275,7 @@
     <Compile Include="CollectionView\LoopListSource.cs" />
     <Compile Include="CollectionView\ILoopItemsViewSource.cs" />
     <Compile Include="Renderers\IDisconnectable.cs" />
+    <Compile Include="Extensions\BrushExtensions.shared.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />


### PR DESCRIPTION
### Description of Change ###

On Android, using a `GradientDrawable` renders the gradient even without setting the offsets. On iOS (or macOS), the gradient does not render without setting the offsets.

This PR adds changes to set the default values in case of not having any offset set in the Brush. In this way, we have the same behavior between different platforms.

### Issues Resolved ### 

- fixes #13092 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="383" alt="Captura de pantalla 2020-12-10 a las 14 00 01" src="https://user-images.githubusercontent.com/6755973/101775912-771ec780-3af0-11eb-8341-6e8a8d406089.png">

### Testing Procedure ###

Launch Core Gallery and navigate to the Brushes samples. Select the new "GradientBrush Offsets Gallery" to verify that the gradient is rendered in the same way on iOS (and macOS) as on Android.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
