### PR TITLE
[Core] Change IProvideParentValues from internal to public

### DIFF
--- a/Xamarin.Forms.Core/IProvideParentValues.cs
+++ b/Xamarin.Forms.Core/IProvideParentValues.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 
 namespace Xamarin.Forms.Xaml
 {
-	internal interface IProvideParentValues : IProvideValueTarget
+	public interface IProvideParentValues : IProvideValueTarget
 	{
 		IEnumerable<object> ParentObjects { get; }
 	}


### PR DESCRIPTION
### Description of Change ###

Changes the accessibility of `IProvideParentValues` from internal to public to allow a markup extension to access its parent hierarchy. See #13298.

I have made this change to allow me to PR two markup extensions, [`GridLocation`](https://github.com/matthewrdev/Xamarin.Forms.GridLocationExtension/blob/main/GridLocationMarkupExtension/GridLocationExtension.cs) and [`GridSpan`](https://github.com/matthewrdev/Xamarin.Forms.GridLocationExtension/blob/main/GridLocationMarkupExtension/GridSpanExtension.cs), into Xamarin Community Toolkit. These markup extensions will allow developers to place views in a grid by name; without `IProvideParentValues` being made public, these extensions would need to rely on runtime reflection to work.

See: https://github.com/matthewrdev/Xamarin.Forms.GridLocationExtension

Please note that this interface behaves the same way in both interpreted and compiled XAML. This was verified as part of the enhancement request.

### Issues Resolved ### 

Fixes #13298.

### API Changes ###
Changed:
 - **internal** class IProvideParentValues  -> **public** class IProvideParentValues

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Run Xamarin.Forms test suite.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
