### PR TITLE
[Gtk] Implement RadioButton

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/RadioButton.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/RadioButton.cs
@@ -29,6 +29,10 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			_label = new Gtk.Label();
 			_container = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
 
+			//TODO: Hack!!! Remove.
+			var otro = new Gtk.RadioButton("ghost");
+			this.Group = otro.Group;
+
 			Add(_container);
 
 			RecreateContainer();

--- a/Xamarin.Forms.Platform.GTK/Controls/RadioButton.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/RadioButton.cs
@@ -29,18 +29,13 @@ namespace Xamarin.Forms.Platform.GTK.Controls
 			_label = new Gtk.Label();
 			_container = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
 
-			//TODO: Hack!!! Remove.
-			var otro = new Gtk.RadioButton("ghost");
-			this.Group = otro.Group;
 
 			Add(_container);
 
 			RecreateContainer();
 		}
 
-		public RadioButton(string label) : this(null, label)
-		{
-		}
+		public RadioButton(string label) : this(null, label) { }
 
 		public RadioButton() : this(string.Empty) { }
 

--- a/Xamarin.Forms.Platform.GTK/Controls/RadioButton.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/RadioButton.cs
@@ -1,0 +1,210 @@
+﻿using Gdk;
+using Xamarin.Forms.Platform.GTK.Extensions;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class RadioButton : Gtk.RadioButton
+	{
+		private Gtk.Alignment _container;
+		private Gtk.Box _imageAndLabelContainer;
+
+		private Gdk.Color _defaultBorderColor;
+		private Gdk.Color _defaultBackgroundColor;
+		private Gdk.Color? _borderColor;
+		private Gdk.Color? _backgroundColor;
+
+		private Gtk.Image _image;
+		private Gtk.Label _label;
+		private uint _imageSpacing = 0;
+		private uint _borderWidth = 0;
+
+		public RadioButton(Gtk.RadioButton radio_group_member, string label) : base(radio_group_member, label)
+		{
+			_defaultBackgroundColor = Style.Backgrounds[(int)Gtk.StateType.Normal];
+			_defaultBorderColor = Style.BaseColors[(int)Gtk.StateType.Active];
+
+			Relief = Gtk.ReliefStyle.None;
+
+			_image = new Gtk.Image();
+			_label = new Gtk.Label();
+			_container = new Gtk.Alignment(0.5f, 0.5f, 0, 0);
+
+			Add(_container);
+
+			RecreateContainer();
+		}
+
+		public RadioButton(string label) : this(null, label)
+		{
+		}
+
+		public RadioButton() : this(string.Empty) { }
+
+		#region Properties
+
+		public Gtk.Label LabelWidget => _label;
+
+		public Gtk.Image ImageWidget => _image;
+
+		public uint ImageSpacing
+		{
+			get
+			{
+				return _imageSpacing;
+			}
+
+			set
+			{
+				_imageSpacing = value;
+				UpdateImageSpacing();
+			}
+		}
+
+		#endregion Properties
+
+		#region Public methods
+
+		public void SetBackgroundColor(Gdk.Color? color)
+		{
+			_backgroundColor = color;
+			QueueDraw();
+		}
+
+		public void ResetBackgroundColor()
+		{
+			_backgroundColor = _defaultBackgroundColor;
+			QueueDraw();
+		}
+
+		public void SetForegroundColor(Gdk.Color color)
+		{
+			_label.ModifyFg(Gtk.StateType.Normal, color);
+			_label.ModifyFg(Gtk.StateType.Prelight, color);
+			_label.ModifyFg(Gtk.StateType.Active, color);
+		}
+
+		public void SetBorderWidth(uint width)
+		{
+			_borderWidth = width;
+			QueueDraw();
+		}
+
+		public void SetBorderColor(Gdk.Color? color)
+		{
+			_borderColor = color;
+			QueueDraw();
+		}
+
+		public void ResetBorderColor()
+		{
+			_borderColor = _defaultBorderColor;
+			QueueDraw();
+		}
+
+		public void SetImagePosition(Gtk.PositionType position)
+		{
+			ImagePosition = position;
+			RecreateContainer();
+		}
+
+		#endregion Public methods
+
+		#region Gtk.RadioButton overrides
+
+		public override void Destroy()
+		{
+			base.Destroy();
+
+			_label = null;
+			_image = null;
+			_imageAndLabelContainer = null;
+			_container = null;
+		}
+
+		#endregion Gtk.RadioButton overrides
+
+		#region Gtk.Widget overrides
+
+		protected override bool OnExposeEvent(EventExpose evnt)
+		{
+			double colorMaxValue = 65535;
+
+			using (var cr = CairoHelper.Create(GdkWindow))
+			{
+				cr.Rectangle(Allocation.Left, Allocation.Top, Allocation.Width, Allocation.Height);
+
+				// Draw BackgroundColor
+				if (_backgroundColor.HasValue)
+				{
+					var color = _backgroundColor.Value;
+					cr.SetSourceRGBA(color.Red / colorMaxValue, color.Green / colorMaxValue, color.Blue / colorMaxValue, 1.0);
+					cr.FillPreserve();
+				}
+
+				// Draw BorderColor
+				if (_borderColor.HasValue)
+				{
+					cr.LineWidth = _borderWidth;
+
+					var color = _borderColor.Value;
+					cr.SetSourceRGB(color.Red / colorMaxValue, color.Green / colorMaxValue, color.Blue / colorMaxValue);
+					cr.Stroke();
+				}
+			}
+
+			return base.OnExposeEvent(evnt);
+		}
+
+		#endregion Gtk.Widget overrides
+
+		#region Private methods
+
+		private void RecreateContainer()
+		{
+			if (_imageAndLabelContainer != null)
+			{
+				_imageAndLabelContainer.RemoveFromContainer(_image);
+				_imageAndLabelContainer.RemoveFromContainer(_label);
+				_container.RemoveFromContainer(_imageAndLabelContainer);
+				_imageAndLabelContainer = null;
+			}
+
+			switch (ImagePosition)
+			{
+				case Gtk.PositionType.Left:
+					_imageAndLabelContainer = new Gtk.HBox();
+					_imageAndLabelContainer.PackStart(_image, false, false, _imageSpacing);
+					_imageAndLabelContainer.PackStart(_label, false, false, 0);
+					break;
+				case Gtk.PositionType.Right:
+					_imageAndLabelContainer = new Gtk.HBox();
+					_imageAndLabelContainer.PackStart(_label, false, false, 0);
+					_imageAndLabelContainer.PackStart(_image, false, false, _imageSpacing);
+					break;
+				case Gtk.PositionType.Top:
+					_imageAndLabelContainer = new Gtk.VBox();
+					_imageAndLabelContainer.PackStart(_image, false, false, _imageSpacing);
+					_imageAndLabelContainer.PackStart(_label, false, false, 0);
+					break;
+				case Gtk.PositionType.Bottom:
+					_imageAndLabelContainer = new Gtk.VBox();
+					_imageAndLabelContainer.PackStart(_label, false, false, 0);
+					_imageAndLabelContainer.PackStart(_image, false, false, _imageSpacing);
+					break;
+			}
+
+			if (_imageAndLabelContainer != null)
+			{
+				_container.Add(_imageAndLabelContainer);
+				_container.ShowAll();
+			}
+		}
+
+		private void UpdateImageSpacing()
+		{
+			_imageAndLabelContainer.SetChildPacking(_image, false, false, _imageSpacing, Gtk.PackType.Start);
+		}
+
+		#endregion Private methods
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.GTK/Properties/AssemblyInfo.cs
@@ -32,6 +32,7 @@ using Xamarin.Forms.Platform.GTK.Renderers;
 [assembly: ExportRenderer(typeof(Page), typeof(PageRenderer))]
 [assembly: ExportRenderer(typeof(Picker), typeof(PickerRenderer))]
 [assembly: ExportRenderer(typeof(ProgressBar), typeof(ProgressBarRenderer))]
+[assembly: ExportRenderer(typeof(RadioButton), typeof(RadioButtonRenderer))]
 [assembly: ExportRenderer(typeof(ScrollView), typeof(ScrollViewRenderer))]
 [assembly: ExportRenderer(typeof(SearchBar), typeof(SearchBarRenderer))]
 [assembly: ExportRenderer(typeof(Slider), typeof(SliderRenderer))]

--- a/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 {
 	public class RadioButtonRenderer : ViewRenderer<RadioButton, Controls.RadioButton>
 	{
+		Gtk.RadioButton _ghost;
+
 		#region VisualElementRenderer overrides
 
 		protected override void Dispose(bool disposing)
@@ -28,11 +30,11 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 					var button = new Controls.RadioButton();
 					button.Clicked += Button_Clicked;
 
+					_ghost = new Gtk.RadioButton(button);
+					_ghost.Active = true;
+
 					SetNativeControl(button);
 				}
-
-				//UpdateContent();
-				//UpdateFont();
 			}
 
 			base.OnElementChanged(e);
@@ -92,12 +94,6 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			}
 		}
 
-		protected override void SetAccessibilityLabel()
-		{
-			//TODO
-			base.SetAccessibilityLabel();
-		}
-
 		protected override void UpdateBackgroundColor()
 		{
 			if (Element == null)
@@ -137,7 +133,16 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		void UpdateCheck()
 		{
-			Control.Active = Element.IsChecked ? true : false;
+			if (Element.IsChecked)
+			{
+				Control.Active = true;
+				_ghost.Active = false;
+			}
+			else
+			{
+				_ghost.Active = true;
+				Control.Active = false;
+			}
 		}
 
 		#endregion Private methods

--- a/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Extensions;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class RadioButtonRenderer : ViewRenderer<RadioButton, Gtk.RadioButton>
+	{
+		#region VisualElementRenderer overrides
+
+		protected override void OnElementChanged(ElementChangedEventArgs<RadioButton> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+				{
+					var button = new Gtk.RadioButton("label");
+					button.Activated += Button_Activated;
+				}
+
+				//UpdateContent();
+				//UpdateFont();
+			}
+		}
+
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == RadioButton.ContentProperty.PropertyName)
+			{
+				UpdateContent();
+			}
+			else if (e.PropertyName == RadioButton.TextColorProperty.PropertyName)
+			{
+				UpdateTextColor();
+			}
+			else if (e.PropertyName == RadioButton.FontFamilyProperty.PropertyName ||
+				e.PropertyName == RadioButton.FontSizeProperty.PropertyName ||
+				e.PropertyName == RadioButton.FontAttributesProperty.PropertyName)
+			{
+				UpdateFont();
+			}
+			else if (e.PropertyName == RadioButton.BorderColorProperty.PropertyName)
+			{
+				UpdateBorderColor();
+			}
+			else if (e.PropertyName == RadioButton.BorderWidthProperty.PropertyName)
+			{
+				UpdateBorderWidth();
+			}
+			else if (e.PropertyName == RadioButton.CornerRadiusProperty.PropertyName)
+			{
+				UpdateBorderRadius();
+			}
+			else if (e.PropertyName == RadioButton.PaddingProperty.PropertyName)
+			{
+				UpdatePadding();
+			}
+			else if (e.PropertyName == RadioButton.IsCheckedProperty.PropertyName)
+			{
+				UpdateCheck();
+			}
+		}
+
+		#endregion VisualElementRenderer overrides
+
+		#region Private methods
+
+		void UpdateContent() { }
+
+		void UpdateTextColor() { }
+
+		void UpdateFont() { }
+
+		void UpdateBorderColor() { }
+
+		void UpdateBorderWidth() { }
+
+		void UpdateBorderRadius() { }
+
+		void UpdatePadding() { }
+
+		void UpdateCheck() { }
+
+		#endregion Private methods
+
+		#region Handlers
+
+		private void Button_Activated(object sender, EventArgs e)
+		{
+			throw new NotImplementedException();
+		}
+
+		#endregion Handlers
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
@@ -35,6 +35,8 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 					SetNativeControl(button);
 				}
+
+				UpdateContent();
 			}
 
 			base.OnElementChanged(e);
@@ -117,7 +119,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		#region Private methods
 
-		void UpdateContent() { }
+		void UpdateContent()
+		{
+			var content = Element?.Content;
+
+			Control.Label = content?.ToString();
+		}
 
 		void UpdateTextColor() { }
 

--- a/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/RadioButtonRenderer.cs
@@ -13,7 +13,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			var formsButton = Control;
 			if (formsButton != null)
 			{
-				formsButton.Activated -= Button_Activated;
+				formsButton.Clicked -= Button_Clicked;
 			}
 
 			base.Dispose(disposing);
@@ -26,7 +26,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				if (Control == null)
 				{
 					var button = new Controls.RadioButton();
-					button.Activated += Button_Activated;
+					button.Clicked += Button_Clicked;
 
 					SetNativeControl(button);
 				}
@@ -144,7 +144,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		#region Handlers
 
-		private void Button_Activated(object sender, EventArgs e)
+		private void Button_Clicked(object sender, EventArgs e)
 		{
 			if (Element == null || sender == null)
 			{

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -207,6 +207,7 @@
     <Compile Include="Renderers\PageRenderer.cs" />
     <Compile Include="Renderers\PickerRenderer.cs" />
     <Compile Include="Renderers\ProgressBarRenderer.cs" />
+    <Compile Include="Renderers\RadioButtonRenderer.cs" />
     <Compile Include="Renderers\ScrollViewRenderer.cs" />
     <Compile Include="Renderers\SearchBarRenderer.cs" />
     <Compile Include="Renderers\SliderRenderer.cs" />

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -136,6 +136,7 @@
     <Compile Include="Controls\NavigationChildPage.cs" />
     <Compile Include="Controls\NotebookWrapper.cs" />
     <Compile Include="Controls\OpenGLView.cs" />
+    <Compile Include="Controls\RadioButton.cs" />
     <Compile Include="Controls\ScrolledTextView.cs" />
     <Compile Include="Controls\PageContainer.cs" />
     <Compile Include="Controls\SearchEntry.cs" />


### PR DESCRIPTION
### Description of Change ###

Adds missing implementation of RadioButton for Gtk.

### Issues Resolved ### 

None

### API Changes ###

Added:
 - class Xamarin.Forms.Platform.GTK.Controls.RadioButton
 - Xamarin.Forms.Platform.GTK.Renderers.RadioButtonRenderer

### Platforms Affected ### 

- Gtk

### Behavioral/Visual Changes ###

RadioButtons under Gtk get rendered, shown, and behave consistently with other platforms.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

1. Start ControlGallery.Gtk.
2. Open the RadioButtonGroup page.
3. Verify RadioButtons show up and grouping behavior works.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
