### PR TITLE
[Android] Fix TalkBack to read back button title when it is set

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8701.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8701.cs
@@ -1,0 +1,67 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8701, "TalkBack reads labeled back button as 'Unlabeled button'", PlatformAffected.Android)]
+	public class Issue8701 : TestNavigationPage
+	{
+		protected override void Init()
+		{
+			Navigation.PushAsync(new Issue8701FirstPage());
+		}
+
+		class Issue8701FirstPage : ContentPage
+		{
+			public Issue8701FirstPage()
+			{
+				Title = "Issue 8701 first page";
+				SetBackButtonTitle(this, "Back button title is set");
+
+				Button button = new Button() { Text = "Navigate to the second page" };
+				button.Clicked += async (sender, args) => await Navigation.PushAsync(new Issue8701SecondPage());
+
+				Content = new StackLayout()
+				{
+					Margin = 20,
+
+					Children =
+					{
+						button
+					}
+				};
+					
+			}
+		}
+
+		class Issue8701SecondPage : ContentPage
+		{
+			public Issue8701SecondPage()
+			{
+				Title = "Issue 8701 second page";
+
+				Label label = new Label() { Text = "Tap on the back button. TalkBack should read: Back button title is set" };
+
+				Content = new StackLayout()
+				{
+					Margin = 20,
+
+					Children =
+					{
+						label
+					}
+				};
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8701.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8701.cs
@@ -50,7 +50,7 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				Title = "Issue 8701 second page";
 
-				Label label = new Label() { Text = "Tap on the back button. TalkBack should read: Back button title is set" };
+				Label label = new Label() { Text = "Enable TalkBack and tap on the back button. Test passes if TalkBack reads: 'Back button title is set'" };
 
 				Content = new StackLayout()
 				{

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1706,6 +1706,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentOffest.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContentWithZeroMargin.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13436.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8701.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 
-			SetMainPage(CreateDefaultMainPage());
+			SetMainPage(new Issue8701());
 
 			//TestMainPageSwitches();
 

--- a/Xamarin.Forms.Controls/App.cs
+++ b/Xamarin.Forms.Controls/App.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Forms.Controls
 		{
 			_testCloudService = DependencyService.Get<ITestCloudService>();
 
-			SetMainPage(new Issue8701());
+			SetMainPage(CreateDefaultMainPage());
 
 			//TestMainPageSwitches();
 

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -969,7 +969,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					bar.NavigationIcon = icon;
 
 					var prevPage = Element.Peek(1);
-					_defaultNavigationContentDescription = bar.SetNavigationContentDescription(prevPage, _defaultNavigationContentDescription);
+					var backButtonTitle = NavigationPage.GetBackButtonTitle(prevPage);
+					_defaultNavigationContentDescription = backButtonTitle != null
+						? bar.SetNavigationContentDescription(prevPage, backButtonTitle)
+						: bar.SetNavigationContentDescription(prevPage, _defaultNavigationContentDescription);
 				}
 				else if (toggle != null && _flyoutPage != null)
 				{


### PR DESCRIPTION
### Description of Change ###
TalkBack would read back button as 'Unlabeled button' even when a back button title is set.
Now, TalkBack will read the back button title when it is set.

### Issues Resolved ### 

- fixes #8701
 
### Platforms Affected ### 
- Android

### Testing Procedure ###
- Set main page to Issue8701 > Run on Android > Follow on-screen instructions

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
