### PR TITLE
Fix test filenames in yaml after the rename

### DIFF
--- a/eng/pipelines/common/build-windows.yml
+++ b/eng/pipelines/common/build-windows.yml
@@ -42,7 +42,7 @@ steps:
     displayName: 'XAML Unit Tests'
     inputs:
       testAssemblyVer2: |
-        **/bin/$(BuildConfiguration)/**/Xamarin.Forms.Xaml.UnitTests.dll
+        **/bin/$(BuildConfiguration)/**/Microsoft.Maui.Controls.Xaml.UnitTests.dll
       searchFolder: ${{ parameters.nunitTestFolder }}
       codeCoverageEnabled: true
       testRunTitle: '$(BuildConfiguration)_UnitTests'
@@ -55,9 +55,11 @@ steps:
     displayName: 'Unit Tests'
     inputs:
       command: test
-      projects:   |
-        **/Xamarin.Forms.Core.UnitTests.csproj
-        **/Xamarin.Platform.Handlers.UnitTests.csproj
+      projects: |
+        **/Controls.Core.UnitTests.csproj
+        **/Core.UnitTests.csproj
+        **/Essentials.UnitTests.csproj
+        **/Resizetizer.UnitTests.csproj
       arguments: '--configuration $(BuildConfiguration)'
 
   - task: CopyFiles@2


### PR DESCRIPTION
### Description of Change ###

Make sure the tests are running after the rename.

This just "enables" the tests and do not fix it. This PR does that: https://github.com/xamarin/Xamarin.Forms/pull/13864