### PR TITLE
Fix NRE if user immediately completes Deferral

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task CancelNavigationShellItems()
+		public async Task CancelNavigationOccurringOutsideGotoAsync()
 		{
 			var flyoutItem = CreateShellItem<FlyoutItem>();
 			TestShell shell = new TestShell()

--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -48,6 +48,38 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public void CancelNavigationOccurringOutsideGotoAsyncWithoutDelay()
+		{
+			var flyoutItem = CreateShellItem<FlyoutItem>();
+			TestShell shell = new TestShell()
+			{
+				Items = { flyoutItem }
+			};
+
+			var navigatingToShellContent = CreateShellContent();
+			shell.Items[0].Items[0].Items.Add(navigatingToShellContent);
+
+			bool executed = false;
+			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
+
+			ShellContent contentActiveBeforeCompletingDeferral = null;
+			shell.Navigating += (_, args) =>
+			{
+				var deferral = args.GetDeferral();
+				contentActiveBeforeCompletingDeferral = flyoutItem.Items[0].Items[0];
+				args.Cancel();
+				deferral.Complete();
+				executed = true;
+			};
+
+			bool result = shell.Controller.ProposeNavigation(
+				ShellNavigationSource.ShellContentChanged, flyoutItem, flyoutItem.Items[0], navigatingToShellContent, flyoutItem.Items[0].Stack, true);
+
+			Assert.IsTrue(executed);
+			Assert.IsFalse(result);
+		}
+
+		[Test]
 		public async Task CancelNavigationOccurringOutsideGotoAsync()
 		{
 			var flyoutItem = CreateShellItem<FlyoutItem>();
@@ -63,6 +95,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			TaskCompletionSource<object> taskCompletionSource = new TaskCompletionSource<object>();
 
 			ShellContent contentActiveBeforeCompletingDeferral = null;
+
 			shell.Navigating += async (_, args) =>
 			{
 				var deferral = args.GetDeferral();

--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -155,9 +155,9 @@ namespace Xamarin.Forms.Core.UnitTests
 		[TestCase("Pop")]
 		[TestCase("GoToAsync")]
 		[TestCase("Push")]
-		public async Task NavigationTaskCompletesAfterDeferalHasFinished(string testCase)
+		public async Task NavigationTaskCompletesAfterDeferralHasFinished(string testCase)
 		{
-			Routing.RegisterRoute(nameof(NavigationTaskCompletesAfterDeferalHasFinished), typeof(ContentPage));
+			Routing.RegisterRoute(nameof(NavigationTaskCompletesAfterDeferralHasFinished), typeof(ContentPage));
 			var shell = new TestShell()
 			{
 				Items = { CreateShellItem<FlyoutItem>() }
@@ -180,7 +180,7 @@ namespace Xamarin.Forms.Core.UnitTests
 					await shell.Navigation.PopAsync();
 					break;
 				case "GoToAsync":
-					await shell.GoToAsync(nameof(NavigationTaskCompletesAfterDeferalHasFinished));
+					await shell.GoToAsync(nameof(NavigationTaskCompletesAfterDeferralHasFinished));
 					break;
 				case "Push":
 					await shell.Navigation.PushAsync(new ContentPage());
@@ -191,7 +191,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public void CompletingTheSameDeferalTokenTwiceDoesntDoAnything()
+		public void CompletingTheSameDeferralTokenTwiceDoesntDoAnything()
 		{
 			var args = CreateShellNavigatedEventArgs();
 			var token = args.GetDeferral();

--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -330,13 +330,13 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await shell.GoToAsync("//two/tab21/");
 
-			await shell.GoToAsync("/tab22", false, true);
+			await shell.NavigationManager.GoToAsync("/tab22", false, true);
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//two/tab22/content"));
 
-			await shell.GoToAsync("tab21", false, true);
+			await shell.NavigationManager.GoToAsync("tab21", false, true);
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//two/tab21/content"));
 
-			await shell.GoToAsync("/tab23", false, true);
+			await shell.NavigationManager.GoToAsync("/tab23", false, true);
 			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//two/tab23/content"));
 
 			await shell.GoToAsync("RelativeGoTo_Page1", false);

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -251,7 +251,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			await shell.GoToAsync("//rootlevelcontent1");
 			var location = shell.CurrentState.FullLocation;
-			await shell.GoToAsync("edit", false, true);
+			await shell.NavigationManager.GoToAsync("edit", false, true);
 
 			Assert.AreEqual(editShellContent, shell.CurrentItem.CurrentItem.CurrentItem);
 		}

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -238,7 +238,6 @@ namespace Xamarin.Forms
 
 		List<(IAppearanceObserver Observer, Element Pivot)> _appearanceObservers = new List<(IAppearanceObserver Observer, Element Pivot)>();
 		List<IFlyoutBehaviorObserver> _flyoutBehaviorObservers = new List<IFlyoutBehaviorObserver>();
-		ShellNavigatingEventArgs _deferredEventArgs;
 
 
 		internal static BindableObject GetBindableObjectWithFlyoutItemTemplate(BindableObject bo)
@@ -365,7 +364,7 @@ namespace Xamarin.Forms
 		}
 
 		ShellNavigationState IShellController.GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, bool includeStack)
-			=> GetNavigationState(shellItem, shellSection, shellContent, includeStack ? shellSection.Stack.ToList() : null, includeStack ? shellSection.Navigation.ModalStack.ToList() : null);
+			=> ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, includeStack ? shellSection.Stack.ToList() : null, includeStack ? shellSection.Navigation.ModalStack.ToList() : null);
 
 		async void IShellController.OnFlyoutItemSelected(Element element)
 		{
@@ -406,7 +405,7 @@ namespace Xamarin.Forms
 			shellSection = shellSection ?? shellItem.CurrentItem;
 			shellContent = shellContent ?? shellSection?.CurrentItem;
 
-			var state = GetNavigationState(shellItem, shellSection, shellContent, null, null);
+			var state = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, null, null);
 
 			if (FlyoutIsPresented && GetEffectiveFlyoutBehavior() != FlyoutBehavior.Locked)
 				SetValueFromRenderer(FlyoutIsPresentedProperty, false);
@@ -433,8 +432,7 @@ namespace Xamarin.Forms
 
 		bool IShellController.ProposeNavigation(ShellNavigationSource source, ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> stack, bool canCancel)
 		{
-			var proposedState = GetNavigationState(shellItem, shellSection, shellContent, stack, shellSection.Navigation.ModalStack);
-			return ProposeNavigation(source, proposedState, canCancel, null);
+			return _navigationManager.ProposeNavigationOutsideGotoAsync(source, shellItem, shellSection, shellContent, stack, canCancel);
 		}
 
 		bool IShellController.RemoveAppearanceObserver(IAppearanceObserver observer)
@@ -461,11 +459,11 @@ namespace Xamarin.Forms
 			var shellContent = shellSection?.CurrentItem;
 			var stack = shellSection?.Stack;
 			var modalStack = shellSection?.Navigation?.ModalStack;
-			var result = GetNavigationState(shellItem, shellSection, shellContent, stack, modalStack);
+			var result = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, stack, modalStack);
 
 			SetValueFromRenderer(CurrentStatePropertyKey, result);
 
-			HandleNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
+			_navigationManager.HandleNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
 		}
 		ReadOnlyCollection<ShellItem> IShellController.GetItems() =>
 			new ReadOnlyCollection<ShellItem>(((ShellItemCollection)Items).VisibleItemsReadOnly.ToList());
@@ -478,339 +476,15 @@ namespace Xamarin.Forms
 
 		public static Shell Current => Application.Current?.MainPage as Shell;
 
-		internal Task CompleteDeferredNavigating(ShellNavigatingEventArgs deferredArgs)
-		{
-			return GoToAsync(deferredArgs.Target, deferredArgs.Animate, false, deferredArgs);
-		}
-
+		internal ShellNavigationManager NavigationManager => _navigationManager;
 		public Task GoToAsync(ShellNavigationState state)
 		{
-			return GoToAsync(state, null, false);
+			return _navigationManager.GoToAsync(state, null, false);
 		}
 
 		public Task GoToAsync(ShellNavigationState state, bool animate)
 		{
-			return GoToAsync(state, animate, false);
-		}
-
-		internal Task GoToAsync(ShellNavigationState state, bool? animate, bool enableRelativeShellRoutes, ShellNavigatingEventArgs deferredArgs = null)
-		{
-			return GoToAsync(new ShellNavigationParameters
-			{
-				TargetState = state,
-				Animated = animate,
-				EnableRelativeShellRoutes = enableRelativeShellRoutes,
-				DeferredArgs = deferredArgs
-			});
-		}
-
-		internal async Task GoToAsync(ShellNavigationParameters shellNavigationParameters)
-		{
-			if (shellNavigationParameters.PagePushing != null)
-				Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
-
-			ShellNavigationState state = shellNavigationParameters.TargetState ?? Routing.GetRoute(shellNavigationParameters.PagePushing);
-			bool? animate = shellNavigationParameters.Animated;
-			bool enableRelativeShellRoutes = shellNavigationParameters.EnableRelativeShellRoutes;
-			ShellNavigatingEventArgs deferredArgs = shellNavigationParameters.DeferredArgs;
-
-			if (_deferredEventArgs != null && _deferredEventArgs != deferredArgs)
-			{
-				throw new InvalidOperationException("Not all ShellNavigatingDeferrals have been completed from the previous operation");
-			}
-
-			var navigationRequest = ShellUriHandler.GetNavigationRequest(this, state.FullLocation, enableRelativeShellRoutes, shellNavigationParameters: shellNavigationParameters);
-			bool isRelativePopping = ShellUriHandler.IsTargetRelativePop(shellNavigationParameters);
-
-			ShellNavigationSource source = CalculateNavigationSource(CurrentState, navigationRequest);
-
-			var accept = ProposeNavigation(source, state, this.CurrentState != null, deferredArgs);
-
-			if (deferredArgs == null && _deferredEventArgs != null)
-			{
-				await _deferredEventArgs.DeferredTask.ConfigureAwait(false);
-				return;
-			}
-
-			if (!accept)
-			{
-				return;
-			}
-
-			Routing.RegisterImplicitPageRoutes(this);
-
-
-			_accumulateNavigatedEvents = true;
-
-			var uri = navigationRequest.Request.FullUri;
-			var queryString = navigationRequest.Query;
-			var queryData = ParseQueryString(queryString);
-
-			ApplyQueryAttributes(this, queryData, false, false);
-
-			var shellItem = navigationRequest.Request.Item;
-			var shellSection = navigationRequest.Request.Section;
-			var currentShellSection = CurrentItem?.CurrentItem;
-			var nextActiveSection = shellSection ?? shellItem?.CurrentItem;
-
-
-			ShellContent shellContent = navigationRequest.Request.Content;
-			bool modalStackPreBuilt = false;
-
-
-
-			// If we're replacing the whole stack and there are global routes then build the navigation stack before setting the shell section visible
-			if (navigationRequest.Request.GlobalRoutes.Count > 0 &&
-				nextActiveSection != null &&
-				navigationRequest.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
-			{
-				modalStackPreBuilt = true;
-
-				bool? isAnimated = (nextActiveSection != currentShellSection) ? false : animate;
-				await nextActiveSection.GoToAsync(navigationRequest, queryData, isAnimated, isRelativePopping);
-			}
-
-			if (shellItem != null)
-			{
-				ApplyQueryAttributes(shellItem, queryData, navigationRequest.Request.Section == null, false);
-				bool navigatedToNewShellElement = false;
-
-				if (shellSection != null && shellContent != null)
-				{
-					ApplyQueryAttributes(shellContent, queryData, navigationRequest.Request.GlobalRoutes.Count == 0, isRelativePopping);
-					if (shellSection.CurrentItem != shellContent)
-					{
-						shellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
-						navigatedToNewShellElement = true;
-					}
-				}
-
-				if (shellSection != null)
-				{
-					Shell.ApplyQueryAttributes(shellSection, queryData, navigationRequest.Request.Content == null, false);
-					if (shellItem.CurrentItem != shellSection)
-					{
-						shellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, shellSection);
-						navigatedToNewShellElement = true;
-					}
-				}
-
-				if (CurrentItem != shellItem)
-				{
-					SetValueFromRenderer(CurrentItemProperty, shellItem);
-					navigatedToNewShellElement = true;
-				}
-
-				if (!modalStackPreBuilt && currentShellSection?.Navigation.ModalStack.Count > 0)
-				{
-					// - navigating to new shell element so just pop everything
-					// - or route contains no global route requests
-					if (navigatedToNewShellElement || navigationRequest.Request.GlobalRoutes.Count == 0)
-					{
-						// remove all non visible pages first so the transition just smoothly goes from
-						// currently visible modal to base page
-						if (navigationRequest.Request.GlobalRoutes.Count == 0)
-						{
-							for (int i = currentShellSection.Stack.Count - 1; i >= 1; i--)
-								currentShellSection.Navigation.RemovePage(currentShellSection.Stack[i]);
-						}
-
-						await currentShellSection.PopModalStackToPage(null, animate);
-					}
-				}
-
-				if (navigationRequest.Request.GlobalRoutes.Count > 0 && navigationRequest.StackRequest != NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
-				{
-					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
-					await Device.InvokeOnMainThreadAsync(() =>
-					{
-						return CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
-					});
-				}
-				else if (navigationRequest.Request.GlobalRoutes.Count == 0 &&
-					navigationRequest.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt &&
-					currentShellSection?.Navigation?.NavigationStack?.Count > 1)
-				{
-					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
-					await Device.InvokeOnMainThreadAsync(() =>
-					{
-						return CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
-					});
-				}
-			}
-			else
-			{
-				await CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
-			}
-
-			_accumulateNavigatedEvents = false;
-
-			// this can be null in the event that no navigation actually took place!
-			if (_accumulatedEvent != null)
-				HandleNavigated(_accumulatedEvent);
-		}
-
-		internal static void ApplyQueryAttributes(Element element, IDictionary<string, string> query, bool isLastItem, bool isPopping)
-		{
-			string prefix = "";
-			if (!isLastItem)
-			{
-				var route = Routing.GetRoute(element);
-				if (string.IsNullOrEmpty(route) || Routing.IsImplicit(route))
-					return;
-				prefix = route + ".";
-			}
-
-			//if the lastItem is implicitly wrapped, get the actual ShellContent
-			if (isLastItem)
-			{
-				if (element is IShellItemController shellitem && shellitem.GetItems().FirstOrDefault() is ShellSection section)
-					element = section;
-				if (element is IShellSectionController shellsection && shellsection.GetItems().FirstOrDefault() is ShellContent content)
-					element = content;
-				if (element is ShellContent shellcontent && shellcontent.Content is Element e)
-					element = e;
-			}
-
-			if (!(element is BaseShellItem baseShellItem))
-				baseShellItem = element?.Parent as BaseShellItem;
-
-			//filter the query to only apply the keys with matching prefix
-			var filteredQuery = new Dictionary<string, string>(query.Count);
-
-			foreach (var q in query)
-			{
-				if (!q.Key.StartsWith(prefix, StringComparison.Ordinal))
-					continue;
-				var key = q.Key.Substring(prefix.Length);
-				if (key.Contains("."))
-					continue;
-				filteredQuery.Add(key, q.Value);
-			}
-
-
-			if (baseShellItem is ShellContent)
-				baseShellItem.ApplyQueryAttributes(MergeData(element, filteredQuery, isPopping));
-			else if (isLastItem)
-				element.SetValue(ShellContent.QueryAttributesProperty, MergeData(element, query, isPopping));
-
-			IDictionary<string, string> MergeData(Element shellElement, IDictionary<string, string> data, bool isPopping)
-			{
-				if (!isPopping)
-					return data;
-
-				var returnValue = new Dictionary<string, string>(data);
-
-				var existing = (IDictionary<string, string>)shellElement.GetValue(ShellContent.QueryAttributesProperty);
-
-				if (existing == null)
-					return data;
-
-				foreach (var datum in existing)
-				{
-					if (!returnValue.ContainsKey(datum.Key))
-						returnValue[datum.Key] = datum.Value;
-				}
-
-				return returnValue;
-			}
-		}
-
-		internal static ShellNavigationState GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> sectionStack, IReadOnlyList<Page> modalStack)
-		{
-			List<string> routeStack = new List<string>();
-
-			bool stackAtRoot = sectionStack == null || sectionStack.Count <= 1;
-			bool hasUserDefinedRoute =
-				(Routing.IsUserDefined(shellItem)) ||
-				(Routing.IsUserDefined(shellSection)) ||
-				(Routing.IsUserDefined(shellContent));
-
-			if (shellItem != null)
-			{
-				var shellItemRoute = shellItem.Route;
-				routeStack.Add(shellItemRoute);
-
-				if (shellSection != null)
-				{
-					var shellSectionRoute = shellSection.Route;
-					routeStack.Add(shellSectionRoute);
-
-					if (shellContent != null)
-					{
-						var shellContentRoute = shellContent.Route;
-						routeStack.Add(shellContentRoute);
-					}
-
-					if (!stackAtRoot)
-					{
-						for (int i = 1; i < sectionStack.Count; i++)
-						{
-							var page = sectionStack[i];
-							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack, hasUserDefinedRoute));
-						}
-					}
-
-					if (modalStack != null && modalStack.Count > 0)
-					{
-						for (int i = 0; i < modalStack.Count; i++)
-						{
-							var topPage = modalStack[i];
-
-							routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage), routeStack, hasUserDefinedRoute));
-
-							for (int j = 1; j < topPage.Navigation.NavigationStack.Count; j++)
-							{
-								routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack, hasUserDefinedRoute));
-							}
-						}
-					}
-				}
-			}
-
-			if (routeStack.Count > 0)
-				routeStack.Insert(0, "/");
-
-			return new ShellNavigationState(String.Join("/", routeStack), true);
-
-
-			List<string> CollapsePath(
-				string myRoute,
-				IEnumerable<string> currentRouteStack,
-				bool userDefinedRoute)
-			{
-				var localRouteStack = currentRouteStack.ToList();
-				for (var i = localRouteStack.Count - 1; i >= 0; i--)
-				{
-					var route = localRouteStack[i];
-					if (Routing.IsImplicit(route) ||
-						(Routing.IsDefault(route) && userDefinedRoute))
-					{
-						localRouteStack.RemoveAt(i);
-					}
-				}
-
-				var paths = myRoute.Split('/').ToList();
-
-				// collapse similar leaves
-				int walkBackCurrentStackIndex = localRouteStack.Count - (paths.Count - 1);
-
-				while (paths.Count > 1 && walkBackCurrentStackIndex >= 0)
-				{
-					if (paths[0] == localRouteStack[walkBackCurrentStackIndex])
-					{
-						paths.RemoveAt(0);
-					}
-					else
-					{
-						break;
-					}
-
-					walkBackCurrentStackIndex++;
-				}
-
-				return paths;
-			}
+			return _navigationManager.GoToAsync(state, animate, false);
 		}
 
 		public static readonly BindableProperty CurrentItemProperty =
@@ -862,14 +536,26 @@ namespace Xamarin.Forms
 		public static readonly BindableProperty FlyoutVerticalScrollModeProperty =
 			BindableProperty.Create(nameof(FlyoutVerticalScrollMode), typeof(ScrollMode), typeof(Shell), ScrollMode.Auto);
 
-		ShellNavigatedEventArgs _accumulatedEvent;
-		bool _accumulateNavigatedEvents;
 		View _flyoutHeaderView;
 		View _flyoutFooterView;
 		List<List<Element>> _currentFlyoutViews;
+		ShellNavigationManager _navigationManager;
 
 		public Shell()
 		{
+			_navigationManager = new ShellNavigationManager(this);
+			_navigationManager.Navigated += (_, args) =>
+			{
+				OnNavigated(args);
+				Navigated?.Invoke(this, args);
+			};
+
+			_navigationManager.Navigating += (_, args) =>
+			{
+				Navigating?.Invoke(this, args);
+				OnNavigating(args);
+			};
+
 			Navigation = new NavigationImpl(this);
 			Route = Routing.GenerateImplicitRoute("shell");
 			Initialize();
@@ -1292,7 +978,7 @@ namespace Xamarin.Forms
 			}
 
 			var args = new ShellNavigatingEventArgs(this.CurrentState, "", ShellNavigationSource.Pop, true);
-			HandleNavigating(args);
+			_navigationManager.HandleNavigating(args);
 			return args.Cancelled;
 
 			async void NavigationPop()
@@ -1322,42 +1008,6 @@ namespace Xamarin.Forms
 			}
 		}
 
-		internal void HandleNavigated(ShellNavigatedEventArgs args)
-		{
-			if (_accumulateNavigatedEvents)
-			{
-				if (_accumulatedEvent == null)
-					_accumulatedEvent = args;
-			}
-			else
-			{
-				_accumulatedEvent = null;
-				BaseShellItem baseShellItem = CurrentItem?.CurrentItem?.CurrentItem;
-
-				if (baseShellItem != null)
-				{
-					baseShellItem.OnAppearing(() =>
-					{
-						FireNavigatedEvents(args, this);
-					});
-				}
-				else
-				{
-					FireNavigatedEvents(args, this);
-				}
-
-				void FireNavigatedEvents(ShellNavigatedEventArgs a, Shell shell)
-				{
-					shell.OnNavigated(a);
-					shell.Navigated?.Invoke(this, args);
-					// reset active page route tree
-					Routing.ClearImplicitPageRoutes();
-					Routing.RegisterImplicitPageRoutes(this);
-				}
-			}
-
-		}
-
 		protected virtual void OnNavigated(ShellNavigatedEventArgs args)
 		{
 		}
@@ -1365,35 +1015,6 @@ namespace Xamarin.Forms
 		protected virtual void OnNavigating(ShellNavigatingEventArgs args)
 		{
 
-		}
-
-		void HandleNavigating(ShellNavigatingEventArgs args)
-		{
-			if (!args.DeferredEventArgs)
-			{
-				_deferredEventArgs = null;
-				Navigating?.Invoke(this, args);
-				OnNavigating(args);
-			}
-			else
-			{
-				return;
-			}
-
-			if (args.DeferralCount > 0 && args.CanCancel)
-			{
-				_deferredEventArgs = args;
-				args.RegisterDeferralCompletedCallBack(async () =>
-				{
-					_deferredEventArgs = null;
-					if (args.Cancelled)
-					{
-						return;
-					}
-
-					await CompleteDeferredNavigating(args);
-				});
-			}
 		}
 
 		static void OnCurrentItemChanged(BindableObject bindable, object oldValue, object newValue)
@@ -1421,17 +1042,11 @@ namespace Xamarin.Forms
 
 			if (!shell.Items.Contains(shellItem))
 				shell.Items.Add(shellItem);
-
-			if (!shell._accumulateNavigatedEvents)
-			{
-				// We are not in the middle of a GoToAsync so this is a user requested change.
-				// We need to emit the Navigating event since GoToAsync wont be emitting it.
-
-				var shellSection = shellItem.CurrentItem;
-				var shellContent = shellSection.CurrentItem;
-				var stack = shellSection.Stack;
-				shell.ShellController.ProposeNavigation(ShellNavigationSource.ShellItemChanged, shellItem, shellSection, shellContent, stack, false);
-			}
+			
+			var shellSection = shellItem.CurrentItem;
+			var shellContent = shellSection.CurrentItem;
+			var stack = shellSection.Stack;
+			shell._navigationManager.ProposeNavigationOutsideGotoAsync(ShellNavigationSource.ShellItemChanged, shellItem, shellSection, shellContent, stack, false);
 		}
 
 		static void UpdateChecked(Element root, bool isChecked = true)
@@ -1515,24 +1130,6 @@ namespace Xamarin.Forms
 
 			if (newView != null)
 				newView.Parent = owner;
-		}
-
-		static Dictionary<string, string> ParseQueryString(string query)
-		{
-			if (query.StartsWith("?", StringComparison.Ordinal))
-				query = query.Substring(1);
-			Dictionary<string, string> lookupDict = new Dictionary<string, string>();
-			if (query == null)
-				return lookupDict;
-			foreach (var part in query.Split('&'))
-			{
-				var p = part.Split('=');
-				if (p.Length != 2)
-					continue;
-				lookupDict[p[0]] = p[1];
-			}
-
-			return lookupDict;
 		}
 
 		internal FlyoutBehavior GetEffectiveFlyoutBehavior()
@@ -1684,89 +1281,6 @@ namespace Xamarin.Forms
 				var newFooterView = (View)newValue.CreateContent(FlyoutFooter, this);
 				FlyoutFooterView = newFooterView;
 			}
-		}
-
-		bool ProposeNavigation(ShellNavigationSource source, ShellNavigationState proposedState, bool canCancel, ShellNavigatingEventArgs deferredArgs)
-		{
-			if (_accumulateNavigatedEvents)
-				return true;
-
-			var navArgs = deferredArgs ?? new ShellNavigatingEventArgs(CurrentState, proposedState, source, canCancel);
-			HandleNavigating(navArgs);
-			return !navArgs.Cancelled && navArgs.DeferralCount == 0;
-		}
-
-		ShellNavigationSource CalculateNavigationSource(ShellNavigationState current, NavigationRequest request)
-		{
-			if (request.StackRequest == NavigationRequest.WhatToDoWithTheStack.PushToIt)
-				return ShellNavigationSource.Push;
-
-			if (current == null)
-				return ShellNavigationSource.ShellItemChanged;
-
-			var targetUri = ShellUriHandler.ConvertToStandardFormat(this, request.Request.FullUri);
-			var currentUri = ShellUriHandler.ConvertToStandardFormat(this, current.FullLocation);
-
-			var targetPaths = ShellUriHandler.RetrievePaths(targetUri.PathAndQuery);
-			var currentPaths = ShellUriHandler.RetrievePaths(currentUri.PathAndQuery);
-
-			var targetPathsLength = targetPaths.Length;
-			var currentPathsLength = currentPaths.Length;
-
-			if (targetPathsLength < 4 || currentPathsLength < 4)
-				return ShellNavigationSource.Unknown;
-
-			if (targetPaths[1] != currentPaths[1])
-				return ShellNavigationSource.ShellItemChanged;
-			if (targetPaths[2] != currentPaths[2])
-				return ShellNavigationSource.ShellSectionChanged;
-			if (targetPaths[3] != currentPaths[3])
-				return ShellNavigationSource.ShellContentChanged;
-
-			if (targetPathsLength == currentPathsLength)
-				return ShellNavigationSource.Unknown;
-
-			if (targetPathsLength < currentPathsLength)
-			{
-				for (var i = 0; i < targetPathsLength; i++)
-				{
-					var targetPath = targetPaths[i];
-					if (targetPath != currentPaths[i])
-						break;
-
-					if (i == targetPathsLength - 1)
-					{
-						if (targetPathsLength == 4)
-							return ShellNavigationSource.PopToRoot;
-
-						return ShellNavigationSource.Pop;
-					}
-				}
-
-				if (targetPaths[targetPathsLength - 1] == currentPaths[currentPathsLength - 1])
-					return ShellNavigationSource.Remove;
-
-				if (targetPathsLength == 4)
-					return ShellNavigationSource.PopToRoot;
-
-				return ShellNavigationSource.Pop;
-			}
-			else if (targetPathsLength > currentPathsLength)
-			{
-				for (var i = 0; i < currentPathsLength; i++)
-				{
-					if (targetPaths[i] != currentPaths[i])
-						break;
-
-					if (i == targetPathsLength - 1)
-						return ShellNavigationSource.Push;
-				}
-			}
-
-			if (targetPaths[targetPathsLength - 1] == currentPaths[currentPathsLength - 1])
-				return ShellNavigationSource.Insert;
-
-			return ShellNavigationSource.Push;
 		}
 
 		internal Element GetVisiblePage()

--- a/Xamarin.Forms.Core/Shell/ShellNavigatingEventArgs.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigatingEventArgs.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms
 {
 	public class ShellNavigatingEventArgs : EventArgs
 	{
-		int _deferalCount;
+		int _deferralCount;
 		Func<Task> _deferralFinishedTask;
 		TaskCompletionSource<bool> _deferredTaskCompletionSource;
 		bool _deferralCompleted = false;
@@ -54,7 +54,7 @@ namespace Xamarin.Forms
 				return null;
 
 			DeferredEventArgs = true;
-			var currentCount = Interlocked.Increment(ref _deferalCount);
+			var currentCount = Interlocked.Increment(ref _deferralCount);
 			if (currentCount == 1)
 			{
 				_deferredTaskCompletionSource = new TaskCompletionSource<bool>();
@@ -65,7 +65,7 @@ namespace Xamarin.Forms
 
 		async void DecrementDeferral()
 		{
-			if (Interlocked.Decrement(ref _deferalCount) == 0)
+			if (Interlocked.Decrement(ref _deferralCount) == 0)
 			{
 				_deferralCompleted = true;
 
@@ -93,7 +93,7 @@ namespace Xamarin.Forms
 		internal bool Animate { get; set; }
 		internal bool DeferredEventArgs { get; set; }
 
-		internal int DeferralCount => _deferalCount;
+		internal int DeferralCount => _deferralCount;
 
 		internal bool NavigationDelayedOrCancelled =>
 			Cancelled || DeferralCount > 0;

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -1,0 +1,517 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Xamarin.Forms
+{
+	internal class ShellNavigationManager
+	{
+		readonly Shell _shell;
+		ShellNavigatedEventArgs _accumulatedEvent;
+		bool _accumulateNavigatedEvents;
+
+		public event EventHandler<ShellNavigatedEventArgs> Navigated;
+		public event EventHandler<ShellNavigatingEventArgs> Navigating;
+
+		public ShellNavigationManager(Shell shell)
+		{
+			_shell = shell;
+		}
+
+		public Task GoToAsync(ShellNavigationState state, bool? animate, bool enableRelativeShellRoutes, ShellNavigatingEventArgs deferredArgs = null)
+		{
+			return GoToAsync(new ShellNavigationParameters
+			{
+				TargetState = state,
+				Animated = animate,
+				EnableRelativeShellRoutes = enableRelativeShellRoutes,
+				DeferredArgs = deferredArgs
+			});
+		}
+
+		public async Task GoToAsync(ShellNavigationParameters shellNavigationParameters)
+		{
+			if (shellNavigationParameters.PagePushing != null)
+				Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
+
+			ShellNavigationState state = shellNavigationParameters.TargetState ?? Routing.GetRoute(shellNavigationParameters.PagePushing);
+			bool? animate = shellNavigationParameters.Animated;
+			bool enableRelativeShellRoutes = shellNavigationParameters.EnableRelativeShellRoutes;
+			ShellNavigatingEventArgs deferredArgs = shellNavigationParameters.DeferredArgs;
+
+			var navigationRequest = ShellUriHandler.GetNavigationRequest(_shell, state.FullLocation, enableRelativeShellRoutes, shellNavigationParameters: shellNavigationParameters);
+			bool isRelativePopping = ShellUriHandler.IsTargetRelativePop(shellNavigationParameters);
+
+			ShellNavigationSource source = CalculateNavigationSource(_shell, _shell.CurrentState, navigationRequest);
+
+			// If the deferredArgs are non null that means we are processing a delayed navigation
+			// so the user has indicated they want to go forward with navigation
+			// This scenario only comes up from UI iniated navigation (i.e. switching tabs)
+			if (deferredArgs == null)
+			{
+				var navigatingArgs = ProposeNavigation(source, state, _shell.CurrentState != null);
+
+				bool accept = !navigatingArgs.NavigationDelayedOrCancelled;
+				if (navigatingArgs.DeferredTask != null)
+					accept = await navigatingArgs.DeferredTask;
+
+				if (!accept)
+					return;
+			}
+
+			Routing.RegisterImplicitPageRoutes(_shell);
+
+			_accumulateNavigatedEvents = true;
+
+			var uri = navigationRequest.Request.FullUri;
+			var queryString = navigationRequest.Query;
+			var queryData = ParseQueryString(queryString);
+
+			ApplyQueryAttributes(_shell, queryData, false, false);
+
+			var shellItem = navigationRequest.Request.Item;
+			var shellSection = navigationRequest.Request.Section;
+			var currentShellSection = _shell.CurrentItem?.CurrentItem;
+			var nextActiveSection = shellSection ?? shellItem?.CurrentItem;
+
+			ShellContent shellContent = navigationRequest.Request.Content;
+			bool modalStackPreBuilt = false;
+
+			// If we're replacing the whole stack and there are global routes then build the navigation stack before setting the shell section visible
+			if (navigationRequest.Request.GlobalRoutes.Count > 0 &&
+				nextActiveSection != null &&
+				navigationRequest.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
+			{
+				modalStackPreBuilt = true;
+
+				bool? isAnimated = (nextActiveSection != currentShellSection) ? false : animate;
+				await nextActiveSection.GoToAsync(navigationRequest, queryData, isAnimated, isRelativePopping);
+			}
+
+			if (shellItem != null)
+			{
+				ApplyQueryAttributes(shellItem, queryData, navigationRequest.Request.Section == null, false);
+				bool navigatedToNewShellElement = false;
+
+				if (shellSection != null && shellContent != null)
+				{
+					ApplyQueryAttributes(shellContent, queryData, navigationRequest.Request.GlobalRoutes.Count == 0, isRelativePopping);
+					if (shellSection.CurrentItem != shellContent)
+					{
+						shellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, shellContent);
+						navigatedToNewShellElement = true;
+					}
+				}
+
+				if (shellSection != null)
+				{
+					ApplyQueryAttributes(shellSection, queryData, navigationRequest.Request.Content == null, false);
+					if (shellItem.CurrentItem != shellSection)
+					{
+						shellItem.SetValueFromRenderer(ShellItem.CurrentItemProperty, shellSection);
+						navigatedToNewShellElement = true;
+					}
+				}
+
+				if (_shell.CurrentItem != shellItem)
+				{
+					_shell.SetValueFromRenderer(Shell.CurrentItemProperty, shellItem);
+					navigatedToNewShellElement = true;
+				}
+
+				if (!modalStackPreBuilt && currentShellSection?.Navigation.ModalStack.Count > 0)
+				{
+					// - navigating to new shell element so just pop everything
+					// - or route contains no global route requests
+					if (navigatedToNewShellElement || navigationRequest.Request.GlobalRoutes.Count == 0)
+					{
+						// remove all non visible pages first so the transition just smoothly goes from
+						// currently visible modal to base page
+						if (navigationRequest.Request.GlobalRoutes.Count == 0)
+						{
+							for (int i = currentShellSection.Stack.Count - 1; i >= 1; i--)
+								currentShellSection.Navigation.RemovePage(currentShellSection.Stack[i]);
+						}
+
+						await currentShellSection.PopModalStackToPage(null, animate);
+					}
+				}
+
+				if (navigationRequest.Request.GlobalRoutes.Count > 0 && navigationRequest.StackRequest != NavigationRequest.WhatToDoWithTheStack.ReplaceIt)
+				{
+					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
+					await Device.InvokeOnMainThreadAsync(() =>
+					{
+						return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+					});
+				}
+				else if (navigationRequest.Request.GlobalRoutes.Count == 0 &&
+					navigationRequest.StackRequest == NavigationRequest.WhatToDoWithTheStack.ReplaceIt &&
+					currentShellSection?.Navigation?.NavigationStack?.Count > 1)
+				{
+					// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
+					await Device.InvokeOnMainThreadAsync(() =>
+					{
+						return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+					});
+				}
+			}
+			else
+			{
+				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+			}
+
+			_accumulateNavigatedEvents = false;
+
+			// this can be null in the event that no navigation actually took place!
+			if (_accumulatedEvent != null)
+				HandleNavigated(_accumulatedEvent);
+		}
+
+		public void HandleNavigated(ShellNavigatedEventArgs args)
+		{
+			if (_accumulateNavigatedEvents)
+			{
+				if (_accumulatedEvent == null)
+					_accumulatedEvent = args;
+			}
+			else
+			{
+				_accumulatedEvent = null;
+				BaseShellItem baseShellItem = _shell.CurrentItem?.CurrentItem?.CurrentItem;
+
+				if (baseShellItem != null)
+				{
+					baseShellItem.OnAppearing(() =>
+					{
+						FireNavigatedEvents(args, _shell);
+					});
+				}
+				else
+				{
+					FireNavigatedEvents(args, _shell);
+				}
+
+				void FireNavigatedEvents(ShellNavigatedEventArgs a, Shell shell)
+				{
+					Navigated?.Invoke(this, args);
+					// reset active page route tree
+					Routing.ClearImplicitPageRoutes();
+					Routing.RegisterImplicitPageRoutes(_shell);
+				}
+			}
+		}
+
+		public static void ApplyQueryAttributes(Element element, IDictionary<string, string> query, bool isLastItem, bool isPopping)
+		{
+			string prefix = "";
+			if (!isLastItem)
+			{
+				var route = Routing.GetRoute(element);
+				if (string.IsNullOrEmpty(route) || Routing.IsImplicit(route))
+					return;
+				prefix = route + ".";
+			}
+
+			//if the lastItem is implicitly wrapped, get the actual ShellContent
+			if (isLastItem)
+			{
+				if (element is IShellItemController shellitem && shellitem.GetItems().FirstOrDefault() is ShellSection section)
+					element = section;
+				if (element is IShellSectionController shellsection && shellsection.GetItems().FirstOrDefault() is ShellContent content)
+					element = content;
+				if (element is ShellContent shellcontent && shellcontent.Content is Element e)
+					element = e;
+			}
+
+			if (!(element is BaseShellItem baseShellItem))
+				baseShellItem = element?.Parent as BaseShellItem;
+
+			//filter the query to only apply the keys with matching prefix
+			var filteredQuery = new Dictionary<string, string>(query.Count);
+
+			foreach (var q in query)
+			{
+				if (!q.Key.StartsWith(prefix, StringComparison.Ordinal))
+					continue;
+				var key = q.Key.Substring(prefix.Length);
+				if (key.Contains("."))
+					continue;
+				filteredQuery.Add(key, q.Value);
+			}
+
+
+			if (baseShellItem is ShellContent)
+				baseShellItem.ApplyQueryAttributes(MergeData(element, filteredQuery, isPopping));
+			else if (isLastItem)
+				element.SetValue(ShellContent.QueryAttributesProperty, MergeData(element, query, isPopping));
+
+			IDictionary<string, string> MergeData(Element shellElement, IDictionary<string, string> data, bool isPopping)
+			{
+				if (!isPopping)
+					return data;
+
+				var returnValue = new Dictionary<string, string>(data);
+
+				var existing = (IDictionary<string, string>)shellElement.GetValue(ShellContent.QueryAttributesProperty);
+
+				if (existing == null)
+					return data;
+
+				foreach (var datum in existing)
+				{
+					if (!returnValue.ContainsKey(datum.Key))
+						returnValue[datum.Key] = datum.Value;
+				}
+
+				return returnValue;
+			}
+		}
+
+		// This is used for cases where the user is navigating via native UI navigation i.e. clicking on Tabs
+		// If the user defers this type of navigation we generate the equivalent GotoAsync call
+		// so when the deferral is completed the same navigation can complete
+		public bool ProposeNavigationOutsideGotoAsync(ShellNavigationSource source, ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> stack, bool canCancel)
+		{
+			if (_accumulateNavigatedEvents)
+				return true;
+
+			var proposedState = GetNavigationState(shellItem, shellSection, shellContent, stack, shellSection.Navigation.ModalStack);
+			var navArgs = ProposeNavigation(source, proposedState, canCancel);
+
+			if (navArgs.DeferralCount > 0)
+			{
+				navArgs.RegisterDeferralCompletedCallBack(async () =>
+				{
+					if (navArgs.Cancelled)
+					{
+						return;
+					}
+
+					Func<Task> navigationTask = () => GoToAsync(navArgs.Target, navArgs.Animate, false, navArgs);
+
+					if (Device.IsInvokeRequired)
+						await Device.InvokeOnMainThreadAsync(navigationTask);
+					else
+						await navigationTask();
+				});
+			}
+
+			return navArgs.NavigationDelayedOrCancelled;
+		}
+
+		ShellNavigatingEventArgs ProposeNavigation(ShellNavigationSource source, ShellNavigationState proposedState, bool canCancel)
+		{
+			if (_accumulateNavigatedEvents)
+				return null;
+
+			var navArgs = new ShellNavigatingEventArgs(_shell.CurrentState, proposedState, source, canCancel);
+			HandleNavigating(navArgs);
+			
+			return navArgs;
+		}
+
+		public void HandleNavigating(ShellNavigatingEventArgs args)
+		{
+			if (!args.DeferredEventArgs)
+			{
+				Navigating?.Invoke(this, args);
+			}
+			else
+			{
+				return;
+			}
+		}
+
+		public static ShellNavigationSource CalculateNavigationSource(Shell shell, ShellNavigationState current, NavigationRequest request)
+		{
+			if (request.StackRequest == NavigationRequest.WhatToDoWithTheStack.PushToIt)
+				return ShellNavigationSource.Push;
+
+			if (current == null)
+				return ShellNavigationSource.ShellItemChanged;
+
+			var targetUri = ShellUriHandler.ConvertToStandardFormat(shell, request.Request.FullUri);
+			var currentUri = ShellUriHandler.ConvertToStandardFormat(shell, current.FullLocation);
+
+			var targetPaths = ShellUriHandler.RetrievePaths(targetUri.PathAndQuery);
+			var currentPaths = ShellUriHandler.RetrievePaths(currentUri.PathAndQuery);
+
+			var targetPathsLength = targetPaths.Length;
+			var currentPathsLength = currentPaths.Length;
+
+			if (targetPathsLength < 4 || currentPathsLength < 4)
+				return ShellNavigationSource.Unknown;
+
+			if (targetPaths[1] != currentPaths[1])
+				return ShellNavigationSource.ShellItemChanged;
+			if (targetPaths[2] != currentPaths[2])
+				return ShellNavigationSource.ShellSectionChanged;
+			if (targetPaths[3] != currentPaths[3])
+				return ShellNavigationSource.ShellContentChanged;
+
+			if (targetPathsLength == currentPathsLength)
+				return ShellNavigationSource.Unknown;
+
+			if (targetPathsLength < currentPathsLength)
+			{
+				for (var i = 0; i < targetPathsLength; i++)
+				{
+					var targetPath = targetPaths[i];
+					if (targetPath != currentPaths[i])
+						break;
+
+					if (i == targetPathsLength - 1)
+					{
+						if (targetPathsLength == 4)
+							return ShellNavigationSource.PopToRoot;
+
+						return ShellNavigationSource.Pop;
+					}
+				}
+
+				if (targetPaths[targetPathsLength - 1] == currentPaths[currentPathsLength - 1])
+					return ShellNavigationSource.Remove;
+
+				if (targetPathsLength == 4)
+					return ShellNavigationSource.PopToRoot;
+
+				return ShellNavigationSource.Pop;
+			}
+			else if (targetPathsLength > currentPathsLength)
+			{
+				for (var i = 0; i < currentPathsLength; i++)
+				{
+					if (targetPaths[i] != currentPaths[i])
+						break;
+
+					if (i == targetPathsLength - 1)
+						return ShellNavigationSource.Push;
+				}
+			}
+
+			if (targetPaths[targetPathsLength - 1] == currentPaths[currentPathsLength - 1])
+				return ShellNavigationSource.Insert;
+
+			return ShellNavigationSource.Push;
+		}
+
+		static Dictionary<string, string> ParseQueryString(string query)
+		{
+			if (query.StartsWith("?", StringComparison.Ordinal))
+				query = query.Substring(1);
+			Dictionary<string, string> lookupDict = new Dictionary<string, string>();
+			if (query == null)
+				return lookupDict;
+			foreach (var part in query.Split('&'))
+			{
+				var p = part.Split('=');
+				if (p.Length != 2)
+					continue;
+				lookupDict[p[0]] = p[1];
+			}
+
+			return lookupDict;
+		}
+
+		public static ShellNavigationState GetNavigationState(ShellItem shellItem, ShellSection shellSection, ShellContent shellContent, IReadOnlyList<Page> sectionStack, IReadOnlyList<Page> modalStack)
+		{
+			List<string> routeStack = new List<string>();
+
+			bool stackAtRoot = sectionStack == null || sectionStack.Count <= 1;
+			bool hasUserDefinedRoute =
+				(Routing.IsUserDefined(shellItem)) ||
+				(Routing.IsUserDefined(shellSection)) ||
+				(Routing.IsUserDefined(shellContent));
+
+			if (shellItem != null)
+			{
+				var shellItemRoute = shellItem.Route;
+				routeStack.Add(shellItemRoute);
+
+				if (shellSection != null)
+				{
+					var shellSectionRoute = shellSection.Route;
+					routeStack.Add(shellSectionRoute);
+
+					if (shellContent != null)
+					{
+						var shellContentRoute = shellContent.Route;
+						routeStack.Add(shellContentRoute);
+					}
+
+					if (!stackAtRoot)
+					{
+						for (int i = 1; i < sectionStack.Count; i++)
+						{
+							var page = sectionStack[i];
+							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack, hasUserDefinedRoute));
+						}
+					}
+
+					if (modalStack != null && modalStack.Count > 0)
+					{
+						for (int i = 0; i < modalStack.Count; i++)
+						{
+							var topPage = modalStack[i];
+
+							routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage), routeStack, hasUserDefinedRoute));
+
+							for (int j = 1; j < topPage.Navigation.NavigationStack.Count; j++)
+							{
+								routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack, hasUserDefinedRoute));
+							}
+						}
+					}
+				}
+			}
+
+			if (routeStack.Count > 0)
+				routeStack.Insert(0, "/");
+
+			return new ShellNavigationState(String.Join("/", routeStack), true);
+
+
+			List<string> CollapsePath(
+				string myRoute,
+				IEnumerable<string> currentRouteStack,
+				bool userDefinedRoute)
+			{
+				var localRouteStack = currentRouteStack.ToList();
+				for (var i = localRouteStack.Count - 1; i >= 0; i--)
+				{
+					var route = localRouteStack[i];
+					if (Routing.IsImplicit(route) ||
+						(Routing.IsDefault(route) && userDefinedRoute))
+					{
+						localRouteStack.RemoveAt(i);
+					}
+				}
+
+				var paths = myRoute.Split('/').ToList();
+
+				// collapse similar leaves
+				int walkBackCurrentStackIndex = localRouteStack.Count - (paths.Count - 1);
+
+				while (paths.Count > 1 && walkBackCurrentStackIndex >= 0)
+				{
+					if (paths[0] == localRouteStack[walkBackCurrentStackIndex])
+					{
+						paths.RemoveAt(0);
+					}
+					else
+					{
+						break;
+					}
+
+					walkBackCurrentStackIndex++;
+				}
+
+				return paths;
+			}
+		}
+
+	}
+}

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -299,7 +299,7 @@ namespace Xamarin.Forms
 				});
 			}
 
-			return navArgs.NavigationDelayedOrCancelled;
+			return !navArgs.NavigationDelayedOrCancelled;
 		}
 
 		ShellNavigatingEventArgs ProposeNavigation(ShellNavigationSource source, ShellNavigationState proposedState, bool canCancel)

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -400,7 +400,7 @@ namespace Xamarin.Forms
 							// if the routes do match and this is the last in the loop
 							// pop everything after this route
 							popCount = i + 2;
-							Shell.ApplyQueryAttributes(navPage, queryData, isLast, isRelativePopping);
+							ShellNavigationManager.ApplyQueryAttributes(navPage, queryData, isLast, isRelativePopping);
 
 							// If we're not on the last loop of the stack then continue
 							// otherwise pop the rest of the stack
@@ -501,7 +501,7 @@ namespace Xamarin.Forms
 				Internals.Log.Warning(nameof(Shell), $"Failed to Create Content For: {route}");
 			}
 
-			Shell.ApplyQueryAttributes(content, queryData, isLast, isPopping);
+			ShellNavigationManager.ApplyQueryAttributes(content, queryData, isLast, isPopping);
 			return content;
 		}
 
@@ -1082,7 +1082,7 @@ namespace Xamarin.Forms
 				};
 
 				var returnedPage = (_owner as IShellSectionController).PresentedPage;
-				await _owner.Shell.GoToAsync(navigationParameters);
+				await _owner.Shell.NavigationManager.GoToAsync(navigationParameters);
 
 				// This means the page wasn't popped and navigation was cancelled
 				if ((_owner as IShellSectionController).PresentedPage == returnedPage)
@@ -1100,7 +1100,7 @@ namespace Xamarin.Forms
 
 				var shell = _owner.Shell;
 				var targetState =
-					Shell.GetNavigationState(
+					ShellNavigationManager.GetNavigationState(
 						shell.CurrentItem,
 						_owner,
 						_owner.CurrentItem,
@@ -1114,7 +1114,7 @@ namespace Xamarin.Forms
 					PopAllPagesNotSpecifiedOnTargetState = true
 				};
 
-				return _owner.Shell.GoToAsync(navigationParameters);
+				return _owner.Shell.NavigationManager.GoToAsync(navigationParameters);
 			}
 
 			protected override Task OnPushAsync(Page page, bool animated)
@@ -1128,7 +1128,7 @@ namespace Xamarin.Forms
 					PagePushing = page
 				};
 
-				return (_owner.Shell).GoToAsync(navigationParameters);
+				return _owner.Shell.NavigationManager.GoToAsync(navigationParameters);
 			}
 
 			protected override void OnRemovePage(Page page) => _owner.OnRemovePage(page);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 
 			var stack = shellSection.Stack.ToList();
-			bool result = ((IShellController)_shellContext.Shell).ProposeNavigation(ShellNavigationSource.ShellContentChanged,
+			bool result = ShellController.ProposeNavigation(ShellNavigationSource.ShellContentChanged,
 				(ShellItem)shellSection.Parent, shellSection, shellContent, stack, true);
 
 			if (result)
@@ -118,7 +118,7 @@ namespace Xamarin.Forms.Platform.Android
 		IShellToolbarTracker _toolbarTracker;
 		FormsViewPager _viewPager;
 		bool _disposed;
-
+		IShellController ShellController => _shellContext.Shell;
 		public ShellSectionRenderer(IShellContext shellContext)
 		{
 			_shellContext = shellContext;


### PR DESCRIPTION
### Description of Change ###

The deferral code was naively assuming there would be a delay between `GetDeferral` and `Complete` so the DeferralTask was never getting created. 

- Moved all of the shell navigation code into a specific ShellNavigationManager class so it's easier to follow
- Streamlined the Deferral flow so the execution flow is more linear

### Issues Resolved ### 
- fixes #13131

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
