### PR TITLE
[Android] Fix set CurrentItem to null on CarouselView

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml
@@ -12,6 +12,7 @@
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
             <RowDefinition Height="Auto" />
+            <RowDefinition Height="Auto" />
         </Grid.RowDefinitions>
         <Grid.ColumnDefinitions>
             <ColumnDefinition />
@@ -29,9 +30,11 @@
             <Button Command="{Binding RemoveCommand}"  AutomationId="btnRemove" Text="{Binding Path=Selected.Index, StringFormat='Remove {0}'}" BackgroundColor="LightGray" TextColor="Black" />
             <Button Command="{Binding NextCommand}"  AutomationId="btnNext" Text="&gt;" FontAttributes="Bold" BackgroundColor="LightGray" TextColor="Black" />
         </StackLayout>
+        <Button Grid.Row="5" Text="Clear" Command="{Binding ClearCommand}" AutomationId="btnClear"/>
+        <Button Grid.Row="5" Grid.Column="1" Text="Set" Command="{Binding SetCommand}" AutomationId="btnSet"/>
         <CarouselView
             x:Name="carousel"
-            Grid.Row="5" Grid.ColumnSpan="2"
+            Grid.Row="6" Grid.ColumnSpan="2"
             Loop="{Binding IsLoop}"
             AutomationId="TheCarouselView"
             ItemsSource="{Binding Items}"

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -160,5 +160,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 		public string Image { get; set; }
 
 		public string FeaturedImage { get; set; }
+
+		public override string ToString()
+		{
+			return Index.ToString();
+		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselXamlGallery.xaml.cs
@@ -35,27 +35,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			IsLoop = loop;
 			_type = type;
 
-			var items = new List<CarouselItem>();
-			for (int i = 0; i < initialItems; i++)
-			{
-				switch (_type)
-				{
-					case CarouselXamlSampleType.Peek:
-						items.Add(new CarouselItem(i, "cardBackground.png"));
-						break;
-					default:
-						items.Add(new CarouselItem(i));
-						break;
-				}
-			}
-
-			MessagingCenter.Subscribe<ExampleTemplateCarousel>(this, "remove", (obj) => Items.Remove(obj.BindingContext as CarouselItem));
-
-			Items = new ObservableCollection<CarouselItem>(items);
-			Count = Items.Count - 1;
-
-			if (startCurrentItem != -1)
-				Selected = Items[startCurrentItem];
+			SetItems(initialItems, startCurrentItem);
 		}
 
 		public bool IsLoop
@@ -124,6 +104,44 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				Selected = newItem;
 			}
 		});
+
+		public ICommand ClearCommand => new Command(ClearItems);
+
+		public ICommand SetCommand => new Command(() =>
+		{
+			SetItems(10, 5);
+		});
+
+		void ClearItems()
+		{
+			Items.Clear();
+			Selected = null;
+		}
+
+		void SetItems(int initialItems, int startCurrentItem)
+		{
+			var items = new List<CarouselItem>();
+			for (int i = 0; i < initialItems; i++)
+			{
+				switch (_type)
+				{
+					case CarouselXamlSampleType.Peek:
+						items.Add(new CarouselItem(i, "cardBackground.png"));
+						break;
+					default:
+						items.Add(new CarouselItem(i));
+						break;
+				}
+			}
+
+			MessagingCenter.Subscribe<ExampleTemplateCarousel>(this, "remove", (obj) => Items.Remove(obj.BindingContext as CarouselItem));
+
+			Items = new ObservableCollection<CarouselItem>(items);
+			Count = Items.Count - 1;
+
+			if (startCurrentItem != -1)
+				Selected = Items[startCurrentItem];
+		}
 	}
 
 	[Preserve(AllMembers = true)]

--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -504,7 +504,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateFromCurrentItem()
 		{
-			var currentItemPosition = ItemsViewAdapter.ItemsSource.GetPosition(Carousel.CurrentItem);
+			var currentItem = Carousel?.CurrentItem;
+
+			if (currentItem == null)
+				return;
+
+			var currentItemPosition = ItemsViewAdapter.ItemsSource.GetPosition(currentItem);
 			var carouselPosition = Carousel.Position;
 
 			if (_gotoPosition == -1 && currentItemPosition != carouselPosition)


### PR DESCRIPTION
### Description of Change ###

Fix crash trying to ScrollTo a null item

### Issues Resolved ### 

- fixes #13296 

### API Changes ###
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
