### PR TITLE
Close popup before exiting test

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11969.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11969.xaml.cs
@@ -73,6 +73,7 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.Tap("SwipeViewContentCheckBoxId");
 			RunningApp.Tap(SwipeButtonId);
 			RunningApp.WaitForElement(q => q.Marked(Success));
+			RunningApp.Tap("Ok");
 		}
 #endif
 	}


### PR DESCRIPTION
### Description of Change ###

The PopUp from test 11969 remains on the screen after navigating to the next test which makes the next test fail. 

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- iOS tests all pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
