### PR TITLE
[Tizen] Fix CollectionView layout issue

### DIFF
--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
@@ -476,6 +476,7 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				(Adaptor as INotifyCollectionChanged).CollectionChanged -= OnCollectionChanged;
 				Adaptor.CollectionView = null;
 			}
+			_innerLayout.UnPackAll();
 		}
 
 		void OnAdaptorChanged()

--- a/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
+++ b/Xamarin.Forms.Platform.Tizen/Native/CollectionView/CollectionView.cs
@@ -613,7 +613,8 @@ namespace Xamarin.Forms.Platform.Tizen.Native
 				Scroller.HorizontalStepSize = _layoutManager.GetScrollBlockSize();
 				Scroller.VerticalStepSize = _layoutManager.GetScrollBlockSize();
 				UpdateSnapPointsType(SnapPointsType);
-				Device.BeginInvokeOnMainThread(SendScrolledEvent);
+				if (Geometry.Width > 0 && Geometry.Height > 0 )
+					Device.BeginInvokeOnMainThread(SendScrolledEvent);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
@@ -51,6 +51,11 @@ namespace Xamarin.Forms.Platform.Tizen
 					Element.ScrollToRequested -= OnScrollToRequest;
 					ItemsLayout.PropertyChanged -= OnLayoutPropertyChanged;
 					Control.Scrolled -= OnScrolled;
+					// Remove all child that created by ItemTemplate
+					foreach (var child in Element.LogicalChildren.ToList())
+					{
+						Element.RemoveLogicalChild(child);
+					}
 				}
 				if (_observableSource != null)
 				{

--- a/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Tizen/Renderers/ItemsViewRenderer.cs
@@ -168,6 +168,10 @@ namespace Xamarin.Forms.Platform.Tizen
 		{
 			if (!initialize)
 			{
+				if (Control.Adaptor != null)
+				{
+					Control.Adaptor.ItemSelected -= OnItemSelectedFromUI;
+				}
 				if (Element.ItemsSource == null || !Element.ItemsSource.Cast<object>().Any())
 				{
 					Control.Adaptor = EmptyItemAdaptor.Create(Element);


### PR DESCRIPTION
### Description of Change ###

This PR fixes
1. Add guard for invalid reference
- Prevent access to values before they are assigned
2. Fix CollectionView re-layouting issue
- Reset `LogicalChild` items so that re-layout can occur when `Element` is reused.
3. Fix adaptor for CollectionView
- Clean up adaptor when they change

### Issues Resolved ### 

- N/A

### API Changes ###
 
 None

### Platforms Affected ### 

- Tizen

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
