### PR TITLE
Setup Shell to only use the LogicalChildren for reporting its LogicalChildren

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTests.cs
@@ -768,10 +768,10 @@ namespace Xamarin.Forms.Core.UnitTests
 			shell.FlyoutHeader = null;
 			shell.FlyoutHeader = layout;
 
-			Assert.True(shell.ChildrenNotDrawnByThisElement.Contains(layout));
+			Assert.True(shell.LogicalChildren.Contains(layout));
 			shell.FlyoutHeader = null;
 
-			Assert.False(shell.ChildrenNotDrawnByThisElement.Contains(layout));
+			Assert.False(shell.LogicalChildren.Contains(layout));
 		}
 
 

--- a/Xamarin.Forms.Core/Page.cs
+++ b/Xamarin.Forms.Core/Page.cs
@@ -379,7 +379,7 @@ namespace Xamarin.Forms
 				var element = LogicalChildren[i];
 				if (element is VisualElement c)
 				{
-					if (c.Bounds != startingLayout[i])
+					if (startingLayout.Count <= i || c.Bounds != startingLayout[i])
 					{
 						LayoutChanged?.Invoke(this, EventArgs.Empty);
 						return;

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1129,9 +1129,9 @@ namespace Xamarin.Forms
 		void OnFlyoutHeaderTemplateChanged(DataTemplate oldValue, DataTemplate newValue)
 		{
 			ShellTemplatedViewManager.OnViewTemplateChanged(
-				FlyoutHeaderTemplate,
-				ref _flyoutHeaderView,
 				newValue,
+				ref _flyoutHeaderView,
+				FlyoutHeader,
 				OnChildRemoved,
 				OnChildAdded,
 				this);
@@ -1150,9 +1150,9 @@ namespace Xamarin.Forms
 		void OnFlyoutFooterTemplateChanged(DataTemplate oldValue, DataTemplate newValue)
 		{
 			ShellTemplatedViewManager.OnViewTemplateChanged(
-				FlyoutFooterTemplate,
-				ref _flyoutFooterView,
 				newValue,
+				ref _flyoutFooterView,
+				FlyoutFooter,
 				OnChildRemoved,
 				OnChildAdded,
 				this);
@@ -1245,9 +1245,9 @@ namespace Xamarin.Forms
 		void OnFlyoutContentTemplateChanged(DataTemplate oldValue, DataTemplate newValue)
 		{
 			ShellTemplatedViewManager.OnViewTemplateChanged(
-				FlyoutContentTemplate,
-				ref _flyoutContentView,
 				newValue,
+				ref _flyoutContentView,
+				FlyoutContent,
 				OnChildRemoved,
 				OnChildAdded,
 				this);

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -784,38 +784,17 @@ namespace Xamarin.Forms
 		View FlyoutHeaderView
 		{
 			get => _flyoutHeaderView;
-			set
-			{
-				if (_flyoutHeaderView == value)
-					return;
-
-				if (_flyoutHeaderView != null)
-					OnChildRemoved(_flyoutHeaderView, -1);
-				_flyoutHeaderView = value;
-				if (_flyoutHeaderView != null)
-					OnChildAdded(_flyoutHeaderView);
-			}
 		}
 
 		View FlyoutFooterView
 		{
 			get => _flyoutFooterView;
-			set
-			{
-				if (_flyoutFooterView == value)
-					return;
-
-				if (_flyoutFooterView != null)
-					OnChildRemoved(_flyoutFooterView, -1);
-				_flyoutFooterView = value;
-				if (_flyoutFooterView != null)
-					OnChildAdded(_flyoutFooterView);
-			}
 		}
 
 		protected override void OnBindingContextChanged()
 		{
 			base.OnBindingContextChanged();
+
 			if (FlyoutHeaderView != null)
 				SetInheritedBindingContext(FlyoutHeaderView, BindingContext);
 
@@ -1106,56 +1085,44 @@ namespace Xamarin.Forms
 
 		void OnFlyoutHeaderChanged(object oldVal, object newVal)
 		{
-			if (FlyoutHeaderTemplate == null)
-			{
-				if (newVal is View newFlyoutHeader)
-					FlyoutHeaderView = newFlyoutHeader;
-				else
-					FlyoutHeaderView = null;
-			}
+			ShellTemplatedViewManager.OnViewDataChanged(
+				FlyoutHeaderTemplate,
+				ref _flyoutHeaderView,
+				newVal,
+				OnChildRemoved,
+				OnChildAdded);
 		}
 
 		void OnFlyoutHeaderTemplateChanged(DataTemplate oldValue, DataTemplate newValue)
 		{
-			if (newValue == null)
-			{
-				if (FlyoutHeader is View flyoutHeaderView)
-					FlyoutHeaderView = flyoutHeaderView;
-				else
-					FlyoutHeaderView = null;
-			}
-			else
-			{
-				var newHeaderView = (View)newValue.CreateContent(FlyoutHeader, this);
-				FlyoutHeaderView = newHeaderView;
-			}
+			ShellTemplatedViewManager.OnViewTemplateChanged(
+				FlyoutHeaderTemplate,
+				ref _flyoutHeaderView,
+				newValue,
+				OnChildRemoved,
+				OnChildAdded,
+				this);
 		}
 
 		void OnFlyoutFooterChanged(object oldVal, object newVal)
 		{
-			if (FlyoutFooterTemplate == null)
-			{
-				if (newVal is View newFlyoutFooter)
-					FlyoutFooterView = newFlyoutFooter;
-				else
-					FlyoutFooterView = null;
-			}
+			ShellTemplatedViewManager.OnViewDataChanged(
+				FlyoutFooterTemplate,
+				ref _flyoutFooterView,
+				newVal,
+				OnChildRemoved,
+				OnChildAdded);
 		}
 
 		void OnFlyoutFooterTemplateChanged(DataTemplate oldValue, DataTemplate newValue)
 		{
-			if (newValue == null)
-			{
-				if (FlyoutFooter is View flyoutFooterView)
-					FlyoutFooterView = flyoutFooterView;
-				else
-					FlyoutFooterView = null;
-			}
-			else
-			{
-				var newFooterView = (View)newValue.CreateContent(FlyoutFooter, this);
-				FlyoutFooterView = newFooterView;
-			}
+			ShellTemplatedViewManager.OnViewTemplateChanged(
+				FlyoutFooterTemplate,
+				ref _flyoutFooterView,
+				newValue,
+				OnChildRemoved,
+				OnChildAdded,
+				this);
 		}
 
 		internal Element GetVisiblePage()
@@ -1194,6 +1161,8 @@ namespace Xamarin.Forms
 				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { FlyoutHeaderView });
 			if (FlyoutFooterView != null)
 				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { FlyoutFooterView });
+			if (FlyoutContentView != null)
+				PropertyPropagationExtensions.PropagatePropertyChanged(propertyName, this, new[] { FlyoutContentView });
 		}
 
 
@@ -1223,44 +1192,27 @@ namespace Xamarin.Forms
 		View FlyoutContentView
 		{
 			get => _flyoutContentView;
-			set
-			{
-				if (_flyoutContentView == value)
-					return;
-
-				if (_flyoutContentView != null)
-					OnChildRemoved(_flyoutContentView, -1);
-				_flyoutContentView = value;
-				if (_flyoutContentView != null)
-					OnChildAdded(_flyoutContentView);
-			}
 		}
 
 		void OnFlyoutContentChanged(object oldVal, object newVal)
 		{
-			if (FlyoutContentTemplate == null)
-			{
-				if (newVal is View newFlyoutContent)
-					FlyoutContentView = newFlyoutContent;
-				else
-					FlyoutContentView = null;
-			}
+			ShellTemplatedViewManager.OnViewDataChanged(
+				FlyoutContentTemplate,
+				ref _flyoutContentView,
+				newVal,
+				OnChildRemoved,
+				OnChildAdded);
 		}
 
 		void OnFlyoutContentTemplateChanged(DataTemplate oldValue, DataTemplate newValue)
 		{
-			if (newValue == null)
-			{
-				if (FlyoutContent is View flyoutContentView)
-					FlyoutContentView = flyoutContentView;
-				else
-					FlyoutContentView = null;
-			}
-			else
-			{
-				var newContentView = (View)newValue.CreateContent(FlyoutContent, this);
-				FlyoutContentView = newContentView;
-			}
+			ShellTemplatedViewManager.OnViewTemplateChanged(
+				FlyoutContentTemplate,
+				ref _flyoutContentView,
+				newValue,
+				OnChildRemoved,
+				OnChildAdded,
+				this);
 		}
 
 		static void OnFlyoutContentChanging(BindableObject bindable, object oldValue, object newValue)

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1107,11 +1107,11 @@ namespace Xamarin.Forms
 		{
 			if (e.NewItems != null)
 				foreach (Element element in e.NewItems)
-					_logicalChildren.Add(element);
+					AddLogicalChild(element);
 
 			if (e.OldItems != null)
 				foreach (Element element in e.OldItems)
-					_logicalChildren.Add(element);
+					RemoveLogicalChild(element);
 		}
 
 		void NotifyFlyoutBehaviorObservers()

--- a/Xamarin.Forms.Core/Shell/ShellTemplatedViewManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellTemplatedViewManager.cs
@@ -7,13 +7,17 @@ namespace Xamarin.Forms
 {
 	public static class ShellTemplatedViewManager
 	{
-		public static void SetView(ref View localView, View newView, Action<Element, int> OnChildRemoved, Action<Element> OnChildAdded)
+		public static void SetView(
+			ref View localView, 
+			View newView, 
+			Action<Element> OnChildRemoved, 
+			Action<Element> OnChildAdded)
 		{
 			if (localView == newView)
 				return;
 
 			if (localView != null)
-				OnChildRemoved(localView, -1);
+				OnChildRemoved(localView);
 			localView = newView;
 			if (localView != null)
 				OnChildAdded(localView);
@@ -24,7 +28,7 @@ namespace Xamarin.Forms
 			DataTemplate currentViewTemplate,
 			ref View localViewRef,
 			object newViewData,
-			Action<Element, int> OnChildRemoved,
+			Action<Element> OnChildRemoved,
 			Action<Element> OnChildAdded)
 		{
 			if (currentViewTemplate == null)
@@ -40,7 +44,7 @@ namespace Xamarin.Forms
 			DataTemplate newViewTemplate,
 			ref View localViewRef,
 			object currentViewData,
-			Action<Element, int> OnChildRemoved,
+			Action<Element> OnChildRemoved,
 			Action<Element> OnChildAdded,
 			Shell shell)
 		{

--- a/Xamarin.Forms.Core/Shell/ShellTemplatedViewManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellTemplatedViewManager.cs
@@ -21,13 +21,13 @@ namespace Xamarin.Forms
 
 
 		public static void OnViewDataChanged(
-			DataTemplate viewTemplate,
+			DataTemplate currentViewTemplate,
 			ref View localViewRef,
 			object newViewData,
 			Action<Element, int> OnChildRemoved,
 			Action<Element> OnChildAdded)
 		{
-			if (viewTemplate == null)
+			if (currentViewTemplate == null)
 			{
 				SetView(ref localViewRef,
 					newViewData as View,
@@ -37,22 +37,20 @@ namespace Xamarin.Forms
 		}
 
 		public static void OnViewTemplateChanged(
-			DataTemplate viewTemplate,
+			DataTemplate newViewTemplate,
 			ref View localViewRef,
-			object newViewData,
+			object currentViewData,
 			Action<Element, int> OnChildRemoved,
 			Action<Element> OnChildAdded,
 			Shell shell)
 		{
-			View newContentView = newViewData as View;
-			if (viewTemplate != null)
+			View newContentView = currentViewData as View;
+			if (newViewTemplate != null)
 			{ 
-				newContentView = (View)viewTemplate.CreateContent(viewTemplate, shell);
+				newContentView = (View)newViewTemplate.CreateContent(newViewTemplate, shell);
 			}
 
-			OnViewDataChanged(
-				viewTemplate,
-				ref localViewRef,
+			SetView(ref localViewRef,
 				newContentView,
 				OnChildRemoved,
 				OnChildAdded);

--- a/Xamarin.Forms.Core/Shell/ShellTemplatedViewManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellTemplatedViewManager.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms
+{
+	public static class ShellTemplatedViewManager
+	{
+		public static void SetView(ref View localView, View newView, Action<Element, int> OnChildRemoved, Action<Element> OnChildAdded)
+		{
+			if (localView == newView)
+				return;
+
+			if (localView != null)
+				OnChildRemoved(localView, -1);
+			localView = newView;
+			if (localView != null)
+				OnChildAdded(localView);
+		}
+
+
+		public static void OnViewDataChanged(
+			DataTemplate viewTemplate,
+			ref View localViewRef,
+			object newViewData,
+			Action<Element, int> OnChildRemoved,
+			Action<Element> OnChildAdded)
+		{
+			if (viewTemplate == null)
+			{
+				SetView(ref localViewRef,
+					newViewData as View,
+					OnChildRemoved,
+					OnChildAdded);
+			}
+		}
+
+		public static void OnViewTemplateChanged(
+			DataTemplate viewTemplate,
+			ref View localViewRef,
+			object newViewData,
+			Action<Element, int> OnChildRemoved,
+			Action<Element> OnChildAdded,
+			Shell shell)
+		{
+			View newContentView = newViewData as View;
+			if (viewTemplate != null)
+			{ 
+				newContentView = (View)viewTemplate.CreateContent(viewTemplate, shell);
+			}
+
+			OnViewDataChanged(
+				viewTemplate,
+				ref localViewRef,
+				newContentView,
+				OnChildRemoved,
+				OnChildAdded);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -64,6 +64,16 @@ namespace Xamarin.Forms.Platform.Android
 			return id;
 		}
 
+		public override void OnViewRecycled(Java.Lang.Object holder)
+		{
+			if(holder is ElementViewHolder evh)
+			{
+				evh.Element = null;
+			}
+
+			base.OnViewRecycled(holder);
+		}
+
 		public override void OnBindViewHolder(RecyclerView.ViewHolder holder, int position)
 		{
 			var item = _listItems[position];
@@ -279,6 +289,7 @@ namespace Xamarin.Forms.Platform.Android
 					if (_element == value)
 						return;
 
+					_shell.RemoveLogicalChild(View);
 					if (_element != null && _element is BaseShellItem)
 					{
 						_element.ClearValue(Platform.RendererProperty);
@@ -287,12 +298,12 @@ namespace Xamarin.Forms.Platform.Android
 
 					_element = value;
 
-					// Set Parent after binding context so parent binding context doesn't propagate to view
-					View.BindingContext = value;
-					View.Parent = _shell;
+					// Set binding context before calling AddLogicalChild so parent binding context doesn't propagate to view
+					View.BindingContext = value;			
 
 					if (_element != null)
 					{
+						_shell.AddLogicalChild(View);
 						FastRenderers.AutomationPropertiesProvider.AccessibilitySettingsChanged(_itemView, value);
 						_element.SetValue(Platform.RendererProperty, _itemView);
 						_element.PropertyChanged += OnElementPropertyChanged;

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellFlyoutItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellFlyoutItemRenderer.cs
@@ -21,7 +21,7 @@ namespace Xamarin.Forms.Platform.UWP
 		object _previousDataContext;
 		double _previousWidth;
 		FrameworkElement FrameworkElement { get; set; }
-
+		Shell _shell;
 		public ShellFlyoutItemRenderer()
 		{
 			this.DataContextChanged += OnDataContextChanged;
@@ -46,6 +46,7 @@ namespace Xamarin.Forms.Platform.UWP
 				if (_content.BindingContext is INotifyPropertyChanged inpc)
 					inpc.PropertyChanged -= ShellElementPropertyChanged;
 
+				_shell?.RemoveLogicalChild(_content);
 				_content.Cleanup();
 				_content.MeasureInvalidated -= OnMeasureInvalidated;
 				_content.BindingContext = null;
@@ -55,8 +56,8 @@ namespace Xamarin.Forms.Platform.UWP
 
 			var bo = (BindableObject)args.NewValue;
 			var element = bo as Element;
-			var shell = element?.FindParent<Shell>();
-			DataTemplate dataTemplate = (shell as IShellController)?.GetFlyoutItemDataTemplate(bo);
+			_shell = element?.FindParent<Shell>();
+			DataTemplate dataTemplate = (_shell as IShellController)?.GetFlyoutItemDataTemplate(bo);
 
 			if (bo != null)
 				bo.PropertyChanged += ShellElementPropertyChanged;
@@ -65,7 +66,8 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_content = (View)dataTemplate.CreateContent();
 				_content.BindingContext = bo;
-				_content.Parent = shell;
+				_shell.AddLogicalChild(_content);
+				
 				_content.MeasureInvalidated += OnMeasureInvalidated;
 				IVisualElementRenderer renderer = Platform.CreateRenderer(_content);
 				Platform.SetRenderer(_content, renderer);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSearchResultsRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSearchResultsRenderer.cs
@@ -95,8 +95,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (cell == null)
 			{
 				var view = (View)template.CreateContent(context, _context.Shell);
-				view.Parent = _context.Shell;
 				view.BindingContext = context;
+				view.Parent = _context.Shell;
 				cell = new UIContainerCell(cellId, view);
 			}
 			else

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 					if (_cells != null)
 					{
 						foreach (var cell in _cells.Values)
-							cell.Disconnect();
+							cell.Disconnect(_context.Shell);
 					}
 
 					_cells = new Dictionary<Element, UIContainerCell>();
@@ -57,7 +57,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (_cells != null)
 				{
 					foreach (var cell in _cells.Values)
-						cell.Disconnect();
+						cell.Disconnect(_context.Shell);
 				}
 				_cells = new Dictionary<Element, UIContainerCell>();
 			}
@@ -124,12 +124,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 				// Set Parent after binding context so parent binding context doesn't propagate to view
 				cell.BindingContext = context;
-				view.Parent = _context.Shell;
+				_context.Shell.AddLogicalChild(view);
 			}
 			else
 			{
 				var view = _cells[context].View;
-				cell.Disconnect();
+				cell.Disconnect(_context.Shell);
 				cell = new UIContainerCell(cellId, view);
 				cell.BindingContext = context;
 			}

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewSource.cs
@@ -120,18 +120,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!_cells.TryGetValue(context, out cell))
 			{
 				var view = (View)template.CreateContent(context, _context.Shell);
-				cell = new UIContainerCell(cellId, view);
-
-				// Set Parent after binding context so parent binding context doesn't propagate to view
-				cell.BindingContext = context;
-				_context.Shell.AddLogicalChild(view);
+				cell = new UIContainerCell(cellId, view, _context.Shell, context);
 			}
 			else
 			{
 				var view = _cells[context].View;
-				cell.Disconnect(_context.Shell);
-				cell = new UIContainerCell(cellId, view);
-				cell.BindingContext = context;
+				cell.Disconnect();
+				cell = new UIContainerCell(cellId, view, _context.Shell, context);
 			}
 
 			cell.SetAccessibilityProperties(context);

--- a/Xamarin.Forms.Platform.iOS/Renderers/UIContainerCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/UIContainerCell.cs
@@ -8,22 +8,32 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		IVisualElementRenderer _renderer;
 		object _bindingContext;
+
 		internal Action<UIContainerCell> ViewMeasureInvalidated { get; set; }
 		internal NSIndexPath IndexPath { get; set; }
 		internal UITableView TableView { get; set; }
 
-		public UIContainerCell(string cellId, View view) : base(UITableViewCellStyle.Default, cellId)
+		internal UIContainerCell(string cellId, View view, Shell shell, object context) : base(UITableViewCellStyle.Default, cellId)
 		{
 			View = view;
 			View.MeasureInvalidated += MeasureInvalidated;
 			SelectionStyle = UITableViewCellSelectionStyle.None;
-
+			
 			_renderer = Platform.CreateRenderer(view);
 			Platform.SetRenderer(view, _renderer);
 
 			ContentView.AddSubview(_renderer.NativeView);
 			_renderer.NativeView.ClipsToBounds = true;
 			ContentView.ClipsToBounds = true;
+
+			BindingContext = context;
+			if (shell != null)
+				shell.AddLogicalChild(View);
+		}
+
+
+		public UIContainerCell(string cellId, View view) : this(cellId, view, null, null)
+		{
 		}
 
 		void MeasureInvalidated(object sender, System.EventArgs e)
@@ -39,7 +49,7 @@ namespace Xamarin.Forms.Platform.iOS
 			TableView.ReloadRows(new[] { IndexPath }, UITableViewRowAnimation.Automatic);
 		}
 
-		internal void Disconnect(Shell shell)
+		internal void Disconnect(Shell shell = null)
 		{
 			ViewMeasureInvalidated = null;
 			View.MeasureInvalidated -= MeasureInvalidated;
@@ -48,7 +58,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_bindingContext = null;
 			Platform.SetRenderer(View, null);
-			shell.RemoveLogicalChild(View);
+			if (shell != null)
+				shell.RemoveLogicalChild(shell);
+
 			View = null;
 			TableView = null;
 		}
@@ -73,7 +85,6 @@ namespace Xamarin.Forms.Platform.iOS
 					baseShell2.PropertyChanged += OnElementPropertyChanged;
 					UpdateVisualState();
 				}
-
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/UIContainerCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/UIContainerCell.cs
@@ -39,7 +39,7 @@ namespace Xamarin.Forms.Platform.iOS
 			TableView.ReloadRows(new[] { IndexPath }, UITableViewRowAnimation.Automatic);
 		}
 
-		internal void Disconnect()
+		internal void Disconnect(Shell shell)
 		{
 			ViewMeasureInvalidated = null;
 			View.MeasureInvalidated -= MeasureInvalidated;
@@ -48,6 +48,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_bindingContext = null;
 			Platform.SetRenderer(View, null);
+			shell.RemoveLogicalChild(View);
 			View = null;
 			TableView = null;
 		}


### PR DESCRIPTION
### Description of Change ###
Shift Shell over so it returns everything from the Logical Children structure which plays into Hot Reload and the Live Visual Tree better. Initially I didn't use LogicalChildren because Page (the base class of Shell) makes a bunch of assumptions against its LogicalChildren. This PR intercepts those assumptions and just lets Shell manage its logical children 

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #13171 


### Testing Procedure ###
- Validate that Live Visual Tree displays flyout items/flyoutheader/flyoutfooter/flyoutcontent

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
