### PR TITLE
[xamlg] improve performance by reusing Mono.Cecil objects

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -83,14 +83,11 @@
 		DependsOnTargets="_FindXamlGFiles; PrepareResourceNames; AfterResolveReferences"
 		Inputs="@(_XamlGInputs)"
 		Outputs="@(_XamlGOutputs)">
-		<PropertyGroup>
-			<ReferencedAssemblies>@(ReferencePath)</ReferencedAssemblies>
-		</PropertyGroup>
 		<XamlGTask
 			XamlFiles="@(_XamlGInputs)"
 			OutputFiles="@(_XamlGOutputs)"
 			Language="$(Language)"
-			References = "$(ReferencedAssemblies)"
+			References="@(ReferencePath)"
 			AssemblyName="$(AssemblyName)" />
 		<ItemGroup>
 			<FileWrites Include="@(_XamlGOutputs)" />

--- a/Xamarin.Forms.Build.Tasks/XamlGTask.cs
+++ b/Xamarin.Forms.Build.Tasks/XamlGTask.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Build.Tasks
 
 		public string Language { get; set; }
 		public string AssemblyName { get; set; }
-		public string References { get; set; }
+		public string[] References { get; set; }
 
 		public override bool Execute()
 		{
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Build.Tasks
 				return false;
 			}
 
+			using var xmlnsCache = new XmlnsCache(References);
 			for (int i = 0; i < XamlFiles.Length; i++)
 			{
 				var xamlFile = XamlFiles[i];
@@ -46,7 +47,8 @@ namespace Xamarin.Forms.Build.Tasks
 				else if (IOPath.DirectorySeparatorChar == '\\' && outputFile.Contains(@"/"))
 					outputFile = outputFile.Replace('/', '\\');
 
-				var generator = new XamlGenerator(xamlFile, Language, AssemblyName, outputFile, References, Log);
+				// NOTE: do not Dispose() each generator, so we can reuse a single xmlnsCache
+				var generator = new XamlGenerator(xamlFile, Language, AssemblyName, outputFile, References, Log, xmlnsCache);
 				try
 				{
 					if (!generator.Execute())

--- a/Xamarin.Forms.Build.Tasks/XmlnsCache.cs
+++ b/Xamarin.Forms.Build.Tasks/XmlnsCache.cs
@@ -1,0 +1,86 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mono.Cecil;
+using IOPath = System.IO.Path;
+
+namespace Xamarin.Forms.Build.Tasks
+{
+	class XmlnsCache : IDisposable
+	{
+		readonly string[] _references;
+		readonly List<XmlnsDefinitionAttribute> _xmlnsDefinitions = new List<XmlnsDefinitionAttribute>();
+		readonly Dictionary<string, ModuleDefinition> _xmlnsModules = new Dictionary<string, ModuleDefinition>();
+		bool _initialized;
+
+		public List<XmlnsDefinitionAttribute> XmlnsDefinitions
+		{
+			get { Initialize(); return _xmlnsDefinitions; }
+		}
+
+		public Dictionary<string, ModuleDefinition> XmlnsModules
+		{
+			get { Initialize(); return _xmlnsModules; }
+		}
+
+		public XmlnsCache(string[] references)
+		{
+			_references = references;
+		}
+
+		void Initialize()
+		{
+			if (_initialized)
+				return;
+			_initialized = true;
+
+			var paths = _references?.ToList() ?? new List<string>();
+			//Load xmlnsdef from Core and Xaml
+			paths.Add(typeof(Label).Assembly.Location);
+			paths.Add(typeof(Xamarin.Forms.Xaml.Extensions).Assembly.Location);
+
+			foreach (var path in paths.Distinct())
+			{
+				string asmName = IOPath.GetFileName(path);
+				if (AssemblyIsSystem(asmName))
+					// Skip the myriad "System." assemblies and others
+					continue;
+
+				using (var asmDef = AssemblyDefinition.ReadAssembly(path))
+				{
+					foreach (var ca in asmDef.CustomAttributes)
+					{
+						if (ca.AttributeType.FullName == typeof(XmlnsDefinitionAttribute).FullName)
+						{
+							_xmlnsDefinitions.Add(ca.GetXmlnsDefinition(asmDef));
+							_xmlnsModules[asmDef.FullName] = asmDef.MainModule;
+						}
+					}
+				}
+			}
+		}
+
+		bool AssemblyIsSystem(string name)
+		{
+			if (name.StartsWith("System.Maui", StringComparison.OrdinalIgnoreCase))
+				return false;
+			if (name.StartsWith("System.", StringComparison.OrdinalIgnoreCase))
+				return true;
+			else if (name.Equals("mscorlib.dll", StringComparison.OrdinalIgnoreCase))
+				return true;
+			else if (name.Equals("netstandard.dll", StringComparison.OrdinalIgnoreCase))
+				return true;
+			else
+				return false;
+		}
+
+		public void Dispose()
+		{
+			foreach (var module in _xmlnsModules.Values)
+			{
+				module.Dispose();
+			}
+			_xmlnsModules.Clear();
+		}
+	}
+}

--- a/Xamarin.Forms.Xaml.UnitTests/Issues/GH2691.xaml.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/Issues/GH2691.xaml.cs
@@ -113,14 +113,14 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					"Release";
 #endif
 
-				var references = string.Join(";",
+				var references = new[] {
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-					);
+				};
 				var xamlg = new XamlGTask()
 				{
 					BuildEngine = new DummyBuildEngine(),
@@ -131,7 +131,7 @@ namespace Xamarin.Forms.Xaml.UnitTests
 					References = references
 				};
 
-				var generator = new XamlGenerator(item, xamlg.Language, xamlg.AssemblyName, xamlOutputFile, xamlg.References, null);
+				using var generator = new XamlGenerator(item, xamlg.Language, xamlg.AssemblyName, xamlOutputFile, xamlg.References, logger: null, xmlnsCache: null);
 				Assert.IsTrue(generator.Execute());
 
 				Assert.IsTrue(xamlg.Execute());

--- a/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
+++ b/Xamarin.Forms.Xaml.UnitTests/XamlgTests.cs
@@ -24,16 +24,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-					);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 			Assert.NotNull(generator.RootType);
 			Assert.NotNull(generator.RootClrNamespace);
@@ -60,16 +60,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 			Assert.NotNull(generator.RootType);
 			Assert.NotNull(generator.RootClrNamespace);
@@ -106,16 +106,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual(2, generator.NamedFields.Count());
@@ -145,16 +145,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 						</StackLayout>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.Contains("included", generator.NamedFields.Select(cmf => cmf.Name).ToList());
@@ -183,16 +183,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 						</StackLayout>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.False(generator.NamedFields.Select(cmf => cmf.Name).Contains("notincluded"));
@@ -210,16 +210,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual("FooBar", generator.RootType);
@@ -239,16 +239,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual("FooBar", generator.RootType);
@@ -269,16 +269,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual("FooBar", generator.RootType);
@@ -302,16 +302,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual("FooBar", generator.RootType);
@@ -335,16 +335,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			/>";
 			var reader = new StringReader(xaml);
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(reader);
 
 			Assert.AreEqual("FooBar", generator.RootType);
@@ -367,16 +367,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 			</ContentPage>";
 			using (var reader = new StringReader(xaml))
 			{
-				var references = string.Join(";",
+				var references = new[] {
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-					);
+				};
 
-				var generator = new XamlGenerator(null, null, null, null, null, null, references);
+				using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 				generator.ParseXaml(reader);
 
 				Assert.IsTrue(generator.BaseType.Options.HasFlag(CodeTypeReferenceOptions.GlobalReference));
@@ -401,16 +401,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 
 			using (var reader = new StringReader(xaml))
 			{
-				var references = string.Join(";",
+				var references = new[] {
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 					IOPath.GetFullPath(
 						IOPath.Combine(
 							TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-					);
+				};
 
-				var generator = new XamlGenerator(null, null, null, null, null, null, references);
+				using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 				generator.ParseXaml(reader);
 
 				Assert.That(generator.NamedFields.First(cmf => cmf.Name == "privateLabel").Attributes, Is.EqualTo(MemberAttributes.Private));
@@ -430,16 +430,16 @@ namespace Xamarin.Forms.MSBuild.UnitTests
 		x:Name=""bar"">
 	</ContentPage>";
 
-			var references = string.Join(";",
+			var references = new[] {
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Controls.dll")),
 								IOPath.GetFullPath(
 									IOPath.Combine(
 										TestContext.CurrentContext.TestDirectory, "Xamarin.Forms.Core.dll"))
-								);
+			};
 
-			var generator = new XamlGenerator(null, null, null, null, null, null, references);
+			using var generator = new XamlGenerator(null, null, null, null, null, null, references);
 			generator.ParseXaml(new StringReader(xaml));
 
 			Assert.AreEqual(1, generator.NamedFields.Count());


### PR DESCRIPTION
### Description of Change ###

I found that for each iteration of a `XamlFile`, `<XamlGTask/>` would:

* Iterate over each item in `@(ReferencePath)`.
* Load the assembly with Mono.Cecil.
* Find all the `XmlnsDefinitionAttribute` and create dictionaries.

This would happen for every `.xaml.g.cs` file generated. In
`Xamarin.Forms.Controls.csproj` this resulted in 122 references X 379
`.xaml.g.cs` files.

I moved this logic into a new `XmlnsCache` class. This work can be
done once, and `_xmlnsDefinitions` and `_xmlnsModules` can be reused
for each `.xaml.g.cs` file.

This changes the "lifetime" of `XamlGenerator` a bit, now unit tests
should dispose of `XamlGenerator`, while the `<XamlGTask/>` should
only dispose the `XmlnsCache` after all work is complete.

I also wrote the `XmlnsCache`, so the assemblies are loaded lazily if
the `XmlnsDefinitions` or `XmlnsModules` properties are not accessed.

Other small improvements:

* Don't create the `$(ReferencedAssemblies)` property. This is
  equivalent to doing a `string.Join()` with many full paths.
* We can use `@(ReferencePath)` as-is, to pass into a `string[]`
  property to the `<XamlGTask/>`. This way we don't have to split on
  `;` ourselves.
* The `AssemblyIsSystem()` method should use
  `StringComparison.OrdinalIgnoreCase` as `CurrentCultureIgnoreCase`
  is slower and can produce incorrect results in some cultures.

### Results ###

On Windows, when building `Xamarin.Forms.Controls`:

    Before:
    2643 ms  XamlG                                      1 calls
    2626 ms  XamlGTask                                  1 calls
    After:
     388 ms  XamlG                                      1 calls
     374 ms  XamlGTask                                  1 calls

On macOS, running under Mono:

    Before:
    5003 ms  XamlG                                      1 calls
    4926 ms  XamlGTask                                  1 calls
    After:
     772 ms  XamlG                                      1 calls
     688 ms  XamlGTask                                  1 calls

`Xamarin.Forms.Controls` might resemble a larger customer project?
These changes would help the most for projects with lots of
`.xaml.g.cs` files.

### Issues Resolved ### 

None

### API Changes ###
 
None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

We may want to do some manual testing in IDEs, I can help with this.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
