### PR TITLE
[iOS] Allow VC renderers of FlyoutPage to specify UIStatusBarStyle

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/AppDelegate.cs
@@ -9,6 +9,7 @@ using Foundation;
 using UIKit;
 using Xamarin.Forms;
 using Xamarin.Forms.ControlGallery.iOS;
+using Xamarin.Forms.ControlGallery.iOS.CustomRenderers;
 using Xamarin.Forms.Controls;
 using Xamarin.Forms.Controls.Issues;
 using Xamarin.Forms.Platform.iOS;
@@ -17,6 +18,8 @@ using IOPath = System.IO.Path;
 [assembly: Dependency(typeof(TestCloudService))]
 [assembly: Dependency(typeof(CacheService))]
 [assembly: ExportRenderer(typeof(DisposePage), typeof(DisposePageRenderer))]
+[assembly: ExportRenderer(typeof(CoreFlyoutView), typeof(FlyoutPageStatusRenderer))]
+[assembly: ExportRenderer(typeof(CoreNavigationPage), typeof(DetailPageStatusBarRenderer))]
 [assembly: ExportRenderer(typeof(DisposeLabel), typeof(DisposeLabelRenderer))]
 [assembly: ExportEffect(typeof(BorderEffect), nameof(BorderEffect))]
 namespace Xamarin.Forms.ControlGallery.iOS

--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/UIStatusBarStyleRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers/UIStatusBarStyleRenderer.cs
@@ -1,0 +1,22 @@
+﻿using UIKit;
+using Xamarin.Forms.Platform.iOS;
+
+namespace Xamarin.Forms.ControlGallery.iOS.CustomRenderers
+{
+	public class DetailPageStatusBarRenderer : NavigationRenderer
+	{
+		public override UIStatusBarStyle PreferredStatusBarStyle()
+		{
+			return UIStatusBarStyle.DarkContent;
+		}
+	}
+
+	public class FlyoutPageStatusRenderer : PageRenderer
+	{
+		public override UIStatusBarStyle PreferredStatusBarStyle()
+		{
+			return UIStatusBarStyle.LightContent;
+		}
+	}
+
+}

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <iOSPlatform Condition=" '$(iOSPlatform)' == '' ">iPhone</iOSPlatform>
-    <Platform Condition=" '$(Platform)' == '' ">$(iOSPlatform)</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
     <ProjectGuid>{C7131F14-274F-4B55-ACA9-E81731AD012F}</ProjectGuid>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>
@@ -145,6 +145,7 @@
     <Compile Include="CustomEffects\FooEffect.cs" />
     <Compile Include="_10337CustomRenderer.cs" />
     <Compile Include="_11132CustomRenderer.cs" />
+    <Compile Include="CustomRenderers\UIStatusBarStyleRenderer.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Controls\Xamarin.Forms.Controls.csproj">

--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -5,7 +5,7 @@
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <iOSPlatform Condition=" '$(iOSPlatform)' == '' ">iPhone</iOSPlatform>
-    <Platform Condition=" '$(Platform)' == '' ">iPhoneSimulator</Platform>
+    <Platform Condition=" '$(Platform)' == '' ">$(iOSPlatform)</Platform>
     <ProjectGuid>{C7131F14-274F-4B55-ACA9-E81731AD012F}</ProjectGuid>
     <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <OutputType>Exe</OutputType>

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -109,17 +109,13 @@ namespace Xamarin.Forms.Controls
 
 		public Page CreateDefaultMainPage()
 		{
-			var layout = new StackLayout { BackgroundColor = Color.Red };
-			layout.Children.Add(new Label { Text = "This is master Page" });
-			var master = new ContentPage { Title = "Flyout", Content = layout, BackgroundColor = Color.SkyBlue, IconImageSource = "menuIcon" };
-			master.On<iOS>().SetUseSafeArea(true);
 			var mdp = new FlyoutPage
 			{
 				AutomationId = DefaultMainPageId,
-				Flyout = master,
+				Flyout = CoreGallery.GetFlyoutPage(),
 				Detail = CoreGallery.GetMainPage()
 			};
-			master.IconImageSource.AutomationId = "btnMDPAutomationID";
+		
 			mdp.SetAutomationPropertiesName("Main page");
 			mdp.SetAutomationPropertiesHelpText("Main page help text");
 			mdp.Flyout.IconImageSource.SetAutomationPropertiesHelpText("This as MDP icon");

--- a/Xamarin.Forms.Controls/CoreGallery.cs
+++ b/Xamarin.Forms.Controls/CoreGallery.cs
@@ -81,8 +81,23 @@ namespace Xamarin.Forms.Controls
 			Detail = detailPage;
 		}
 	}
+
 	[Preserve(AllMembers = true)]
-	internal class CoreNavigationPage : NavigationPage
+	public class CoreFlyoutView : ContentPage
+	{
+		public CoreFlyoutView()
+		{
+			On<iOS>().SetUseSafeArea(true);
+			Title = "Flyout";
+			Content = new StackLayout { BackgroundColor = Color.Red, Children = { new Label { Text = "This is master Page" } } };
+			BackgroundColor = Color.SkyBlue;
+			IconImageSource = "menuIcon";
+			IconImageSource.AutomationId = "btnMDPAutomationID";
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class CoreNavigationPage : NavigationPage
 	{
 		public CoreNavigationPage()
 		{
@@ -667,6 +682,11 @@ namespace Xamarin.Forms.Controls
 		public static Page GetMainPage()
 		{
 			return new CoreNavigationPage();
+		}
+
+		public static Page GetFlyoutPage()
+		{
+			return new CoreFlyoutView();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletFlyoutPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletFlyoutPageRenderer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Linq;
 using CoreGraphics;
 using Foundation;
 using UIKit;
@@ -12,6 +13,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			foreach (var vc in ChildViewControllers)
 				vc.View.Frame = View.Bounds;
+		}
+
+		public override UIViewController ChildViewControllerForStatusBarStyle()
+		{
+			return ChildViewControllers?.LastOrDefault() ?? base.ChildViewControllerForStatusBarStyle();
 		}
 	}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabletFlyoutPageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabletFlyoutPageRenderer.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override UIViewController ChildViewControllerForStatusBarStyle()
 		{
-			return ChildViewControllers?.LastOrDefault() ?? base.ChildViewControllerForStatusBarStyle();
+			return ChildViewControllers.Length > 0 ? ChildViewControllers[0] : base.ChildViewControllerForStatusBarStyle();
 		}
 	}
 


### PR DESCRIPTION

### Description of Change ###

Since we were wrapping the renderers of FlyoutPage and DetailPage on a internal ViewController, the users couldn't provide overrides for `PreferredStatusBarStyle()`.
To fix this we override `ChildViewControllerForStatusBarStyle` on our internal `ChildViewController` and point to page's VC.

### Issues Resolved ### 

- fixes #13053 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

Should be able to provide UIStatusBar color

### Before/After Screenshots ### 

Before:
<img width="946" alt="Screenshot 2020-12-14 at 23 36 46" src="https://user-images.githubusercontent.com/1235097/102148916-3f53af00-3e65-11eb-9c33-6b292f3dc874.png">


After:
<img width="961" alt="Screenshot 2020-12-14 at 23 34 21" src="https://user-images.githubusercontent.com/1235097/102148729-e71cad00-3e64-11eb-8d01-0b5edc8882ab.png">

### Testing Procedure ###

Start the ControlGallery and check if the UIStatus bar shows white content on the left, and black content on the right.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
