### PR TITLE
Remove the CheckParameters boilerplate method from handlers

### DIFF
--- a/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.Android.cs
@@ -43,15 +43,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapText(ButtonHandler handler, IButton button)
 		{
-			ViewHandler.CheckParameters(handler, button);
-
 			handler.TypedNativeView?.UpdateText(button);
 		}
 
 		public static void MapTextColor(ButtonHandler handler, IButton button)
 		{
-			ViewHandler.CheckParameters(handler, button);
-
 			handler.TypedNativeView?.UpdateTextColor(button);
 		}
 

--- a/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
+++ b/src/Core/src/Handlers/Button/ButtonHandler.iOS.cs
@@ -46,15 +46,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapText(ButtonHandler handler, IButton button)
 		{
-			ViewHandler.CheckParameters(handler, button);
-
 			handler.TypedNativeView?.UpdateText(button);
 		}
 
 		public static void MapTextColor(ButtonHandler handler, IButton button)
 		{
-			ViewHandler.CheckParameters(handler, button);
-
 			handler.TypedNativeView?.UpdateTextColor(button, ButtonTextColorDefaultNormal, ButtonTextColorDefaultHighlighted, ButtonTextColorDefaultDisabled);
 		}
 

--- a/src/Core/src/Handlers/Label/LabelHandler.Android.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.Android.cs
@@ -23,15 +23,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapText(LabelHandler handler, ILabel label)
 		{
-			ViewHandler.CheckParameters(handler, label);
-
 			handler.TypedNativeView?.UpdateText(label);
 		}
 
 		public static void MapTextColor(LabelHandler handler, ILabel label)
 		{
-			ViewHandler.CheckParameters(handler, label);
-
 			handler.TypedNativeView?.UpdateTextColor(label, DefaultTextColor);
 		}
 	}

--- a/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
+++ b/src/Core/src/Handlers/Label/LabelHandler.iOS.cs
@@ -8,15 +8,11 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapText(LabelHandler handler, ILabel label)
 		{
-			ViewHandler.CheckParameters(handler, label);
-
 			handler.TypedNativeView?.UpdateText(label);
 		}
 
 		public static void MapTextColor(LabelHandler handler, ILabel label)
 		{
-			ViewHandler.CheckParameters(handler, label);
-
 			handler.TypedNativeView?.UpdateTextColor(label);
 		}
 	}

--- a/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.Android.cs
@@ -46,43 +46,31 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapMinimum(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMinimum(slider);
 		}
 
 		public static void MapMaximum(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMaximum(slider);
 		}
 
 		public static void MapValue(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateValue(slider);
 		}
 
 		public static void MapMinimumTrackColor(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMinimumTrackColor(slider, DefaultProgressBackgroundTintList, DefaultProgressBackgroundTintMode);
 		}
 
 		public static void MapMaximumTrackColor(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMaximumTrackColor(slider, DefaultProgressTintList, DefaultProgressTintMode);
 		}
 
 		public static void MapThumbColor(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateThumbColor(slider, DefaultThumbColorFilter);
 		}
 

--- a/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
+++ b/src/Core/src/Handlers/Slider/SliderHandler.iOS.cs
@@ -34,43 +34,31 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapMinimum(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMinimum(slider);
 		}
 
 		public static void MapMaximum(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMaximum(slider);
 		}
 
 		public static void MapValue(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateValue(slider);
 		}
 
 		public static void MapMinimumTrackColor(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMinimumTrackColor(slider, DefaultMinTrackColor);
 		}
 
 		public static void MapMaximumTrackColor(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateMaximumTrackColor(slider, DefaultMaxTrackColor);
 		}
 
 		public static void MapThumbColor(SliderHandler handler, ISlider slider)
 		{
-			ViewHandler.CheckParameters(handler, slider);
-
 			handler.TypedNativeView?.UpdateThumbColor(slider, DefaultThumbColor);
 		}
 

--- a/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.Android.cs
@@ -54,19 +54,16 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIsToggled(SwitchHandler handler, ISwitch view)
 		{
-			ViewHandler.CheckParameters(handler, view);
 			handler.TypedNativeView?.UpdateIsToggled(view);
 		}
 
 		public static void MapTrackColor(SwitchHandler handler, ISwitch view)
 		{
-			ViewHandler.CheckParameters(handler, view);
 			handler.TypedNativeView?.UpdateTrackColor(view, DefaultTrackColorStateList);
 		}
 
 		public static void MapThumbColor(SwitchHandler handler, ISwitch view)
 		{
-			ViewHandler.CheckParameters(handler, view);
 			handler.TypedNativeView?.UpdateThumbColor(view, DefaultThumbColorStateList);
 		}
 

--- a/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
+++ b/src/Core/src/Handlers/Switch/SwitchHandler.iOS.cs
@@ -34,19 +34,16 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapIsToggled(SwitchHandler handler, ISwitch view)
 		{
-			ViewHandler.CheckParameters(handler, view);
 			handler.TypedNativeView?.UpdateIsToggled(view);
 		}
 
 		public static void MapTrackColor(SwitchHandler handler, ISwitch view)
 		{
-			ViewHandler.CheckParameters(handler, view);
 			handler.TypedNativeView?.UpdateTrackColor(view, DefaultOnTrackColor, DefaultOffTrackColor);
 		}
 
 		public static void MapThumbColor(SwitchHandler handler, ISwitch view)
 		{
-			ViewHandler.CheckParameters(handler, view);
 			handler.TypedNativeView?.UpdateThumbColor(view, DefaultThumbColor);
 		}
 

--- a/src/Core/src/Handlers/View/ViewHandler.cs
+++ b/src/Core/src/Handlers/View/ViewHandler.cs
@@ -24,27 +24,18 @@ namespace Microsoft.Maui.Handlers
 
 		public static void MapFrame(IViewHandler handler, IView view)
 		{
-			CheckParameters(handler, view);
 			handler.SetFrame(view.Frame);
 		}
 
 		public static void MapIsEnabled(IViewHandler handler, IView view)
 		{
-			CheckParameters(handler, view);
 			(handler.NativeView as NativeView)?.UpdateIsEnabled(view);
 		}
 
 		public static void MapBackgroundColor(IViewHandler handler, IView view)
 		{
-			CheckParameters(handler, view);
 			(handler.NativeView as NativeView)?.UpdateBackgroundColor(view);
 		}
 
-		[MethodImpl(MethodImplOptions.AggressiveInlining)]
-		internal static void CheckParameters(IViewHandler handler, IView view)
-		{
-			_ = handler ?? throw new ArgumentNullException(nameof(handler));
-			_ = view ?? throw new ArgumentNullException(nameof(view));
-		}
 	}
 }


### PR DESCRIPTION
Removes the CheckParameters method from ViewHandler.

The null checks it does are unnecessary; the calls to the mapping methods all come from UpdatePropertyCore, and the only callers of it already check the IView for null. And both callers are only called from AbstractViewHandler, so the IViewHandler property is necessarily non-null.

If we ever decide in the future that null-checking these parameters is necessary, we can do so in UpdatePropertyCore rather than adding boilerplate code to every mapping.