### PR TITLE
Invoke AnimationFinished from fragment if no animation has been added

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.Android/CustomRenderers.cs
@@ -52,6 +52,8 @@ using IOPath = System.IO.Path;
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Controls.Tests.TestClasses.CustomButton), typeof(CustomButtonRenderer))]
 [assembly: ExportRenderer(typeof(ScrolView11185), typeof(ScrollViewFadeRenderer))]
 
+[assembly: ExportRenderer(typeof(ShellWithCustomRendererDisabledAnimations), typeof(ShellWithCustomRendererDisabledAnimationsRenderer))]
+
 #if PRE_APPLICATION_CLASS
 #elif FORMS_APPLICATION_ACTIVITY
 #else
@@ -59,6 +61,30 @@ using IOPath = System.IO.Path;
 #endif
 namespace Xamarin.Forms.ControlGallery.Android
 {
+	public class ShellWithCustomRendererDisabledAnimationsRenderer : ShellRenderer
+	{
+		public ShellWithCustomRendererDisabledAnimationsRenderer(Context context) : base(context)
+		{
+		}
+
+		protected override IShellItemRenderer CreateShellItemRenderer(ShellItem shellItem)
+		{
+			return new ShellWithCustomRendererDisabledAnimationsShellItemRenderer(this);
+		}
+
+		public class ShellWithCustomRendererDisabledAnimationsShellItemRenderer : ShellItemRenderer
+		{
+			public ShellWithCustomRendererDisabledAnimationsShellItemRenderer(IShellContext shellContext) : base(shellContext)
+			{
+			}
+
+			protected override void SetupAnimation(ShellNavigationSource navSource, AndroidX.Fragment.App.FragmentTransaction t, Page page)
+			{
+				// Don't setup any animations
+			}
+		}
+	}
+
 	public sealed class ScrollViewFadeRenderer : ScrollViewRenderer
 	{
 		public ScrollViewFadeRenderer(Context context) : base(context)

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellWithCustomRendererDisabledAnimations.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellWithCustomRendererDisabledAnimations.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "[Shell] Overriding animation with custom renderer to remove animation breaks next navigation",
+		PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellWithCustomRendererDisabledAnimations : TestShell
+	{
+		protected override void Init()
+		{
+			ContentPage contentPage = new ContentPage();
+			base.AddFlyoutItem(contentPage, "Root");
+
+			contentPage.Content = new Button()
+			{
+				Text = "Click Me",
+				AutomationId = "PageLoaded",
+				Command = new Command(async () =>
+				{
+					await Navigation.PushAsync(CreateSecondPage());
+				})
+			};
+		}
+
+		ContentPage CreateSecondPage()
+		{
+			ContentPage page = new ContentPage();
+
+			page.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						Text = "If clicking `Go Back` goes back to previous page then test has passed"
+					},
+					new Button()
+					{
+						Text = "Go Back",
+						Command	= new Command(async () =>
+						{
+							await GoToAsync("..");
+						}),
+						AutomationId = "GoBack"
+					}
+				}
+			};
+
+			return page;
+		}
+
+#if UITEST  && __ANDROID__
+		[Test]
+		public void NavigationWithACustomRendererThatDoesntSetAnAnimationStillWorks()
+		{
+			RunningApp.Tap("PageLoaded");
+			RunningApp.Tap("GoBack");
+			RunningApp.WaitForElement("PageLoaded");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4720.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10897.xaml.cs">

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -53,12 +53,15 @@ namespace Xamarin.Forms
 			{
 				var navigatingArgs = ProposeNavigation(source, state, _shell.CurrentState != null, animate ?? true);
 
-				bool accept = !navigatingArgs.NavigationDelayedOrCancelled;
-				if (navigatingArgs.DeferredTask != null)
-					accept = await navigatingArgs.DeferredTask;
+				if (navigatingArgs != null)
+				{
+					bool accept = !navigatingArgs.NavigationDelayedOrCancelled;
+					if (navigatingArgs.DeferredTask != null)
+						accept = await navigatingArgs.DeferredTask;
 
-				if (!accept)
-					return;
+					if (!accept)
+						return;
+				}
 			}
 
 			Routing.RegisterImplicitPageRoutes(_shell);

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -71,7 +71,7 @@ namespace Xamarin.Forms.Platform.Android
 		public event EventHandler AnimationFinished;
 
 		public Fragment Fragment => this;
-
+				
 		public override AndroidAnimation OnCreateAnimation(int transit, bool enter, int nextAnim)
 		{
 			var result = base.OnCreateAnimation(transit, enter, nextAnim);
@@ -82,7 +82,10 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			if (result == null)
+			{
+				AnimationFinished?.Invoke(this, EventArgs.Empty);
 				return result;
+			}
 
 			// we only want to use a hardware layer for the entering view because its quite likely
 			// the view exiting is animating a button press of some sort. This means lots of GPU


### PR DESCRIPTION
### Description of Change ###

ShellItemRenederer on Android let's users override `SetupAnimation` to define custom animations.  The navigation code on android subscribes to "AnimationFinished" to know when the animation has finished and complete the navigation Task. The problem here is that if the SetupAnimation doesn't actually setup an animation then "AnimationFinished" never gets called from ShellContentFragment.  The real fix here will be to add a better API for the SetupAnimation override. Currently it's just

```C#
SetupAnimation(ShellNavigationSource navSource, AndroidX.Fragment.App.FragmentTransaction t, Page page)
```

But it should really be something like
```C#
SetupAnimation(ShellNavigationSource navSource, AndroidX.Fragment.App.FragmentTransaction t, Page page, Action callMeWhenAnimationHasFinished)
```

Or something similar to indicate to the caller that they need to tell the calling code when the animation has completed.


### Platforms Affected ### 
- Android


### Testing Procedure ###
- UI Test Included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
