### PR TITLE
[Tizen] Support to ListView.SeparatorColor and SeparatorVisibility

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/ListView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/ListView.cs
@@ -6,6 +6,7 @@ using ElmSharp;
 using Xamarin.Forms.Internals;
 using ERect = ElmSharp.Rect;
 using EScroller = ElmSharp.Scroller;
+using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen.Native
 {
@@ -146,6 +147,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 					Scroller.HorizontalScrollBarVisiblePolicy = value;
 			}
 		}
+
+		public EColor BottomLineColor { get; set; }
 
 		/// <summary>
 		/// Occurs when the ListView has scrolled.
@@ -464,6 +467,14 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			if (itemContext != null && itemContext.Cell != null)
 			{
 				itemContext.Cell.SendSignalToItem(evt.Item);
+				if (BottomLineColor.IsDefault)
+				{
+					evt.Item.DeleteBottomlineColor();
+				}
+				else
+				{
+					evt.Item.SetBottomlineColor(BottomLineColor);
+				}
 				(itemContext.Cell as ICellController).SendAppearing();
 			}
 		}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ListViewRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Specialized;
 using ElmSharp;
 using Xamarin.Forms.Internals;
+using EColor = ElmSharp.Color;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
@@ -45,6 +46,8 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(ListView.SelectionModeProperty, UpdateSelectionMode);
 			RegisterPropertyHandler(ListView.VerticalScrollBarVisibilityProperty, UpdateVerticalScrollBarVisibility);
 			RegisterPropertyHandler(ListView.HorizontalScrollBarVisibilityProperty, UpdateHorizontalScrollBarVisibility);
+			RegisterPropertyHandler(ListView.SeparatorColorProperty, UpdateSeparator);
+			RegisterPropertyHandler(ListView.SeparatorVisibilityProperty, UpdateSeparator);
 		}
 
 		/// <summary>
@@ -387,6 +390,11 @@ namespace Xamarin.Forms.Platform.Tizen
 		void UpdateHorizontalScrollBarVisibility()
 		{
 			Control.HorizontalScrollBarVisibility = Element.HorizontalScrollBarVisibility.ToNative();
+		}
+
+		void UpdateSeparator()
+		{
+			Control.BottomLineColor = Element.SeparatorVisibility == SeparatorVisibility.Default ? Element.SeparatorColor.ToNative() : EColor.Transparent;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
This PR supports `ListView.SeparatorColor` and `ListView.SeparatorVisibility` in Tizen. 

#### Limitations
- According to the product UX policy, the separator of `ListView` is not supported in  Galaxy Watch series (`TargetIdiom.Watch`) and and Samsung Smart TV model (`TargetIdiom.TV`), and nothing happens when using these properties.


### Issues Resolved ### 
None

### API Changes ###
**```namespace Xamarin.Forms.Platform.Tizen.Native```**
Added:
 - Color ListView.BottomLineColor { get; set; } 

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
