### PR TITLE
[UWP] Fixed NRE load image from ImageSource

### DIFF
--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/Xamarin.Forms.ControlGallery.WindowsUniversal.csproj
@@ -141,6 +141,7 @@
     <Compile Include="SecondaryWindowService.cs" />
     <Compile Include="Tests\PlatformTestSettings.cs" />
     <Compile Include="Tests\TestingPlatformService.cs" />
+    <Compile Include="_13109IssueHelper.cs" />
     <Compile Include="_2489CustomRenderer.cs" />
     <Compile Include="_57114Renderer.cs" />
     <Compile Include="_58406EffectRenderer.cs" />

--- a/Xamarin.Forms.ControlGallery.WindowsUniversal/_13109IssueHelper.cs
+++ b/Xamarin.Forms.ControlGallery.WindowsUniversal/_13109IssueHelper.cs
@@ -1,0 +1,32 @@
+﻿using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.UWP;
+using Xamarin.Forms.Controls.Issues;
+using Xamarin.Forms.ControlGallery.WindowsUniversal;
+using Bitmap = Windows.UI.Xaml.Media.ImageSource;
+
+[assembly: Dependency(typeof(_13109IssueHelper))]
+namespace Xamarin.Forms.ControlGallery.WindowsUniversal
+{
+	public class _13109IssueHelper : IIssue13109Helper
+	{
+		public void SetImage(ImageSource imageSource)
+		{
+			var bitmap = imageSource.GetImage().ConfigureAwait(true);
+		}
+	}
+
+	internal static class ImageHandler
+	{
+		internal static IImageSourceHandler GetHandler(this ImageSource source)
+		{
+			IImageSourceHandler returnValue = new FileImageSourceHandler();
+			return returnValue;
+		}
+
+		internal static Task<Bitmap> GetImage(this ImageSource source)
+		{
+			return source.GetHandler().LoadImageAsync(source);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var instructions = new Label
 			{
+				AutomationId = "TestReady",
 				Padding = 12,
 				BackgroundColor = Color.Black,
 				TextColor = Color.White,
@@ -39,8 +40,18 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			
+
 		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.ManualReview)]
+		public void Issue13109ImageTest()
+		{
+			RunningApp.WaitForElement("TestReady");
+			RunningApp.Screenshot("Without exceptions, the test has passed");
+		}
+#endif
 	}
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
@@ -42,16 +42,6 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 
 		}
-
-#if UITEST && __WINDOWS__
-		[Test]
-		[Category(UITestCategories.ManualReview)]
-		public void Issue13109ImageTest()
-		{
-			RunningApp.WaitForElement("TestReady");
-			RunningApp.Screenshot("Without exceptions, the test has passed");
-		}
-#endif
 	}
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		}
 
-#if UITEST
+#if UITEST && __WINDOWS__
 		[Test]
 		[Category(UITestCategories.ManualReview)]
 		public void Issue13109ImageTest()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13109.cs
@@ -1,0 +1,74 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Image)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13109, "[Bug] NullReference Exception thrown when load image from ImageSource in Xamarin Forms UWP", PlatformAffected.UWP)]
+	public class Issue13109 : TestContentPage
+	{
+		public Issue13109()
+		{
+			Title = "Issue 13109";
+
+			Issue13109Icon issue13109Icon = new Issue13109Icon();
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Without exceptions, the test has passed."
+			};
+
+			layout.Children.Add(instructions);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+			
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue13109Icon
+	{
+		ImageSource _icon = "Xamarin.Forms.ControlGallery.WindowsUniversal/calculator.png";
+
+		public ImageSource Icon
+		{
+			get
+			{
+				return _icon;
+			}
+			set
+			{
+				_icon = value;
+			}
+		}
+
+		public Issue13109Icon()
+		{
+			DependencyService.Get<IIssue13109Helper>().SetImage(Icon);
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public interface IIssue13109Helper
+	{
+		void SetImage(ImageSource imageSource);
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1646,7 +1646,6 @@
       <DependentUpon>Issue11938.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
-	  <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4720.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10897.xaml.cs">
       <DependentUpon>Issue10897.xaml</DependentUpon>
@@ -1639,8 +1640,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11938.xaml.cs">
       <DependentUpon>Issue11938.xaml</DependentUpon>
     </Compile>
-	<Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs">

--- a/Xamarin.Forms.Platform.UAP/FileImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.UAP/FileImageSourceHandler.cs
@@ -56,7 +56,12 @@ namespace Xamarin.Forms.Platform.UWP
 			if (fileSource == null || fileSource.File == null)
 				return;
 
-			var imageDirectory = Application.Current.OnThisPlatform().GetImageDirectory();
+			var currentApp = Application.Current;
+
+			if (currentApp == null)
+				return;
+
+			var imageDirectory = currentApp.OnThisPlatform().GetImageDirectory();
 
 			if (!string.IsNullOrEmpty(imageDirectory))
 			{


### PR DESCRIPTION
### Description of Change ###

Fixed NRE load image from ImageSource in UWP.

### Issues Resolved ### 

- fixes #13109

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###


None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13109. Without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
