### PR TITLE
Fix popping with ".." and QueryString

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -317,8 +317,9 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 
-		[Test]
-		public async Task PoppingWithQueryString()
+		[TestCase("..")]
+		[TestCase("../")]
+		public async Task PoppingWithQueryString(string input)
 		{
 			Routing.RegisterRoute("details", typeof(ShellTestPage));
 			var shell = new TestShell(CreateShellItem());
@@ -326,7 +327,7 @@ namespace Xamarin.Forms.Core.UnitTests
 			await shell.GoToAsync("details");
 			await shell.GoToAsync("ModalTestPage");
 
-			await shell.GoToAsync(new ShellNavigationState($"..?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			await shell.GoToAsync(new ShellNavigationState($"{input}?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
 			shell.AssertCurrentStateEquals($"//{shell.CurrentItem.CurrentItem.CurrentItem.Route}/details");
 
 			var testPage = shell.CurrentPage as ShellTestPage;

--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -316,6 +316,23 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual("1234", testPage.SomeQueryParameter);
 		}
 
+
+		[Test]
+		public async Task PoppingWithQueryString()
+		{
+			Routing.RegisterRoute("details", typeof(ShellTestPage));
+			var shell = new TestShell(CreateShellItem());
+
+			await shell.GoToAsync("details");
+			await shell.GoToAsync("ModalTestPage");
+
+			await shell.GoToAsync(new ShellNavigationState($"..?{nameof(ShellTestPage.SomeQueryParameter)}=1234"));
+			shell.AssertCurrentStateEquals($"//{shell.CurrentItem.CurrentItem.CurrentItem.Route}/details");
+
+			var testPage = shell.CurrentPage as ShellTestPage;
+			Assert.AreEqual("1234", testPage.SomeQueryParameter);
+		}
+
 		[Test]
 		public async Task NavigatingAndNavigatedFiresForShellModal()
 		{

--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -341,6 +341,11 @@ namespace Xamarin.Forms.Core.UnitTests
 				Routing.RegisterRoute(route, new ConcretePageFactory(contentPage));
 			}
 
+			public void AssertCurrentStateEquals(string expectedState)
+			{
+				Assert.AreEqual(expectedState, CurrentState.Location.ToString());
+			}
+
 			public class ConcretePageFactory : RouteFactory
 			{
 				ContentPage _contentPage;

--- a/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
+++ b/Xamarin.Forms.Core/Shell/ShellUriHandler.cs
@@ -17,12 +17,15 @@ namespace Xamarin.Forms
 		{
 			if (path.OriginalString.StartsWith("..") && shell?.CurrentState != null)
 			{
+				var pathAndQueryString = path.OriginalString.Split(new[] { '?' }, 2);
+				string pathPart = pathAndQueryString[0];
+				string queryString = (pathAndQueryString.Length > 1) ? $"?{pathAndQueryString[1]}" : String.Empty;
+
 				var pages = ShellNavigationManager.BuildFlattenedNavigationStack(shell);
-				var currentState = shell.CurrentState.FullLocation.OriginalString;
 
 				List<string> restOfPath = new List<string>();
 				bool dotsAllParsed = false;
-				foreach (var p in path.OriginalString.Split(_pathSeparators))
+				foreach (var p in pathPart.Split(_pathSeparators))
 				{
 					if (p != ".." || dotsAllParsed)
 					{
@@ -54,7 +57,7 @@ namespace Xamarin.Forms
 				restOfPath.Insert(0, shell.CurrentItem.CurrentItem.CurrentItem.Route);
 				restOfPath.Insert(0, shell.CurrentItem.CurrentItem.Route);
 				restOfPath.Insert(0, shell.CurrentItem.Route);
-				var result = String.Join(_pathSeparator, restOfPath);
+				var result = $"{String.Join(_pathSeparator, restOfPath)}{queryString}";
 				var returnValue = ConvertToStandardFormat("scheme", "host", null, new Uri(result, UriKind.Relative));
 				return new Uri(FormatUri(returnValue.PathAndQuery), UriKind.Relative);
 			}


### PR DESCRIPTION
### Description of Change ###
When processing a ".." operation to recalculate the new shell path query strings were incorrectly being processed as part of the path. The changes in this PR properly process only the path part when recalculating the destination path 

### Issues Resolved ### 
- fixes #13506


### Platforms Affected ### 
- Core/XAML (all platforms)


### Testing Procedure ###
- unit test included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
