### PR TITLE
[Tizen] Fix Frame show clipper canvas issue

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/SkiaSharp/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/SkiaSharp/FrameRenderer.cs
@@ -98,6 +98,9 @@ namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
 
 		void OnCliperPaint(object sender, SKPaintSurfaceEventArgs e)
 		{
+			if (Element.Content == null)
+				return;
+
 			var canvas = e.Surface.Canvas;
 			var bound = e.Info.Rect;
 			canvas.Clear();
@@ -114,7 +117,7 @@ namespace Xamarin.Forms.Platform.Tizen.SkiaSharp
 				canvas.DrawRoundRect(roundRect, paint);
 			}
 
-			Element.Content?.SetClipperCanvas(_clipper);
+			Element.Content.SetClipperCanvas(_clipper);
 		}
 
 		void UpdateCornerRadius()


### PR DESCRIPTION
### Description of Change ###
This PR fixes `Frame` not creating unused clipper.
The clipper only needs to be created when `Frame` has `Content`.
Otherwise, white color clipper will be unexpectedly drawn in `Frame` as background.

### Issues Resolved ### 
- N/A

### API Changes ###
- None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###

Before:
1) Frame without Content : This includes white background which is unexpected.
2) Frame with BackgroundColor which has alpha : The background blends with white background which is unexpected.
3) Frame with Content : Proper behavior.
![image](https://user-images.githubusercontent.com/14328614/103989433-0cd27300-51d3-11eb-82e6-9295d85bfb77.png)


After:
1) Frame without Content : This includes empty background. (Proper behavior.)
2) Frame with BackgroundColor which has alpha : The background blends with real background. (Proper behavior.)
3) Frame with Content : (Proper behavior.)
![image](https://user-images.githubusercontent.com/14328614/103989418-08a65580-51d3-11eb-9ffd-f1ed4ab57adb.png)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
