### PR TITLE
Add the ability to open the pin info window from code. Added option t…

### DIFF
--- a/Xamarin.Forms.Maps.Android/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.Android/MapRenderer.cs
@@ -26,6 +26,8 @@ namespace Xamarin.Forms.Maps.Android
 	{
 		const string MoveMessageName = "MapMoveToRegion";
 
+		const string MapShowPinInfoWindowMessageName = "MapShowPinInfoWindow";
+
 		static Bundle s_bundle;
 
 		bool _disposed;
@@ -82,6 +84,7 @@ namespace Xamarin.Forms.Maps.Android
 				if (Element != null)
 				{
 					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+					MessagingCenter.Unsubscribe<Map, Pin>(this, MapShowPinInfoWindowMessageName);
 
 					((ObservableCollection<Pin>)Element.Pins).CollectionChanged -= OnPinCollectionChanged;
 					foreach (Pin pin in Element.Pins)
@@ -142,6 +145,7 @@ namespace Xamarin.Forms.Maps.Android
 				}
 
 				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+				MessagingCenter.Unsubscribe<Map, Pin>(this, MapShowPinInfoWindowMessageName);
 
 				if (NativeMap != null)
 				{
@@ -158,6 +162,8 @@ namespace Xamarin.Forms.Maps.Android
 			Control.GetMapAsync(this);
 
 			MessagingCenter.Subscribe<Map, MapSpan>(this, MoveMessageName, OnMoveToRegionMessage, Map);
+
+			MessagingCenter.Subscribe<Map, Pin>(this, MapShowPinInfoWindowMessageName, OnMapShowPinInfoWindow, Map);
 
 			((INotifyCollectionChanged)Map.Pins).CollectionChanged += OnPinCollectionChanged;
 			((INotifyCollectionChanged)Map.MapElements).CollectionChanged += OnMapElementCollectionChanged;
@@ -241,6 +247,7 @@ namespace Xamarin.Forms.Maps.Android
 			map.UiSettings.ZoomControlsEnabled = Map.HasZoomEnabled;
 			map.UiSettings.ZoomGesturesEnabled = Map.HasZoomEnabled;
 			map.UiSettings.ScrollGesturesEnabled = Map.HasScrollEnabled;
+			map.UiSettings.MapToolbarEnabled = Map.HasMapToolbarEnabled;
 			SetUserVisible();
 			SetMapType();
 		}
@@ -464,6 +471,11 @@ namespace Xamarin.Forms.Maps.Android
 		void OnMoveToRegionMessage(Map s, MapSpan a)
 		{
 			MoveToRegion(a, true);
+		}
+
+		void OnMapShowPinInfoWindow(Map s, Pin a)
+		{
+			ShowPinInfoWindow(a);
 		}
 
 		void RemovePins(IList pins)
@@ -1049,6 +1061,16 @@ namespace Xamarin.Forms.Maps.Android
 		void GoogleMap.IOnCameraMoveListener.OnCameraMove()
 		{
 			UpdateVisibleRegion(NativeMap.CameraPosition.Target);
+		}
+
+		void ShowPinInfoWindow(Pin pin)
+		{
+			var currentMarker = GetMarkerForPin(pin);
+
+			if(currentMarker != null)
+			{
+				currentMarker.ShowInfoWindow();
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Maps.iOS/MapRenderer.cs
+++ b/Xamarin.Forms.Maps.iOS/MapRenderer.cs
@@ -32,6 +32,8 @@ namespace Xamarin.Forms.Maps.MacOS
 
 		const string MoveMessageName = "MapMoveToRegion";
 
+		const string MapShowPinInfoWindowMessageName = "MapShowPinInfoWindow";
+
 		public override SizeRequest GetDesiredSize(double widthConstraint, double heightConstraint)
 		{
 			return Control.GetSizeRequest(widthConstraint, heightConstraint);
@@ -61,6 +63,7 @@ namespace Xamarin.Forms.Maps.MacOS
 				{
 					var mapModel = (Map)Element;
 					MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+					MessagingCenter.Unsubscribe<Map, Pin>(this, MapShowPinInfoWindowMessageName);
 					((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnPinCollectionChanged;
 					((ObservableCollection<MapElement>)mapModel.MapElements).CollectionChanged -= OnMapElementCollectionChanged;
 					foreach (Pin pin in mapModel.Pins)
@@ -115,6 +118,7 @@ namespace Xamarin.Forms.Maps.MacOS
 				var mapModel = (Map)e.OldElement;
 
 				MessagingCenter.Unsubscribe<Map, MapSpan>(this, MoveMessageName);
+				MessagingCenter.Unsubscribe<Map, Pin>(this, MapShowPinInfoWindowMessageName);
 
 				((ObservableCollection<Pin>)mapModel.Pins).CollectionChanged -= OnPinCollectionChanged;
 				foreach (Pin pin in mapModel.Pins)
@@ -162,6 +166,8 @@ namespace Xamarin.Forms.Maps.MacOS
 				}
 
 				MessagingCenter.Subscribe<Map, MapSpan>(this, MoveMessageName, (s, a) => MoveToRegion(a), mapModel);
+				MessagingCenter.Subscribe<Map, Pin>(this, MapShowPinInfoWindowMessageName, (s, a) => OnMapShowPinInfoWindow(a), mapModel);
+				
 				if (mapModel.LastMoveToRegion != null)
 					MoveToRegion(mapModel.LastMoveToRegion, false);
 
@@ -409,6 +415,14 @@ namespace Xamarin.Forms.Maps.MacOS
 			Position center = mapSpan.Center;
 			var mapRegion = new MKCoordinateRegion(new CLLocationCoordinate2D(center.Latitude, center.Longitude), new MKCoordinateSpan(mapSpan.LatitudeDegrees, mapSpan.LongitudeDegrees));
 			((MKMapView)Control).SetRegion(mapRegion, animated);
+		}
+
+		void OnMapShowPinInfoWindow(Pin pin)
+		{
+			if (pin != null)
+			{
+				((MKMapView)Control).SelectAnnotation((IMKAnnotation)pin.MarkerId, true);
+			}
 		}
 
 		void OnPinCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)

--- a/Xamarin.Forms.Maps/Map.cs
+++ b/Xamarin.Forms.Maps/Map.cs
@@ -19,7 +19,7 @@ namespace Xamarin.Forms.Maps
 
 		public static readonly BindableProperty HasScrollEnabledProperty = BindableProperty.Create("HasScrollEnabled", typeof(bool), typeof(Map), true);
 
-		public static readonly BindableProperty HasMapToolbarEnabledProperty = BindableProperty.Create("HasMapToolbarEnabled", typeof(bool), typeof(Map), false);
+		public static readonly BindableProperty HasMapToolbarEnabledProperty = BindableProperty.Create("HasMapToolbarEnabled", typeof(bool), typeof(Map), true);
 
 		public static readonly BindableProperty HasZoomEnabledProperty = BindableProperty.Create("HasZoomEnabled", typeof(bool), typeof(Map), true);
 

--- a/Xamarin.Forms.Maps/Map.cs
+++ b/Xamarin.Forms.Maps/Map.cs
@@ -19,6 +19,8 @@ namespace Xamarin.Forms.Maps
 
 		public static readonly BindableProperty HasScrollEnabledProperty = BindableProperty.Create("HasScrollEnabled", typeof(bool), typeof(Map), true);
 
+		public static readonly BindableProperty HasMapToolbarEnabledProperty = BindableProperty.Create("HasMapToolbarEnabled", typeof(bool), typeof(Map), false);
+
 		public static readonly BindableProperty HasZoomEnabledProperty = BindableProperty.Create("HasZoomEnabled", typeof(bool), typeof(Map), true);
 
 		public static readonly BindableProperty ItemsSourceProperty = BindableProperty.Create(nameof(ItemsSource), typeof(IEnumerable), typeof(Map), default(IEnumerable),
@@ -48,6 +50,12 @@ namespace Xamarin.Forms.Maps
 		// center on Rome by default
 		public Map() : this(new MapSpan(new Position(41.890202, 12.492049), 0.1, 0.1))
 		{
+		}
+
+		public bool HasMapToolbarEnabled
+		{
+			get { return (bool)GetValue(HasMapToolbarEnabledProperty); }
+			set { SetValue(HasMapToolbarEnabledProperty, value); }
 		}
 
 		public bool HasScrollEnabled
@@ -152,6 +160,13 @@ namespace Xamarin.Forms.Maps
 				throw new ArgumentNullException(nameof(mapSpan));
 			LastMoveToRegion = mapSpan;
 			MessagingCenter.Send(this, "MapMoveToRegion", mapSpan);
+		}
+
+		public void ShowPinInfoWindow(Pin pin)
+		{
+			if (pin == null)
+				throw new ArgumentNullException(nameof(pin));
+			MessagingCenter.Send(this, "MapShowPinInfoWindow", pin);
 		}
 
 		void PinsOnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)


### PR DESCRIPTION
…o disable the bottom right Android toolbar.
### Description of Change ###

It is currently not possible to open the pin info window on the Xamarin.Forms.Maps through the code, only when the user clicks it. I added code so if you pass in the pin to the map you can open the pin info window. 

Also for Android only I added the ability to disable the bottom right tooltip window. This window only appears if the user clicks the pin and not if you call the pin open window from code behind.

### Issues Resolved ### 
Not currently created issue for this just the bug I submitted below. 

https://github.com/xamarin/Xamarin.Forms/issues/14211

### API Changes ###
none

Added:
 
To Map.cs in Xamarin.Forms.Maps

public void ShowPinInfoWindow(Pin pin)
public bool HasMapToolbarEnabled

To iOS and Android MapRender in the respective maps project

void OnMapShowPinInfoWindow(Pin pin)

To Android only MapRender

map.UiSettings.MapToolbarEnabled = Map.HasMapToolbarEnabled;


Changed:
 none
 
 Removed:
none
 
 -->
 
 None

### Platforms Affected ### 

- iOS and Android


### Behavioral/Visual Changes ###
None, unless you call into the method to view the pin info window or disable the Android toolbar at the bottom right.

### Before/After Screenshots ### 

<img width="353" alt="Screen Shot 2021-04-29 at 11 48 51 AM" src="https://user-images.githubusercontent.com/80698694/116580567-7ccf4b00-a8e1-11eb-82f2-f8043e51d159.png">

<img width="356" alt="Screen Shot 2021-04-29 at 11 47 08 AM" src="https://user-images.githubusercontent.com/80698694/116580533-75a83d00-a8e1-11eb-873f-4b2f46287400.png">




### Testing Procedure ###
You can test this change by adding Pins to a Xamarin.Forms.Map and then call this function with your pin 

Map.ShowPinInfoWindow(yourPin);

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
