### PR TITLE
[C] Invalidate Grid when row/col def is replaced

### DIFF
--- a/Xamarin.Forms.Core/Grid.cs
+++ b/Xamarin.Forms.Core/Grid.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms
 					((ColumnDefinitionCollection)oldvalue).ItemSizeChanged -= ((Grid)bindable).OnDefinitionChanged;
 				if (newvalue != null)
 					((ColumnDefinitionCollection)newvalue).ItemSizeChanged += ((Grid)bindable).OnDefinitionChanged;
+				((Grid)bindable).OnDefinitionChanged(bindable, EventArgs.Empty);
 			}, defaultValueCreator: bindable =>
 			{
 				var colDef = new ColumnDefinitionCollection();
@@ -44,6 +45,7 @@ namespace Xamarin.Forms
 					((RowDefinitionCollection)oldvalue).ItemSizeChanged -= ((Grid)bindable).OnDefinitionChanged;
 				if (newvalue != null)
 					((RowDefinitionCollection)newvalue).ItemSizeChanged += ((Grid)bindable).OnDefinitionChanged;
+				((Grid)bindable).OnDefinitionChanged(bindable, EventArgs.Empty);
 			}, defaultValueCreator: bindable =>
 			{
 				var rowDef = new RowDefinitionCollection();


### PR DESCRIPTION
### Description of Change ###

We invalidate when the items of the row/col def are modified. With this,
we also invalidate when the full collection is swapped.


### Issues Resolved ### 

- fixes #13154

### API Changes ###

 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
