### PR TITLE
Use internal tag android

### DIFF
--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/AppCompat/CheckBoxRendererBase.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/AppCompat/CheckBoxRendererBase.cs
@@ -48,7 +48,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			SoundEffectsEnabled = false;
 			SetOnCheckedChangeListener(this);
-			Tag = this;
+			SetTag(Resource.Id.maui_internal_tag, this);
 			OnFocusChangeListener = this;
 
 			this.SetClipToOutline(true);

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/AppCompat/ImageButtonRenderer.cs
@@ -69,7 +69,7 @@ namespace Xamarin.Forms.Platform.Android
 			OnFocusChangeListener = this;
 
 			// Setting the tag will break Glide
-			// Tag = this;
+			// SetTag(Resource.Id.maui_internal_tag, this);
 
 			_backgroundTracker = new BorderBackgroundManager(this, false);
 		}

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/AppCompat/RadioButtonRenderer.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/AppCompat/RadioButtonRenderer.cs
@@ -240,7 +240,7 @@ namespace Xamarin.Forms.Platform.Android
 			OnFocusChangeListener = this;
 			SetOnCheckedChangeListener(this);
 
-			Tag = this;
+			SetTag(Resource.Id.maui_internal_tag, this);
 		}
 
 		void UpdateFont()

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Cells/CellRenderer.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Cells/CellRenderer.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (convertView != null)
 			{
-				Object tag = convertView.Tag;
+				Object tag = convertView.GetTag(Resource.Id.maui_internal_tag);
 				CellRenderer renderer = (tag as RendererHolder)?.Renderer;
 
 				Cell oldCell = renderer?.Cell;
@@ -52,9 +52,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			WireUpForceUpdateSizeRequested(item, view);
 
-			var holder = view.Tag as RendererHolder;
+			var holder = view.GetTag(Resource.Id.maui_internal_tag) as RendererHolder;
 			if (holder == null)
-				view.Tag = new RendererHolder(this);
+				view.SetTag(Resource.Id.maui_internal_tag, new RendererHolder(this));
 			else
 				holder.Renderer = this;
 

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/FastRenderers/ButtonRenderer.cs
@@ -312,7 +312,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			AddOnAttachStateChangeListener(this);
 			OnFocusChangeListener = this;
 
-			Tag = this;
+			SetTag(Resource.Id.maui_internal_tag, this);
 		}
 
 		void UpdateFont()

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
@@ -308,7 +308,7 @@ namespace Xamarin.Forms.Platform.Android
 		AImageButton CreateImageButton(Context context, BindableObject bindable, BindableProperty property, int defaultImage, int leftMargin, int rightMargin, string tag)
 		{
 			var result = new AImageButton(context);
-			result.Tag = tag;
+			result.SetTag(Resource.Id.maui_internal_tag, tag);
 			result.SetPadding(0, 0, 0, 0);
 			result.Focusable = false;
 			result.SetScaleType(ImageView.ScaleType.FitCenter);

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Resources/values/ids.xml
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Resources/values/ids.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <item type="id" name="maui_internal_tag" />
+</resources>

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/StepperRendererManager.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/StepperRendererManager.cs
@@ -18,10 +18,10 @@ namespace Xamarin.Forms.Platform.Android
 			upButton.Focusable = true;
 
 			downButton.Gravity = GravityFlags.Center;
-			downButton.Tag = renderer as Java.Lang.Object;
+			downButton.SetTag(Resource.Id.maui_internal_tag, renderer as Java.Lang.Object);
 			downButton.SetOnClickListener(StepperListener.Instance);
 			upButton.Gravity = GravityFlags.Center;
-			upButton.Tag = renderer as Java.Lang.Object;
+			upButton.SetTag(Resource.Id.maui_internal_tag, renderer as Java.Lang.Object);
 			upButton.SetOnClickListener(StepperListener.Instance);
 
 			// IMPORTANT:
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			public void OnClick(AView v)
 			{
-				if (!(v?.Tag is IStepperRenderer renderer))
+				if (!(v?.GetTag(Resource.Id.maui_internal_tag) is IStepperRenderer renderer))
 					return;
 
 				if (!(renderer?.Element is Stepper stepper))

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -31,6 +31,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\values\attrs.xml" />
+    <None Remove="Resources\values\ids.xml" />
   </ItemGroup>
   <ItemGroup>
     <Compile Include="..\..\..\Forms\src\Xamarin.Forms.Core\Crc64.cs" Link="Crc64.cs" />


### PR DESCRIPTION
### Description of Change ###

1. Added an Android resource identifier `maui_internal_tag` for use with `GetTag(int, Object)` and `SetTag(int, Object)` where `int` is required to be an android resource identifier.

2. Updated all usages of `.Tag` on Android to instead use `SetTag` and `GetTag` with the `maui_internal_tag` resource id so that `Tag` is free for other uses.


### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###


### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
