### PR TITLE
Fix Shell Navigation for Hierarchally registered Global Routes

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -315,6 +315,10 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			public TestShell()
 			{
+				Routing.RegisterRoute(nameof(TestPage1), typeof(TestPage1));
+				Routing.RegisterRoute(nameof(TestPage2), typeof(TestPage2));
+				Routing.RegisterRoute(nameof(TestPage3), typeof(TestPage3));
+
 				this.Navigated += (_, __) => NavigatedCount++;
 				this.Navigating += (_, __) => NavigatingCount++;
 			}
@@ -458,5 +462,9 @@ namespace Xamarin.Forms.Core.UnitTests
 				}
 			}
 		}
+
+		public class TestPage1 : ContentPage { }
+		public class TestPage2 : ContentPage { }
+		public class TestPage3 : ContentPage { }
 	}
 }

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -116,6 +116,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
 		}
 
+
+		[Test]
+		public async Task RemovePageWithNestedRoutes()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails");
+			await shell.GoToAsync("monkeygenome");
+			shell.Navigation.RemovePage(shell.Navigation.NavigationStack[1]);
+			await shell.Navigation.PopAsync();
+		}
+
 		[Test]
 		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyWithAdditionalItems()
 		{
@@ -145,9 +161,27 @@ namespace Xamarin.Forms.Core.UnitTests
 			);
 
 			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.Navigation.PopAsync();
 			await shell.Navigation.PopAsync();
 		}
 
+
+		[Test]
+		public async Task GoBackFromRouteWithMultiplePathsHierarchical()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+
+			var shell = new TestShell(
+				CreateShellItem()
+			);
+
+			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.GoToAsync("monkeygenome");
+			await shell.Navigation.PopAsync();
+			await shell.Navigation.PopAsync();
+		}
 
 		[Test]
 		public void NodeWalkingBasic()

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -79,6 +79,27 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("//rootlevelcontent1/details", shell.CurrentState.Location.ToString());
 		}
 
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectly()
+		{
+			Routing.RegisterRoute("first", typeof(TestPage1));
+			Routing.RegisterRoute("first/second", typeof(TestPage2));
+			Routing.RegisterRoute("first/second/third", typeof(TestPage3));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "MainPage")
+			);
+
+			await shell.GoToAsync("//MainPage/first/second");
+
+			Assert.AreEqual(typeof(TestPage1), shell.Navigation.NavigationStack[1].GetType());
+			Assert.AreEqual(typeof(TestPage2), shell.Navigation.NavigationStack[2].GetType());
+
+			await shell.GoToAsync("//MainPage/first/second/third");
+
+			Assert.AreEqual(typeof(TestPage1), shell.Navigation.NavigationStack[1].GetType());
+			Assert.AreEqual(typeof(TestPage2), shell.Navigation.NavigationStack[2].GetType());
+			Assert.AreEqual(typeof(TestPage3), shell.Navigation.NavigationStack[3].GetType());
+		}
 
 		[Test]
 		public async Task GlobalRegisterAbsoluteMatching()
@@ -355,6 +376,7 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			Assert.That(async () => await shell.GoToAsync($"domestic"), Throws.Exception);
 		}
+
 
 		[Test]
 		public async Task RelativeNavigationWithRoute()

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -135,6 +135,19 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
 		}
 
+		[Test]
+		public async Task GoBackFromRouteWithMultiplePaths()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+
+			var shell = new TestShell(
+				CreateShellItem()
+			);
+
+			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.Navigation.PopAsync();
+		}
+
 
 		[Test]
 		public void NodeWalkingBasic()

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -116,6 +116,25 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
 		}
 
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyWithAdditionalItems()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "cats", shellSectionRoute:"domestic", shellItemRoute: "animals")
+			);
+
+			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "monkeys"));
+			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "elephants"));
+			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "bears"));
+			shell.Items[0].Items[0].Items.Add(CreateShellContent(shellContentRoute: "dogs"));
+			shell.Items.Add(CreateShellContent(shellContentRoute: "about"));
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			await shell.GoToAsync("monkeygenome");
+			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
+		}
+
 
 		[Test]
 		public void NodeWalkingBasic()

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -116,6 +116,22 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
 		}
 
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyWithDoublePop()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			await shell.GoToAsync("monkeygenome");
+			await shell.GoToAsync("../..");
+			Assert.AreEqual("//animals/monkeys", shell.CurrentState.Location.ToString());
+		}
+
 
 		[Test]
 		public async Task RemovePageWithNestedRoutes()

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -132,6 +132,18 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("//animals/monkeys", shell.CurrentState.Location.ToString());
 		}
 
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyWithDoubleSplash()
+		{
+			Routing.RegisterRoute("//animals/monkeys/monkeyDetails", typeof(TestPage1));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			Assert.AreEqual("//animals/monkeys/monkeyDetails", shell.CurrentState.Location.ToString());
+		}
+
 
 		[Test]
 		public async Task RemovePageWithNestedRoutes()

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -102,6 +102,71 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyVariation()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			await shell.GoToAsync("monkeygenome");
+			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
+		}
+
+
+		[Test]
+		public void NodeWalkingBasic()
+		{
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			ShellUriHandler.NodeLocation nodeLocation = new ShellUriHandler.NodeLocation();
+			nodeLocation.SetNode(shell);
+
+			nodeLocation = nodeLocation.WalkToNextNode();
+			Assert.AreEqual(nodeLocation.Content, shell.Items[0].Items[0].Items[0]);
+
+			nodeLocation = nodeLocation.WalkToNextNode();
+			Assert.AreEqual(nodeLocation.Content, shell.Items[1].Items[0].Items[0]);
+		}
+
+
+		[Test]
+		public void NodeWalkingMultipleContent()
+		{
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals1"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals3"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals4")
+			);
+
+			var content = CreateShellContent();
+			shell.Items[1].Items[0].Items.Add(content);
+			shell.Items[2].Items[0].Items.Add(CreateShellContent());
+
+			// add a section with now content
+			shell.Items[0].Items.Add(new ShellSection());
+
+			ShellUriHandler.NodeLocation nodeLocation = new ShellUriHandler.NodeLocation();
+			nodeLocation.SetNode(content);
+
+			nodeLocation = nodeLocation.WalkToNextNode();
+			Assert.AreEqual(shell.Items[2].Items[0].Items[0], nodeLocation.Content);
+
+			nodeLocation = nodeLocation.WalkToNextNode();
+			Assert.AreEqual(shell.Items[2].Items[0].Items[1], nodeLocation.Content);
+
+			nodeLocation = nodeLocation.WalkToNextNode();
+			Assert.AreEqual(shell.Items[3].Items[0].Items[0], nodeLocation.Content);
+		}
+
+		[Test]
 		public async Task GlobalRegisterAbsoluteMatching()
 		{
 			var shell = new Shell();

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.ComponentModel;
 using System.Diagnostics;
@@ -486,6 +487,41 @@ namespace Xamarin.Forms
 				grid.Resources = new ResourceDictionary() { defaultGridClass, defaultLabelClass, defaultImageClass };
 				return grid;
 			});
+		}
+
+		internal BaseShellItem WalkToNextElement()
+		{
+			var parentItems = GetItems(Parent);
+			var myIndex = parentItems.IndexOf(this);
+			myIndex++;
+			if(parentItems.Count >= myIndex)
+			{
+				if(Parent is BaseShellItem bsi)
+				{
+					var nextValidElement = bsi.WalkToNextElement();
+				}
+			}
+
+			return parentItems[myIndex];
+		}
+
+		static ShellElementCollection GetItems(object node)
+		{
+			object results = null;
+			switch (node)
+			{
+				case Shell shell:
+					results = shell.Items;
+					break;
+				case ShellItem item:
+					results = item.Items;
+					break;
+				case ShellSection section:
+					results = section.Items;
+					break;
+			}
+
+			return (ShellElementCollection)results;
 		}
 	}
 

--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -488,41 +488,6 @@ namespace Xamarin.Forms
 				return grid;
 			});
 		}
-
-		internal BaseShellItem WalkToNextElement()
-		{
-			var parentItems = GetItems(Parent);
-			var myIndex = parentItems.IndexOf(this);
-			myIndex++;
-			if(parentItems.Count >= myIndex)
-			{
-				if(Parent is BaseShellItem bsi)
-				{
-					var nextValidElement = bsi.WalkToNextElement();
-				}
-			}
-
-			return parentItems[myIndex];
-		}
-
-		static ShellElementCollection GetItems(object node)
-		{
-			object results = null;
-			switch (node)
-			{
-				case Shell shell:
-					results = shell.Items;
-					break;
-				case ShellItem item:
-					results = item.Items;
-					break;
-				case ShellSection section:
-					results = section.Items;
-					break;
-			}
-
-			return (ShellElementCollection)results;
-		}
 	}
 
 	public interface IQueryAttributable

--- a/Xamarin.Forms.Core/Shell/NavigationRequest.cs
+++ b/Xamarin.Forms.Core/Shell/NavigationRequest.cs
@@ -1,0 +1,27 @@
+﻿using System.Diagnostics;
+
+namespace Xamarin.Forms
+{
+	[DebuggerDisplay("RequestDefinition = {Request}, StackRequest = {StackRequest}")]
+	internal class NavigationRequest
+	{
+		public enum WhatToDoWithTheStack
+		{
+			ReplaceIt,
+			PushToIt
+		}
+
+		public NavigationRequest(RequestDefinition definition, WhatToDoWithTheStack stackRequest, string query, string fragment)
+		{
+			StackRequest = stackRequest;
+			Query = query;
+			Fragment = fragment;
+			Request = definition;
+		}
+
+		public WhatToDoWithTheStack StackRequest { get; }
+		public string Query { get; }
+		public string Fragment { get; }
+		public RequestDefinition Request { get; }
+	}
+}

--- a/Xamarin.Forms.Core/Shell/RequestDefinition.cs
+++ b/Xamarin.Forms.Core/Shell/RequestDefinition.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+
+namespace Xamarin.Forms
+{
+	[DebuggerDisplay("Full = {FullUri}, Short = {ShortUri}")]
+	internal class RequestDefinition
+	{
+		public RequestDefinition(RouteRequestBuilder theWinningRoute, Shell shell)
+		{
+			Item = theWinningRoute.Item;
+			Section = theWinningRoute.Section ?? Item?.CurrentItem;
+			Content = theWinningRoute.Content ?? Section?.CurrentItem;
+			GlobalRoutes = theWinningRoute.GlobalRouteMatches;
+
+			List<String> builder = new List<string>();
+			if (Item?.Route != null)
+				builder.Add(Item.Route);
+
+			if (Section?.Route != null)
+				builder.Add(Section?.Route);
+
+			if (Content?.Route != null)
+				builder.Add(Content?.Route);
+
+			if (GlobalRoutes != null)
+				builder.AddRange(GlobalRoutes);
+
+			var uriPath = MakeUriString(builder);
+			var uri = ShellUriHandler.CreateUri(uriPath);
+			FullUri = ShellUriHandler.ConvertToStandardFormat(shell, uri);
+
+		}
+
+		string MakeUriString(List<string> segments)
+		{
+			if (segments[0].StartsWith("/", StringComparison.Ordinal) || segments[0].StartsWith("\\", StringComparison.Ordinal))
+				return String.Join("/", segments);
+
+			return $"//{String.Join("/", segments)}";
+		}
+
+		public Uri FullUri { get; }
+		public ShellItem Item { get; }
+		public ShellSection Section { get; }
+		public ShellContent Content { get; }
+		public List<string> GlobalRoutes { get; }
+	}
+}

--- a/Xamarin.Forms.Core/Shell/RouteRequestBuilder.cs
+++ b/Xamarin.Forms.Core/Shell/RouteRequestBuilder.cs
@@ -109,9 +109,6 @@ namespace Xamarin.Forms
 					if (Item == item)
 						return;
 
-					if (item.Parent is Shell s)
-						Shell = s;
-
 					Item = item;
 					break;
 				case ShellSection section:
@@ -146,6 +143,9 @@ namespace Xamarin.Forms
 
 					break;
 			}
+
+			if (Item?.Parent is Shell s)
+				Shell = s;
 
 			// if shellSegment == userSegment it means the implicit route is part of the request
 			if (Routing.IsUserDefined(shellSegment) || shellSegment == userSegment || shellSegment == NextSegment)

--- a/Xamarin.Forms.Core/Shell/RouteRequestBuilder.cs
+++ b/Xamarin.Forms.Core/Shell/RouteRequestBuilder.cs
@@ -1,0 +1,217 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Forms
+{
+	/// <summary>
+	/// This attempts to locate the intended route trying to be navigated to
+	/// </summary>
+	internal class RouteRequestBuilder
+	{
+		readonly List<string> _globalRouteMatches = new List<string>();
+		readonly List<string> _matchedSegments = new List<string>();
+		readonly List<string> _fullSegments = new List<string>();
+		readonly string[] _allSegments = null;
+		readonly static string _uriSeparator = "/";
+
+		public Shell Shell { get; private set; }
+		public ShellItem Item { get; private set; }
+		public ShellSection Section { get; private set; }
+		public ShellContent Content { get; private set; }
+		public object LowestChild =>
+			(object)Content ?? (object)Section ?? (object)Item ?? (object)Shell;
+
+		public RouteRequestBuilder(string[] allSegments)
+		{
+			_allSegments = allSegments;
+		}
+
+
+		public RouteRequestBuilder(string shellSegment, string userSegment, object node, string[] allSegments) : this(allSegments)
+		{
+			if (node != null)
+				AddMatch(shellSegment, userSegment, node);
+			else
+				AddGlobalRoute(userSegment, shellSegment);
+		}
+
+		public RouteRequestBuilder(RouteRequestBuilder builder) : this(builder._allSegments)
+		{
+			_matchedSegments.AddRange(builder._matchedSegments);
+			_fullSegments.AddRange(builder._fullSegments);
+			_globalRouteMatches.AddRange(builder._globalRouteMatches);
+			Shell = builder.Shell;
+			Item = builder.Item;
+			Section = builder.Section;
+			Content = builder.Content;
+		}
+
+		public void AddGlobalRoute(string routeName, string segment)
+		{
+			_globalRouteMatches.Add(routeName);
+			_fullSegments.Add(segment);
+			_matchedSegments.Add(segment);
+		}
+
+
+		public bool AddMatch(ShellUriHandler.NodeLocation nodeLocation)
+		{
+			if (Item == null && !AddNode(nodeLocation.Item, NextSegment))
+				return false;
+
+			if (Section == null && !AddNode(nodeLocation.Section, NextSegment))
+				return false;
+
+			if (Content == null && !AddNode(nodeLocation.Content, NextSegment))
+				return false;
+
+			return true;
+
+			bool AddNode(BaseShellItem baseShellItem, string nextSegment)
+			{
+				if (Routing.IsUserDefined(baseShellItem.Route) && baseShellItem.Route != nextSegment)
+				{
+					return false;
+				}
+
+				AddMatch(baseShellItem.Route, GetUserSegment(baseShellItem), baseShellItem);
+				return true;
+			}
+
+			string GetUserSegment(BaseShellItem baseShellItem)
+			{
+				if (Routing.IsUserDefined(baseShellItem))
+					return baseShellItem.Route;
+
+				return String.Empty;
+			}
+		}
+
+		public void AddMatch(string shellSegment, string userSegment, object node)
+		{
+			if (node == null)
+				throw new ArgumentNullException(nameof(node));
+
+			switch (node)
+			{
+				case ShellUriHandler.GlobalRouteItem globalRoute:
+					if (globalRoute.IsFinished)
+						_globalRouteMatches.Add(globalRoute.SourceRoute);
+					break;
+				case Shell shell:
+					if (shell == Shell)
+						return;
+
+					Shell = shell;
+					break;
+				case ShellItem item:
+					if (Item == item)
+						return;
+
+					if (item.Parent is Shell s)
+						Shell = s;
+
+					Item = item;
+					break;
+				case ShellSection section:
+					if (Section == section)
+						return;
+
+					Section = section;
+
+					if (Item == null)
+					{
+						Item = Section.Parent as ShellItem;
+						_fullSegments.Add(Item.Route);
+					}
+
+					break;
+				case ShellContent content:
+					if (Content == content)
+						return;
+
+					Content = content;
+					if (Section == null)
+					{
+						Section = Content.Parent as ShellSection;
+						_fullSegments.Add(Section.Route);
+					}
+
+					if (Item == null)
+					{
+						Item = Section.Parent as ShellItem;
+						_fullSegments.Insert(0, Item.Route);
+					}
+
+					break;
+			}
+
+			// if shellSegment == userSegment it means the implicit route is part of the request
+			if (Routing.IsUserDefined(shellSegment) || shellSegment == userSegment || shellSegment == NextSegment)
+				_matchedSegments.Add(shellSegment);
+
+			_fullSegments.Add(shellSegment);
+		}
+
+		public string NextSegment
+		{
+			get
+			{
+				var nextMatch = _matchedSegments.Count;
+				if (nextMatch >= _allSegments.Length)
+					return null;
+
+				return _allSegments[nextMatch];
+			}
+		}
+
+		public string RemainingPath
+		{
+			get
+			{
+				var nextMatch = _matchedSegments.Count;
+				if (nextMatch >= _allSegments.Length)
+					return null;
+
+				return Routing.FormatRoute(String.Join(_uriSeparator, _allSegments.Skip(nextMatch)));
+			}
+		}
+
+		public string[] RemainingSegments
+		{
+			get
+			{
+				var nextMatch = _matchedSegments.Count;
+				if (nextMatch >= _allSegments.Length)
+					return null;
+
+				return _allSegments.Skip(nextMatch).ToArray();
+			}
+		}
+
+		string MakeUriString(List<string> segments)
+		{
+			if (segments[0].StartsWith(_uriSeparator, StringComparison.Ordinal) || segments[0].StartsWith("\\", StringComparison.Ordinal))
+				return String.Join(_uriSeparator, segments);
+
+			return $"//{String.Join(_uriSeparator, segments)}";
+		}
+
+		public string PathNoImplicit => MakeUriString(_matchedSegments);
+		public string PathFull => MakeUriString(_fullSegments);
+
+		public bool IsFullMatch => _matchedSegments.Count == _allSegments.Length;
+		public List<string> GlobalRouteMatches => _globalRouteMatches;
+		public List<string> SegmentsMatched => _matchedSegments;
+		public IReadOnlyList<string> FullSegments => _fullSegments;
+		public ShellUriHandler.NodeLocation GetNodeLocation()
+		{
+			ShellUriHandler.NodeLocation nodeLocation = new ShellUriHandler.NodeLocation();
+			nodeLocation.SetNode(Item);
+			nodeLocation.SetNode(Section);
+			nodeLocation.SetNode(Content);
+			return nodeLocation;
+		}
+	}
+}

--- a/Xamarin.Forms.Core/Shell/RouteRequestBuilder.cs
+++ b/Xamarin.Forms.Core/Shell/RouteRequestBuilder.cs
@@ -160,19 +160,26 @@ namespace Xamarin.Forms
 
 		public string GetNextSegmentMatch(string matchMe)
 		{
+			var segmentsToMatch = ShellUriHandler.RetrievePaths(matchMe).ToList();
 			// if matchMe is an absolute route then we only match 
 			// if there are no routes already present
-			if (matchMe.StartsWith("//", StringComparison.Ordinal) || 
-				matchMe.StartsWith("\\\\", StringComparison.Ordinal))
+			if (matchMe.StartsWith("/", StringComparison.Ordinal) || 
+				matchMe.StartsWith("\\", StringComparison.Ordinal))
 			{
-				if (MatchedParts > 0)
-					return String.Empty;
+				for (var i = 0; i < _matchedSegments.Count; i++)
+				{
+					var seg = _matchedSegments[i];
+					if (segmentsToMatch.Count <= i || segmentsToMatch[i] != seg)
+						return String.Empty;
+
+					segmentsToMatch.Remove(seg);
+				}
 			}
 
 			List<string> matches = new List<string>();
 			List<string> currentSet = new List<string>(_matchedSegments);
 
-			foreach(var split in ShellUriHandler.RetrievePaths(matchMe))
+			foreach(var split in segmentsToMatch)
 			{
 				string next = GetNextSegment(currentSet);
 				if(next == split)

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -493,5 +493,28 @@ namespace Xamarin.Forms
 			
 		}
 
+		public static List<Page> BuildFlattenedNavigationStack(Shell shell)
+		{
+			var section = shell.CurrentItem.CurrentItem;
+			return BuildFlattenedNavigationStack(section.Stack, section.Navigation.ModalStack);
+		}
+		
+		public static List<Page> BuildFlattenedNavigationStack(IReadOnlyList<Page> startingList, IReadOnlyList<Page> modalStack)
+		{
+			var returnValue = startingList.ToList();
+			if (modalStack == null)
+				return returnValue;
+
+			for (int i = 0; i < modalStack.Count; i++)
+			{
+				returnValue.Add(modalStack[i]);
+				for (int j = 1; j < modalStack[i].Navigation.NavigationStack.Count; j++)
+				{
+					returnValue.Add(modalStack[i].Navigation.NavigationStack[j]);
+				}
+			}
+
+			return returnValue;
+		}
 	}
 }

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -465,7 +465,7 @@ namespace Xamarin.Forms
 						for (int i = 1; i < sectionStack.Count; i++)
 						{
 							var page = sectionStack[i];
-							routeStack.AddRange(CollapsePath(Routing.GetRoute(page), routeStack, hasUserDefinedRoute));
+							routeStack.AddRange(ShellUriHandler.CollapsePath(Routing.GetRoute(page), routeStack, hasUserDefinedRoute));
 						}
 					}
 
@@ -475,11 +475,11 @@ namespace Xamarin.Forms
 						{
 							var topPage = modalStack[i];
 
-							routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage), routeStack, hasUserDefinedRoute));
+							routeStack.AddRange(ShellUriHandler.CollapsePath(Routing.GetRoute(topPage), routeStack, hasUserDefinedRoute));
 
 							for (int j = 1; j < topPage.Navigation.NavigationStack.Count; j++)
 							{
-								routeStack.AddRange(CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack, hasUserDefinedRoute));
+								routeStack.AddRange(ShellUriHandler.CollapsePath(Routing.GetRoute(topPage.Navigation.NavigationStack[j]), routeStack, hasUserDefinedRoute));
 							}
 						}
 					}
@@ -490,45 +490,7 @@ namespace Xamarin.Forms
 				routeStack.Insert(0, "/");
 
 			return new ShellNavigationState(String.Join("/", routeStack), true);
-
-
-			List<string> CollapsePath(
-				string myRoute,
-				IEnumerable<string> currentRouteStack,
-				bool userDefinedRoute)
-			{
-				var localRouteStack = currentRouteStack.ToList();
-				for (var i = localRouteStack.Count - 1; i >= 0; i--)
-				{
-					var route = localRouteStack[i];
-					if (Routing.IsImplicit(route) ||
-						(Routing.IsDefault(route) && userDefinedRoute))
-					{
-						localRouteStack.RemoveAt(i);
-					}
-				}
-
-				var paths = myRoute.Split('/').ToList();
-
-				// collapse similar leaves
-				int walkBackCurrentStackIndex = localRouteStack.Count - (paths.Count - 1);
-
-				while (paths.Count > 1 && walkBackCurrentStackIndex >= 0)
-				{
-					if (paths[0] == localRouteStack[walkBackCurrentStackIndex])
-					{
-						paths.RemoveAt(0);
-					}
-					else
-					{
-						break;
-					}
-
-					walkBackCurrentStackIndex++;
-				}
-
-				return paths;
-			}
+			
 		}
 
 	}

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -382,7 +382,7 @@ namespace Xamarin.Forms
 					bool isLast = i == globalRoutes.Count - 1;
 					route = globalRoutes[i];
 
-					navStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
+					navStack = ShellNavigationManager.BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 
 					// if the navStack count is one that means there is nothing pushed
 					if (navStack.Count == 1)
@@ -422,7 +422,7 @@ namespace Xamarin.Forms
 								await Navigation.ModalStack[Navigation.ModalStack.Count - 1].Navigation.PopAsync(isAnimated);
 							}
 
-							navStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
+							navStack = ShellNavigationManager.BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 						}
 
 						while (_navStack.Count > popCount)
@@ -440,7 +440,7 @@ namespace Xamarin.Forms
 							}
 						}
 
-						navStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
+						navStack = ShellNavigationManager.BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 
 						IsPoppingModalStack = false;
 
@@ -475,24 +475,6 @@ namespace Xamarin.Forms
 			}
 		}
 
-		List<Page> BuildFlattenedNavigationStack(List<Page> startingList, IReadOnlyList<Page> modalStack)
-		{
-			startingList = startingList.ToList();
-			if (modalStack == null)
-				return startingList;
-
-			for (int i = 0; i < modalStack.Count; i++)
-			{
-				startingList.Add(modalStack[i]);
-				for (int j = 1; j < modalStack[i].Navigation.NavigationStack.Count; j++)
-				{
-					startingList.Add(modalStack[i].Navigation.NavigationStack[j]);
-				}
-			}
-
-			return startingList;
-		}
-
 		Page GetOrCreateFromRoute(string route, IDictionary<string, string> queryData, bool isLast, bool isPopping)
 		{
 			var content = Routing.GetOrCreateContent(route) as Page;
@@ -522,7 +504,7 @@ namespace Xamarin.Forms
 
 			List<Page> modalPageStacks = new List<Page>();
 			List<Page> nonModalPageStacks = new List<Page>();
-			var currentNavStack = BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
+			var currentNavStack = ShellNavigationManager.BuildFlattenedNavigationStack(_navStack, Navigation?.ModalStack);
 
 			// populate global routes and build modal stacks
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -443,6 +443,9 @@ namespace Xamarin.Forms
 			{
 				var collapsedRoute = String.Join(_pathSeparator, CollapsePath(routeKey, possibleRoutePath.SegmentsMatched, true));
 
+				if (routeKey.StartsWith("//"))
+					collapsedRoute = "//" + collapsedRoute;
+
 				string collapsedMatch = possibleRoutePath.GetNextSegmentMatch(collapsedRoute);
 				if (!String.IsNullOrWhiteSpace(collapsedMatch))
 				{
@@ -477,6 +480,9 @@ namespace Xamarin.Forms
 
 						var collapsedLeafRoute = String.Join(_pathSeparator, CollapsePath(routeKey, leafSearch.SegmentsMatched, true));
 
+						if (routeKey.StartsWith("//"))
+							collapsedLeafRoute = "//" + collapsedLeafRoute;
+						
 						string segmentMatch = leafSearch.GetNextSegmentMatch(collapsedLeafRoute);
 						if (!String.IsNullOrWhiteSpace(segmentMatch))
 						{

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -455,13 +455,6 @@ namespace Xamarin.Forms
 				return true;
 			}
 
-			//// See if they registered in a way that just matches the whole path
-			//if (routeKeys.Contains(possibleRoutePath.RemainingPath))
-			//{
-			//	possibleRoutePath.AddGlobalRoute(possibleRoutePath.RemainingPath, possibleRoutePath.RemainingPath);
-			//	return true;
-			//}
-
 			return false;
 		}
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -34,11 +34,7 @@ namespace Xamarin.Forms
 						break;
 					
 					pages.Remove(lastPage);
-					/*var route = Routing.GetRoute(lastPage);
-					var lastIndex = currentState.LastIndexOf(route);
-					currentState = currentState.Remove(lastIndex);*/
 
-					List<string> routes = new List<string>();
 					List<string> buildUpPages = new List<string>();
 
 					foreach(var page in pages)
@@ -57,7 +53,6 @@ namespace Xamarin.Forms
 				restOfPath.Insert(0, shell.CurrentItem.CurrentItem.Route);
 				restOfPath.Insert(0, shell.CurrentItem.Route);
 				var result = String.Join(_pathSeparator, restOfPath);
-				//var result = IOPath.Combine(currentState, destination);
 				var returnValue = ConvertToStandardFormat("scheme", "host", null, new Uri(result, UriKind.Relative));
 				return new Uri(FormatUri(returnValue.PathAndQuery), UriKind.Relative);
 			}

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -382,7 +382,7 @@ namespace Xamarin.Forms
 			// check for exact matches
 			if(routeKeys.Contains(possibleRoutePath.NextSegment))
 			{
-				possibleRoutePath.AddGlobalRoute(possibleRoutePath.RemainingPath, possibleRoutePath.RemainingPath);
+				possibleRoutePath.AddGlobalRoute(possibleRoutePath.NextSegment, possibleRoutePath.NextSegment);
 				return true;
 			}
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -426,12 +426,16 @@ namespace Xamarin.Forms
 							(possibleRoutePath.Section != null && nextNode.Section != possibleRoutePath.Section) ||
 							(possibleRoutePath.Content != null && nextNode.Content != possibleRoutePath.Content))
 						{
-							break;
+							nextNode = nextNode.WalkToNextNode();
+							continue;
 						}
 
 						var leafSearch = new RouteRequestBuilder(possibleRoutePath);
 						if (!leafSearch.AddMatch(nextNode))
-							break;
+						{
+							nextNode = nextNode.WalkToNextNode();
+							continue;
+						}
 
 						var collapsedLeafRoute = String.Join(_pathSeparator, CollapsePath(routeKey, leafSearch.SegmentsMatched, true));
 

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -21,10 +21,12 @@ namespace Xamarin.Forms
 				var currentState = shell.CurrentState.FullLocation.OriginalString;
 
 				List<string> restOfPath = new List<string>();
+				bool dotsAllParsed = false;
 				foreach(var p in path.OriginalString.Split(_pathSeparators))
 				{
-					if (p != ".." || restOfPath.Count > 0)
+					if (p != ".." || dotsAllParsed)
 					{
+						dotsAllParsed = true;
 						restOfPath.Add(p);
 						continue;
 					}

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -414,7 +414,7 @@ namespace Xamarin.Forms
 				}
 			}
 
-			var paths = myRoute.Split('/').ToList();
+			var paths = RetrievePaths(myRoute).ToList();
 
 			// collapse similar leaves
 			int walkBackCurrentStackIndex = localRouteStack.Count - (paths.Count - 1);


### PR DESCRIPTION
### Description of Change ###

Fixed Hierarchical Global Route Registration so that it would correctly apply the route registered to the current state of shell

If a user is registering full route path  `Route.Register("path1/path2/path3")` and Shell is currently at `"path1/path2"`

Then the user should be able to navigate to that route via
- `GotoAsync("path3")` or `Route.Register("path1/path2/path3")`



### Issues Resolved ### 
- fixes #13328
- fixes #11237

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
