### PR TITLE
[Android] Align NavBar BarBackground behavior between Android and iOS

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientNavigationPageGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/GradientGalleries/GradientNavigationPageGallery.xaml
@@ -24,7 +24,7 @@
     <FlyoutPage.Flyout>
         <ContentPage
             Title="Flyout"
-            BackgroundColor="White"
+            BackgroundColor="Transparent"
             Background="{StaticResource HorizontalLinearGradient}">
             <Label
                 FontSize="24"
@@ -36,6 +36,7 @@
     </FlyoutPage.Flyout>
     <FlyoutPage.Detail>
         <NavigationPage
+            BarBackgroundColor="Transparent"
             BarBackground="{StaticResource HorizontalLinearGradient}"
             Title="Gradient NavigationPage">
         <x:Arguments>

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -989,32 +989,37 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				}
 			}
 
-			Color tintColor = Element.BarBackgroundColor;
+			Color barBackgroundColor = Element.BarBackgroundColor;
+			Brush barBackground = Element.BarBackground;
 
-			if (Forms.IsLollipopOrNewer)
+			if (Brush.IsNullOrEmpty(barBackground))
 			{
-				if (tintColor.IsDefault)
-					bar.BackgroundTintMode = null;
+				if (Forms.IsLollipopOrNewer)
+				{
+					if (barBackgroundColor.IsDefault)
+						bar.BackgroundTintMode = null;
+					else
+					{
+						bar.BackgroundTintMode = PorterDuff.Mode.Src;
+						bar.BackgroundTintList = ColorStateList.ValueOf(barBackgroundColor.ToAndroid());
+					}
+				}
 				else
 				{
-					bar.BackgroundTintMode = PorterDuff.Mode.Src;
-					bar.BackgroundTintList = ColorStateList.ValueOf(tintColor.ToAndroid());
+					if (barBackgroundColor.IsDefault && _backgroundDrawable != null)
+						bar.SetBackground(_backgroundDrawable);
+					else if (!barBackgroundColor.IsDefault)
+					{
+						if (_backgroundDrawable == null)
+							_backgroundDrawable = bar.Background;
+						bar.SetBackgroundColor(barBackgroundColor.ToAndroid());
+					}
 				}
 			}
 			else
 			{
-				if (tintColor.IsDefault && _backgroundDrawable != null)
-					bar.SetBackground(_backgroundDrawable);
-				else if (!tintColor.IsDefault)
-				{
-					if (_backgroundDrawable == null)
-						_backgroundDrawable = bar.Background;
-					bar.SetBackgroundColor(tintColor.ToAndroid());
-				}
-			}
-
-			Brush barBackground = Element.BarBackground;
-			bar.UpdateBackground(barBackground);
+				bar.UpdateBackground(barBackground);
+			}	
 
 			Color textColor = Element.BarTextColor;
 			if (!textColor.IsDefault)


### PR DESCRIPTION
### Description of Change ###

Align NavBar BarBackground behavior between Android and iOS.
Actually we have two properties to set a background, `BackgroundColor` and `Background`. Since both can be set, having set color and brush, the Brush must take precedence.
This PR include changes to align the behavior using `BarBackground` between Android and iOS.

### Issues Resolved ### 

- fixes #13491 

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="1578" alt="Captura de pantalla 2021-01-22 a las 9 53 10" src="https://user-images.githubusercontent.com/6755973/105469042-f8dd4580-5c97-11eb-93b0-9475d804be63.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the Brushes gallery. Select the "NavigationPage Brush Gallery". Having set color and brush in the NavBar, the Brush must take precedence.
### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
