### PR TITLE
[Tizen] Added Fast Layout Opt-in

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms
 		public StaticRegistrarStrategy StaticRegistarStrategy { get; set; }
 		public PlatformType PlatformType { get; set; }
 		public bool UseMessagingCenter { get; set; } = true;
+		public bool UseFastLayout { get; set; } = false;
 
 		public DisplayResolutionUnit DisplayResolutionUnit { get; set; }
 
@@ -271,6 +272,8 @@ namespace Xamarin.Forms
 
 		public static bool UseSkiaSharp { get; private set; }
 
+		public static bool UseFastLayout { get; private set; }
+
 		public static DisplayResolutionUnit DisplayResolutionUnit { get; private set; }
 
 		public static int ScreenDPI => s_dpi.Value;
@@ -480,6 +483,7 @@ namespace Xamarin.Forms
 					s_platformType = options.PlatformType;
 					s_useMessagingCenter = options.UseMessagingCenter;
 					UseSkiaSharp = options.UseSkiaSharp;
+					UseFastLayout = options.UseFastLayout;
 
 					if (options.Assemblies != null && options.Assemblies.Length > 0)
 					{
@@ -532,6 +536,9 @@ namespace Xamarin.Forms
 
 							if (UseSkiaSharp)
 								RegisterSkiaSharpRenderers();
+
+							if (UseFastLayout)
+								Registrar.Registered.Register(typeof(Layout), typeof(FastLayoutRenderer));
 						}
 					}
 

--- a/Xamarin.Forms.Platform.Tizen/Native/EvasBox.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EvasBox.cs
@@ -1,0 +1,131 @@
+﻿using System;
+using System.Runtime.InteropServices;
+using ElmSharp;
+using EColor = ElmSharp.Color;
+using ERectangle = ElmSharp.Rectangle;
+
+namespace Xamarin.Forms.Platform.Tizen.Native
+{
+	public class EvasBox : Container
+	{
+		Interop.CanvasBoxLayoutCallback _layoutCallback;
+		Lazy<ERectangle> _rectangle;
+
+		public event EventHandler<LayoutEventArgs> LayoutUpdated;
+
+		public EvasBox(EvasObject parent) : base(parent)
+		{
+			_rectangle = new Lazy<ERectangle>(() =>
+			{
+				var rectangle = new ERectangle(this) { AlignmentX = -1, AlignmentY = -1, WeightX = 1, WeightY = 1 };
+				Interop.evas_object_box_insert_at(Handle, rectangle, 0);
+				rectangle.Lower();
+				rectangle.Show();
+				return rectangle;
+			});
+
+			SetLayoutCallback(() => { NotifyOnLayout(); });
+		}
+
+		public override EColor BackgroundColor
+		{
+			get
+			{
+				return _rectangle.Value.Color;
+			}
+			set
+			{
+				_rectangle.Value.Color = value.IsDefault ? EColor.Transparent : value;
+			}
+		}
+
+		public void PackEnd(EvasObject content)
+		{
+			Interop.evas_object_box_append(Handle, content);
+			AddChild(content);
+		}
+
+		public bool UnPack(EvasObject content)
+		{
+			var ret = Interop.evas_object_box_remove(Handle, content);
+			if (ret)
+				RemoveChild(content);
+			return ret;
+		}
+
+		public bool UnPackAll()
+		{
+			var ret = Interop.evas_object_box_remove_all(Handle, true);
+			if (ret)
+			{
+				ClearChildren();
+				if (_rectangle.IsValueCreated)
+				{
+					Interop.evas_object_box_append(Handle, _rectangle.Value);
+				}
+			}
+			return ret;
+		}
+
+		public void SetLayoutCallback(Action action)
+		{
+			_layoutCallback = (obj, priv, data) =>
+			{
+				if (_rectangle.IsValueCreated)
+				{
+					_rectangle.Value.Geometry = Geometry;
+				}
+				action();
+			};
+			Interop.evas_object_box_layout_set(Handle, _layoutCallback, IntPtr.Zero, null);
+		}
+
+		protected override IntPtr CreateHandle(EvasObject parent)
+		{
+			return Interop.evas_object_box_add(Interop.evas_object_evas_get(parent.Handle));
+		}
+
+		void NotifyOnLayout()
+		{
+			if (null != LayoutUpdated)
+			{
+				LayoutUpdated(this, new LayoutEventArgs() { Geometry = Geometry });
+			}
+		}
+
+		class Interop
+		{
+			public const string LibEvas = "libevas.so.1";
+
+			public delegate void CanvasBoxLayoutCallback(IntPtr obj, IntPtr priv, IntPtr userData);
+
+			public delegate void CanvasBoxDataFreeCallback(IntPtr data);
+
+			[DllImport(LibEvas)]
+			internal static extern IntPtr evas_object_box_add(IntPtr evas);
+
+			[DllImport(LibEvas)]
+			internal static extern IntPtr evas_object_evas_get(IntPtr obj);
+
+			[DllImport(LibEvas)]
+			internal static extern void evas_object_box_append(IntPtr obj, IntPtr child);
+
+			[DllImport(LibEvas)]
+			internal static extern void evas_object_box_insert_at(IntPtr obj, IntPtr child, int pos);
+
+			[DllImport(LibEvas)]
+			[return: MarshalAs(UnmanagedType.U1)]
+			internal static extern bool evas_object_box_remove(IntPtr obj, IntPtr child);
+
+			[DllImport(LibEvas)]
+			[return: MarshalAs(UnmanagedType.U1)]
+			internal static extern bool evas_object_box_remove_all(IntPtr obj, bool clear);
+
+			[DllImport(LibEvas)]
+			internal static extern void evas_object_box_layout_set(IntPtr obj, CanvasBoxLayoutCallback cb, IntPtr data, CanvasBoxDataFreeCallback dataFreeCb);
+
+			[DllImport(LibEvas)]
+			internal static extern void evas_object_box_layout_set(IntPtr obj, CanvasBoxLayoutCallback cb, IntPtr data, IntPtr dataFreeCb);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/EvasFormsCanvas.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/EvasFormsCanvas.cs
@@ -1,0 +1,82 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using ElmSharp;
+
+namespace Xamarin.Forms.Platform.Tizen.Native
+{
+	public class EvasFormsCanvas : EvasBox, IContainable<EvasObject>
+	{
+		public EvasFormsCanvas(EvasObject parent) : base(parent)
+		{
+			Initilize();
+		}
+
+		readonly ObservableCollection<EvasObject> _children = new ObservableCollection<EvasObject>();
+
+		public new IList<EvasObject> Children
+		{
+			get
+			{
+				return _children;
+			}
+		}
+
+		protected override void OnUnrealize()
+		{
+			foreach (var child in _children)
+			{
+				child.Unrealize();
+			}
+
+			base.OnUnrealize();
+		}
+
+		void Initilize()
+		{
+			_children.CollectionChanged += (o, e) =>
+			{
+				if (e.Action == NotifyCollectionChangedAction.Add)
+				{
+					foreach (var v in e.NewItems)
+					{
+						var view = v as EvasObject;
+						if (null != view)
+						{
+							OnAdd(view);
+						}
+					}
+				}
+				else if (e.Action == NotifyCollectionChangedAction.Remove)
+				{
+					foreach (var v in e.OldItems)
+					{
+						var view = v as EvasObject;
+						if (null != view)
+						{
+							OnRemove(view);
+						}
+					}
+				}
+				else if (e.Action == NotifyCollectionChangedAction.Reset)
+				{
+					OnRemoveAll();
+				}
+			};
+		}
+
+		void OnAdd(EvasObject view)
+		{
+			PackEnd(view);
+		}
+
+		void OnRemove(EvasObject view)
+		{
+			UnPack(view);
+		}
+
+		void OnRemoveAll()
+		{
+			UnPackAll();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Native/Page.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/Page.cs
@@ -18,7 +18,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <summary>
 		/// Exposes the Children property, mapping it to the _canvas' Children property.
 		/// </summary>
-		public new IList<EvasObject> Children => _canvas.Children;
+		public new IList<EvasObject> Children => Forms.UseFastLayout ? EvasFormsCanvas?.Children : Canvas?.Children;
 
 		/// <summary>
 		/// The canvas, used as a container for other objects.
@@ -26,14 +26,21 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		/// <remarks>
 		/// The canvas holds all the Views that the ContentPage is composed of.
 		/// </remarks>
-		internal Canvas _canvas;
+		internal Container _canvas;
+
+		EvasFormsCanvas EvasFormsCanvas => _canvas as EvasFormsCanvas;
+
+		Canvas Canvas => _canvas as Canvas;
 
 		/// <summary>
 		/// Initializes a new instance of the ContentPage class.
 		/// </summary>
 		public Page(EvasObject parent) : base(parent)
 		{
-			_canvas = new Canvas(this);
+			if (Forms.UseFastLayout)
+				_canvas = new EvasFormsCanvas(this);
+			else
+				_canvas = new Canvas(this);
 			this.SetOverlayPart(_canvas);
 		}
 
@@ -44,11 +51,18 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			add
 			{
-				_canvas.LayoutUpdated += value;
+				if (Forms.UseFastLayout)
+					EvasFormsCanvas.LayoutUpdated += value;
+				else
+					Canvas.LayoutUpdated += value;
+
 			}
 			remove
 			{
-				_canvas.LayoutUpdated -= value;
+				if (Forms.UseFastLayout)
+					EvasFormsCanvas.LayoutUpdated -= value;
+				else
+					Canvas.LayoutUpdated -= value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/FastLayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/FastLayoutRenderer.cs
@@ -1,0 +1,159 @@
+using System;
+using System.ComponentModel;
+using SkiaSharp.Views.Tizen;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class FastLayoutRenderer : ViewRenderer<Layout, Native.EvasFormsCanvas>, SkiaSharp.IBackgroundCanvas
+	{
+		bool _layoutUpdatedRegistered = false;
+
+		Lazy<SKCanvasView> _backgroundCanvas;
+
+		public SKCanvasView BackgroundCanvas => _backgroundCanvas.Value;
+
+		public void RegisterOnLayoutUpdated()
+		{
+			if (!_layoutUpdatedRegistered)
+			{
+				Control.LayoutUpdated += OnLayoutUpdated;
+				_layoutUpdatedRegistered = true;
+			}
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Layout> e)
+		{
+			if (null == Control)
+			{
+				SetNativeControl(new Native.EvasFormsCanvas(Forms.NativeParent));
+			}
+
+			if (Forms.UseSkiaSharp)
+			{
+				Control.LayoutUpdated += OnBackgroundLayoutUpdated;
+				_backgroundCanvas = new Lazy<SKCanvasView>(() =>
+				{
+					var canvas = new SKCanvasView(Forms.NativeParent);
+					canvas.PassEvents = true;
+					canvas.PaintSurface += OnBackgroundPaint;
+					canvas.Show();
+					Control.Children.Add(canvas);
+					canvas.Lower();
+					return canvas;
+				});
+			}
+			base.OnElementChanged(e);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			if (e.PropertyName == Layout.CascadeInputTransparentProperty.PropertyName)
+			{
+				UpdateInputTransparent(false);
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+			{
+				if (_layoutUpdatedRegistered)
+				{
+					Control.LayoutUpdated -= OnLayoutUpdated;
+					_layoutUpdatedRegistered = false;
+				}
+
+				if (Forms.UseSkiaSharp)
+				{
+					Control.LayoutUpdated -= OnBackgroundLayoutUpdated;
+
+					if (_backgroundCanvas.IsValueCreated)
+					{
+						BackgroundCanvas.PaintSurface -= OnBackgroundPaint;
+						BackgroundCanvas.Unrealize();
+						_backgroundCanvas = null;
+					}
+				}
+			}
+			base.Dispose(disposing);
+		}
+
+		protected override void UpdateInputTransparent(bool initialize)
+		{
+			if (initialize && Element.InputTransparent == default(bool))
+			{
+				return;
+			}
+
+			if (Element.InputTransparent)
+			{
+				if (Element.CascadeInputTransparent)
+				{
+					//Ignore all events of both layout and it's chidren
+					NativeView.PassEvents = true;
+				}
+				else
+				{
+					//Ignore Layout's event only. Children's events should be allowded.
+					NativeView.PassEvents = false;
+					NativeView.RepeatEvents = true;
+				}
+			}
+			else
+			{
+				//Allow layout's events and children's events would be determined by CascadeInputParent.
+				NativeView.PassEvents = false;
+				NativeView.RepeatEvents = false;
+			}
+
+			if (GestureDetector != null)
+			{
+				GestureDetector.InputTransparent = Element.InputTransparent;
+			}
+		}
+
+		protected override void UpdateLayout()
+		{
+			if (!_layoutUpdatedRegistered)
+			{
+				base.UpdateLayout();
+			}
+			else
+			{
+				ApplyTransformation();
+			}
+		}
+
+		protected virtual void OnBackgroundPaint(object sender, SKPaintSurfaceEventArgs e)
+		{
+			var canvas = e.Surface.Canvas;
+			canvas.Clear();
+
+			var bounds = e.Info.Rect;
+			var paint = Element.GetBackgroundPaint(bounds);
+
+			if (paint != null)
+			{
+				using (paint)
+				using (var path = bounds.ToPath())
+				{
+					canvas.DrawPath(path, paint);
+				}
+			}
+		}
+
+		protected virtual void OnBackgroundLayoutUpdated(object sender, Native.LayoutEventArgs e)
+		{
+			if (_backgroundCanvas.IsValueCreated)
+			{
+				BackgroundCanvas.Geometry = Control.Geometry;
+			}
+		}
+
+		void OnLayoutUpdated(object sender, Native.LayoutEventArgs e)
+		{
+			Element.Layout(e.Geometry.ToDP());
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ScrollViewRenderer.cs
@@ -1,7 +1,9 @@
 ﻿using System;
 using System.ComponentModel;
 using ElmSharp;
+using Xamarin.Forms.Platform.Tizen.Native;
 using ERect = ElmSharp.Rect;
+using EContainer = ElmSharp.Container;
 using NBox = Xamarin.Forms.Platform.Tizen.Native.Box;
 using NScroller = Xamarin.Forms.Platform.Tizen.Native.Scroller;
 using Specific = Xamarin.Forms.PlatformConfiguration.TizenSpecific.ScrollView;
@@ -10,9 +12,13 @@ namespace Xamarin.Forms.Platform.Tizen
 {
 	public class ScrollViewRenderer : ViewRenderer<ScrollView, NScroller>
 	{
-		NBox _scrollCanvas;
+		EContainer _scrollCanvas;
 		int _defaultVerticalStepSize;
 		int _defaultHorizontalStepSize;
+
+		EvasFormsCanvas EvasFormsCanvas => _scrollCanvas as EvasFormsCanvas;
+
+		Canvas Canvas => _scrollCanvas as Canvas;
 
 		public ScrollViewRenderer()
 		{
@@ -26,7 +32,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		public override ERect GetNativeContentGeometry()
 		{
-			return _scrollCanvas.Geometry;
+			return Forms.UseFastLayout ? EvasFormsCanvas.Geometry : Canvas.Geometry;
 		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<ScrollView> e)
@@ -35,8 +41,18 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				SetNativeControl(CreateNativeControl());
 				Control.Scrolled += OnScrolled;
-				_scrollCanvas = new NBox(Control);
-				_scrollCanvas.LayoutUpdated += OnContentLayoutUpdated;
+
+				if (Forms.UseFastLayout)
+				{
+					_scrollCanvas = new EvasBox(Control);
+					EvasFormsCanvas.LayoutUpdated += OnContentLayoutUpdated;
+				}
+				else
+				{
+					_scrollCanvas = new NBox(Control);
+					Canvas.LayoutUpdated += OnContentLayoutUpdated;
+				}
+
 				Control.SetContent(_scrollCanvas);
 				_defaultVerticalStepSize = Control.VerticalStepSize;
 				_defaultHorizontalStepSize = Control.HorizontalStepSize;
@@ -92,9 +108,13 @@ namespace Xamarin.Forms.Platform.Tizen
 				{
 					Control.Scrolled -= OnScrolled;
 				}
-				if (_scrollCanvas != null)
+				if (Canvas != null)
 				{
-					_scrollCanvas.LayoutUpdated -= OnContentLayoutUpdated;
+					Canvas.LayoutUpdated -= OnContentLayoutUpdated;
+				}
+				if (EvasFormsCanvas != null)
+				{
+					EvasFormsCanvas.LayoutUpdated -= OnContentLayoutUpdated;
 				}
 			}
 
@@ -103,13 +123,24 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		void FillContent()
 		{
-			_scrollCanvas.UnPackAll();
-			if (Element.Content != null)
+			if (Forms.UseFastLayout)
 			{
-				_scrollCanvas.PackEnd(Platform.GetOrCreateRenderer(Element.Content).NativeView);
-				UpdateContentSize();
+				EvasFormsCanvas.UnPackAll();
+				if (Element.Content != null)
+				{
+					EvasFormsCanvas.PackEnd(Platform.GetOrCreateRenderer(Element.Content).NativeView);
+					UpdateContentSize();
+				}
 			}
-
+			else
+			{
+				Canvas.UnPackAll();
+				if (Element.Content != null)
+				{
+					Canvas.PackEnd(Platform.GetOrCreateRenderer(Element.Content).NativeView);
+					UpdateContentSize();
+				}
+			}
 		}
 
 		void OnContentLayoutUpdated(object sender, Native.LayoutEventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -70,7 +70,14 @@ namespace Xamarin.Forms.Platform.Tizen
 		public static void RegisterHandlers(Dictionary<Type, Func<IRegisterable>> customHandlers)
 		{
 			//Renderers
-			Registered.Register(typeof(Layout), () => new LayoutRenderer());
+			if (Forms.UseFastLayout)
+			{
+				Registered.Register(typeof(Layout), () => new FastLayoutRenderer());
+			}
+			else
+			{
+				Registered.Register(typeof(Layout), () => new LayoutRenderer());
+			}
 			Registered.Register(typeof(ScrollView), () => new ScrollViewRenderer());
 			Registered.Register(typeof(CarouselPage), () => new CarouselPageRenderer());
 			Registered.Register(typeof(Page), () => new PageRenderer());


### PR DESCRIPTION
### Description of Change ###

This PR is for improving layouting (especially on scrolling) performance. Previously, we were using `ElmSharp.Box` internally for layouting. In normal case this works fine, but we found an issue where scrolling performance degrades as more controls are included in the `ScrollView` and the layout hierarchy gets more complex. For target devices with severe resource constraints, scrolling performance decreases more noticeably.

To solve this problem, this PR implements and uses `EvasBox` (from evas) instead of `Box` (from elementary) to optimize unnecessary coordinate calculation during layout. As a result, it was confirmed that the scroll performance was improved by about 1 to 2 times compared to the previous one.

You can use `FastLayoutRenderer` through opt-in as shown below. (The default is `false`.)

```cs
var option = new InitializationOptions(app)
{ 
   //....
    UseFastLayout = true
};

Forms.Init(option);
```

#### Limitations 
- When using `EvasBox`, there may be functional restrictions such as focus movement and accessibility through key events. (It is not recommended when the focus is moved by key input on the remote control rather than by touch, such as on a TV device.)

### Issues Resolved ### 
None

### API Changes ###
**```namespace Xamarin.Forms```**
Added:
 - InitilizationOptions.UseFastLayout {get; set;}
 - Forms.UseFastLayout {get; set;}

**```namespace Xamarin.Forms.Platform.Tizen```**
Added:
 - class FastLayoutRenderer

**```namespace Xamarin.Forms.Platform.Tizen.Native```**
Added:
 - class EvasBox
 - class EvasFormsCanvas


### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
