### PR TITLE
Fix 'effectiveAppearance' crash on pre-Mojave

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -756,16 +756,17 @@ namespace Xamarin.Forms
 							return OSAppTheme.Unspecified;
 					};
 #else
-                    return AppearanceIsDark(NSApplication.SharedApplication.EffectiveAppearance) ? OSAppTheme.Dark : OSAppTheme.Light;
+                    return AppearanceIsDark() ? OSAppTheme.Dark : OSAppTheme.Light;
 #endif
 				}
 			}
 
 #if __MACOS__
-			bool AppearanceIsDark(NSAppearance appearance)
+			bool AppearanceIsDark()
 			{
 				if (IsMojaveOrNewer)
 				{
+					var appearance = NSApplication.SharedApplication.EffectiveAppearance;
 					var matchedAppearance = appearance.FindBestMatch(new string[] { NSAppearance.NameAqua, NSAppearance.NameDarkAqua });
 
 					return matchedAppearance == NSAppearance.NameDarkAqua;


### PR DESCRIPTION
### Description of Change ###

Moves use of NSApplication EffectiveAppearance property inside of Mojave or later check.

### Issues Resolved ### 

- fixes #13071

### API Changes ###

None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Run this on High Sierra, see if it crashes. (It shouldn't.)

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
