### PR TITLE
[macOS] Fix back button for nested nav pages

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843.cs
@@ -1,0 +1,78 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Navigation)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8843, "[Bug] [macOS] Fix back button for nested nav pages",
+		PlatformAffected.macOS)]
+	public partial class Issue8843 : TestContentPage
+	{
+		public Issue8843()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		private void UpdateLabel(Label label)
+		{
+			var tapGestureRecognizer = new TapGestureRecognizer();
+			tapGestureRecognizer.Tapped += (_s, _e) =>
+			{
+				var page2 = new Issue8843_Page2();
+				SwitchToNewPage(this, page2, true);
+			};
+			label.GestureRecognizers.Add(tapGestureRecognizer);
+		}
+
+		protected override void Init()
+		{
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				var mainLayout = this.FindByName<StackLayout>("mainLayout");
+				var theLabel = mainLayout.FindByName<Label>("theLabel");
+				UpdateLabel(theLabel);
+
+				// workaround for bug https://github.com/xamarin/Xamarin.Forms/issues/9526
+				theLabel.TextColor = Color.Black;
+			});
+		}
+
+		private void SwitchToNewPage(Page currentPage, Page newPage, bool navBar)
+		{
+			NavigationPage.SetHasNavigationBar(newPage, navBar);
+			var navPage = new NavigationPage(newPage);
+			NavigationPage.SetHasNavigationBar(navPage, navBar);
+			Device.BeginInvokeOnMainThread(() => DoubleCheckCompletionNonGeneric(currentPage.Navigation.PushAsync(navPage))
+			);
+		}
+		private void DoubleCheckCompletionNonGeneric(Task task)
+		{
+			task.ContinueWith((Task t) => { MaybeCrash(false, t.Exception); }, TaskContinuationOptions.OnlyOnFaulted);
+		}
+
+		private void MaybeCrash(bool canBeCancelled, Exception ex)
+		{
+			if (ex == null)
+			{
+				return;
+			}
+			else
+			{
+				Device.BeginInvokeOnMainThread(() => { throw ex; });
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843.xaml
@@ -1,0 +1,20 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8843"
+    Title="Issue 8843">
+    <StackLayout x:Name="mainLayout"
+                 Orientation="Vertical"
+                 VerticalOptions="Center"
+                 HorizontalOptions="Center">
+
+        <Label Text="Click here to go to next navigation page" x:Name="theLabel"
+               VerticalOptions="Center" HorizontalOptions="Center" />
+
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843_Page2.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843_Page2.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	public partial class Issue8843_Page2 : TestContentPage
+	{
+
+		public Issue8843_Page2()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843_Page2.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8843_Page2.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8843_Page2"
+    Title="Issue 8843">
+    <StackLayout x:Name="mainLayout"
+                 Padding="10,10,10,10"
+                 VerticalOptions="Center">
+        <Label x:Name="theLabel"
+               Text="&lt;- now go back..."
+               HorizontalOptions="Center" />
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -18,6 +18,8 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13126.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13126_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8843.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8843_Page2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -1860,6 +1862,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8787.xaml" />
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8843.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8843_Page2.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9771.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>


### PR DESCRIPTION
<!-- WAIT! 

After July 15, 2020, feature related pull requests cannot be guaranteed to merge by Xamarin.Forms 5.0. They will be labeled "maui" for transition to dotnet/maui. See the [transition to .NET MAUI](https://github.com/xamarin/Xamarin.Forms/wiki/Feature-Roadmap#transition-to-net-maui) for more information.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/main/.github/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

In the current implementation of NativeToolbarTracker,
having a nested navigation page causes the toolbar to get
overwritten by the child navigation page which in turns
causes the back button to be unusable because it only moves
in the scope of the child navigation stack so to mitigate
the issue this commit adds the possiblity for the back button
to move out of the child navigation stack back into the parent
navigation stack.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #8843

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- macOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

Toolbar back button now can move out of a nested navigation page into the parent page.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

Build and run the test case repo provided by the author of the issue before and after this change and compare the toolbar behaviour after moving to the new page

### PR Checklist ###
<!-- To be completed by reviewers -->

- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
