### PR TITLE
[UWP] Avoid open more than one ContentDialog

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Extensions/ContentDialogExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions/ContentDialogExtensions.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Threading.Tasks;
+using Windows.UI.Xaml.Controls;
+
+namespace Xamarin.Forms.Platform.UAP.Extensions
+{
+	public static class ContentDialogExtensions
+	{
+		static TaskCompletionSource<object> PreviousDialogCompletion;
+
+		public static async Task<ContentDialogResult> EnqueueAndShowAsync(this ContentDialog contentDialog, Func<int> numberOfContentDialogs = null)
+		{
+			TaskCompletionSource<object> currentDialogCompletion = new TaskCompletionSource<object>();
+
+			var previousDialogCompletion = PreviousDialogCompletion;
+			PreviousDialogCompletion = currentDialogCompletion;
+
+			if (previousDialogCompletion != null)
+				await previousDialogCompletion.Task;
+			
+			var contentDialogResult = ContentDialogResult.None;
+
+			if (numberOfContentDialogs == null || numberOfContentDialogs() <= 1)
+				contentDialogResult = await contentDialog.ShowAsync();
+						
+			currentDialogCompletion.SetResult(null);
+
+			return contentDialogResult;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/Platform.cs
+++ b/Xamarin.Forms.Platform.UAP/Platform.cs
@@ -13,6 +13,8 @@ using Xamarin.Forms.Internals;
 using NativeAutomationProperties = Windows.UI.Xaml.Automation.AutomationProperties;
 using WImage = Windows.UI.Xaml.Controls.Image;
 using WFlowDirection = Windows.UI.Xaml.FlowDirection;
+using Windows.UI.Xaml.Media;
+using Xamarin.Forms.Platform.UAP.Extensions;
 
 namespace Xamarin.Forms.Platform.UWP
 {
@@ -23,6 +25,7 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		static Task<bool> s_currentAlert;
 		static Task<string> s_currentPrompt;
+		static int DialogDisplayCount;
 
 		internal static readonly BindableProperty RendererProperty = BindableProperty.CreateAttached("Renderer",
 			typeof(IVisualElementRenderer), typeof(Windows.Foundation.Metadata.Platform), default(IVisualElementRenderer));
@@ -656,10 +659,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static async Task<string> ShowPrompt(PromptDialog prompt)
 		{
-			ContentDialogResult result = await prompt.ShowAsync();
+			DialogDisplayCount++;
+
+			ContentDialogResult result = await prompt.EnqueueAndShowAsync(() => DialogDisplayCount);
+
+			DialogDisplayCount = 0;
 
 			if (result == ContentDialogResult.Primary)
 				return prompt.Input;
+
 			return null;
 		}
 
@@ -715,8 +723,12 @@ namespace Xamarin.Forms.Platform.UWP
 
 		static async Task<bool> ShowAlert(ContentDialog alert)
 		{
-			ContentDialogResult result = await alert.ShowAsync();
+			DialogDisplayCount++;
 
+			ContentDialogResult result = await alert.EnqueueAndShowAsync(() => DialogDisplayCount);
+
+			DialogDisplayCount = 0;
+			
 			return result == ContentDialogResult.Primary;
 		}
 


### PR DESCRIPTION
### Description of Change ###

Added extension method to avoid open a `ContentDialog` (Alert or Prompt) if there is one already open.

### Issues Resolved ### 

- fixes #13185 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
