### PR TITLE
Check font file length Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/EmbeddedFontLoader.cs
+++ b/Xamarin.Forms.Platform.Android/EmbeddedFontLoader.cs
@@ -14,7 +14,8 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var tmpdir = IOPath.GetTempPath();
 			var filePath = IOPath.Combine(tmpdir, font.FontName);
-			if (File.Exists(filePath))
+			var fileInfo = new FileInfo(filePath);
+			if (fileInfo.Exists && fileInfo.Length == font.ResourceStream.Length)
 				return (true, filePath);
 			try
 			{


### PR DESCRIPTION

### Description of Change ###

Check if a stored fontfile has a different size as the the embedded fontstream. If only the name is checked, changes in the embedded font are not taken into account.


### Issues Resolved ### 


- fixes #11843

### API Changes ###

 
 None

### Platforms Affected ### 


- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###


### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
