### PR TITLE
Move core tests to xUnit

### DIFF
--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/AbstractViewHandlerTests.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/AbstractViewHandlerTests.cs
@@ -1,45 +1,41 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Text;
-using NUnit.Framework;
+﻿using Xamarin.Platform.Handlers.Tests;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.UnitTests
 {
-
-	[TestFixture]
+	[Category(TestCategory.Core, TestCategory.Lifecycle)]
 	public class AbstractViewHandlerTests
 	{
-		[Test]
+		[Fact]
 		public void ConnectAndDisconnectFireAppropriateNumberOfTimes()
 		{
 			HandlerStub handlerStub = new HandlerStub();
 			handlerStub.SetVirtualView(new Forms.Button());
 
-			Assert.AreEqual(1, handlerStub.ConnectHandlerCount);
-			Assert.AreEqual(0, handlerStub.DisconnectHandlerCount);
+			Assert.Equal(1, handlerStub.ConnectHandlerCount);
+			Assert.Equal(0, handlerStub.DisconnectHandlerCount);
 
 			handlerStub.SetVirtualView(new Forms.Button());
 			handlerStub.SetVirtualView(new Forms.Button());
 			handlerStub.SetVirtualView(new Forms.Button());
-			Assert.AreEqual(1, handlerStub.ConnectHandlerCount);
-			Assert.AreEqual(0, handlerStub.DisconnectHandlerCount);
+			Assert.Equal(1, handlerStub.ConnectHandlerCount);
+			Assert.Equal(0, handlerStub.DisconnectHandlerCount);
 
 			(handlerStub as IViewHandler).DisconnectHandler();
-			Assert.AreEqual(1, handlerStub.ConnectHandlerCount);
-			Assert.AreEqual(1, handlerStub.DisconnectHandlerCount);
+			Assert.Equal(1, handlerStub.ConnectHandlerCount);
+			Assert.Equal(1, handlerStub.DisconnectHandlerCount);
 
 			(handlerStub as IViewHandler).DisconnectHandler();
-			Assert.AreEqual(1, handlerStub.ConnectHandlerCount);
-			Assert.AreEqual(1, handlerStub.DisconnectHandlerCount);
+			Assert.Equal(1, handlerStub.ConnectHandlerCount);
+			Assert.Equal(1, handlerStub.DisconnectHandlerCount);
 
 
 			handlerStub.SetVirtualView(new Forms.Button());
-			Assert.AreEqual(2, handlerStub.ConnectHandlerCount);
-			Assert.AreEqual(1, handlerStub.DisconnectHandlerCount);
+			Assert.Equal(2, handlerStub.ConnectHandlerCount);
+			Assert.Equal(1, handlerStub.DisconnectHandlerCount);
 			(handlerStub as IViewHandler).DisconnectHandler();
-			Assert.AreEqual(2, handlerStub.ConnectHandlerCount);
-			Assert.AreEqual(2, handlerStub.DisconnectHandlerCount);
+			Assert.Equal(2, handlerStub.ConnectHandlerCount);
+			Assert.Equal(2, handlerStub.DisconnectHandlerCount);
 		}
 	}
-
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/ConstraintTests.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/ConstraintTests.cs
@@ -1,43 +1,43 @@
-﻿using NUnit.Framework;
-using Xamarin.Platform.Handlers.Tests;
+﻿using Xamarin.Platform.Handlers.Tests;
 using Xamarin.Platform.Layouts;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 {
-	[TestFixture(Category = TestCategory.Layout)]
-	public class ConstraintTests 
+	[Category(TestCategory.Core, TestCategory.Layout)]
+	public class ConstraintTests
 	{
-		[Test(Description = "When resolving constraints, external constraints take precedence")]
-		[TestCase(100, 200, 100)]
-		[TestCase(100, 100, 100)]
-		[TestCase(100, -1, 100)]
-		public void ExternalWinsOverDesired(double externalConstraint, double desiredLength, double expected) 
+		[Theory("When resolving constraints, external constraints take precedence")]
+		[InlineData(100, 200, 100)]
+		[InlineData(100, 100, 100)]
+		[InlineData(100, -1, 100)]
+		public void ExternalWinsOverDesired(double externalConstraint, double desiredLength, double expected)
 		{
 			var resolution = LayoutManager.ResolveConstraints(externalConstraint, desiredLength);
-			Assert.That(resolution, Is.EqualTo(expected));
+			Assert.Equal(expected, resolution);
 		}
 
-		[Test(Description = "When resolving constraints, external constraints take precedence")]
-		[TestCase(100, 200, 130, 100)]
-		[TestCase(100, -1, 130, 100)]
-		public void ExternalWinsOverDesired(double externalConstraint, double desiredLength, double measured, double expected)
+		[Theory("When resolving constraints, external constraints take precedence")]
+		[InlineData(100, 200, 130, 100)]
+		[InlineData(100, -1, 130, 100)]
+		public void ExternalWinsOverDesiredAndMeasured(double externalConstraint, double desiredLength, double measured, double expected)
 		{
 			var resolution = LayoutManager.ResolveConstraints(externalConstraint, desiredLength, measured);
-			Assert.That(resolution, Is.EqualTo(expected));
+			Assert.Equal(expected, resolution);
 		}
 
-		[Test(Description = "If external and request constraints don't apply, constrain to measured value")]
+		[Fact("If external and request constraints don't apply, constrain to measured value")]
 		public void MeasuredWinsIfNothingElseApplies()
 		{
 			var resolution = LayoutManager.ResolveConstraints(double.PositiveInfinity, -1, 245);
-			Assert.That(resolution, Is.EqualTo(245));
+			Assert.Equal(245, resolution);
 		}
 
-		[Test(Description = "If external constraints don't apply, constraing to requested value")]
+		[Fact("If external constraints don't apply, constrain to requested value")]
 		public void RequestedTakesPrecedenceOverMeasured()
 		{
 			var resolution = LayoutManager.ResolveConstraints(double.PositiveInfinity, 90, 245);
-			Assert.That(resolution, Is.EqualTo(90));
+			Assert.Equal(90, resolution);
 		}
 	}
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/HorizontalStackLayoutManagerTests.cs
@@ -1,21 +1,22 @@
 ﻿using System.Collections.Generic;
 using NSubstitute;
-using NUnit.Framework;
 using Xamarin.Forms;
 using Xamarin.Platform.Handlers.Tests;
 using Xamarin.Platform.Layouts;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 {
-	[TestFixture(Category = TestCategory.Layout)]
+	[Category(TestCategory.Core, TestCategory.Layout)]
 	public class HorizontalStackLayoutManagerTests : StackLayoutManagerTests
 	{
-		[TestCase(0, 100, 0, 0, Description = "No items, width should be zero")]
-		[TestCase(1, 100, 0, 100, Description = "One item, width should match the item")]
-		[TestCase(1, 100, 13, 100, Description = "One item, spacing should have no effect")]
-		[TestCase(2, 100, 13, 213, Description = "Two items, spacing should count once [(100 * 2) + 13 = 213]")]
-		[TestCase(3, 100, 13, 326, Description = "Three items, spacing should count twice [(100 * 3) + (2 * 13) = 326]")]
-		[TestCase(3, 100, -13, 274, Description = "Negative spacing overlaps items [(100 * 3) + (2 * -13) = 274]")]
+		[Theory]
+		[InlineData(0, 100, 0, 0)]
+		[InlineData(1, 100, 0, 100)]
+		[InlineData(1, 100, 13, 100)]
+		[InlineData(2, 100, 13, 213)]
+		[InlineData(3, 100, 13, 326)]
+		[InlineData(3, 100, -13, 274)]
 		public void SpacingMeasurement(int viewCount, double viewWidth, int spacing, double expectedWidth)
 		{
 			var stack = BuildStack(viewCount, viewWidth, 100);
@@ -24,11 +25,11 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(double.PositiveInfinity, 100);
 
-			Assert.That(measuredSize.Width, Is.EqualTo(expectedWidth));
+			Assert.Equal(expectedWidth, measuredSize.Width);
 		}
 
-		[Test(Description = "Spacing should not affect arrangement with only one item")]
-		[TestCase(0), TestCase(26), TestCase(-54)]
+		[Theory("Spacing should not affect arrangement with only one item")]
+		[InlineData(0), InlineData(26), InlineData(-54)]
 		public void SpacingArrangementOneItem(int spacing)
 		{
 			var stack = BuildStack(1, 100, 100);
@@ -43,8 +44,8 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			stack.Children[0].Received().Arrange(Arg.Is(expectedRectangle));
 		}
 
-		[Test(Description = "Spacing should affect arrangement with more than one item")]
-		[TestCase(26), TestCase(-54)]
+		[Theory("Spacing should affect arrangement with more than one item")]
+		[InlineData(26), InlineData(-54)]
 		public void SpacingArrangementTwoItems(int spacing)
 		{
 			var stack = BuildStack(2, 100, 100);
@@ -62,9 +63,10 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			stack.Children[1].Received().Arrange(Arg.Is(expectedRectangle1));
 		}
 
-		[TestCase(150, 100, 100, Description = "The Stack's specified width of 100 should override the child's measured width of 150")]
-		[TestCase(150, 200, 200, Description = "The Stack's specified width of 200 should override the child's measured width of 150")]
-		[TestCase(1250, -1, 1250, Description = "The Stack doesn't specify width, so the child determines the width")]
+		[Theory]
+		[InlineData(150, 100, 100)]
+		[InlineData(150, 200, 200)]
+		[InlineData(1250, -1, 1250)]
 		public void StackAppliesWidth(double viewWidth, double stackWidth, double expectedWidth)
 		{
 			var stack = CreateTestLayout();
@@ -78,11 +80,11 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 
 			var manager = new HorizontalStackLayoutManager(stack);
 			var measurement = manager.Measure(double.PositiveInfinity, 100);
-			Assert.That(measurement.Width, Is.EqualTo(expectedWidth));
+			Assert.Equal(expectedWidth, measurement.Width);
 		}
 
-		[Test]
-		public void ViewsArrangedWithDesiredHeights() 
+		[Fact]
+		public void ViewsArrangedWithDesiredHeights()
 		{
 			var stack = CreateTestLayout();
 			var manager = new HorizontalStackLayoutManager(stack);
@@ -97,7 +99,7 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			manager.Arrange(new Rectangle(Point.Zero, measurement));
 
 			// The tallest IView is 200, so the stack should be that tall
-			Assert.That(measurement.Height, Is.EqualTo(200));
+			Assert.Equal(200, measurement.Height);
 
 			// We expect the first IView to be at 0,0 with a width of 100 and a height of 200
 			var expectedRectangle1 = new Rectangle(0, 0, 100, 200);

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/LayoutExtensionTests.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/LayoutExtensionTests.cs
@@ -1,16 +1,16 @@
-﻿using NUnit.Framework;
-using Xamarin.Platform.Handlers.Tests;
+﻿using Xamarin.Platform.Handlers.Tests;
 using NSubstitute;
 using Xamarin.Forms;
 using Xamarin.Platform.Layouts;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 {
-	[TestFixture(Category = TestCategory.Layout)]
+	[Category(TestCategory.Core, TestCategory.Layout)]
 	public class LayoutExtensionTests
 	{
-		[Test]
-		public void FrameExcludesMargin() 
+		[Fact]
+		public void FrameExcludesMargin()
 		{
 			var element = Substitute.For<IFrameworkElement>();
 			var margin = new Thickness(20);
@@ -22,13 +22,13 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			// With a margin of 20 all the way around, we expect the actual frame
 			// to be 60x60, with an x,y position of 20,20
 
-			Assert.That(frame.Top, Is.EqualTo(20));
-			Assert.That(frame.Left, Is.EqualTo(20));
-			Assert.That(frame.Width, Is.EqualTo(60));
-			Assert.That(frame.Height, Is.EqualTo(60));
+			Assert.Equal(20, frame.Top);
+			Assert.Equal(20, frame.Left);
+			Assert.Equal(60, frame.Width);
+			Assert.Equal(60, frame.Height);
 		}
 
-		[Test]
+		[Fact]
 		public void FrameSizeGoesToZeroWhenMarginsExceedBounds()
 		{
 			var element = Substitute.For<IFrameworkElement>();
@@ -40,13 +40,13 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 
 			// The margin is simply too large for the bounds; since negative widths/heights on a frame don't make sense,
 			// we expect them to collapse to zero
-			
-			Assert.That(frame.Width, Is.EqualTo(0));
-			Assert.That(frame.Height, Is.EqualTo(0));
+
+			Assert.Equal(0, frame.Height);
+			Assert.Equal(0, frame.Width);
 		}
 
-		[Test]
-		public void DesiredSizeIncludesMargin() 
+		[Fact]
+		public void DesiredSizeIncludesMargin()
 		{
 			var widthConstraint = 400;
 			var heightConstraint = 655;
@@ -66,8 +66,8 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			// and the margin on the IFrameworkElement is 20, the expected width is (100 + 20 + 20) = 140
 			// and the expected height is (50 + 20 + 20) = 90
 
-			Assert.That(desiredSize.Width, Is.EqualTo(140));
-			Assert.That(desiredSize.Height, Is.EqualTo(90));
+			Assert.Equal(140, desiredSize.Width);
+			Assert.Equal(90, desiredSize.Height);
 		}
 	}
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Layouts/VerticalStackLayoutManagerTests.cs
@@ -1,21 +1,22 @@
 ﻿using System.Collections.Generic;
 using NSubstitute;
-using NUnit.Framework;
 using Xamarin.Forms;
 using Xamarin.Platform.Handlers.Tests;
 using Xamarin.Platform.Layouts;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 {
-	[TestFixture(Category = TestCategory.Layout)]
+	[Category(TestCategory.Core, TestCategory.Layout)]
 	public class VerticalStackLayoutManagerTests : StackLayoutManagerTests
 	{
-		[TestCase(0, 100, 0, 0, Description = "No items, height should be zero")]
-		[TestCase(1, 100, 0, 100, Description = "One item, height should match the item")]
-		[TestCase(1, 100, 13, 100, Description = "One item, spacing should have no effect")]
-		[TestCase(2, 100, 13, 213, Description = "Two items, spacing should count once [(100 * 2) + 13 = 213]")]
-		[TestCase(3, 100, 13, 326, Description = "Three items, spacing should count twice [(100 * 3) + (2 * 13) = 326]")]
-		[TestCase(3, 100, -13, 274, Description = "Negative spacing overlaps items [(100 * 3) + (2 * -13) = 274]")]
+		[Theory]
+		[InlineData(0, 100, 0, 0)]
+		[InlineData(1, 100, 0, 100)]
+		[InlineData(1, 100, 13, 100)]
+		[InlineData(2, 100, 13, 213)]
+		[InlineData(3, 100, 13, 326)]
+		[InlineData(3, 100, -13, 274)]
 		public void SpacingMeasurement(int viewCount, double viewHeight, int spacing, double expectedHeight)
 		{
 			var stack = BuildStack(viewCount, 100, viewHeight);
@@ -24,11 +25,11 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			var manager = new VerticalStackLayoutManager(stack);
 			var measuredSize = manager.Measure(100, double.PositiveInfinity);
 
-			Assert.That(measuredSize.Height, Is.EqualTo(expectedHeight));
+			Assert.Equal(expectedHeight, measuredSize.Height);
 		}
 
-		[Test(Description = "Spacing should not affect arrangement with only one item")]
-		[TestCase(0), TestCase(26), TestCase(-54)]
+		[Theory("Spacing has no effect when there's only one item")]
+		[InlineData(0), InlineData(26), InlineData(-54)]
 		public void SpacingArrangementOneItem(int spacing)
 		{
 			var stack = BuildStack(1, 100, 100);
@@ -43,8 +44,8 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			stack.Children[0].Received().Arrange(Arg.Is(expectedRectangle));
 		}
 
-		[Test(Description = "Spacing should affect arrangement with more than one item")]
-		[TestCase(26), TestCase(-54)]
+		[Theory("Spacing has an effect when there's more than one item")]
+		[InlineData(26), InlineData(-54)]
 		public void SpacingArrangementTwoItems(int spacing)
 		{
 			var stack = BuildStack(2, 100, 100);
@@ -62,9 +63,10 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			stack.Children[1].Received().Arrange(Arg.Is(expectedRectangle1));
 		}
 
-		[TestCase(150, 100, 100, Description = "The Stack's specified height of 100 should override the child's measured height of 150")]
-		[TestCase(150, 200, 200, Description = "The Stack's specified height of 200 should override the child's measured height of 150")]
-		[TestCase(1250, -1, 1250, Description = "The Stack doesn't specify height, so the child determines the height")]
+		[Theory]
+		[InlineData(150, 100, 100)]
+		[InlineData(150, 200, 200)]
+		[InlineData(1250, -1, 1250)]
 		public void StackAppliesHeight(double viewHeight, double stackHeight, double expectedHeight) 
 		{
 			var stack = CreateTestLayout();
@@ -78,10 +80,10 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 
 			var manager = new VerticalStackLayoutManager(stack);
 			var measurement = manager.Measure(100, double.PositiveInfinity);
-			Assert.That(measurement.Height, Is.EqualTo(expectedHeight));
+			Assert.Equal(expectedHeight, measurement.Height);
 		}
 
-		[Test]
+		[Fact]
 		public void ViewsArrangedWithDesiredWidths()
 		{
 			var stack = CreateTestLayout();
@@ -97,7 +99,7 @@ namespace Xamarin.Platform.Handlers.UnitTests.Layouts
 			manager.Arrange(new Rectangle(Point.Zero, measurement));
 
 			// The widest IView is 200, so the stack should be that wide
-			Assert.That(measurement.Width, Is.EqualTo(200));
+			Assert.Equal(200, measurement.Width);
 
 			// We expect the first IView to be at 0,0 with a width of 200 and a height of 100
 			var expectedRectangle1 = new Rectangle(0, 0, 200, 100);

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/PropertyMapperTests.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/PropertyMapperTests.cs
@@ -1,13 +1,15 @@
 using System;
-using NUnit.Framework;
 using Xamarin.Forms;
+using Xamarin.Platform.Handlers.UnitTests;
+using Xunit;
+using Fact = Xamarin.Platform.Handlers.UnitTests.FactAttribute;
 
 namespace Xamarin.Platform.Handlers.Tests
 {
-	[TestFixture]
+	[Category(TestCategory.Core, TestCategory.PropertyMapping)]
 	public class PropertyMapperTests
 	{
-		[Test]
+		[Fact]
 		public void ChainingMappersOverrideBase()
 		{
 			bool wasMapper1Called = false;
@@ -28,7 +30,7 @@ namespace Xamarin.Platform.Handlers.Tests
 			Assert.True(wasMapper2Called);
 		}
 
-		[Test]
+		[Fact]
 		public void ChainingMappersWorks()
 		{
 			bool wasMapper1Called = false;
@@ -49,7 +51,7 @@ namespace Xamarin.Platform.Handlers.Tests
 			Assert.True(wasMapper2Called);
 		}
 
-		[Test]
+		[Fact]
 		public void ChainingMappersStillAllowReplacingChainedRoot()
 		{
 			bool wasMapper1Called = false;
@@ -74,7 +76,7 @@ namespace Xamarin.Platform.Handlers.Tests
 			Assert.True(wasMapper3Called, "Mapper 3 was called");
 		}
 
-		[Test]
+		[Fact]
 		public void MappersActionsAreNotCalledOnUpdateProperties()
 		{
 			bool wasMapper1Called = false;
@@ -96,7 +98,7 @@ namespace Xamarin.Platform.Handlers.Tests
 			Assert.True(mapperActionWasCalled);
 		}
 
-		[Test]
+		[Fact]
 		public void ChainedMapperActionsRespectNewUpdate()
 		{
 			bool wasMapper1Called = false;
@@ -116,13 +118,13 @@ namespace Xamarin.Platform.Handlers.Tests
 				[mapperActionKey] = (r, v) => wasMapper2Called = true
 			};
 
-			Assert.AreEqual(2, mapper1.Keys.Count);
-			Assert.AreEqual(1, mapper1.ActionKeys.Count);
-			Assert.AreEqual(1, mapper1.UpdateKeys.Count);
+			Assert.Equal(2, mapper1.Keys.Count);
+			Assert.Equal(1, mapper1.ActionKeys.Count);
+			Assert.Equal(1, mapper1.UpdateKeys.Count);
 
-			Assert.AreEqual(2, mapper2.Keys.Count);
-			Assert.AreEqual(0, mapper2.ActionKeys.Count);
-			Assert.AreEqual(2, mapper2.UpdateKeys.Count);
+			Assert.Equal(2, mapper2.Keys.Count);
+			Assert.Equal(0, mapper2.ActionKeys.Count);
+			Assert.Equal(2, mapper2.UpdateKeys.Count);
 
 			mapper2.UpdateProperties(null, new Button());
 
@@ -133,7 +135,7 @@ namespace Xamarin.Platform.Handlers.Tests
 
 
 
-		[Test]
+		[Fact]
 		public void GenericMappersWorks()
 		{
 			bool wasMapper1Called = false;

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/TestCategory.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/TestCategory.cs
@@ -2,6 +2,9 @@
 {
 	public static class TestCategory
 	{
+		public const string Core = "Core";
 		public const string Layout = "Layout";
+		public const string PropertyMapping = "PropertyMapping";
+		public const string Lifecycle = "Lifecycle";
 	}
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/TestClasses/HandlerStub.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/TestClasses/HandlerStub.cs
@@ -1,8 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Text;
-using NUnit.Framework;
-
 
 namespace Xamarin.Platform.Handlers.UnitTests
 {

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Xamarin.Platform.Handlers.UnitTests.csproj
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/Xamarin.Platform.Handlers.UnitTests.csproj
@@ -12,8 +12,11 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="NSubstitute" Version="4.2.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
-    <PackageReference Include="NUnit" Version="3.13.0" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/xUnitCustomizations.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.UnitTests/xUnitCustomizations.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xunit.Abstractions;
+using Xunit.Sdk;
+
+namespace Xamarin.Platform.Handlers.UnitTests
+{
+	public class CategoryDiscoverer : ITraitDiscoverer
+	{
+		public IEnumerable<KeyValuePair<string, string>> GetTraits(IAttributeInfo traitAttribute)
+		{
+			var args = traitAttribute.GetConstructorArguments().ToList();
+
+			if (args[0] is string[] categories)
+			{
+				foreach (var category in categories)
+				{
+					yield return new KeyValuePair<string, string>("Category", category.ToString());
+				}
+			}
+		}
+	}
+
+	/// <summary>
+	/// Conveninence attribute for setting a Category trait on a test or test class
+	/// </summary>
+	[TraitDiscoverer("Xamarin.Platform.Handlers.UnitTests.CategoryDiscoverer", "Xamarin.Platform.Handlers.UnitTests")]
+	[AttributeUsage(AttributeTargets.Method | AttributeTargets.Class, AllowMultiple = true)]
+	public class CategoryAttribute : Attribute, ITraitAttribute
+	{
+		// Yes, it looks like the cateory parameter is not used; CategoryDiscoverer uses it. 
+		public CategoryAttribute(params string[] categories) { }
+	}
+
+	/// <summary>
+	/// Custom Fact attribute which defaults to using the test method name for the DisplayName property
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	[XunitTestCaseDiscoverer("Xunit.Sdk.FactDiscoverer", "xunit.execution.{Platform}")]
+	public class FactAttribute : Xunit.FactAttribute
+	{
+		public FactAttribute([CallerMemberName] string displayName = "")
+		{
+			base.DisplayName = displayName;
+		}
+	}
+
+	/// <summary>
+	/// Custom Theory attribute which defaults to using the test method name for the DisplayName property
+	/// </summary>
+	[AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
+	[XunitTestCaseDiscoverer("Xunit.Sdk.TheoryDiscoverer", "xunit.execution.{Platform}")]
+	public class TheoryAttribute : Xunit.TheoryAttribute
+	{
+		public TheoryAttribute([CallerMemberName] string displayName = "")
+		{
+			base.DisplayName = displayName;
+		}
+	}
+}


### PR DESCRIPTION
Move core tests from NUnit -> xUnit for consistency.

Also added a couple of custom xUnit attributes to make the test output nicer and make categories easier:

FactAttribute - defaults the display name of the test to the method name, rather than the full namespace + method.
TheoryAttribute - same thing, but for Theory
CategoryAttribute - Convenience attribute for setting a Trait with the name "Category" on test classes and methods. Handles multiple categories at once.