### PR TITLE
Ignore tests that are currently irrelevant for UWP

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12642.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12642.cs
@@ -19,25 +19,32 @@ namespace Xamarin.Forms.Controls.Issues
 	[Category(UITestCategories.Shell)]
 #endif
 	public class Issue12642 : TestShell
-	{
+	{	
 		protected override void Init()
 		{
 			var page = AddTopTab("Tab 1");
 			var page2 = AddTopTab("Tab 2");
 
-			page.Content = CreateContent();
-			page2.Content = CreateContent();
-
-			StackLayout CreateContent()
+			Label successLabel = new Label()
 			{
-				return new StackLayout()
+				Text = "Success",
+				AutomationId = "Success",
+				IsVisible = false
+			};
+
+			page.Content = CreateContent();
+			page2.Content = CreateContent(successLabel);
+
+			StackLayout CreateContent(Label label = null)
+			{
+				StackLayout layout = null;
+				layout = new StackLayout()
 				{
 					Children =
 					{
 						new Label()
 						{
-							Text = "Click quickly between the tabs. If you stop clicking and the content is blank then the test has failed.",
-							AutomationId = "Success"
+							Text = "Click quickly between the tabs. If you stop clicking and the content is blank then the test has failed."
 						},
 						new Button()
 						{
@@ -45,6 +52,7 @@ namespace Xamarin.Forms.Controls.Issues
 							AutomationId = "AutomatedRun",
 							Command = new Command(async () =>
 							{
+								successLabel.IsVisible = false;
 								for(int i = 0; i < 20; i++)
 								{
 									this.CurrentItem = Items[0].Items[0].Items[0];
@@ -52,10 +60,16 @@ namespace Xamarin.Forms.Controls.Issues
 									this.CurrentItem = Items[0].Items[0].Items[1];
 									await Task.Delay(10);
 								}
+								successLabel.IsVisible = true;
 							})
 						}
 					}
 				};
+
+				if (label != null)
+					layout.Children.Add(label);
+
+				return layout;
 			}
 		}
 
@@ -64,9 +78,9 @@ namespace Xamarin.Forms.Controls.Issues
 		public void ClickingQuicklyBetweenTopTabsBreaksContent()
 		{
 			RunningApp.Tap("AutomatedRun");
-			RunningApp.Tap("Success");
+			RunningApp.WaitForElement("Success");
 			RunningApp.Tap("AutomatedRun");
-			RunningApp.Tap("Success");
+			RunningApp.WaitForElement("Success");
 		}
 #endif
 	}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12848.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12848.xaml.cs
@@ -13,6 +13,10 @@ namespace Xamarin.Forms.Controls.Issues
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 12848, "[Bug] CarouselView position resets when visibility toggled",
 		PlatformAffected.Android)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CarouselView)]
+	[NUnit.Framework.Category(UITestCategories.UwpIgnore)]
+#endif
 	public partial class Issue12848 : TestContentPage
 	{
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5500.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue5500.cs
@@ -61,7 +61,8 @@ namespace Xamarin.Forms.Controls.Issues
 			Device.BeginInvokeOnMainThread(GarbageCollectionHelper.Collect);
 		}
 
-#if UITEST
+
+#if UITEST && __IOS__
 		[Test]
 		public void VerifyEditorTextChangeEventsAreFiring()
 		{


### PR DESCRIPTION
### Description of Change ###

- 12848 deals with the CarouselView so the behavior being tested on 12848 for the CV will need to be fixed
- 5500 is testing a bug on iOS with visual so the test isn't relevant for UWP. It's occasionally failing on UWP because the win app driver sometimes won't type the first letter of text


### Platforms Affected ### 
- UWP


### Testing Procedure ###
- UWP tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
