### PR TITLE
[UWP] Protect InputScope InvalidCastException

### DIFF
--- a/Xamarin.Forms.Platform.UAP/KeyboardExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/KeyboardExtensions.cs
@@ -41,7 +41,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				name.NameValue = InputScopeNameValue.Url;
 			}
-			else
+			else if (self is CustomKeyboard)
 			{
 				var custom = (CustomKeyboard)self;
 				var capitalizedSentenceEnabled = (custom.Flags & KeyboardFlags.CapitalizeSentence) == KeyboardFlags.CapitalizeSentence;
@@ -76,6 +76,11 @@ namespace Xamarin.Forms.Platform.UWP
 				}
 
 				name.NameValue = nameValue;
+			}
+			else
+			{
+				// Should never happens
+				name.NameValue = InputScopeNameValue.Default;
 			}
 
 			result.Names.Add(name);


### PR DESCRIPTION
### Description of Change ###

Protect InputScope InvalidCastException on UWP and align behavior with WPF implementation.

### Issues Resolved ### 

- fixes #13608 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
