### PR TITLE
Break up legacy and Maui arrange code

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -56,7 +56,20 @@ namespace Microsoft.Maui.Controls
 
 			var newRect = this.ComputeFrame(bounds);
 
-			Layout(newRect);
+			Bounds = newRect;
+			Handler?.SetFrame(Bounds);
+		}
+
+		// TODO: MAUI
+		// This is here to support layout calls from legacy code
+		// This should go away once we get everything piping through
+		// Maui based layout code
+		public void Layout(Rectangle bounds)
+		{
+			Bounds = bounds;
+			// If Layout is called without arrange getting called this ensures
+			// all the necessary arranged parts are set so that handlers will layout			
+			IsArrangeValid = true;
 			Handler?.SetFrame(Bounds);
 		}
 

--- a/src/Controls/src/Core/StackLayout.cs
+++ b/src/Controls/src/Core/StackLayout.cs
@@ -69,17 +69,6 @@ namespace Microsoft.Maui.Controls
 			}
 		}
 
-		// IFrameworkElement Measure
-		Size IFrameworkElement.Measure(double widthConstraint, double heightConstraint)
-		{
-			if (!IsMeasureValid)
-#pragma warning disable CS0618 // Type or member is obsolete
-				DesiredSize = OnSizeRequest(widthConstraint, heightConstraint).Request;
-#pragma warning restore CS0618 // Type or member is obsolete
-			IsMeasureValid = true;
-			return DesiredSize;
-		}
-
 		[Obsolete("OnSizeRequest is obsolete as of version 2.2.0. Please use OnMeasure instead.")]
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		protected override SizeRequest OnSizeRequest(double widthConstraint, double heightConstraint)

--- a/src/Controls/src/Core/VisualElement.cs
+++ b/src/Controls/src/Core/VisualElement.cs
@@ -777,17 +777,6 @@ namespace Microsoft.Maui.Controls
 			return r;
 		}
 
-		public void Layout(Rectangle bounds)
-		{
-			if (Bounds == bounds)
-				return;
-
-			Bounds = bounds;
-			// If Layout is called without arrange getting called this ensures
-			// all the necessary arranged parts are set so that handlers will layout
-			(this as IFrameworkElement).Arrange(bounds);
-		}
-
 		public SizeRequest Measure(double widthConstraint, double heightConstraint, MeasureFlags flags = MeasureFlags.None)
 		{
 			bool includeMargins = (flags & MeasureFlags.IncludeMargins) != 0;


### PR DESCRIPTION
### Description of Change ###

The call to arrange on Layout to make sure that new style handlers get arranged wasn't accounting for the fact that that arrange code is going to add an additional margin. This code just splits up the old Layout call and the new Arrange call so they don't call each other and can just act predictably according to its scenario.

### Testing Procedure ###
- make sure the unit tests all pass

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
