### PR TITLE
Don't set IsAccessibilityElement for everything

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -223,12 +223,6 @@ namespace Xamarin.Forms.Platform.MacOS
 			_controlChanging?.Invoke(this, EventArgs.Empty);
 #if __MOBILE__
 			_defaultColor = uiview.BackgroundColor;
-
-			// UIKit UIViews created via storyboard default IsAccessibilityElement to true, BUT
-			// UIViews created programmatically default IsAccessibilityElement to false.
-			// We need to default to true to allow all elements to be accessible by default and
-			// allow users to override this later via AutomationProperties.IsInAccessibleTree
-			uiview.IsAccessibilityElement = true;
 #else
 			uiview.WantsLayer = true;
 			_defaultColor = uiview.Layer.BackgroundColor;


### PR DESCRIPTION
### Description of Change ###

The original comment says this
```
		// UIKit UIViews created via storyboard default IsAccessibilityElement to true, BUT	
			// UIViews created programmatically default IsAccessibilityElement to false.	
			// We need to default to true to allow all elements to be accessible by default and	
			// allow users to override this later via AutomationProperties.IsInAccessibleTree
```

I don't feel like that's completely accurate. If you inspect IsAccessibilityElement directly after instantiating a control then it is indeed false but by the time the control is rendering it is set to the correct value for the given control. If you breakpoint SetAccessibilityElement inside the Automation Extensions you will see that IsAccessibilityElement is true when it should be true and false when it should be false

There are certain controls (UIScrollView, ListView, really anything that's a container of views) that should always remain false. If they get set to true then it causes all the content inside the view to become unreachable. 

Just let the OS do what the OS is going to do

### Issues Resolved ### 
- fixes #12252


### Platforms Affected ### 
- iOS

### Testing Procedure ###
- Test any of the collection view samples using voice over and make sure they still work
- Test all samples that are voice over related and make sure they still work

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
