### PR TITLE
[UWP] Maintain Editor BackgroundColor when focused 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13573.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13573.xaml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13573"
+    Title="Issue 13573"
+    BackgroundColor="Black">
+    <ContentPage.Content>
+        <StackLayout>
+            <Label
+                Padding="12"
+                TextColor="White"
+                Text="Put the focus on the Editor, if the background color remains white, the test has passed. "/>
+            <StackLayout>
+                <Label
+                    Text="Entry"/>
+                <Entry  
+                    Placeholder="Some long text, doesn't really matter" 
+                    PlaceholderColor="Gray" 
+                    VerticalOptions="Start" 
+                    HorizontalOptions="FillAndExpand" 
+                    MaxLength="4000" 
+                    FontSize="12" 
+                    BackgroundColor="White"
+                    TextColor="Black" />
+                <Label
+                    Text="Editor"/>
+                <Editor 
+                    Placeholder="Some long text, doesn't really matter" 
+                    PlaceholderColor="Gray" 
+                    VerticalOptions="Start" 
+                    HorizontalOptions="FillAndExpand" 
+                    MaxLength="4000" 
+                    FontSize="12" 
+                    HeightRequest="100" 
+                    BackgroundColor="White"
+                    TextColor="Black"  />
+            </StackLayout>
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13573.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13573.xaml.cs
@@ -1,0 +1,24 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13573, "[Bug] Editor PlaceholderColor and BackgroundColor incorrect on UWP after upgrading to Xamarin.Forms 4.8 (from 4.5)", PlatformAffected.UWP)]
+	public partial class Issue13573 : TestContentPage
+	{
+		public Issue13573()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -44,6 +44,9 @@
       <DependentUpon>Issue14765.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue14764.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13573.xaml.cs">
+      <DependentUpon>Issue13573.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -2927,6 +2930,10 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14765.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13573.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
+++ b/Xamarin.Forms.Platform.UAP/FormsTextBoxStyle.xaml
@@ -4,6 +4,7 @@
 	xmlns:uwp="using:Xamarin.Forms.Platform.UWP">
 
 	<uwp:TextAlignmentToHorizontalAlignmentConverter x:Key="AlignmentConverter" />
+    
 	<Style x:Key="FormsTextBoxStyle" TargetType="uwp:FormsTextBox">
 		<Setter Property="MinWidth" Value="{ThemeResource TextControlThemeMinWidth}" />
 		<Setter Property="MinHeight" Value="{ThemeResource TextControlThemeMinHeight}" />
@@ -157,16 +158,11 @@
 								</VisualState>
 								<VisualState x:Name="Focused">
 									<Storyboard>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Foreground"
 										                               Storyboard.TargetName="PlaceholderTextContentPresenter">
-											<DiscreteObjectKeyFrame KeyTime="0" Value="{Binding PlaceholderForegroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
-										                               Storyboard.TargetName="BackgroundElement">
-											<DiscreteObjectKeyFrame KeyTime="0"
-											                        Value="{Binding BackgroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}" />
-										</ObjectAnimationUsingKeyFrames>
-										<ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
+                                            <DiscreteObjectKeyFrame KeyTime="0" Value="{Binding PlaceholderForegroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}" />
+                                        </ObjectAnimationUsingKeyFrames>
+                                        <ObjectAnimationUsingKeyFrames Storyboard.TargetProperty="Background"
 										                               Storyboard.TargetName="BorderElement">
 											<DiscreteObjectKeyFrame KeyTime="0"
 											                        Value="{Binding BackgroundFocusBrush, RelativeSource={RelativeSource TemplatedParent}}" />


### PR DESCRIPTION
### Description of Change ###

Maintain Editor BackgroundColor when focused. Removed unwanted behavior from `FormsTextBoxStyle`.

### Issues Resolved ### 

- fixes #13573 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix13573](https://user-images.githubusercontent.com/6755973/107624339-ffd5f300-6c5a-11eb-8433-092f9b8f9069.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13573. Put the focus on the Editor, if the background color remains white, the test has passed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
