### PR TITLE
[XamlC] Fix the variable holding the result of GetNameScope

### DIFF
--- a/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
+++ b/Xamarin.Forms.Build.Tasks/SetNamescopesAndRegisterNamesVisitor.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Build.Tasks
 		VariableDefinition GetOrCreateNameScope(ElementNode node)
 		{
 			var module = Context.Body.Method.Module;
-			var vardef = new VariableDefinition(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "NameScope")));
+			var vardef = new VariableDefinition(module.ImportReference(("Xamarin.Forms.Core", "Xamarin.Forms.Internals", "INameScope")));
 			Context.Body.Variables.Add(vardef);
 			var stloc = Instruction.Create(OpCodes.Stloc, vardef);
 


### PR DESCRIPTION
### Description of Change ###

Fix the variable holding the result of `GetNameScope`. This bug was introduced with commit 395dc293f16111123dcdc6217647456bc4fe5694.

### Issues Resolved ### 

I have not checked issues.

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Compile a XAML for `BindableObject` and see the output.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
