### PR TITLE
fix memory leak (and some crashes) in ItemsViewController (iOS)

### DIFF
--- a/Xamarin.Forms.Platform.iOS.UnitTests/ItemsViewControllerLeakTest.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/ItemsViewControllerLeakTest.cs
@@ -1,0 +1,140 @@
+﻿using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Runtime.CompilerServices;
+using System.Threading.Tasks;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.Platform.iOS.UnitTests
+{
+
+	class MyTestAdapter : List<int>, INotifyCollectionChanged
+	{
+		public event NotifyCollectionChangedEventHandler CollectionChanged;
+
+		public int NumberOfListener { get => CollectionChanged?.GetInvocationList().Length ?? 0; }
+		public bool ExceptionHappened { get; private set; } = false;
+
+		public new void Add(int item)
+		{
+			base.Add(item);
+			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Add, item));
+		}
+
+		public new void Clear()
+		{
+			base.Clear();
+			OnCollectionChanged(new NotifyCollectionChangedEventArgs(NotifyCollectionChangedAction.Reset));
+		}
+
+		private void OnCollectionChanged(NotifyCollectionChangedEventArgs args)
+		{
+			if (CollectionChanged != null)
+			{
+				try
+				{
+					CollectionChanged.Invoke(this, args);
+				}
+				catch (System.Exception)
+				{
+					ExceptionHappened = true;
+				}
+			}
+		}
+	}
+
+	class MyTestViewModel : System.ComponentModel.INotifyPropertyChanged
+	{
+		private MyTestAdapter _myTestAdapter;
+		public MyTestAdapter MyTestAdapter
+		{
+			get => _myTestAdapter;
+			set => RaiseAndSetIfChanged(ref _myTestAdapter, value);
+		}
+
+		public event System.ComponentModel.PropertyChangedEventHandler PropertyChanged;
+
+		protected void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			PropertyChanged?.Invoke(this, new System.ComponentModel.PropertyChangedEventArgs(propertyName));
+		}
+
+		protected void RaiseAndSetIfChanged<T>(ref T backingField, T value, [CallerMemberName] string propertyName = null)
+		{
+			if (!EqualityComparer<T>.Default.Equals(backingField, value))
+			{
+				backingField = value;
+				OnPropertyChanged(propertyName);
+			}
+		}
+	}
+
+
+	[TestFixture]
+	public class ItemsViewControllerLeakTest : PlatformTestFixture
+	{
+		[Test, Category("ItemsView")]
+		public async Task ItemsViewControllerDoesNotLeakAsync()
+		{
+			var myAdapter1 = new MyTestAdapter();
+			var myAdapter2 = new MyTestAdapter();
+			var vm = new MyTestViewModel { MyTestAdapter = myAdapter1 };
+
+			var view = new CollectionView
+			{
+				ItemTemplate = new DataTemplate(() => new ContentView()),
+				BindingContext = vm
+			};
+			view.SetBinding(ItemsView.ItemsSourceProperty, nameof(MyTestViewModel.MyTestAdapter));
+			await GetRendererProperty(view, ver => ver.NativeView, requiresLayout: true);
+
+			await Device.InvokeOnMainThreadAsync(() =>
+			{
+				vm.MyTestAdapter = myAdapter2;
+				vm.MyTestAdapter = myAdapter1;
+				vm.MyTestAdapter = myAdapter2;
+				vm.MyTestAdapter = myAdapter1;
+
+				myAdapter1.Add(1);
+			});
+			Assert.That(myAdapter1.NumberOfListener, Is.EqualTo(1));
+			Assert.That(myAdapter2.NumberOfListener, Is.EqualTo(0));
+		}
+
+		[Test, Category("ItemsView")]
+		public async Task ItemsViewControllerDoesNotCrashAsync()
+		{
+			var myAdapter = new MyTestAdapter();
+			var view1 = new CollectionView
+			{
+				BindingContext = new MyTestViewModel { MyTestAdapter = myAdapter }
+			};
+			view1.SetBinding(ItemsView.ItemsSourceProperty, nameof(MyTestViewModel.MyTestAdapter));
+			await GetRendererProperty(view1, ver => ver.NativeView, requiresLayout: true);
+
+			await Device.InvokeOnMainThreadAsync(() =>
+			{
+				myAdapter.Add(1);
+				myAdapter.Clear();
+				view1.BindingContext = null;
+			});
+
+			var view2 = new CollectionView
+			{
+				BindingContext = new MyTestViewModel { MyTestAdapter = myAdapter }
+			};
+
+			view2.SetBinding(ItemsView.ItemsSourceProperty, nameof(MyTestViewModel.MyTestAdapter));
+			await GetRendererProperty(view2, (ver) => ver.NativeView, requiresLayout: true);
+
+
+			await Device.InvokeOnMainThreadAsync(() =>
+			{
+				myAdapter.Add(2);
+				myAdapter.Clear();
+				view2.BindingContext = null;
+			});
+
+			Assert.That(myAdapter.ExceptionHappened, Is.EqualTo(false));
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/Xamarin.Forms.Platform.iOS.UnitTests.csproj
@@ -48,6 +48,7 @@
     </Compile>
     <Compile Include="AssertionExtensions.cs" />
     <Compile Include="BackgroundColorTests.cs" />
+    <Compile Include="ItemsViewControllerLeakTest.cs" />
     <Compile Include="ColorComparison.cs" />
     <Compile Include="CornerRadiusTests.cs" />
     <Compile Include="DatePickerTests.cs" />

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -12,7 +12,8 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public const int EmptyTag = 333;
 
-		public IItemsViewSource ItemsSource { get; protected set; }
+
+		public IItemsViewSource ItemsSource { get; set; }
 		public TItemsView ItemsView { get; }
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
 		bool _initialized;
@@ -209,6 +210,7 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			_measurementCells.Clear();
 			ItemsViewLayout?.ClearCellSizeCache();
+			ItemsSource?.Dispose();
 			ItemsSource = CreateItemsViewSource();
 			CollectionView.ReloadData();
 			CollectionView.CollectionViewLayout.InvalidateLayout();
@@ -403,7 +405,7 @@ namespace Xamarin.Forms.Platform.iOS
 		protected virtual void HandleFormsElementMeasureInvalidated(VisualElement formsElement)
 		{
 			RemeasureLayout(formsElement);
-        }
+		}
 
 		internal void UpdateView(object view, DataTemplate viewTemplate, ref UIView uiView, ref VisualElement formsElement)
 		{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -12,8 +12,8 @@ namespace Xamarin.Forms.Platform.iOS
 	{
 		public const int EmptyTag = 333;
 
-
-		public IItemsViewSource ItemsSource { get; set; }
+		public IItemsViewSource ItemsSource { get; protected set; }
+		
 		public TItemsView ItemsView { get; }
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
 		bool _initialized;


### PR DESCRIPTION
### Description of Change ###

When a CollectionView is removed from a layout or removed from view hierarchy (My use case is the following: when the user rotate the screen the layout changes. So, in my code, I recreate a new layout with a new CollectionView), the BindingContext is set to null, hence the ItemsSourceProperty is set to null and the ItemsSource property in the  Xamarin.Forms.Platform.iOS.ItemsViewController will be updated (through ItemsViewRenderer.OnElementPropertyChanged).

The problem is, if the IItemsViewSource is an Xamarin.Forms.Platform.iOS.ObservableItemsSource , the dispose method on the old ItemsSource value is not called and that dispose method is supposed to unsubscribe from the event delegate.
In the end, that object is still subscribed on the ObservableCollection in my ViewModel that has not reached the end of its lifetime(I continue using the same viewmodel), hence the ObservableItemSource is leaked because still referenced by the CollectionChanged event delegate, but the ItemsViewController which is supposed to own the reference to that ObservableItemsSource has no reference anymore.

The change in this PR is:
- Disposing pre-existing ObservableItemsSource(if any) when setting ItemsSource property to a new value (in ItemsViewController)

### Issues Resolved ### 
I did not yet do a complete check of what issues could be affected by this change.
One of the crash i encountered myself was exactly the same as in #13910 (same stacktrace) (when on INotifyCollectionChanged collection call the CollectionChanged event with the Reset event).

The reason this crash was happening is (i think) because the ObservableItemsSource, or the referenced views (if any) are removed from view hierarchy and they are not in a valid state anymore.

I will work on creating an issue with a minimal reproduction for my problem as soon as this PR is submitted.
EDIT: -> #14113 

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###


### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
