### PR TITLE
[Android/iOS] Fix the issue with Shapes size navigating several times

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13164.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13164.cs
@@ -1,0 +1,105 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Shapes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shape)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13164, "[Bug] Shapes broken in Xamarin if used within NavigationPage once and navigated back",
+		PlatformAffected.Android | PlatformAffected.iOS)]
+	public class Issue13164 : TestContentPage
+	{
+		Issue13164SecondPage _issue13164SecondPage;
+
+		public Issue13164()
+		{
+		}
+
+		protected override void Init()
+		{
+			Title = "Issue 13164";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Tap the Button to navigate to the details page with some Shapes."
+			};
+
+			var navigateButton = new Button
+			{
+				Text = "Navigate"
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(navigateButton);
+
+			Content = layout;
+
+			navigateButton.Clicked += (sender, args) =>
+			{
+				if (_issue13164SecondPage == null)
+				{
+					_issue13164SecondPage = new Issue13164SecondPage();
+				}
+
+				var navPage = new NavigationPage(_issue13164SecondPage);
+				Navigation.PushAsync(navPage);
+			};
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue13164SecondPage : ContentPage
+	{
+		public Issue13164SecondPage()
+		{
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Navigate back, and navigate again to this page several times. If shapes are always rendered, the test has passed."
+			};
+
+			var ellipse = new Ellipse
+			{
+				HorizontalOptions = LayoutOptions.Start,
+				Stroke = Brush.DarkBlue,
+				Fill = Brush.BlueViolet,
+				HeightRequest = 50,
+				WidthRequest = 100
+			};
+
+			var rectangle = new Shapes.Rectangle
+			{
+				HorizontalOptions = LayoutOptions.Start,
+				StrokeThickness = 3,
+				Stroke = Brush.DarkOliveGreen,
+				Fill = Brush.Orange,
+				HeightRequest = 80,
+				WidthRequest = 120
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(ellipse);
+			layout.Children.Add(rectangle);
+
+			Content = layout;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1671,6 +1671,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8833.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10086.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13136.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13164.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
@@ -17,9 +17,6 @@ namespace Xamarin.Forms.Platform.Android
 		 where TShape : Shape
 		 where TNativeShape : ShapeView
 	{
-		double _height;
-		double _width;
-
 		public ShapeRenderer(Context context) : base(context)
 		{
 
@@ -48,16 +45,10 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnElementPropertyChanged(sender, args);
 
-			if (args.PropertyName == VisualElement.HeightProperty.PropertyName)
-			{
-				_height = Element.Height;
+			if (args.PropertyName == VisualElement.HeightProperty.PropertyName ||
+				args.PropertyName == VisualElement.WidthProperty.PropertyName ||
+				args.PropertyName == Platform.RendererProperty.PropertyName)
 				UpdateSize();
-			}
-			else if (args.PropertyName == VisualElement.WidthProperty.PropertyName)
-			{
-				_width = Element.Width;
-				UpdateSize();
-			}
 			else if (args.PropertyName == Shape.AspectProperty.PropertyName)
 				UpdateAspect();
 			else if (args.PropertyName == Shape.FillProperty.PropertyName)
@@ -90,7 +81,13 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateSize()
 		{
-			Control.UpdateSize(_width, _height);
+			if (Control == null)
+				return;
+
+			double height = Math.Max(Element.Height, 0);
+			double width = Math.Max(Element.Width, 0);
+
+			Control.UpdateSize(width, height);
 		}
 
 		void UpdateAspect()

--- a/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
@@ -19,9 +19,6 @@ namespace Xamarin.Forms.Platform.MacOS
         where TShape : Shape
         where TNativeShape : ShapeView
     {
-        double _height;
-        double _width;
-
         protected override void OnElementChanged(ElementChangedEventArgs<TShape> args)
         {
             base.OnElementChanged(args);
@@ -44,16 +41,10 @@ namespace Xamarin.Forms.Platform.MacOS
         {
             base.OnElementPropertyChanged(sender, args);
 
-            if (args.PropertyName == VisualElement.HeightProperty.PropertyName)
-            {
-                _height = Element.Height;
+            if (args.PropertyName == VisualElement.HeightProperty.PropertyName ||
+                args.PropertyName == VisualElement.WidthProperty.PropertyName ||
+                args.PropertyName == Platform.RendererProperty.PropertyName)
                 UpdateSize();
-            }
-            else if (args.PropertyName == VisualElement.WidthProperty.PropertyName)
-            {
-                _width = Element.Width;
-                UpdateSize();
-            }
             else if (args.PropertyName == Shape.AspectProperty.PropertyName)
                 UpdateAspect();
             else if (args.PropertyName == Shape.FillProperty.PropertyName)
@@ -91,7 +82,10 @@ namespace Xamarin.Forms.Platform.MacOS
 
         void UpdateSize()
         {
-            Control.ShapeLayer.UpdateSize(new CGSize(new nfloat(_width), new nfloat(_height)));
+            nfloat height = new nfloat(Math.Max(Element.Height, 0));
+            nfloat width = new nfloat(Math.Max(Element.Width, 0));
+
+            Control.ShapeLayer.UpdateSize(new CGSize(width, height));
         }
 
         void UpdateFill()


### PR DESCRIPTION
### Description of Change ###

Fix the issue with Shapes size navigating several times on Android, iOS and macOS.

NOTE: The fix (and mostly the issue) is the same as https://github.com/xamarin/Xamarin.Forms/pull/11927

### Issues Resolved ### 

- fixes #13164 
- fixes #12245

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- Android
- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix13164](https://user-images.githubusercontent.com/6755973/102372868-ee0c0280-3fbf-11eb-86c3-24f0b798ae4e.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13164. Tap the Button to navigate to the details page with some Shapes. Then, navigate back, and navigate again to this page several times. If shapes are always rendered, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
