### PR TITLE
Fix 4143: improved Span region calculation

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml
@@ -1,0 +1,103 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+                          xmlns:system="clr-namespace:System;assembly=mscorlib"
+                          x:Name="This"
+                          x:Class="Xamarin.Forms.Controls.Issues.Issue4143">
+
+    <StackLayout>
+        <Label 
+            Text="This test is passed if all tappable spans (blue and underlined texts) react to touches by changing its background color. Only the touched span should react and not others."/>
+
+        <Label
+            Margin="10"
+            HorizontalOptions="Center"
+            TextColor="Black"
+            BackgroundColor="CadetBlue">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Two clickable spans in one line:&#10;" />
+                    <Span
+                        x:Name="Link1"
+                        TextDecorations="Underline"
+                        Text="Link1"
+                        TextColor="Blue">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnLink1Tapped"/>
+                        </Span.GestureRecognizers>
+                    </Span>
+                    <Span Text=" " />
+                    <Span
+                        x:Name="Link2"
+                        Text="Link2&#10;"
+                          TextDecorations="Underline"
+                          TextColor="Blue">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnLink2Tapped" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                    
+                    <Span Text="Multiline tappable span:&#10;" />
+                    <Span
+                        x:Name="Link3"
+                        TextDecorations="Underline"
+                        Text="Link3_1&#10;Link3_2"
+                        TextColor="Blue">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnLink3Tapped" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+
+        <Label 
+            Margin="10"
+            HorizontalOptions="Center"
+            VerticalOptions="CenterAndExpand"
+            Padding="10,20"
+            BackgroundColor="CadetBlue">
+            
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="Clickable Span in a Label with padding:&#10;" />
+                    <Span
+                        x:Name="Link4"
+                        Text="Link4"
+                          TextDecorations="Underline"
+                          TextColor="Blue">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnLink4Tapped"/>
+                        </Span.GestureRecognizers>
+                    </Span>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+        
+        <Label 
+            Margin = "10"
+            FlowDirection="RightToLeft" 
+            TextColor="Black"
+            BackgroundColor="CadetBlue">
+
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي." />
+                    <Span Text="{x:Static system:Environment.NewLine}"/>
+                    <Span
+                        x:Name="Link5"
+                        Text="و سأعرض مثال حي لهذا، من منا لم يتحمل جهد بدني شاق إلا من أجل الحصول على ميزة أو فائدة؟ ولكن من لديه الحق أن ينتقد شخص ما أراد أن يشعر بالسعادة التي لا تشوبها عواقب أليمة أو آخر أراد أن يتجنب الألم الذي ربما تنجم عنه بعض المتعة ؟ "
+                        TextDecorations="Underline"
+                        TextColor="Blue">
+                        <Span.GestureRecognizers>
+                            <TapGestureRecognizer Tapped="OnLink5Tapped" />
+                        </Span.GestureRecognizers>
+                    </Span>
+                    <Span Text="علي الجانب الآخر نشجب ونستنكر هؤلاء الرجال المفتونون بنشوة اللحظة الهائمون في رغباتهم فلا يدركون ما يعقبها من الألم والأسي المحتم، واللوم كذلك يشمل هؤلاء الذين أخفقوا في واجباتهم نتيجة لضعف إرادتهم فيتساوي مع هؤلاء الذين يتجنبون وينأون عن تحمل الكدح والألم ." />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml
@@ -6,98 +6,100 @@
                           x:Name="This"
                           x:Class="Xamarin.Forms.Controls.Issues.Issue4143">
 
-    <StackLayout>
-        <Label 
-            Text="This test is passed if all tappable spans (blue and underlined texts) react to touches by changing its background color. Only the touched span should react and not others."/>
+    <ScrollView>
+        <StackLayout>
+            <Label 
+                Text="This test is passed if all tappable spans (blue and underlined texts) react to touches by changing its background color. Only the touched span should react and not others."/>
 
-        <Label
-            Margin="10"
-            HorizontalOptions="Center"
-            TextColor="Black"
-            BackgroundColor="CadetBlue">
-            <Label.FormattedText>
-                <FormattedString>
-                    <Span Text="Two clickable spans in one line:&#10;" />
-                    <Span
-                        x:Name="Link1"
-                        TextDecorations="Underline"
-                        Text="Link1"
-                        TextColor="Blue">
-                        <Span.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnLink1Tapped"/>
-                        </Span.GestureRecognizers>
-                    </Span>
-                    <Span Text=" " />
-                    <Span
-                        x:Name="Link2"
-                        Text="Link2&#10;"
-                          TextDecorations="Underline"
-                          TextColor="Blue">
-                        <Span.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnLink2Tapped" />
-                        </Span.GestureRecognizers>
-                    </Span>
-                    
-                    <Span Text="Multiline tappable span:&#10;" />
-                    <Span
-                        x:Name="Link3"
-                        TextDecorations="Underline"
-                        Text="Link3_1&#10;Link3_2"
-                        TextColor="Blue">
-                        <Span.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnLink3Tapped" />
-                        </Span.GestureRecognizers>
-                    </Span>
-                </FormattedString>
-            </Label.FormattedText>
-        </Label>
+            <Label
+                Margin="10"
+                HorizontalOptions="Center"
+                TextColor="Black"
+                BackgroundColor="CadetBlue">
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="Two clickable spans in one line:&#10;" />
+                        <Span
+                            x:Name="Link1"
+                            TextDecorations="Underline"
+                            Text="Link1"
+                            TextColor="Blue">
+                            <Span.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnLink1Tapped"/>
+                            </Span.GestureRecognizers>
+                        </Span>
+                        <Span Text=" " />
+                        <Span
+                            x:Name="Link2"
+                            Text="Link2&#10;"
+                              TextDecorations="Underline"
+                              TextColor="Blue">
+                            <Span.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnLink2Tapped" />
+                            </Span.GestureRecognizers>
+                        </Span>
 
-        <Label 
-            Margin="10"
-            HorizontalOptions="Center"
-            VerticalOptions="CenterAndExpand"
-            Padding="10,20"
-            BackgroundColor="CadetBlue">
-            
-            <Label.FormattedText>
-                <FormattedString>
-                    <Span Text="Clickable Span in a Label with padding:&#10;" />
-                    <Span
-                        x:Name="Link4"
-                        Text="Link4"
-                          TextDecorations="Underline"
-                          TextColor="Blue">
-                        <Span.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnLink4Tapped"/>
-                        </Span.GestureRecognizers>
-                    </Span>
-                </FormattedString>
-            </Label.FormattedText>
-        </Label>
-        
-        <Label 
-            Margin = "10"
-            FlowDirection="RightToLeft" 
-            TextColor="Black"
-            BackgroundColor="CadetBlue">
+                        <Span Text="Multiline tappable span:&#10;" />
+                        <Span
+                            x:Name="Link3"
+                            TextDecorations="Underline"
+                            Text="Link3_1&#10;Link3_2"
+                            TextColor="Blue">
+                            <Span.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnLink3Tapped" />
+                            </Span.GestureRecognizers>
+                        </Span>
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
 
-            <Label.FormattedText>
-                <FormattedString>
-                    <Span Text="لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي." />
-                    <Span Text="{x:Static system:Environment.NewLine}"/>
-                    <Span
-                        x:Name="Link5"
-                        Text="و سأعرض مثال حي لهذا، من منا لم يتحمل جهد بدني شاق إلا من أجل الحصول على ميزة أو فائدة؟ ولكن من لديه الحق أن ينتقد شخص ما أراد أن يشعر بالسعادة التي لا تشوبها عواقب أليمة أو آخر أراد أن يتجنب الألم الذي ربما تنجم عنه بعض المتعة ؟ "
-                        TextDecorations="Underline"
-                        TextColor="Blue">
-                        <Span.GestureRecognizers>
-                            <TapGestureRecognizer Tapped="OnLink5Tapped" />
-                        </Span.GestureRecognizers>
-                    </Span>
-                    <Span Text="علي الجانب الآخر نشجب ونستنكر هؤلاء الرجال المفتونون بنشوة اللحظة الهائمون في رغباتهم فلا يدركون ما يعقبها من الألم والأسي المحتم، واللوم كذلك يشمل هؤلاء الذين أخفقوا في واجباتهم نتيجة لضعف إرادتهم فيتساوي مع هؤلاء الذين يتجنبون وينأون عن تحمل الكدح والألم ." />
-                </FormattedString>
-            </Label.FormattedText>
-        </Label>
+            <Label 
+                Margin="10"
+                HorizontalOptions="Center"
+                VerticalOptions="CenterAndExpand"
+                Padding="10,20"
+                BackgroundColor="CadetBlue">
 
-    </StackLayout>
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="Clickable Span in a Label with padding:&#10;" />
+                        <Span
+                            x:Name="Link4"
+                            Text="Link4"
+                              TextDecorations="Underline"
+                              TextColor="Blue">
+                            <Span.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnLink4Tapped"/>
+                            </Span.GestureRecognizers>
+                        </Span>
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+
+            <Label 
+                Margin = "10"
+                FlowDirection="RightToLeft" 
+                TextColor="Black"
+                BackgroundColor="CadetBlue">
+
+                <Label.FormattedText>
+                    <FormattedString>
+                        <Span Text="لكن لا بد أن أوضح لك أن كل هذه الأفكار المغلوطة حول استنكار  النشوة وتمجيد الألم نشأت بالفعل، وسأعرض لك التفاصيل لتكتشف حقيقة وأساس تلك السعادة البشرية، فلا أحد يرفض أو يكره أو يتجنب الشعور بالسعادة، ولكن بفضل هؤلاء الأشخاص الذين لا يدركون بأن السعادة لا بد أن نستشعرها بصورة أكثر عقلانية ومنطقية فيعرضهم هذا لمواجهة الظروف الأليمة، وأكرر بأنه لا يوجد من يرغب في الحب ونيل المنال ويتلذذ بالآلام، الألم هو الألم ولكن نتيجة لظروف ما قد تكمن السعاده فيما نتحمله من كد وأسي." />
+                        <Span Text="{x:Static system:Environment.NewLine}"/>
+                        <Span
+                            x:Name="Link5"
+                            Text="و سأعرض مثال حي لهذا، من منا لم يتحمل جهد بدني شاق إلا من أجل الحصول على ميزة أو فائدة؟ ولكن من لديه الحق أن ينتقد شخص ما أراد أن يشعر بالسعادة التي لا تشوبها عواقب أليمة أو آخر أراد أن يتجنب الألم الذي ربما تنجم عنه بعض المتعة ؟ "
+                            TextDecorations="Underline"
+                            TextColor="Blue">
+                            <Span.GestureRecognizers>
+                                <TapGestureRecognizer Tapped="OnLink5Tapped" />
+                            </Span.GestureRecognizers>
+                        </Span>
+                        <Span Text="علي الجانب الآخر نشجب ونستنكر هؤلاء الرجال المفتونون بنشوة اللحظة الهائمون في رغباتهم فلا يدركون ما يعقبها من الألم والأسي المحتم، واللوم كذلك يشمل هؤلاء الذين أخفقوا في واجباتهم نتيجة لضعف إرادتهم فيتساوي مع هؤلاء الذين يتجنبون وينأون عن تحمل الكدح والألم ." />
+                    </FormattedString>
+                </Label.FormattedText>
+            </Label>
+
+        </StackLayout>
+    </ScrollView>
 </controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml.cs
@@ -1,0 +1,72 @@
+﻿using System;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 4143, "Span inaccuracies", PlatformAffected.Android)]
+	public partial class Issue4143 : TestContentPage
+	{
+		Color[] _colors = new Color[]{ Color.Red, Color.Blue, Color.Green, Color.Yellow, Color.Brown, Color.Purple, Color.Orange, Color.Gray };
+		Random _rand = new Random();
+
+		protected override void Init()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+#if APP		
+		void OnLink1Tapped(object sender, EventArgs e)
+		{
+			SetRandomBackgroundColor(Link1);
+		}
+		void OnLink2Tapped(object sender, EventArgs e)
+		{
+			SetRandomBackgroundColor(Link2);
+		}
+		void OnLink3Tapped(object sender, EventArgs e)
+		{
+			SetRandomBackgroundColor(Link3);
+		}
+		void OnLink4Tapped(object sender, EventArgs e)
+		{
+			SetRandomBackgroundColor(Link4);
+		}
+		void OnLink5Tapped(object sender, EventArgs e)
+		{
+			SetRandomBackgroundColor(Link5);
+		}
+#endif
+
+		void SetRandomBackgroundColor(Span span)
+		{
+			var oldColor = span.BackgroundColor;
+			Color newColor;
+			do
+			{
+				newColor = _colors[_rand.Next(_colors.Length)];
+			} while(oldColor == newColor);
+
+			span.BackgroundColor = newColor;
+		}
+
+		//ToDo:
+		/*
+#if UITEST
+		[Test]
+		public void Issue4143Test ()
+		{
+			RunningApp.TapCoordinates();
+		}
+#endif
+		*/
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue4143.xaml.cs
@@ -57,16 +57,5 @@ namespace Xamarin.Forms.Controls.Issues
 
 			span.BackgroundColor = newColor;
 		}
-
-		//ToDo:
-		/*
-#if UITEST
-		[Test]
-		public void Issue4143Test ()
-		{
-			RunningApp.TapCoordinates();
-		}
-#endif
-		*/
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -862,6 +862,9 @@
       <DependentUpon>Issue5268.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue4143.xaml.cs">
+      <DependentUpon>Issue4143.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue6713.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6705.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)LegacyComponents\NonAppCompatSwitch.cs" />
@@ -2617,6 +2620,10 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)ShellFlyoutItemIsVisible.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4143.xaml">
+        <SubType>Designer</SubType>
+        <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Core/Region.cs
+++ b/Xamarin.Forms.Core/Region.cs
@@ -1,5 +1,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace Xamarin.Forms
 {
@@ -20,6 +21,12 @@ namespace Xamarin.Forms
 		Region(IList<Rectangle> positions, Thickness inflation) : this(positions)
 		{
 			_inflation = inflation;
+		}
+		
+		public static Region FromRectangles(IEnumerable<Rectangle> rectangles)
+		{
+			var list = rectangles.ToList();
+			return new Region(list);
 		}
 
 		public static Region FromLines(double[] lineHeights, double maxWidth, double startX, double endX, double startY)

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -121,12 +121,13 @@ namespace Xamarin.Forms.Platform.Android
 				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
 				var spanEndLine = layout.GetLineForOffset(spanEndOffset);
 				
-				//go through all lines that are affected by the span and calculate an rectangle for each
+				// go through all lines that are affected by the span and calculate a rectangle for each
 				var spanRectangles = new List<Rectangle>();
 				for (var curLine = spanStartLine; curLine <= spanEndLine; curLine++)
 				{
 					global::Android.Graphics.Rect bounds = new global::Android.Graphics.Rect();
 					layout.GetLineBounds(curLine, bounds);
+					
 					var lineHeight = bounds.Height();
 					var lineStartOffset = layout.GetLineStart(curLine);
 					var lineVisibleEndOffset = layout.GetLineVisibleEnd(curLine);
@@ -139,7 +140,7 @@ namespace Xamarin.Forms.Platform.Android
 
 					var spanWidth = spanEndX - spanStartX;
 					var spanLeftX = spanStartX;
-					//if rtl is used, startX would be bigger than endX
+					// if rtl is used, startX would be bigger than endX
 					if (spanStartX > spanEndX)
 					{
 						spanWidth = spanStartX - spanEndX;

--- a/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/TextViewExtensions.cs
@@ -90,8 +90,11 @@ namespace Xamarin.Forms.Platform.Android
 
 			int next = 0;
 			int count = 0;
-			IList<int> totalLineHeights = new List<int>();
 
+			var padding = element.Padding;
+			var padLeft = (int)textView.Context.ToPixels(padding.Left);
+			var padTop = (int)textView.Context.ToPixels(padding.Top);
+			
 			for (int i = 0; i < spannableString.Length(); i = next)
 			{
 				var type = Java.Lang.Class.FromType(typeof(Java.Lang.Object));
@@ -108,47 +111,49 @@ namespace Xamarin.Forms.Platform.Android
 
 				// get all spans in the range - Android can have overlapping spans				
 				var spans = spannableString.GetSpans(i, next, type);
-
+				
 				var startSpan = spans[0];
 				var endSpan = spans[spans.Length - 1];
 
-				var startSpanOffset = spannableString.GetSpanStart(startSpan);
-				var endSpanOffset = spannableString.GetSpanEnd(endSpan);
+				var spanStartOffset = spannableString.GetSpanStart(startSpan);
+				var spanEndOffset = spannableString.GetSpanEnd(endSpan);
 
-				var thisLine = layout.GetLineForOffset(endSpanOffset);
-				var lineStart = layout.GetLineStart(thisLine);
-				var lineEnd = layout.GetLineEnd(thisLine);
-
-				//If this is true, endSpanOffset has the value for another line that belong to the next span and not it self. 
-				//So it should be rearranged to value not pass the lineEnd.
-				if (endSpanOffset > (lineEnd - lineStart))
-					endSpanOffset = lineEnd;
-
-				var startX = layout.GetPrimaryHorizontal(startSpanOffset);
-				var endX = layout.GetPrimaryHorizontal(endSpanOffset);
-
-				var startLine = layout.GetLineForOffset(startSpanOffset);
-				var endLine = layout.GetLineForOffset(endSpanOffset);
-
-				double[] lineHeights = new double[endLine - startLine + 1];
-
-				// calculate all the different line heights
-				for (var lineCount = startLine; lineCount <= endLine; lineCount++)
+				var spanStartLine = layout.GetLineForOffset(spanStartOffset);
+				var spanEndLine = layout.GetLineForOffset(spanEndOffset);
+				
+				//go through all lines that are affected by the span and calculate an rectangle for each
+				var spanRectangles = new List<Rectangle>();
+				for (var curLine = spanStartLine; curLine <= spanEndLine; curLine++)
 				{
-					var lineHeight = layout.GetLineBottom(lineCount) - layout.GetLineTop(lineCount);
-					lineHeights[lineCount - startLine] = lineHeight;
+					global::Android.Graphics.Rect bounds = new global::Android.Graphics.Rect();
+					layout.GetLineBounds(curLine, bounds);
+					var lineHeight = bounds.Height();
+					var lineStartOffset = layout.GetLineStart(curLine);
+					var lineVisibleEndOffset = layout.GetLineVisibleEnd(curLine);
+					
+					var startOffset = (curLine == spanStartLine) ? spanStartOffset : lineStartOffset;
+					var spanStartX = (int)layout.GetPrimaryHorizontal(startOffset);
 
-					if (totalLineHeights.Count <= lineCount)
-						totalLineHeights.Add(lineHeight);
+					var endOffset = (curLine == spanEndLine) ? spanEndOffset : lineVisibleEndOffset;;
+					var spanEndX = (int)layout.GetSecondaryHorizontal(endOffset);
+
+					var spanWidth = spanEndX - spanStartX;
+					var spanLeftX = spanStartX;
+					//if rtl is used, startX would be bigger than endX
+					if (spanStartX > spanEndX)
+					{
+						spanWidth = spanStartX - spanEndX;
+						spanLeftX = spanEndX;
+					}
+
+					if (spanWidth > 1)
+					{
+						var rectangle = new Rectangle(spanLeftX + padLeft, bounds.Top + padTop, spanWidth, lineHeight);
+						spanRectangles.Add(rectangle);
+					}
 				}
 
-				var yaxis = 0.0;
-
-
-				for (var line = startLine; line > 0; line--)
-					yaxis += totalLineHeights[line];
-
-				((ISpatialElement)span).Region = Region.FromLines(lineHeights, labelWidth, startX, endX, yaxis).Inflate(10);
+				((ISpatialElement)span).Region = Region.FromRectangles(spanRectangles).Inflate(10);
 			}
 		}
 	}


### PR DESCRIPTION
### Description of Change ###
There are a lot of problems that are connected to the incorrect calculation of the region of a Span, especially on Android. This causes diffferent effects like calling two commands with one tap due to overlapping regions or the reacting area for the tap is not where it is supposed to be.

This PR is an attempt to fix those problems currently for Android only. To completely fix #4143 some problems on iOS need to be fixed to and I am willing to fix them too, but I would like to discuss my Android approach here first with this PR.

### Issues Resolved ### 

- fixes #4143 (on Android)
- fixes #6992
- fixes #11650
- fixes #7655 (on Android)
- fixes #11657
- fixes #10520 (on Android) (not tested)
- fixes #4829 (on Android)

### API Changes ###
Added:
 - static Region Region.FromRectangles(IEnumerable<Rectangle> rectangles)


### Platforms Affected ### 

- [x] Android
- [ ] iOS (would add it later, depending on the discussion) 

### Behavioral/Visual Changes ###
Some regions now might be shorter, because certain lines were tappable as a whole. Now, it should only go as far as there is some visible character. 


### Before/After Screenshots ### 
There are no visual changes but in order to verify my code I added code to the LabelRenderer that would draw rectangles around the span regions. Here are the drawn regions before and after my code changes and with and without region inflation:

**Current State:**
![unfixed_inflated](https://user-images.githubusercontent.com/12396893/104062073-0f948e80-51fa-11eb-97df-6585073a337e.png)

**Fixed State:**
![fixed_inflated](https://user-images.githubusercontent.com/12396893/104062078-11f6e880-51fa-11eb-9c17-dc527ed380bf.png)

**Current State without inflation:**
![unfixed_not_inflated](https://user-images.githubusercontent.com/12396893/104062077-10c5bb80-51fa-11eb-97bd-7c594025f926.png)

**Fixed State without inflation:**
![fixed_not_inflated](https://user-images.githubusercontent.com/12396893/104062079-128f7f00-51fa-11eb-8d66-cd9bb75c35e9.png)

I am not sure if the exisiting region inflation is working as it should, so that's why I put uninflated examples here for better comparison.

### Testing Procedure ###
I created a Test Case in the Android ControlGallery (Issue4143). There are three Labels with text in it and some texts are colored blue to determine a tappable Span. If such a Span is tapped, its background color should change. Make sure that only the tapped Span changes its background color. Also make sure that tapping outside of blue text areas does not trigger any color changes.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
