### PR TITLE
Isolate the TemplatedView check inside Platform.cs to just RadioButton until we can provide a more generalized fix

### DIFF
--- a/Xamarin.Forms.ControlGallery.Android/_12484CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_12484CustomRenderer.cs
@@ -18,7 +18,19 @@ namespace Xamarin.Forms.ControlGallery.Android
         {
             base.OnElementChanged(e);
 
-            Console.WriteLine("Issue12484 Test passed.");
+			if(e.NewElement.Children[0] is Issue12484CustomView.Issue12484Template t &&
+				t.Content is Grid g)
+			{
+				var label = new Label
+				{
+					AutomationId = "Success",
+					Text = "If this text appear, the test has passed.",
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.Center
+				};
+
+				g.Children.Add(label);
+			}
         }
     }
 }

--- a/Xamarin.Forms.ControlGallery.Android/_12484CustomRenderer.cs
+++ b/Xamarin.Forms.ControlGallery.Android/_12484CustomRenderer.cs
@@ -19,12 +19,12 @@ namespace Xamarin.Forms.ControlGallery.Android
             base.OnElementChanged(e);
 
 			if(e.NewElement.Children[0] is Issue12484CustomView.Issue12484Template t &&
-				t.Content is Grid g)
+				t.Content is StackLayout g)
 			{
 				var label = new Label
 				{
 					AutomationId = "Success",
-					Text = "If this text appear, the test has passed.",
+					Text = "Success",
 					HorizontalOptions = LayoutOptions.Center,
 					VerticalOptions = LayoutOptions.Center
 				};

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12484.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12484.xaml.cs
@@ -49,7 +49,16 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			public Issue12484Template()
 			{
-				var content = new Grid();
+				var content = new StackLayout()
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = "If a label with text `Success` does not show up this test has failed"
+						}
+					}
+				};
 				Content = content;
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12484.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12484.xaml.cs
@@ -49,17 +49,7 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 			public Issue12484Template()
 			{
-				var label = new Label
-				{
-					AutomationId = "Success",
-					Text = "If this text appear, the test has passed.",
-					HorizontalOptions = LayoutOptions.Center,
-					VerticalOptions = LayoutOptions.Center
-				};
-
 				var content = new Grid();
-				content.Children.Add(label);
-
 				Content = content;
 			}
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RadioButtonTemplateFromStyle.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RadioButtonTemplateFromStyle.cs
@@ -13,8 +13,7 @@ using NUnit.Framework;
 namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
-	[Category(UITestCategories.CollectionView)]
-	[Category(UITestCategories.UwpIgnore)]
+	[Category(UITestCategories.RadioButton)]
 #endif
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RadioButtonTemplateFromStyle.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/RadioButtonTemplateFromStyle.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+	[Category(UITestCategories.UwpIgnore)]
+#endif
+
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "RadioButton: Template From Style", PlatformAffected.All)]
+	public class RadioButtonTemplateFromStyle : TestNavigationPage
+	{
+		protected override void Init()
+		{
+#if APP
+			PushAsync(new GalleryPages.RadioButtonGalleries.TemplateFromStyle());
+#endif
+		}
+
+#if UITEST
+		[Test]
+		public void ContentRenderers()
+		{
+			RunningApp.WaitForElement("A");
+			RunningApp.WaitForElement("B");
+			RunningApp.WaitForElement("C");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContent.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue4720.cs" />

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -341,7 +341,10 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			IVisualElementRenderer renderer = null;
 
-			if (element is TemplatedView tv && tv.ResolveControlTemplate() != null)
+			// temporary hack to fix the following issues
+			// https://github.com/xamarin/Xamarin.Forms/issues/13261
+			// https://github.com/xamarin/Xamarin.Forms/issues/12484
+			if (element is RadioButton tv && tv.ResolveControlTemplate() != null)
 			{
 				renderer = new DefaultRenderer(context);
 			}

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -339,11 +339,20 @@ namespace Xamarin.Forms.Platform.Android
 
 		internal static IVisualElementRenderer CreateRenderer(VisualElement element, Context context)
 		{
-			IVisualElementRenderer renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, context)
-				?? new DefaultRenderer(context);
+			IVisualElementRenderer renderer = null;
+
+			if (element is TemplatedView tv && tv.ResolveControlTemplate() != null)
+			{
+				renderer = new DefaultRenderer(context);
+			}
+			
+			if (renderer == null)
+			{
+				renderer = Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element, context)
+					?? new DefaultRenderer(context);
+			}
 
 			renderer.SetElement(element);
-
 			return renderer;
 		}
 

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -45,7 +45,10 @@ namespace Xamarin.Forms.Platform.UWP
 
 			IVisualElementRenderer renderer = null;
 
-			if (element is TemplatedView tv && tv.ResolveControlTemplate() != null)
+			// temporary hack to fix the following issues
+			// https://github.com/xamarin/Xamarin.Forms/issues/13261
+			// https://github.com/xamarin/Xamarin.Forms/issues/12484
+			if (element is RadioButton tv && tv.ResolveControlTemplate() != null)
 			{
 				renderer = new DefaultRenderer();
 			}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -224,7 +224,10 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			IVisualElementRenderer renderer = null;
 
-			if (element is TemplatedView tv && tv.ResolveControlTemplate() != null)
+			// temporary hack to fix the following issues
+			// https://github.com/xamarin/Xamarin.Forms/issues/13261
+			// https://github.com/xamarin/Xamarin.Forms/issues/12484
+			if (element is RadioButton tv && tv.ResolveControlTemplate() != null)
 			{
 				renderer = new DefaultRenderer();
 			}

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -222,9 +222,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public static IVisualElementRenderer CreateRenderer(VisualElement element)
 		{
-			IVisualElementRenderer renderer = Internals.Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element)
-				?? new DefaultRenderer();
-						
+			IVisualElementRenderer renderer = null;
+
+			if (element is TemplatedView tv && tv.ResolveControlTemplate() != null)
+			{
+				renderer = new DefaultRenderer();
+			}
+
+			if (renderer == null)
+			{
+				renderer = Internals.Registrar.Registered.GetHandlerForObject<IVisualElementRenderer>(element) ?? new DefaultRenderer();
+			}
+
 			renderer.SetElement(element);
 
 			return renderer;


### PR DESCRIPTION
### Description of Change ###

Isolate the TemplatedView check inside Platform.cs to just RadioButton for now to accommodate the two fixes referenced in this issue. The issue with the changes inside Platform.cs means that if someone inherits from TemplatedView and registers a custom renderer it won't use that CustomRenderer it will just use a DefaultRenderer. 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #12484
- fixes #13261

### Platforms Affected ### 
- Android

### Testing Procedure ###
- UI Test included
- Test Templating with RadioButton (Automated test incoming)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
