### PR TITLE
Fix FlyoutItem recycling

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -18,10 +18,10 @@ namespace Xamarin.Forms.Platform.Android
 		List<List<Element>> _flyoutGroupings;
 		Action<Element> _selectedCallback;
 		bool _disposed;
-		ElementViewHolder _elementViewHolder;
 
 		public ShellFlyoutRecyclerAdapter(IShellContext shellContext, Action<Element> selectedCallback)
 		{
+			HasStableIds = true;
 			_shellContext = shellContext;
 
 			ShellController.FlyoutItemsChanged += OnFlyoutItemsChanged;
@@ -42,12 +42,22 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override int GetItemViewType(int position)
 		{
-			return position;
+			return _listItems[position].Index;
 		}
 
-		DataTemplate GetDataTemplate(int position)
+		DataTemplate GetDataTemplate(int viewTypeId)
 		{
-			var item = _listItems[position];
+			AdapterListItem item = null;
+
+			foreach(var ali in _listItems)
+			{
+				if(viewTypeId == ali.Index)
+				{
+					item = ali;
+					break;
+				}
+			}
+
 			DataTemplate dataTemplate = ShellController.GetFlyoutItemDataTemplate(item.Element);
 			if (item.Element is IMenuItemController)
 			{
@@ -61,7 +71,6 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			var template = dataTemplate.SelectDataTemplate(item.Element, Shell);
-
 			return template;
 		}
 
@@ -69,7 +78,19 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (holder is ElementViewHolder evh)
 			{
-				evh.Element = null;
+				// only clear out the Element if the item has been removed
+				bool found = false;
+				foreach(var item in _listItems)
+				{
+					if(item.Element == evh.Element)
+					{
+						found = true;
+						break;
+					}
+				}
+
+				if(!found)
+					evh.Element = null;
 			}
 
 			base.OnViewRecycled(holder);
@@ -176,14 +197,13 @@ namespace Xamarin.Forms.Platform.Android
 			container.LayoutParameters = new LP(LP.MatchParent, LP.WrapContent);
 			linearLayout.AddView(container);
 
-			_elementViewHolder = new ElementViewHolder(content, linearLayout, bar, _selectedCallback, _shellContext.Shell);
-
-			return _elementViewHolder;
+			return new ElementViewHolder(content, linearLayout, bar, _selectedCallback, _shellContext.Shell);
 		}
 
 		protected virtual List<AdapterListItem> GenerateItemList()
 		{
 			var result = new List<AdapterListItem>();
+			_listItems = _listItems ?? result;
 
 			List<List<Element>> grouping = ((IShellController)_shellContext.Shell).GenerateFlyoutGrouping();
 
@@ -199,7 +219,18 @@ namespace Xamarin.Forms.Platform.Android
 				bool first = !skip;
 				foreach (var element in sublist)
 				{
-					result.Add(new AdapterListItem(element, first));
+					AdapterListItem toAdd = null;
+					foreach (var existingItem in _listItems)
+					{
+						if(existingItem.Element == element)
+						{
+							existingItem.DrawTopLine = first;
+							toAdd = existingItem;
+						}
+					}
+
+					toAdd = toAdd ?? new AdapterListItem(element, first);
+					result.Add(toAdd);
 					first = false;
 				}
 				skip = false;
@@ -230,11 +261,8 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				((IShellController)Shell).FlyoutItemsChanged -= OnFlyoutItemsChanged;
 
-				_elementViewHolder?.Dispose();
-
 				_listItems = null;
 				_selectedCallback = null;
-				_elementViewHolder = null;
 			}
 
 			base.Dispose(disposing);
@@ -242,12 +270,18 @@ namespace Xamarin.Forms.Platform.Android
 
 		public class AdapterListItem
 		{
+			// This ensures that we have a stable id for each element
+			// if the elements change position
+			static int IndexCounter = 0;
+
 			public AdapterListItem(Element element, bool drawTopLine = false)
 			{
 				DrawTopLine = drawTopLine;
 				Element = element;
+				Index = IndexCounter++;
 			}
 
+			public int Index { get; }
 			public bool DrawTopLine { get; set; }
 			public Element Element { get; set; }
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Platform.Android
 		readonly IShellContext _shellContext;
 		List<AdapterListItem> _listItems;
 		List<List<Element>> _flyoutGroupings;
-		Dictionary<int, DataTemplate> _templateMap = new Dictionary<int, DataTemplate>();
 		Action<Element> _selectedCallback;
 		bool _disposed;
 		ElementViewHolder _elementViewHolder;
@@ -43,6 +42,11 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override int GetItemViewType(int position)
 		{
+			return position;
+		}
+
+		DataTemplate GetDataTemplate(int position)
+		{
 			var item = _listItems[position];
 			DataTemplate dataTemplate = ShellController.GetFlyoutItemDataTemplate(item.Element);
 			if (item.Element is IMenuItemController)
@@ -57,11 +61,8 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			var template = dataTemplate.SelectDataTemplate(item.Element, Shell);
-			var id = ((IDataTemplateController)template).Id;
 
-			_templateMap[id] = template;
-
-			return id;
+			return template;
 		}
 
 		public override void OnViewRecycled(Java.Lang.Object holder)
@@ -154,7 +155,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public override RecyclerView.ViewHolder OnCreateViewHolder(ViewGroup parent, int viewType)
 		{
-			var template = _templateMap[viewType];
+			var template = GetDataTemplate(viewType);
 
 			var content = (View)template.CreateContent();
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellTableViewController.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnFlyoutItemsChanged(object sender, EventArgs e)
 		{
-			_source.ClearCache();
+			_source.ReSyncCache();
 			TableView.ReloadData();
 			ShellFlyoutContentManager.UpdateVerticalScrollMode();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/UIContainerCell.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/UIContainerCell.cs
@@ -18,9 +18,14 @@ namespace Xamarin.Forms.Platform.iOS
 			View = view;
 			View.MeasureInvalidated += MeasureInvalidated;
 			SelectionStyle = UITableViewCellSelectionStyle.None;
-			
-			_renderer = Platform.CreateRenderer(view);
-			Platform.SetRenderer(view, _renderer);
+
+			_renderer = Platform.GetRenderer(view);
+
+			if (_renderer == null)
+			{
+				_renderer = Platform.CreateRenderer(view);
+				Platform.SetRenderer(view, _renderer);
+			}
 
 			ContentView.AddSubview(_renderer.NativeView);
 			_renderer.NativeView.ClipsToBounds = true;
@@ -49,7 +54,7 @@ namespace Xamarin.Forms.Platform.iOS
 			TableView.ReloadRows(new[] { IndexPath }, UITableViewRowAnimation.Automatic);
 		}
 
-		internal void Disconnect(Shell shell = null)
+		internal void Disconnect(Shell shell = null, bool keepRenderer = false)
 		{
 			ViewMeasureInvalidated = null;
 			View.MeasureInvalidated -= MeasureInvalidated;
@@ -57,7 +62,10 @@ namespace Xamarin.Forms.Platform.iOS
 				baseShell.PropertyChanged -= OnElementPropertyChanged;
 
 			_bindingContext = null;
-			Platform.SetRenderer(View, null);
+
+			if (!keepRenderer)
+				Platform.SetRenderer(View, null);
+
 			if (shell != null)
 				shell.RemoveLogicalChild(shell);
 
@@ -70,7 +78,8 @@ namespace Xamarin.Forms.Platform.iOS
 		public object BindingContext
 		{
 			get => _bindingContext;
-			set {
+			set
+			{
 				if (value == _bindingContext)
 					return;
 
@@ -91,7 +100,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public override void LayoutSubviews()
 		{
 			base.LayoutSubviews();
-			if(View != null)
+			if (View != null)
 				View.Layout(Bounds.ToRectangle());
 		}
 


### PR DESCRIPTION
### Description of Change ###

Currently on iOS and Android when you scroll the Flyout the Flyout Items will clear and recreate renderers. They will also clear and recreate renderers if you remove items or rearrange. This causes a lot of churn. This PR disables cell recycling on iOS and Android since we're not dealing with massive lists. If users want full virtualization for the FlyoutItems they should use a custom FlyoutContent with a CollectionView. These changes also keep track of FlyoutItems so when the list is modified that cells/renderers are reused instead of recreating everything. 

These changes are optimized around a small to medium sized list

### Platforms Affected ### 
- iOS
- Android

### Testing Procedure ###
- make sure the store shell flyout scrolls nicely
- Test a few of the UI tests that involve flyout visibility to make sure items show and vanish

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
