### PR TITLE
Restore ability to display header, footer, and empty view simultaneously

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -480,9 +480,8 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-			CollectionView.AddSubview(_emptyUIView);
-
 			_emptyUIView.Tag = EmptyTag;
+			CollectionView.AddSubview(_emptyUIView);
 
 			if (!ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (_emptyViewDisplayed)
 			{
-				FlipEmptyView();
+				AlignEmptyView();
 			}
 
 			Layout.InvalidateLayout();
@@ -462,13 +462,33 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
-		void FlipEmptyView() 
+		void AlignEmptyView() 
 		{
 			if (_emptyUIView == null)
 			{
 				return;
 			}
 
+			if (CollectionView.EffectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.RightToLeft)
+			{
+				if (_emptyUIView.Transform.xx == -1)
+				{
+					return;
+				}
+
+				FlipEmptyView();
+			}
+			else
+			{
+				if (_emptyUIView.Transform.xx == -1)
+				{
+					FlipEmptyView();
+				}
+			}
+		}
+
+		void FlipEmptyView()
+		{
 			// Flip the empty view 180 degrees around the X axis 
 			_emptyUIView.Transform = CGAffineTransform.Scale(_emptyUIView.Transform, -1, 1);
 		}
@@ -488,13 +508,9 @@ namespace Xamarin.Forms.Platform.iOS
 				ItemsView.AddLogicalChild(_emptyViewFormsElement);
 			}
 
-			if (CollectionView.EffectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.RightToLeft)
-			{
-				// The UICollectionView's layout flip will also affect the empty view, so we'll have to flip it back around
-				FlipEmptyView();
-			}
-
 			LayoutEmptyView();
+
+			AlignEmptyView();
 			_emptyViewDisplayed = true;
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -155,21 +155,13 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewWillLayoutSubviews();
 
-			if (!_initialized)
-			{
-				UpdateEmptyView();
-			}
-
 			// We can't set this constraint up on ViewDidLoad, because Forms does other stuff that resizes the view
 			// and we end up with massive layout errors. And View[Will/Did]Appear do not fire for this controller
 			// reliably. So until one of those options is cleared up, we set this flag so that the initial constraints
 			// are set up the first time this method is called.
 			EnsureLayoutInitialized();
 
-			if (_initialized)
-			{
-				LayoutEmptyView();
-			}
+			LayoutEmptyView();
 		}
 
 		void EnsureLayoutInitialized()
@@ -195,6 +187,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			ItemsViewLayout.SetInitialConstraints(CollectionView.Bounds.Size);
 			CollectionView.SetCollectionViewLayout(ItemsViewLayout, false);
+
+			UpdateEmptyView();
 		}
 
 		protected virtual UICollectionViewDelegateFlowLayout CreateDelegator()
@@ -220,9 +214,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			CollectionView.UpdateFlowDirection(ItemsView);
 
-			if (ItemsSource?.ItemCount == 0)
-				_emptyUIView?.UpdateFlowDirection(_emptyViewFormsElement);
-			
+			if (_emptyViewDisplayed)
+			{
+				FlipEmptyView();
+			}
+
 			Layout.InvalidateLayout();
 		}
 
@@ -375,34 +371,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected abstract bool IsHorizontal { get; }
 
-		internal void UpdateEmptyView()
-		{
-			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
-
-			// If the empty view is being displayed, we might need to update it
-			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
-		}
-
 		protected virtual CGRect DetermineEmptyViewFrame() 
 		{
 			return new CGRect(CollectionView.Frame.X, CollectionView.Frame.Y,
 				CollectionView.Frame.Width, CollectionView.Frame.Height);
-		}
-
-		void LayoutEmptyView()
-		{
-			if (_emptyUIView == null)
-			{
-				UpdateEmptyView();
-				return;
-			}
-
-			var frame = DetermineEmptyViewFrame();
-
-			_emptyUIView.Frame = frame;
-
-			if (_emptyViewFormsElement != null && ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
-				_emptyViewFormsElement.Layout(frame.ToRectangle());
 		}
 
 		protected void RemeasureLayout(VisualElement formsElement)
@@ -453,53 +425,113 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		internal void UpdateEmptyView()
+		{
+			if (!_initialized)
+			{
+				return;
+			}
+
+			// Get rid of the old view
+			TearDownEmptyView();
+
+			// Set up the new empty view
+			(_emptyUIView, _emptyViewFormsElement) = TemplateHelpers.RealizeView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ItemsView);
+
+			// We may need to show the updated empty view
+			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
+		}
+
 		void UpdateEmptyViewVisibility(bool isEmpty)
 		{
-			if (isEmpty && _emptyUIView != null)
+			if (!_initialized)
 			{
-				var emptyView = CollectionView.Superview.ViewWithTag(EmptyTag);
+				return;
+			}
 
-				if(emptyView != null)
-				{
-					emptyView.RemoveFromSuperview();
-					ItemsView.RemoveLogicalChild(_emptyViewFormsElement);
-				}
-
-				_emptyUIView.Tag = EmptyTag;
-
-				var collectionViewContainer = CollectionView.Superview;
-				collectionViewContainer.AddSubview(_emptyUIView);
-				
-				LayoutEmptyView();
-
-				if (_emptyViewFormsElement != null)
-				{
-					if (ItemsView.EmptyViewTemplate == null)
-					{
-						ItemsView.AddLogicalChild(_emptyViewFormsElement);
-					}
-
-					// Now that the native empty view's frame is sized to the UICollectionView, we need to handle
-					// the Forms layout for its content
-					_emptyViewFormsElement.Layout(_emptyUIView.Frame.ToRectangle());
-				}
-
-				_emptyViewDisplayed = true;
+			if (isEmpty)
+			{
+				ShowEmptyView();
 			}
 			else
 			{
-				// Is the empty view currently in the background? Swap back to the default.
-				if (_emptyViewDisplayed)
-				{
-					_emptyUIView.RemoveFromSuperview();
-					_emptyUIView.Dispose();
-					_emptyUIView = null;
-
-					ItemsView.RemoveLogicalChild(_emptyViewFormsElement);
-				}
-
-				_emptyViewDisplayed = false;
+				HideEmptyView();
 			}
+		}
+
+		void FlipEmptyView() 
+		{
+			if (_emptyUIView == null)
+			{
+				return;
+			}
+
+			// Flip the empty view 180 degrees around the X axis 
+			_emptyUIView.Transform = CGAffineTransform.Scale(_emptyUIView.Transform, -1, 1);
+		}
+
+		void ShowEmptyView() 
+		{
+			if (_emptyViewDisplayed)
+			{
+				return;
+			}
+
+			CollectionView.AddSubview(_emptyUIView);
+
+			_emptyUIView.Tag = EmptyTag;
+
+			if (!ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
+			{
+				ItemsView.AddLogicalChild(_emptyViewFormsElement);
+			}
+
+			if (CollectionView.EffectiveUserInterfaceLayoutDirection == UIUserInterfaceLayoutDirection.RightToLeft)
+			{
+				// The UICollectionView's layout flip will also affect the empty view, so we'll have to flip it back around
+				FlipEmptyView();
+			}
+
+			LayoutEmptyView();
+			_emptyViewDisplayed = true;
+		}
+
+		void HideEmptyView() 
+		{
+			if (!_emptyViewDisplayed)
+			{
+				return;
+			}
+
+			_emptyUIView.RemoveFromSuperview();
+
+			_emptyViewDisplayed = false;
+		}
+
+		void TearDownEmptyView() 
+		{
+			HideEmptyView();
+
+			// RemoveLogicalChild will trigger a disposal of the native view and its content
+			ItemsView.RemoveLogicalChild(_emptyViewFormsElement);
+			
+			_emptyUIView = null;
+			_emptyViewFormsElement = null;
+		}
+
+		void LayoutEmptyView()
+		{
+			if (!_initialized || _emptyUIView == null || _emptyUIView.Superview == null)
+			{
+				return;
+			}
+
+			var frame = DetermineEmptyViewFrame();
+
+			_emptyUIView.Frame = frame;
+
+			if (_emptyViewFormsElement != null && ItemsView.LogicalChildren.Contains(_emptyViewFormsElement))
+				_emptyViewFormsElement.Layout(frame.ToRectangle());
 		}
 
 		TemplatedCell CreateAppropriateCellForLayout()

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -438,9 +438,6 @@ namespace Xamarin.Forms.Platform.iOS
 			// Set up the new empty view
 			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
 
-//			(_emptyUIView, _emptyViewFormsElement) = TemplateHelpers.RealizeView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ItemsView);
-
-
 			// We may need to show the updated empty view
 			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);
 		}
@@ -495,7 +492,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void ShowEmptyView() 
 		{
-			if (_emptyViewDisplayed)
+			if (_emptyViewDisplayed || _emptyUIView == null)
 			{
 				return;
 			}
@@ -516,7 +513,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HideEmptyView() 
 		{
-			if (!_emptyViewDisplayed)
+			if (!_emptyViewDisplayed || _emptyUIView == null)
 			{
 				return;
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -436,7 +436,10 @@ namespace Xamarin.Forms.Platform.iOS
 			TearDownEmptyView();
 
 			// Set up the new empty view
-			(_emptyUIView, _emptyViewFormsElement) = TemplateHelpers.RealizeView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ItemsView);
+			UpdateView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ref _emptyUIView, ref _emptyViewFormsElement);
+
+//			(_emptyUIView, _emptyViewFormsElement) = TemplateHelpers.RealizeView(ItemsView?.EmptyView, ItemsView?.EmptyViewTemplate, ItemsView);
+
 
 			// We may need to show the updated empty view
 			UpdateEmptyViewVisibility(ItemsSource?.ItemCount == 0);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -92,7 +92,7 @@ namespace Xamarin.Forms.Platform.iOS
 				else
 				{
 					if (_footerUIView.Frame.Y != ItemsViewLayout.CollectionViewContentSize.Height ||
-						_footerUIView.Frame.Y < emptyView?.Frame.Y)
+						_footerUIView.Frame.Y < (emptyView?.Frame.Y + emptyView?.Frame.Height))
 						UpdateHeaderFooterPosition();
 				}
 			}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplateHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplateHelpers.cs
@@ -36,9 +36,9 @@ namespace Xamarin.Forms.Platform.iOS
 				PropertyPropagationExtensions.PropagatePropertyChanged(null, templateElement, itemsView);
 
 				var renderer = CreateRenderer(templateElement);
-				
-				// and set the EmptyView as its BindingContext
-				BindableObject.SetInheritedBindingContext(renderer.Element, view);
+
+				// and set the view as its BindingContext
+				renderer.Element.BindingContext = view;
 
 				return (renderer.NativeView, renderer.Element);
 			}


### PR DESCRIPTION
### Description of Change ###

Somewhere along the way the CollectionView's EmptyView on iOS regressed and no longer could display the header, footer, and EmptyView at the same time (the EmptyView would sit on top of the header, obscuring it).

These changes undo the changes which caused the regression and fix the problem a different way, leaving the EmptyView and Header intact.

No automated test for the regression here, because it's already included in #13032.

### Issues Resolved ### 

- fixes #8326 (again)
- fixes #13252

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery -> Issue 8326; the header, footer, and empty view should all be visible when the test loads.
Control Gallery -> CollectionView Gallery -> EmptyView Gallery -> EmptyView RTL; the empty view text should only shift alignment when the page is set to RTL, rather than horizontally flipping the text (see #12892).


### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
