### PR TITLE
Scale potential star row/column values by the appropriate star value

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/GridTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/GridTests.cs
@@ -591,6 +591,47 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.That(column0Height, Is.EqualTo(column1Height / 2));
 		}
 
+		[Test]
+		public void Issue13127() 
+		{
+			var scrollView = new ScrollView() { IsPlatformEnabled = true };
+			var outerGrid = new Grid() { RowSpacing = 0, IsPlatformEnabled = true };
+			var outerStackLayout = new StackLayout() { Spacing = 0, IsPlatformEnabled = true };
+
+			var innerGrid = new Grid() { RowSpacing = 0, IsPlatformEnabled = true };
+			innerGrid.RowDefinitions = new RowDefinitionCollection() {
+				new RowDefinition(){ Height = new GridLength(6, GridUnitType.Star)},
+				new RowDefinition(){ Height = new GridLength(4, GridUnitType.Star)},
+			};
+
+			// Set up the background view, only covers the first row
+			var background = new BoxView() { IsPlatformEnabled = true };
+			Grid.SetRowSpan(background, 1);
+
+			// Create the foreground, which spans both rows
+			var foreground = new StackLayout() { Spacing = 0, IsPlatformEnabled = true };
+			var view1 = new FixedSizeLabel(new Size(200, 50)) { IsPlatformEnabled = true };
+			var view2 = new FixedSizeLabel(new Size(200, 100)) { IsPlatformEnabled = true };
+			foreground.Children.Add(view1);
+			foreground.Children.Add(view2);
+			Grid.SetRowSpan(foreground, 2);
+
+			innerGrid.Children.Add(background);
+			innerGrid.Children.Add(foreground);
+
+			outerStackLayout.Children.Add(innerGrid);
+			outerGrid.Children.Add(outerStackLayout);
+			scrollView.Content = outerGrid;
+
+			var sizeRequest = scrollView.Measure(500, 1000);
+			scrollView.Layout(new Rectangle(0, 0, sizeRequest.Request.Width, 1000));
+
+			Assert.That(innerGrid.Height, Is.EqualTo(foreground.Height));
+			Assert.That(background.Height, Is.EqualTo(foreground.Height * 0.6).Within(0.01));
+
+			Assert.That(background.Height, Is.EqualTo(165));
+		}
+
 		abstract class TestLabel : Label
 		{
 			protected TestLabel()

--- a/Xamarin.Forms.Core/GridCalc.cs
+++ b/Xamarin.Forms.Core/GridCalc.cs
@@ -689,8 +689,8 @@ namespace Xamarin.Forms
 					if (!col.Width.IsStar || col.Width.Value == 0 || col.ActualWidth <= 0)
 						continue;
 
-					starColRequestWidth = Math.Max(starColRequestWidth, col.ActualWidth);
-					starColMinWidth = Math.Max(starColMinWidth, col.MinimumWidth);
+					starColRequestWidth = Math.Max(starColRequestWidth, col.ActualWidth / col.Width.Value);
+					starColMinWidth = Math.Max(starColMinWidth, col.MinimumWidth / col.Width.Value);
 				}
 
 				if (starColRequestWidth * totalStarsWidth <= widthConstraint)
@@ -750,8 +750,8 @@ namespace Xamarin.Forms
 					if (!row.Height.IsStar || row.Height.Value == 0 || row.ActualHeight <= 0)
 						continue;
 
-					starRowRequestHeight = Math.Max(starRowRequestHeight, row.ActualHeight);
-					starRowMinHeight = Math.Max(starRowMinHeight, row.MinimumHeight);
+					starRowRequestHeight = Math.Max(starRowRequestHeight, row.ActualHeight / row.Height.Value);
+					starRowMinHeight = Math.Max(starRowMinHeight, row.MinimumHeight / row.Height.Value);
 				}
 
 				if (starRowRequestHeight * totalStarsHeight <= heightConstraint)


### PR DESCRIPTION
### Description of Change ###

The problems displayed in issue 13127 were a combination of the issues addressed in #13085, plus an additional missing scale by the appropriate star value when determining the dominant star row/column value. These changes apply the scaling.

### Issues Resolved ### 

- fixes #13127
- fixes #13034

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
