### PR TITLE
Fix formatted text text type crash

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LabelFormattedTextHtmlPadding.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LabelFormattedTextHtmlPadding.cs
@@ -1,0 +1,55 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.None, 0, "Label with FormattedText, HTML, and Padding shouldn't cause crash", PlatformAffected.iOS)]
+	public class LabelFormattedTextHtmlPadding : TestContentPage
+	{
+		protected override void Init()
+		{
+			var formattedString = new FormattedString();
+			formattedString.Spans.Add(new Span { Text = "This test passes if app doesn't crash. Label is not expected to actually work" });
+
+			Content = new StackLayout()
+			{
+				Margin = 20,
+
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = "LabelFormattedTextHtmlPaddingTest",
+						Text = "If you can see this text, this test has passed"
+					},
+					new Label()
+					{
+						AutomationId = "LabelFormattedTextHtmlPadding",
+						FormattedText = formattedString,
+						TextType = TextType.Html,
+						Padding = 5
+					}
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void LabelFormattedTextHtmlPaddingTest()
+		{
+			RunningApp.WaitForElement("LabelWithFormattedTextHtmlAndPadding");
+			RunningApp.Screenshot("I am at LabelWithFormattedTextHtmlAndPadding");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LabelFormattedTextHtmlPadding.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/LabelFormattedTextHtmlPadding.cs
@@ -42,14 +42,5 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			};
 		}
-
-#if UITEST
-		[Test]
-		public void LabelFormattedTextHtmlPaddingTest()
-		{
-			RunningApp.WaitForElement("LabelWithFormattedTextHtmlAndPadding");
-			RunningApp.Screenshot("I am at LabelWithFormattedTextHtmlAndPadding");
-		}
-#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1703,6 +1703,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutBackground.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentOffest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)LabelFormattedTextHtmlPadding.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
@@ -89,32 +89,20 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		{
 			var formattedString = new FormattedString();
 			formattedString.Spans.Add(new Span { Text = "Label with FormattedText, HTML, and Padding" });
-			var label = new Label {
+			var label = new Label
+			{
 				FormattedText = formattedString,
 				TextType = TextType.Html,
 				Padding = 5
 			};
 
-			var content = new StackLayout()
-			{
-				Margin = 20,
-
-				Children =
-				{
-					new Label()
-					{
-						AutomationId = "LabelFormattedTextHtmlPaddingTest",
-						Text = "If you can see this text, this test has passed"
-					},
-					label
-				}
-			};
-
-
 			var expected = TextType.Html;
-			var actual = await GetRendererProperty(content, renderer =>
+			var actual = await GetRendererProperty(label, renderer =>
 			{
-				return (Platform.GetRenderer(label).Element as Label).TextType;
+				var uiLabel = (UILabel)(renderer as LabelRenderer).Control;
+				uiLabel.Frame = new CoreGraphics.CGRect(0, 0, 200, 200);
+				uiLabel.RecalculateSpanPositions(label);
+				return label.TextType;
 			}, true);
 
 			Assert.That(actual, Is.EqualTo(expected));

--- a/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
@@ -94,8 +94,29 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 				TextType = TextType.Html,
 				Padding = 5
 			};
+
+			var content = new StackLayout()
+			{
+				Margin = 20,
+
+				Children =
+				{
+					new Label()
+					{
+						AutomationId = "LabelFormattedTextHtmlPaddingTest",
+						Text = "If you can see this text, this test has passed"
+					},
+					label
+				}
+			};
+
+
 			var expected = TextType.Html;
-			var actual = await GetRendererProperty(label, renderer => (renderer.Element as Label).TextType, true);
+			var actual = await GetRendererProperty(content, renderer =>
+			{
+				return (Platform.GetRenderer(label).Element as Label).TextType;
+			}, true);
+
 			Assert.That(actual, Is.EqualTo(expected));
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/HtmlLabelTests.cs
@@ -82,5 +82,21 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 
 			Assert.That(actualFont.PointSize, Is.EqualTo(expectedFontSize));
 		}
+
+		[Test, Category("Label"), Category("FormattedText")]
+		[Description("If Label has FormattedText, HTML, and Padding, app should not crash")]
+		public async Task LabelWithFormattedTextHTMLAndPaddingDoesNotCrashApp()
+		{
+			var formattedString = new FormattedString();
+			formattedString.Spans.Add(new Span { Text = "Label with FormattedText, HTML, and Padding" });
+			var label = new Label {
+				FormattedText = formattedString,
+				TextType = TextType.Html,
+				Padding = 5
+			};
+			var expected = TextType.Html;
+			var actual = await GetRendererProperty(label, renderer => (renderer.Element as Label).TextType, true);
+			Assert.That(actual, Is.EqualTo(expected));
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
@@ -21,6 +21,12 @@ namespace Xamarin.Forms.Platform.MacOS
 	{
 		public static void RecalculateSpanPositions(this NativeLabel control, Label element)
 		{
+			if (element == null)
+				return;
+
+			if (element.TextType == TextType.Html)
+				return;
+
 			if (element?.FormattedText?.Spans == null
 				|| element.FormattedText.Spans.Count == 0)
 				return;


### PR DESCRIPTION
### Description of Change ###
Prevent app crashing when there's a label with FormattedText, TextType=Html, and Padding properties.

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
App no longer crashes

### Testing Procedure ###
Set main page to LabelFormattedTextHtmlPadding
Ensure app doesn't crash > Test passes

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
