### PR TITLE
[WiP] Setup NET6 device tests for CI

### DIFF
--- a/Maui.sln
+++ b/Maui.sln
@@ -23,6 +23,14 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maui.Controls.Compatibility
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Xamarin.Forms.Platform.Android.FormsViewGroup-net6", "src\Platform.Renderers\src\Xamarin.Forms.Platform.Android.FormsViewGroup\Xamarin.Forms.Platform.Android.FormsViewGroup-net6.csproj", "{EB956381-F3E6-437C-9069-36B8BF5C6E2F}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tests", "tests", "{6330DD15-98A9-446E-9063-71BF5EF19BFE}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maui.DeviceTests", "src\Platform.Handlers\tests\Xamarin.Platform.Handlers.DeviceTests\Maui.DeviceTests.csproj", "{0E01EA07-00D2-4B73-9A0D-5D1F78540EB7}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maui.DeviceTests.Droid", "src\Platform.Handlers\tests\Xamarin.Platform.Handlers.DeviceTests.Android\Maui.DeviceTests.Droid.csproj", "{290466A3-FA26-4ED3-9D82-019809222F3D}"
+EndProject
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Maui.DeviceTests.iOS", "src\Platform.Handlers\tests\Xamarin.Platform.Handlers.DeviceTests.iOS\Maui.DeviceTests.iOS.csproj", "{E0511D6C-E59C-44F9-8035-F2CDA98F37BA}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -58,9 +66,28 @@ Global
 		{EB956381-F3E6-437C-9069-36B8BF5C6E2F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{EB956381-F3E6-437C-9069-36B8BF5C6E2F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EB956381-F3E6-437C-9069-36B8BF5C6E2F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0E01EA07-00D2-4B73-9A0D-5D1F78540EB7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0E01EA07-00D2-4B73-9A0D-5D1F78540EB7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0E01EA07-00D2-4B73-9A0D-5D1F78540EB7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0E01EA07-00D2-4B73-9A0D-5D1F78540EB7}.Release|Any CPU.Build.0 = Release|Any CPU
+		{290466A3-FA26-4ED3-9D82-019809222F3D}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{290466A3-FA26-4ED3-9D82-019809222F3D}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{290466A3-FA26-4ED3-9D82-019809222F3D}.Debug|Any CPU.Deploy.0 = Debug|Any CPU
+		{290466A3-FA26-4ED3-9D82-019809222F3D}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{290466A3-FA26-4ED3-9D82-019809222F3D}.Release|Any CPU.Build.0 = Release|Any CPU
+		{290466A3-FA26-4ED3-9D82-019809222F3D}.Release|Any CPU.Deploy.0 = Release|Any CPU
+		{E0511D6C-E59C-44F9-8035-F2CDA98F37BA}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{E0511D6C-E59C-44F9-8035-F2CDA98F37BA}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{E0511D6C-E59C-44F9-8035-F2CDA98F37BA}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{E0511D6C-E59C-44F9-8035-F2CDA98F37BA}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{0E01EA07-00D2-4B73-9A0D-5D1F78540EB7} = {6330DD15-98A9-446E-9063-71BF5EF19BFE}
+		{290466A3-FA26-4ED3-9D82-019809222F3D} = {6330DD15-98A9-446E-9063-71BF5EF19BFE}
+		{E0511D6C-E59C-44F9-8035-F2CDA98F37BA} = {6330DD15-98A9-446E-9063-71BF5EF19BFE}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {0B8ABEAD-D2B5-4370-A187-62B5ABE4EE50}

--- a/src/ControlGallery/src/Xamarin.Forms.ControlGallery.Android/LinkDescription.xml
+++ b/src/ControlGallery/src/Xamarin.Forms.ControlGallery.Android/LinkDescription.xml
@@ -15,4 +15,5 @@
     <type fullname="System.Runtime.CompilerServices.TaskAwaiter" />
   </assembly>
   <assembly fullname="Xamarin.Forms.Platform.Android.UnitTests" />
+  <assembly fullname="Xamarin.Platform" />
 </linker>

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests.Android/Maui.DeviceTests.Droid.csproj
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests.Android/Maui.DeviceTests.Droid.csproj
@@ -1,0 +1,25 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-android</TargetFramework>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Maui.DeviceTests.Android</RootNamespace>
+    <AssemblyName>Maui.DeviceTests.Android</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Xamarin.Platform.Handlers.DeviceTests\Maui.DeviceTests.csproj" />
+    <PackageReference Include="Xamarin.Essentials" Version="1.6.1" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+    <PackageReference Include="Xamarin.Forms">
+      <Version>5.0.0.1931</Version>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20602.1" />
+    <PackageReference Include="xunit.runner.devices">
+      <Version>2.5.25</Version>
+    </PackageReference>
+
+  </ItemGroup>
+</Project>

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests.iOS/Maui.DeviceTests.iOS.csproj
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests.iOS/Maui.DeviceTests.iOS.csproj
@@ -1,0 +1,30 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net6.0-ios</TargetFramework>
+    <RuntimeIdentifier>ios-x64</RuntimeIdentifier>
+    <OutputType>Exe</OutputType>
+    <RootNamespace>Maui.DeviceTests.iOS</RootNamespace>
+    <AssemblyName>Maui.DeviceTests.iOS</AssemblyName>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Remove="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Xamarin.Platform.Handlers.DeviceTests\Maui.DeviceTests.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Essentials">
+      <Version>1.6.1</Version>
+    </PackageReference>
+    <PackageReference Include="Xamarin.Forms">
+      <Version>5.0.0.1931</Version>
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.devices" Version="2.5.25" />
+    <PackageReference Include="Microsoft.DotNet.XHarness.TestRunners.Xunit" Version="1.0.0-prerelease.20602.1" />
+    <PackageReference Include="System.Numerics.Vectors" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Properties\" />
+  </ItemGroup>
+</Project>

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Maui.DeviceTests.csproj
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Maui.DeviceTests.csproj
@@ -1,0 +1,18 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFrameworks>net6.0-android;net6.0-ios;</TargetFrameworks>
+    <RootNamespace>Maui.DeviceTests</RootNamespace>
+    <AssemblyName>Maui.DeviceTests</AssemblyName>
+    <Nullable>disable</Nullable>
+  </PropertyGroup>
+  <Import Project="..\..\..\..\.nuspec\Xamarin.Forms.MultiTargeting.targets" />
+  <ItemGroup>
+    <PackageReference Include="Xamarin.Essentials" Version="1.6.1">
+    </PackageReference>
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="UnitTests.HeadlessRunner" Version="2.0.0" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\src\Xamarin.Platform.Handlers\Xamarin.Platform.Handlers-net6.csproj" />
+  </ItemGroup>
+</Project>


### PR DESCRIPTION
Currently the NET6 app heads don't seem to be working correctly

### Description of Change ###

Setup NET 6 projects heads for running device tests.

The ultimate goal would be to just launch a single project that's multi targeted to ios/android but the IDE currently doesn't support multi targeted project launch scenarios so for now we'll use the two separate project head

### Testing Procedure ###
- projects run and tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
