### PR TITLE
[Tizen] Use System.AppDomain on Init

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Forms.cs
+++ b/Xamarin.Forms.Platform.Tizen/Forms.cs
@@ -485,11 +485,6 @@ namespace Xamarin.Forms
 					UseSkiaSharp = options.UseSkiaSharp;
 					UseFastLayout = options.UseFastLayout;
 
-					if (options.Assemblies != null && options.Assemblies.Length > 0)
-					{
-						TizenPlatformServices.AppDomain.CurrentDomain.AddAssemblies(options.Assemblies);
-					}
-
 					// renderers
 					if (options.Handlers != null)
 					{
@@ -497,9 +492,6 @@ namespace Xamarin.Forms
 					}
 					else
 					{
-						// Add Xamarin.Forms.Core assembly by default to apply the styles.
-						TizenPlatformServices.AppDomain.CurrentDomain.AddAssembly(Assembly.GetAssembly(typeof(Xamarin.Forms.View)));
-
 						// static registrar
 						if (options.StaticRegistarStrategy != StaticRegistrarStrategy.None)
 						{
@@ -523,8 +515,6 @@ namespace Xamarin.Forms
 						}
 						else
 						{
-							// The assembly of the executing application and referenced assemblies of it are added into the list here.
-							TizenPlatformServices.AppDomain.CurrentDomain.RegisterAssemblyRecursively(application.GetType().GetTypeInfo().Assembly);
 							Registrar.RegisterAll(new Type[]
 							{
 								typeof(ExportRendererAttribute),
@@ -558,11 +548,6 @@ namespace Xamarin.Forms
 				}
 				else
 				{
-					// In .NETCore, AppDomain feature is not supported.
-					// The list of assemblies returned by AppDomain.GetAssemblies() method should be registered manually.
-					// The assembly of the executing application and referenced assemblies of it are added into the list here.
-					TizenPlatformServices.AppDomain.CurrentDomain.RegisterAssemblyRecursively(application.GetType().GetTypeInfo().Assembly);
-
 					Registrar.RegisterAll(new Type[]
 					{
 						typeof(ExportRendererAttribute),

--- a/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
+++ b/Xamarin.Forms.Platform.Tizen/TizenPlatformServices.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -171,83 +170,11 @@ namespace Xamarin.Forms.Platform.Tizen
 			Forms.Context.Exit();
 		}
 
-		public bool IsInvokeRequired
-		{
-			get
-			{
-				return !EcoreMainloop.IsMainThread;
-			}
-		}
+		public bool IsInvokeRequired => !EcoreMainloop.IsMainThread;
 
 		public string RuntimePlatform => Device.Tizen;
 
 		#endregion
-
-		// In .NETCore, AppDomain is not supported. The list of the assemblies should be generated manually.
-		internal class AppDomain
-		{
-			public static AppDomain CurrentDomain { get; private set; }
-
-			readonly HashSet<Assembly> _assemblies;
-
-			static AppDomain()
-			{
-				CurrentDomain = new AppDomain();
-			}
-
-			AppDomain()
-			{
-				_assemblies = new HashSet<Assembly>();
-
-				// Add this renderer assembly to the list
-				_assemblies.Add(GetType().GetTypeInfo().Assembly);
-			}
-
-			public void AddAssembly(Assembly assembly)
-			{
-				if (!_assemblies.Contains(assembly))
-				{
-					_assemblies.Add(assembly);
-				}
-			}
-
-			public void AddAssemblies(Assembly[] assemblies)
-			{
-				foreach (var asm in assemblies)
-				{
-					AddAssembly(asm);
-				}
-			}
-
-			internal void RegisterAssemblyRecursively(Assembly asm)
-			{
-				if (_assemblies.Contains(asm))
-					return;
-
-				_assemblies.Add(asm);
-
-				foreach (var refName in asm.GetReferencedAssemblies())
-				{
-					if (!refName.Name.StartsWith("System.") && !refName.Name.StartsWith("Microsoft.") && !refName.Name.StartsWith("mscorlib"))
-					{
-						try
-						{
-							Assembly refAsm = Assembly.Load(refName);
-							RegisterAssemblyRecursively(refAsm);
-						}
-						catch
-						{
-							Log.Warn("Reference Assembly can not be loaded. {0}", refName.FullName);
-						}
-					}
-				}
-			}
-
-			public Assembly[] GetAssemblies()
-			{
-				return _assemblies.ToArray();
-			}
-		}
 
 		public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 		{


### PR DESCRIPTION
### Description of Change ###

This PR modifies to use [System.AppDomain](https://docs.microsoft.com/en-us/dotnet/api/system.appdomain?view=netcore-2.1#properties) instead of local AppDomain implementation to get assemblies.

### Issues Resolved ### 
- fixes https://github.com/xamarin/MobileBlazorBindings/issues/307 (partially)

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
