### PR TITLE
Fix error deleting items from BindableLayout using SwipeView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14066.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14066.xaml
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14066"
+    Title="Issue 14066">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Swipe any SwipeView, without exceptions, the test has passed." /> 
+        <StackLayout
+            Margin="30"
+            Orientation="Vertical">
+            <Button
+                Text="Add Items to the List"
+                Command="{Binding AddCommand}"
+                TextColor="White"
+                BackgroundColor="Black" />
+            <StackLayout
+                x:Name="MyList"
+                BindableLayout.ItemsSource="{Binding CollectionsList}">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate>
+                        <SwipeView>
+                            <Grid
+                                HeightRequest="40"
+                                BackgroundColor="White"
+                                Margin="10">
+                                <Label
+                                    VerticalOptions="CenterAndExpand"
+                                    Text="{Binding Name}" />
+                            </Grid>
+                            <SwipeView.LeftItems>
+                                <SwipeItems Mode="Execute">
+                                    <SwipeItemView
+                                        BackgroundColor="Red"
+                                        Command="{Binding Path=BindingContext.DeleteCommand, Source={x:Reference MyList}}"
+                                        CommandParameter="{Binding .}" />
+                                </SwipeItems>
+                            </SwipeView.LeftItems>
+                            <SwipeView.RightItems>
+                                <SwipeItems Mode="Execute">
+                                    <SwipeItemView
+                                        BackgroundColor="Red"
+                                        Command="{Binding Path=BindingContext.DeleteCommand, Source={x:Reference MyList}}"
+                                        CommandParameter="{Binding .}" />
+                                </SwipeItems>
+                            </SwipeView.RightItems>
+                        </SwipeView>
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+            </StackLayout>
+        </StackLayout>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14066.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14066.xaml.cs
@@ -1,0 +1,89 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14066, "[Bug] Deleting items with SwipeView in StackLayout",
+		PlatformAffected.Android)]
+	public partial class Issue14066 : TestContentPage
+	{
+		public Issue14066()
+		{
+#if APP
+			InitializeComponent();
+            BindingContext = new Issue14066ViewModel();
+#endif
+        }
+
+        protected override void Init()
+		{
+
+		}
+    }
+
+    public class Issue14066Model
+    {
+        public string Name { get; set; }
+    }
+
+    public class Issue14066ViewModel : BindableObject
+    {
+        ObservableCollection<Issue14066Model> _collectionsList;
+
+        public ObservableCollection<Issue14066Model> CollectionsList
+        {
+            get { return _collectionsList; }
+            set
+            {
+                _collectionsList = value;
+                OnPropertyChanged();
+            }
+        }
+
+        public ICommand DeleteCommand { get; }
+
+        public ICommand AddCommand { get; }
+
+
+        public Issue14066ViewModel()
+        {
+            CollectionsList = new ObservableCollection<Issue14066Model>()
+            {
+                new Issue14066Model { Name= "Item 1" },
+                new Issue14066Model { Name= "Item 2" },
+                new Issue14066Model { Name= "Item 3" },
+                new Issue14066Model { Name= "Item 4" },
+            };
+
+            DeleteCommand = new Command(OnDeleteTapped);
+
+            AddCommand = new Command(AddItmes);
+        }
+
+        void AddItmes(object obj)
+        {
+            Issue14066Model offersModel = new Issue14066Model
+            {
+				Name = "New Item Added"
+			};
+
+			CollectionsList.Add(offersModel);
+        }
+
+        void OnDeleteTapped(object obj)
+        {
+            var content = obj as Issue14066Model;
+            CollectionsList.Remove(content);
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1731,6 +1731,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13390.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13616.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14066.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2140,6 +2141,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13684.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14066.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -441,7 +441,7 @@ namespace Xamarin.Forms.Platform.Android
 				case MotionEventActions.Up:
 					handled = HandleTouchInteractions(GestureStatus.Completed, point);
 
-					if (Parent == null)
+					if (_isDisposed || Parent == null)
 						break;
 
 					Parent.RequestDisallowInterceptTouchEvent(false);
@@ -457,7 +457,7 @@ namespace Xamarin.Forms.Platform.Android
 				case MotionEventActions.Cancel:
 					handled = HandleTouchInteractions(GestureStatus.Canceled, point);
 
-					if (Parent == null)
+					if (_isDisposed || Parent == null)
 						break;
 
 					Parent.RequestDisallowInterceptTouchEvent(false);


### PR DESCRIPTION
### Description of Change ###

Fix error deleting items from BindableLayout using SwipeView.

### Issues Resolved ### 

- fixes #14066 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix14066](https://user-images.githubusercontent.com/6755973/112642072-3a7aa000-8e43-11eb-8f24-487efa587e03.gif)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14066. Swipe any SwipeView, without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
