### PR TITLE
[GTK] Fix Entry focus behavior

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
@@ -23,6 +23,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 				wrapper.Entry.Changed += OnChanged;
 				wrapper.Entry.Focused += OnFocused;
+				wrapper.Entry.FocusOutEvent += OnFocusedOut;
 				wrapper.Entry.EditingDone += OnEditingDone;
 				wrapper.Entry.KeyReleaseEvent += OnKeyReleased;
 			}
@@ -77,6 +78,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				{
 					Control.Entry.Changed -= OnChanged;
 					Control.Entry.Focused -= OnFocused;
+					Control.Entry.FocusOutEvent -= OnFocusedOut;
 					Control.Entry.EditingDone -= OnEditingDone;
 					Control.Entry.KeyReleaseEvent -= OnKeyReleased;
 				}
@@ -142,6 +144,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 		private void OnFocused(object o, FocusedArgs args)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
+		}
+
+		private void OnFocusedOut(object o, FocusOutEventArgs args)
+		{
+			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, false);
 		}
 
 		private void OnEditingDone(object sender, System.EventArgs e)

--- a/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/EntryRenderer.cs
@@ -22,7 +22,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				SetNativeControl(wrapper);
 
 				wrapper.Entry.Changed += OnChanged;
-				wrapper.Entry.Focused += OnFocused;
+				wrapper.Entry.FocusInEvent += OnFocusedIn;
 				wrapper.Entry.FocusOutEvent += OnFocusedOut;
 				wrapper.Entry.EditingDone += OnEditingDone;
 				wrapper.Entry.KeyReleaseEvent += OnKeyReleased;
@@ -77,7 +77,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				if (Control != null)
 				{
 					Control.Entry.Changed -= OnChanged;
-					Control.Entry.Focused -= OnFocused;
+					Control.Entry.FocusInEvent -= OnFocusedIn;
 					Control.Entry.FocusOutEvent -= OnFocusedOut;
 					Control.Entry.EditingDone -= OnEditingDone;
 					Control.Entry.KeyReleaseEvent -= OnKeyReleased;
@@ -141,7 +141,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			ElementController.SetValueFromRenderer(Entry.TextProperty, Control.Entry.Text);
 		}
 
-		private void OnFocused(object o, FocusedArgs args)
+		private void OnFocusedIn(object o, FocusInEventArgs args)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
 		}


### PR DESCRIPTION
### Description of Change ###

Correctly wires `Entry` focus/unfocus events in GTK.

### API Changes ###
 
 None

### Platforms Affected ### 

- Gtk

### Behavioral/Visual Changes ###

`Entry` now correctly triggers `IsFocused` `true` and `false` states and corresponding events.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
1. Run `ControlGallery.GTK`.
2. Open `Entry Gallery`.
3. Set/unset focus on the tested element (`Entry`). Observe the now correct `IsFocused?` label updates.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
