### PR TITLE
[Android] Changes in CarouselView initial position 

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -335,18 +335,18 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateInitialPosition()
 		{
 			int position = 0;
-			var items = Carousel.ItemsSource as IList;
-			var itemCount = items?.Count ?? 0;
+			int itemCount = 0;
 
-			if (Carousel.CurrentItem != null || items == null)
+			if (Carousel.CurrentItem != null)
 			{
-				for (int n = 0; n < itemCount; n++)
+				var carouselEnumerator = Carousel.ItemsSource.GetEnumerator();
+
+				while (carouselEnumerator.MoveNext())
 				{
-					if (items[n] == Carousel.CurrentItem)
-					{
-						position = n;
-						break;
-					}
+					if(carouselEnumerator.Current == Carousel.CurrentItem)
+						position = itemCount;
+
+					itemCount++;
 				}
 
 				Carousel.Position = position;


### PR DESCRIPTION
### Description of Change ###

Recently, fixing a TabView issue https://github.com/xamarin/XamarinCommunityToolkit/issues/630 (which internally uses CarouselView) in the Xamarin Community Toolkit, I noticed some unexpected behavior with the initial position of the CarouselView.

The problem is that the casting:

`var items = Carousel.ItemsSource as IList;`

It is not correct in all cases. This PR adds changes to use an enumerator.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
