### PR TITLE
Add Exception Message when trying to use FlyoutPage with NonAppCompat

### DIFF
--- a/Stubs/Xamarin.Forms.Platform.cs
+++ b/Stubs/Xamarin.Forms.Platform.cs
@@ -163,7 +163,11 @@ namespace Xamarin.Forms.Platform
 
 
 
-#if !__IOS__
+#if __ANDROID__
+	// current previewer doesn't work with appcompat so this renderer is here for the previewer only
+	// once previewer switches to appcompat then we can remove this
+	[RenderWith(typeof(FlyoutPageRendererNonAppCompat))]
+#elif !__IOS__
 	[RenderWith(typeof(FlyoutPageRenderer))]
 #else
 	[RenderWith (typeof (PhoneFlyoutPageRenderer))]

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -127,6 +127,9 @@ namespace Xamarin.Forms.Platform.Android
 			RegisterHandler(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
 			RegisterHandler(typeof(CheckBox), typeof(CheckBoxRenderer), typeof(CheckBoxDesignerRenderer));
 			RegisterHandler(typeof(FlyoutPage), typeof(FlyoutPageRenderer), typeof(FlyoutPageRendererNonAppCompat));
+#pragma warning disable CS0618 // Type or member is obsolete
+			RegisterHandler(typeof(MasterDetailPage), typeof(MasterDetailPageRenderer), typeof(MasterDetailRenderer));
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (Forms.Flags.Contains(Flags.UseLegacyRenderers))
 			{

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -126,6 +126,7 @@ namespace Xamarin.Forms.Platform.Android
 			RegisterHandler(typeof(Picker), typeof(AppCompat.PickerRenderer), typeof(PickerRenderer));
 			RegisterHandler(typeof(CarouselPage), typeof(AppCompat.CarouselPageRenderer), typeof(CarouselPageRenderer));
 			RegisterHandler(typeof(CheckBox), typeof(CheckBoxRenderer), typeof(CheckBoxDesignerRenderer));
+			RegisterHandler(typeof(FlyoutPage), typeof(FlyoutPageRenderer), typeof(FlyoutPageRendererNonAppCompat));
 
 			if (Forms.Flags.Contains(Flags.UseLegacyRenderers))
 			{

--- a/Xamarin.Forms.Platform.Android/Renderers/FlyoutPageRendererNonAppCompat.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FlyoutPageRendererNonAppCompat.cs
@@ -10,6 +10,10 @@ namespace Xamarin.Forms.Platform.Android
 	{
 		public FlyoutPageRendererNonAppCompat(Context context) : base(context)
 		{
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Page> e)
+		{
 			throw new Exception("FlyoutPage only works with Theme.AppCompat theme (or descendant)");
 		}
 	}

--- a/Xamarin.Forms.Platform.Android/Renderers/FlyoutPageRendererNonAppCompat.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FlyoutPageRendererNonAppCompat.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Content;
+using AView = Android.Views.View;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	sealed class FlyoutPageRendererNonAppCompat : PageRenderer
+	{
+		public FlyoutPageRendererNonAppCompat(Context context) : base(context)
+		{
+			throw new Exception("FlyoutPage only works with Theme.AppCompat theme (or descendant)");
+		}
+	}
+}


### PR DESCRIPTION
### Description of Change ###

As part of the shift to FlyoutPage from MasterDetailPage we only moved over the AppCompat renderers so if someone is still on non appcompat and tries to use FlyoutPage they will just get a blank screen. This PR will give them a more useful message. 


### Platforms Affected ### 
- Android

### Testing Procedure ###
- Make sure Flyout Page still works with AppCompat (and other platforms)
- Verify Exception Message when switching to non appcompat

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
