### PR TITLE
Remove unnecessary edge inset for vertically scrolling groups; Fixes …

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GridGrouping.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/GroupingGalleries/GridGrouping.xaml
@@ -9,7 +9,7 @@
         <CollectionView x:Name="CollectionView" IsGrouped="True" Header="This is a header" Footer="This is a footer.">
 
             <CollectionView.ItemsLayout>
-                <GridItemsLayout Span="2" Orientation="Vertical"></GridItemsLayout>
+                <GridItemsLayout Span="2" HorizontalItemSpacing="5" Orientation="Vertical"></GridItemsLayout>
             </CollectionView.ItemsLayout>
             
             <CollectionView.ItemTemplate>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -217,34 +217,24 @@ namespace Xamarin.Forms.Platform.iOS
 				return uIEdgeInsets;
 			}
 
-			// If we're grouping, we'll need to inset the sections to maintain the item spacing between the 
-			// groups and/or their group headers/footers
+			// If we're grouping, we'll need to inset the sections to maintain the spacing between the 
+			// groups and their group headers/footers
 
-			var itemsLayout = ItemsView.ItemsLayout;
-			var scrollDirection = itemsViewLayout.ScrollDirection;
-			nfloat lineSpacing = itemsViewLayout.GetMinimumLineSpacingForSection(collectionView, itemsViewLayout, section);
+			nfloat spacing = itemsViewLayout.GetMinimumLineSpacingForSection(collectionView, itemsViewLayout, section);
 
-			if (itemsLayout is GridItemsLayout)
+			var top = uIEdgeInsets.Top;
+			var left = uIEdgeInsets.Left;
+
+			if (itemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
 			{
-				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
-				{
-					nfloat itemSpacing = itemsViewLayout.GetMinimumInteritemSpacingForSection(collectionView, itemsViewLayout, section);
-
-					return new UIEdgeInsets(uIEdgeInsets.Top, itemSpacing + uIEdgeInsets.Left,
-						uIEdgeInsets.Bottom, uIEdgeInsets.Right);
-				}
-
-				return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left,
-					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
+				left += spacing;
+			}
+			else
+			{
+				top += spacing;
 			}
 
-			if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
-			{
-				return new UIEdgeInsets(uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left,
-					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
-			}
-
-			return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left,
+			return new UIEdgeInsets(top, left,
 				uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GroupableItemsViewController.cs
@@ -226,15 +226,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (itemsLayout is GridItemsLayout)
 			{
-				nfloat itemSpacing = itemsViewLayout.GetMinimumInteritemSpacingForSection(collectionView, itemsViewLayout, section);
-
 				if (scrollDirection == UICollectionViewScrollDirection.Horizontal)
 				{
-					return new UIEdgeInsets(itemSpacing + uIEdgeInsets.Top, lineSpacing + uIEdgeInsets.Left,
+					nfloat itemSpacing = itemsViewLayout.GetMinimumInteritemSpacingForSection(collectionView, itemsViewLayout, section);
+
+					return new UIEdgeInsets(uIEdgeInsets.Top, itemSpacing + uIEdgeInsets.Left,
 						uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 				}
 
-				return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, itemSpacing + uIEdgeInsets.Left,
+				return new UIEdgeInsets(lineSpacing + uIEdgeInsets.Top, uIEdgeInsets.Left,
 					uIEdgeInsets.Bottom, uIEdgeInsets.Right);
 			}
 


### PR DESCRIPTION
### Description of Change ###

The UIEdgeInsets adjustment to make spacing between group headers and the group itself was adding the horizontal item spacing value to the left edge of vertically scrolling groups. These changes remove that unnecessary extra space (which, in addition to making the left edge of the group offset incorrectly, also would cause the last column of a grid layout to move to the next row).

### Issues Resolved ### 

- fixes #13347

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Control Gallery -> CollectionView Gallery -> Grouping Galleries -> Grouping, Grid

There should be two columns of items in each group; if there's just one, this is still broken.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
