### PR TITLE
Additional changes to propagate measures and arranges between layouts

### DIFF
--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -67,9 +67,6 @@ namespace Microsoft.Maui.Controls
 		public void Layout(Rectangle bounds)
 		{
 			Bounds = bounds;
-			// If Layout is called without arrange getting called this ensures
-			// all the necessary arranged parts are set so that handlers will layout			
-			
 			Handler?.SetFrame(Bounds);
 		}
 

--- a/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
+++ b/src/Controls/src/Core/HandlerImpl/VisualElement.Impl.cs
@@ -69,7 +69,7 @@ namespace Microsoft.Maui.Controls
 			Bounds = bounds;
 			// If Layout is called without arrange getting called this ensures
 			// all the necessary arranged parts are set so that handlers will layout			
-			IsArrangeValid = true;
+			
 			Handler?.SetFrame(Bounds);
 		}
 

--- a/src/Controls/src/Core/Layout.cs
+++ b/src/Controls/src/Core/Layout.cs
@@ -64,7 +64,7 @@ namespace Microsoft.Maui.Controls
 		}
 	}
 
-	public abstract class Layout : View, ILayout, ILayoutController, IPaddingElement
+	public abstract class Layout : View, ILayout, ILayoutController, IPaddingElement, IFrameworkElement
 	{
 		public static readonly BindableProperty IsClippedToBoundsProperty =
 			BindableProperty.Create(nameof(IsClippedToBounds), typeof(bool), typeof(Layout), false);
@@ -215,15 +215,18 @@ namespace Microsoft.Maui.Controls
 		{
 		}
 
-		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
+		Size IFrameworkElement.Measure(double widthConstraint, double heightConstraint)
 		{
 			if (!IsMeasureValid)
-#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete	
 				DesiredSize = OnSizeRequest(widthConstraint, heightConstraint).Request;
-#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete	
 			IsMeasureValid = true;
 			return DesiredSize;
 		}
+
+		protected override Size MeasureOverride(double widthConstraint, double heightConstraint) 
+			=> (this as IFrameworkElement).Measure(widthConstraint, heightConstraint);
 
 		protected override void OnSizeAllocated(double width, double height)
 		{

--- a/src/Controls/src/Core/Layout/Layout.cs
+++ b/src/Controls/src/Core/Layout/Layout.cs
@@ -24,6 +24,14 @@ namespace Microsoft.Maui.Controls.Layout2
 
 		IEnumerator IEnumerable.GetEnumerator() => _children.GetEnumerator();
 
+#pragma warning disable CS0672 // Member overrides obsolete member
+		public override SizeRequest GetSizeRequest(double widthConstraint, double heightConstraint)
+#pragma warning restore CS0672 // Member overrides obsolete member
+		{
+			var size = (this as IFrameworkElement).Measure(widthConstraint, heightConstraint);
+			return new SizeRequest(size);
+		}
+
 		protected override Size MeasureOverride(double widthConstraint, double heightConstraint)
 		{
 			if (IsMeasureValid)

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -44,7 +44,12 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			stackLayout.Children.Add(verticalStackLayout);
 			verticalStackLayout.Add(button);
 
-			Layout(verticalStackLayout, 100, 100);
+			var rect = new Rectangle(0, 0, 100, 100);
+			Layout.LayoutChildIntoBoundingRegion(stackLayout, rect);
+
+			// Normally this would get called from the native platform
+			(verticalStackLayout as IFrameworkElement).Arrange(rect);
+
 			Assert.AreEqual(expectedSize, button.Bounds.Size);
 		}
 
@@ -52,6 +57,7 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 		[Test]
 		public void StackLayoutInsideVerticalStackLayout()
 		{
+			ContentPage contentPage = new ContentPage();
 			var stackLayout = new StackLayout() { IsPlatformEnabled = true };
 			var verticalStackLayout = new VerticalStackLayout() { IsPlatformEnabled = true };
 			var button = new Button() { IsPlatformEnabled = true, HeightRequest = 100, WidthRequest = 100 };
@@ -62,17 +68,13 @@ namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
 			button.Handler = view;
 
 			verticalStackLayout.Add(stackLayout);
-			stackLayout.Add(button);
+			stackLayout.Children.Add(button);
+			contentPage.Content = verticalStackLayout;
 
-			Layout(verticalStackLayout, 100, 100);
+			var rect = new Rectangle(0, 0, 100, 100);
+			(contentPage as IFrameworkElement).Measure(expectedSize.Width, expectedSize.Height);
+			(contentPage as IFrameworkElement).Arrange(rect);
 			Assert.AreEqual(expectedSize, button.Bounds.Size);
-		}
-
-
-		void Layout(IFrameworkElement frameworkElement, double width, double height)
-		{
-			var size = frameworkElement.Measure(100, 100);
-			frameworkElement.Arrange(new Rectangle(0, 0, size.Width, size.Height));
 		}
 	}
 }

--- a/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
+++ b/src/Controls/tests/Core.UnitTests/Layouts/LayoutCompatTests.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using NSubstitute;
+using NUnit.Framework;
+
+namespace Microsoft.Maui.Controls.Core.UnitTests.Layouts
+{
+	public class LayoutCompatTests : BaseTestFixture
+	{
+		[Test]
+		public void BasicContentPage()
+		{
+			var page = new ContentPage() { IsPlatformEnabled = true };
+			var layout = new VerticalStackLayout() { IsPlatformEnabled = true };
+			var button = new Button() { IsPlatformEnabled = true };
+			var expectedSize = new Size(100, 100);
+
+			var view = Substitute.For<IViewHandler>();
+			view.GetDesiredSize(default, default).ReturnsForAnyArgs(expectedSize);
+			button.Handler = view;
+
+			layout.Add(button);
+			page.Content = layout;
+			(page as IFrameworkElement).Arrange(new Rectangle(0, 0, 100, 100));
+
+			Assert.AreEqual(expectedSize, button.Bounds.Size);
+		}
+
+		[Test]
+		public void VerticalStackLayoutInsideStackLayout()
+		{
+			var stackLayout = new StackLayout() { IsPlatformEnabled = true };
+			var verticalStackLayout = new VerticalStackLayout() { IsPlatformEnabled = true };
+			var button = new Button() { IsPlatformEnabled = true, HeightRequest = 100, WidthRequest = 100 };
+			var expectedSize = new Size(100, 100);
+
+			var view = Substitute.For<IViewHandler>();
+			view.GetDesiredSize(default, default).ReturnsForAnyArgs(expectedSize);
+			button.Handler = view;
+
+			stackLayout.Children.Add(verticalStackLayout);
+			verticalStackLayout.Add(button);
+
+			Layout(verticalStackLayout, 100, 100);
+			Assert.AreEqual(expectedSize, button.Bounds.Size);
+		}
+
+
+		[Test]
+		public void StackLayoutInsideVerticalStackLayout()
+		{
+			var stackLayout = new StackLayout() { IsPlatformEnabled = true };
+			var verticalStackLayout = new VerticalStackLayout() { IsPlatformEnabled = true };
+			var button = new Button() { IsPlatformEnabled = true, HeightRequest = 100, WidthRequest = 100 };
+			var expectedSize = new Size(100, 100);
+
+			var view = Substitute.For<IViewHandler>();
+			view.GetDesiredSize(default, default).ReturnsForAnyArgs(expectedSize);
+			button.Handler = view;
+
+			verticalStackLayout.Add(stackLayout);
+			stackLayout.Add(button);
+
+			Layout(verticalStackLayout, 100, 100);
+			Assert.AreEqual(expectedSize, button.Bounds.Size);
+		}
+
+
+		void Layout(IFrameworkElement frameworkElement, double width, double height)
+		{
+			var size = frameworkElement.Measure(100, 100);
+			frameworkElement.Arrange(new Rectangle(0, 0, size.Width, size.Height));
+		}
+	}
+}

--- a/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
+++ b/src/Core/src/Platform/iOS/MauiUIApplicationDelegate.cs
@@ -30,7 +30,7 @@ namespace Microsoft.Maui
 			//Hack for now we set this on the App Static but this should be on IFrameworkElement
 			App.Current.SetHandlerContext(window.MauiContext);
 
-			var content = window.Page.View;
+			var content = (window.Page as IView) ?? window.Page.View;
 
 			var uiWindow = new UIWindow
 			{


### PR DESCRIPTION
### Description of Change ###

- No longer sets IsArrangeValid from Layout. If Layout is called by legacy code that shouldn't stop the Arrange call
- Override GetSizeRequest on Layout2 to forward calls to measure because even though GetSizeRequest has been obsolete forever it's still called from different parts of the code
- Added tests for different arrangement scenarios of mixing Layout2 layouts and Controls layouts 

### Testing Procedure ###
- unit tests pass
- test different variations of layouts/controls in the sample appp

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
