### PR TITLE
[iOS] Fixed date formatter issue with different timezone

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -168,10 +168,12 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_picker.Date.ToDateTime().Date != Element.Date.Date)
 				_picker.SetDate(Element.Date.ToNSDate(), animate);
 
-			//can't use Element.Format because it won't display the correct format if the region and language are set differently
-			if (String.IsNullOrWhiteSpace(Element.Format) || Element.Format.Equals("d") || Element.Format.Equals("D"))
+			// Can't use Element.Format because it won't display the correct format if the region and language are set differently
+			if (string.IsNullOrWhiteSpace(Element.Format) || Element.Format.Equals("d") || Element.Format.Equals("D"))
 			{
 				NSDateFormatter dateFormatter = new NSDateFormatter();
+				dateFormatter.TimeZone = NSTimeZone.FromGMT(0);
+
 				if (Element.Format?.Equals("D") == true)
 				{
 					dateFormatter.DateStyle = NSDateFormatterStyle.Long;


### PR DESCRIPTION
### Description of Change ###

Fixed date formatter issue with different timezone on iOS. From this changes: https://github.com/xamarin/Xamarin.Forms/commit/938700b28f500ae0beb7967e10516199b03b2b71#diff-e232660a1722e87a9febc4d293b145e11c6b707d432ae3f637d208e92d70a27d
We use a `NSDateFormatter`. Since we didn’t specify otherwise, the date formatter uses the system time zone, which is set to the location.
The fix is specify a time zone with a fixed temporal offset instead of a location.

### Issues Resolved ### 

- fixes #13366 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Set the system datetime to 01/07/21 19:01h and timezone GMT+5. 
2. Launch Core Gallery.
3. Look at the DatePicker, the date must be 01/07/21.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
