### PR TITLE
Fix infinite slider width issue

### DIFF
--- a/src/Compatibility/Core/src/Android/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/Android/HandlerToRendererShim.cs
@@ -37,8 +37,7 @@ namespace Microsoft.Maui.Controls.Compatibility
 
 		public SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
 		{
-			View.Measure(widthConstraint, heightConstraint);
-			return new Size(View.MeasuredWidth, View.MeasuredHeight);
+			return ViewHandler.GetDesiredSize(widthConstraint, heightConstraint);
 		}
 
 		public void SetElement(VisualElement element)

--- a/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
+++ b/src/Compatibility/Core/src/iOS/HandlerToRendererShim.cs
@@ -64,7 +64,8 @@ namespace Microsoft.Maui.Controls.Compatibility.Platform.iOS
 
 		public SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			return NativeView.GetSizeRequest(widthConstraint, heightConstraint);
+			var size = ViewHandler.GetDesiredSize(widthConstraint, heightConstraint);
+			return new SizeRequest(size, size);
 		}
 
 		public void SetElementSize(Size size)

--- a/src/Core/src/Handlers/View/AbstractViewHandler.MaciOS.cs
+++ b/src/Core/src/Handlers/View/AbstractViewHandler.MaciOS.cs
@@ -18,16 +18,25 @@ namespace Microsoft.Maui.Handlers
 
 		public virtual Size GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
-			var sizeThatFits = TypedNativeView?.SizeThatFits(new CoreGraphics.CGSize((float)widthConstraint, (float)heightConstraint));
-
-			if (sizeThatFits.HasValue)
+			if (TypedNativeView == null)
 			{
-				return new Size(
-					sizeThatFits.Value.Width == float.PositiveInfinity ? double.PositiveInfinity : sizeThatFits.Value.Width,
-					sizeThatFits.Value.Height == float.PositiveInfinity ? double.PositiveInfinity : sizeThatFits.Value.Height);
+				return new Size(widthConstraint, heightConstraint);
 			}
 
-			return new Size(widthConstraint, heightConstraint);
+			var sizeThatFits = TypedNativeView.SizeThatFits(new CoreGraphics.CGSize((float)widthConstraint, (float)heightConstraint));
+
+			var size = new Size(
+				sizeThatFits.Width == float.PositiveInfinity ? double.PositiveInfinity : sizeThatFits.Width,
+				sizeThatFits.Height == float.PositiveInfinity ? double.PositiveInfinity : sizeThatFits.Height);
+
+			if (double.IsInfinity(size.Width) || double.IsInfinity(size.Height))
+			{
+				TypedNativeView.SizeToFit();
+
+				size = new Size(TypedNativeView.Frame.Width, TypedNativeView.Frame.Height);
+			}
+
+			return size;
 		}
 
 		void SetupContainer()

--- a/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.cs
+++ b/src/Core/tests/DeviceTests/Handlers/Slider/SliderHandlerTests.cs
@@ -88,5 +88,16 @@ namespace Microsoft.Maui.DeviceTests
 			await ValidatePropertyInitValue(slider, () => slider.Maximum, GetNativeMaximum, 1);
 		}
 #endif
+
+		[Fact]
+		public async Task NativeMeasurementFiniteGivenInfiniteConstraints()
+		{
+			var slider = new SliderStub();
+
+			var size = await GetValueAsync(slider, (h) => h.GetDesiredSize(double.PositiveInfinity, double.PositiveInfinity));
+
+			Assert.False(double.IsInfinity(size.Width));
+			Assert.False(double.IsInfinity(size.Height));
+		}
 	}
 }


### PR DESCRIPTION
### Description of Change ###

Fix issue with UISlider (and possibly other controls) misbehaving when calling SizeThatFits with infinite width.

If the control tries to claim infinite width or height, call SizeToFit and return the frame instead. (This is basically the same fix Forms has for SliderRenderer).

### Issues Resolved ### 

- (hopefully) fixes broken 7361 test in CG

### API Changes ###
 
None

### Platforms Affected ### 

- iOS

### Testing Procedure ###

Automated device test

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
