### PR TITLE
[Tizen] Optimize Shell Flyout for TV

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/EmptyItemAdaptor.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/EmptyItemAdaptor.cs
@@ -47,7 +47,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			View emptyView = null;
 			if (ItemTemplate is DataTemplateSelector selector)
 			{
-				emptyView = selector.SelectTemplate(this[index], _itemsView).CreateContent() as View;
+				emptyView = selector.SelectTemplate(this[index], Element).CreateContent() as View;
 			}
 			else
 			{
@@ -68,7 +68,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				layout.Children.Add(footer);
 			}
 
-			layout.Parent = _itemsView;
+			layout.Parent = Element;
 			var renderer = Platform.GetOrCreateRenderer(layout);
 			(renderer as ILayoutRenderer)?.RegisterOnLayoutUpdated();
 			return renderer.NativeView;

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ItemTemplateAdaptor.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ItemTemplateAdaptor.cs
@@ -47,23 +47,23 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 	{
 		Dictionary<EvasObject, View> _nativeFormsTable = new Dictionary<EvasObject, View>();
 		Dictionary<object, View> _dataBindedViewTable = new Dictionary<object, View>();
-		protected ItemsView _itemsView;
 		protected View _headerCache;
 		protected View _footerCache;
 
-		bool IsSelectable { get; }
-
-
 		public ItemTemplateAdaptor(ItemsView itemsView) : this(itemsView, itemsView.ItemsSource, itemsView.ItemTemplate) { }
 
-		protected ItemTemplateAdaptor(ItemsView itemsView, IEnumerable items, DataTemplate template) : base(items)
+		protected ItemTemplateAdaptor(Element itemsView, IEnumerable items, DataTemplate template) : base(items)
 		{
 			ItemTemplate = template;
-			_itemsView = itemsView;
+			Element = itemsView;
 			IsSelectable = itemsView is SelectableItemsView;
 		}
 
 		protected DataTemplate ItemTemplate { get; set; }
+
+		protected Element Element { get; set; }
+
+		protected virtual bool IsSelectable { get; }
 
 		public View GetTemplatedView(EvasObject evasObject)
 		{
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		{
 			if (ItemTemplate is DataTemplateSelector selector)
 			{
-				return selector.SelectTemplate(this[index], _itemsView);
+				return selector.SelectTemplate(this[index], Element);
 			}
 			return base.GetViewCategory(index);
 		}
@@ -94,7 +94,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			View view = null;
 			if (ItemTemplate is DataTemplateSelector selector)
 			{
-				view = selector.SelectTemplate(this[index], _itemsView).CreateContent() as View;
+				view = selector.SelectTemplate(this[index], Element).CreateContent() as View;
 			}
 			else
 			{
@@ -102,7 +102,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 			var renderer = Platform.GetOrCreateRenderer(view);
 			var native = renderer.NativeView;
-			view.Parent = _itemsView;
+
+			view.Parent = Element;
 			(renderer as ILayoutRenderer)?.RegisterOnLayoutUpdated();
 
 			_nativeFormsTable[native] = view;
@@ -119,7 +120,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			_headerCache = CreateHeaderView();
 			if (_headerCache != null)
 			{
-				_headerCache.Parent = _itemsView;
+				_headerCache.Parent = Element;
 				var renderer = Platform.GetOrCreateRenderer(_headerCache);
 				(renderer as ILayoutRenderer)?.RegisterOnLayoutUpdated();
 				return renderer.NativeView;
@@ -132,7 +133,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			_footerCache = CreateFooterView();
 			if (_footerCache != null)
 			{
-				_footerCache.Parent = _itemsView;
+				_footerCache.Parent = Element;
 				var renderer = Platform.GetOrCreateRenderer(_footerCache);
 				(renderer as ILayoutRenderer)?.RegisterOnLayoutUpdated();
 				return renderer.NativeView;
@@ -159,7 +160,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				_dataBindedViewTable[this[index]] = view;
 
 				view.MeasureInvalidated += OnItemMeasureInvalidated;
-				_itemsView.AddLogicalChild(view);
+				AddLogicalChild(view);
 			}
 		}
 
@@ -187,7 +188,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			View view = null;
 			if (ItemTemplate is DataTemplateSelector selector)
 			{
-				view = selector.SelectTemplate(this[index], _itemsView).CreateContent() as View;
+				view = selector.SelectTemplate(this[index], Element).CreateContent() as View;
 			}
 			else
 			{
@@ -195,7 +196,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			}
 			using (var renderer = Platform.GetOrCreateRenderer(view))
 			{
-				view.Parent = _itemsView;
+				view.Parent = Element;
 				if (Count > index)
 					view.BindingContext = this[index];
 				var request = view.Measure(Forms.ConvertToScaledDP(widthConstraint), Forms.ConvertToScaledDP(heightConstraint), MeasureFlags.IncludeMargins).Request;
@@ -238,7 +239,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		protected virtual View CreateHeaderView()
 		{
-			if (_itemsView is StructuredItemsView structuredItemsView)
+			if (Element is StructuredItemsView structuredItemsView)
 			{
 				if (structuredItemsView.Header != null)
 				{
@@ -264,7 +265,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		protected virtual View CreateFooterView()
 		{
-			if (_itemsView is StructuredItemsView structuredItemsView)
+			if (Element is StructuredItemsView structuredItemsView)
 			{
 				if (structuredItemsView.Footer != null)
 				{
@@ -293,7 +294,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			if (view.BindingContext != null && _dataBindedViewTable.ContainsKey(view.BindingContext))
 			{
 				_dataBindedViewTable[view.BindingContext] = null;
-				_itemsView.RemoveLogicalChild(view);
+				RemoveLogicalChild(view);
 				view.BindingContext = null;
 			}
 		}
@@ -307,5 +308,30 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				CollectionView?.ItemMeasureInvalidated(index);
 			}
 		}
+
+		void AddLogicalChild(Element element)
+		{
+			if (Element is ItemsView iv)
+			{
+				iv.AddLogicalChild(element);
+			}
+			else
+			{
+				element.Parent = Element;
+			}
+		}
+
+		void RemoveLogicalChild(Element element)
+		{
+			if (Element is ItemsView iv)
+			{
+				iv.RemoveLogicalChild(element);
+			}
+			else
+			{
+				element.Parent = null;
+			}
+		}
+
 	}
 }

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/LinearLayoutManager.cs
@@ -44,7 +44,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		public void SizeAllocated(ESize size)
 		{
-			Reset();
+			_scrollCanvasSize = new ESize(0, 0);
 			_allocatedSize = size;
 			InitializeMeasureCache();
 		}

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ViewHolder.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/ViewHolder.cs
@@ -18,6 +18,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 		EvasObject _content;
 		ViewHolderState _state;
 		bool _isSelected;
+		bool _isFocused;
 
 		public ViewHolder(EvasObject parent) : base(parent)
 		{
@@ -58,7 +59,13 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			get { return _state; }
 			set
 			{
-				_state = value;
+				if (value == ViewHolderState.Normal)
+					_isSelected = false;
+				else if (value == ViewHolderState.Selected)
+					_isSelected = true;
+
+				_state = _isFocused ? ViewHolderState.Focused : (_isSelected ? ViewHolderState.Selected : ViewHolderState.Normal);
+
 				UpdateState();
 			}
 		}
@@ -82,7 +89,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 			_focusArea.SetEffectColor(EColor.Transparent);
 			_focusArea.Clicked += OnClicked;
 			_focusArea.Focused += OnFocused;
-			_focusArea.Unfocused += OnFocused;
+			_focusArea.Unfocused += OnUnfocused;
 			_focusArea.KeyUp += OnKeyUp;
 			_focusArea.RepeatEvents = true;
 			_focusArea.Show();
@@ -93,14 +100,12 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 
 		protected virtual void OnFocused(object sender, EventArgs e)
 		{
-			if (_focusArea.IsFocused)
-			{
-				State = ViewHolderState.Focused;
-			}
-			else
-			{
-				State = _isSelected ? ViewHolderState.Selected : ViewHolderState.Normal;
-			}
+			UpdateFocusState();
+		}
+
+		protected virtual void OnUnfocused(object sender, EventArgs e)
+		{
+			UpdateFocusState();
 		}
 
 		protected virtual void OnClicked(object sender, EventArgs e)
@@ -127,6 +132,20 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				RaiseTop();
 
 			StateUpdated?.Invoke(this, EventArgs.Empty);
+		}
+
+		void UpdateFocusState()
+		{
+			if (_focusArea.IsFocused)
+			{
+				_isFocused = true;
+				State = ViewHolderState.Focused;
+			}
+			else
+			{
+				_isFocused = false;
+				State = _isSelected ? ViewHolderState.Selected : ViewHolderState.Normal;
+			}
 		}
 
 		void OnKeyUp(object sender, EvasKeyEventArgs e)

--- a/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.Tizen/Properties/AssemblyInfo.cs
@@ -69,6 +69,7 @@ using Xamarin.Forms.Shapes;
 [assembly: ExportHandler(typeof(DropGestureRecognizer), typeof(DropGestureHandler))]
 
 [assembly: ExportRenderer(typeof(Shell), typeof(Xamarin.Forms.Platform.Tizen.Watch.ShellRenderer), TargetIdiom.Watch)]
+[assembly: ExportRenderer(typeof(Shell), typeof(Xamarin.Forms.Platform.Tizen.TV.TVShellRenderer), TargetIdiom.TV)]
 
 [assembly: ExportRenderer(typeof(Ellipse), typeof(EllipseRenderer))]
 [assembly: ExportRenderer(typeof(Line), typeof(LineRenderer))]

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellItemRenderer.cs
@@ -132,6 +132,23 @@ namespace Xamarin.Forms.Platform.Tizen
 			_disposed = true;
 		}
 
+		protected virtual void UpdateTabsItems()
+		{
+			ResetTabs();
+			if (ShellItem.Items.Count > 1)
+			{
+				InitializeTabs();
+				foreach (ShellSection section in ShellItem.Items)
+				{
+					AddTabsItem(section);
+				}
+			}
+			else
+			{
+				DeinitializeTabs();
+			}
+		}
+
 		protected virtual IShellTabs CreateTabs()
 		{
 			return new ShellTabs(Forms.NativeParent);
@@ -284,23 +301,6 @@ namespace Xamarin.Forms.Platform.Tizen
 			foreach (EToolbarItem item in _tabsItems)
 			{
 				item.SetTextColor(color);
-			}
-		}
-
-		void UpdateTabsItems()
-		{
-			ResetTabs();
-			if (ShellItem.Items.Count > 1)
-			{
-				InitializeTabs();
-				foreach (ShellSection section in ShellItem.Items)
-				{
-					AddTabsItem(section);
-				}
-			}
-			else
-			{
-				DeinitializeTabs();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellNavBar.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellNavBar.cs
@@ -267,7 +267,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			}
 			else if (_flyoutBehavior == FlyoutBehavior.Flyout)
 			{
-				Shell.Current.FlyoutIsPresented = true;
+				Shell.Current.FlyoutIsPresented = !Shell.Current.FlyoutIsPresented;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellRenderer.cs
@@ -24,6 +24,8 @@ namespace Xamarin.Forms.Platform.Tizen
 			RegisterPropertyHandler(Shell.FlyoutHeaderBehaviorProperty, UpdateFlyoutHeaderBehavior);
 		}
 
+		protected INavigationDrawer NavigationDrawer => _drawer;
+
 		protected override void OnElementChanged(ElementChangedEventArgs<Shell> e)
 		{
 			if (_drawer == null)
@@ -130,7 +132,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			_navigationView.BackgroundImageSource = Element.FlyoutBackgroundImage;
 		}
 
-		void UpdateFlyoutIsPresented()
+		protected virtual void UpdateFlyoutIsPresented()
 		{
 			// It is workaround of Panel.IsOpen bug, Panel.IsOpen property is not working when layouting was triggered
 			Device.BeginInvokeOnMainThread(() =>

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionRenderer.cs
@@ -9,7 +9,12 @@ using EToolbarItem = ElmSharp.ToolbarItem;
 
 namespace Xamarin.Forms.Platform.Tizen
 {
-	public class ShellSectionRenderer : IAppearanceObserver, IDisposable
+	public interface IShellSectionRenderer : IDisposable
+	{
+		EvasObject NativeView { get; }
+	}
+
+	public class ShellSectionRenderer : IAppearanceObserver, IShellSectionRenderer
 	{
 		EBox _mainLayout = null;
 		EBox _contentArea = null;
@@ -51,7 +56,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 		bool _tabBarIsVisible = true;
 
-		bool TabBarIsVisible
+		protected virtual bool TabBarIsVisible
 		{
 			get => _tabBarIsVisible;
 			set

--- a/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionStack.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/ShellSectionStack.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		ShellNavBar _navBar = null;
 		Page _currentPage = null;
 		SimpleViewStack _viewStack = null;
-		ShellSectionRenderer _shellSectionRenderer;
+		IShellSectionRenderer _shellSectionRenderer;
 
 		bool _disposed = false;
 		bool _navBarIsVisible = true;
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			InitializeComponent();
 		}
 
-		public bool NavBarIsVisible
+		public virtual bool NavBarIsVisible
 		{
 			get
 			{
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.Tizen
 			_disposed = true;
 		}
 
-		protected virtual ShellSectionRenderer CreateShellSectionRenderer(ShellSection section)
+		protected virtual IShellSectionRenderer CreateShellSectionRenderer(ShellSection section)
 		{
 			return new ShellSectionRenderer(section);
 		}
@@ -147,7 +147,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		}
 
 
-		void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
+		protected virtual void OnPagePropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == Page.TitleProperty.PropertyName)
 			{
@@ -255,7 +255,7 @@ namespace Xamarin.Forms.Platform.Tizen
 
 			var bound = Geometry;
 			int navBarHeight;
-			if (_navBarIsVisible)
+			if (NavBarIsVisible)
 			{
 				var navBound = bound;
 				navBarHeight = Forms.ConvertToScaledPixel(_navBar.GetDefaultHeight());

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/FlyoutItemTemplateAdaptor.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/FlyoutItemTemplateAdaptor.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections;
+using Xamarin.Forms.Platform.Tizen.Native;
+
+namespace Xamarin.Forms.Platform.Tizen.TV
+{
+	public class FlyoutItemTemplateAdaptor : ItemTemplateAdaptor
+	{
+		public FlyoutItemTemplateAdaptor(Element itemsView, IEnumerable items, DataTemplate template, bool hasHeader)
+			: base(itemsView, items, template)
+		{
+			HasHeader = hasHeader;
+		}
+
+		public bool HasHeader { get; set; }
+
+		protected override bool IsSelectable => true;
+
+		protected override View CreateHeaderView()
+		{
+			if (!HasHeader)
+				return null;
+
+			View header = null;
+			if (Element is IShellController shell)
+			{
+				header = shell.FlyoutHeader;
+			}
+			return header;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/FlyoutItemTemplateSelector.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/FlyoutItemTemplateSelector.cs
@@ -1,0 +1,164 @@
+﻿using System;
+using System.Globalization;
+
+namespace Xamarin.Forms.Platform.Tizen.TV
+{
+	public class FlyoutItemTemplateSelector : DataTemplateSelector
+	{
+		public DataTemplate DefaultTemplate { get; private set; }
+		public DataTemplate FlyoutItemTemplate { get; private set; }
+		public DataTemplate MenuItemTemplate { get; private set; }
+
+		public FlyoutItemTemplateSelector(INavigationView nv)
+		{
+			DefaultTemplate = new DataTemplate(() =>
+			{
+				var grid = new Grid
+				{
+					HeightRequest = nv.GetFlyoutItemHeight(),
+					WidthRequest = nv.GetFlyoutItemWidth()
+				};
+
+				ColumnDefinitionCollection columnDefinitions = new ColumnDefinitionCollection();
+				columnDefinitions.Add(new ColumnDefinition { Width = nv.GetFlyoutIconColumnSize() });
+				columnDefinitions.Add(new ColumnDefinition { Width = GridLength.Star });
+				grid.ColumnDefinitions = columnDefinitions;
+
+				var image = new Image
+				{
+					VerticalOptions = LayoutOptions.Center,
+					HorizontalOptions = LayoutOptions.Center,
+					HeightRequest = nv.GetFlyoutIconSize(),
+					WidthRequest = nv.GetFlyoutIconSize(),
+					Margin = new Thickness(nv.GetFlyoutMargin(), 0, 0, 0),
+				};
+				image.SetBinding(Image.SourceProperty, new Binding("FlyoutIcon"));
+				grid.Children.Add(image);
+
+				var label = new Label
+				{
+					FontSize = nv.GetFlyoutItemFontSize(),
+					VerticalTextAlignment = TextAlignment.Center,
+					Margin = new Thickness(nv.GetFlyoutMargin(), 0, 0, 0),
+				};
+				label.SetBinding(Label.TextProperty, new Binding("Title"));
+				label.SetBinding(Label.TextColorProperty, new Binding("BackgroundColor",  converter: new TextColorConverter(), source: grid));
+
+				grid.Children.Add(label, 1, 0);
+
+				var groups = new VisualStateGroupList();
+
+				var commonGroup = new VisualStateGroup();
+				commonGroup.Name = "CommonStates";
+				groups.Add(commonGroup);
+
+				var normalState = new VisualState();
+				normalState.Name = "Normal";
+				normalState.Setters.Add(new Setter
+				{
+					Property = VisualElement.BackgroundColorProperty,
+					Value = nv.GetTvFlyoutItemDefaultColor()
+				});
+
+				var focusedState = new VisualState();
+				focusedState.Name = "Focused";
+				focusedState.Setters.Add(new Setter
+				{
+					Property = VisualElement.BackgroundColorProperty,
+					Value = nv.GetTvFlyoutItemFocusedColor()
+				});
+
+				var selectedState = new VisualState();
+				selectedState.Name = "Selected";
+				selectedState.Setters.Add(new Setter
+				{
+					Property = VisualElement.BackgroundColorProperty,
+					Value = nv.GetTvFlyoutItemDefaultColor()
+				});
+
+				commonGroup.States.Add(normalState);
+				commonGroup.States.Add(focusedState);
+				commonGroup.States.Add(selectedState);
+
+				VisualStateManager.SetVisualStateGroups(grid, groups);
+				return grid;
+			});
+		}
+
+		public FlyoutItemTemplateSelector(INavigationView nv, DataTemplate flyoutItemTemplate, DataTemplate menuItemTemplate) : this(nv)
+		{
+			FlyoutItemTemplate = flyoutItemTemplate;
+			MenuItemTemplate = menuItemTemplate;
+		}
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			var bo = item as BindableObject;
+			if (bo == null)
+				return DefaultTemplate;
+
+			if (item is IMenuItemController)
+			{
+				if (item is MenuItem mi && mi.Parent != null && mi.Parent.IsSet(Shell.MenuItemTemplateProperty))
+				{
+					return Shell.GetMenuItemTemplate(mi.Parent);
+				}
+				else if (bo.IsSet(Shell.MenuItemTemplateProperty))
+				{
+					return Shell.GetMenuItemTemplate(bo);
+				}
+
+				if (MenuItemTemplate != null)
+				{
+					return MenuItemTemplate;
+				}
+				else
+				{
+					return DefaultTemplate;
+				}
+			}
+			else
+			{
+				if (Shell.GetItemTemplate(bo) != null)
+				{
+					return Shell.GetItemTemplate(bo);
+				}
+
+				if (FlyoutItemTemplate != null)
+				{
+					return FlyoutItemTemplate;
+				}
+				else
+				{
+					return DefaultTemplate;
+				}
+			}
+		}
+		class TextColorConverter : IValueConverter
+		{
+			public object Convert(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				if (value is Color c && c == Color.Transparent)
+				{
+					return Color.White;
+				}
+				else
+				{
+					return Color.Black;
+				}
+			}
+
+			public object ConvertBack(object value, Type targetType, object parameter, CultureInfo culture)
+			{
+				if (value is Color c && c == Color.White)
+				{
+					return Color.Transparent;
+				}
+				else
+				{
+					return Color.Black;
+				}
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/TVNavigationDrawer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/TVNavigationDrawer.cs
@@ -1,0 +1,273 @@
+﻿using System;
+using ElmSharp;
+using EBox = ElmSharp.Box;
+using EButton = ElmSharp.Button;
+using EColor = ElmSharp.Color;
+
+namespace Xamarin.Forms.Platform.Tizen.TV
+{
+	public class TVNavigationDrawer : EBox, INavigationDrawer, IAnimatable, IFlyoutBehaviorObserver
+	{
+		EBox _drawerBox;
+		EBox _mainBox;
+		EvasObject _main;
+		TVNavigationView _drawer;
+		EButton _focusControlArea;
+
+		FlyoutBehavior _behavior;
+		bool _isOpen;
+
+		double _openRatio;
+
+		public TVNavigationDrawer(EvasObject parent) : base(parent)
+		{
+			Initialize(parent);
+		}
+
+		public event EventHandler Toggled;
+
+		public EvasObject TargetView => this;
+
+		public EvasObject NavigationView
+		{
+			get => _drawer;
+			set => UpdateNavigationView(value);
+		}
+
+		public EvasObject Main
+		{
+			get => _main;
+			set => UpdateMain(value);
+		}
+
+		public bool IsOpen
+		{
+			get => _isOpen;
+			set => UpdateOpenState(value);
+		}
+
+		void Initialize(EvasObject parent)
+		{
+			SetLayoutCallback(OnLayout);
+
+			_drawerBox = new EBox(parent);
+			_drawerBox.Show();
+			PackEnd(_drawerBox);
+
+			_mainBox = new EBox(parent);
+			_mainBox.SetLayoutCallback(OnMainBoxLayout);
+			_mainBox.Show();
+			PackEnd(_mainBox);
+
+			_focusControlArea = new EButton(parent);
+			_focusControlArea.Color = EColor.Transparent;
+			_focusControlArea.BackgroundColor = EColor.Transparent;
+			_focusControlArea.SetEffectColor(EColor.Transparent);
+			_focusControlArea.Show();
+			_mainBox.PackEnd(_focusControlArea);
+
+			_drawerBox.KeyUp += (s, e) =>
+			{
+				if (e.KeyName == "Return" || e.KeyName == "Right")
+				{
+					IsOpen = false;
+				}
+			};
+
+			_mainBox.KeyUp += (s, e) =>
+			{
+				if (e.KeyName == "Left")
+				{
+					if (_focusControlArea.IsFocused)
+						IsOpen = true;
+				}
+				else
+				{
+					// Workaround to prevent unexpected movement of the focus to drawer during page pushing.
+					if (_behavior == FlyoutBehavior.Locked)
+						_drawerBox.AllowTreeFocus = true;
+				}
+			};
+
+			_mainBox.KeyDown += (s, e) =>
+			{
+				if (e.KeyName != "Left")
+				{
+					// Workaround to prevent unexpected movement of the focus to drawer during page pushing.
+					if (_behavior == FlyoutBehavior.Locked)
+						_drawerBox.AllowTreeFocus = false;
+				}
+			};
+
+			UpdateFocusPolicy();
+		}
+
+		void UpdateNavigationView(EvasObject navigationView)
+		{
+			if (_drawer != null)
+			{
+				_drawer.ContentFocused -= OnNavigationViewItemFocused;
+				_drawer.ContentUnfocused -= OnNavigationViewItemUnfocused;
+				_drawerBox.UnPack(_drawer);
+				_drawer.Hide();
+			}
+
+			_drawer = navigationView as TVNavigationView;
+
+			if (_drawer != null)
+			{
+				_drawer.SetAlignment(-1, -1);
+				_drawer.SetWeight(1, 1);
+				_drawer.Show();
+				_drawerBox.PackEnd(_drawer);
+
+				_drawer.ContentFocused += OnNavigationViewItemFocused;
+				_drawer.ContentUnfocused += OnNavigationViewItemUnfocused;
+			}
+		}
+
+		void OnNavigationViewItemFocused(object sender, EventArgs args)
+		{
+			IsOpen = true;
+		}
+
+		void OnNavigationViewItemUnfocused(object sender, EventArgs args)
+		{
+			IsOpen = false;
+		}
+
+		void UpdateMain(EvasObject main)
+		{
+			if (_main != null)
+			{
+				_mainBox.UnPack(_main);
+				_main.Hide();
+			}
+			_main = main;
+
+			if (_main != null)
+			{
+				_main.SetAlignment(-1, -1);
+				_main.SetWeight(1, 1);
+				_main.Show();
+				_mainBox.PackStart(_main);
+			}
+		}
+
+		void UpdateBehavior(FlyoutBehavior behavior)
+		{
+			_behavior = behavior;
+			_focusControlArea.IsEnabled = _behavior == FlyoutBehavior.Flyout;
+
+			var open = false;
+
+			if (_behavior == FlyoutBehavior.Locked)
+				open = true;
+			else if (_behavior == FlyoutBehavior.Disabled)
+				open = false;
+			else
+				open = _drawerBox.IsFocused;
+
+			UpdateOpenState(open);
+		}
+
+		void OnMainBoxLayout()
+		{
+			if(_main != null)
+			{
+				_main.Geometry = _mainBox.Geometry;
+			}
+
+			var focusedButtonGeometry = _mainBox.Geometry;
+			focusedButtonGeometry.X = focusedButtonGeometry.X - 100;
+			focusedButtonGeometry.Width = 0;
+			_focusControlArea.Geometry = focusedButtonGeometry;
+		}
+
+		void OnLayout()
+		{
+			if (Geometry.Width == 0 || Geometry.Height == 0)
+				return;
+
+			var bound = Geometry;
+
+			var ratio = this.GetFlyoutRatio(Geometry.Width, Geometry.Height);
+			var collapseRatio = (_behavior == FlyoutBehavior.Disabled) ? 0 : this.GetFlyoutCollapseRatio();
+			var drawerWidthMax = (int)(bound.Width * ratio);
+			var drawerWidthMin = (int)(bound.Width * collapseRatio);
+
+			var drawerWidthOutBound = (int)((drawerWidthMax - drawerWidthMin) * (1 - _openRatio));
+			var drawerWidthInBound = drawerWidthMax - drawerWidthOutBound;
+
+			var drawerGeometry = bound;
+			drawerGeometry.Width = drawerWidthInBound;
+			_drawerBox.Geometry = drawerGeometry;
+
+			var containerGeometry = bound;
+			containerGeometry.X = drawerWidthInBound;
+			containerGeometry.Width = (_behavior == FlyoutBehavior.Locked) ? (bound.Width - drawerWidthInBound) : (bound.Width - drawerWidthMin);
+			_mainBox.Geometry = containerGeometry;
+		}
+
+		void UpdateOpenState(bool isOpen)
+		{
+			if (_behavior == FlyoutBehavior.Locked && !isOpen)
+				return;
+
+			double endState = ((_behavior != FlyoutBehavior.Disabled) && isOpen) ? 1 : 0;
+			new Animation((r) =>
+			{
+				_openRatio = r;
+				OnLayout();
+			}, _openRatio, endState, Easing.SinOut).Commit(this, "DrawerMove", finished: (f, aborted) =>
+			{
+				if (!aborted)
+				{
+					if (_isOpen != isOpen)
+					{
+						_isOpen = isOpen;
+						UpdateFocusPolicy();
+						Toggled?.Invoke(this, EventArgs.Empty);
+					}
+				}
+			});
+		}
+
+		void UpdateFocusPolicy()
+		{
+			if (_isOpen)
+			{
+				if(_behavior == FlyoutBehavior.Locked)
+				{
+					_drawerBox.AllowTreeFocus = true;
+					_mainBox.AllowTreeFocus = true;
+				}
+				else
+				{
+					_mainBox.AllowTreeFocus = false;
+					_drawerBox.AllowTreeFocus = true;
+					_drawerBox.SetFocus(true);
+				}
+			}
+			else
+			{
+				_mainBox.AllowTreeFocus = true;
+				_drawerBox.AllowTreeFocus = false;
+				_mainBox.SetFocus(true);
+			}
+		}
+
+		void IFlyoutBehaviorObserver.OnFlyoutBehaviorChanged(FlyoutBehavior behavior)
+		{
+			UpdateBehavior(behavior);
+		}
+
+		void IAnimatable.BatchBegin()
+		{
+		}
+
+		void IAnimatable.BatchCommit()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/TVNavigationView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/TVNavigationView.cs
@@ -1,0 +1,379 @@
+using System;
+using System.Collections.Generic;
+using ElmSharp;
+using Xamarin.Forms.Platform.Tizen.Native;
+using Xamarin.Forms.Platform.Tizen.TV;
+using EBox = ElmSharp.Box;
+using EColor = ElmSharp.Color;
+using EImage = ElmSharp.Image;
+using NCollectionView = Xamarin.Forms.Platform.Tizen.Native.CollectionView;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class TVNavigationView : Background, INavigationView
+	{
+		static EColor s_defaultBackgroundColor = EColor.Black;
+
+		EBox _mainLayout;
+
+		EImage _backgroundImage;
+		Aspect _bgImageAspect;
+		ImageSource _bgImageSource;
+
+		View _header;
+		EvasObject _nativeHeader;
+
+		NCollectionView _list;
+
+		EColor _backgroundColor;
+
+		List<List<Element>> _cachedGroups;
+
+		IEnumerable<Element> _cacheditems;
+
+		public TVNavigationView(EvasObject parent) : base(parent)
+		{
+			InitializeComponent(parent);
+		}
+
+		public TVNavigationView(EvasObject parent, Element element) : this(parent)
+		{
+			Element = element;
+		}
+
+		public event EventHandler<SelectedItemChangedEventArgs> SelectedItemChanged;
+
+		public event EventHandler ContentFocused;
+
+		public event EventHandler ContentUnfocused;
+
+		public EvasObject NativeView => this;
+
+		public Element Element { get; }
+
+		FlyoutHeaderBehavior _headerBehavior = FlyoutHeaderBehavior.Fixed;
+
+		public View Header
+		{
+			get
+			{
+				return _header;
+			}
+			set
+			{
+				UpdateHeader(value);
+			}
+		}
+
+		public FlyoutHeaderBehavior HeaderBehavior
+		{
+			get => _headerBehavior;
+			set
+			{
+				if (_headerBehavior == value)
+					return;
+				_headerBehavior = value;
+				UpdateHeaderBehavior();
+			}
+		}
+
+		public override EColor BackgroundColor
+		{
+			get
+			{
+				return _backgroundColor;
+			}
+			set
+			{
+				_backgroundColor = value;
+				EColor effectiveColor = _backgroundColor.IsDefault ? s_defaultBackgroundColor : _backgroundColor;
+				base.BackgroundColor = effectiveColor;
+			}
+		}
+
+		public Aspect BackgroundImageAspect
+		{
+			get
+			{
+				return _bgImageAspect;
+			}
+			set
+			{
+				_bgImageAspect = value;
+				_backgroundImage?.ApplyAspect(_bgImageAspect);
+			}
+		}
+
+		public ImageSource BackgroundImageSource
+		{
+			get
+			{
+				return _bgImageSource;
+			}
+			set
+			{
+				_bgImageSource = value;
+				UpdateBackgroundImage();
+			}
+		}
+
+		bool HeaderOnMenu => _headerBehavior == FlyoutHeaderBehavior.Scroll ||
+							 _headerBehavior == FlyoutHeaderBehavior.CollapseOnScroll;
+
+		public void BuildMenu(List<List<Element>> flyoutGroups)
+		{
+			if (!IsMenuItemChanged(flyoutGroups))
+			{
+				return;
+			}
+			_cachedGroups = flyoutGroups;
+
+			var items = new List<Element>();
+			foreach (var group in flyoutGroups)
+			{
+				foreach (var element in group)
+				{
+					items.Add(element);
+				}
+			}
+
+			BuildMenu(items);
+		}
+
+		public void BuildMenu(IEnumerable<Element> items, DataTemplate itemTemplate = null)
+		{
+			var datatemplate = new FlyoutItemTemplateSelector(this, itemTemplate, null);
+			if (Element is Shell shell)
+			{
+				datatemplate = new FlyoutItemTemplateSelector(this, shell.ItemTemplate, shell.MenuItemTemplate);
+			}
+
+			_cacheditems = items;
+			_list.Adaptor = new FlyoutItemTemplateAdaptor(Element, items, datatemplate, HeaderOnMenu);
+			_list.Adaptor.ItemSelected += OnItemSelected;
+		}
+
+		public int GetDrawerWidth()
+		{
+			if (_list is ICollectionViewController controller)
+				return controller.GetItemSize(Forms.NativeParent.Geometry.Width / 2, Forms.NativeParent.Geometry.Height).Width;
+			else
+				return 0;
+		}
+
+		void OnItemSelected(object sender, SelectedItemChangedEventArgs e)
+		{
+			SelectedItemChanged?.Invoke(this, new SelectedItemChangedEventArgs(e.SelectedItem, -1));
+		}
+
+		void InitializeComponent(EvasObject parent)
+		{
+			base.BackgroundColor = s_defaultBackgroundColor;
+
+			_mainLayout = new EBox(parent)
+			{
+				AlignmentX = -1,
+				AlignmentY = -1,
+				WeightX = 1,
+				WeightY = 1,
+			};
+			_mainLayout.SetLayoutCallback(OnLayout);
+			_mainLayout.Show();
+
+			SetContent(_mainLayout);
+			CreateMenu();
+		}
+
+		void CreateMenu()
+		{
+			_list = new NCollectionView(Forms.NativeParent)
+			{
+				AlignmentX = -1,
+				AlignmentY = -1,
+				WeightX = 1,
+				WeightY = 1,
+				SelectionMode = Native.CollectionViewSelectionMode.Single,
+				HorizontalScrollBarVisiblePolicy = ScrollBarVisiblePolicy.Invisible,
+				VerticalScrollBarVisiblePolicy = ScrollBarVisiblePolicy.Invisible,
+				LayoutManager = new Native.LinearLayoutManager(false, ItemSizingStrategy.MeasureFirstItem)
+			};
+
+			_list.Show();
+			_mainLayout.PackEnd(_list);
+
+			_list.Focused += OnListFocused;
+			_list.Unfocused += OnListUnfocused;
+
+		}
+
+		void OnListFocused(object sender, EventArgs args)
+		{
+			ContentFocused?.Invoke(this, EventArgs.Empty);
+		}
+
+		void OnListUnfocused(object sender, EventArgs args)
+		{
+			ContentUnfocused?.Invoke(this, EventArgs.Empty);
+		}
+
+		bool IsMenuItemChanged(List<List<Element>> flyoutGroups)
+		{
+			if (_cachedGroups == null)
+				return true;
+
+			if (_cachedGroups.Count != flyoutGroups.Count)
+				return true;
+
+			for (int i = 0; i < flyoutGroups.Count; i++)
+			{
+				if (_cachedGroups[i].Count != flyoutGroups[i].Count)
+					return true;
+
+				for (int j = 0; j < flyoutGroups[i].Count; j++)
+				{
+					if (_cachedGroups[i][j] != flyoutGroups[i][j])
+						return true;
+				}
+			}
+			return false;
+		}
+
+		void UpdateBackgroundImage()
+		{
+			if (BackgroundImageSource == null)
+			{
+				if (_backgroundImage != null)
+				{
+					this.SetBackgroundPart(null);
+					_backgroundImage = null;
+				}
+			}
+			else
+			{
+				if (_backgroundImage == null)
+				{
+					_backgroundImage = new EImage(this);
+					this.SetBackgroundPart(_backgroundImage);
+				}
+				_backgroundImage.LoadFromImageSourceAsync(BackgroundImageSource).GetAwaiter().OnCompleted(() =>
+				{
+					_backgroundImage.ApplyAspect(_bgImageAspect);
+				});
+			}
+		}
+
+		void UpdateHeader(View header)
+		{
+			if (_header != null)
+			{
+				_header.MeasureInvalidated -= OnHeaderSizeChanged;
+
+				if (HeaderOnMenu)
+				{
+					ResetHeader();
+				}
+				
+				if (_nativeHeader != null)
+				{
+					_mainLayout.UnPack(_nativeHeader);
+					_nativeHeader.Unrealize();
+					_nativeHeader = null;
+				}
+			}
+
+			if (header != null)
+			{
+				header.MeasureInvalidated += OnHeaderSizeChanged;
+
+				if (HeaderOnMenu)
+				{
+					UpdateHeaderOnMenu();
+				}
+				else
+				{
+					var renderer = Platform.GetOrCreateRenderer(header);
+					(renderer as ILayoutRenderer)?.RegisterOnLayoutUpdated();
+					_nativeHeader = renderer.NativeView;
+					_mainLayout.PackEnd(_nativeHeader);
+				}
+			}
+
+			_header = header;
+		}
+
+		void UpdateHeaderBehavior()
+		{
+			if (_header == null)
+				return;
+
+			if (HeaderOnMenu)
+			{
+				if (_nativeHeader != null)
+				{
+					_mainLayout.UnPack(_nativeHeader);
+					_nativeHeader.Unrealize();
+					_nativeHeader = null;
+				}
+			}
+			else
+			{
+				ResetHeader();
+				if(_nativeHeader == null)
+				{
+					var renderer = Platform.GetOrCreateRenderer(_header);
+					(renderer as LayoutRenderer)?.RegisterOnLayoutUpdated();
+					_nativeHeader = renderer.NativeView;
+					_mainLayout.PackEnd(_nativeHeader);
+				}
+			}
+			UpdateHeaderOnMenu();
+			OnLayout();
+		}
+
+		void UpdateHeaderOnMenu()
+		{
+			if (_list.Adaptor != null)
+				_list.Adaptor.ItemSelected -= OnItemSelected;
+
+			BuildMenu(_cacheditems);
+		}
+
+		void ResetHeader()
+		{
+			if (_header != null)
+			{
+				Platform.GetRenderer(_header)?.Dispose();
+				_nativeHeader = null;
+			}
+		}
+
+		void OnHeaderSizeChanged(object sender, EventArgs e)
+		{
+			Device.BeginInvokeOnMainThread(OnLayout);
+		}
+
+		void OnLayout()
+		{
+			if (Geometry.Width == 0 || Geometry.Height == 0)
+				return;
+
+			var bound = Geometry;
+			int headerHeight = 0;
+			if (Header != null)
+			{
+				if (!HeaderOnMenu)
+				{
+					var requestSize = Header.Measure(Forms.ConvertToScaledDP(bound.Width), Forms.ConvertToScaledDP(bound.Height));
+					headerHeight = Forms.ConvertToScaledPixel(requestSize.Request.Height);
+					var headerBound = Geometry;
+					headerBound.Height = headerHeight;
+					_nativeHeader.Geometry = headerBound;
+				}
+			}
+			bound.Y += headerHeight;
+			bound.Height -= headerHeight;
+
+			_list.Geometry = bound;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellItemRenderer.cs
@@ -1,0 +1,20 @@
+﻿using System;
+
+namespace Xamarin.Forms.Platform.Tizen.TV
+{
+	public class TVShellItemRenderer : ShellItemRenderer
+	{
+		public TVShellItemRenderer(ShellItem item) : base(item)
+		{
+		}
+
+		protected override ShellSectionStack CreateShellSectionStack(ShellSection section)
+		{
+			return new TVShellSectionStack(section);
+		}
+
+		protected override void UpdateTabsItems()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellRenderer.cs
@@ -1,0 +1,29 @@
+﻿using System;
+
+namespace Xamarin.Forms.Platform.Tizen.TV
+{
+	public class TVShellRenderer : ShellRenderer
+	{
+		protected override INavigationDrawer CreateNavigationDrawer()
+		{
+			var drawer = new TVNavigationDrawer(Forms.NativeParent);
+			((IShellController)Element).AddFlyoutBehaviorObserver(drawer);
+			return drawer;
+		}
+
+		protected override ShellItemRenderer CreateShellItemRenderer(ShellItem item)
+		{
+			return new TVShellItemRenderer(item);
+		}
+
+		protected override INavigationView CreateNavigationView()
+		{
+			return new TVNavigationView(Forms.NativeParent, Element);
+		}
+
+		protected override void UpdateFlyoutIsPresented()
+		{
+			NavigationDrawer.IsOpen = Element.FlyoutIsPresented;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellSectionRenderer.cs
@@ -1,0 +1,180 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using ElmSharp;
+using EBox = ElmSharp.Box;
+
+namespace Xamarin.Forms.Platform.Tizen
+{
+	public class TVShellSectionRenderer : IShellSectionRenderer, IDisposable
+	{
+		EBox _mainLayout = null;
+		EBox _contentArea = null;
+
+		EvasObject _currentContent = null;
+		TVNavigationView _navigationView;
+
+		Dictionary<ShellContent, EvasObject> _contentCache = new Dictionary<ShellContent, EvasObject>();
+
+		bool _disposed = false;
+		bool _drawerIsVisible => (ShellSection != null) ? (ShellSection.Items.Count > 1) : false;
+
+		public TVShellSectionRenderer(ShellSection section)
+		{
+			ShellSection = section;
+			ShellSection.PropertyChanged += OnSectionPropertyChanged;
+			(ShellSection.Items as INotifyCollectionChanged).CollectionChanged += OnShellSectionCollectionChanged;
+
+			_mainLayout = new EBox(Forms.NativeParent);
+			_mainLayout.SetLayoutCallback(OnLayout);
+
+			_contentArea = new EBox(Forms.NativeParent);
+			_contentArea.Show();
+			_mainLayout.PackEnd(_contentArea);
+
+			UpdateSectionItems();
+			UpdateCurrentItem(ShellSection.CurrentItem);
+		}
+
+		public ShellSection ShellSection { get; }
+
+		public EvasObject NativeView
+		{
+			get
+			{
+				return _mainLayout;
+			}
+		}
+
+		~TVShellSectionRenderer()
+		{
+			Dispose(false);
+		}
+
+		public void Dispose()
+		{
+			Dispose(true);
+			GC.SuppressFinalize(this);
+		}
+
+		protected virtual void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			if (disposing)
+			{
+				if (ShellSection != null)
+				{
+					ShellSection.PropertyChanged -= OnSectionPropertyChanged;
+				}
+
+				NativeView.Unrealize();
+			}
+			_disposed = true;
+		}
+
+		void OnNavigationViewSelectedItemChanged(object sender, SelectedItemChangedEventArgs e)
+		{
+			if (e.SelectedItem == null)
+				return;
+
+			var content = e.SelectedItem;
+			if (ShellSection.CurrentItem != content)
+			{
+				ShellSection.SetValueFromRenderer(ShellSection.CurrentItemProperty, content);
+			}
+		}
+
+		void OnSectionPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (e.PropertyName == "CurrentItem")
+			{
+				UpdateCurrentItem(ShellSection.CurrentItem);
+			}
+		}
+
+		void UpdateSectionItems()
+		{
+			if (!_drawerIsVisible)
+			{
+				return;
+			}
+
+			if (_navigationView == null)
+			{
+				_navigationView = new TVNavigationView(Forms.NativeParent, ShellSection);
+				_navigationView.SetAlignment(-1, -1);
+				_navigationView.SetWeight(1, 1);
+				_navigationView.Show();
+				_mainLayout.PackStart(_navigationView);
+
+				_navigationView.SelectedItemChanged += OnNavigationViewSelectedItemChanged;
+			}
+
+			(_navigationView as TVNavigationView).BuildMenu(ShellSection.Items, Shell.GetItemTemplate(ShellSection));
+		}
+
+		void UpdateCurrentItem(ShellContent content)
+		{
+			if (_currentContent != null)
+			{
+				_currentContent.Hide();
+				_contentArea.UnPack(_currentContent);
+				_currentContent = null;
+			}
+
+			if (content == null)
+			{
+				return;
+			}
+
+			if (!_contentCache.ContainsKey(content))
+			{
+				var native = CreateShellContent(content);
+				native.SetAlignment(-1, -1);
+				native.SetWeight(1, 1);
+				_contentCache[content] = native;
+			}
+			_currentContent = _contentCache[content];
+			_currentContent.Show();
+			_contentArea.PackEnd(_currentContent);
+		}
+
+		EvasObject CreateShellContent(ShellContent content)
+		{
+			Page xpage = ((IShellContentController)content).GetOrCreateContent();
+			return Platform.GetOrCreateRenderer(xpage).NativeView;
+		}
+
+		void OnLayout()
+		{
+			if (NativeView.Geometry.Width == 0 || NativeView.Geometry.Height == 0)
+				return;
+
+			var bound = NativeView.Geometry;
+			var drawerWidth = 0;
+
+			if (_drawerIsVisible && _navigationView != null)
+			{
+				var drawerBound = bound;
+				drawerWidth = _navigationView.GetDrawerWidth();
+				drawerBound.Width = drawerWidth;
+
+				_navigationView.Geometry = drawerBound;
+			}
+
+			var contentBound = bound;
+
+			contentBound.X += drawerWidth;
+			contentBound.Width -= drawerWidth;
+			_contentArea.Geometry = contentBound;
+		}
+
+		void OnShellSectionCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			UpdateSectionItems();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellSectionStack.cs
+++ b/Xamarin.Forms.Platform.Tizen/Shell/TV/TVShellSectionStack.cs
@@ -1,0 +1,19 @@
+﻿using System.ComponentModel;
+
+namespace Xamarin.Forms.Platform.Tizen.TV
+{
+	public class TVShellSectionStack : ShellSectionStack
+	{
+
+		public TVShellSectionStack(ShellSection section) : base(section)
+		{
+		}
+
+		public override bool NavBarIsVisible => false;
+
+		protected override IShellSectionRenderer CreateShellSectionRenderer(ShellSection section)
+		{
+			return new TVShellSectionRenderer(section);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
+++ b/Xamarin.Forms.Platform.Tizen/StaticRegistrar.cs
@@ -120,6 +120,10 @@ namespace Xamarin.Forms.Platform.Tizen
 			{
 				Registered.Register(typeof(Shell), () => new Watch.ShellRenderer());
 			}
+			else if (Device.Idiom == TargetIdiom.TV)
+			{
+				Registered.Register(typeof(Shell), () => new TV.TVShellRenderer());
+			}
 			else
 			{
 				Registered.Register(typeof(Shell), () => new ShellRenderer());

--- a/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
+++ b/Xamarin.Forms.Platform.Tizen/ThemeManager.cs
@@ -1,6 +1,7 @@
 using System;
 using ElmSharp;
 using ElmSharp.Wearable;
+using Xamarin.Forms.Platform.Tizen.TV;
 using static Xamarin.Forms.Platform.Tizen.Native.TableView;
 using EButton = ElmSharp.Button;
 using EColor = ElmSharp.Color;
@@ -909,18 +910,26 @@ namespace Xamarin.Forms.Platform.Tizen
 		}
 		#endregion
 
-		#region NavigationView
+		#region INavigationView
 
 		static double s_navigationViewFlyoutItemHeight = -1;
-		public static double GetFlyoutItemHeight(this NavigationView nav)
+		public static double GetFlyoutItemHeight(this INavigationView nav)
 		{
 			if (s_navigationViewFlyoutItemHeight > 0)
 				return s_navigationViewFlyoutItemHeight;
 			return s_navigationViewFlyoutItemHeight = CalculateDoubleScaledSizeInLargeScreen(60);
 		}
 
+		static double s_navigationViewFlyoutItemWidth = -1;
+		public static double GetFlyoutItemWidth(this INavigationView nav)
+		{
+			if (s_navigationViewFlyoutItemWidth > 0)
+				return s_navigationViewFlyoutItemWidth;
+			return s_navigationViewFlyoutItemWidth = CalculateDoubleScaledSizeInLargeScreen(200);
+		}
+
 		static double s_navigationViewFlyoutIconColumnSize = -1;
-		public static double GetFlyoutIconColumnSize(this NavigationView nav)
+		public static double GetFlyoutIconColumnSize(this INavigationView nav)
 		{
 			if (s_navigationViewFlyoutIconColumnSize > 0)
 				return s_navigationViewFlyoutIconColumnSize;
@@ -928,7 +937,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		}
 
 		static double s_navigationViewFlyoutIconSize = -1;
-		public static double GetFlyoutIconSize(this NavigationView nav)
+		public static double GetFlyoutIconSize(this INavigationView nav)
 		{
 			if (s_navigationViewFlyoutIconSize > 0)
 				return s_navigationViewFlyoutIconSize;
@@ -936,7 +945,7 @@ namespace Xamarin.Forms.Platform.Tizen
 		}
 
 		static double s_navigationViewFlyoutMargin = -1;
-		public static double GetFlyoutMargin(this NavigationView nav)
+		public static double GetFlyoutMargin(this INavigationView nav)
 		{
 			if (s_navigationViewFlyoutMargin > 0)
 				return s_navigationViewFlyoutMargin;
@@ -944,21 +953,46 @@ namespace Xamarin.Forms.Platform.Tizen
 		}
 
 		static double s_navigationViewFlyoutItemFontSize = -1;
-		public static double GetFlyoutItemFontSize(this NavigationView nav)
+		public static double GetFlyoutItemFontSize(this INavigationView nav)
 		{
 			if (s_navigationViewFlyoutItemFontSize > 0)
 				return s_navigationViewFlyoutItemFontSize;
 			return s_navigationViewFlyoutItemFontSize = CalculateDoubleScaledSizeInLargeScreen(25);
 		}
 
+		public static Color GetTvFlyoutItemDefaultColor(this INavigationView nav)
+		{
+			return Color.Transparent;
+		}
+
+		public static Color GetTvFlyoutItemFocusedColor(this INavigationView nav)
+		{
+			return new Color(0.95);
+		}
+
+		public static Color GetTvFlyoutItemTextDefaultColor(this INavigationView nav)
+		{
+			return Color.White;
+		}
+
+		public static Color GetTvFlyoutItemTextFocusedColor(this INavigationView nav)
+		{
+			return Color.Black;
+		}
+
 		#endregion
 
-		#region NavigationDrawer
+		#region INavigationDrawer
 
 		static double s_navigationDrawerRatio = -1;
-		public static double GetFlyoutRatio(this NavigationDrawer drawer, int width, int height)
+		public static double GetFlyoutRatio(this INavigationDrawer drawer, int width, int height)
 		{
 			return s_navigationDrawerRatio = (width > height) ? 0.4 : 0.83;
+		}
+
+		public static double GetFlyoutCollapseRatio(this INavigationDrawer drawer)
+		{
+			return 0.05;
 		}
 		#endregion
 


### PR DESCRIPTION
### Description of Change ###

This PR is to optimize Shell navigation UI for Tizen TV.

### Issues Resolved ### 
 None

### API Changes ###
 None

### Platforms Affected ### 
- Tizen

### Behavioral/Visual Changes ###
On TV, users navigate pages using remote controller that limits movement to up, down, left, right.  `Flyout` and `Tabs` are updated to be easily controlled by remote controller as below.
- `Flyout`
`Flyout` is displayed on the far left of the screen. It will be minimized while the user is browsing the `ShellContent` area. The user can open `Flyout` by moving the focus to the left pressing left button or changing the IsPresented property to true.
- Bottom tabs
Button tabs are not displayed on TV. Tab items will not be displayed on Flyout if `FlyoutDisplayOptions` value is `AsSingleItem`. (if the user want to represent tab items, it should be set `AsMultipleItems`)
- Top tabs
If `FlyoutItem` or `Tab` item contains on or more ShellContent, another navigation drawer is represented on the left side of `Shellcontent` area. Unlike `Flyout` it is not minimized while the user is browding the content.

![tv_shell_1](https://user-images.githubusercontent.com/20968023/108795945-df972400-75ca-11eb-9c2b-f4e44f061148.gif)


### Before/After Screenshots ### 
- Flyout behavior (Flyout/Locked/Disabled)
![tv_shell_2](https://user-images.githubusercontent.com/20968023/108796306-c6db3e00-75cb-11eb-9fb9-b53491a47e78.gif)

- Flyout header options(Scroll/Fixed)
![tv_shell_3](https://user-images.githubusercontent.com/20968023/108796349-e96d5700-75cb-11eb-9dde-560f0d1df756.gif)

- Flyout Item templates
![tv_shell_itemtemplate](https://user-images.githubusercontent.com/20968023/108796419-1588d800-75cc-11eb-9c7a-f2772876b4af.PNG)


### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
