### PR TITLE
[Android] Crash in CarouselView adjusting PeekAreaInsets in OnSizeAllocated

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml
@@ -13,10 +13,10 @@
             BackgroundColor="Black"
             TextColor="White"
             Text="Without exceptions, the test has passed."/>
-       <CarouselView
-            x:Name="carouselView"
+        <CarouselView
+            x:Name="Carousel"
+            AutomationId="CarouselId"
             HorizontalScrollBarVisibility="Never"
-            IndicatorView="Indicator"
             Loop="False"
             VerticalOptions="Center">
             <CarouselView.ItemsLayout>
@@ -48,12 +48,5 @@
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
-        <IndicatorView
-            x:Name="Indicator"
-			Padding="10"
-			IndicatorColor="LightGray"
-			SelectedIndicatorColor="Black"
-			IndicatorSize="10"
-			HorizontalOptions="Center" />
     </StackLayout>
 </local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml
@@ -1,0 +1,59 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 13436" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13436">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Without exceptions, the test has passed."/>
+       <CarouselView
+            x:Name="carouselView"
+            HorizontalScrollBarVisibility="Never"
+            IndicatorView="Indicator"
+            Loop="False"
+            VerticalOptions="Center">
+            <CarouselView.ItemsLayout>
+                <LinearItemsLayout
+                    Orientation="Horizontal"
+                    SnapPointsAlignment="Center"
+                    SnapPointsType="MandatorySingle" />
+            </CarouselView.ItemsLayout>
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Grid BackgroundColor="{Binding Color}">
+                        <Grid Margin="20">
+                            <Grid.RowDefinitions>
+                                <RowDefinition Height="Auto" />
+                                <RowDefinition Height="*" />
+                            </Grid.RowDefinitions>
+                            <Label
+                                Grid.Row="0"
+                                Margin="0,0,0,20"
+                                Text="{Binding Name}"
+                                TextColor="Black" />
+                            <Label
+                                Grid.Row="1"
+                                Margin="0,0,0,20"
+                                Text="{Binding Desc}"
+                                TextColor="Black" />
+                        </Grid>
+                    </Grid>
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+        <IndicatorView
+            x:Name="Indicator"
+			Padding="10"
+			IndicatorColor="LightGray"
+			SelectedIndicatorColor="Black"
+			IndicatorSize="10"
+			HorizontalOptions="Center" />
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml.cs
@@ -1,0 +1,83 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using System;
+using System.Collections.Generic;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13436,
+        "[Bug] Java.Lang.IllegalArgumentException in CarouselView adjusting PeekAreaInsets in OnSizeAllocated using XF 5.0",
+		PlatformAffected.Android)]
+	public partial class Issue13436 : TestContentPage
+	{
+        public Issue13436()
+		{
+#if APP
+			InitializeComponent();
+#endif
+        }
+
+#if APP
+        double _prevWidth;
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+
+            Carousel.ItemsSource = new List<Issue13436Model>
+            {
+                new Issue13436Model
+                {
+                    Name = "N1",
+                    Desc = "D1",
+                    Color = Color.Yellow
+                },
+                new Issue13436Model
+                {
+                    Name = "N2",
+                    Desc = "D2",
+                    Color = Color.Orange
+                },
+                new Issue13436Model
+                {
+                    Name = "N3",
+                    Desc = "D3",
+                    Color = Color.AliceBlue
+                }
+            };
+        }
+
+        protected override void OnSizeAllocated(double width, double height)
+        {
+            base.OnSizeAllocated(width, height);
+
+            if (Math.Abs(width - _prevWidth) < .1)
+            {
+                return;
+            }
+
+            _prevWidth = width;
+
+            //Exception arises here
+            //especially with Loop = false
+            Carousel.PeekAreaInsets = width * .15;
+        }
+#endif
+        protected override void Init()
+		{
+		}
+	}
+
+    public class Issue13436Model
+    {
+        public string Name { get; set; }
+        public string Desc { get; set; }
+        public Color Color { get; set; }
+        public double Scale { get; set; }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13436.xaml.cs
@@ -1,6 +1,7 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using System;
 using System.Collections.Generic;
+using Xamarin.Forms.Internals;
 
 #if UITEST
 using Xamarin.UITest;
@@ -10,7 +11,8 @@ using Xamarin.Forms.Core.UITests;
 
 namespace Xamarin.Forms.Controls.Issues
 {
-	[Issue(IssueTracker.Github, 13436,
+    [Preserve(AllMembers = true)]
+    [Issue(IssueTracker.Github, 13436,
         "[Bug] Java.Lang.IllegalArgumentException in CarouselView adjusting PeekAreaInsets in OnSizeAllocated using XF 5.0",
 		PlatformAffected.Android)]
 	public partial class Issue13436 : TestContentPage
@@ -62,17 +64,23 @@ namespace Xamarin.Forms.Controls.Issues
             }
 
             _prevWidth = width;
-
-            //Exception arises here
-            //especially with Loop = false
             Carousel.PeekAreaInsets = width * .15;
         }
 #endif
         protected override void Init()
 		{
-		}
-	}
+        }
 
+#if UITEST && __ANDROID__
+		[Test]
+		public void ChangePeekAreaInsetsInOnSizeAllocatedTest()
+        {
+            RunningApp.WaitForElement("CarouselId");
+        }
+#endif
+    }
+
+    [Preserve(AllMembers = true)]
     public class Issue13436Model
     {
         public string Name { get; set; }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1704,6 +1704,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBackground.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentOffest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13436.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2095,6 +2096,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12911.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13436.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

The issue is a crash in `CarouselView` adjusting `PeekAreaInsets` in `OnSizeAllocated`. However, cannot reproduce the issue in 5.0.0 branch. For that reason, this PR only include the test.

@rmarinho The exception comes from `UpdateFromCurrentItem` method. It could be fixed with one of the last PRs like https://github.com/xamarin/Xamarin.Forms/pull/13182?

### Issues Resolved ### 

- fixes #13436 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix13436](https://user-images.githubusercontent.com/6755973/104913381-ced10e00-598d-11eb-8db2-0de292ce7e50.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13436. Without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
