### PR TITLE
Fix up Android Accessibility behind a flag

### DIFF
--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -19,6 +19,7 @@
         <dependency id="Xamarin.Google.Android.Material" version="1.2.1.1" />
         <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.6" />
         <dependency id="Xamarin.AndroidX.Browser" version="1.3.0" />
+        <dependency id="Xamarin.AndroidX.Navigation.UI" version="2.3.2.1" />
       </group>
       <group targetFramework="uap10.0.14393">
         <dependency id="NETStandard.Library" version="2.0.1"/>

--- a/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.ControlGallery.Android/FormsAppCompatActivity.cs
@@ -49,7 +49,10 @@ namespace Xamarin.Forms.ControlGallery.Android
 #else
 			Forms.SetFlags("UseLegacyRenderers");
 #endif
+			// Forms.SetFlags("AccessibilityExperimental");
 			Forms.Init(this, bundle);
+
+
 
 			// null out the assembly on the Resource Manager
 			// so all of our tests run without using the reflection APIs

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -11,6 +11,7 @@ namespace Xamarin.Forms
 	{
 		internal const string ShellUWPExperimental = "Shell_UWP_Experimental";
 
+		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void VerifyFlagEnabled(
 			string coreComponentName,
 			string flagName,

--- a/Xamarin.Forms.Core/ExperimentalFlags.cs
+++ b/Xamarin.Forms.Core/ExperimentalFlags.cs
@@ -11,7 +11,6 @@ namespace Xamarin.Forms
 	{
 		internal const string ShellUWPExperimental = "Shell_UWP_Experimental";
 
-		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static void VerifyFlagEnabled(
 			string coreComponentName,
 			string flagName,

--- a/Xamarin.Forms.Platform.Android/AccessibilityDelegateAutomationId.cs
+++ b/Xamarin.Forms.Platform.Android/AccessibilityDelegateAutomationId.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Text;
 using Android.Views.Accessibility;
 using AndroidX.AppCompat.Widget;
+using AndroidX.Core.View;
+using AndroidX.Core.View.Accessibiity;
 using Xamarin.Forms.Platform.Android.FastRenderers;
-using AAccessibilityDelegate = Android.Views.View.AccessibilityDelegate;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	class AccessibilityDelegateAutomationId : AAccessibilityDelegate
+	class AccessibilityDelegateAutomationId : AccessibilityDelegateCompat
+
 	{
 		BindableObject _element;
 
@@ -18,7 +20,7 @@ namespace Xamarin.Forms.Platform.Android
 		}
 
 
-		public override void OnInitializeAccessibilityNodeInfo(global::Android.Views.View host, AccessibilityNodeInfo info)
+		public override void OnInitializeAccessibilityNodeInfo(global::Android.Views.View host, AccessibilityNodeInfoCompat info)
 		{
 			base.OnInitializeAccessibilityNodeInfo(host, info);
 

--- a/Xamarin.Forms.Platform.Android/AccessibilityDelegateAutomationId.cs
+++ b/Xamarin.Forms.Platform.Android/AccessibilityDelegateAutomationId.cs
@@ -1,0 +1,49 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Text;
+using Android.Views.Accessibility;
+using AndroidX.AppCompat.Widget;
+using Xamarin.Forms.Platform.Android.FastRenderers;
+using AAccessibilityDelegate = Android.Views.View.AccessibilityDelegate;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	class AccessibilityDelegateAutomationId : AAccessibilityDelegate
+	{
+		BindableObject _element;
+
+		public AccessibilityDelegateAutomationId(BindableObject element) : base()
+		{
+			_element = element;
+		}
+
+
+		public override void OnInitializeAccessibilityNodeInfo(global::Android.Views.View host, AccessibilityNodeInfo info)
+		{
+			base.OnInitializeAccessibilityNodeInfo(host, info);
+
+			if (_element == null)
+				return;
+
+			if(Flags.IsAccessibilityExperimentalSet())
+			{
+				var value = AutomationPropertiesProvider.ConcatenateNameAndHelpText(_element);
+				if (!string.IsNullOrWhiteSpace(value))
+				{
+					host.ContentDescription = value;
+				}
+				else if(host.ContentDescription == (_element as VisualElement)?.AutomationId)
+				{
+					host.ContentDescription = null;
+				}
+			}
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			_element = null;
+			base.Dispose(disposing);
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -61,8 +61,8 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					var textField = CreateNativeControl();
 
 					SetNativeControl(textField);
-
-					ViewCompat.SetAccessibilityDelegate(ControlUsedForAutomation, _pickerAccessibilityDelegate);
+					ViewCompat.SetAccessibilityDelegate(
+						ControlUsedForAutomation, _pickerAccessibilityDelegate = new EntryAccessibilityDelegate(Element));
 				}
 				UpdateFont();
 				UpdatePicker();

--- a/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/PickerRenderer.cs
@@ -8,6 +8,7 @@ using Android.Text;
 using Android.Text.Style;
 using Android.Util;
 using Android.Widget;
+using AndroidX.Core.View;
 
 namespace Xamarin.Forms.Platform.Android.AppCompat
 {
@@ -61,7 +62,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 					SetNativeControl(textField);
 
-					ControlUsedForAutomation.SetAccessibilityDelegate(_pickerAccessibilityDelegate = new EntryAccessibilityDelegate(Element));
+					ViewCompat.SetAccessibilityDelegate(ControlUsedForAutomation, _pickerAccessibilityDelegate);
 				}
 				UpdateFont();
 				UpdatePicker();

--- a/Xamarin.Forms.Platform.Android/EntryAccessibilityDelegate.cs
+++ b/Xamarin.Forms.Platform.Android/EntryAccessibilityDelegate.cs
@@ -3,13 +3,13 @@ using Xamarin.Forms.Platform.Android.FastRenderers;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	class EntryAccessibilityDelegate : global::Android.Views.View.AccessibilityDelegate
+	class EntryAccessibilityDelegate : AccessibilityDelegateAutomationId
 	{
 		BindableObject _element;
 
-		public EntryAccessibilityDelegate(BindableObject Element) : base()
+		public EntryAccessibilityDelegate(BindableObject element) : base(element)
 		{
-			_element = Element;
+			_element = element;
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/EntryAccessibilityDelegate.cs
+++ b/Xamarin.Forms.Platform.Android/EntryAccessibilityDelegate.cs
@@ -1,4 +1,5 @@
 ﻿using Android.Views.Accessibility;
+using AndroidX.Core.View.Accessibiity;
 using Xamarin.Forms.Platform.Android.FastRenderers;
 
 namespace Xamarin.Forms.Platform.Android
@@ -22,7 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 
 		public string ClassName { get; set; } = "android.widget.Button";
 
-		public override void OnInitializeAccessibilityNodeInfo(global::Android.Views.View host, AccessibilityNodeInfo info)
+		public override void OnInitializeAccessibilityNodeInfo(global::Android.Views.View host, AccessibilityNodeInfoCompat info)
 		{
 			base.OnInitializeAccessibilityNodeInfo(host, info);
 			info.ClassName = ClassName;

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -32,8 +32,14 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		}
 
 		static bool ShoudISetImportantForAccessibilityToNoIfAutomationIdIsSet(AView control, Element element)
-		{
+		{			
 			if (!Flags.IsAccessibilityExperimentalSet())
+				return false;
+
+			if (element == null)
+				return false;
+
+			if (String.IsNullOrWhiteSpace(element.AutomationId))
 				return false;
 
 			// User has specifically said what they want

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Runtime.InteropServices.WindowsRuntime;
 using Android.Views;
 using Android.Widget;
+using AndroidX.Core.View;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android.FastRenderers
@@ -85,7 +86,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 					control.ImportantForAccessibility = ImportantForAccessibility.No;
 				}
 				else if (Flags.IsAccessibilityExperimentalSet() && control.GetAccessibilityDelegate() == null)
-					control.SetAccessibilityDelegate(new AccessibilityDelegateAutomationId(element));
+					ViewCompat.SetAccessibilityDelegate(control, new AccessibilityDelegateAutomationId(element));
 
 			}
 		}

--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -1,5 +1,6 @@
 using System;
 using System.ComponentModel;
+using System.Runtime.InteropServices.WindowsRuntime;
 using Android.Views;
 using Android.Widget;
 using AView = Android.Views.View;
@@ -30,52 +31,96 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			resourceIdClose = context.Resources.GetIdentifier($"{automationIdParent}{s_defaultDrawerIdCloseSuffix}", "string", context.ApplicationInfo.PackageName);
 		}
 
-
-		internal static void SetAutomationId(AView control, Element element, string value = null)
+		static bool ShoudISetImportantForAccessibilityToNoIfAutomationIdIsSet(AView control, Element element)
 		{
-			if (!control.IsAlive() || element == null)
+			if (!Flags.IsAccessibilityExperimentalSet())
+				return false;
+
+			// User has specifically said what they want
+			if (AutomationProperties.GetIsInAccessibleTree(element) == true)
+				return false;
+
+			// User has explicitly set name and help text so we honor that
+			if (!String.IsNullOrWhiteSpace(ConcatenateNameAndHelpText(element)))
+				return false;
+
+			if (element is Layout ||
+				element is ItemsView ||
+				element is BoxView ||
+				element is ScrollView ||
+				element is TableView ||
+				element is WebView ||
+				element is Page ||
+				element is Shapes.Path ||
+				element is Frame ||
+				element is ListView ||
+				element is Image)
 			{
-				return;
+				return true;
 			}
 
-			SetAutomationId(control, element.AutomationId, value);
+			return false;
 		}
 
-		internal static void SetAutomationId(AView control, string automationId, string value = null)
+		internal static void SetAutomationId(AView control, Element element, string value = null)
 		{
 			if (!control.IsAlive())
 			{
 				return;
 			}
 
-			automationId = value ?? automationId;
+			string automationId = value ?? element?.AutomationId;
 			if (!string.IsNullOrEmpty(automationId))
 			{
 				control.ContentDescription = automationId;
+
+				if (ShoudISetImportantForAccessibilityToNoIfAutomationIdIsSet(control, element))
+				{
+					control.ImportantForAccessibility = ImportantForAccessibility.No;
+				}
+				else if (Flags.IsAccessibilityExperimentalSet() && control.GetAccessibilityDelegate() == null)
+					control.SetAccessibilityDelegate(new AccessibilityDelegateAutomationId(element));
+
 			}
 		}
 
 		internal static void SetBasicContentDescription(
 			AView control,
-			BindableObject bindableObject,
+			Element element,
 			string defaultContentDescription)
 		{
-			if (bindableObject == null || control == null)
+			if (element == null || control == null)
 				return;
 
-			string value = ConcatenateNameAndHelpText(bindableObject);
+			string value = ConcatenateNameAndHelpText(element);
 
 			var contentDescription = !string.IsNullOrWhiteSpace(value) ? value : defaultContentDescription;
 
-			if (String.IsNullOrWhiteSpace(contentDescription) && bindableObject is Element element)
+			if (String.IsNullOrWhiteSpace(contentDescription))
+			{
+				if(Flags.IsAccessibilityExperimentalSet())
+				{
+					SetAutomationId(control, element, element.AutomationId);
+					return;
+				}
+
 				contentDescription = element.AutomationId;
+			}
+
+			if (Flags.IsAccessibilityExperimentalSet())
+			{
+				if (!AutomationProperties.GetIsInAccessibleTree(element).HasValue)
+				{
+					control.ImportantForAccessibility = ImportantForAccessibility.Auto;
+				}
+			}
 
 			control.ContentDescription = contentDescription;
 		}
 
 		internal static void SetContentDescription(
 			AView control,
-			BindableObject element,
+			Element element,
 			string defaultContentDescription,
 			string defaultHint)
 		{
@@ -96,12 +141,21 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			{
 				defaultFocusable = control.Focusable;
 			}
+						
 			if (!defaultImportantForAccessibility.HasValue)
 			{
-				defaultImportantForAccessibility = control.ImportantForAccessibility;
+				// Auto is the default just use that
+				if (Flags.IsAccessibilityExperimentalSet())
+					defaultImportantForAccessibility = ImportantForAccessibility.Auto;
+				else
+					defaultImportantForAccessibility = control.ImportantForAccessibility;
 			}
 
 			bool? isInAccessibleTree = (bool?)element.GetValue(AutomationProperties.IsInAccessibleTreeProperty);
+
+			if (!isInAccessibleTree.HasValue && Flags.IsAccessibilityExperimentalSet())
+				return;
+
 			control.Focusable = (bool)(isInAccessibleTree ?? defaultFocusable);
 			control.ImportantForAccessibility = !isInAccessibleTree.HasValue ? (ImportantForAccessibility)defaultImportantForAccessibility : (bool)isInAccessibleTree ? ImportantForAccessibility.Yes : ImportantForAccessibility.No;
 		}
@@ -253,12 +307,16 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 		internal static void SetupDefaults(AView control, ref string defaultContentDescription, ref string defaultHint)
 		{
-			if (defaultContentDescription == null)
-				defaultContentDescription = control.ContentDescription;
-
-			if (control is TextView textView && defaultHint == null)
+			// Setting defaults for these values makes no sense
+			if (!Flags.IsAccessibilityExperimentalSet())
 			{
-				defaultHint = textView.Hint;
+				if (defaultContentDescription == null)
+					defaultContentDescription = control.ContentDescription;
+
+				if (control is TextView textView && defaultHint == null)
+				{
+					defaultHint = textView.Hint;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Flags.cs
+++ b/Xamarin.Forms.Platform.Android/Flags.cs
@@ -6,7 +6,7 @@ namespace Xamarin.Forms
 	{
 		internal const string UseLegacyRenderers = "UseLegacyRenderers";
 
-		internal const string AccessibilityExperimental = "AccessibilityExperimental";
+		internal const string AccessibilityExperimental = "Accessibility_Experimental";
 
 		public static bool IsFlagSet(string flagName)
 		{
@@ -15,7 +15,7 @@ namespace Xamarin.Forms
 
 		public static bool IsAccessibilityExperimentalSet()
 		{
-			return IsFlagSet(nameof(AccessibilityExperimental));
+			return IsFlagSet(AccessibilityExperimental);
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Flags.cs
+++ b/Xamarin.Forms.Platform.Android/Flags.cs
@@ -1,7 +1,21 @@
+using System.Linq;
+
 namespace Xamarin.Forms
 {
 	internal static class Flags
 	{
 		internal const string UseLegacyRenderers = "UseLegacyRenderers";
+
+		internal const string AccessibilityExperimental = "AccessibilityExperimental";
+
+		public static bool IsFlagSet(string flagName)
+		{
+			return Device.Flags != null && Device.Flags.Contains(flagName);
+		}
+
+		public static bool IsAccessibilityExperimentalSet()
+		{
+			return IsFlagSet(nameof(AccessibilityExperimental));
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
@@ -17,8 +17,11 @@ namespace Xamarin.Forms.Platform.Android
 		public PlatformRenderer(Context context, IPlatformLayout canvas) : base(context)
 		{
 			_canvas = canvas;
-			Focusable = true;
-			FocusableInTouchMode = true;
+			if (!Flags.IsAccessibilityExperimentalSet())
+			{
+				Focusable = true;
+				FocusableInTouchMode = true;
+			}
 		}
 
 		public override bool DispatchTouchEvent(MotionEvent e)

--- a/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PageRenderer.cs
@@ -80,7 +80,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			UpdateBackground(false);
 
-			Clickable = true;
+			if(!Flags.IsAccessibilityExperimentalSet())
+				Clickable = true;
 		}
 
 		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/PickerRenderer.cs
@@ -9,6 +9,7 @@ using Android.Text.Style;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using AndroidX.Core.View;
 using AColor = Android.Graphics.Color;
 using Orientation = Android.Widget.Orientation;
 
@@ -67,7 +68,7 @@ namespace Xamarin.Forms.Platform.Android
 				{
 					var textField = CreateNativeControl();
 
-					textField.SetAccessibilityDelegate(_pickerAccessibilityDelegate = new EntryAccessibilityDelegate(Element));
+					ViewCompat.SetAccessibilityDelegate(textField, _pickerAccessibilityDelegate = new EntryAccessibilityDelegate(Element));
 
 					var useLegacyColorManagement = e.NewElement.UseLegacyColorManagement();
 					_textColorSwitcher = new TextColorSwitcher(textField.TextColors, useLegacyColorManagement);

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
@@ -117,8 +117,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			FastRenderers
 				.AutomationPropertiesProvider
-				.SetAutomationId(_editText, _searchHandler?.AutomationId);
-
+				.SetAutomationId(_editText, null, _searchHandler?.AutomationId);
 		}
 
 		void UpdateFont()

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSectionRenderer.cs
@@ -144,6 +144,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			_toolbar = root.FindViewById<Toolbar>(Resource.Id.main_toolbar);
 			_viewPager = root.FindViewById<FormsViewPager>(Resource.Id.main_viewpager);
+
 			_tablayout = root.FindViewById<TabLayout>(Resource.Id.main_tablayout);
 
 			_viewPager.EnableGesture = false;
@@ -177,7 +178,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (SectionController.GetItems().Count == 1)
 			{
-				_tablayout.Visibility = ViewStates.Gone;
+				UpdateTablayoutVisibility();
 			}
 
 			_tablayout.LayoutChange += OnTabLayoutChange;
@@ -264,8 +265,22 @@ namespace Xamarin.Forms.Platform.Android
 			AnimationFinished?.Invoke(this, e);
 		}
 
-		protected virtual void OnItemsCollectionChagned(object sender, NotifyCollectionChangedEventArgs e) =>
+		protected virtual void OnItemsCollectionChagned(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			UpdateTablayoutVisibility();
+		}
+
+		void UpdateTablayoutVisibility()
+		{
 			_tablayout.Visibility = (SectionController.GetItems().Count > 1) ? ViewStates.Visible : ViewStates.Gone;
+			if (Flags.IsAccessibilityExperimentalSet())
+			{
+				if (_tablayout.Visibility == ViewStates.Gone)
+					_viewPager.ImportantForAccessibility = ImportantForAccessibility.No;
+				else
+					_viewPager.ImportantForAccessibility = ImportantForAccessibility.Auto;
+			}
+		}
 
 		protected virtual void OnShellItemPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -333,7 +333,11 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			if (_drawerToggle == null && !context.IsDesignerContext())
 			{
-				_drawerToggle = new ActionBarDrawerToggle(context.GetActivity(), drawerLayout, toolbar, R.String.Ok, R.String.Ok)
+				var openId = R.String.Ok;
+				if (Flags.IsAccessibilityExperimentalSet())
+					openId = Resource.String.nav_app_bar_open_drawer_description;
+
+				_drawerToggle = new ActionBarDrawerToggle(context.GetActivity(), drawerLayout, toolbar, openId, R.String.Ok)
 				{
 					ToolbarNavigationClickListener = this,
 				};
@@ -451,8 +455,13 @@ namespace Xamarin.Forms.Platform.Android
 			else if (image == null ||
 				toolbar.SetNavigationContentDescription(image) == null)
 			{
-				if(CanNavigateBack && Flags.IsAccessibilityExperimentalSet())
-					toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_navigate_up_description);
+				if (Flags.IsAccessibilityExperimentalSet())
+				{
+					if(CanNavigateBack)
+						toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_navigate_up_description);
+					else
+						toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_open_drawer_description);
+				}
 				else
 					toolbar.SetNavigationContentDescription(R.String.Ok);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -451,7 +451,10 @@ namespace Xamarin.Forms.Platform.Android
 			else if (image == null ||
 				toolbar.SetNavigationContentDescription(image) == null)
 			{
-				toolbar.SetNavigationContentDescription(R.String.Ok);
+				if(CanNavigateBack)
+					toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_navigate_up_description);
+				else
+					toolbar.SetNavigationContentDescription(R.String.Ok);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -451,7 +451,7 @@ namespace Xamarin.Forms.Platform.Android
 			else if (image == null ||
 				toolbar.SetNavigationContentDescription(image) == null)
 			{
-				if(CanNavigateBack)
+				if(CanNavigateBack && Flags.IsAccessibilityExperimentalSet())
 					toolbar.SetNavigationContentDescription(Resource.String.nav_app_bar_navigate_up_description);
 				else
 					toolbar.SetNavigationContentDescription(R.String.Ok);

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -45,6 +45,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.2.0.4" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.2.1.1" />
+    <PackageReference Include="Xamarin.AndroidX.Navigation.UI" Version="2.3.2.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.6" />
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
### Description of Change ###
- added Xamarin.AndroidX.Navigation.UI so I can use the resource id for reading the back button as "Navigate up"
- added AccessibilityDelegateAutomationId so that if you set an AutomationId and the HelpText it'll read back the HelpText instead of the AutomationID
- When setting AutomationId on controls that aren't implicitly accessible we need to turn "ImportantForAccessibility" off so that TalkBack doesn't start reading it
- Disable extracting the defaults for hint and CD
- Remove the "Touch" settings on the PlatformRenderer
- Remove Clickable on the PageRenderer
- Fix Shell so that it doesn't read out the ViewPager if the page has no top tabs



### API Changes ###
Added:
 - Accessibility_Experimental Flag so that you can toggle these changes on and off. 

### Platforms Affected ### 
- Android


### Testing Procedure ###
- Turn this flag on and then click around in Control Gallery on the various TalkBack scenarios for Android. You'll see a flag you can uncomment inside FormsAppCompatActivity. The AutomationId page is a pretty good one to test. Before the flag it reads the AutomationId but then after the flag it continues to read the text

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
