### PR TITLE
Fix UWP threading exception

### DIFF
--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -56,11 +56,7 @@ namespace Xamarin.Forms.Platform.UWP
 			switch (size)
 			{
 				case NamedSize.Default:
-					if(DefaultFontSize == double.NegativeInfinity)
-					{
-						DefaultFontSize = (double)WApplication.Current.Resources["ControlContentThemeFontSize"];
-					}
-					return DefaultFontSize;
+					return 14.667;
 				case NamedSize.Micro:
 					return 15.667;
 				case NamedSize.Small:

--- a/Xamarin.Forms.Platform.UAP/FontExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/FontExtensions.cs
@@ -15,7 +15,6 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		[ThreadStatic]
 		static Dictionary<string, FontFamily> FontFamilies = new Dictionary<string, FontFamily>();
-		static double DefaultFontSize = double.NegativeInfinity;
 
 		public static void ApplyFont(this Control self, Font font)
 		{


### PR DESCRIPTION
### Description of Change ###

Removes an instance of an inverted dependency where creating a Xamarin.Forms object (including a Label with a font size) causes an exception, leading to crashes on user systems when done off the UI thread.

### Issues Resolved ### 

- fixes #8840

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

- UWP apps will not get unexpected crashes when creating Xamarin.Forms objects off the UI thread.
- There is a rare instance where sizing of fonts could be different (developer has changed ControlContentThemeFontSize manually and then not used font sizes).

### Testing Procedure ###
Force the creation of the following object off the UI thread:
```fsharp
Label(FontSize = 10.)
```
This should not give an exception.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
