### PR TITLE
[Android] Fix occasional wrong touch interception in SwipeView Content 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13726.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13726.xaml
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 13726" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13726">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Tap several times the Button. If the counter is always updated, the test has passed."/>
+        <StackLayout
+            Padding="12">
+            <Label
+                Text="Button"/>
+            <Button
+                Text="Tap"
+                Clicked="OnButtonClicked"/>
+            <Label
+                x:Name="ButtonInfoLabel"
+                FontSize="Medium"
+                HorizontalOptions="Center"/>
+            <Label
+                Text="Button inside SwipeView"/>
+            <SwipeView>
+                <SwipeView.RightItems>
+                    <SwipeItem
+                        Text="Delete"
+                        BackgroundColor="Red"/>
+                </SwipeView.RightItems>
+                <Grid
+                    BackgroundColor="LightGray">
+                    <Button
+                        AutomationId="SwipeViewButtonId"
+                        Text="Tap"
+                        Clicked="OnSwipeViewButtonClicked"/>
+                </Grid>
+            </SwipeView>
+            <Label
+                x:Name="SwipeViewInfoLabel"
+                AutomationId="SwipeViewInfoLabelId"
+                FontSize="Medium"
+                HorizontalOptions="Center"/>
+        </StackLayout>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13726.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13726.xaml.cs
@@ -1,0 +1,73 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13726,
+		"[Bug] Clicks on elements within a SwipeView are buggy",
+		PlatformAffected.Android)]
+	public partial class Issue13726 : TestContentPage
+	{
+#if APP
+		int _buttonCounter = 0;
+		int _swipeViewCounter = 0;
+#endif
+
+		public Issue13726()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+
+#if APP
+		void OnButtonClicked(object sender, EventArgs e)
+		{
+			_buttonCounter++;
+			ButtonInfoLabel.Text = $"SwipeView Button tapped {_buttonCounter} times";
+		}
+
+		void OnSwipeViewButtonClicked(object sender, EventArgs e)
+		{
+			_swipeViewCounter++;
+			SwipeViewInfoLabel.Text = $"SwipeView Button tapped {_swipeViewCounter} times";
+		}
+#endif
+
+#if UITEST && __ANDROID__
+		[Test]
+		public void TouchSwipeViewContentTest()
+		{
+			string swipeViewButtonId = "SwipeViewButtonId";
+			string swipeViewInfoLabelId = "SwipeViewInfoLabelId";
+
+			RunningApp.WaitForElement(q => q.Marked(swipeViewButtonId));
+
+			for (int i = 0; i < 10; i++)
+				RunningApp.Tap(q => q.Marked(swipeViewButtonId));
+
+			RunningApp.SwipeRightToLeft(q => q.Marked(swipeViewButtonId));
+
+			for (int i = 0; i < 10; i++)
+				RunningApp.Tap(q => q.Marked(swipeViewButtonId));
+
+			var infoLabel = RunningApp.WaitForFirstElement(swipeViewInfoLabelId);
+
+			Assert.AreEqual("SwipeView Button tapped 20 times", infoLabel.ReadText());
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1753,6 +1753,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12150.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2186,6 +2187,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13684.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13726.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -251,7 +251,9 @@ namespace Xamarin.Forms.Platform.Android
 			var diffY = interceptPoint.Y - _initialPoint.Y;
 			var aDiffY = Math.Abs(diffY);
 
-			if (aDiffX >= SwipeMinimumDelta || aDiffY >= SwipeMinimumDelta)
+			var swipeMinimumDelta = 1.0f;
+
+			if (aDiffX >= swipeMinimumDelta || aDiffY >= swipeMinimumDelta)
 			{
 				SwipeDirection swipeDirection;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -246,21 +246,29 @@ namespace Xamarin.Forms.Platform.Android
 			var interceptPoint = new Point(e.GetX() / _density, e.GetY() / _density);
 
 			var diffX = interceptPoint.X - _initialPoint.X;
+			var aDiffX = Math.Abs(diffX);
+
 			var diffY = interceptPoint.Y - _initialPoint.Y;
+			var aDiffY = Math.Abs(diffY);
 
-			SwipeDirection swipeDirection;
+			if (aDiffX >= SwipeMinimumDelta || aDiffY >= SwipeMinimumDelta)
+			{
+				SwipeDirection swipeDirection;
 
-			if (Math.Abs(diffX) > Math.Abs(diffY))
-				swipeDirection = diffX > 0 ? SwipeDirection.Right : SwipeDirection.Left;
-			else
-				swipeDirection = diffY > 0 ? SwipeDirection.Down : SwipeDirection.Up;
+				if (aDiffX > aDiffY)
+					swipeDirection = diffX > 0 ? SwipeDirection.Right : SwipeDirection.Left;
+				else
+					swipeDirection = diffY > 0 ? SwipeDirection.Down : SwipeDirection.Up;
 
-			var items = GetSwipeItemsByDirection(swipeDirection);
+				var items = GetSwipeItemsByDirection(swipeDirection);
 
-			if (items == null || items.Count == 0)
-				return false;
+				if (items == null || items.Count == 0)
+					return false;
 
-			return ShouldInterceptScrollChildrenTouch(swipeDirection);
+				return ShouldInterceptScrollChildrenTouch(swipeDirection);
+			}
+
+			return false;
 		}
 
 		bool ShouldInterceptScrollChildrenTouch(SwipeDirection swipeDirection)


### PR DESCRIPTION
### Description of Change ###

Fix occasional wrong touch interception in SwipeView Content on Android.

### Issues Resolved ### 

- fixes #13726 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13726. Tap several times the Button. If the counter is always updated, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
