### PR TITLE
[iOS] NavigationPage.HideNavigationBarSeparator="true"

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10578.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10578.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<NavigationPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core"
+    mc:Ignorable="d"
+    Title="Test 12912"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue10578"
+    BarBackgroundColor="CornSilk"
+    ios:NavigationPage.HideNavigationBarSeparator="True">
+</NavigationPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10578.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10578.xaml.cs
@@ -1,0 +1,83 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10578,
+		"[Bug][iOS] NavigationPage.HideNavigationBarSeparator=true doesn't work from XAML",
+		PlatformAffected.iOS)]
+	public partial class Issue10578 : NavigationPage
+	{
+		public Issue10578()
+		{
+#if APP
+			InitializeComponent();
+			PushAsync(new Issue10578Instructions(this));
+#endif
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue10578Instructions : ContentPage
+	{
+		NavigationPage _navigationPage;
+
+		public Issue10578Instructions(NavigationPage navigationPage)
+		{
+			_navigationPage = navigationPage;
+
+			Title = "Issue 10578";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				Margin = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If the NavigationBar Separator is hidden, the test has passed."
+			};
+
+			var showButton = new Button
+			{
+				Text = "Show separator"
+			};
+
+			showButton.Clicked += OnShowButtonClicked;
+
+			var hideButton = new Button
+			{
+				Text = "Hide separator"
+			};
+
+			hideButton.Clicked += OnHideButtonClicked;
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(showButton);
+			layout.Children.Add(hideButton);
+
+			Content = layout;
+		}
+
+		void OnHideButtonClicked(object sender, EventArgs e)
+		{
+			_navigationPage.On<iOS>().SetHideNavigationBarSeparator(true);
+		}
+
+		void OnShowButtonClicked(object sender, EventArgs e)
+		{
+			_navigationPage.On<iOS>().SetHideNavigationBarSeparator(false);
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1666,6 +1666,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12512.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12685.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12642.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10578.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2024,6 +2025,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12084.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10578.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Cannot reproduce the issue with Xamarin.Forms 5.0-pre NuGet package nor in the 5.0.0 branch. For that reason, this PR only include a sample where validate the issue.

### Issues Resolved ### 

- fixes #10578 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![issue10578](https://user-images.githubusercontent.com/6755973/102084596-b06b7600-3e15-11eb-9ddb-03bf62645169.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10578. If the NavigationBar Separator is hidden, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
