### PR TITLE
Make RadioButton default template's ContentPresenter fill the Frame

### DIFF
--- a/Xamarin.Forms.Core/RadioButton.cs
+++ b/Xamarin.Forms.Core/RadioButton.cs
@@ -477,8 +477,8 @@ namespace Xamarin.Forms
 
 			var contentPresenter = new ContentPresenter
 			{
-				HorizontalOptions = LayoutOptions.Center,
-				VerticalOptions = LayoutOptions.Center
+				HorizontalOptions = LayoutOptions.Fill,
+				VerticalOptions = LayoutOptions.Fill
 			};
 
 			contentPresenter.SetBinding(MarginProperty, new Binding("Padding", source: RelativeBindingSource.TemplatedParent));


### PR DESCRIPTION
### Description of Change ###

The ContentPresenter inside the Frame for the default RadioButton template was centered, rather than filling the Frame as expected. These changes make the ContentPresenter fill the Frame.

### Issues Resolved ### 

- fixes #13374

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Before:

![before](https://user-images.githubusercontent.com/538025/104380442-3e578100-54e8-11eb-9efb-1c09d2911a44.png)

After:

![after](https://user-images.githubusercontent.com/538025/104380640-8d9db180-54e8-11eb-8e19-410684a14062.png)


### Testing Procedure ###

Control Gallery -> RadioButton Gallery -> RadioButton Content

The "Option A" text on the first RadioButton should be left-aligned, not centered.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
