### PR TITLE
Google material bump and set hint to transparent for multi line

### DIFF
--- a/.nuspec/Xamarin.Forms.Visual.Material.nuspec
+++ b/.nuspec/Xamarin.Forms.Visual.Material.nuspec
@@ -23,7 +23,7 @@
 
       <group targetFramework="MonoAndroid10.0">
         <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="2.2.0.4" />
-        <dependency id="Xamarin.Google.Android.Material" version="1.1.0.5" />
+        <dependency id="Xamarin.Google.Android.Material" version="1.2.1.1" />
       </group>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.iOS.MaterialComponents" version="92.0.0"/>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -16,7 +16,7 @@
     <dependencies>
       <group targetFramework="MonoAndroid10.0">
         <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="2.2.0.4" />
-        <dependency id="Xamarin.Google.Android.Material" version="1.1.0.5" />
+        <dependency id="Xamarin.Google.Android.Material" version="1.2.1.1" />
         <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.6" />
         <dependency id="Xamarin.AndroidX.Browser" version="1.3.0" />
       </group>

--- a/DualScreen/DualScreen.Android/DualScreen.Android.csproj
+++ b/DualScreen/DualScreen.Android/DualScreen.Android.csproj
@@ -116,7 +116,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
   </ItemGroup>
   <ItemGroup>

--- a/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
+++ b/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
@@ -3,7 +3,7 @@
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0" />
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.1" />
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.1" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -24,7 +24,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
   </ItemGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -24,7 +24,7 @@
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.1.0.6" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.6" />
   </ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
@@ -7,7 +7,7 @@
     <ItemGroup>
         <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.1.0" />
         <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0" />
-        <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+        <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
         <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0" />
         <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0" />
     </ItemGroup>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml
@@ -361,7 +361,6 @@
                     <Label Text="Background GradientColor" Margin="0,0,0,-10" />
                     <CheckBox Background="{StaticResource GreenGradient}" IsChecked="True" />
                     <CheckBox Background="{StaticResource BlueGradient}" IsChecked="True" />
-
                 </StackLayout>
             </ScrollView>
         </ContentPage>
@@ -374,6 +373,19 @@
                     <StackLayout Orientation="Horizontal">
                         <Button Text="Enabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="#b19cd9" BorderWidth="1" HorizontalOptions="FillAndExpand" />
                         <Button Text="Disabled" BackgroundColor="{StaticResource PrimaryColor}" BorderColor="#b19cd9" BorderWidth="1" IsEnabled="false" HorizontalOptions="FillAndExpand" />
+                    </StackLayout>
+                </StackLayout>
+            </ScrollView>
+        </ContentPage>
+    </FlyoutItem>
+    <FlyoutItem Title="Placeholder Test">
+        <ContentPage>
+            <ScrollView>
+                <StackLayout Spacing="20" Padding="10" BackgroundColor="White">
+                    <Label Text="Placeholder looks correcct" Margin="0,0,0,-10" />
+                    <StackLayout Orientation="Vertical">
+                        <Editor x:Name="delayLoadingEditor" Placeholder="Text" AutoSize="TextChanges" BackgroundColor="White" />
+                        <Entry x:Name="delayLoadingEntry" Placeholder="Text"  BackgroundColor="White" />
                     </StackLayout>
                 </StackLayout>
             </ScrollView>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/VisualControlsPage.xaml.cs
@@ -20,8 +20,10 @@ namespace Xamarin.Forms.Controls.Issues
 		{
 #if APP
 			InitializeComponent();
+			Device.BeginInvokeOnMainThread(OnAppearing);
 #endif
 		}
+
 		protected override void Init()
 		{
 			BindingContext = this;

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -56,7 +56,7 @@
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="117.0.0" />
   </ItemGroup>

--- a/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
+++ b/Xamarin.Forms.Material.Android/MaterialEditorRenderer.cs
@@ -53,6 +53,9 @@ namespace Xamarin.Forms.Material.Android
 				return;
 
 			_textInputLayout?.SetHint(Element.Placeholder, Element);
+
+			if(!string.IsNullOrWhiteSpace(Element.Placeholder))
+				EditText.SetHintTextColor(global::Android.Graphics.Color.Transparent);
 		}
 
 		protected override void UpdatePlaceholderColor() => ApplyTheme();

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -16,7 +16,7 @@
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) " >
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -44,7 +44,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.1.0.5" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###

It looks like the latest material libraries only partially fixes the duplicated place holder. If you are using a multi line editor then the place holder shows as duplicate until you start typing. After you start typing the hint text disappears.

### Issues Resolved ### 
- fixes #13541

### Platforms Affected ### 
- Android

### Testing Procedure ###
- open the visual gallery and verify that the place holder and other controls look to render correctly

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
