### PR TITLE
[Android] Fix swipe issue using SwipeView inside TabbedPage using IsSwipePagingEnabled

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13337.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13337.xaml
@@ -16,7 +16,8 @@
             VerticalOptions="CenterAndExpand"
             HorizontalOptions="CenterAndExpand">
             <Label
-                Text="If this page not swipe, the test has passed." />
+                Text="Interact with the SwipeView available in Page 2 and then, try to swipe to move between tabs. If the page not swipe, the test has passed."
+                Margin="12"/>
         </StackLayout>
     </ContentPage>
     <ContentPage

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13337.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13337.xaml
@@ -1,0 +1,52 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestTabbedPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    Title="Test 13337"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13337"
+    xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+    android:TabbedPage.IsSwipePagingEnabled="False">
+    <ContentPage
+        Title="Page 1">
+        <StackLayout
+            VerticalOptions="CenterAndExpand"
+            HorizontalOptions="CenterAndExpand">
+            <Label
+                Text="If this page not swipe, the test has passed." />
+        </StackLayout>
+    </ContentPage>
+    <ContentPage
+        Title="Page 2">
+        <SwipeView
+            VerticalOptions="CenterAndExpand"
+            Padding="50"
+            BackgroundColor="Blue">
+            <Grid
+                HeightRequest="50"
+                BackgroundColor="White">
+                <Label
+                    Text="Swipe Left or Right"
+                    HorizontalOptions="Center"
+                    VerticalOptions="Center"/>
+            </Grid>
+            <SwipeView.LeftItems>
+                <SwipeItems>
+                    <SwipeItem
+                        BackgroundColor="Red"
+                        Text="Left SwipeItem" />
+                </SwipeItems>
+            </SwipeView.LeftItems>
+            <SwipeView.RightItems>
+                <SwipeItems>
+                    <SwipeItem
+                        BackgroundColor="Green"
+                        Text="Right SwipeItem" />
+                </SwipeItems>
+            </SwipeView.RightItems>
+        </SwipeView>
+    </ContentPage>
+</local:TestTabbedPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13337.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13337.xaml.cs
@@ -1,0 +1,30 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13337,
+		"[Bug] [5.0] [Android] Interacting with a SwipeView on a TabbedPage with IsSwipePagingEnabled=false re-enables page swiping",
+		PlatformAffected.Android)]
+	public partial class Issue13337 : TestTabbedPage
+	{
+		public Issue13337()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1699,6 +1699,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBackground.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentOffest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13337.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2084,6 +2085,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13136.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13337.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

 Fix swipe issue using SwipeView inside TabbedPage using `IsSwipePagingEnabled` on Android.

### Issues Resolved ### 

- fixes #13337 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix13337](https://user-images.githubusercontent.com/6755973/104613399-7ba64500-5687-11eb-875d-1d733a64ac95.gif)

And the behavior with a TabbedPage with swipe gesture enabled.
![sw-tp-behavior](https://user-images.githubusercontent.com/6755973/104613381-78ab5480-5687-11eb-95fb-0481581e72c6.gif)

### Testing Procedure ###
Launch Core and navigate to the issue 13337. Interact with the SwipeView available in Page 2 and then, try to swipe to move between tabs. If the page not swipe, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
