### PR TITLE
Prevent overeager cache invalidation when the CollectionView height changes by very small amounts

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewLayout.cs
@@ -17,6 +17,8 @@ namespace Xamarin.Forms.Platform.iOS
 		CGSize _adjustmentSize1;
 		CGSize _currentSize;
 
+		const double ConstraintSizeTolerance = 0.00001;
+
 		Dictionary<object, CGSize> _cellSizeCache = new Dictionary<object, CGSize>();
 
 		public ItemsUpdatingScrollMode ItemsUpdatingScrollMode { get; set; }
@@ -88,7 +90,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal virtual void UpdateConstraints(CGSize size)
 		{
-			if (size == _currentSize)
+			if (!RequiresConstraintUpdate(size, _currentSize))
 			{
 				return;
 			}
@@ -587,6 +589,21 @@ namespace Xamarin.Forms.Platform.iOS
 		internal void ClearCellSizeCache() 
 		{
 			_cellSizeCache.Clear();
+		}
+
+		bool RequiresConstraintUpdate(CGSize newSize, CGSize current)
+		{
+			if (Math.Abs(newSize.Width - current.Width) > ConstraintSizeTolerance)
+			{
+				return true;
+			}
+
+			if (Math.Abs(newSize.Height - current.Height) > ConstraintSizeTolerance)
+			{
+				return true;
+			}
+
+			return false;
 		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Under the right layout circumstances, the UICollectionView's size can repeatedly change by very, very small amounts (height differences less than 0.0001). The layout cell sizes cache was blindly invalidating even for very small changes, which caused layout jumps and incorrect scrollbar positions.

These changes prevent cache invalidation in those scenarios.

### Issues Resolved ### 

- fixes #13719

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Grab the repro project from #13231 and update it to this PR; the CollectionView should scroll smoothly and should scroll all the way to the bottom of the last item. If the last item will no scroll fully into view, this PR is failing.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
