### PR TITLE
Fix poor choice for FlyoutItem BP Name

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -395,7 +395,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties TriggeredFromHotReload="False" XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" />
+      <UserProperties XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" TriggeredFromHotReload="False" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutItemIsVisible.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutItemIsVisible.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestShell xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:local="clr-namespace:Xamarin.Forms.Controls"
+             x:Class="Xamarin.Forms.Controls.Issues.ShellFlyoutItemIsVisible">
+
+    <FlyoutItem Route="Home" Title="Home">
+        <ContentPage>
+            <StackLayout>
+                <Label x:Name="lblResult" Text="Hello" AutomationId="Hello"></Label>
+                <Button AutomationId="GoToUnreachable" Text="Try to Navigate to Removed Content" Clicked="GoToUnreachable"></Button>
+                <Button AutomationId="GoToNoFlyoutItem" Text="Try to Navigate to Content with no Flyout Item" Clicked="GoToNoFlyoutItem"></Button>
+            </StackLayout>
+        </ContentPage>
+    </FlyoutItem>
+    <FlyoutItem Title="Unreachable" Route="Unrechable" IsVisible="{Binding ItemIsVisible}">
+        <ContentPage>
+            <Label Text="This Page Should Be Unreachable" AutomationId="Failure"></Label>
+        </ContentPage>
+    </FlyoutItem>
+    <ShellContent Route="NoFlyoutItem"  Title="If you are reading this the test has failed" AutomationId="Failure" Shell.FlyoutItemIsVisible="{Binding FlyoutItemNotVisible}">
+        <ContentPage>
+            <StackLayout>
+                <Label Text="Successfully navigated" AutomationId="Success"></Label>
+                <Button AutomationId="GoBackHome" Text="Go Back Home" Clicked="GoBackHome"></Button>
+            </StackLayout>
+        </ContentPage>
+    </ShellContent>
+    <ShellContent Route="FlyoutItem"  Title="Flyout Item Showing Correctly" AutomationId="FlyoutItemShowing" Shell.FlyoutItemIsVisible="{Binding FlyoutItemVisible}">
+        <ContentPage>
+            <StackLayout>
+                <Label Text="Successfully navigated "></Label>
+                <Button AutomationId="GoBackHome" Text="Go Back Home" Clicked="GoBackHome"></Button>
+            </StackLayout>
+        </ContentPage>
+    </ShellContent>
+</local:TestShell>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutItemIsVisible.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutItemIsVisible.xaml.cs
@@ -1,0 +1,86 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell.FlyoutItemIsVisible")]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public partial class ShellFlyoutItemIsVisible : TestShell
+    {
+		public bool ItemIsVisible { get; } = false;
+		public bool FlyoutItemNotVisible { get; } = false;
+		public bool FlyoutItemVisible { get; } = true;
+
+		public ShellFlyoutItemIsVisible()
+        {
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		async void GoToUnreachable(object sender, System.EventArgs e)
+		{
+			try
+			{
+				await GoToAsync("//Unreachable");
+			}
+			catch
+			{
+#if APP
+				lblResult.Text = "Expected Result. Navigation has failed";
+#endif
+			}
+		}
+
+		async void GoToNoFlyoutItem(object sender, System.EventArgs e)
+		{
+			await GoToAsync("//NoFlyoutItem");
+		}
+
+		async void GoBackHome(object sender, System.EventArgs e)
+		{
+			await GoToAsync("//Home");
+		}
+
+		protected override void Init()
+		{
+			BindingContext = this;
+		}
+
+
+#if UITEST
+		[Test, NUnit.Framework.Category(UITestCategories.Shell)]
+		public void CanStillNavigateToContentNotPresentInFlyout()
+		{
+			RunningApp.Tap("GoToNoFlyoutItem");
+			RunningApp.WaitForElement("Success");
+		}
+
+		[Test, NUnit.Framework.Category(UITestCategories.Shell)]
+		public void NavigationFailsTryingToNavigateToContentSetToNotVisible()
+		{
+			RunningApp.Tap("GoToUnreachable");
+			RunningApp.WaitForNoElement("Failure");
+		}
+
+
+		[Test, NUnit.Framework.Category(UITestCategories.Shell)]
+		public void BasicFlyoutItemIsVisibleValidate()
+		{			
+			ShowFlyout();
+			RunningApp.WaitForNoElement("Failure");
+			RunningApp.WaitForElement("FlyoutItemShowing");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellItemIsVisible.cs
@@ -147,7 +147,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			pageItem1.SetBinding(Page.IsVisibleProperty, "Item1");
 			pageItem2.SetBinding(Page.IsVisibleProperty, "Item2");
-			item3.SetBinding(FlyoutItem.IsVisibleProperty, "Item3");
+			item3.SetBinding(Shell.FlyoutItemIsVisibleProperty, "Item3");
 
 			this.Items.Add(new MenuShellItem(new MenuItem()
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -316,6 +316,10 @@
     <Compile Include="$(MSBuildThisFileDirectory)ScrollToGroup.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)NestedCollectionViews.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7339.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutItemIsVisible.xaml.cs">
+      <DependentUpon>ShellFlyoutItemIsVisible.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellAppearanceChange.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10234.cs" />
@@ -1640,8 +1644,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11938.xaml.cs">
       <DependentUpon>Issue11938.xaml</DependentUpon>
     </Compile>
-	<Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs">
@@ -2548,6 +2552,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue2448.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)ShellFlyoutItemIsVisible.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1645,7 +1645,6 @@
       <DependentUpon>Issue11938.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Core.UnitTests/ShellFlyoutItemGroupTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellFlyoutItemGroupTests.cs
@@ -224,7 +224,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		MenuItem CreateNonVisibleMenuItem()
 		{
 			MenuItem item = new MenuItem();
-			FlyoutItem.SetIsVisible(item, false);
+			Shell.SetFlyoutItemIsVisible(item, false);
 			return item;
 		}
 	}

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -960,7 +960,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.Items.Add(item1);
 			shell.Items.Add(item2);
 
-			FlyoutItem.SetIsVisible(item1, false);
+			Shell.SetFlyoutItemIsVisible(item1, false);
 			Assert.IsTrue(GetItems(shell).Contains(item1));
 
 			bool hasFlyoutItem =

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -126,6 +126,12 @@ namespace Xamarin.Forms
 			set => SetValue(IsVisibleProperty, value);
 		}
 
+		public bool FlyoutItemIsVisible
+		{
+			get => (bool)GetValue(Shell.FlyoutItemIsVisibleProperty);
+			set => SetValue(Shell.FlyoutItemIsVisibleProperty, value);
+		}
+
 		internal bool IsPartOfVisibleTree()
 		{
 			if (Parent is IShellController shell)

--- a/Xamarin.Forms.Core/Shell/MenuShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/MenuShellItem.cs
@@ -10,7 +10,7 @@ namespace Xamarin.Forms
 		{
 			MenuItem = menuItem;
 			MenuItem.Parent = this;
-			FlyoutItem.SetIsVisible(this, FlyoutItem.GetIsVisible(menuItem));
+			Shell.SetFlyoutItemIsVisible(this, Shell.GetFlyoutItemIsVisible(menuItem));
 			SetBinding(TitleProperty, new Binding(nameof(MenuItem.Text), BindingMode.OneWay, source: menuItem));
 			SetBinding(IconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
 			SetBinding(FlyoutIconProperty, new Binding(nameof(MenuItem.IconImageSource), BindingMode.OneWay, source: menuItem));
@@ -30,7 +30,7 @@ namespace Xamarin.Forms
 			else if (e.PropertyName == TitleProperty.PropertyName)
 				OnPropertyChanged(MenuItem.TextProperty.PropertyName);
 			else if (e.PropertyName == FlyoutItem.IsVisibleProperty.PropertyName)
-				FlyoutItem.SetIsVisible(this, FlyoutItem.GetIsVisible(MenuItem));
+				Shell.SetFlyoutItemIsVisible(this, Shell.GetFlyoutItemIsVisible(MenuItem));
 		}
 
 		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -55,6 +55,19 @@ namespace Xamarin.Forms
 				SetInheritedBindingContext(newHandler, bindable.BindingContext);
 		}
 
+		public static readonly BindableProperty FlyoutItemIsVisibleProperty =
+			BindableProperty.CreateAttached(nameof(IsVisible), typeof(bool), typeof(Shell), true, propertyChanged: OnFlyoutItemIsVisibleChanged);
+		public static bool GetFlyoutItemIsVisible(BindableObject obj) => (bool)obj.GetValue(FlyoutItemIsVisibleProperty);
+		public static void SetFlyoutItemIsVisible(BindableObject obj, bool isVisible) => obj.SetValue(FlyoutItemIsVisibleProperty, isVisible);
+
+		static void OnFlyoutItemIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			if (bindable is Element element)
+				element
+					.FindParentOfType<Shell>()
+					?.SendStructureChanged();
+		}
+
 		public static readonly BindableProperty TabBarIsVisibleProperty =
 			BindableProperty.CreateAttached("TabBarIsVisible", typeof(bool), typeof(Shell), true);
 
@@ -1236,9 +1249,9 @@ namespace Xamarin.Forms
 			bool ShowInFlyoutMenu(BindableObject bo)
 			{
 				if (bo is MenuShellItem msi)
-					return FlyoutItem.GetIsVisible(msi.MenuItem);
+					return Shell.GetFlyoutItemIsVisible(msi.MenuItem);
 
-				return FlyoutItem.GetIsVisible(bo);
+				return Shell.GetFlyoutItemIsVisible(bo);
 			}
 
 			void AddMenuItems(MenuItemCollection menuItems)

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -22,19 +22,9 @@ namespace Xamarin.Forms
 
 		}
 
-		public static readonly new BindableProperty IsVisibleProperty =
-			BindableProperty.CreateAttached(nameof(IsVisible), typeof(bool), typeof(FlyoutItem), true, propertyChanged: OnFlyoutItemIsVisibleChanged);
-
+		public static readonly new BindableProperty IsVisibleProperty = BaseShellItem.IsVisibleProperty;
 		public static bool GetIsVisible(BindableObject obj) => (bool)obj.GetValue(IsVisibleProperty);
 		public static void SetIsVisible(BindableObject obj, bool isVisible) => obj.SetValue(IsVisibleProperty, isVisible);
-
-		static void OnFlyoutItemIsVisibleChanged(BindableObject bindable, object oldValue, object newValue)
-		{
-			if (bindable is Element element)
-				element
-					.FindParentOfType<Shell>()
-					?.SendStructureChanged();
-		}
 	}
 
 	[EditorBrowsable(EditorBrowsableState.Always)]


### PR DESCRIPTION
### Description of Change ###

The idea here was to have an attached property called `FlyoutItem.IsVisible` that users could use to indicate when they wanted to hide just the FlyoutItem. This works great in code but in XAML when binding to "IsVisible" on a FlyoutItem that will now gets routed to the Attached property that's shadowing the non attached property. 

### API Changes ###
Added:
 - Shell.FlyoutItemIsVisible //Attached BP
 - BaseShellItem.FlyoutItemIsVisible //Attached BP that allows for easy access to this property on each BaseShellItem

Removed:
 - FlyoutItem.IsVisible //Attached BP

 
### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
- Removed the attached property FlyoutItem.IsVisible. Users wanting to just hide something in the Flyout will need to use Shell.FlyoutItemIsVisible.  

None

### Testing Procedure ###
- unit tests modified
- UI Test Included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
