### PR TITLE
FlyoutContent should return type object

### DIFF
--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1208,9 +1208,9 @@ namespace Xamarin.Forms
 
 		View _flyoutContentView;
 
-		public View FlyoutContent
+		public object FlyoutContent
 		{
-			get => (View)GetValue(FlyoutContentProperty);
+			get => GetValue(FlyoutContentProperty);
 			set => SetValue(FlyoutContentProperty, value);
 		}
 


### PR DESCRIPTION
### Description of Change ###
Like it's related properties (FlyoutHeader/FlyoutFooter) the FlyoutContent should be returning type object and not View

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- tests run

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
