### PR TITLE
[Android] On UpdateInitialPosition reset _gotoPosition state

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -47,6 +47,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 							new CarouselItemsGallery(useNativeIndicators: true, setPositionOnAppearing: true), Navigation),
 						GalleryBuilder.NavButton("CarouselView loop", () =>
 							new CarouselXamlGallery(true), Navigation),
+						GalleryBuilder.NavButton("CarouselView Set CurrentItem", () =>
+							new CarouselXamlGallery(false, 3), Navigation),
+						GalleryBuilder.NavButton("CarouselView Set CurrentItem Loop", () =>
+							new CarouselXamlGallery(true, 3), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -8,10 +8,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 	[Preserve(AllMembers = true)]
 	public partial class CarouselXamlGallery : ContentPage
 	{
-		public CarouselXamlGallery(bool useLooping)
+		public CarouselXamlGallery(bool useLooping, int startCurrentItem = -1)
 		{
 			InitializeComponent();
-			BindingContext = new CarouselViewModel(CarouselXamlSampleType.Peek, useLooping);
+			BindingContext = new CarouselViewModel(CarouselXamlSampleType.Peek, useLooping, startCurrentItem: startCurrentItem);
 		}
 	}
 
@@ -30,7 +30,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		int _position;
 		ObservableCollection<CarouselItem> _items;
 		CarouselXamlSampleType _type;
-		public CarouselViewModel(CarouselXamlSampleType type, bool loop, int initialItems = 5)
+		public CarouselViewModel(CarouselXamlSampleType type, bool loop, int initialItems = 5, int startCurrentItem = -1)
 		{
 			IsLoop = loop;
 			_type = type;
@@ -53,6 +53,9 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			Items = new ObservableCollection<CarouselItem>(items);
 			Count = Items.Count - 1;
+
+			if (startCurrentItem != -1)
+				Selected = Items[startCurrentItem];
 		}
 
 		public bool IsLoop

--- a/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
+++ b/Xamarin.Forms.Core.UITests.Shared/Tests/CarouselViewUITests.cs
@@ -68,22 +68,27 @@ namespace Xamarin.Forms.Core.UITests
 			App.Back();
 		}
 
-		[TestCase("CarouselView (XAML, Horizontal)")]
-		[TestCase("CarouselView (XAML, Horizontal, Loop)")]
-		public void CarouselViewGoToNextCurrentItem(string subgallery)
+		[TestCase("CarouselView (XAML, Horizontal)", 0)]
+		[TestCase("CarouselView (XAML, Horizontal, Loop)", 0)]
+		[TestCase("CarouselView Set CurrentItem", 3)]
+		[TestCase("CarouselView Set CurrentItem Loop", 3)]
+		public void CarouselViewGoToNextCurrentItem(string subgallery, int indexToTest)
 		{
 			VisitSubGallery(subgallery);
 
-			CheckLabelValue("lblPosition", "0");
-			CheckLabelValue("lblCurrentItem", "0");
+			var index = indexToTest.ToString();
+			var nextIndex = (indexToTest + 1).ToString();
+
+			CheckLabelValue("lblPosition", index);
+			CheckLabelValue("lblCurrentItem", index);
 			App.Tap(x => x.Marked("btnNext"));
-			CheckLabelValue("lblPosition", "1");
-			CheckLabelValue("lblCurrentItem", "1");
-			CheckLabelValue("lblSelected", "1");
+			CheckLabelValue("lblPosition", nextIndex);
+			CheckLabelValue("lblCurrentItem", nextIndex);
+			CheckLabelValue("lblSelected", nextIndex);
 			App.Tap(x => x.Marked("btnPrev"));
-			CheckLabelValue("lblPosition", "0");
-			CheckLabelValue("lblCurrentItem", "0");
-			CheckLabelValue("lblSelected", "0");
+			CheckLabelValue("lblPosition", index);
+			CheckLabelValue("lblCurrentItem", index);
+			CheckLabelValue("lblSelected", index);
 
 			App.Back();
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -349,6 +349,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			var index = Carousel.Loop ? itemCount * 5000 + _oldPosition : _oldPosition;
 			ScrollHelper.JumpScrollToPosition(index, Xamarin.Forms.ScrollToPosition.Center);
+			_gotoPosition = -1;
 		}
 
 		void UpdatePositionFromVisibilityChanges()


### PR DESCRIPTION
### Description of Change ###

There could be a issue where the position is being set and we are then also calling `UpdateIntialPosition`, we should reset the _goToPosition because we aren't using the animate scroll on `UpdateIntialPosition` 

### Issues Resolved ### 

- fixes #13122 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###

Added UITest 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
