### PR TITLE
[Android] Fix shadow in Thumb setting a custom color

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12150.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12150.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Switch)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12150, "[Bug] Switch control not respecting Material Design on Android",
+		PlatformAffected.Android)]
+	public class Issue12150 : TestContentPage
+	{
+		public Issue12150()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 12150";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If each Switch has a shadow on the Thumb, the test has passed."
+			};
+
+			var defaultRadioButton = new Switch
+			{
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var thumbColorRadioButton = new Switch
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				ThumbColor = Color.White
+			};
+
+			var onColorRadioButton = new Switch
+			{
+				HorizontalOptions = LayoutOptions.Center,
+				OnColor = Color.Red,
+				ThumbColor = Color.White
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(defaultRadioButton);
+			layout.Children.Add(thumbColorRadioButton);
+			layout.Children.Add(onColorRadioButton);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1749,6 +1749,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13616.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13670.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12150.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/SwitchRenderer.cs
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 			if (Element.ThumbColor != Color.Default)
 			{
-				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor, FilterMode.SrcAtop);
+				Control.ThumbDrawable?.SetColorFilter(Element.ThumbColor, FilterMode.Multiply);
 				_changedThumbColor = true;
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/DrawableExtensions.cs
@@ -94,7 +94,14 @@ namespace Xamarin.Forms.Platform.Android
 		public static void SetColorFilter(this ADrawable drawable, AColor color, FilterMode mode)
 		{
 			if (Forms.Is29OrNewer)
-				drawable.SetColorFilter(new BlendModeColorFilter(color, GetFilterMode(mode)));
+			{
+				if(mode == FilterMode.Multiply)
+#pragma warning disable CS0612 // Type or member is obsolete
+					drawable.SetColorFilter(new PorterDuffColorFilter(color, GetFilterModePre29(mode)));
+#pragma warning restore CS0612 // Type or member is obsolete
+				else
+					drawable.SetColorFilter(new BlendModeColorFilter(color, GetFilterMode(mode)));
+			}
 			else
 #pragma warning disable CS0612 // Type or member is obsolete
 #pragma warning disable CS0618 // Type or member is obsolete


### PR DESCRIPTION
### Description of Change ###

Fix shadow in Thumb setting a custom color on Android **Switch**.

### Issues Resolved ### 

- fixes #12150 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix12150](https://user-images.githubusercontent.com/6755973/102368409-1ba27d00-3fbb-11eb-82e1-9fdbad8afcc8.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12150. If each Switch has a shadow on the Thumb, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
