### PR TITLE
[UWP] Implement CollectionView RemainingItemsThreshold

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Github5623.xaml.cs
@@ -20,7 +20,6 @@ namespace Xamarin.Forms.Controls.Issues
 {
 #if UITEST
 	[Category(UITestCategories.CollectionView)]
-	[Category(UITestCategories.UwpIgnore)]
 	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
 #endif
 #if APP

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -524,6 +524,17 @@ namespace Xamarin.Forms.Platform.UWP
 			itemsViewScrolledEventArgs = ComputeVisibleIndexes(itemsViewScrolledEventArgs, layoutOrientaton, advancing);
 
 			Element.SendScrolled(itemsViewScrolledEventArgs);
+
+			if (IsRemainingItemsThresholdReached(itemsViewScrolledEventArgs.LastVisibleItemIndex))
+				ItemsView.SendRemainingItemsThresholdReached();
+		}
+
+		private bool IsRemainingItemsThresholdReached(int lastVisibleItemIndex)
+		{
+			if (ItemsView == null || lastVisibleItemIndex == -1 || ItemsView.RemainingItemsThreshold == -1)
+				return false;
+
+			return (ItemCount - 1 - lastVisibleItemIndex) <= ItemsView.RemainingItemsThreshold;
 		}
 
 		protected virtual ItemsViewScrolledEventArgs ComputeVisibleIndexes(ItemsViewScrolledEventArgs args, ItemsLayoutOrientation orientation, bool advancing) 


### PR DESCRIPTION
### Description of Change ###
The implementation  of CollectionView RemainingItemsThreshold for UWP

### Issues Resolved ### 
- fixes #5623

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
The automated test created by @adrianknight89 now works on UWP.
Launch Control Gallery and navigate to issue G5623. Scroll items down until you reach item 99.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)

