### PR TITLE
[UWP] Update Device.Idiom when flipping tablet mode state

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8218.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8218.cs
@@ -1,0 +1,42 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8218, "[Bug] -UWP - Device.Idiom is not updated when flipping tablet mode state", PlatformAffected.UWP)]
+	class Issue8218 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Title = "Issue 8218";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.White,
+				TextColor = Color.Black,
+				Text = "Switch to the tablet mode and tap the button. If the Idiom value is Tablet, the test has passed."
+			};
+
+			var idiomButton = new Button
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				Text = "Idiom",
+				Margin = new Thickness(0, 24)
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(idiomButton);
+
+			Content = layout;
+
+			idiomButton.Clicked += (sender, args) =>
+			{
+				DisplayAlert("Issue 8218", Device.Idiom.ToString(), "Ok");
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -90,6 +90,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue2448.xaml.cs">
       <DependentUpon>Issue2448.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8218.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8814.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13203.cs" />


### PR DESCRIPTION
### Description of Change ###

Update `Device.Idiom` when flipping tablet mode state on UWP.

### Issues Resolved ### 

- fixes #8218

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 8218. Switch to the tablet mode and tap the button. If the Idiom value is Tablet, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
