### PR TITLE
Potential fix for #Issue12489

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12489.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12489.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 12489, "Unable to get positon when dropping an item", PlatformAffected.All)]
+	public class Issue12489 : ContentPage
+	{
+		public Issue12489()
+		{
+			var dragGestureRecognizers = new DragGestureRecognizer();
+			var dropGestureRecognizers = new DropGestureRecognizer();
+			var dropContainer = new DropGestureRecognizer();
+
+			dragGestureRecognizers.DragStarting += DragGestureRecognizers_DragStarting;
+			dropContainer.Drop += DropGestureRecognizers_Drop;
+			dropContainer.AllowDrop = true;
+
+			AbsoluteLayout absoluteLayout = new AbsoluteLayout
+			{
+				BackgroundColor = Color.Blue.WithLuminosity(0.9),
+				VerticalOptions = LayoutOptions.FillAndExpand
+			};
+
+			absoluteLayout.GestureRecognizers.Add(dropContainer);
+
+			Label header = new Label
+			{
+				Text = "Drag the Box and drop anywhere on the screen to see it's drop location...",
+				FontSize = Device.GetNamedSize(NamedSize.Large, typeof(Label)),
+				HorizontalOptions = LayoutOptions.Center
+			};
+
+			var frame = new Frame
+			{
+				HeightRequest = 100,
+				WidthRequest = 50,
+				BackgroundColor = Color.Red
+			};
+
+			frame.GestureRecognizers.Add(dragGestureRecognizers);
+			AbsoluteLayout.SetLayoutFlags(frame, AbsoluteLayoutFlags.PositionProportional);
+			AbsoluteLayout.SetLayoutBounds(frame,
+				new Rectangle(0.5f,
+								0.5f, AbsoluteLayout.AutoSize, AbsoluteLayout.AutoSize));
+
+
+			absoluteLayout.Children.Add(header);
+			absoluteLayout.Children.Add(frame);
+
+			Content = absoluteLayout;
+		}
+
+		private void DropGestureRecognizers_Drop(object sender, DropEventArgs e)
+		{
+			var X = e.DropX;
+			var Y = e.DropY;
+			DisplayAlert("Dropped!", $"Was dropped at X:{X}  Y:{Y}", "OK");
+		}
+
+		private void DragGestureRecognizers_DragStarting(object sender, DragStartingEventArgs e)
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -11,6 +11,7 @@
   <ItemGroup>
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12489.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />

--- a/Xamarin.Forms.Core/DragAndDrop/DropEventArgs.cs
+++ b/Xamarin.Forms.Core/DragAndDrop/DropEventArgs.cs
@@ -12,5 +12,8 @@ namespace Xamarin.Forms
 
 		public DataPackageView Data { get; }
 		public bool Handled { get; set; }
+
+		public double DropX { get; set; }
+		public double DropY { get; set; }
 	}
 }

--- a/Xamarin.Forms.Platform.Android/DragAndDropGestureHandler.cs
+++ b/Xamarin.Forms.Platform.Android/DragAndDropGestureHandler.cs
@@ -222,7 +222,12 @@ namespace Xamarin.Forms.Platform.Android
 					datapackage.Image = text;
 			}
 
-			var args = new DropEventArgs(datapackage?.View);
+			var args = new DropEventArgs(datapackage?.View)
+			{
+				DropX = e.GetX(),
+				DropY = e.GetY()
+			};
+
 			SendEventArgs<DropGestureRecognizer>(async rec =>
 			{
 				if (!rec.AllowDrop)

--- a/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementTracker.cs
@@ -28,6 +28,8 @@ namespace Xamarin.Forms.Platform.UWP
 		TNativeElement _control;
 		TElement _element;
 
+		Point _point;
+
 		bool _invalidateArrangeNeeded;
 
 		bool _isDisposed;
@@ -143,6 +145,10 @@ namespace Xamarin.Forms.Platform.UWP
 			var package = e.DataView.Properties["_XFPropertes_DONTUSE"] as DataPackage;
 			var dragEventArgs = new DragEventArgs(package);
 
+			var point = e.GetPosition(_container);
+			_point.X = point.X;
+			_point.Y = point.Y;
+
 			SendEventArgs<DropGestureRecognizer>(rec =>
 			{
 				if(!rec.AllowDrop)
@@ -174,6 +180,9 @@ namespace Xamarin.Forms.Platform.UWP
 			}
 
 			var args = new DropEventArgs(datapackage?.View);
+			args.DropX = _point.X;
+			args.DropY = _point.Y;
+
 			SendEventArgs<DropGestureRecognizer>(async rec =>
 			{
 				if (!rec.AllowDrop)

--- a/Xamarin.Forms.Platform.iOS/DragAndDropDelegate.cs
+++ b/Xamarin.Forms.Platform.iOS/DragAndDropDelegate.cs
@@ -237,7 +237,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void HandleDrop(View element, DataPackage datapackage)
 		{
-			var args = new DropEventArgs(datapackage?.View);
+			var args = new DropEventArgs(datapackage?.View)
+			{
+				DropX = element.X,
+				DropY = element.Y
+			};
+
 			SendEventArgs<DropGestureRecognizer>(async rec =>
 			{
 				if (!rec.AllowDrop)


### PR DESCRIPTION
### Description of Change ###

Edits to the UWP/Droid and iOS DragAndDrop Handlers to add a DropX and DropY (Naming!!!) that reports the location of the Drop on Screen.

### Issues Resolved ### 

- fixes #12489 

### API Changes ###

Added:

Inside the DropEventArgs.cs

public double DropX { get; set; }
public double DropY { get; set; }
 
### Platforms Affected ### 

iOS (<- Unable to test as Mac is currently broken)
Android
UWP

### Behavioral/Visual Changes ###

When a drop occurs in the DropEventArgs that the user has access to, they will now be able to get the Drop location by looking up the DropX and DropY properties.
None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

There is an Issue12489.cs test case in the Controls.Issues so available inside the Test cases of the Build, this has a red box that can be dragged around the screen and when dropped will trigger a DisplayAlert showing the Drop Location.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
