### PR TITLE
Move layout change resolution calls up to VisualElementRenderer

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13203.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 			var source = new List<Item> { new Item { Text = Success } };
 			cv.ItemsSource = source;
+
 			Content = cv;
 
 			Appearing += (sender, args) => { cv.IsVisible = true; };
@@ -49,7 +50,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 #if UITEST
 		[Test]
-		public void SettingGroupedCollectionViewItemSourceNullShouldNotCrash()
+		public void CollectionShouldInvalidateOnVisibilityChange()
 		{
 			RunningApp.WaitForElement(Success);
 		}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13551.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13551.cs
@@ -1,0 +1,136 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13551, "[Bug] [iOS] CollectionView does not display items if `IsVisible` modified via a binding/trigger", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+	public class Issue13551 : TestContentPage
+	{
+		const string Success1 = "Success1";
+		const string Success2 = "Success2";
+
+		public ObservableCollection<Item> Source1 { get; } = new ObservableCollection<Item>();
+		public ObservableCollection<Item> Source2 { get; } = new ObservableCollection<Item>();
+
+		CollectionView BindingWithConverter() 
+		{
+			var cv = new CollectionView
+			{
+				IsVisible = true,
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding(nameof(Item.Text)));
+					return label;
+				})
+			};
+
+			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Source1"));
+			cv.SetBinding(VisualElement.IsVisibleProperty, new Binding("Source1.Count", converter: new IntToBoolConverter()));
+
+			return cv;
+		}
+
+		CollectionView WithTrigger()
+		{
+			var cv = new CollectionView
+			{
+				IsVisible = true,
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding(nameof(Item.Text)));
+					return label;
+				})
+			};
+
+			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Source2"));
+
+			var trigger = new DataTrigger(typeof(CollectionView));
+			trigger.Value = 0;
+			trigger.Setters.Add(new Setter() { Property = VisualElement.IsVisibleProperty, Value = false });
+			trigger.Binding = new Binding("Source2.Count");
+
+			cv.Triggers.Add(trigger);
+
+			return cv;
+		}
+
+		protected override void Init()
+		{
+			BindingContext = this;
+
+			var cv1 = BindingWithConverter();
+			var cv2 = WithTrigger();
+
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition() { Height = GridLength.Star },
+					new RowDefinition() { Height = GridLength.Star },
+				}
+			};
+
+			grid.Children.Add(cv1);
+			grid.Children.Add(cv2);
+			Grid.SetRow(cv2, 1);
+
+			Content = grid;
+
+			Device.StartTimer(TimeSpan.FromMilliseconds(300), () =>
+			{
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					Source1.Add(new Item { Text = Success1 });
+					Source2.Add(new Item { Text = Success2 });
+				});
+
+				return false;
+			});
+		}
+
+		class IntToBoolConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				return value is int val && val > 0;
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		public class Item
+		{
+			public string Text { get; set; }
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionInLayoutShouldInvalidateOnVisibilityChange()
+		{
+			RunningApp.WaitForElement(Success1);
+			RunningApp.WaitForElement(Success2);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellFlyoutContent.cs" />

--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -1315,16 +1315,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			bool ILayoutChanges.HasLayoutOccurred => _hasLayoutOccurred;
 
-			protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-			{
-				if (Element is Layout layout)
-				{
-					layout.ResolveLayoutChanges();
-				}
-
-				base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-			}
-
 			protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
 			{
 				base.OnLayout(changed, left, top, right, bottom);

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -505,5 +505,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IVisualElementRenderer.SetLabelFor(int? id)
 			=> ViewCompat.SetLabelFor(this, id ?? ViewCompat.GetLabelFor(this));
+
+		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			if (Element is Layout layout)
+			{
+				layout.ResolveLayoutChanges();
+			}
+
+			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/LayoutRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/LayoutRenderer.cs
@@ -80,11 +80,5 @@ namespace Xamarin.Forms.Platform.UWP
 				Clip = new RectangleGeometry { Rect = new WRect(0, 0, ActualWidth, ActualHeight) };
 			}
 		}
-
-		protected override Windows.Foundation.Size MeasureOverride(Windows.Foundation.Size availableSize)
-		{
-			Element?.ResolveLayoutChanges();
-			return base.MeasureOverride(availableSize);
-		}
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -294,6 +294,11 @@ namespace Xamarin.Forms.Platform.UWP
 			if (Element == null || availableSize.Width * availableSize.Height == 0)
 				return new Windows.Foundation.Size(0, 0);
 
+			if (Element is Layout layout)
+			{
+				layout.ResolveLayoutChanges();
+			}
+
 			Element.IsInNativeLayout = true;
 
 			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)

--- a/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/GridViewLayout.cs
@@ -57,7 +57,16 @@ namespace Xamarin.Forms.Platform.iOS
 			// Truncating to 177 means the rows fit, but there's a very slight gap
 			// There may not be anything we can do about this.
 
-			ConstrainedDimension = (int)ConstrainedDimension;
+			// Possibly the solution is to round to the tenths or hundredths place, we should look into that. 
+			// But for the moment, we need a special case for dimensions < 1, because upon transition from invisible to visible,
+			// Forms will briefly layout the CollectionView at a size of 1,1. For a spanned collectionview, that means we 
+			// need to accept a constrained dimension of 1/span. If we don't, autolayout will start throwing a flurry of 
+			// exceptions (which we can't catch) and either crash the app or spin until we kill the app. 
+			if (ConstrainedDimension > 1)
+			{
+				ConstrainedDimension = (int)ConstrainedDimension;
+			}
+
 			DetermineCellSize();
 		}
 
@@ -288,6 +297,12 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			var maxSpacing = (available - span) / (span - 1);
+
+			if (maxSpacing < 0)
+			{
+				return 0;
+			}
+
 			return (nfloat)Math.Min(requestedSpacing, maxSpacing);
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -618,7 +618,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Layout.InvalidateLayout();
 					CollectionView.LayoutIfNeeded();
-					//(ItemsView as IViewController).InvalidateMeasure(Internals.InvalidationTrigger.MeasureChanged);
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -160,10 +160,6 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			base.ViewWillLayoutSubviews();
 
-			// We can't set this constraint up on ViewDidLoad, because Forms does other stuff that resizes the view
-			// and we end up with massive layout errors. And View[Will/Did]Appear do not fire for this controller
-			// reliably. So until one of those options is cleared up, we set this flag so that the initial constraints
-			// are set up the first time this method is called.
 			EnsureLayoutInitialized();
 
 			LayoutEmptyView();
@@ -610,6 +606,7 @@ namespace Xamarin.Forms.Platform.iOS
 				if (ItemsView.IsVisible)
 				{
 					Layout.InvalidateLayout();
+					CollectionView.LayoutIfNeeded();
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -562,11 +562,22 @@ namespace Xamarin.Forms.Platform.iOS
 			return new VerticalCell(frame);
 		}
 
-		public TemplatedCell CreateMeasurementCell(NSIndexPath indexPath) 
+		public UICollectionViewCell CreateMeasurementCell(NSIndexPath indexPath) 
 		{
 			if (ItemsView.ItemTemplate == null)
 			{
-				return null;
+				var frame = new CGRect(0, 0, ItemsViewLayout.EstimatedItemSize.Width, ItemsViewLayout.EstimatedItemSize.Height);
+
+				if (ItemsViewLayout.ScrollDirection == UICollectionViewScrollDirection.Horizontal)
+				{
+					var cell1 = new HorizontalDefaultCell(frame);
+					UpdateDefaultCell(cell1, indexPath);
+					return cell1;
+				}
+
+				var cell = new VerticalDefaultCell(frame);
+				UpdateDefaultCell(cell, indexPath);
+				return cell;
 			}
 
 			TemplatedCell templatedCell = CreateAppropriateCellForLayout(); 
@@ -607,6 +618,7 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Layout.InvalidateLayout();
 					CollectionView.LayoutIfNeeded();
+					//(ItemsView as IViewController).InvalidateMeasure(Internals.InvalidationTrigger.MeasureChanged);
 				}
 			}
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -206,7 +206,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (prototype == null)
 			{
-				EstimatedItemSize = CGSize.Empty;
 				return;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -206,6 +206,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (prototype == null)
 			{
+				EstimatedItemSize = CGSize.Empty;
 				return;
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -586,26 +586,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 				return result;
 			}
-
-			void ResolveLayoutChanges() 
-			{
-				if (Element is Layout layout)
-				{
-					layout.ResolveLayoutChanges();
-				}
-			}
-
-			public override void LayoutSubviews()
-			{
-				ResolveLayoutChanges();
-				base.LayoutSubviews();
-			}
-
-			public override CGSize SizeThatFits(CGSize size)
-			{
-				ResolveLayoutChanges();
-				return base.SizeThatFits(size);
-			}
 		}
 
 		internal static string ResolveMsAppDataUri(Uri uri)

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -312,13 +312,25 @@ namespace Xamarin.Forms.Platform.MacOS
 		}
 
 #if __MOBILE__
+
+		void ResolveLayoutChanges()
+		{
+			if (Element is Layout layout)
+			{
+				layout.ResolveLayoutChanges();
+			}
+		}
+
 		public override SizeF SizeThatFits(SizeF size)
 		{
+			ResolveLayoutChanges();
 			return new SizeF(0, 0);
 		}
 
 		public override void LayoutSubviews()
 		{
+			ResolveLayoutChanges();
+
 			base.LayoutSubviews();
 
 			if (_blur != null && Superview != null)


### PR DESCRIPTION
### Description of Change ###

The change to on-demand layout resolution in 5.0.0-pre2 moved the layout resolution to the layout renderers. Unfortunately, this meant that some ContentView uses (13492) and any custom renderer which replaced the layout renderers (13418) would not update their layout changes properly. 

These changes move the layout resolution call to the base VisualElementRenderer class on each platform; this way, they encompass content views and any custom layout renderers. 

### Issues Resolved ### 

- fixes #13418
- fixes #13492
- fixes #13551 
- fixes #13126

### API Changes ###
 
None

### Platforms Affected ### 

- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Unfortunately, this one is hard to write a test for without breaking all of Control Gallery. Best we can do is load up the repro projects from #13418 and #13492, apply the NuGet package from this PR, and verify that the problems are fixed.

For #13551 there is an automated UI test.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
