### PR TITLE
[Handlers] Map TextDecorations property in LabelHandlers

### DIFF
--- a/src/Forms/samples/Maui.Controls.Sample/Pages/MainPage.cs
+++ b/src/Forms/samples/Maui.Controls.Sample/Pages/MainPage.cs
@@ -9,10 +9,12 @@ namespace Maui.Controls.Sample.Pages
 	public class MainPage : ContentPage, IPage
 	{
 		MainPageViewModel _viewModel;
+
 		public MainPage() : this(App.Current.Services.GetService<MainPageViewModel>())
 		{
 
 		}
+
 		public MainPage(MainPageViewModel viewModel)
 		{
 			BindingContext = _viewModel = viewModel;
@@ -24,6 +26,9 @@ namespace Maui.Controls.Sample.Pages
 			label.Margin = new Thickness(15, 10, 20, 15);
 
 			verticalStack.Add(label);
+
+			var underlineLabel = new Label { Text = "underline", TextDecorations = TextDecorations.Underline };
+			verticalStack.Add(underlineLabel);
 
 			var button = new Button() { Text = _viewModel.Text, WidthRequest = 200 };
 			var button2 = new Button()

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Core/ILabel.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Core/ILabel.cs
@@ -4,6 +4,6 @@ namespace Xamarin.Platform
 {
 	public interface ILabel : IView, IText
 	{
-		
+		TextDecorations TextDecorations { get; }
 	}
 }

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.Android.cs
@@ -34,5 +34,12 @@ namespace Xamarin.Platform.Handlers
 
 			handler.TypedNativeView?.UpdateTextColor(label, DefaultTextColor);
 		}
+
+		public static void MapTextDecorations(LabelHandler handler, ILabel label)
+		{
+			ViewHandler.CheckParameters(handler, label);
+
+			handler.TypedNativeView?.UpdateTextDecorations(label);
+		}
 	}
 }

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.Standard.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.Standard.cs
@@ -8,5 +8,6 @@ namespace Xamarin.Platform.Handlers
 
 		public static void MapText(IViewHandler handler, ILabel label) { }
 		public static void MapTextColor(IViewHandler handler, ILabel label) { }
+		public static void MapTextDecorations(IViewHandler handler, ILabel label) { }
 	}
 }

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.cs
@@ -6,6 +6,7 @@
 		{
 			[nameof(ILabel.TextColor)] = MapTextColor,
 			[nameof(ILabel.Text)] = MapText,
+			[nameof(ILabel.TextDecorations)] = MapTextDecorations
 		};
 
 		public LabelHandler() : base(LabelMapper)

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Handlers/Label/LabelHandler.iOS.cs
@@ -19,5 +19,12 @@ namespace Xamarin.Platform.Handlers
 
 			handler.TypedNativeView?.UpdateTextColor(label);
 		}
+
+		public static void MapTextDecorations(LabelHandler handler, ILabel label)
+		{
+			ViewHandler.CheckParameters(handler, label);
+
+			handler.TypedNativeView?.UpdateTextDecorations(label);
+		}
 	}
 }

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Platform/Android/LabelExtensions.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Platform/Android/LabelExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Android.Widget;
+﻿using Android.Graphics;
+using Android.Widget;
+using Xamarin.Forms;
 
 namespace Xamarin.Platform
 {
@@ -21,6 +23,21 @@ namespace Xamarin.Platform
 			{
 				textView.SetTextColor(textColor.ToNative());
 			}				
+		}
+
+		public static void UpdateTextDecorations(this TextView textView, ILabel label)
+		{
+			var textDecorations = label.TextDecorations;
+
+			if ((textDecorations & TextDecorations.Strikethrough) == 0)
+				textView.PaintFlags &= ~PaintFlags.StrikeThruText;
+			else
+				textView.PaintFlags |= PaintFlags.StrikeThruText;
+
+			if ((textDecorations & TextDecorations.Underline) == 0)
+				textView.PaintFlags &= ~PaintFlags.UnderlineText;
+			else
+				textView.PaintFlags |= PaintFlags.UnderlineText;
 		}
 	}
 }

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Platform/Standard/LabelExtensions.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Platform/Standard/LabelExtensions.cs
@@ -11,5 +11,10 @@
 		{
 
 		}
+
+		public static void UpdateTextDecorations(this object nothing, ILabel label)
+		{
+
+		}
 	}
 }

--- a/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Platform/iOS/LabelExtensions.cs
+++ b/src/Platform.Handlers/src/Xamarin.Platform.Handlers/Platform/iOS/LabelExtensions.cs
@@ -1,4 +1,6 @@
-﻿using UIKit;
+﻿using Foundation;
+using UIKit;
+using Xamarin.Forms;
 
 namespace Xamarin.Platform
 {
@@ -22,6 +24,32 @@ namespace Xamarin.Platform
 			{
 				nativeLabel.TextColor = textColor.ToNative(textColor);
 			}
+		}
+
+		public static void UpdateTextDecorations(this UILabel nativeLabel, ILabel label)
+		{
+			if (nativeLabel.AttributedText != null && !(nativeLabel.AttributedText?.Length > 0))
+				return;
+
+			var textDecorations = label?.TextDecorations;
+
+			var newAttributedText = nativeLabel.AttributedText != null ? new NSMutableAttributedString(nativeLabel.AttributedText) : new NSMutableAttributedString(label?.Text ?? string.Empty);
+			var strikeThroughStyleKey = UIStringAttributeKey.StrikethroughStyle;
+			var underlineStyleKey = UIStringAttributeKey.UnderlineStyle;
+
+			var range = new NSRange(0, newAttributedText.Length);
+
+			if ((textDecorations & TextDecorations.Strikethrough) == 0)
+				newAttributedText.RemoveAttribute(strikeThroughStyleKey, range);
+			else
+				newAttributedText.AddAttribute(strikeThroughStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
+
+			if ((textDecorations & TextDecorations.Underline) == 0)
+				newAttributedText.RemoveAttribute(underlineStyleKey, range);
+			else
+				newAttributedText.AddAttribute(underlineStyleKey, NSNumber.FromInt32((int)NSUnderlineStyle.Single), range);
+
+			nativeLabel.AttributedText = newAttributedText;
 		}
 	}
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Handlers/Label/LabelHandlerTests.Android.cs
@@ -1,6 +1,9 @@
 ﻿using System.Threading.Tasks;
+using Android.Graphics;
 using Android.Widget;
 using Xamarin.Forms;
+using Xamarin.Platform.Handlers.DeviceTests.Stubs;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.DeviceTests
 {
@@ -12,15 +15,43 @@ namespace Xamarin.Platform.Handlers.DeviceTests
 		string GetNativeText(LabelHandler labelHandler) =>
 			GetNativeLabel(labelHandler).Text;
 
-		Color GetNativeTextColor(LabelHandler labelHandler) =>
+		Forms.Color GetNativeTextColor(LabelHandler labelHandler) =>
 		   ((uint)GetNativeLabel(labelHandler).CurrentTextColor).ToColor();
 
-		Task ValidateNativeBackgroundColor(ILabel label, Color color)
+		Task ValidateNativeBackgroundColor(ILabel label, Forms.Color color)
 		{
 			return InvokeOnMainThreadAsync(() =>
 			{
 				GetNativeLabel(CreateHandler(label)).AssertContainsColor(color);
 			});
+		}
+
+		PaintFlags GetNativeTextDecorations(LabelHandler labelHandler) =>
+			GetNativeLabel(labelHandler).PaintFlags;
+
+		[Fact(DisplayName = "[LabelHandler] TextDecorations Initializes Correctly")]
+		public async Task TextDecorationsInitializesCorrectly()
+		{
+			var xplatTextDecorations = TextDecorations.Underline;
+
+			var labelHandler = new LabelStub()
+			{
+				TextDecorations = xplatTextDecorations
+			};
+
+			var values = await GetValueAsync(labelHandler, (handler) =>
+			{
+				return new
+				{
+					ViewValue = labelHandler.TextDecorations,
+					NativeViewValue = GetNativeTextDecorations(handler)
+				};
+			});
+
+			PaintFlags expectedValue = PaintFlags.UnderlineText;
+
+			Assert.Equal(xplatTextDecorations, values.ViewValue);
+			Assert.True(values.NativeViewValue.HasFlag(expectedValue));
 		}
 	}
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Handlers/Label/LabelHandlerTests.iOS.cs
@@ -1,6 +1,9 @@
 ﻿using System.Threading.Tasks;
+using Foundation;
 using UIKit;
 using Xamarin.Forms;
+using Xamarin.Platform.Handlers.DeviceTests.Stubs;
+using Xunit;
 
 namespace Xamarin.Platform.Handlers.DeviceTests
 {
@@ -21,6 +24,32 @@ namespace Xamarin.Platform.Handlers.DeviceTests
 			{
 				GetNativeLabel(CreateHandler(label)).AssertContainsColor(color);
 			});
+		}
+
+		NSAttributedString GetNativeTextDecorations(LabelHandler labelHandler) =>
+			GetNativeLabel(labelHandler).AttributedText;
+
+		[Fact(DisplayName = "[LabelHandler] TextDecorations Initializes Correctly")]
+		public async Task TextDecorationsInitializesCorrectly()
+		{
+			var xplatTextDecorations = TextDecorations.Underline;
+
+			var labelHandler = new LabelStub()
+			{
+				TextDecorations = xplatTextDecorations
+			};
+
+			var values = await GetValueAsync(labelHandler, (handler) =>
+			{
+				return new
+				{
+					ViewValue = labelHandler.TextDecorations,
+					NativeViewValue = GetNativeTextDecorations(handler)
+				};
+			});
+
+			Assert.Equal(xplatTextDecorations, values.ViewValue);
+			Assert.True(values.NativeViewValue != null);
 		}
 	}
 }

--- a/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Stubs/Label.cs
+++ b/src/Platform.Handlers/tests/Xamarin.Platform.Handlers.DeviceTests/Stubs/Label.cs
@@ -8,10 +8,12 @@ namespace Xamarin.Platform.Handlers.DeviceTests.Stubs
 
 		public Color TextColor { get; set; }
 
-		public FontAttributes FontAttributes => throw new System.NotImplementedException();
+		public FontAttributes FontAttributes { get; set; }
 
-		public string FontFamily => throw new System.NotImplementedException();
+		public string FontFamily { get; set; }
 
-		public double FontSize => throw new System.NotImplementedException();
+		public double FontSize { get; set; }
+
+		public TextDecorations TextDecorations { get; set; }
 	}
 }

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.Android/FastRenderers/LabelRenderer.cs
@@ -7,6 +7,7 @@ using Android.Text;
 using Android.Util;
 using Android.Views;
 using AndroidX.Core.View;
+using Xamarin.Platform;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
@@ -328,6 +329,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			}
 		}
 
+		[PortHandler]
 		void UpdateTextDecorations()
 		{
 			if (!Element.IsSet(Label.TextDecorationsProperty))

--- a/src/Platform.Renderers/src/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/src/Platform.Renderers/src/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -250,6 +250,7 @@ namespace Xamarin.Forms.Platform.MacOS
 				_perfectSizeValid = false;
 		}
 
+		[PortHandler]
 		void UpdateTextDecorations()
 		{
 			if (IsElementOrControlEmpty)


### PR DESCRIPTION
### Description of Change ###

Map `TextDecorations` property in LabelHandlers.

### Platforms Affected ### 

- Android
- UWP

### PR Checklist ###

- [x] Targets the correct branch
- [x]  Include handlers tests
- [ ] Tests are passing (or failures are unrelated)
