### PR TITLE
[iOS] Fix incorrect refresh indicador position using RefreshView with CollectionView Header

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8282.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8282.xaml
@@ -1,0 +1,62 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8282"
+    Title="Issue 8282">
+    <Grid
+        RowSpacing="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Select am item from the list. If the selection background color is green, the test has passed."/>
+        <Grid
+            Grid.Row="1">
+            <RefreshView
+                BackgroundColor="Yellow"
+                RefreshColor="Black"
+                IsRefreshing="{Binding IsRefreshing}"
+                Command="{Binding RefreshCommand}">
+            <CollectionView
+                ItemsSource="{Binding Items}">
+                <CollectionView.Header>
+                    <Grid
+                        HeightRequest="200"
+                        BackgroundColor="#aadddddd">
+                        <Label
+                            Text="Issue 8282"
+                            HorizontalOptions="Center"
+                            VerticalOptions="Center"/>
+                    </Grid>
+                </CollectionView.Header>
+                <CollectionView.ItemsLayout>
+                    <LinearItemsLayout
+                        Orientation="Vertical"
+                        ItemSpacing="5"/>
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Grid
+                            HeightRequest="100"
+                            BackgroundColor="Beige">
+                            <Label
+                                Text="{Binding Position}"
+                                HorizontalTextAlignment="Center"
+                                VerticalTextAlignment="Center"/>
+                        </Grid>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </RefreshView>
+        </Grid>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8282.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8282.xaml
@@ -18,7 +18,7 @@
             Padding="12"
             BackgroundColor="Black"
             TextColor="White"
-            Text="Select am item from the list. If the selection background color is green, the test has passed."/>
+            Text="Pull to Refresh. If the loading indicator appears above the CollectionView header, the test has passed. "/>
         <Grid
             Grid.Row="1">
             <RefreshView

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8282.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8282.xaml.cs
@@ -1,0 +1,123 @@
+﻿using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.RefreshView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8282, "[Bug] [iOS] RefreshView draws behind CollectionView Header", PlatformAffected.iOS)]
+	public partial class Issue8282 : TestContentPage
+	{
+		public Issue8282()
+		{
+#if APP
+			Title = "Issue 8282";
+			InitializeComponent();
+			BindingContext = new Issue8282ViewModel();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8282Model : INotifyPropertyChanged
+	{
+		private int _position;
+
+		public int Position
+		{
+			get
+			{
+				return _position;
+			}
+			set
+			{
+				_position = value;
+
+				OnPropertyChanged("Position");
+			}
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged(string name)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue8282ViewModel : INotifyPropertyChanged
+	{
+		bool _isRefreshing;
+
+		public Issue8282ViewModel()
+		{
+			PopulateItems();
+
+			RefreshCommand = new Command(async () =>
+			{
+				IsRefreshing = true;
+
+				await Task.Delay(2000);
+				PopulateItems();
+
+				IsRefreshing = false;
+			});
+		}
+
+		public ObservableCollection<Issue8282Model> Items { get; set; } = new ObservableCollection<Issue8282Model>();
+
+		public bool IsRefreshing
+		{
+			get
+			{
+				return _isRefreshing;
+			}
+			set
+			{
+				_isRefreshing = value;
+
+				OnPropertyChanged("IsRefreshing");
+			}
+		}
+
+
+		public Command RefreshCommand { get; set; }
+
+		void PopulateItems()
+		{
+			var count = Items.Count;
+
+			for (var i = count; i < count + 10; i++)
+				Items.Add(new Issue8282Model() { Position = i });
+		}
+
+		public event PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged(string name)
+		{
+			PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(name));
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1708,6 +1708,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8833.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue10086.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13136.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8282.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13164.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11924.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12521.xaml.cs" />
@@ -2113,6 +2114,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13136.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8282.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12521.xaml">

--- a/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/StructuredItemsViewController.cs
@@ -4,12 +4,15 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class StructuredItemsViewController<TItemsView> : ItemsViewController<TItemsView>
-		where TItemsView : StructuredItemsView
+	public class ItemsViewTags
 	{
 		public const int HeaderTag = 111;
 		public const int FooterTag = 222;
+	}
 
+	public class StructuredItemsViewController<TItemsView> : ItemsViewController<TItemsView>
+		where TItemsView : StructuredItemsView
+	{
 		bool _disposed;
 
 		UIView _headerUIView;
@@ -58,13 +61,13 @@ namespace Xamarin.Forms.Platform.iOS
 		protected override CGRect DetermineEmptyViewFrame()
 		{
 			nfloat headerHeight = 0;
-			var headerView = CollectionView.ViewWithTag(HeaderTag);
+			var headerView = CollectionView.ViewWithTag(ItemsViewTags.HeaderTag);
 
 			if (headerView != null)
 				headerHeight = headerView.Frame.Height;
 
 			nfloat footerHeight = 0;
-			var footerView = CollectionView.ViewWithTag(FooterTag);
+			var footerView = CollectionView.ViewWithTag(ItemsViewTags.FooterTag);
 
 			if (footerView != null)
 				footerHeight = footerView.Frame.Height;
@@ -100,14 +103,14 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal void UpdateFooterView()
 		{
-			UpdateSubview(ItemsView?.Footer, ItemsView?.FooterTemplate, FooterTag,
+			UpdateSubview(ItemsView?.Footer, ItemsView?.FooterTemplate, ItemsViewTags.FooterTag,
 				ref _footerUIView, ref _footerViewFormsElement);
 			UpdateHeaderFooterPosition();
 		}
 
 		internal void UpdateHeaderView()
 		{
-			UpdateSubview(ItemsView?.Header, ItemsView?.HeaderTemplate, HeaderTag,
+			UpdateSubview(ItemsView?.Header, ItemsView?.HeaderTemplate, ItemsViewTags.HeaderTag,
 				ref _headerUIView, ref _headerViewFormsElement);
 			UpdateHeaderFooterPosition();
 		}

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -191,19 +191,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 				if (scrollView is UICollectionView collectionView)
 				{
-					bool hasHeaderFooter = collectionView.ContentInset != UIEdgeInsets.Zero;
-
-					if (hasHeaderFooter)
+					if (HasCollectionViewHeader(collectionView))
 					{
-						if (collectionView.BackgroundView == null)
-						{
-							if (collectionView.BackgroundView == null)
-								collectionView.BackgroundView = _refreshControl;
-							else
-								collectionView.BackgroundView.InsertSubview(_refreshControl, index);
-
-							addedRefreshControl = true;
-						}
+						collectionView.BackgroundView = _refreshControl;
+						addedRefreshControl = true;	
 					}
 				}
 
@@ -280,6 +271,22 @@ namespace Xamarin.Forms.Platform.iOS
 		bool CanUseRefreshControlProperty()
 		{
 			return Forms.IsiOS10OrNewer && !_usingLargeTitles;
+		}
+
+		bool HasCollectionViewHeader(UICollectionView collectionView)
+		{
+			bool hasHeader = false;
+
+			foreach (var children in collectionView.Subviews)
+			{
+				if (children.Tag == ItemsViewTags.HeaderTag)
+				{
+					hasHeader = true;
+					break;
+				}
+			}
+
+			return hasHeader;
 		}
 
 		void OnRefresh(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -187,10 +187,33 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (view is UIScrollView scrollView)
 			{
-				if (CanUseRefreshControlProperty())
-					scrollView.RefreshControl = _refreshControl;
-				else
-					scrollView.InsertSubview(_refreshControl, index);
+				bool addedRefreshControl = false;
+
+				if (scrollView is UICollectionView collectionView)
+				{
+					bool hasHeaderFooter = collectionView.ContentInset != UIEdgeInsets.Zero;
+
+					if (hasHeaderFooter)
+					{
+						if (collectionView.BackgroundView == null)
+						{
+							if (collectionView.BackgroundView == null)
+								collectionView.BackgroundView = _refreshControl;
+							else
+								collectionView.BackgroundView.InsertSubview(_refreshControl, index);
+
+							addedRefreshControl = true;
+						}
+					}
+				}
+
+				if (!addedRefreshControl)
+				{
+					if (CanUseRefreshControlProperty())
+						scrollView.RefreshControl = _refreshControl;
+					else
+						scrollView.InsertSubview(_refreshControl, index);
+				}
 
 				scrollView.AlwaysBounceVertical = true;
 


### PR DESCRIPTION
### Description of Change ###

Fix incorrect refresh indicador position using RefreshView with CollectionView with Header on iOS.

### Issues Resolved ### 

- fixes #8282

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

#### Before
![issue82822](https://user-images.githubusercontent.com/6755973/108062978-d8b46280-705a-11eb-943a-40b27bfa144d.gif)

#### After
![fix8282](https://user-images.githubusercontent.com/6755973/108062984-db16bc80-705a-11eb-9980-5cfeefe7e9c4.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 8282. Pull to Refresh. If the loading indicator appears above the CollectionView header, the test has passed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
