### PR TITLE
[macOS] Fix RadioButton activated behaviour

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
@@ -29,6 +29,12 @@ namespace Xamarin.Forms.Platform.MacOS
 		{
 			ObserveStateChange(false);
 
+			var formsButton = Control as FormsNSButton;
+			if (formsButton != null)
+			{
+				formsButton.Activated -= HandleActivated;
+			}
+
 			base.Dispose(disposing);
 		}
 
@@ -44,6 +50,8 @@ namespace Xamarin.Forms.Platform.MacOS
 					btn.SetButtonType(NSButtonType.Radio);
 					SetNativeControl(btn);
 					ObserveStateChange(true);
+
+					btn.Activated += HandleActivated;
 				}
 
 				UpdateContent();
@@ -155,6 +163,16 @@ namespace Xamarin.Forms.Platform.MacOS
 			}
 
 			Element.IsChecked = Control.State == NSCellStateValue.On;
+		}
+
+		void HandleActivated(object sender, EventArgs args)
+		{
+			if (Element == null || sender == null)
+			{
+				return;
+			}
+
+			Element.IsChecked = (sender as FormsNSButton).State == NSCellStateValue.On;
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
@@ -52,9 +52,6 @@ namespace Xamarin.Forms.Platform.MacOS
 					ObserveStateChange(true);
 
 					btn.Activated += HandleActivated;
-
-					if (e.NewElement.IsChecked)
-						Control.State = NSCellStateValue.On;
 				}
 
 				UpdateContent();

--- a/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.MacOS/Renderers/RadioButtonRenderer.cs
@@ -52,6 +52,9 @@ namespace Xamarin.Forms.Platform.MacOS
 					ObserveStateChange(true);
 
 					btn.Activated += HandleActivated;
+
+					if (e.NewElement.IsChecked)
+						Control.State = NSCellStateValue.On;
 				}
 
 				UpdateContent();


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->
Allows RadioButton in macOS to respond to the Activated event, thus propagating the necessary property changes.

### Issues Resolved ### 

- closes #13984

### API Changes ###
 
 None

### Platforms Affected ### 

- macOS

### Behavioral/Visual Changes ###

Radio buttons within a group get exclusively activated, as intended.

### Before/After Screenshots ### 

Before:
![image](https://user-images.githubusercontent.com/4507319/114268827-0f9e5900-99b8-11eb-98e0-16e0231daad3.png)

After:
![image](https://user-images.githubusercontent.com/4507319/114269086-9ef83c00-99b9-11eb-9b0c-522962758476.png)
![image](https://user-images.githubusercontent.com/4507319/114269071-90aa2000-99b9-11eb-85ae-8d095ea48192.png)
![image](https://user-images.githubusercontent.com/4507319/114269093-ad465800-99b9-11eb-9f48-91f1175b96a0.png)


### Testing Procedure ###

1. Add a group of RadioButton elements.
2. Click on each one of them, verifying only one is active at a time.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
