### PR TITLE
If the measure is invalid don't perform an arrange

### DIFF
--- a/src/Forms/src/Xamarin.Forms.Core/Layout/Layout.cs
+++ b/src/Forms/src/Xamarin.Forms.Core/Layout/Layout.cs
@@ -40,12 +40,17 @@ namespace Xamarin.Forms.Layout2
 
 		protected override void ArrangeOverride(Rectangle bounds)
 		{
-			if (IsArrangeValid || !IsMeasureValid)
+			if (!IsMeasureValid)
 			{
 				return;
 			}
 
-			base.Arrange(bounds);
+			if (IsArrangeValid)
+			{
+				return;
+			}
+
+			Arrange(bounds);
 
 			LayoutManager.Arrange(Frame);
 			IsArrangeValid = true;

--- a/src/Forms/src/Xamarin.Forms.Core/Layout/Layout.cs
+++ b/src/Forms/src/Xamarin.Forms.Core/Layout/Layout.cs
@@ -40,7 +40,7 @@ namespace Xamarin.Forms.Layout2
 
 		protected override void ArrangeOverride(Rectangle bounds)
 		{
-			if (IsArrangeValid)
+			if (IsArrangeValid || !IsMeasureValid)
 			{
 				return;
 			}

--- a/src/Forms/test/Xamarin.Forms.Core.UnitTests/Layouts/LayoutTests.cs
+++ b/src/Forms/test/Xamarin.Forms.Core.UnitTests/Layouts/LayoutTests.cs
@@ -1,0 +1,41 @@
+﻿using NSubstitute;
+using NUnit.Framework;
+using Xamarin.Platform;
+
+namespace Xamarin.Forms.Core.UnitTests.Layouts
+{
+	[TestFixture(Category = "Layout")]
+	public class LayoutTests
+	{
+		[Test]
+		public void IgnoreArrangeWithoutMeasure()
+		{
+			var layout = new VerticalStackLayout();
+
+			var view = Substitute.For<IView>();
+			view.IsMeasureValid.Returns(true);
+
+			layout.Add(view);
+
+			(layout as IFrameworkElement).Arrange(new Rectangle(0, 0, 100, 100));
+
+			view.DidNotReceive().Arrange(Arg.Any<Rectangle>());
+		}
+
+		[Test]
+		public void ArrangeAfterMeasure()
+		{
+			var layout = new VerticalStackLayout();
+
+			var view = Substitute.For<IView>();
+			view.IsMeasureValid.Returns(true);
+
+			layout.Add(view);
+
+			var size = (layout as IFrameworkElement).Measure(100, 100);
+			(layout as IFrameworkElement).Arrange(new Rectangle(0, 0, size.Width, size.Height));
+
+			view.Received().Arrange(Arg.Any<Rectangle>());
+		}
+	}
+}

--- a/src/Forms/test/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/src/Forms/test/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -12,6 +12,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="NSubstitute" Version="4.2.2" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.17.0" />
     <PackageReference Include="NUnit" Version="3.13.0" />
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Fix it so Arrange isn't called if the measure is invalid. 

As is the arrange was getting called and then the measure but then not another arrange so nothing would layout


### Testing Procedure ###
- Run the new .net maui galleries on CG. Without this change the pages are blank
- Automated unit tests
 
### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
