### PR TITLE
#8293 - uwp - imagebutton - Font Icon Disappears when Minimizing Wind…

### DIFF
--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Platform.UWP
 		public ImageButtonRenderer() : base()
 		{
 			ImageElementManager.Init(this);
+			Windows.UI.Xaml.Application.Current.Resuming += OnResumingAsync;
 		}
 
 		protected override void Dispose(bool disposing)
@@ -40,6 +41,7 @@ namespace Xamarin.Forms.Platform.UWP
 				{
 					_image.ImageOpened -= OnImageOpened;
 					_image.ImageFailed -= OnImageFailed;
+					Windows.UI.Xaml.Application.Current.Resuming -= OnResumingAsync;
 				}
 			}
 
@@ -149,6 +151,18 @@ namespace Xamarin.Forms.Platform.UWP
 			await ImageElementManager.UpdateSource(this).ConfigureAwait(false);
 		}
 
+		async void OnResumingAsync(object sender, object e)
+		{
+			try
+			{
+				await ImageElementManager.UpdateSource(this);
+			}
+			catch (Exception exception)
+			{
+				Log.Warning("Update image source after app resume", 
+					$"ImageSource failed to update after app resume: {exception.Message}");				
+			}
+		}
 
 		void OnImageOpened(object sender, RoutedEventArgs routedEventArgs)
 		{


### PR DESCRIPTION
### Description of Change ###
Uwp seems to replace images with transparent images inside a button image when resuming the app after suspending it.
To fix this issue we set the ImageSource again when the app is resuming.
Refreshing the ImageSource is not enough.
To accomplish this the ButtonImageRenderer has to subscribe to the Resuming eventhandler.

### Issues Resolved ### 
- fixes #8293

### API Changes ###
Added:
 - `async void OnResumingAsync(object sender, object e)` in the `Xamarin.Forms.Platform.UWP.ButtonImageRenderer` which subscribed to `Windows.UI.Xaml.Application.Current.Resuming `
Changed:
 - none
 
 Removed:
 - none

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
- icon Images in an imagebutton are not transparent after suspending and then resuming the app again

### Before/After Screenshots ### 
- not fixed
  - before suspend
![image](https://user-images.githubusercontent.com/1429104/110437332-8db7c900-80b5-11eb-8a2a-14954e87bbba.png)
  - after suspend
![image](https://user-images.githubusercontent.com/1429104/110437504-bfc92b00-80b5-11eb-8c42-36619908d1af.png)
- fixed
  - before suspend
![image](https://user-images.githubusercontent.com/1429104/110437637-e25b4400-80b5-11eb-87f5-dbdebeceb640.png)
  - after suspend
![image](https://user-images.githubusercontent.com/1429104/110437676-ebe4ac00-80b5-11eb-9091-861d514205cb.png)

### Testing Procedure ###
1. Create a new Xamarin Forms app with an UWP project
2. Add a fonticon ([fa-regular-400.ttf](https://github.com/FortAwesome/Font-Awesome/blob/master/webfonts/fa-regular-400.ttf)) as Embedded resource into the shared project
3. Add in the assemblyInfo.cs this line:
```c# 
[assembly: ExportFont("fa-regular-400.ttf", Alias = "far")] 
```
4. Add an image button to the MainPage with an icon inside:
```xaml
<ImageButton HeightRequest="50" Margin="6" WidthRequest="50" BackgroundColor="Transparent" 
                           HorizontalOptions="FillAndExpand" VerticalOptions="Center">
  <ImageButton.Source>
    <FontImageSource Glyph="&#xf06e;" FontFamily="far" Size="44" Color="White"/>
  </ImageButton.Source>
</ImageButton>
```
5. Start the app
6. When the app is loaded suspend the app.
7. Resume the app
8. Image/icon should be visible and should not be transparent

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
