### PR TITLE
Fix NRE when using Custom Slide Transition

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
+++ b/Xamarin.Forms.ControlGallery.iOS/CustomRenderers.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using CoreGraphics;
 using CoreLocation;
 using Foundation;
 using MapKit;
@@ -25,8 +26,27 @@ using RectangleF = CoreGraphics.CGRect;
 [assembly: ExportRenderer(typeof(Issue1683.EntryKeyboardFlags), typeof(EntryRendererKeyboardFlags))]
 [assembly: ExportRenderer(typeof(Issue1683.EditorKeyboardFlags), typeof(EditorRendererKeyboardFlags))]
 [assembly: ExportRenderer(typeof(Issue5830.ExtendedEntryCell), typeof(ExtendedEntryCellRenderer))]
+[assembly: ExportRenderer(typeof(Issue13390), typeof(Issue13390Renderer))]
 namespace Xamarin.Forms.ControlGallery.iOS
 {
+	public class Issue13390Renderer : ShellRenderer
+	{
+		protected override IShellFlyoutRenderer CreateFlyoutRenderer()
+		{
+			return new ShellFlyoutRenderer()
+			{
+				FlyoutTransition = new SlideFlyoutTransition2()
+			};
+		}
+
+		public class SlideFlyoutTransition2 : IShellFlyoutTransition
+		{
+			public void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)
+			{
+				flyout.Frame = new CGRect(0, 0, 0, 0);
+			}
+		}
+	}
 
 	public class CustomIOSMapRenderer : ViewRenderer<Bugzilla39987.CustomMapView, MKMapView>
 	{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13390.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13390.cs
@@ -1,0 +1,40 @@
+﻿using System.Linq;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13390, "Custom SlideFlyoutTransition is not working",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue13390 : TestShell
+	{
+		protected override void Init()
+		{
+			CreateContentPage()
+				.Content = new Label()
+				{
+					Text = "If app has not crashed test has passed",
+					AutomationId = "Success"
+				};
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void CustomSlideFlyoutTransitionCausesCrash()
+		{
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1706,6 +1706,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentOffest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13436.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13390.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_backdropBrush = appearance.FlyoutBackdrop;
 
-				if (SlideFlyoutTransition?.SetFlyoutSizes(appearance.FlyoutHeight, appearance.FlyoutWidth) ==
+				if (SlideFlyoutTransition?.UpdateFlyoutSize(appearance.FlyoutHeight, appearance.FlyoutWidth) ==
 					true)
 				{
 					if(_layoutOccured)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellFlyoutRenderer.cs
@@ -22,11 +22,9 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				_backdropBrush = appearance.FlyoutBackdrop;
 
-				if (appearance.FlyoutHeight != SlideFlyoutTransition.Height ||
-					appearance.FlyoutWidth != SlideFlyoutTransition.Width)
+				if (SlideFlyoutTransition?.SetFlyoutSizes(appearance.FlyoutHeight, appearance.FlyoutWidth) ==
+					true)
 				{
-					SlideFlyoutTransition?.SetFlyoutSizes(appearance.FlyoutHeight, appearance.FlyoutWidth);
-
 					if(_layoutOccured)
 						LayoutSidebar(false, true);
 				}

--- a/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
@@ -9,10 +9,17 @@ namespace Xamarin.Forms.Platform.iOS
 		internal double Height { get; private set; } = -1d;
 		internal double Width { get; private set; } = -1d;
 
-		internal void SetFlyoutSizes(double height, double width)
+		internal bool SetFlyoutSizes(double height, double width)
 		{
-			Height = height;
-			Width = width;
+			if (Height != height ||
+				Width != width)
+			{
+				Height = height;
+				Width = width;
+				return true;
+			}
+
+			return false;
 		}
 
 		public void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)

--- a/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SlideFlyoutTransition.cs
@@ -9,7 +9,7 @@ namespace Xamarin.Forms.Platform.iOS
 		internal double Height { get; private set; } = -1d;
 		internal double Width { get; private set; } = -1d;
 
-		internal bool SetFlyoutSizes(double height, double width)
+		public virtual bool UpdateFlyoutSize(double height, double width)
 		{
 			if (Height != height ||
 				Width != width)
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return false;
 		}
 
-		public void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)
+		public virtual void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)
 		{
 			if (behavior == FlyoutBehavior.Locked)
 				openPercent = 1;


### PR DESCRIPTION
### Description of Change ###

ShellFlyoutRenderer wasn't correctly checking for scenarios where users are implementing a Custom Slide Flyout Transition class which was causing an NRE.  I've also set the `LayoutViews` method to be virtual and add made `UpdateFlyoutSize` public so users can reuse SlideFlyoutTransition

### Issues Resolved ### 
- fixes #13390 

### API Changes ###

Added:

```C#
public class SlideFlyoutTransition 
     public virtual bool UpdateFlyoutSize(double height, double width)
```
Changed:
```C#
public class SlideFlyoutTransition 
     public virtual void LayoutViews(CGRect bounds, nfloat openPercent, UIView flyout, UIView shell, FlyoutBehavior behavior)
```
 


### Platforms Affected ### 
- iOS


### Testing Procedure ###
- ui test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
