### PR TITLE
Add new xplat event to to propagate FlyoutItemsChanged events to the platforms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11214.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11214.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11214, "When adding FlyoutItems during Navigating only first one is shown",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue11214 : TestShell
+	{
+		FlyoutItem _itemexpanderItems;
+		protected override void Init()
+		{
+			_itemexpanderItems = new FlyoutItem()
+			{
+				Title = "Expando Magic",
+				FlyoutDisplayOptions = FlyoutDisplayOptions.AsMultipleItems
+			};
+
+			ContentPage contentPage = new ContentPage()
+			{
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "Open the Flyout",
+							AutomationId = "PageLoaded"
+						}
+					}
+				}
+			};
+
+			AddFlyoutItem(contentPage, "Top Item");
+			
+			var flyoutItem = AddFlyoutItem("Click Me and You Should see 2 Items show up");
+			flyoutItem.Route = "ExpandMe";
+			flyoutItem.AutomationId = "ExpandMe";
+			Items.Add(_itemexpanderItems);
+		}
+
+		protected override void OnNavigating(ShellNavigatingEventArgs args)
+		{
+			base.OnNavigating(args);
+
+			if(!args.Target.FullLocation.ToString().Contains("ExpandMe"))
+			{
+				return;
+			}
+
+			args.Cancel();
+
+			if (_itemexpanderItems.Items.Count == 0 ||
+				_itemexpanderItems.Items[0].Items.Count == 0)
+			{
+				for (int i = 0; i < 2; i++)
+				{
+					_itemexpanderItems.Items.Add(new ShellContent()
+					{
+						Title = $"Some Item: {i}",
+						Content = new ContentPage()
+					});
+				}
+			}
+			else
+			{
+				_itemexpanderItems.Items.Clear();
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void FlyoutItemChangesPropagateCorrectlyToPlatformForShellElementsNotCurrentlyActive()
+		{
+			RunningApp.WaitForElement("PageLoaded");
+			TapInFlyout("ExpandMe", makeSureFlyoutStaysOpen: true);
+
+			for (int i = 0; i < 2; i++)
+				RunningApp.WaitForElement($"Some Item: {i}");
+
+			TapInFlyout("ExpandMe", makeSureFlyoutStaysOpen: true);
+
+			for (int i = 0; i < 2; i++)
+				RunningApp.WaitForNoElement($"Some Item: {i}");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -10,6 +10,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4720.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10897.xaml.cs">
       <DependentUpon>Issue10897.xaml</DependentUpon>

--- a/Xamarin.Forms.Core/Shell/IShellController.cs
+++ b/Xamarin.Forms.Core/Shell/IShellController.cs
@@ -19,6 +19,7 @@ namespace Xamarin.Forms
 	public interface IShellController : IPageController
 	{
 		event EventHandler StructureChanged;
+		event EventHandler FlyoutItemsChanged;
 
 		View FlyoutHeader { get; }
 

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -65,7 +65,7 @@ namespace Xamarin.Forms
 			if (bindable is Element element)
 				element
 					.FindParentOfType<Shell>()
-					?.SendStructureChanged();
+					?.SendFlyoutItemsChanged();
 		}
 
 		public static readonly BindableProperty TabBarIsVisibleProperty =

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -295,6 +295,14 @@ namespace Xamarin.Forms
 
 		event EventHandler _structureChanged;
 
+		event EventHandler IShellController.FlyoutItemsChanged
+		{
+			add { _flyoutItemsChanged += value; }
+			remove { _flyoutItemsChanged -= value; }
+		}
+
+		event EventHandler _flyoutItemsChanged;
+
 		View IShellController.FlyoutHeader => FlyoutHeaderView;
 		View IShellController.FlyoutFooter => FlyoutFooterView;
 
@@ -884,6 +892,7 @@ namespace Xamarin.Forms
 			{
 				SetCurrentItem();
 				SendStructureChanged();
+				SendFlyoutItemsChanged();
 			};
 
 			async void SetCurrentItem()
@@ -1128,8 +1137,18 @@ namespace Xamarin.Forms
 			if (FlyoutFooterView != null)
 				SetInheritedBindingContext(FlyoutFooterView, BindingContext);
 		}
+		
 
-		List<List<Element>> IShellController.GenerateFlyoutGrouping()
+		internal void SendFlyoutItemsChanged()
+		{
+			if (UpdateFlyoutGroupings())
+				_flyoutItemsChanged?.Invoke(this, EventArgs.Empty);
+		}
+
+		List<List<Element>> IShellController.GenerateFlyoutGrouping() =>
+			_currentFlyoutViews;
+
+		bool UpdateFlyoutGroupings()
 		{
 			// The idea here is to create grouping such that the Flyout would
 			// render correctly if it renderered each item in the groups in order
@@ -1240,11 +1259,11 @@ namespace Xamarin.Forms
 				}
 
 				if (!hasChanged)
-					return _currentFlyoutViews;
+					return false;
 			}
 
 			_currentFlyoutViews = result;
-			return result;
+			return true;
 
 			bool ShowInFlyoutMenu(BindableObject bo)
 			{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1145,8 +1145,13 @@ namespace Xamarin.Forms
 				_flyoutItemsChanged?.Invoke(this, EventArgs.Empty);
 		}
 
-		List<List<Element>> IShellController.GenerateFlyoutGrouping() =>
-			_currentFlyoutViews;
+		List<List<Element>> IShellController.GenerateFlyoutGrouping()
+		{
+			if(_currentFlyoutViews == null)
+				UpdateFlyoutGroupings();
+
+			return _currentFlyoutViews;
+		}
 
 		bool UpdateFlyoutGroupings()
 		{

--- a/Xamarin.Forms.Core/Shell/ShellGroupItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellGroupItem.cs
@@ -1,9 +1,16 @@
-﻿namespace Xamarin.Forms
+﻿using System;
+
+namespace Xamarin.Forms
 {
 	public class ShellGroupItem : BaseShellItem
 	{
 		public static readonly BindableProperty FlyoutDisplayOptionsProperty =
-			BindableProperty.Create(nameof(FlyoutDisplayOptions), typeof(FlyoutDisplayOptions), typeof(ShellItem), FlyoutDisplayOptions.AsSingleItem, BindingMode.OneTime);
+			BindableProperty.Create(nameof(FlyoutDisplayOptions), typeof(FlyoutDisplayOptions), typeof(ShellGroupItem), FlyoutDisplayOptions.AsSingleItem, BindingMode.OneTime, propertyChanged: OnFlyoutDisplayOptionsPropertyChanged);
+
+		static void OnFlyoutDisplayOptionsPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+		{
+			((Element)bindable).FindParentOfType<Shell>()?.SendFlyoutItemsChanged();
+		}
 
 		public FlyoutDisplayOptions FlyoutDisplayOptions
 		{

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -164,9 +164,12 @@ namespace Xamarin.Forms
 
 		internal void SendStructureChanged()
 		{
-			if (Parent is Shell shell && IsVisibleItem)
+			if (Parent is Shell shell)
 			{
-				shell.SendStructureChanged();
+				if (IsVisibleItem)
+					shell.SendStructureChanged();
+				else
+					shell.SendFlyoutItemsChanged();
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/ShellItem.cs
@@ -168,8 +168,8 @@ namespace Xamarin.Forms
 			{
 				if (IsVisibleItem)
 					shell.SendStructureChanged();
-				else
-					shell.SendFlyoutItemsChanged();
+
+				shell.SendFlyoutItemsChanged();
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -626,8 +626,8 @@ namespace Xamarin.Forms
 			{
 				if (IsVisibleSection)
 					shell.SendStructureChanged();
-				else
-					shell.SendFlyoutItemsChanged();
+
+				shell.SendFlyoutItemsChanged();
 			}
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -622,9 +622,12 @@ namespace Xamarin.Forms
 
 		internal void SendStructureChanged()
 		{
-			if (Parent?.Parent is Shell shell && IsVisibleSection)
+			if (Parent?.Parent is Shell shell)
 			{
-				shell.SendStructureChanged();
+				if (IsVisibleSection)
+					shell.SendStructureChanged();
+				else
+					shell.SendFlyoutItemsChanged();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -25,7 +25,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			_shellContext = shellContext;
 
-			ShellController.StructureChanged += OnShellStructureChanged;
+			ShellController.FlyoutItemsChanged += OnFlyoutItemsChanged;
 
 			_listItems = GenerateItemList();
 			_selectedCallback = selectedCallback;
@@ -197,7 +197,7 @@ namespace Xamarin.Forms.Platform.Android
 			return result;
 		}
 
-		protected virtual void OnShellStructureChanged(object sender, EventArgs e)
+		protected virtual void OnFlyoutItemsChanged(object sender, EventArgs e)
 		{
 			var newListItems = GenerateItemList();
 
@@ -217,7 +217,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
-				((IShellController)Shell).StructureChanged -= OnShellStructureChanged;
+				((IShellController)Shell).FlyoutItemsChanged -= OnFlyoutItemsChanged;
 
 				_elementViewHolder?.Dispose();
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_source = CreateShellTableViewSource();
 			_source.ScrolledEvent += OnScrolled;
 
-			ShellController.StructureChanged += OnStructureChanged;
+			ShellController.FlyoutItemsChanged += OnFlyoutItemsChanged;
 			_context.Shell.PropertyChanged += OnShellPropertyChanged;
 		}
 
@@ -90,7 +90,7 @@ namespace Xamarin.Forms.Platform.iOS
 			LayoutParallax();
 		}
 
-		void OnStructureChanged(object sender, EventArgs e)
+		void OnFlyoutItemsChanged(object sender, EventArgs e)
 		{
 			_source.ClearCache();
 			TableView.ReloadData();
@@ -181,8 +181,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				if ((_context?.Shell as IShellController) != null)
-					((IShellController)_context.Shell).StructureChanged -= OnStructureChanged;
+				if (ShellController != null)
+					ShellController.FlyoutItemsChanged -= OnFlyoutItemsChanged;
 
 				if (_source != null)
 					_source.ScrolledEvent -= OnScrolled;

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.iOS
 		List<List<Element>> _groups;
 		Dictionary<Element, UIContainerCell> _cells;
 
-		IShellController ShellController => (IShellController)_context.Shell;
+		IShellController ShellController => _context.Shell;
 
 		public ShellTableViewSource(IShellContext context, Action<Element> onElementSelected)
 		{
@@ -29,7 +29,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (_groups == null)
 				{
-					_groups = ((IShellController)_context.Shell).GenerateFlyoutGrouping();
+					_groups = ShellController.GenerateFlyoutGrouping();
 
 					if (_cells != null)
 					{


### PR DESCRIPTION
### Description of Change ###

- Added an event to IShellController that can specifically be used to indicate FlyoutItems have changed. Currently this is based on the StructureChanged event but as of 4.6 the StructureChanged event only fires for currently visible pages. This was changed in 4.6 because it was sending a "StructureChanged" event every time you added a new Shell Element which was causing some performance issues and visual artifacts. These changes also for intelligently fire the FlyoutItem changed event when it detects that the list of Flyout Items has actually changed opposed to just firing it off all of the time

- Converted the Flyout Items on UWP shell to use an ObservableCollection. NavigationView doesn't really do very well if you just swap out the Source.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11214

### API Changes ###

Added:
 - event EventHandler IShellController.FlyoutItemsChanged


### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- UI Test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
