### PR TITLE
Fix Flyout Footer measuring and Content Margin

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/HeaderFooterShellFlyout.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/HeaderFooterShellFlyout.cs
@@ -161,40 +161,40 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("PageLoaded");
 
 			// Verify Header an Footer show up at all
-			TapInFlyout("ToggleHeaderFooter");
+			TapInFlyout("ToggleHeaderFooter", makeSureFlyoutStaysOpen: true);
 			RunningApp.WaitForElement("Header View");
 			RunningApp.WaitForElement("Footer View");
 
 			// Verify Template takes priority over header footer
-			TapInFlyout("ToggleHeaderFooterTemplate");
+			TapInFlyout("ToggleHeaderFooterTemplate", makeSureFlyoutStaysOpen: true);
 			RunningApp.WaitForElement("Header Template");
 			RunningApp.WaitForElement("Footer Template");
 			RunningApp.WaitForNoElement("Header View");
 			RunningApp.WaitForNoElement("Footer View");
 
 			// Verify turning off Template shows Views again
-			TapInFlyout("ToggleHeaderFooterTemplate");
+			TapInFlyout("ToggleHeaderFooterTemplate", makeSureFlyoutStaysOpen: true);
 			RunningApp.WaitForElement("Header View");
 			RunningApp.WaitForElement("Footer View");
 			RunningApp.WaitForNoElement("Header Template");
 			RunningApp.WaitForNoElement("Footer Template");
 
 			// Verify turning off header/footer clear out views correctly
-			TapInFlyout("ToggleHeaderFooter");
+			TapInFlyout("ToggleHeaderFooter", makeSureFlyoutStaysOpen: true);
 			RunningApp.WaitForNoElement("Header Template");
 			RunningApp.WaitForNoElement("Footer Template");
 			RunningApp.WaitForNoElement("Header View");
 			RunningApp.WaitForNoElement("Footer View");
 
 			// verify header and footer react to size changes
-			TapInFlyout("ResizeHeaderFooter");
+			TapInFlyout("ResizeHeaderFooter", makeSureFlyoutStaysOpen: true);
 			var headerSizeSmall = RunningApp.WaitForElement("Header View")[0].Rect;
 			var footerSizeSmall = RunningApp.WaitForElement("Footer View")[0].Rect;
-			TapInFlyout("ResizeHeaderFooter");
+			TapInFlyout("ResizeHeaderFooter", makeSureFlyoutStaysOpen: true);
 			var headerSizeLarge = RunningApp.WaitForElement("Header View")[0].Rect;
 			var footerSizeLarge = RunningApp.WaitForElement("Footer View")[0].Rect;
 
-			TapInFlyout("ResizeHeaderFooter");
+			TapInFlyout("ResizeHeaderFooter", makeSureFlyoutStaysOpen: true);
 			var headerSizeSmall2 = RunningApp.WaitForElement("Header View")[0].Rect;
 			var footerSizeSmall2 = RunningApp.WaitForElement("Footer View")[0].Rect;
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/HeaderFooterShellFlyout.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/HeaderFooterShellFlyout.cs
@@ -52,8 +52,15 @@ namespace Xamarin.Forms.Controls.Issues
 				{
 					if (FlyoutHeaderTemplate == null)
 					{
-						FlyoutHeaderTemplate = new DataTemplate(() => new Label() { Text = "Header Template" });
-						FlyoutFooterTemplate = new DataTemplate(() => new Label() { Text = "Footer Template" });
+						FlyoutHeaderTemplate = new DataTemplate(() =>
+						{
+							return new Label() { Text = "Header Template" };
+						});
+
+						FlyoutFooterTemplate = new DataTemplate(() =>
+						{
+							return new Label() { Text = "Footer Template" };
+						});
 					}
 					else if (FlyoutHeaderTemplate != null)
 					{
@@ -76,8 +83,22 @@ namespace Xamarin.Forms.Controls.Issues
 					}
 					else
 					{
-						FlyoutHeader = new Label() { Text = "Header View" };
-						FlyoutFooter = new Label() { Text = "Footer View" };
+						FlyoutHeader = new StackLayout()
+						{
+							Children = {
+								new Label() { Text = "Header" }
+							},
+							AutomationId = "Header View"
+						};
+
+						FlyoutFooter = new StackLayout()
+						{
+							Orientation = StackOrientation.Horizontal,
+							Children = {
+								new Label() { Text = "Footer" }
+							},
+							AutomationId = "Footer View"
+						};
 					}
 				}),
 				AutomationId = "ToggleHeaderFooter"
@@ -138,43 +159,42 @@ namespace Xamarin.Forms.Controls.Issues
 		public void FlyoutTests()
 		{
 			RunningApp.WaitForElement("PageLoaded");
-			ShowFlyout();
 
 			// Verify Header an Footer show up at all
-			OpenFlyout("ToggleHeaderFooter");
+			TapInFlyout("ToggleHeaderFooter");
 			RunningApp.WaitForElement("Header View");
 			RunningApp.WaitForElement("Footer View");
 
 			// Verify Template takes priority over header footer
-			OpenFlyout("ToggleHeaderFooterTemplate");
+			TapInFlyout("ToggleHeaderFooterTemplate");
 			RunningApp.WaitForElement("Header Template");
 			RunningApp.WaitForElement("Footer Template");
 			RunningApp.WaitForNoElement("Header View");
 			RunningApp.WaitForNoElement("Footer View");
 
 			// Verify turning off Template shows Views again
-			OpenFlyout("ToggleHeaderFooterTemplate");
+			TapInFlyout("ToggleHeaderFooterTemplate");
 			RunningApp.WaitForElement("Header View");
 			RunningApp.WaitForElement("Footer View");
 			RunningApp.WaitForNoElement("Header Template");
 			RunningApp.WaitForNoElement("Footer Template");
 
 			// Verify turning off header/footer clear out views correctly
-			OpenFlyout("ToggleHeaderFooter");
+			TapInFlyout("ToggleHeaderFooter");
 			RunningApp.WaitForNoElement("Header Template");
 			RunningApp.WaitForNoElement("Footer Template");
 			RunningApp.WaitForNoElement("Header View");
 			RunningApp.WaitForNoElement("Footer View");
 
 			// verify header and footer react to size changes
-			OpenFlyout("ResizeHeaderFooter");
+			TapInFlyout("ResizeHeaderFooter");
 			var headerSizeSmall = RunningApp.WaitForElement("Header View")[0].Rect;
 			var footerSizeSmall = RunningApp.WaitForElement("Footer View")[0].Rect;
-			OpenFlyout("ResizeHeaderFooter");
+			TapInFlyout("ResizeHeaderFooter");
 			var headerSizeLarge = RunningApp.WaitForElement("Header View")[0].Rect;
 			var footerSizeLarge = RunningApp.WaitForElement("Footer View")[0].Rect;
 
-			OpenFlyout("ResizeHeaderFooter");
+			TapInFlyout("ResizeHeaderFooter");
 			var headerSizeSmall2 = RunningApp.WaitForElement("Header View")[0].Rect;
 			var footerSizeSmall2 = RunningApp.WaitForElement("Footer View")[0].Rect;
 
@@ -183,19 +203,6 @@ namespace Xamarin.Forms.Controls.Issues
 			Assert.AreEqual(headerSizeSmall2.Height, headerSizeSmall.Height);
 			Assert.AreEqual(footerSizeSmall2.Height, footerSizeSmall.Height);
 		}
-
-		void OpenFlyout(string text)
-		{
-			RunningApp.Tap(text);
-
-#if __WINDOWS__
-			// UWP closes the flyout after selecting an item
-			System.Threading.Thread.Sleep(1000);
-			ShowFlyout();
-#endif
-		}
-
-
 #endif
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -38,6 +38,10 @@ namespace Xamarin.Forms.Platform.Android
 		int _actionBarHeight;
 		ScrollLayoutManager _layoutManager;
 
+		protected IShellContext ShellContext => _shellContext;
+		protected AView FooterView => _footerView?.NativeView;
+		protected AView View => _rootView;
+
 		public ShellFlyoutTemplatedContentRenderer(IShellContext shellContext)
 		{
 			_shellContext = shellContext;
@@ -152,7 +156,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateFlyoutFooter();
 		}
 
-		void UpdateFlyoutHeader()
+		protected virtual void UpdateFlyoutHeader()
 		{
 			if (_headerView != null)
 			{
@@ -184,7 +188,7 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateFlyoutHeaderBehavior();
 		}
 
-		void UpdateFlyoutFooter()
+		protected virtual void UpdateFlyoutFooter()
 		{
 			if (_footerView != null)
 			{
@@ -201,7 +205,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			_footerView = new ShellViewRenderer(_shellContext.AndroidContext, footer);
 
-
 			_footerView.NativeView.LayoutParameters = new CoordinatorLayout.LayoutParams(LP.MatchParent, LP.WrapContent)
 			{
 				Gravity = (int)(GravityFlags.Bottom | GravityFlags.End)
@@ -209,6 +212,10 @@ namespace Xamarin.Forms.Platform.Android
 
 			_footerView.LayoutView(_shellContext.AndroidContext.FromPixels(_rootView.LayoutParameters.Width), -1);
 			_rootView.AddView(_footerView.NativeView);
+			if(_recycler?.LayoutParameters is CoordinatorLayout.LayoutParams cl)
+			{
+				cl.BottomMargin = (int)_shellContext.AndroidContext.ToPixels(_footerView.View.Height);
+			}
 		}
 
 		void UpdateVerticalScrollMode()

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutTemplatedContentRenderer.cs
@@ -210,7 +210,7 @@ namespace Xamarin.Forms.Platform.Android
 				Gravity = (int)(GravityFlags.Bottom | GravityFlags.End)
 			};
 
-			_footerView.LayoutView(_shellContext.AndroidContext.FromPixels(_rootView.LayoutParameters.Width), -1);
+			_footerView.LayoutView(_shellContext.AndroidContext.FromPixels(_rootView.LayoutParameters.Width), double.PositiveInfinity);
 			_rootView.AddView(_footerView.NativeView);
 			if(_recycler?.LayoutParameters is CoordinatorLayout.LayoutParams cl)
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -407,7 +407,7 @@ namespace Xamarin.Forms.Platform.Android
 				SetupMenu(menu, _bottomView.MaxItemCount, ShellItem);
 		}
 
-		void UpdateTabBarVisibility()
+		protected virtual void UpdateTabBarVisibility()
 		{
 			if (DisplayedPage == null)
 				return;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellViewRenderer.cs
@@ -12,11 +12,11 @@ namespace Xamarin.Forms.Platform.Android
 	// This is used to monitor an xplat View and apply layout changes
 	internal class ShellViewRenderer
 	{
-		IVisualElementRenderer _renderer;
+		public IVisualElementRenderer Renderer { get; private set; }
 		View _view;
 		WeakReference<Context> _context;
-		private double _width;
-		private double _height;
+		public double Width { get; private set; }
+		public double Height { get; private set; }
 
 		public ShellViewRenderer(Context context, View view)
 		{
@@ -36,36 +36,48 @@ namespace Xamarin.Forms.Platform.Android
 		public void TearDown()
 		{
 			View = null;
-			_renderer?.Dispose();
-			_renderer = null;
+			Renderer?.Dispose();
+			Renderer = null;
 			_view = null;
 			_context = null;
 		}
 
-		public void LayoutView(double width, double height)
+		public void LayoutView(double width, double height, double? maxWidth = null, double? maxHeight = null)
 		{
-			_width = width;
-			_height = height;
+			if (width == -1)
+				width = double.PositiveInfinity;
+
+			if (height == -1)
+				height = double.PositiveInfinity;
+
+			Width = width;
+			Height = height;
 			Context context;
 
-			if (_renderer == null || !(_context.TryGetTarget(out context)) || !_renderer.View.IsAlive())
+			if (Renderer == null || !(_context.TryGetTarget(out context)) || !Renderer.View.IsAlive())
 				return;
 
 			if (View == null)
 			{
 				var empty = MeasureSpecFactory.GetSize(0);
-				_renderer.View.Measure(empty, empty);
+				Renderer.View.Measure(empty, empty);
 				return;
 			}
 
 			var request = View.Measure(width, height, MeasureFlags.None);
 
 			var layoutParams = NativeView.LayoutParameters;
-			if (height == -1)
+			if (height == -1 || double.IsInfinity(height))
 				height = request.Request.Height;
 
-			if (width == -1)
+			if (width == -1 || double.IsInfinity(width))
 				width = request.Request.Width;
+
+			if (height > maxHeight)
+				height = maxHeight.Value;
+
+			if (width > maxWidth)
+				width = maxWidth.Value;
 
 			if (layoutParams.Width != LP.MatchParent)
 				layoutParams.Width = (int)context.ToPixels(width);
@@ -75,10 +87,10 @@ namespace Xamarin.Forms.Platform.Android
 
 			NativeView.LayoutParameters = layoutParams;
 			View.Layout(new Rectangle(0, 0, width, height));
-			_renderer.UpdateLayout();
+			Renderer.UpdateLayout();
 		}
 
-		public void OnViewSet(View view)
+		public virtual void OnViewSet(View view)
 		{
 			if (View != null)
 				View.SizeChanged -= OnViewSizeChanged;
@@ -86,11 +98,11 @@ namespace Xamarin.Forms.Platform.Android
 			if (View is VisualElement oldView)
 				oldView.MeasureInvalidated -= OnViewSizeChanged;
 
-			if (_renderer != null)
+			if (Renderer != null)
 			{
-				_renderer.View.RemoveFromParent();
-				_renderer.Dispose();
-				_renderer = null;
+				Renderer.View.RemoveFromParent();
+				Renderer.Dispose();
+				Renderer = null;
 			}
 
 			_view = view;
@@ -101,19 +113,23 @@ namespace Xamarin.Forms.Platform.Android
 				if (!(_context.TryGetTarget(out context)))
 					return;
 
-				_renderer = Platform.CreateRenderer(view, context);
-				Platform.SetRenderer(view, _renderer);
-				NativeView = _renderer.View;
+				Renderer = Platform.CreateRenderer(view, context);
+				Platform.SetRenderer(view, Renderer);
+				NativeView = Renderer.View;
 
 				if (View is VisualElement ve)
 					ve.MeasureInvalidated += OnViewSizeChanged;
 				else
 					View.SizeChanged += OnViewSizeChanged;
 			}
+			else
+			{
+				NativeView = null;
+			}
 		}
 
 		void OnViewSizeChanged(object sender, EventArgs e) =>
-			LayoutView(_width, _height);
+			LayoutView(Width, Height);
 
 		public AView NativeView
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellViewRenderer.cs
@@ -67,10 +67,10 @@ namespace Xamarin.Forms.Platform.Android
 			var request = View.Measure(width, height, MeasureFlags.None);
 
 			var layoutParams = NativeView.LayoutParameters;
-			if (height == -1 || double.IsInfinity(height))
+			if (double.IsInfinity(height))
 				height = request.Request.Height;
 
-			if (width == -1 || double.IsInfinity(width))
+			if (double.IsInfinity(width))
 				width = request.Request.Width;
 
 			if (height > maxHeight)


### PR DESCRIPTION
### Description of Change ###

- Open up a few renderer APIs to make it easier to customize parts of the Shell Flyout
- Fix measuring on the footer to pass in double.Infinity instead of -1. 
- Set the bottom margin on the content inside the flyout so it doesn't flow behind the footer view

### API Changes ###

Added:
 - protected virtual ShellFlyoutTemplatedContentRenderer.ShellContext
 - protected virtual ShellFlyoutTemplatedContentRenderer.FooterView
 - protected virtual ShellFlyoutTemplatedContentRenderer.View
 - protected virtual ShellFlyoutTemplatedContentRenderer.UpdateFlyoutHeader()
 - protected virtual ShellFlyoutTemplatedContentRenderer.UpdateFlyoutFooter()
 - protected virtual ShellItemRenderer.UpdateTabBarVisibility()

### Platforms Affected ### 
- Android


### Testing Procedure ###
- UI Test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
