### PR TITLE
Fix string constructor for ShellNavigationState

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -12,6 +12,12 @@ namespace Xamarin.Forms.Core.UnitTests
 	[TestFixture]
 	public class ShellNavigatingTests : ShellTestBase
 	{
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Routing.Clear();
+		}
 
 		[Test]
 		public void CancelNavigation()
@@ -635,6 +641,296 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			shell.TestNavigationArgs(ShellNavigationSource.ShellItemChanged,
 				null, "//item");
+		}
+
+
+		[TestCase(true, 2)]
+		[TestCase(false, 2)]
+		[TestCase(true, 3)]
+		[TestCase(false, 3)]
+		public async Task ShellItemContentRouteWithGlobalRouteRelative(bool modal, int depth)
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
+
+			string route = "monkeys/details";
+
+			if (depth == 3)
+			{
+				route = "animals/monkeys/details";
+			}
+
+			if (modal)
+				Routing.RegisterRoute(route, typeof(ShellModalTests.ModalTestPage));
+			else
+				Routing.RegisterRoute(route, typeof(ContentPage));
+
+			shell.Items.Add(item1);
+
+			await shell.GoToAsync("details");
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//animals/monkeys/details"));
+		}
+
+		[TestCase(true)]
+		[TestCase(false)]
+		public async Task GotoSameGlobalRoutesCollapsesUriCorrectly(bool modal)
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
+
+			if (modal)
+				Routing.RegisterRoute("details", typeof(ShellModalTests.ModalTestPage));
+			else
+				Routing.RegisterRoute("details", typeof(ContentPage));
+
+			shell.Items.Add(item1);
+
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("details");
+			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//animals/monkeys/details/details"));
+		}
+
+		[Test]
+		public async Task ShellSectionWithGlobalRouteAbsolute()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1", shellSectionRoute: "section1");
+
+			Routing.RegisterRoute("edit", typeof(ContentPage));
+
+			shell.Items.Add(item1);
+
+			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("//rootlevelcontent1/edit"));
+
+			Assert.AreEqual(1, request.Request.GlobalRoutes.Count);
+			Assert.AreEqual("edit", request.Request.GlobalRoutes.First());
+		}
+
+		[Test]
+		public async Task ShellSectionWithRelativeEdit()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1", shellSectionRoute: "section1");
+			var editShellContent = CreateShellContent(shellContentRoute: "edit");
+
+
+			item1.Items[0].Items.Add(editShellContent);
+			shell.Items.Add(item1);
+
+			await shell.GoToAsync("//rootlevelcontent1");
+			var location = shell.CurrentState.FullLocation;
+			await shell.NavigationManager.GoToAsync("edit", false, true);
+
+			Assert.AreEqual(editShellContent, shell.CurrentItem.CurrentItem.CurrentItem);
+		}
+
+
+		[Test]
+		public async Task ShellContentOnlyWithGlobalEdit()
+		{
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
+			var item2 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent2");
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			Routing.RegisterRoute("//rootlevelcontent1/edit", typeof(ContentPage));
+			await shell.GoToAsync("//rootlevelcontent1/edit");
+		}
+
+
+		[Test]
+		public async Task RouteWithGlobalPageRoute()
+		{
+
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
+			var item2 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "cats");
+
+			shell.Items.Add(item1);
+			shell.Items.Add(item2);
+
+			Routing.RegisterRoute("catdetails", typeof(ContentPage));
+			await shell.GoToAsync("//cats/catdetails?name=3");
+
+			Assert.AreEqual("//animals/domestic/cats/catdetails", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task AbsoluteRoutingToPage()
+		{
+
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
+			shell.Items.Add(item1);
+
+			Routing.RegisterRoute("catdetails", typeof(ContentPage));
+
+			Assert.That(async () => await shell.GoToAsync($"//catdetails"), Throws.Exception);
+		}
+
+		[Test]
+		public async Task LocationRemovesImplicit()
+		{
+
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
+
+			shell.Items.Add(item1);
+
+			Assert.AreEqual("//rootlevelcontent1", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task GlobalNavigateTwice()
+		{
+
+			var shell = new Shell();
+			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
+
+			shell.Items.Add(item1);
+			Routing.RegisterRoute("cat", typeof(ContentPage));
+			Routing.RegisterRoute("details", typeof(ContentPage));
+
+			await shell.GoToAsync("cat");
+			await shell.GoToAsync("details");
+
+			Assert.AreEqual("//rootlevelcontent1/cat/details", shell.CurrentState.Location.ToString());
+			await shell.GoToAsync("//rootlevelcontent1/details");
+			Assert.AreEqual("//rootlevelcontent1/details", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectly()
+		{
+			Routing.RegisterRoute("first", typeof(TestPage1));
+			Routing.RegisterRoute("first/second", typeof(TestPage2));
+			Routing.RegisterRoute("first/second/third", typeof(TestPage3));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "MainPage")
+			);
+
+			await shell.GoToAsync("//MainPage/first/second");
+
+			Assert.AreEqual(typeof(TestPage1), shell.Navigation.NavigationStack[1].GetType());
+			Assert.AreEqual(typeof(TestPage2), shell.Navigation.NavigationStack[2].GetType());
+
+			await shell.GoToAsync("//MainPage/first/second/third");
+
+			Assert.AreEqual(typeof(TestPage1), shell.Navigation.NavigationStack[1].GetType());
+			Assert.AreEqual(typeof(TestPage2), shell.Navigation.NavigationStack[2].GetType());
+			Assert.AreEqual(typeof(TestPage3), shell.Navigation.NavigationStack[3].GetType());
+		}
+
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyVariation()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			await shell.GoToAsync("monkeygenome");
+			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyWithDoublePop()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			await shell.GoToAsync("monkeygenome");
+			await shell.GoToAsync("../..");
+			Assert.AreEqual("//animals/monkeys", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyWithDoubleSplash()
+		{
+			Routing.RegisterRoute("//animals/monkeys/monkeyDetails", typeof(TestPage1));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			Assert.AreEqual("//animals/monkeys/monkeyDetails", shell.CurrentState.Location.ToString());
+		}
+
+
+		[Test]
+		public async Task RemovePageWithNestedRoutes()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
+			);
+
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails");
+			await shell.GoToAsync("monkeygenome");
+			shell.Navigation.RemovePage(shell.Navigation.NavigationStack[1]);
+			await shell.Navigation.PopAsync();
+		}
+
+		[Test]
+		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyWithAdditionalItems()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "cats", shellSectionRoute: "domestic", shellItemRoute: "animals")
+			);
+
+			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "monkeys"));
+			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "elephants"));
+			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "bears"));
+			shell.Items[0].Items[0].Items.Add(CreateShellContent(shellContentRoute: "dogs"));
+			shell.Items.Add(CreateShellContent(shellContentRoute: "about"));
+			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
+			await shell.GoToAsync("monkeygenome");
+			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task GoBackFromRouteWithMultiplePaths()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+
+			var shell = new TestShell(
+				CreateShellItem()
+			);
+
+			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.Navigation.PopAsync();
+			await shell.Navigation.PopAsync();
+		}
+
+
+		[Test]
+		public async Task GoBackFromRouteWithMultiplePathsHierarchical()
+		{
+			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
+			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
+
+			var shell = new TestShell(
+				CreateShellItem()
+			);
+
+			await shell.GoToAsync("monkeys/monkeyDetails");
+			await shell.GoToAsync("monkeygenome");
+			await shell.Navigation.PopAsync();
+			await shell.Navigation.PopAsync();
 		}
 
 		public class NavigationMonitoringTab : Tab

--- a/Xamarin.Forms.Core.UnitTests/ShellNavigationStateTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigationStateTests.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class ShellNavigationStateTests : ShellTestBase
+	{
+		[Test]
+		public void LocationInitializedWithUri()
+		{
+			var uri = new Uri($"//test/IMPL_TEST/D_FAULT_TEST", UriKind.Relative);
+			var uriState = new ShellNavigationState(uri);
+
+			Assert.AreEqual("//test", uriState.Location.ToString());
+			Assert.AreEqual("//test/IMPL_TEST/D_FAULT_TEST", uriState.FullLocation.ToString());
+		}
+
+		[Test]
+		public void LocationInitializedWithString()
+		{
+			var uri = new Uri("//test/IMPL_TEST/D_FAULT_TEST", UriKind.Relative);
+			var strState = new ShellNavigationState(uri.ToString());
+
+			Assert.AreEqual("//test", strState.Location.ToString());
+			Assert.AreEqual("//test/IMPL_TEST/D_FAULT_TEST", strState.FullLocation.ToString());
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellUriHandlerTests.cs
@@ -17,201 +17,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task RouteWithGlobalPageRoute()
-		{
-
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
-			var item2 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "cats");
-
-			shell.Items.Add(item1);
-			shell.Items.Add(item2);
-
-			Routing.RegisterRoute("catdetails", typeof(ContentPage));
-			await shell.GoToAsync("//cats/catdetails?name=3");
-
-			Assert.AreEqual("//animals/domestic/cats/catdetails", shell.CurrentState.Location.ToString());
-		}
-
-		[Test]
-		public async Task AbsoluteRoutingToPage()
-		{
-
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellItemRoute: "animals", shellSectionRoute: "domestic", shellContentRoute: "dogs");
-			shell.Items.Add(item1);
-
-			Routing.RegisterRoute("catdetails", typeof(ContentPage));
-
-			Assert.That(async () => await shell.GoToAsync($"//catdetails"), Throws.Exception);
-		}
-
-
-		[Test]
-		public async Task LocationRemovesImplicit()
-		{
-
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
-
-			shell.Items.Add(item1);
-
-			Assert.AreEqual("//rootlevelcontent1", shell.CurrentState.Location.ToString());
-		}
-
-
-		[Test]
-		public async Task GlobalNavigateTwice()
-		{
-
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
-
-			shell.Items.Add(item1);
-			Routing.RegisterRoute("cat", typeof(ContentPage));
-			Routing.RegisterRoute("details", typeof(ContentPage));
-
-			await shell.GoToAsync("cat");
-			await shell.GoToAsync("details");
-
-			Assert.AreEqual("//rootlevelcontent1/cat/details", shell.CurrentState.Location.ToString());
-			await shell.GoToAsync("//rootlevelcontent1/details");
-			Assert.AreEqual("//rootlevelcontent1/details", shell.CurrentState.Location.ToString());
-		}
-
-		[Test]
-		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectly()
-		{
-			Routing.RegisterRoute("first", typeof(TestPage1));
-			Routing.RegisterRoute("first/second", typeof(TestPage2));
-			Routing.RegisterRoute("first/second/third", typeof(TestPage3));
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "MainPage")
-			);
-
-			await shell.GoToAsync("//MainPage/first/second");
-
-			Assert.AreEqual(typeof(TestPage1), shell.Navigation.NavigationStack[1].GetType());
-			Assert.AreEqual(typeof(TestPage2), shell.Navigation.NavigationStack[2].GetType());
-
-			await shell.GoToAsync("//MainPage/first/second/third");
-
-			Assert.AreEqual(typeof(TestPage1), shell.Navigation.NavigationStack[1].GetType());
-			Assert.AreEqual(typeof(TestPage2), shell.Navigation.NavigationStack[2].GetType());
-			Assert.AreEqual(typeof(TestPage3), shell.Navigation.NavigationStack[3].GetType());
-		}
-
-		[Test]
-		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyVariation()
-		{
-			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
-			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
-				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
-			);
-
-			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
-			await shell.GoToAsync("monkeygenome");
-			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
-		}
-
-		[Test]
-		public async Task GlobalRoutesRegisteredHierarchicallyWithDoublePop()
-		{
-			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
-			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals2"),
-				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
-			);
-
-			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
-			await shell.GoToAsync("monkeygenome");
-			await shell.GoToAsync("../..");
-			Assert.AreEqual("//animals/monkeys", shell.CurrentState.Location.ToString());
-		}
-
-		[Test]
-		public async Task GlobalRoutesRegisteredHierarchicallyWithDoubleSplash()
-		{
-			Routing.RegisterRoute("//animals/monkeys/monkeyDetails", typeof(TestPage1));
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
-			);
-
-			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
-			Assert.AreEqual("//animals/monkeys/monkeyDetails", shell.CurrentState.Location.ToString());
-		}
-
-
-		[Test]
-		public async Task RemovePageWithNestedRoutes()
-		{
-			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
-			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "monkeys", shellItemRoute: "animals")
-			);
-
-			await shell.GoToAsync("//animals/monkeys/monkeyDetails");
-			await shell.GoToAsync("monkeygenome");
-			shell.Navigation.RemovePage(shell.Navigation.NavigationStack[1]);
-			await shell.Navigation.PopAsync();
-		}
-
-		[Test]
-		public async Task GlobalRoutesRegisteredHierarchicallyNavigateCorrectlyWithAdditionalItems()
-		{
-			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
-			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "cats", shellSectionRoute: "domestic", shellItemRoute: "animals")
-			);
-
-			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "monkeys"));
-			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "elephants"));
-			shell.Items[0].Items.Add(CreateShellContent(shellContentRoute: "bears"));
-			shell.Items[0].Items[0].Items.Add(CreateShellContent(shellContentRoute: "dogs"));
-			shell.Items.Add(CreateShellContent(shellContentRoute: "about"));
-			await shell.GoToAsync("//animals/monkeys/monkeyDetails?id=123");
-			await shell.GoToAsync("monkeygenome");
-			Assert.AreEqual("//animals/monkeys/monkeyDetails/monkeygenome", shell.CurrentState.Location.ToString());
-		}
-
-		[Test]
-		public async Task GoBackFromRouteWithMultiplePaths()
-		{
-			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
-
-			var shell = new TestShell(
-				CreateShellItem()
-			);
-
-			await shell.GoToAsync("monkeys/monkeyDetails");
-			await shell.GoToAsync("monkeys/monkeyDetails");
-			await shell.Navigation.PopAsync();
-			await shell.Navigation.PopAsync();
-		}
-
-
-		[Test]
-		public async Task GoBackFromRouteWithMultiplePathsHierarchical()
-		{
-			Routing.RegisterRoute("monkeys/monkeyDetails", typeof(TestPage1));
-			Routing.RegisterRoute("monkeyDetails/monkeygenome", typeof(TestPage2));
-
-			var shell = new TestShell(
-				CreateShellItem()
-			);
-
-			await shell.GoToAsync("monkeys/monkeyDetails");
-			await shell.GoToAsync("monkeygenome");
-			await shell.Navigation.PopAsync();
-			await shell.Navigation.PopAsync();
-		}
-
-		[Test]
 		public void NodeWalkingBasic()
 		{
 			var shell = new TestShell(
@@ -270,19 +75,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("app://shell/IMPL_shell/seg1/seg2/seg3", request.Request.FullUri.ToString());
 		}
 
-		[Test]
-		public async Task ShellContentOnlyWithGlobalEdit()
-		{
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1");
-			var item2 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent2");
-
-			shell.Items.Add(item1);
-			shell.Items.Add(item2);
-
-			Routing.RegisterRoute("//rootlevelcontent1/edit", typeof(ContentPage));
-			await shell.GoToAsync("//rootlevelcontent1/edit");
-		}
 
 		[Test]
 		public async Task ShellRelativeGlobalRegistration()
@@ -322,21 +114,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("section1/edit", request.Request.GlobalRoutes.Skip(1).First());
 		}
 
-		[Test]
-		public async Task ShellSectionWithGlobalRouteAbsolute()
-		{
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1", shellSectionRoute: "section1");
-
-			Routing.RegisterRoute("edit", typeof(ContentPage));
-
-			shell.Items.Add(item1);
-
-			var request = ShellUriHandler.GetNavigationRequest(shell, CreateUri("//rootlevelcontent1/edit"));
-
-			Assert.AreEqual(1, request.Request.GlobalRoutes.Count);
-			Assert.AreEqual("edit", request.Request.GlobalRoutes.First());
-		}
 
 		[Test]
 		public async Task ShellSectionWithGlobalRouteRelative()
@@ -355,53 +132,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("edit", request.Request.GlobalRoutes.First());
 		}
 
-		[TestCase(true, 2)]
-		[TestCase(false, 2)]
-		[TestCase(true, 3)]
-		[TestCase(false, 3)]
-		public async Task ShellItemContentRouteWithGlobalRouteRelative(bool modal, int depth)
-		{
-			var shell = new Shell();
-			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
-
-			string route = "monkeys/details";
-
-			if (depth == 3)
-			{
-				route = "animals/monkeys/details";
-			}
-
-			if (modal)
-				Routing.RegisterRoute(route, typeof(ShellModalTests.ModalTestPage));
-			else
-				Routing.RegisterRoute(route, typeof(ContentPage));
-
-			shell.Items.Add(item1);
-
-			await shell.GoToAsync("details");
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//animals/monkeys/details"));
-		}
-
-		[TestCase(true)]
-		[TestCase(false)]
-		public async Task GotoSameGlobalRoutesCollapsesUriCorrectly(bool modal)
-		{
-			var shell = new Shell();
-			var item1 = CreateShellItem<FlyoutItem>(asImplicit: true, shellItemRoute: "animals", shellContentRoute: "monkeys");
-
-			if (modal)
-				Routing.RegisterRoute("details", typeof(ShellModalTests.ModalTestPage));
-			else
-				Routing.RegisterRoute("details", typeof(ContentPage));
-
-			shell.Items.Add(item1);
-
-			await shell.GoToAsync("details");
-			await shell.GoToAsync("details");
-			Assert.That(shell.CurrentState.Location.ToString(), Is.EqualTo("//animals/monkeys/details/details"));
-		}
-
-
 		[Test]
 		public async Task ShellSectionWithRelativeEditUpOneLevel()
 		{
@@ -418,23 +148,6 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("section1/edit", request.Request.GlobalRoutes.First());
 		}
 
-		[Test]
-		public async Task ShellSectionWithRelativeEdit()
-		{
-			var shell = new Shell();
-			var item1 = CreateShellItem(asImplicit: true, shellContentRoute: "rootlevelcontent1", shellSectionRoute: "section1");
-			var editShellContent = CreateShellContent(shellContentRoute: "edit");
-
-
-			item1.Items[0].Items.Add(editShellContent);
-			shell.Items.Add(item1);
-
-			await shell.GoToAsync("//rootlevelcontent1");
-			var location = shell.CurrentState.FullLocation;
-			await shell.NavigationManager.GoToAsync("edit", false, true);
-
-			Assert.AreEqual(editShellContent, shell.CurrentItem.CurrentItem.CurrentItem);
-		}
 
 
 		[Test]

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ShellFlyoutItemGroupTests.cs" />
     <Compile Include="ShellFlyoutItemTemplateTests.cs" />
     <Compile Include="ShellModalTests.cs" />
+    <Compile Include="ShellNavigationStateTests.cs" />
     <Compile Include="ShellNavigatingTests.cs" />
     <Compile Include="ShellTestBase.cs" />
     <Compile Include="ShellLifeCycleTests.cs" />

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -852,7 +852,7 @@ namespace Xamarin.Forms
 				return true;
 			}
 
-			var args = new ShellNavigatingEventArgs(this.CurrentState, "", ShellNavigationSource.Pop, true);
+			var args = new ShellNavigatingEventArgs(this.CurrentState, new ShellNavigationState(""), ShellNavigationSource.Pop, true);
 			_navigationManager.HandleNavigating(args);
 			return args.Cancelled;
 

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -36,7 +36,7 @@ namespace Xamarin.Forms
 			if (shellNavigationParameters.PagePushing != null)
 				Routing.RegisterImplicitPageRoute(shellNavigationParameters.PagePushing);
 
-			ShellNavigationState state = shellNavigationParameters.TargetState ?? Routing.GetRoute(shellNavigationParameters.PagePushing);
+			var state = shellNavigationParameters.TargetState ?? new ShellNavigationState(Routing.GetRoute(shellNavigationParameters.PagePushing), false);
 			bool? animate = shellNavigationParameters.Animated;
 			bool enableRelativeShellRoutes = shellNavigationParameters.EnableRelativeShellRoutes;
 			ShellNavigatingEventArgs deferredArgs = shellNavigationParameters.DeferredArgs;

--- a/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationState.cs
@@ -26,7 +26,7 @@ namespace Xamarin.Forms
 		}
 
 		public ShellNavigationState() { }
-		public ShellNavigationState(string location) : this(location, false)
+		public ShellNavigationState(string location) : this(location, true)
 		{
 		}
 
@@ -45,7 +45,12 @@ namespace Xamarin.Forms
 				Location = FullLocation;
 		}
 
-		public ShellNavigationState(Uri location) => FullLocation = location;
+		public ShellNavigationState(Uri location)
+		{
+			FullLocation = location;
+			Location = TrimDownImplicitAndDefaultPaths(FullLocation);
+		}
+
 		public static implicit operator ShellNavigationState(Uri uri) => new ShellNavigationState(uri);
 		public static implicit operator ShellNavigationState(string value) => new ShellNavigationState(value);
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -1063,7 +1063,7 @@ namespace Xamarin.Forms
 				var navigationParameters = new ShellNavigationParameters()
 				{
 					Animated = animated,
-					TargetState = ".."
+					TargetState = new ShellNavigationState("..")
 				};
 
 				var returnedPage = (_owner as IShellSectionController).PresentedPage;


### PR DESCRIPTION
### Description of Change ###

Fix string constructor for ShellNavigationState so it sets both Location and FullLocation

### Issues Resolved ### 

- fixes #13422 

### Platforms Affected ### 
- Core/XAML (all platforms)

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
