### PR TITLE
Fix parsing of azure devops unit test filters

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -978,6 +978,25 @@ Task("_cg-ios-run-tests")
                 }
             };
 
+        if(isCIBuild)
+        {
+            Information("defaults write com.apple.CrashReporter DialogType none");
+            IEnumerable<string> redirectedStandardOutput;
+            StartProcess("defaults", 
+                new ProcessSettings {
+                    Arguments = new ProcessArgumentBuilder().Append(@"write com.apple.CrashReporter DialogType none"),
+                    RedirectStandardOutput = true
+                },
+                out redirectedStandardOutput
+            );
+
+
+            foreach (var item in redirectedStandardOutput)
+            {
+                Information(item);
+            }
+        }
+
         RunTests(IOS_TEST_LIBRARY, settings, ctx);
     });
 

--- a/build.cake
+++ b/build.cake
@@ -134,9 +134,6 @@ Information ("Agent.Name: {0}", agentName);
 Information ("isCIBuild: {0}", isCIBuild);
 Information ("artifactStagingDirectory: {0}", artifactStagingDirectory);
 Information("workingDirectory: {0}", workingDirectory);
-
-
-PrintEnvironmentVariables();
 Information("NUNIT_TEST_WHERE: {0}", NUNIT_TEST_WHERE);
 
 var releaseChannel = ReleaseChannel.Stable;
@@ -1079,7 +1076,10 @@ RunTarget(target);
 
 T GetBuildVariable<T>(string key, T defaultValue)
 {
-    return Argument(key, EnvironmentVariable(key, defaultValue));
+    // on MAC all environment variables are upper case regardless of how you specify them in devops
+    // And then Environment Variable check is case sensitive
+    T upperCaseReturnValue = Argument(key.ToUpper(), EnvironmentVariable(key.ToUpper(), defaultValue));
+    return Argument(key, EnvironmentVariable(key, upperCaseReturnValue));
 }
 
 void StartVisualStudio(string sln = "Xamarin.Forms.sln")
@@ -1213,9 +1213,9 @@ public void SetEnvironmentVariable(string key, string value, ICakeContext contex
 
 public string ParseDevOpsInputs(string nunitWhere)
 {
-    var ExcludeCategory = GetBuildVariable("ExcludeCategory", GetBuildVariable("EXCLUDECATEGORY", ""))?.Replace("\"", "");
-    var ExcludeCategory2 = GetBuildVariable("ExcludeCategory2", GetBuildVariable("EXCLUDECATEGORY2", ""))?.Replace("\"", "");
-    var IncludeCategory = GetBuildVariable("IncludeCategory", GetBuildVariable("INCLUDECATEGORY", ""))?.Replace("\"", "");
+    var ExcludeCategory = GetBuildVariable("ExcludeCategory", "")?.Replace("\"", "");
+    var ExcludeCategory2 = GetBuildVariable("ExcludeCategory2", "")?.Replace("\"", "");
+    var IncludeCategory = GetBuildVariable("IncludeCategory", "")?.Replace("\"", "");
 
     Information("ExcludeCategory: {0}", ExcludeCategory);
     Information("IncludeCategory: {0}", IncludeCategory);

--- a/build.cake
+++ b/build.cake
@@ -1047,13 +1047,6 @@ Task("Default")
 
 RunTarget(target);
 
-
-
-void SetNunitEnvironmentVariables()
-{
-
-}
-
 void RunTests(string unitTestLibrary, NUnit3Settings settings, ICakeContext ctx)
 {
     try

--- a/build.cake
+++ b/build.cake
@@ -139,6 +139,15 @@ Information ("Agent.Name: {0}", agentName);
 Information ("isCIBuild: {0}", isCIBuild);
 Information ("artifactStagingDirectory: {0}", artifactStagingDirectory);
 Information("workingDirectory: {0}", workingDirectory);
+
+var ExcludeCategory = GetBuildVariable("ExcludeCategory", "")?.Replace("\"", "");
+var ExcludeCategory2 = GetBuildVariable("ExcludeCategory2", "")?.Replace("\"", "");
+var IncludeCategory = GetBuildVariable("IncludeCategory", "")?.Replace("\"", "");
+
+PrintEnvironmentVariables();
+Information("ExcludeCategory: {0}", ExcludeCategory);
+Information("IncludeCategory: {0}", IncludeCategory);
+Information("ExcludeCategory2: {0}", ExcludeCategory2);
 Information("NUNIT_TEST_WHERE: {0}", NUNIT_TEST_WHERE);
 
 var releaseChannel = ReleaseChannel.Stable;

--- a/build.cake
+++ b/build.cake
@@ -73,11 +73,6 @@ if(target.ToLower().Contains("uwp"))
     defaultUnitTestWhere = "cat != UwpIgnore";
 
 var NUNIT_TEST_WHERE = Argument("NUNIT_TEST_WHERE", defaultUnitTestWhere);
-var ExcludeCategory = GetBuildVariable("ExcludeCategory", "")?.Replace("\"", "");
-var ExcludeCategory2 = GetBuildVariable("ExcludeCategory2", "")?.Replace("\"", "");
-var IncludeCategory = GetBuildVariable("IncludeCategory", "")?.Replace("\"", "");
-
-
 NUNIT_TEST_WHERE = ParseDevOpsInputs(NUNIT_TEST_WHERE);
 
 var ANDROID_HOME = EnvironmentVariable("ANDROID_HOME") ??
@@ -140,14 +135,8 @@ Information ("isCIBuild: {0}", isCIBuild);
 Information ("artifactStagingDirectory: {0}", artifactStagingDirectory);
 Information("workingDirectory: {0}", workingDirectory);
 
-var ExcludeCategory = GetBuildVariable("ExcludeCategory", "")?.Replace("\"", "");
-var ExcludeCategory2 = GetBuildVariable("ExcludeCategory2", "")?.Replace("\"", "");
-var IncludeCategory = GetBuildVariable("IncludeCategory", "")?.Replace("\"", "");
 
 PrintEnvironmentVariables();
-Information("ExcludeCategory: {0}", ExcludeCategory);
-Information("IncludeCategory: {0}", IncludeCategory);
-Information("ExcludeCategory2: {0}", ExcludeCategory2);
 Information("NUNIT_TEST_WHERE: {0}", NUNIT_TEST_WHERE);
 
 var releaseChannel = ReleaseChannel.Stable;
@@ -1224,6 +1213,13 @@ public void SetEnvironmentVariable(string key, string value, ICakeContext contex
 
 public string ParseDevOpsInputs(string nunitWhere)
 {
+    var ExcludeCategory = GetBuildVariable("ExcludeCategory", GetBuildVariable("EXCLUDECATEGORY", ""))?.Replace("\"", "");
+    var ExcludeCategory2 = GetBuildVariable("ExcludeCategory2", GetBuildVariable("EXCLUDECATEGORY2", ""))?.Replace("\"", "");
+    var IncludeCategory = GetBuildVariable("IncludeCategory", GetBuildVariable("INCLUDECATEGORY", ""))?.Replace("\"", "");
+
+    Information("ExcludeCategory: {0}", ExcludeCategory);
+    Information("IncludeCategory: {0}", IncludeCategory);
+    Information("ExcludeCategory2: {0}", ExcludeCategory2);
     string excludeString = String.Empty;
     string includeString = String.Empty;
     string returnValue = String.Empty;


### PR DESCRIPTION
### Description of Change ###

When running UI Tests against iOS and Android via cake the nunit where isn't parsing correctly. This fixes the issue

### Testing Procedure ###
- make sure iOS 14 tests and UWP tests run and are filtered correctly 

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
