### PR TITLE
More efficiently process rapid Flyout Item Changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10608.cs
@@ -41,7 +41,8 @@ namespace Xamarin.Forms.Controls.Issues
 										Text = "Learn More",
 										Margin = new Thickness(0,10,0,0),
 										BackgroundColor = Color.Purple,
-										TextColor = Color.White
+										TextColor = Color.White,
+										AutomationId = "LearnMoreButton"
 									}
 								}
 							}
@@ -110,16 +111,21 @@ namespace Xamarin.Forms.Controls.Issues
 			for (int i = 0; i < 5; i++)
 			{
 				RunningApp.WaitForElement("Tab1AutomationId");
+				RunningApp.WaitForElement("LearnMoreButton");
 				RunningApp.Tap("FlyoutItem0");
 				RunningApp.Tap("FlyoutItem1");
 				RunningApp.Tap("FlyoutItem0");
+				RunningApp.WaitForElement("LearnMoreButton");
 			}
 
 			RunningApp.WaitForElement("Tab1AutomationId");
+			RunningApp.WaitForElement("LearnMoreButton");
 			RunningApp.Tap("FlyoutItem1");
 			RunningApp.WaitForElement("Tab2AutomationId");
+			RunningApp.WaitForElement("LearnMoreButton");
 			RunningApp.Tap("FlyoutItem0");
 			RunningApp.WaitForElement("Tab1AutomationId");
+			RunningApp.WaitForElement("LearnMoreButton");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1641,7 +1641,7 @@
       <DependentUpon>Issue11938.xaml</DependentUpon>
     </Compile>
 	<Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs">
@@ -2539,11 +2539,11 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2447.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2448.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemTransition.cs
@@ -10,12 +10,17 @@ namespace Xamarin.Forms.Platform.iOS
 			TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
 			var oldView = oldRenderer.ViewController.View;
 			var newView = newRenderer.ViewController.View;
+			var keys = oldView.Layer.AnimationKeys;
+
 			oldView.Layer.RemoveAllAnimations();
 			newView.Alpha = 0;
 
-			newView.Superview.InsertSubviewAbove(newView, oldView);
+			oldView.Superview.InsertSubviewAbove(newView, oldView);
 
-			UIView.Animate(0.5, 0, UIViewAnimationOptions.BeginFromCurrentState, () => newView.Alpha = 1, () => task.TrySetResult(true));
+			UIView.Animate(0.5, 0, UIViewAnimationOptions.BeginFromCurrentState, () => newView.Alpha = 1, () =>
+			{
+				task.TrySetResult(true);
+			});
 
 			return task.Task;
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellItemTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellItemTransition.cs
@@ -10,7 +10,6 @@ namespace Xamarin.Forms.Platform.iOS
 			TaskCompletionSource<bool> task = new TaskCompletionSource<bool>();
 			var oldView = oldRenderer.ViewController.View;
 			var newView = newRenderer.ViewController.View;
-			var keys = oldView.Layer.AnimationKeys;
 
 			oldView.Layer.RemoveAllAnimations();
 			newView.Alpha = 0;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellRenderer.cs
@@ -63,6 +63,8 @@ namespace Xamarin.Forms.Platform.iOS
 		IShellItemRenderer _currentShellItemRenderer;
 		bool _disposed;
 		IShellFlyoutRenderer _flyoutRenderer;
+		Task _activeTransition = Task.CompletedTask;
+		IShellItemRenderer _incomingRenderer;
 
 		IShellFlyoutRenderer FlyoutRenderer
 		{
@@ -261,9 +263,6 @@ namespace Xamarin.Forms.Platform.iOS
 			element.PropertyChanged += OnElementPropertyChanged;
 		}
 
-		Task _activeTransition = Task.CompletedTask;
-		IShellItemRenderer _incomingRenderer;
-
 		protected async void SetCurrentShellItemController(IShellItemRenderer value)
 		{
 			try
@@ -298,6 +297,8 @@ namespace Xamarin.Forms.Platform.iOS
 			_currentShellItemRenderer = value;
 
 			AddChildViewController(newRenderer.ViewController);
+			View.AddSubview(newRenderer.ViewController.View);
+			View.SendSubviewToBack(newRenderer.ViewController.View);
 
 			newRenderer.ViewController.View.Frame = View.Bounds;
 			

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRootRenderer.cs
@@ -204,7 +204,8 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_renderers.TryGetValue(shellContent, out var renderer))
 				{
 					var view = renderer.NativeView;
-					view.Frame = new CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
+					if(view != null)
+						view.Frame = new CGRect(0, 0, View.Bounds.Width, View.Bounds.Height);
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

When the user was rapidly changing Flyout Item it would occasionally cause the content to become blank. These changes better stream line processing ShellItem changes relative to the animation used to process those changes. If the user changed back to a previous FlyouItem mid transition then a second renderer would get created for a flyout item that hadn't yet been removed. 

### Issues Resolved ### 
- fixes #13068

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- automated test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
