### PR TITLE
Invalidate CollectionView Layout on transition to IsVisible = true

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
@@ -1,0 +1,76 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13203, "[Bug] [iOS] CollectionView does not bind to items if `IsVisible=False`", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+	public class Issue13203 : TestContentPage
+	{
+		const string RunTest = "RunTest";
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var cv = new CollectionView
+			{
+				IsVisible = false,
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding(nameof(Item.Text)));
+					return label;
+				})
+			};
+
+			var source = new List<Item> { new Item { Text = Success } };
+			cv.ItemsSource = source;
+
+			var button = new Button { Text = "Set IsVisible to True", AutomationId = RunTest };
+
+			var layout = new StackLayout
+			{
+				Children = { button, cv }
+			};
+
+			button.Clicked += (sender, args) => {
+				cv.IsVisible = true;
+			};
+
+			Content = layout;
+
+			Appearing += (sender, args) => { cv.IsVisible = true; };
+		}
+
+		class Item
+		{
+			public string Text { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void SettingGroupedCollectionViewItemSourceNullShouldNotCrash()
+		{
+			RunningApp.WaitForElement(RunTest);
+			RunningApp.Tap(RunTest);
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
@@ -5,13 +5,11 @@ using System.Text;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
-
 #if UITEST
 using Xamarin.UITest;
 using NUnit.Framework;
 using Xamarin.Forms.Core.UITests;
 #endif
-
 
 namespace Xamarin.Forms.Controls.Issues
 {
@@ -21,7 +19,6 @@ namespace Xamarin.Forms.Controls.Issues
 #endif
 	public class Issue13203 : TestContentPage
 	{
-		const string RunTest = "RunTest";
 		const string Success = "Success";
 
 		protected override void Init()
@@ -40,19 +37,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var source = new List<Item> { new Item { Text = Success } };
 			cv.ItemsSource = source;
-
-			var button = new Button { Text = "Set IsVisible to True", AutomationId = RunTest };
-
-			var layout = new StackLayout
-			{
-				Children = { button, cv }
-			};
-
-			button.Clicked += (sender, args) => {
-				cv.IsVisible = true;
-			};
-
-			Content = layout;
+			Content = cv;
 
 			Appearing += (sender, args) => { cv.IsVisible = true; };
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
@@ -51,8 +51,6 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void SettingGroupedCollectionViewItemSourceNullShouldNotCrash()
 		{
-			RunningApp.WaitForElement(RunTest);
-			RunningApp.Tap(RunTest);
 			RunningApp.WaitForElement(Success);
 		}
 #endif

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -38,6 +38,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue12246.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8613.cs" />
+<Compile Include="$(MSBuildThisFileDirectory)Issue13203.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue9137.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8691.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue7606.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -59,6 +59,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
+				ItemsView.PropertyChanged -= ItemsViewPropertyChanged;
+
 				ItemsSource?.Dispose();
 				CollectionView.Delegate = null;
 				Delegator?.Dispose();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using CoreGraphics;
 using Foundation;
 using UIKit;
@@ -27,6 +28,8 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			ItemsView = itemsView;
 			ItemsViewLayout = layout;
+
+			ItemsView.PropertyChanged += ItemsViewPropertyChanged;
 		}
 
 		public void UpdateLayout(ItemsViewLayout newLayout)
@@ -456,6 +459,17 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateTemplatedCell(templatedCell, indexPath);
 
 			return templatedCell;
+		}
+
+		void ItemsViewPropertyChanged(object sender, PropertyChangedEventArgs changedProperty) 
+		{
+			if (changedProperty.Is(VisualElement.IsVisibleProperty))
+			{
+				if (ItemsView.IsVisible)
+				{
+					Layout.InvalidateLayout();
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

If the CollectionView is the root Content element for a page on iOS and IsVisible transitions from false to true, the CollectionView's layout is not invalidating. This change invalidates the layout so that the CollectionView is refreshed.

Note that this isn't an issue if the CollectionView is inside some other view (e.g., a StackLayout); it's only an issue if it's the root of the page Content.

### Issues Resolved ### 

- fixes #13203

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated UI test

### PR Checklist ###

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
