### PR TITLE
[iOS] Restore wheels date/time picker styles in 5.0

### DIFF
--- a/Xamarin.Forms.Platform.iOS.UnitTests/DatePickerTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/DatePickerTests.cs
@@ -10,6 +10,11 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		[Description("DatePicker should be using wheels-style picker")]
 		public async Task UsingWheelPicker() 
 		{
+			if (!Forms.IsiOS14OrNewer)
+			{
+				return;
+			}
+
 			var datePicker = new DatePicker();
 			var expected = UIKit.UIDatePickerStyle.Wheels;
 			var actual = await GetControlProperty(datePicker, uiDatePicker => uiDatePicker.PreferredDatePickerStyle);

--- a/Xamarin.Forms.Platform.iOS.UnitTests/DatePickerTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/DatePickerTests.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture]
+	public class DatePickerTests : PlatformTestFixture 
+	{
+		[Test, Category("DatePicker")]
+		[Description("DatePicker should be using wheels-style picker")]
+		public async Task UsingWheelPicker() 
+		{
+			var datePicker = new DatePicker();
+			var expected = UIKit.UIDatePickerStyle.Wheels;
+			var actual = await GetControlProperty(datePicker, uiDatePicker => uiDatePicker.PreferredDatePickerStyle);
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/PlatformTestFixture.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/PlatformTestFixture.cs
@@ -169,6 +169,75 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			});
 		}
 
+		protected UITextField GetNativeControl(DatePicker datePicker)
+		{
+			var renderer = GetRenderer(datePicker);
+			var viewRenderer = renderer.NativeView as DatePickerRenderer;
+			return viewRenderer.Control;
+		}
+
+		protected UIDatePicker GetPickerControl(DatePicker datePicker)
+		{
+			var renderer = GetRenderer(datePicker);
+			var viewRenderer = renderer.NativeView as DatePickerRenderer;
+			return viewRenderer.Picker;
+		}
+
+		protected async Task<TProperty> GetControlProperty<TProperty>(DatePicker datePicker, Func<UITextField, TProperty> getProperty)
+		{
+			return await Device.InvokeOnMainThreadAsync(() => {
+				using (var uiTextField = GetNativeControl(datePicker))
+				{
+					return getProperty(uiTextField);
+				}
+			});
+		}
+
+		protected async Task<TProperty> GetControlProperty<TProperty>(DatePicker datePicker, Func<UIDatePicker, TProperty> getProperty)
+		{
+			return await Device.InvokeOnMainThreadAsync(() => {
+				using (var uiDatePicker = GetPickerControl(datePicker))
+				{
+					return getProperty(uiDatePicker);
+				}
+			});
+		}
+
+		protected UITextField GetNativeControl(TimePicker timePicker)
+		{
+			var renderer = GetRenderer(timePicker);
+			var viewRenderer = renderer.NativeView as TimePickerRenderer;
+			return viewRenderer.Control;
+		}
+
+		protected UIDatePicker GetPickerControl(TimePicker timePicker)
+		{
+			var renderer = GetRenderer(timePicker);
+			var viewRenderer = renderer.NativeView as TimePickerRenderer;
+			return viewRenderer.Picker;
+		}
+
+		protected async Task<TProperty> GetControlProperty<TProperty>(TimePicker timePicker, Func<UITextField, TProperty> getProperty)
+		{
+			return await Device.InvokeOnMainThreadAsync(() => {
+				using (var uiTextField = GetNativeControl(timePicker))
+				{
+					return getProperty(uiTextField);
+				}
+			});
+		}
+
+		protected async Task<TProperty> GetControlProperty<TProperty>(TimePicker timePicker, Func<UIDatePicker, TProperty> getProperty)
+		{
+			return await Device.InvokeOnMainThreadAsync(() => {
+				using (var uiDatePicker = GetPickerControl(timePicker))
+				{
+					return getProperty(uiDatePicker);
+				}
+			});
+		}
+
+
 		protected async Task<TProperty> GetRendererProperty<TProperty>(View view,
 			Func<IVisualElementRenderer, TProperty> getProperty, bool requiresLayout = false)
 		{
@@ -234,5 +303,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 				Math.Abs(c1G - c2G) < tolerance &&
 				Math.Abs(c1B - c2B) < tolerance;
 		}
+
+		
 	}
 }

--- a/Xamarin.Forms.Platform.iOS.UnitTests/TimePickerTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/TimePickerTests.cs
@@ -10,6 +10,11 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		[Description("TimePicker should be using wheels-style picker")]
 		public async Task UsingWheelPicker()
 		{
+			if (!Forms.IsiOS14OrNewer)
+			{
+				return;
+			}
+
 			var timePicker = new TimePicker();
 			var expected = UIKit.UIDatePickerStyle.Wheels;
 			var actual = await GetControlProperty(timePicker, uiTimePicker => uiTimePicker.PreferredDatePickerStyle);

--- a/Xamarin.Forms.Platform.iOS.UnitTests/TimePickerTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/TimePickerTests.cs
@@ -1,0 +1,19 @@
+﻿using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+	[TestFixture]
+	public class TimePickerTests : PlatformTestFixture
+	{
+		[Test, Category("TimePicker")]
+		[Description("TimePicker should be using wheels-style picker")]
+		public async Task UsingWheelPicker()
+		{
+			var timePicker = new TimePicker();
+			var expected = UIKit.UIDatePickerStyle.Wheels;
+			var actual = await GetControlProperty(timePicker, uiTimePicker => uiTimePicker.PreferredDatePickerStyle);
+			Assert.That(actual, Is.EqualTo(expected));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -50,6 +50,7 @@
     <Compile Include="BackgroundColorTests.cs" />
     <Compile Include="ColorComparison.cs" />
     <Compile Include="CornerRadiusTests.cs" />
+    <Compile Include="DatePickerTests.cs" />
     <Compile Include="EmbeddingTests.cs" />
     <Compile Include="FlowDirectionTests.cs" />
     <Compile Include="FrameTests.cs" />
@@ -66,6 +67,7 @@
     <Compile Include="ScaleTests.cs" />
     <Compile Include="TextTests.cs" />
     <Compile Include="BackgroundTests.cs" />
+    <Compile Include="TimePickerTests.cs" />
     <Compile Include="TransformationTests.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		IElementController ElementController => Element as IElementController;
 
+		internal UIDatePicker Picker => _picker;
 
 		abstract protected override TControl CreateNativeControl();
 
@@ -73,12 +74,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 				_picker = new UIDatePicker { Mode = UIDatePickerMode.Date, TimeZone = new NSTimeZone("UTC") };
 
-#if __XCODE11__
 				if (Forms.IsiOS14OrNewer)
 				{
 					_picker.PreferredDatePickerStyle = UIKit.UIDatePickerStyle.Wheels;
 				}
-#endif
+
 				_picker.ValueChanged += HandleValueChanged;
 
 				var width = UIScreen.MainScreen.Bounds.Width;

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -31,6 +31,8 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _disposed;
 		bool _useLegacyColorManagement;
 
+		internal UIDatePicker Picker => _picker;
+
 		IElementController ElementController => Element as IElementController;
 
 		[Internals.Preserve(Conditional = true)]
@@ -83,12 +85,12 @@ namespace Xamarin.Forms.Platform.iOS
 					entry.EditingDidEnd += OnEnded;
 
 					_picker = new UIDatePicker { Mode = UIDatePickerMode.Time, TimeZone = new NSTimeZone("UTC") };
-#if __XCODE11__
+
 					if (Forms.IsiOS14OrNewer)
 					{
 						_picker.PreferredDatePickerStyle = UIKit.UIDatePickerStyle.Wheels;
 					}
-#endif
+
 					var width = UIScreen.MainScreen.Bounds.Width;
 					var toolbar = new UIToolbar(new RectangleF(0, 0, width, 44)) { BarStyle = UIBarStyle.Default, Translucent = true };
 					var spacer = new UIBarButtonItem(UIBarButtonSystemItem.FlexibleSpace);


### PR DESCRIPTION
### Description of Change ###

The check for iOS 14 and setting of the "wheels" style date/time pickers was behind an XCode 11 check which is no longer used. So both controls were defaulting to the new inline style (which the renderers do not know how to handle yet). 

These changes revert the style to the "wheels" style on iOS 14, and add tests to ensure that style remains until we're ready to revamp the renderers for inline styles.


### Issues Resolved ### 

- fixes #13331

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated platform tests

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
