### PR TITLE
[Android] Remove listeners on dispose

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ButtonRenderer.cs
@@ -90,6 +90,13 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
+				if (Control.IsAlive())
+				{
+					Control.SetOnClickListener(null);
+					Control.SetOnTouchListener(null);
+					Control.RemoveOnAttachStateChangeListener(this);
+				}
+
 				_backgroundTracker?.Dispose();
 				_backgroundTracker = null;
 				_visualElementRenderer = null;

--- a/Xamarin.Forms.Platform.Android/Renderers/CarouselPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/CarouselPageRenderer.cs
@@ -31,8 +31,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				_previousPage = null;
 
-				if (_viewPager.Adapter != null)
-					_viewPager.Adapter.Dispose();
+				_viewPager.Adapter?.Dispose();
+				_viewPager.ClearOnPageChangeListeners();
 				_viewPager.Dispose();
 				_viewPager = null;
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -196,9 +196,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
-				if (EditText != null && EditText is IFormsEditText formsEditText)
+				if (EditText != null)
 				{
-					formsEditText.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+					EditText.RemoveTextChangedListener(this);
+
+					if (EditText is IFormsEditText formsEditText)
+					{
+						formsEditText.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+					}
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryRenderer.cs
@@ -205,12 +205,20 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
-				if (EditText != null && EditText is IFormsEditText formsEditContext)
+				if (EditText != null)
 				{
-					formsEditContext.OnKeyboardBackPressed -= OnKeyboardBackPressed;
-					formsEditContext.SelectionChanged -= SelectionChanged;
-					ListenForCloseBtnTouch(false);
+					EditText.RemoveTextChangedListener(this);
+					EditText.SetOnEditorActionListener(null);
+
+					if (EditText is IFormsEditText formsEditContext)
+					{
+						formsEditContext.OnKeyboardBackPressed -= OnKeyboardBackPressed;
+						formsEditContext.SelectionChanged -= SelectionChanged;
+						
+						ListenForCloseBtnTouch(false);
+					}
 				}
+
 				_clearBtn = null;
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/MasterDetailRenderer.cs
@@ -216,6 +216,8 @@ namespace Xamarin.Forms.Platform.Android
 					_masterLayout = null;
 				}
 
+				RemoveDrawerListener(this);
+
 				Device.Info.PropertyChanged -= DeviceInfoPropertyChanged;
 
 				if (_page != null)

--- a/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/RefreshViewRenderer.cs
@@ -237,9 +237,9 @@ namespace Xamarin.Forms.Platform.Android
 					Element.PropertyChanged -= HandlePropertyChanged;
 				}
 
-				if (_renderer != null)
-					_renderer.View.RemoveFromParent();
+				SetOnRefreshListener(null);
 
+				_renderer?.View.RemoveFromParent();
 				_renderer?.Dispose();
 				_renderer = null;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.Android
 		TextColorSwitcher _textColorSwitcher;
 		TextColorSwitcher _hintColorSwitcher;
 		float _defaultHeight => Context.ToPixels(42);
+		bool _isDisposed;
 
 		public SearchBarRenderer(Context context) : base(context)
 		{
@@ -347,6 +348,25 @@ namespace Xamarin.Forms.Platform.Android
 			// or to filter out input types you don't want to allow
 			// (e.g., inputTypes &= ~InputTypes.NumberFlagSigned to disallow the sign)
 			return LocalizedDigitsKeyListener.Create(inputTypes);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_isDisposed)
+				return;
+
+			_isDisposed = true;
+		
+			if (disposing)
+			{
+				if (Control.IsAlive())
+				{
+					Control.SetOnQueryTextListener(null);
+					Control.SetOnQueryTextFocusChangeListener(null);
+				}
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SliderRenderer.cs
@@ -16,6 +16,7 @@ namespace Xamarin.Forms.Platform.Android
 		ColorFilter defaultthumbcolorfilter;
 		Drawable defaultthumb;
 		PorterDuff.Mode defaultprogresstintmode, defaultprogressbackgroundtintmode;
+		bool _isDisposed;
 
 		public SliderRenderer(Context context) : base(context)
 		{
@@ -212,6 +213,24 @@ namespace Xamarin.Forms.Platform.Android
 			int thumbTop = seekbar.Height / 2 - thumb.IntrinsicHeight / 2;
 
 			thumb.SetBounds(thumb.Bounds.Left, thumbTop, thumb.Bounds.Left + thumb.IntrinsicWidth, thumbTop + thumb.IntrinsicHeight);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_isDisposed)
+				return;
+
+			_isDisposed = true;
+		
+			if (disposing)
+			{
+				if (Control.IsAlive())
+				{
+					Control.SetOnSeekBarChangeListener(null);
+				}
+			}
+
+			base.Dispose(disposing);
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###
When disposing renderers the framework need to unsubscribe events,
because of the different lifetime between the two parts this often cause memory leaks and dispose issues.
For the DotNet part the form is an event with +=/-=, in several past PR I fixed some missing calls of this form.
But for Android part the form is different, it's SetListener or AddListener, and RemoveListener.
I have checked Android renderers code and found that some renderers lack the removal of the setted listeners.
The goal of this PR is to add the missing ones.

### Issues Resolved ### 
- fixes #

### API Changes ###
 None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
As always with dispose and memory leaks issues, not possible to directly test it, just check if current tests not regress.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
