### PR TITLE
Renderer for SwipeView on macOS

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SwipeViewRenderer.cs
@@ -1,0 +1,51 @@
+using AppKit;
+using System;
+using System.Linq;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Platform.MacOS
+{
+    public class SwipeViewRenderer : ViewRenderer<SwipeView, NSView>
+    {
+        SwipeView swipeView;
+
+        protected override void OnElementChanged(ElementChangedEventArgs<SwipeView> e) {
+            base.OnElementChanged(e);
+
+            if ( Control == null )
+                SetNativeControl(new NSView());
+
+            if ( e.NewElement is SwipeView sv ) {
+                swipeView = sv;
+                if ( sv.IsVisible )
+                    Control.Menu = BuildMenu();
+            }
+        }
+
+        NSMenu BuildMenu() {
+            var menu = new NSMenu("SwipeView");
+            swipeView.LeftItems
+                     .Union(swipeView.RightItems)
+                     .Union(swipeView.TopItems)
+                     .Union(swipeView.BottomItems)
+                     .Select(item => item as SwipeItem)
+                     .ForEach(item => menu.AddItem(new NSMenuItemWithCommand(item.Text, (Command)item.Command, item.CommandParameter, (s, e) => {
+                         if ( s is NSMenuItemWithCommand menuItem )
+                             menuItem.Command?.SafelyExecute(menuItem.CommandParameter);
+                     })));
+            return menu;
+        }
+
+        class NSMenuItemWithCommand : NSMenuItem
+        {
+
+            public NSMenuItemWithCommand(string title, Command command, object commandParameter, EventHandler handler) : base(title, handler) {
+                Command = command;
+                CommandParameter = commandParameter;
+            }
+
+            public Command Command { get; set; }
+            public object CommandParameter { get; set; }
+        }
+    }
+}

--- a/Xamarin.Forms.Platform.MacOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/SwipeViewRenderer.cs
@@ -31,7 +31,7 @@ namespace Xamarin.Forms.Platform.MacOS
                      .Select(item => item as SwipeItem)
                      .ForEach(item => menu.AddItem(new NSMenuItemWithCommand(item.Text, (Command)item.Command, item.CommandParameter, (s, e) => {
                          if ( s is NSMenuItemWithCommand menuItem )
-                             menuItem.Command?.SafelyExecute(menuItem.CommandParameter);
+                             menuItem.Command?.Execute(menuItem.CommandParameter);
                      })));
             return menu;
         }


### PR DESCRIPTION
Simple renderer for SwipeView on macOS. It is implemented by converting each SwipeItem to a context menu item.

### Description of Change ###
Add a renderer for SwipeView on macOS

### Issues Resolved ### 
 None

### API Changes ###
 None

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
Support for SwipeView on Xamarin Forms macOS.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Add SwipeViewRenderer.cs to a project and add an ExportRenderer statement to activate it.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
