### PR TITLE
Fixed the memory leak in the collectionview and gallery

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselCodeGallery.cs
@@ -10,7 +10,10 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 	{
 		readonly Label _scrollInfoLabel = new Label();
 		readonly ItemsLayoutOrientation _orientation;
-
+		ItemsSourceGenerator _generator;
+		PositionControl _positionControl;
+		CarouselView _carouselView;
+		Slider _padiSlider;
 		public CarouselCodeGallery(ItemsLayoutOrientation orientation)
 		{
 			On<iOS>().SetLargeTitleDisplay(LargeTitleDisplayMode.Never);
@@ -44,7 +47,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
 			var itemTemplate = ExampleTemplates.CarouselTemplate();
 
-			var carouselView = new CarouselView
+			_carouselView = new CarouselView
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
@@ -55,23 +58,21 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 
 			if (orientation == ItemsLayoutOrientation.Horizontal)
-				carouselView.PeekAreaInsets = new Thickness(30, 0, 30, 0);
+				_carouselView.PeekAreaInsets = new Thickness(30, 0, 30, 0);
 			else
-				carouselView.PeekAreaInsets = new Thickness(0, 30, 0, 30);
+				_carouselView.PeekAreaInsets = new Thickness(0, 30, 0, 30);
 
-			carouselView.Scrolled += CarouselViewScrolled;
+			StackLayout stacklayoutInfo = GetReadOnlyInfo(_carouselView);
 
-			StackLayout stacklayoutInfo = GetReadOnlyInfo(carouselView);
+			_generator = new ItemsSourceGenerator(_carouselView, initialItems: nItems, itemsSourceType: ItemsSourceType.ObservableCollection);
 
-			var generator = new ItemsSourceGenerator(carouselView, initialItems: nItems, itemsSourceType: ItemsSourceType.ObservableCollection);
+			_positionControl = new PositionControl(_carouselView, nItems);
 
-			var positionControl = new PositionControl(carouselView, nItems);
-
-			var spacingModifier = new SpacingModifier(carouselView.ItemsLayout, "Update Spacing");
+			var spacingModifier = new SpacingModifier(_carouselView.ItemsLayout, "Update Spacing");
 
 			var stckPeek = new StackLayout { Orientation = StackOrientation.Horizontal };
 			stckPeek.Children.Add(new Label { Text = "Peek" });
-			var padi = new Slider
+			_padiSlider = new Slider
 			{
 				Maximum = 100,
 				Minimum = 0,
@@ -80,34 +81,24 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 				BackgroundColor = Color.Pink
 			};
 
-			padi.ValueChanged += (s, e) =>
-			{
-				var peek = padi.Value;
-
-				if (orientation == ItemsLayoutOrientation.Horizontal)
-					carouselView.PeekAreaInsets = new Thickness(peek, 0, peek, 0);
-				else
-					carouselView.PeekAreaInsets = new Thickness(0, peek, 0, peek);
-			};
-
-			stckPeek.Children.Add(padi);
+			stckPeek.Children.Add(_padiSlider);
 
 			var content = new Grid();
-			content.Children.Add(carouselView);
+			content.Children.Add(_carouselView);
 
 #if DEBUG
 			// Uncomment this line to add a helper to visualize the center of each element.
 			//content.Children.Add(CreateDebuggerLines());
 #endif
-			layout.Children.Add(generator);
-			layout.Children.Add(positionControl);
+			layout.Children.Add(_generator);
+			layout.Children.Add(_positionControl);
 			layout.Children.Add(stacklayoutInfo);
 			layout.Children.Add(stckPeek);
 			layout.Children.Add(spacingModifier);
 			layout.Children.Add(_scrollInfoLabel);
 			layout.Children.Add(content);
 
-			Grid.SetRow(positionControl, 1);
+			Grid.SetRow(_positionControl, 1);
 			Grid.SetRow(stacklayoutInfo, 2);
 			Grid.SetRow(stckPeek, 3);
 			Grid.SetRow(spacingModifier, 4);
@@ -115,13 +106,50 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			Grid.SetRow(content, 6);
 
 			Content = layout;
-			generator.CollectionChanged += (sender, e) =>
-			{
-				positionControl.UpdatePositionCount(generator.Count);
-			};
 
-			generator.GenerateItems();
-			positionControl.UpdatePosition(1);
+			_generator.GenerateItems();
+			_positionControl.UpdatePosition(1);
+		}
+
+		private void Padi_ValueChanged(object sender, ValueChangedEventArgs e)
+		{
+			var peek = _padiSlider.Value;
+
+			if (_orientation == ItemsLayoutOrientation.Horizontal)
+				_carouselView.PeekAreaInsets = new Thickness(peek, 0, peek, 0);
+			else
+				_carouselView.PeekAreaInsets = new Thickness(0, peek, 0, peek);
+		}
+
+		private void Generator_CollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)
+		{
+			_positionControl.UpdatePositionCount(_generator.Count);
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			_carouselView.Scrolled += CarouselViewScrolled;
+
+			_padiSlider.ValueChanged += Padi_ValueChanged;
+
+			_generator.CollectionChanged += Generator_CollectionChanged;
+
+			_generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			_carouselView.Scrolled -= CarouselViewScrolled;
+
+			_padiSlider.ValueChanged -= Padi_ValueChanged;
+
+			_generator.CollectionChanged -= Generator_CollectionChanged;
+
+			_generator.UnsubscribeEvents();
 		}
 
 		void CarouselViewScrolled(object sender, ItemsViewScrolledEventArgs e)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/IndicatorCodeGallery.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 	[Preserve(AllMembers = true)]
 	public class IndicatorCodeGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
 		CarouselView _carouselView;
 		Button _btnPrev;
 		Button _btnNext;
@@ -51,7 +52,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			};
 
 			layout.Children.Add(_carouselView);
-			var generator = new ItemsSourceGenerator(_carouselView, nItems, ItemsSourceType.ObservableCollection);
+			generator = new ItemsSourceGenerator(_carouselView, nItems, ItemsSourceType.ObservableCollection);
 			layout.Children.Add(generator);
 
 			generator.GenerateItems();
@@ -261,6 +262,20 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 			layout.Children.Add(layoutBtn);
 			Grid.SetRow(layoutBtn, 5);
 			Content = layout;
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 
 		void IndicatorCodeGalleryCollectionChanged(object sender, System.Collections.Specialized.NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/DynamicItemSizeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/DynamicItemSizeGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class DynamicItemSizeGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public DynamicItemSizeGallery(IItemsLayout itemsLayout)
 		{
 			var layout = new Grid
@@ -28,7 +30,7 @@
 				AutomationId = "collectionview"
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
+			generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
 
 			layout.Children.Add(generator);
 			layout.Children.Add(instructions);
@@ -40,6 +42,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/VariableSizeTemplateGridGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemSizeGalleries/VariableSizeTemplateGridGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class VariableSizeTemplateGridGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public VariableSizeTemplateGridGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical)
 		{
 			var layout = new Grid
@@ -26,7 +28,7 @@
 				ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, 100);
+			generator = new ItemsSourceGenerator(collectionView, 100);
 
 			var explanation = new Label();
 			UpdateExplanation(explanation, collectionView.ItemSizingStrategy);
@@ -52,6 +54,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 
 		static void UpdateExplanation(Label explanation, ItemSizingStrategy strategy)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemsSourceGenerator.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ItemsSourceGenerator.cs
@@ -22,6 +22,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 		private readonly ItemsSourceType _itemsSourceType;
 		readonly Entry _entry;
 		int _count = 0;
+		Button button;
 
 		CarouselView carousel => _cv as CarouselView;
 
@@ -38,7 +39,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 				HorizontalOptions = LayoutOptions.Fill
 			};
 
-			var button = new Button { Text = "Update", AutomationId = "btnUpdate" };
+			button = new Button { Text = "Update", AutomationId = "btnUpdate" };
 			var label = new Label { Text = "Items:", VerticalTextAlignment = TextAlignment.Center };
 			_entry = new Entry { Keyboard = Keyboard.Numeric, Text = initialItems.ToString(), WidthRequest = 100, AutomationId = "entryUpdate" };
 
@@ -48,13 +49,23 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 
 			layout.Children.Add(button);
 
+
+			Content = layout;
+		}
+
+		public void SubscribeEvents()
+		{
 			button.Clicked += GenerateItems;
 			MessagingCenter.Subscribe<ExampleTemplateCarousel>(this, "remove", (obj) =>
 			{
-				(cv.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>).Remove(obj.BindingContext as CollectionViewGalleryTestItem);
+				(_cv.ItemsSource as ObservableCollection<CollectionViewGalleryTestItem>).Remove(obj.BindingContext as CollectionViewGalleryTestItem);
 			});
 
-			Content = layout;
+		}
+		public void UnsubscribeEvents()
+		{
+			button.Clicked -= GenerateItems;
+			MessagingCenter.Unsubscribe<ExampleTemplateCarousel>(this, "remove");
 		}
 
 		readonly string[] _images =

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCodeCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCodeCollectionViewGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class ObservableCodeCollectionViewGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public ObservableCodeCollectionViewGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical,
 			bool grid = true, int initialItems = 1000, bool addItemsWithTimer = false, ItemsUpdatingScrollMode scrollMode = ItemsUpdatingScrollMode.KeepItemsInView)
 		{
@@ -34,7 +36,7 @@
 				ItemsUpdatingScrollMode = scrollMode
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems, ItemsSourceType.ObservableCollection);
+			generator = new ItemsSourceGenerator(collectionView, initialItems, ItemsSourceType.ObservableCollection);
 
 			var remover = new ItemRemover(collectionView);
 			var adder = new ItemAdder(collectionView);
@@ -68,6 +70,23 @@
 				generator.GenerateEmptyObservableCollectionAndAddItemsEverySecond();
 			else
 				generator.GenerateItems();
+		}
+
+
+
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionResetGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableCollectionResetGallery.cs
@@ -2,6 +2,9 @@
 {
 	internal class ObservableCollectionResetGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
+
 		public ObservableCollectionResetGallery()
 		{
 			var layout = new Grid
@@ -20,7 +23,7 @@
 
 			var collectionView = new CollectionView { ItemsLayout = itemsLayout, ItemTemplate = itemTemplate };
 
-			var generator = new ItemsSourceGenerator(collectionView, 100, ItemsSourceType.MultiTestObservableCollection);
+			generator = new ItemsSourceGenerator(collectionView, 100, ItemsSourceType.MultiTestObservableCollection);
 
 			layout.Children.Add(generator);
 
@@ -34,6 +37,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableMultiItemCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ObservableMultiItemCollectionViewGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class ObservableMultiItemCollectionViewGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public ObservableMultiItemCollectionViewGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical,
 			bool grid = true, int initialItems = 1000, bool withIndex = false)
 		{
@@ -26,7 +28,7 @@
 
 			var collectionView = new CollectionView { ItemsLayout = itemsLayout, ItemTemplate = itemTemplate, AutomationId = "collectionview" };
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems, ItemsSourceType.MultiTestObservableCollection);
+			generator = new ItemsSourceGenerator(collectionView, initialItems, ItemsSourceType.MultiTestObservableCollection);
 
 			var remover = new MultiItemRemover(collectionView, withIndex);
 
@@ -54,6 +56,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/PropagateCodeGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class PropagateCodeGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public PropagateCodeGallery(IItemsLayout itemsLayout, int itemsCount = 2)
 		{
 			Title = $"Propagate FlowDirection=RTL";
@@ -31,7 +33,7 @@
 				EmptyView = emptyView
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: itemsCount);
+			generator = new ItemsSourceGenerator(collectionView, initialItems: itemsCount);
 			layout.Children.Add(generator);
 			var instructions = new Label();
 			UpdateInstructions(layout, instructions, itemsCount == 0);
@@ -64,6 +66,21 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 
 		static void UpdateInstructions(Layout layout, Label instructions, bool isEmpty)

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/ScrollToCodeGallery.cs
@@ -4,6 +4,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 {
 	internal class ScrollToCodeGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public ScrollToCodeGallery(IItemsLayout itemsLayout, ScrollToMode mode = ScrollToMode.Position, Func<DataTemplate> dataTemplate = null, Func<CollectionView> createCollectionView = null)
 		{
 			createCollectionView = createCollectionView ?? (() => new CollectionView());
@@ -27,7 +29,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			collectionView.ItemsLayout = itemsLayout;
 			collectionView.ItemTemplate = itemTemplate;
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: 50);
+			generator = new ItemsSourceGenerator(collectionView, initialItems: 50);
 			layout.Children.Add(generator);
 
 			if (mode == ScrollToMode.Position)
@@ -50,6 +52,20 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SnapPointsCodeGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SnapPointsCodeGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class SnapPointsCodeGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public SnapPointsCodeGallery(ItemsLayout itemsLayout)
 		{
 			Title = $"Snap Points (Code, {itemsLayout})";
@@ -22,14 +24,14 @@
 			itemsLayout.SnapPointsType = SnapPointsType.None;
 
 			var itemTemplate = ExampleTemplates.SnapPointsTemplate();
-
+			
 			var collectionView = new CollectionView
 			{
 				ItemsLayout = itemsLayout,
 				ItemTemplate = itemTemplate,
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: 50);
+			generator = new ItemsSourceGenerator(collectionView, initialItems: 50);
 
 			var snapPointsTypeSelector = new EnumSelector<SnapPointsType>(() => itemsLayout.SnapPointsType,
 				type => itemsLayout.SnapPointsType = type);
@@ -54,6 +56,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SpacingGalleries/SpacingGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/SpacingGalleries/SpacingGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class SpacingGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public SpacingGallery(IItemsLayout itemsLayout)
 		{
 			var layout = new Grid
@@ -35,7 +37,7 @@
 				Margin = 10
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
+			generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
 			var spacingModifier = new SpacingModifier(collectionView.ItemsLayout, "Update_Spacing");
 
 			layout.Children.Add(generator);
@@ -50,6 +52,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TemplateCodeCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TemplateCodeCollectionViewGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class TemplateCodeCollectionViewGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public TemplateCodeCollectionViewGallery(IItemsLayout itemsLayout)
 		{
 			var layout = new Grid
@@ -23,7 +25,7 @@
 				BackgroundColor = Color.Red
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
+			generator = new ItemsSourceGenerator(collectionView, initialItems: 20);
 
 			layout.Children.Add(generator);
 			layout.Children.Add(collectionView);
@@ -33,6 +35,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TemplateCodeCollectionViewGridGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TemplateCodeCollectionViewGridGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class TemplateCodeCollectionViewGridGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public TemplateCodeCollectionViewGridGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical)
 		{
 			var layout = new Grid
@@ -20,7 +22,7 @@
 
 			var collectionView = new CollectionView { ItemsLayout = itemsLayout, ItemTemplate = itemTemplate, AutomationId = "collectionview" };
 
-			var generator = new ItemsSourceGenerator(collectionView, 100);
+			generator = new ItemsSourceGenerator(collectionView, 100);
 			var spanSetter = new SpanSetter(collectionView);
 
 			layout.Children.Add(generator);
@@ -33,6 +35,20 @@
 
 			spanSetter.UpdateSpan();
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TextCodeCollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TextCodeCollectionViewGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class TextCodeCollectionViewGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public TextCodeCollectionViewGallery(IItemsLayout itemsLayout)
 		{
 			var layout = new Grid
@@ -20,7 +22,7 @@
 				AutomationId = "collectionview"
 			};
 
-			var generator = new ItemsSourceGenerator(collectionView);
+			generator = new ItemsSourceGenerator(collectionView);
 
 			layout.Children.Add(generator);
 			layout.Children.Add(collectionView);
@@ -29,6 +31,20 @@
 			Content = layout;
 
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TextCodeCollectionViewGridGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/TextCodeCollectionViewGridGallery.cs
@@ -2,6 +2,8 @@
 {
 	internal class TextCodeCollectionViewGridGallery : ContentPage
 	{
+		ItemsSourceGenerator generator;
+
 		public TextCodeCollectionViewGridGallery(ItemsLayoutOrientation orientation = ItemsLayoutOrientation.Vertical)
 		{
 			var layout = new Grid
@@ -18,7 +20,7 @@
 
 			var collectionView = new CollectionView { ItemsLayout = itemsLayout, AutomationId = "collectionview" };
 
-			var generator = new ItemsSourceGenerator(collectionView);
+			generator = new ItemsSourceGenerator(collectionView);
 			var spanSetter = new SpanSetter(collectionView);
 
 			layout.Children.Add(generator);
@@ -31,6 +33,20 @@
 
 			spanSetter.UpdateSpan();
 			generator.GenerateItems();
+		}
+
+		protected override void OnAppearing()
+		{
+			base.OnAppearing();
+
+			generator.SubscribeEvents();
+		}
+
+		protected override void OnDisappearing()
+		{
+			base.OnDisappearing();
+
+			generator.UnsubscribeEvents();
 		}
 	}
 }

--- a/Xamarin.Forms.Core/TemplatedItemsList.cs
+++ b/Xamarin.Forms.Core/TemplatedItemsList.cs
@@ -242,6 +242,12 @@ namespace Xamarin.Forms.Internals
 				if (item != null)
 					UnhookItem(item);
 			}
+			
+			for (var i = 0; i < _groupedItems?.Count; i++)
+			{
+				var item = _groupedItems[i];
+				item.CollectionChanged -= OnInnerCollectionChanged;
+			}
 
 			_disposed = true;
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -59,6 +59,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (disposing)
 			{
+				UnbindCells();
+				_measurementCells = null;
+			
 				ItemsSource?.Dispose();
 
 				CollectionView.Delegate = null;
@@ -71,6 +74,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 				ItemsViewLayout?.Dispose();
 				CollectionView?.Dispose();
+
 			}
 
 			base.Dispose(disposing);
@@ -108,6 +112,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (_isEmpty)
 			{
+				UnbindCells();
 				_measurementCells.Clear();
 				ItemsViewLayout?.ClearCellSizeCache();
 			}
@@ -123,6 +128,24 @@ namespace Xamarin.Forms.Platform.iOS
 				// a prototype cell and our itemSize or estimatedItemSize are wrong/unset
 				// So trigger a constraint update; if we need a measurement, that will make it happen
 				ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
+			}
+		}
+
+		private void UnbindCells()
+		{
+			if (_measurementCells == null || _measurementCells.Count == 0)
+				return;
+
+			foreach (var _cell in _measurementCells)
+			{
+				var _tCell = _cell.Value;
+				if (_tCell == null)
+					continue;
+
+				_tCell.Unbind();
+
+				_tCell.ContentSizeChanged -= CellContentSizeChanged;
+				_tCell.LayoutAttributesChanged -= CellLayoutAttributesChanged;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs
@@ -159,6 +159,12 @@ namespace Xamarin.Forms.Platform.iOS
 			CurrentTemplate = itemTemplate;
 		}
 
+		public void Unbind()
+		{
+			if (VisualElementRenderer?.Element != null)
+				VisualElementRenderer.Element.MeasureInvalidated -= MeasureInvalidated;
+		}
+
 		void SetRenderer(IVisualElementRenderer renderer)
 		{
 			VisualElementRenderer = renderer;


### PR DESCRIPTION
### Description of Change ###
Event handlers on the TemplatedCell are not being removed which results in the control to be left in memory which keeps the page where it is loaded also to stay behind in memory.

I added an unbind method on the TemplatedCell and unbind the event handlers in the ItemsViewController.
Also the TemplatedItemsList had a collectionchanged event which was not removed so I removed that as well.

If there is a better way to achieve this, please let me know and I will fix it in a better way.

Xamarin.Forms.Core/TemplatedItemsList.cs
Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
Xamarin.Forms.Platform.iOS/CollectionView/TemplatedCell.cs

All the other files are eventhandler fixes in the Gallery code.

### Issues Resolved ### 

- fixes #9787

### API Changes ###
Added: Unbind() on TemplatedCell.cs to remove events

### Platforms Affected ### 
- iOS
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Go to the templated collectionview pages in the gallery and go back. Repeat couple of times and see page count increasing in the Xamarin Profiler.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
