### PR TITLE
Cast Slider expected value to int

### DIFF
--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Handlers/Slider/SliderHandlerTests.Android.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Handlers/Slider/SliderHandlerTests.Android.cs
@@ -70,7 +70,7 @@ namespace Xamarin.Platform.Handlers.DeviceTests
 				Value = xplatValue
 			};
 
-			double expectedValue = SliderExtensions.NativeMaxValue / 2;
+			int expectedValue = (int)(SliderExtensions.NativeMaxValue / 2);
 
 			var values = await GetValueAsync(slider, (handler) =>
 			{


### PR DESCRIPTION
### Description of Change ###

The Progress value on SeekBar is an int so we need to cast the expected value to int inside the test to account for the loss of precision

### Testing Procedure ###
- Device Tests pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
