### PR TITLE
Signal layout request when CollectionView is in a layout

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var source = new List<Item> { new Item { Text = Success } };
 			cv.ItemsSource = source;
+
 			Content = cv;
 
 			Appearing += (sender, args) => { cv.IsVisible = true; };
@@ -49,7 +50,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void SettingGroupedCollectionViewItemSourceNullShouldNotCrash()
+		public void CollectionShouldInvalidateOnVisibilityChange()
 		{
 			RunningApp.WaitForElement(Success);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13551.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13551.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13551, "[Bug] [iOS] CollectionView does not display items if `IsVisible` modified via a binding/trigger", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+	public class Issue13551 : TestContentPage
+	{
+		const string Success1 = "Success1";
+		const string Success2 = "Success2";
+
+		public ObservableCollection<Item> Source1 { get; } = new ObservableCollection<Item>();
+		public ObservableCollection<Item> Source2 { get; } = new ObservableCollection<Item>();
+
+		CollectionView BindingWithConverter() 
+		{
+			var cv = new CollectionView
+			{
+				IsVisible = true,
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding(nameof(Item.Text)));
+					return label;
+				})
+			};
+
+			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Source1"));
+			cv.SetBinding(VisualElement.IsVisibleProperty, new Binding("Source1.Count", converter: new IntToBoolConverter()));
+
+			return cv;
+		}
+
+		CollectionView WithTrigger()
+		{
+			var cv = new CollectionView
+			{
+				IsVisible = true,
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding(nameof(Item.Text)));
+					return label;
+				})
+			};
+
+			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Source2"));
+
+			var trigger = new DataTrigger(typeof(CollectionView));
+			trigger.Value = 0;
+			trigger.Setters.Add(new Setter() { Property = VisualElement.IsVisibleProperty, Value = false });
+			trigger.Binding = new Binding("Source2.Count");
+
+			cv.Triggers.Add(trigger);
+
+			return cv;
+		}
+
+		protected override void Init()
+		{
+			BindingContext = this;
+
+			var cv1 = BindingWithConverter();
+			var cv2 = WithTrigger();
+
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition() { Height = GridLength.Star },
+					new RowDefinition() { Height = GridLength.Star },
+				}
+			};
+
+			grid.Children.Add(cv1);
+			grid.Children.Add(cv2);
+			Grid.SetRow(cv2, 1);
+
+			Content = grid;
+
+			Device.StartTimer(TimeSpan.FromMilliseconds(300), () =>
+			{
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					Source1.Add(new Item { Text = Success1 });
+					Source2.Add(new Item { Text = Success2 });
+				});
+
+				return false;
+			});
+		}
+
+		class IntToBoolConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				return value is int val && val > 0;
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public class Item
+		{
+			public string Text { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionInLayoutShouldInvalidateOnVisibilityChange()
+		{
+			RunningApp.WaitForElement(Success1);
+			RunningApp.WaitForElement(Success2);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContent.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -610,6 +610,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (ItemsView.IsVisible)
 				{
 					Layout.InvalidateLayout();
+					CollectionView.LayoutIfNeeded();
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

#13370 added a watch for the IsVisible property change to signal a layout request to the UICollectionView control. Since it was 4.8 and using the old deferred layout resolution, there was no need to signal to Forms layouts that a layout update was necessary, as a re-layout due to the IsVisible change was already on the queue. 

In 5.0 layout resolution is on-demand, so the UICollectionView's LayoutIfNeeded must be called to signal that a full layout is due. These changes add that call, and automated tests to verify that visibility changes work for a CollectionView inside of a Layout where the visibility is determined by a DataTrigger or IValueConverter.

### Issues Resolved ### 

- Fixes #13551

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated UI test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
