### PR TITLE
Make sure all the UIViews is iOS are added at the correct hierarchy

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBackground.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBackground.cs
@@ -1,0 +1,153 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Flyout Background",
+		   PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellFlyoutBackground : TestShell
+	{
+		public ShellFlyoutBackground()
+		{
+		}
+
+		protected override void Init()
+		{
+			AddFlyoutItem(CreateContentPage(), "Hello");
+			AddFlyoutItem(CreateContentPage(), "Hello2");
+			FlyoutBackgroundImage = "photo.jpg";
+			FlyoutBackgroundImageAspect = Aspect.AspectFill;
+		}
+
+		ContentPage CreateContentPage()
+		{
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					new Button()
+					{
+						Text = "Toggle Image",
+						Command = new Command(() =>
+						{
+							if(FlyoutBackgroundImage == null)
+								FlyoutBackgroundImage = "photo.jpg";
+							else
+								FlyoutBackgroundImage = null;
+						})
+					},
+					new Button()
+					{
+						Text = "Toggle Color",
+						Command = new Command(() =>
+						{
+							FlyoutBackground = null;
+							if(FlyoutBackgroundColor == Color.Default)
+								FlyoutBackgroundColor = Color.Red;
+							else
+								FlyoutBackgroundColor = Color.Default;
+						})
+					},
+					new Button()
+					{
+						Text = "Toggle Color With Alpha (doesn't work correctly)",
+						Command = new Command(() =>
+						{
+							FlyoutBackground = null;
+							if(FlyoutBackgroundColor == Color.Default)
+								FlyoutBackgroundColor = Color.Red.MultiplyAlpha(0.7);
+							else
+								FlyoutBackgroundColor = Color.Default;
+						})
+					},
+					new Button()
+					{
+						Text = "Toggle Brush",
+						Command = new Command(() =>
+						{
+							RadialGradientBrush radialGradientBrush = new RadialGradientBrush(
+								new GradientStopCollection()
+								{
+									new GradientStop(Color.Red, 0.1f),
+									new GradientStop(Color.DarkBlue, 1.0f),
+								});
+
+							FlyoutBackgroundColor = Color.Default;
+							if(FlyoutBackground != null)
+								FlyoutBackground = null;
+							else
+								FlyoutBackground = radialGradientBrush;
+						})
+					},
+					new Button()
+					{
+						Text = "Toggle Flyout Content",
+						Command = new Command(() =>
+						{
+							if(FlyoutContent == null)
+								FlyoutContent = new Label() { Text = "hello" };
+							else
+								FlyoutContent = null;
+						})
+					}
+				}
+			};
+
+			Button aspectBackgroundChange = null;
+			aspectBackgroundChange = new Button()
+			{
+				Text = $"Change Flyout Background Image Aspect: {FlyoutBackgroundImageAspect}",
+				Command = new Command(() =>
+				{
+					int inc = (int)FlyoutBackgroundImageAspect;
+					inc++;
+
+					if(inc >= Enum.GetNames(typeof(Aspect)).Length)
+					{
+						inc = 0;
+					}
+
+					FlyoutBackgroundImageAspect = (Aspect)inc;
+					aspectBackgroundChange.Text = $"Change Flyout Background Image Aspect: {FlyoutBackgroundImageAspect}";
+				})
+			};
+
+			layout.Children.Add(aspectBackgroundChange);
+
+			return new ContentPage()
+			{
+				Content = layout
+			};
+		}
+
+
+#if UITEST
+		[Test]
+		public void FlyoutBackgroundTest()
+		{
+			TapInFlyout("Hello2");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBackground.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutBackground.cs
@@ -1,15 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Collections.ObjectModel;
-using System.ComponentModel;
-using System.Linq;
-using System.Text;
-using System.Threading;
-using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
-using Xamarin.Forms.PlatformConfiguration;
-using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 
 
 #if UITEST
@@ -25,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 		   PlatformAffected.All)]
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.ManualReview)]
 #endif
 	public class ShellFlyoutBackground : TestShell
 	{
@@ -34,8 +26,9 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			AddFlyoutItem(CreateContentPage(), "Hello");
-			AddFlyoutItem(CreateContentPage(), "Hello2");
+			AddFlyoutItem(CreateContentPage(), "Item 1");
+			AddFlyoutItem(CreateContentPage(), "Item 2");
+
 			FlyoutBackgroundImage = "photo.jpg";
 			FlyoutBackgroundImageAspect = Aspect.AspectFill;
 		}
@@ -46,6 +39,11 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Children =
 				{
+					new Label()
+					{
+						AutomationId = "PageLoaded",
+						Text = "Toggle Different Options to Verify Flyout Behaves as Expected"
+					},
 					new Button()
 					{
 						Text = "Toggle Image",
@@ -59,7 +57,7 @@ namespace Xamarin.Forms.Controls.Issues
 					},
 					new Button()
 					{
-						Text = "Toggle Color",
+						Text = "Toggle Red Color",
 						Command = new Command(() =>
 						{
 							FlyoutBackground = null;
@@ -71,7 +69,8 @@ namespace Xamarin.Forms.Controls.Issues
 					},
 					new Button()
 					{
-						Text = "Toggle Color With Alpha (doesn't work correctly)",
+						// Broken on iOS 14
+						Text = "Toggle Red Color With Alpha",
 						Command = new Command(() =>
 						{
 							FlyoutBackground = null;
@@ -105,11 +104,50 @@ namespace Xamarin.Forms.Controls.Issues
 						Text = "Toggle Flyout Content",
 						Command = new Command(() =>
 						{
-							if(FlyoutContent == null)
-								FlyoutContent = new Label() { Text = "hello" };
-							else
+							if (FlyoutContent is ScrollView)
 								FlyoutContent = null;
-						})
+							else if (FlyoutContent == null)
+								FlyoutContent = new Label()
+								{
+									AutomationId = "LabelContent",
+									Text = "Only Label"
+								};
+							else
+								FlyoutContent = new ScrollView()
+								{
+									AutomationId = "ScrollViewContent",
+									Content = new Label() { Text = "Label inside ScrollView" }
+								};
+						}),
+						AutomationId = "ToggleFlyoutContent"
+					},
+					new Button()
+					{
+						Text = "Toggle Header/Footer",
+						Command = new Command(() =>
+						{
+							if (FlyoutHeader == null)
+							{
+								FlyoutFooter =
+									new BoxView()
+									{
+										BackgroundColor = Color.Purple,
+										HeightRequest = 50
+									};
+
+								FlyoutHeader =
+									new BoxView()
+									{
+										BackgroundColor = Color.Blue,
+										HeightRequest = 50
+									};
+							}
+							else
+							{
+								FlyoutHeader = FlyoutFooter = null;
+							}
+						}),
+						AutomationId = "ToggleHeaderFooter"
 					}
 				}
 			};
@@ -123,7 +161,7 @@ namespace Xamarin.Forms.Controls.Issues
 					int inc = (int)FlyoutBackgroundImageAspect;
 					inc++;
 
-					if(inc >= Enum.GetNames(typeof(Aspect)).Length)
+					if (inc >= Enum.GetNames(typeof(Aspect)).Length)
 					{
 						inc = 0;
 					}
@@ -140,14 +178,5 @@ namespace Xamarin.Forms.Controls.Issues
 				Content = layout
 			};
 		}
-
-
-#if UITEST
-		[Test]
-		public void FlyoutBackgroundTest()
-		{
-			TapInFlyout("Hello2");
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutContentOffest.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutContentOffest.cs
@@ -1,0 +1,140 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Flyout Content Offsets Correctly",
+		   PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
+	public class ShellFlyoutContentOffset : TestShell
+	{
+		public ShellFlyoutContentOffset()
+		{
+		}
+
+		protected override void Init()
+		{
+			AddFlyoutItem(CreateContentPage(), "Item 1");
+			FlyoutFooter = new Button()
+			{
+				HeightRequest = 200,
+				AutomationId = "CloseFlyout",
+				Command = new Command(() => FlyoutIsPresented = false),
+				Text = "Close Flyout"
+			};
+		}
+
+		ContentPage CreateContentPage()
+		{
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = "PageLoaded",
+						Text = "Toggle through the 3 variations of flyout content and verify they all offset the same. Toggle the Header/Footer and then verify again",
+					},
+					new Button()
+					{
+						Text = "Toggle Flyout Content",
+						Command = new Command(() =>
+						{
+							if (FlyoutContent is ScrollView)
+								FlyoutContent = null;
+							else if (FlyoutContent == null)
+								FlyoutContent = new Label()
+								{
+									AutomationId = "LabelContent",
+									Text = "Only Label"
+								};
+							else
+								FlyoutContent = new ScrollView()
+								{
+									Content = new Label()
+									{
+										AutomationId = "ScrollViewContent",
+										Text = "Label inside ScrollView"
+									}
+								};
+						}),
+						AutomationId = "ToggleFlyoutContent"
+					},
+					new Button()
+					{
+						Text = "Toggle Header",
+						Command = new Command(() =>
+						{
+							if (FlyoutHeader == null)
+							{
+								FlyoutHeader =
+									new BoxView()
+									{
+										BackgroundColor = Color.Blue,
+										HeightRequest = 50
+									};
+							}
+							else
+							{
+								FlyoutHeader = FlyoutFooter = null;
+							}
+						}),
+						AutomationId = "ToggleHeader"
+					}
+				}
+			};
+
+			return new ContentPage()
+			{
+				Content = layout
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void FlyoutContentOffsetsCorrectly()
+		{
+			RunningApp.WaitForElement("PageLoaded");
+			var flyoutLoc = GetLocationAndRotateToNextContent("Item 1");
+			var labelLoc = GetLocationAndRotateToNextContent("LabelContent");
+			var scrollViewLoc = GetLocationAndRotateToNextContent("ScrollViewContent");
+
+			Assert.AreEqual(flyoutLoc, labelLoc, "Label Offset Incorrect");
+			Assert.AreEqual(flyoutLoc, scrollViewLoc, "ScrollView Offset Incorrect");
+		}
+
+		[Test]
+		public void FlyoutContentOffsetsCorrectlyWithHeader()
+		{
+			RunningApp.Tap("ToggleHeader");
+			GetLocationAndRotateToNextContent("Item 1");
+			var labelLoc = GetLocationAndRotateToNextContent("LabelContent");
+			var scrollViewLoc = GetLocationAndRotateToNextContent("ScrollViewContent");
+
+			Assert.AreEqual(labelLoc, scrollViewLoc, "ScrollView Offset Incorrect");
+		}
+
+		float GetLocationAndRotateToNextContent(string automationId)
+		{
+			ShowFlyout();
+			var y = RunningApp.WaitForElement(automationId)[0].Rect.Y;
+			RunningApp.Tap("CloseFlyout");
+			RunningApp.Tap("ToggleFlyoutContent");
+
+			return y;
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutContentWithZeroMargin.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellFlyoutContentWithZeroMargin.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Shell Flyout Content With Zero Margin offsets correctly",
+		   PlatformAffected.All)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class ShellFlyoutContentWithZeroMargin : TestShell
+	{
+		public ShellFlyoutContentWithZeroMargin()
+		{
+		}
+
+		protected override void Init()
+		{
+			AddFlyoutItem(CreateContentPage(), "Item 1");
+			FlyoutContent = new Label()
+			{
+				Text = "I should not be offset by the safe area",
+				AutomationId = "FlyoutLabel",
+				Margin = new Thickness(0)
+			};
+		}
+
+		ContentPage CreateContentPage()
+		{
+			var layout = new StackLayout()
+			{
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = "PageLoaded",
+						Text = "Open Flyout. Content should not obey safe area",
+					}
+				}
+			};
+
+			return new ContentPage()
+			{
+				Content = layout
+			};
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void FlyoutContentIgnoresSafeAreaWithZeroMargin()
+		{
+			RunningApp.WaitForElement("PageLoaded");
+			this.ShowFlyout();
+			var flyoutLoc = RunningApp.WaitForElement("FlyoutLabel")[0].Rect.Y;
+			Assert.AreEqual(0, flyoutLoc);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -91,7 +91,7 @@ namespace Xamarin.Forms.Controls
 #if __IOS__
 		static IApp InitializeiOSApp()
 		{
-			string UDID = "3604EE81-824D-4538-AC41-9115CF793CC9";
+			string UDID = "";
 
 			if (TestContext.Parameters.Exists("UDID"))
 			{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/TestPages/TestPages.cs
@@ -91,9 +91,9 @@ namespace Xamarin.Forms.Controls
 #if __IOS__
 		static IApp InitializeiOSApp()
 		{
-			string UDID = null;
+			string UDID = "3604EE81-824D-4538-AC41-9115CF793CC9";
 
-			if(TestContext.Parameters.Exists("UDID"))
+			if (TestContext.Parameters.Exists("UDID"))
 			{
 				UDID = TestContext.Parameters["UDID"];
 			}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1696,6 +1696,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8833.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10086.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13136.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBackground.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1697,6 +1697,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue10086.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13136.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBackground.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentOffest.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -19,11 +19,11 @@ namespace Xamarin.Forms.Platform.iOS
 		public event EventHandler WillAppear;
 		public event EventHandler WillDisappear;
 
-		const short BackgroundImageIndex = 0;
-		const short BlurIndex = 1;
+		const short HeaderIndex = 0;
+		const short FooterIndex = 1;
 		const short ContentIndex = 2;
-		const short FooterIndex = 3;
-		const short HeaderIndex = 4;
+		const short BlurIndex = 3;
+		const short BackgroundImageIndex = 4;
 
 		public ShellFlyoutContentRenderer(IShellContext context)
 		{
@@ -75,7 +75,6 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_tableViewController.View.UpdateFlowDirection(_shellContext.Shell);
 			_headerView.UpdateFlowDirection(_shellContext.Shell);
-			_footerView.UpdateFlowDirection(_shellContext.Shell);
 		}
 
 		void UpdateFlyoutHeader()
@@ -99,8 +98,8 @@ namespace Xamarin.Forms.Platform.iOS
 				_headerView = null;
 
 			_uIViews[HeaderIndex] = _headerView;
-			_tableViewController.HeaderView = _headerView;
 			AddViewInCorrectOrder(_headerView, previousIndex);
+			_tableViewController.HeaderView = _headerView;
 		}
 
 		void UpdateFlyoutFooter()
@@ -158,6 +157,9 @@ namespace Xamarin.Forms.Platform.iOS
 		void AddViewInCorrectOrder(UIView newView, int previousIndex)
 		{
 			if (newView == null)
+				return;
+
+			if (Array.IndexOf(View.Subviews, newView) >= 0)
 				return;
 
 			if (previousIndex >= 0 && View.Subviews.Length <= previousIndex)
@@ -233,10 +235,9 @@ namespace Xamarin.Forms.Platform.iOS
 			var backgroundImage = View.GetBackgroundImage(brush);
 			View.BackgroundColor = backgroundImage != null ? UIColor.FromPatternImage(backgroundImage) : color.ToUIColor(ColorExtensions.BackgroundColor);
 
-			_uIViews[BlurIndex] = null;
 			if (View.BackgroundColor.CGColor.Alpha < 1)
 			{
-				_uIViews[BlurIndex] = _blurView;
+				AddViewInCorrectOrder(_blurView, previousIndex);
 			}
 			else
 			{
@@ -326,6 +327,7 @@ namespace Xamarin.Forms.Platform.iOS
 				ClipsToBounds = true
 			};
 
+			_uIViews[BlurIndex] = _blurView;
 			_uIViews[BackgroundImageIndex] = _bgImage;
 
 			UpdateBackground();
@@ -344,11 +346,11 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				_shellFlyoutContentManager.SetDefaultContent(_tableViewController.TableView);
-				_uIViews[ContentIndex] = _tableViewController.TableView;
 			}
 
 			_uIViews[ContentIndex] = _shellFlyoutContentManager.ContentView;
 			AddViewInCorrectOrder(_uIViews[ContentIndex], previousIndex);
+			_shellFlyoutContentManager.LayoutParallax();
 		}
 
 		public override void ViewWillAppear(bool animated)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutLayoutManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutLayoutManager.cs
@@ -118,6 +118,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_contentView = value;
 
+				ScrollView = null;
+
 				if (ContentView is UIScrollView sv1)
 					ScrollView = sv1;
 				else if (ContentView is IVisualElementRenderer ver && ver.NativeView is UIScrollView uIScroll)
@@ -126,11 +128,8 @@ namespace Xamarin.Forms.Platform.iOS
 				if (ScrollView != null && Forms.IsiOS11OrNewer)
 					ScrollView.ContentInsetAdjustmentBehavior = UIScrollViewContentInsetAdjustmentBehavior.Never;
 
-				if (ScrollView != null)
-				{
-					LayoutParallax();
-					SetHeaderContentInset();
-				}
+				LayoutParallax();
+				SetHeaderContentInset();
 			}
 		}
 
@@ -149,6 +148,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (_headerView != null)
 					_headerView.HeaderSizeChanged += OnHeaderFooterSizeChanged;
+
+				SetHeaderContentInset();
+				LayoutParallax();
 			}
 		}
 
@@ -161,6 +163,8 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				_footerView = value;
+				SetHeaderContentInset();
+				LayoutParallax();
 			}
 		}
 
@@ -243,11 +247,23 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
+				float topMargin = 0;
+				if (Content.IsSet(View.MarginProperty))
+				{
+					topMargin = (float)Content.Margin.Top;
+				}
+				else if(HeaderView == null)
+				{
+					topMargin = (float)Platform.SafeAreaInsetsForWindow.Top;
+				}
+
 				ContentView.Frame =
-						new CGRect(parent.Bounds.X, HeaderTopMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - HeaderTopMargin - footerHeight - contentViewYOffset);
+						new CGRect(parent.Bounds.X, topMargin + contentViewYOffset, parent.Bounds.Width, parent.Bounds.Height - topMargin - footerHeight - contentViewYOffset);
 
 				if (Content != null)
+				{
 					Layout.LayoutChildIntoBoundingRegion(Content, new Rectangle(0, 0, ContentView.Frame.Width, ContentView.Frame.Height));
+				}
 			}
 
 			if (HeaderView != null && !double.IsNaN(_headerSize))


### PR DESCRIPTION
### Description of Change ###

With the Shell Flyout Content PR the Flyout Content started getting inserted behind the FlyoutBackground Image. These changes ensure that all the UIView's that are part of Flyout Content more deterministically get inserted into the Flyout

### Issues Resolved ### 
- fixes #13295

### Platforms Affected ### 
- iOS


### Testing Procedure ###
- included UI Tests for some offset validation
- When the background image overlaps the content the content is still clickable so there isn't a great way to automate the test

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
