### PR TITLE
[iOS] Fix shell search handler background color for iOS 13 or newer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchHandlerAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchHandlerAppearanceTracker.cs
@@ -33,6 +33,7 @@ namespace Xamarin.Forms.Platform.iOS
 			_uiSearchBar.ShowsCancelButton = false;
 			GetDefaultSearchBarColors(_uiSearchBar);
 			var uiTextField = searchBar.FindDescendantView<UITextField>();
+			
 			UpdateSearchBarColors();
 			UpdateSearchBarHorizontalTextAlignment(uiTextField);
 			UpdateSearchBarVerticalTextAlignment(uiTextField);
@@ -135,22 +136,30 @@ namespace Xamarin.Forms.Platform.iOS
 			if (!_hasCustomBackground && backGroundColor.IsDefault)
 				return;
 
-			var backgroundView = textField.Subviews[0];
-
-			if (backGroundColor.IsDefault)
+			if(Forms.IsiOS13OrNewer)
 			{
-				backgroundView.Layer.CornerRadius = 0;
-				backgroundView.ClipsToBounds = false;
-				backgroundView.BackgroundColor = _defaultBackgroundColor;
+				textField.BackgroundColor = backGroundColor.ToUIColor();
 			}
+			else
+			{ 
+				var backgroundView = textField.Subviews[0];
+			
 
-			_hasCustomBackground = true;
+				if (backGroundColor.IsDefault)
+				{
+					backgroundView.Layer.CornerRadius = 0;
+					backgroundView.ClipsToBounds = false;
+					backgroundView.BackgroundColor = _defaultBackgroundColor;
+				}
 
-			backgroundView.Layer.CornerRadius = 10;
-			backgroundView.ClipsToBounds = true;
-			if (_defaultBackgroundColor == null)
-				_defaultBackgroundColor = backgroundView.BackgroundColor;
-			backgroundView.BackgroundColor = backGroundColor.ToUIColor();
+				_hasCustomBackground = true;
+
+				backgroundView.Layer.CornerRadius = 10;
+				backgroundView.ClipsToBounds = true;
+				if (_defaultBackgroundColor == null)
+					_defaultBackgroundColor = backgroundView.BackgroundColor;
+				backgroundView.BackgroundColor = backGroundColor.ToUIColor();
+			}
 		}
 
 		void UpdateCancelButtonColor(UIButton cancelButton)


### PR DESCRIPTION

### Description of Change ###

Change property to set background color in iOS13 or newer.

### Issues Resolved ### 
- fixes #13774
- fixes #9887 

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Search handler will show the right background color.

### Before/After Screenshots ### 
Before:
![before](https://user-images.githubusercontent.com/22226357/108480393-31703f00-7297-11eb-8a2e-2147f01cb3e8.png)

After:
![after](https://user-images.githubusercontent.com/22226357/108480146-dd655a80-7296-11eb-9c1b-c223ed232a02.png)


### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
