### PR TITLE
[iOS] Fix NRE in ViewRenderer.LayoutSubviews

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -74,7 +74,7 @@ namespace Xamarin.Forms.Platform.MacOS
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
-			if (Control != null)
+			if (Control != null && Element != null)
 				Control.Frame = new RectangleF(0, 0, (nfloat)Element.Width, (nfloat)Element.Height);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Protect against Element being null and causing trouble like it did in #13136. 

### API Changes ###

Changed:
 - `if(Control != null)` => `if(Control != null && Element != null)`
 

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I was not able to duplicate this locally but my clients could repeatedly duplicate it on certain devices. After pushing this change to them the crashes stopped.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
