### PR TITLE
[iOS] Fix wrong initial ActionView Layout using Drag SwipeTransitionMode

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13495.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13495.xaml
@@ -1,0 +1,176 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 13495" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13495"
+    xmlns:ios="clr-namespace:Xamarin.Forms.PlatformConfiguration.iOSSpecific;assembly=Xamarin.Forms.Core">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Swipe any SwipeView several times, without a SwipeItem glitch when pulled out (using Drag SwipeTransitionMode), the test has passed."/>
+        <Label
+            Text="Left Items"/>
+        <CollectionView
+            HeightRequest="100"
+            ItemSizingStrategy="MeasureFirstItem">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <SwipeView
+                        ios:SwipeView.SwipeTransitionMode="Drag">
+                        <SwipeView.LeftItems>
+                            <SwipeItems
+                                SwipeBehaviorOnInvoked="RemainOpen">
+                                <SwipeItem
+                                    Text="Delete"
+                                    BackgroundColor="Red"/>
+                            </SwipeItems>
+                        </SwipeView.LeftItems>
+                        <Grid>
+                            <Frame
+                                HorizontalOptions="Start"
+                                BackgroundColor="LightGray"
+                                CornerRadius="12"
+                                Padding="6"
+                                HasShadow="False"
+                                Margin="6"
+                                Opacity="0.75">
+                                <Label
+                                    Text="{Binding .}"/>
+                            </Frame>
+                        </Grid>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Label
+            Text="Top Items"/>
+        <CollectionView
+            HeightRequest="100"
+            ItemSizingStrategy="MeasureFirstItem">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <SwipeView
+                        ios:SwipeView.SwipeTransitionMode="Drag">
+                        <SwipeView.TopItems>
+                            <SwipeItems
+                                SwipeBehaviorOnInvoked="RemainOpen">
+                                <SwipeItem
+                                    Text="Delete"
+                                    BackgroundColor="Red"/>
+                            </SwipeItems>
+                        </SwipeView.TopItems>
+                        <Grid>
+                            <Frame
+                                BackgroundColor="LightGray"
+                                CornerRadius="12"
+                                Padding="6"
+                                HasShadow="False"
+                                Margin="6"
+                                Opacity="0.75">
+                                <Label
+                                    Text="{Binding .}"/>
+                            </Frame>
+                        </Grid>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+         <Label
+            Text="Right Items"/>
+        <CollectionView
+            HeightRequest="100"
+            ItemSizingStrategy="MeasureFirstItem">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <SwipeView
+                        ios:SwipeView.SwipeTransitionMode="Drag">
+                        <SwipeView.RightItems>
+                            <SwipeItems
+                                SwipeBehaviorOnInvoked="RemainOpen">
+                                <SwipeItem
+                                    Text="Delete"
+                                    BackgroundColor="Red"/>
+                            </SwipeItems>
+                        </SwipeView.RightItems>
+                        <Grid>
+                            <Frame
+                                HorizontalOptions="End"
+                                BackgroundColor="LightGray"
+                                CornerRadius="12"
+                                Padding="6"
+                                HasShadow="False"
+                                Margin="6"
+                                Opacity="0.75">
+                                <Label
+                                    Text="{Binding .}"/>
+                            </Frame>
+                        </Grid>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+        <Label
+            Text="Bottom Items"/>
+        <CollectionView
+            HeightRequest="100"
+            ItemSizingStrategy="MeasureFirstItem">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>Item 1</x:String>
+                    <x:String>Item 2</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <SwipeView
+                        ios:SwipeView.SwipeTransitionMode="Drag">
+                        <SwipeView.BottomItems>
+                            <SwipeItems
+                                SwipeBehaviorOnInvoked="RemainOpen">
+                                <SwipeItem
+                                    Text="Delete"
+                                    BackgroundColor="Red"/>
+                            </SwipeItems>
+                        </SwipeView.BottomItems>
+                        <Grid>
+                            <Frame
+                                BackgroundColor="LightGray"
+                                CornerRadius="12"
+                                Padding="6"
+                                HasShadow="False"
+                                Margin="6"
+                                Opacity="0.75">
+                                <Label
+                                    Text="{Binding .}"/>
+                            </Frame>
+                        </Grid>
+                    </SwipeView>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13495.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13495.xaml.cs
@@ -1,0 +1,27 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13495,
+		"[Bug] Regression in XF5: SwipeView glitches when pulled out",
+		PlatformAffected.iOS)]
+	public partial class Issue13495 : TestContentPage
+	{
+		public Issue13495()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1707,6 +1707,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13436.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13390.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13495.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2104,6 +2105,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13436.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13495.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -454,9 +454,29 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_actionView = new UIStackView
 			{
-				Axis = UILayoutConstraintAxis.Horizontal,
-				Frame = new CGRect(0, 0, swipeItemsWidth, _contentView.Frame.Height)
+				Axis = UILayoutConstraintAxis.Horizontal
 			};
+
+			if (_swipeTransitionMode == SwipeTransitionMode.Reveal)
+				_actionView.Frame = new CGRect(0, 0, swipeItemsWidth, _contentView.Frame.Height);
+			else
+			{
+				switch (_swipeDirection)
+				{
+					case SwipeDirection.Left:
+						_actionView.Frame = new CGRect(swipeItemsWidth, 0, swipeItemsWidth, _contentView.Frame.Height);
+						break;
+					case SwipeDirection.Right:
+						_actionView.Frame = new CGRect(-swipeItemsWidth, 0, swipeItemsWidth, _contentView.Frame.Height);
+						break;
+					case SwipeDirection.Up:
+						_actionView.Frame = new CGRect(0, _contentView.Frame.Height, swipeItemsWidth, _contentView.Frame.Height);
+						break;
+					case SwipeDirection.Down:
+						_actionView.Frame = new CGRect(0, -_contentView.Frame.Height, swipeItemsWidth, _contentView.Frame.Height);
+						break;
+				}
+			}
 
 			foreach (var item in items)
 			{


### PR DESCRIPTION
### Description of Change ###

Fix wrong initial ActionView Layout using Drag `SwipeTransitionMode` on iOS.

### Issues Resolved ### 

- fixes #13495 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix13495](https://user-images.githubusercontent.com/6755973/105985000-2f9dcc00-609b-11eb-9954-90ccf714c3a8.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13495. Swipe any SwipeView several times, without a SwipeItem glitch when pulled out (using Drag SwipeTransitionMode), the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
