### PR TITLE
[iOS] Allow observable source update while CollectionView is not visible

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13126.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13126.cs
@@ -1,0 +1,129 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13126, "[Bug] Regression: 5.0.0-pre5 often fails to draw dynamically loaded collection view content", PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+	public class Issue13126 : TestContentPage
+	{
+		_13126VM _vm;
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			_vm = new _13126VM();
+			BindingContext = _vm;
+
+			var collectionView = BindingWithConverter();
+
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition() { Height = GridLength.Star },
+				}
+			};
+
+			grid.Children.Add(collectionView);
+
+			Content = grid;
+
+			_vm.IsBusy = true;
+
+			Device.StartTimer(TimeSpan.FromMilliseconds(300), () =>
+			{
+				Device.BeginInvokeOnMainThread(() =>
+				{
+					_vm.Data.Add(Success);
+					_vm.IsBusy = false;
+				});
+
+				return false;
+			});
+		}
+
+		CollectionView BindingWithConverter()
+		{
+			var cv = new CollectionView
+			{
+				IsVisible = true,
+
+				ItemTemplate = new DataTemplate(() =>
+				{
+					var label = new Label();
+					label.SetBinding(Label.TextProperty, new Binding("."));
+					return label;
+				})
+			};
+
+			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Data"));
+			cv.SetBinding(VisualElement.IsVisibleProperty, new Binding("IsBusy", converter: new BoolInverter()));
+
+			return cv;
+		}
+
+		class BoolInverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				return !((bool)value);
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				throw new NotImplementedException();
+			}
+		}
+
+		class _13126VM : INotifyPropertyChanged
+		{
+			private bool _isBusy;
+
+			public bool IsBusy
+			{
+				get
+				{
+					return _isBusy;
+				}
+
+				set
+				{
+					_isBusy = value;
+					OnPropertyChanged(nameof(IsBusy));
+				}
+			}
+
+			public ObservableCollection<string> Data { get; } = new ObservableCollection<string>();
+
+			public event PropertyChangedEventHandler PropertyChanged;
+
+			void OnPropertyChanged(string name)
+			{
+				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+			}
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionViewShouldSourceShouldUpdateWhileInvisible()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13126.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13126.cs
@@ -1,9 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Globalization;
 using System.Text;
+using System.Threading.Tasks;
 using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
 
@@ -26,9 +28,6 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			_vm = new _13126VM();
-			BindingContext = _vm;
-
 			var collectionView = BindingWithConverter();
 
 			var grid = new Grid
@@ -43,21 +42,23 @@ namespace Xamarin.Forms.Controls.Issues
 
 			Content = grid;
 
-			_vm.IsBusy = true;
-
-			Device.StartTimer(TimeSpan.FromMilliseconds(300), () =>
-			{
-				Device.BeginInvokeOnMainThread(() =>
-				{
-					_vm.Data.Add(Success);
-					_vm.IsBusy = false;
-				});
-
-				return false;
-			});
+			_vm = new _13126VM();
+			BindingContext = _vm;
 		}
 
-		CollectionView BindingWithConverter()
+		protected async override void OnParentSet()
+		{
+			base.OnParentSet();
+			_vm.IsBusy = true;
+
+			await Task.Delay(1000);
+
+			_vm.Data.Add(Success);
+			
+			_vm.IsBusy = false;
+		}
+
+		internal static CollectionView BindingWithConverter()
 		{
 			var cv = new CollectionView
 			{
@@ -70,6 +71,8 @@ namespace Xamarin.Forms.Controls.Issues
 					return label;
 				})
 			};
+
+			cv.EmptyView = new Label { Text = "Should not see me" };
 
 			cv.SetBinding(CollectionView.ItemsSourceProperty, new Binding("Data"));
 			cv.SetBinding(VisualElement.IsVisibleProperty, new Binding("IsBusy", converter: new BoolInverter()));
@@ -90,7 +93,7 @@ namespace Xamarin.Forms.Controls.Issues
 			}
 		}
 
-		class _13126VM : INotifyPropertyChanged
+		internal class _13126VM : INotifyPropertyChanged
 		{
 			private bool _isBusy;
 
@@ -108,13 +111,62 @@ namespace Xamarin.Forms.Controls.Issues
 				}
 			}
 
-			public ObservableCollection<string> Data { get; } = new ObservableCollection<string>();
+			public OptimizedObservableCollection<string> Data { get; } = new OptimizedObservableCollection<string>();
 
 			public event PropertyChangedEventHandler PropertyChanged;
 
 			void OnPropertyChanged(string name)
 			{
 				PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+			}
+		}
+
+		internal class OptimizedObservableCollection<T> : ObservableCollection<T>
+		{
+			bool _shouldRaiseNotifications = true;
+
+			public OptimizedObservableCollection()
+			{
+			}
+
+			public OptimizedObservableCollection(IEnumerable<T> collection)
+				: base(collection)
+			{
+			}
+
+			public IDisposable BeginMassUpdate()
+			{
+				return new MassUpdater(this);
+			}
+
+			protected override void OnCollectionChanged(NotifyCollectionChangedEventArgs e)
+			{
+				if (_shouldRaiseNotifications)
+					base.OnCollectionChanged(e);
+			}
+
+			protected override void OnPropertyChanged(PropertyChangedEventArgs e)
+			{
+				if (_shouldRaiseNotifications)
+					base.OnPropertyChanged(e);
+			}
+
+			class MassUpdater : IDisposable
+			{
+				readonly OptimizedObservableCollection<T> parent;
+				public MassUpdater(OptimizedObservableCollection<T> parent)
+				{
+					this.parent = parent;
+					parent._shouldRaiseNotifications = false;
+				}
+
+				public void Dispose()
+				{
+					parent._shouldRaiseNotifications = true;
+					parent.OnPropertyChanged(new PropertyChangedEventArgs("Count"));
+					parent.OnPropertyChanged(new PropertyChangedEventArgs("Item[]"));
+					parent.OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13126_2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13126_2.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using System.Globalization;
+using System.Text;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using static Xamarin.Forms.Controls.Issues.Issue13126;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13126, "[Bug] Regression: 5.0.0-pre5 often fails to draw dynamically loaded collection view content", 
+		PlatformAffected.iOS, issueTestNumber:1)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+	public class Issue13126_2 : TestContentPage
+	{
+		_13126VM _vm;
+		const string Success = "Success";
+
+		protected override void Init()
+		{
+			var collectionView = BindingWithConverter();
+
+			var grid = new Grid
+			{
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition() { Height = GridLength.Star },
+				}
+			};
+
+			grid.Children.Add(collectionView);
+
+			Content = grid;
+
+			_vm = new _13126VM();
+			BindingContext = _vm;
+		}
+
+		protected async override void OnParentSet()
+		{
+			base.OnParentSet();
+			_vm.IsBusy = true;
+
+			await Task.Delay(1000);
+
+			using (_vm.Data.BeginMassUpdate())
+			{
+				_vm.Data.Add(Success);
+			}
+
+			_vm.IsBusy = false;
+		}
+
+#if UITEST
+		[Test]
+		public void CollectionViewShouldSourceShouldResetWhileInvisible()
+		{
+			RunningApp.WaitForElement(Success);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -13,6 +13,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13126.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13126_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -12,6 +12,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)CollectionViewGroupTypeIssue.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13126.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/CarouselViewController.cs
@@ -469,6 +469,18 @@ namespace Xamarin.Forms.Platform.iOS
 
 			_oldViews = newViews;
 		}
+
+		protected internal override void UpdateVisibility()
+		{
+			if (ItemsView.IsVisible)
+			{
+				CollectionView.Hidden = false;
+			}
+			else
+			{
+				CollectionView.Hidden = true;
+			}
+		}
 	}
 
 	class CarouselViewLoopManager : IDisposable

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -31,8 +31,6 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			ItemsView = itemsView;
 			ItemsViewLayout = layout;
-
-			ItemsView.PropertyChanged += ItemsViewPropertyChanged;
 		}
 
 		public void UpdateLayout(ItemsViewLayout newLayout)
@@ -62,8 +60,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
-				ItemsView.PropertyChanged -= ItemsViewPropertyChanged;
-
 				ItemsSource?.Dispose();
 
 				CollectionView.Delegate = null;
@@ -100,11 +96,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override nint GetItemsCount(UICollectionView collectionView, nint section)
 		{
-			if (!_initialized)
-			{
-				return 0;
-			}
-
 			CheckForEmptySource();
 
 			return ItemsSource.ItemCountInGroup(section);
@@ -172,13 +163,6 @@ namespace Xamarin.Forms.Platform.iOS
 				return;
 			}
 
-			if (!ItemsView.IsVisible)
-			{
-				// If the CollectionView starts out invisible, we'll get a layout pass with a size of 1,1 and everything will
-				// go pear-shaped. So until the first time this CollectionView is visible, we do nothing.
-				return;
-			}
-
 			_initialized = true;
 
 			ItemsViewLayout.GetPrototype = GetPrototype;
@@ -225,11 +209,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override nint NumberOfSections(UICollectionView collectionView)
 		{
-			if(!_initialized)
-			{
-				return 0;
-			}
-
 			CheckForEmptySource();
 			return ItemsSource.GroupCount;
 		}
@@ -610,15 +589,17 @@ namespace Xamarin.Forms.Platform.iOS
 			return ItemsViewLayout.EstimatedItemSize;
 		}
 		
-		void ItemsViewPropertyChanged(object sender, PropertyChangedEventArgs changedProperty) 
+		internal protected virtual void UpdateVisibility() 
 		{
-			if (changedProperty.Is(VisualElement.IsVisibleProperty))
+			if (ItemsView.IsVisible)
 			{
-				if (ItemsView.IsVisible)
-				{
-					Layout.InvalidateLayout();
-					CollectionView.LayoutIfNeeded();
-				}
+				CollectionView.Hidden = false;
+				Layout.InvalidateLayout();
+				CollectionView.LayoutIfNeeded();
+			}
+			else
+			{
+				CollectionView.Hidden = true;
 			}
 		}
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using CoreGraphics;
 using Foundation;
@@ -15,6 +16,8 @@ namespace Xamarin.Forms.Platform.iOS
 		CGSize _adjustmentSize0;
 		CGSize _adjustmentSize1;
 		CGSize _currentSize;
+
+		Dictionary<object, CGSize> _cellSizeCache = new Dictionary<object, CGSize>();
 
 		public ItemsUpdatingScrollMode ItemsUpdatingScrollMode { get; set; }
 
@@ -89,6 +92,8 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				return;
 			}
+
+			ClearCellSizeCache();
 
 			_currentSize = size;
 
@@ -560,6 +565,28 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			return true;
+		}
+
+		internal bool TryGetCachedCellSize(object item, out CGSize size) 
+		{
+			if (_cellSizeCache.TryGetValue(item, out CGSize internalSize))
+			{
+				size = internalSize;
+				return true;
+			}
+
+			size = CGSize.Empty;
+			return false;
+		}
+
+		internal void CacheCellSize(object item, CGSize size) 
+		{
+			_cellSizeCache[item] = size;
+		}
+
+		internal void ClearCellSizeCache() 
+		{
+			_cellSizeCache.Clear();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewRenderer.cs
@@ -71,6 +71,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UpdateFlowDirection();
 			}
+			else if (changedProperty.Is(VisualElement.IsVisibleProperty))
+			{
+				UpdateVisibility();
+			}
 		}
 
 		protected abstract ItemsViewLayout SelectLayout();
@@ -101,6 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateVerticalScrollBarVisibility();
 			UpdateItemsUpdatingScrollMode();
 			UpdateFlowDirection();
+			UpdateVisibility();
 
 			// Listen for ScrollTo requests
 			newElement.ScrollToRequested += ScrollToRequested;
@@ -140,6 +145,11 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			UpdateItemsUpdatingScrollMode();
 			Controller.UpdateItemsSource();
+		}
+
+		protected virtual void UpdateVisibility() 
+		{
+			Controller?.UpdateVisibility();
 		}
 
 		protected abstract TViewController CreateController(TItemsView newElement, ItemsViewLayout layout);

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -167,11 +167,6 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			ResetGroupTracking();
 
-			if (_collectionView.Hidden)
-			{
-				return;
-			}
-
 			_collectionView.ReloadData();
 			_collectionView.CollectionViewLayout.InvalidateLayout();
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -111,12 +111,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
-			if (CollectionView.NumberOfSections() == 0)
-			{
-				// The CollectionView isn't fully initialized yet
-				return;
-			}
-
 			// Force UICollectionView to get the internal accounting straight 
 			CollectionView.NumberOfItemsInSection(_section);
 
@@ -144,6 +138,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Reload()
 		{
+			if (CollectionView.Hidden)
+			{
+				return;
+			}
+
 			var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
 
 			Count = ItemsCount();
@@ -199,9 +198,8 @@ namespace Xamarin.Forms.Platform.iOS
 				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : IndexOf(args.NewItems[0]);
 
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
-				OnCollectionViewUpdating(args);
-				CollectionView.ReloadItems(CreateIndexesFrom(startIndex, newCount));
-				OnCollectionViewUpdated(args);
+
+				Update(() => CollectionView.ReloadItems(CreateIndexesFrom(startIndex, newCount)), args);
 				return;
 			}
 
@@ -220,18 +218,14 @@ namespace Xamarin.Forms.Platform.iOS
 				var oldPath = NSIndexPath.Create(_section, args.OldStartingIndex);
 				var newPath = NSIndexPath.Create(_section, args.NewStartingIndex);
 
-				OnCollectionViewUpdating(args);
-				CollectionView.MoveItem(oldPath, newPath);
-				OnCollectionViewUpdated(args);
+				Update(() => CollectionView.MoveItem(oldPath, newPath), args);
 				return;
 			}
 
 			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
 			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
-			OnCollectionViewUpdating(args);
-			CollectionView.ReloadItems(CreateIndexesFrom(start, end));
 
-			OnCollectionViewUpdated(args);
+			Update(() => CollectionView.ReloadItems(CreateIndexesFrom(start, end)), args);
 		}
 
 		internal int ItemsCount()
@@ -276,8 +270,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return -1;
 		}
+
 		void Update(Action update, NotifyCollectionChangedEventArgs args)
 		{
+			if (CollectionView.Hidden)
+			{
+				return;
+			}
+
 			OnCollectionViewUpdating(args); 
 			update(); 
 			OnCollectionViewUpdated(args); 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -138,11 +138,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Reload()
 		{
-			if (CollectionView.Hidden)
-			{
-				return;
-			}
-
 			var args = new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset);
 
 			Count = ItemsCount();


### PR DESCRIPTION
### Description of Change ###

Fix timing issue where CollectionView items are added to ObservableSource before CollectionView is visible, and CollectionView is later made visible via Binding.

### Issues Resolved ### 

- fixes #13126

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Automated UI test.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
