### PR TITLE
Fix margin on Shell TitleView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Controls.Issues
 			var titleViewBottom = titleView.Y + titleView.Height;
 			var topTabTop = topTab.Y;
 
-			Assert.Greater(topTabTop, titleViewBottom, "Title View is incorrectly positioned behind tabs");
+			Assert.GreaterOrEqual(topTabTop, titleViewBottom, "Title View is incorrectly positioned behind tabs");
 		}
 
 		[Test]

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
@@ -1,5 +1,6 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Threading.Tasks;
 
 
 #if UITEST
@@ -15,6 +16,7 @@ namespace Xamarin.Forms.Controls.Issues
 #if UITEST
 	[NUnit.Framework.Category(UITestCategories.Shell)]
 	[NUnit.Framework.Category(UITestCategories.TitleView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
 #endif
 	public class ShellTitleView : TestShell
 	{
@@ -27,6 +29,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			ContentPage createContentPage(string titleView)
 			{
+				Label safeArea = new Label();
 				ContentPage page = new ContentPage()
 				{
 					Content = new StackLayout()
@@ -35,8 +38,10 @@ namespace Xamarin.Forms.Controls.Issues
 						{
 							new Label()
 							{
-								Text = "Click through the tabs and make sure title view changes and doesn't duplicate"
-							}
+								Text = "Tab 1,3, and 4 should have a single visible TitleView. If the TitleView is duplicated or not visible the test has failed.",
+								AutomationId = "Instructions"
+							},
+							safeArea
 						}
 					}
 				};
@@ -58,7 +63,19 @@ namespace Xamarin.Forms.Controls.Issues
 		}
 
 
-#if UITEST && (__IOS__ || __ANDROID__)
+#if UITEST
+
+		[Test]
+		public void TitleViewPositionsCorrectly()
+		{
+			var titleView = RunningApp.WaitForElement("TitleViewId")[0].Rect;
+			var topTab = RunningApp.WaitForElement("page 2")[0].Rect;
+
+			var titleViewBottom = titleView.Y + titleView.Height;
+			var topTabTop = topTab.Y;
+
+			Assert.Greater(topTabTop, titleViewBottom, "Title View is incorrectly positioned behind tabs");
+		}
 
 		[Test]
 		public void NoDuplicateTitleViews()

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutContentRenderer.cs
@@ -86,7 +86,7 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			if (header != null)
-				_headerView = new UIContainerView(((IShellController)_shellContext.Shell).FlyoutHeader);
+				_headerView = new ShellFlyoutHeaderContainer(((IShellController)_shellContext.Shell).FlyoutHeader);
 			else
 				_headerView = null;
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutHeaderContainer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutHeaderContainer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+namespace Xamarin.Forms.Platform.iOS
+{
+	internal class ShellFlyoutHeaderContainer : UIContainerView
+	{
+		public ShellFlyoutHeaderContainer(View view) : base(view)
+		{
+		}
+
+		public override Thickness Margin
+		{
+			get
+			{
+				if (!View.IsSet(View.MarginProperty))
+				{
+					var newMargin = new Thickness(0, (float)Platform.SafeAreaInsetsForWindow.Top, 0, 0);
+
+					if (newMargin != View.Margin)
+					{
+						View.Margin = newMargin;
+					}
+				}
+
+				return View.Margin;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Renderers/UIContainerView.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/UIContainerView.cs
@@ -22,11 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 			ClipsToBounds = true;
 			view.MeasureInvalidated += OnMeasureInvalidated;
 			MeasuredHeight = double.NaN;
-			_view.BatchCommitted += _view_BatchCommitted;
-		}
-
-		private void _view_BatchCommitted(object sender, Internals.EventArg<VisualElement> e)
-		{
+			Margin = new Thickness(0);
 		}
 
 		internal View View => _view;
@@ -46,22 +42,9 @@ namespace Xamarin.Forms.Platform.iOS
 			return false;
 		}
 
-		public Thickness Margin
+		public virtual Thickness Margin
 		{
-			get
-			{
-				if(!_view.IsSet(View.MarginProperty))
-				{
-					var newMargin = new Thickness(0, (float)Platform.SafeAreaInsetsForWindow.Top, 0, 0);
-
-					if (newMargin != _view.Margin)
-					{
-						_view.Margin = newMargin;
-					}
-				}
-
-				return _view.Margin;
-			}
+			get;
 		}
 
 		void ReMeasure()

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -278,6 +278,7 @@
     <Compile Include="CollectionView\ILoopItemsViewSource.cs" />
     <Compile Include="Renderers\IDisconnectable.cs" />
     <Compile Include="Extensions\BrushExtensions.shared.cs" />
+    <Compile Include="Renderers\ShellFlyoutHeaderContainer.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="Resources\StringResources.ar.resx" />


### PR DESCRIPTION
### Description of Change ###

The same UIContainerView code is used to render the TitleView and the Flyout Header View. In 5.0 the code used to layout the view slightly changed which is causing the TitleView to add a margin equal to the SafeArea. The changes here create a subclass of UIContainerView for the FlyoutHeader so the FlyoutHeader can set a margin that doesn't interfere with the TitleView on iOS 

### Issues Resolved ### 
- fixes #13310
- fixes #13306

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
