### PR TITLE
[GTK] Some Shapes API support

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Controls/Shapes/EllipseView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Shapes/EllipseView.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using Cairo;
+using Xamarin.Forms.Platform.GTK.Extensions;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class EllipseView : ShapeView
+	{
+		protected override void Draw(Gdk.Rectangle area, Context cr)
+		{
+			double width = _width;
+			double height = _height;
+
+			cr.Translate(width / 2, height / 2);
+			cr.Scale(width / 2, height / 2);
+			cr.Arc(0, 0, 1, 0, 2 * Math.PI);
+
+			base.Draw(area, cr);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Controls/Shapes/PathView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Shapes/PathView.cs
@@ -1,0 +1,71 @@
+﻿using System;
+using System.Collections.Generic;
+using Cairo;
+using Gdk;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class PathView : ShapeView
+	{
+		private PathGeometry _geometry;
+
+		public void UpdateGeometry(PathGeometry geometry)
+		{
+			_geometry = geometry;
+			QueueDraw();
+		}
+
+		protected override void Draw(Gdk.Rectangle area, Context cr)
+		{
+			cr.FillRule = _geometry.FillRule == Shapes.FillRule.EvenOdd ? Cairo.FillRule.EvenOdd : Cairo.FillRule.Winding;
+
+			foreach (var figure in _geometry.Figures)
+			{
+				cr.MoveTo(figure.StartPoint.X, figure.StartPoint.Y);
+
+				Point lastPoint = figure.StartPoint;
+
+				foreach (var segment in figure.Segments)
+				{
+					if (segment is LineSegment lineSegment)
+					{
+						cr.LineTo(lineSegment.Point.X, lineSegment.Point.Y);
+
+						lastPoint = lineSegment.Point;
+					}
+					else if (segment is ArcSegment arcSegment)
+					{
+						List<Point> points = new List<Point>();
+
+						GeometryHelper.FlattenArc(points,
+							lastPoint,
+							arcSegment.Point,
+							arcSegment.Size.Width,
+							arcSegment.Size.Height,
+							arcSegment.RotationAngle,
+							arcSegment.IsLargeArc,
+							arcSegment.SweepDirection == SweepDirection.CounterClockwise,
+							1);
+
+						for (int i = 0; i < points.Count; i++)
+						{
+							cr.LineTo(points[i].X, points[i].Y);
+						}
+
+						if (points.Count > 0)
+							lastPoint = points[points.Count - 1];
+
+					}
+				}
+
+				if (figure.IsClosed)
+					cr.ClosePath();
+			}
+
+			base.Draw(area, cr);
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Controls/Shapes/PolygonView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Shapes/PolygonView.cs
@@ -1,0 +1,43 @@
+﻿using System;
+using Cairo;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class PolygonView : ShapeView
+	{
+		PointCollection _points;
+		bool _fillMode;
+
+		protected override void Draw(Gdk.Rectangle area, Context cr)
+		{
+
+			cr.FillRule = _fillMode ? Cairo.FillRule.Winding : Cairo.FillRule.EvenOdd;
+
+			if (_points != null && _points.Count > 1)
+			{
+				cr.MoveTo(_points[0].X, _points[0].Y);
+
+				for (int index = 1; index < _points.Count; index++)
+					cr.LineTo((float)_points[index].X, (float)_points[index].Y);
+
+				cr.ClosePath();
+			}
+
+			base.Draw(area, cr);
+		}
+
+		public void UpdatePoints(PointCollection points)
+		{
+			_points = points;
+			QueueDraw();
+		}
+
+		public void UpdateFillMode(bool fillMode)
+		{
+			_fillMode = fillMode;
+			QueueDraw();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Controls/Shapes/PolylineView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Shapes/PolylineView.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using Cairo;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class PolylineView : ShapeView
+	{
+		PointCollection _points;
+		bool _fillMode;
+
+		protected override void Draw(Gdk.Rectangle area, Context cr)
+		{
+			cr.FillRule = _fillMode ? Cairo.FillRule.Winding : Cairo.FillRule.EvenOdd;
+
+			if (_points != null && _points.Count > 1)
+			{
+				cr.MoveTo(_points[0].X, _points[0].Y);
+
+				for (int index = 1; index < _points.Count; index++)
+					cr.LineTo((float)_points[index].X, (float)_points[index].Y);
+			}
+
+			base.Draw(area, cr);
+		}
+
+		public void UpdatePoints(PointCollection points)
+		{
+			_points = points;
+			QueueDraw();
+		}
+
+		public void UpdateFillMode(bool fillMode)
+		{
+			_fillMode = fillMode;
+			QueueDraw();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Controls/Shapes/RectangleView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Shapes/RectangleView.cs
@@ -1,0 +1,16 @@
+﻿using System;
+using Cairo;
+using Xamarin.Forms.Platform.GTK.Extensions;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class RectangleView : ShapeView
+	{
+		protected override void Draw(Gdk.Rectangle area, Context cr)
+		{
+			cr.Rectangle(0, 0, _width, _height);
+
+			base.Draw(area, cr);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Controls/Shapes/ShapeView.cs
+++ b/Xamarin.Forms.Platform.GTK/Controls/Shapes/ShapeView.cs
@@ -1,0 +1,77 @@
+﻿using System;
+using Cairo;
+using Xamarin.Forms.Platform.GTK.Extensions;
+
+namespace Xamarin.Forms.Platform.GTK.Controls
+{
+	public class ShapeView : GtkFormsContainer
+	{
+		protected Brush _fill, _stroke;
+		protected int _height, _width;
+		double? _strokeThickness;
+		float? _strokeDashOffset, _strokeMiterLimit;
+		double[] _dashArray;
+		LineCap? _strokeCap;
+		LineJoin? _strokeJoin;
+
+		public void UpdateFill(Brush brush)
+		{
+			_fill = brush;
+			QueueDraw();
+		}
+
+		public void UpdateStroke(Brush brush)
+		{
+			_stroke = brush;
+		}
+
+		public void UpdateSize(int height, int width)
+		{
+			_height = height;
+			_width = width;
+			QueueDraw();
+		}
+
+		public void UpdateStrokeThickness(double strokeThickness)
+		{
+			_strokeThickness = strokeThickness;
+		}
+
+		public void UpdateStrokeDashArray(double[] dashArray)
+		{
+			_dashArray = dashArray;
+		}
+
+		public void UpdateStrokeDashOffset(float strokeDashOffset)
+		{
+			_strokeDashOffset = strokeDashOffset;
+		}
+
+		public void UpdateStrokeLineCap(LineCap strokeCap)
+		{
+			_strokeCap = strokeCap;
+		}
+
+		public void UpdateStrokeLineJoin(LineJoin strokeJoin)
+		{
+			_strokeJoin = strokeJoin;
+		}
+
+		public void UpdateStrokeMiterLimit(float strokeMiterLimit)
+		{
+			_strokeMiterLimit = strokeMiterLimit;
+			QueueDraw();
+		}
+
+		protected override void Draw(Gdk.Rectangle area, Context cr)
+		{
+			if (_fill is SolidColorBrush fillBrush)
+			{
+				cr.SetSourceRGBA(fillBrush.Color.R, fillBrush.Color.G, fillBrush.Color.B, fillBrush.Color.A);
+				cr.FillPreserve();
+			}
+			else if (_fill != null)
+				throw new NotImplementedException("Brushes other than SolidColorBrush are not implemented yet");
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.GTK/Properties/AssemblyInfo.cs
@@ -48,3 +48,7 @@ using Xamarin.Forms.Platform.GTK.Renderers;
 [assembly: ExportCell(typeof(Xamarin.Forms.ImageCell), typeof(ImageCellRenderer))]
 [assembly: ExportCell(typeof(Xamarin.Forms.SwitchCell), typeof(SwitchCellRenderer))]
 [assembly: ExportCell(typeof(Xamarin.Forms.ViewCell), typeof(ViewCellRenderer))]
+
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Rectangle), typeof(RectangleRenderer))]
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Ellipse), typeof(EllipseRenderer))]
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Path), typeof(PathRenderer))]

--- a/Xamarin.Forms.Platform.GTK/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Platform.GTK/Properties/AssemblyInfo.cs
@@ -52,3 +52,5 @@ using Xamarin.Forms.Platform.GTK.Renderers;
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Rectangle), typeof(RectangleRenderer))]
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Ellipse), typeof(EllipseRenderer))]
 [assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Path), typeof(PathRenderer))]
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Polygon), typeof(PolygonRenderer))]
+[assembly: ExportRenderer(typeof(Xamarin.Forms.Shapes.Polyline), typeof(PolylineRenderer))]

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/EllipseRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/EllipseRenderer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Controls;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.PlatformConfiguration.GTKSpecific;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class EllipseRenderer : ShapeRenderer<Ellipse, EllipseView>
+	{
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/PathRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/PathRenderer.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Controls;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.PlatformConfiguration.GTKSpecific;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class PathRenderer : ShapeRenderer<Path, PathView>
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<Path> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				SetData(Element.Data);
+			}
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == Shapes.Path.DataProperty.PropertyName)
+				SetData(Element.Data);
+		}
+
+		void SetData(Geometry data)
+		{
+			Control.UpdateGeometry(data as PathGeometry);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/PolygonRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/PolygonRenderer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Controls;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.PlatformConfiguration.GTKSpecific;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class PolygonRenderer : ShapeRenderer<Polygon, PolygonView>
+	{
+		PointCollection _points;
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Polygon> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				UpdatePoints();
+				UpdateFillRule();
+			}
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(sender, args);
+
+			if (args.PropertyName == Polyline.PointsProperty.PropertyName)
+				UpdatePoints();
+			else if (args.PropertyName == Polyline.FillRuleProperty.PropertyName)
+				UpdateFillRule();
+		}
+
+		void UpdatePoints()
+		{
+			if (_points != null)
+				_points.CollectionChanged -= OnCollectionChanged;
+
+			_points = Element.Points;
+
+			_points.CollectionChanged += OnCollectionChanged;
+
+			Control.UpdatePoints(_points);
+		}
+
+		void UpdateFillRule()
+		{
+			Control.UpdateFillMode(Element.FillRule == FillRule.Nonzero);
+		}
+
+		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			UpdatePoints();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/PolylineRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/PolylineRenderer.cs
@@ -1,0 +1,58 @@
+﻿using System;
+using System.Collections.Specialized;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Controls;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.PlatformConfiguration.GTKSpecific;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class PolylineRenderer : ShapeRenderer<Polyline, PolylineView>
+	{
+		PointCollection _points;
+
+		protected override void OnElementChanged(ElementChangedEventArgs<Polyline> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.NewElement != null)
+			{
+				UpdatePoints();
+				UpdateFillRule();
+			}
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs args)
+		{
+			base.OnElementPropertyChanged(sender, args);
+
+			if (args.PropertyName == Polyline.PointsProperty.PropertyName)
+				UpdatePoints();
+			else if (args.PropertyName == Polyline.FillRuleProperty.PropertyName)
+				UpdateFillRule();
+		}
+
+		void UpdatePoints()
+		{
+			if (_points != null)
+				_points.CollectionChanged -= OnCollectionChanged;
+
+			_points = Element.Points;
+
+			_points.CollectionChanged += OnCollectionChanged;
+
+			Control.UpdatePoints(_points);
+		}
+
+		void UpdateFillRule()
+		{
+			Control.UpdateFillMode(Element.FillRule == FillRule.Nonzero);
+		}
+
+		void OnCollectionChanged(object sender, NotifyCollectionChangedEventArgs e)
+		{
+			UpdatePoints();
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/RectangleRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/RectangleRenderer.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Controls;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.PlatformConfiguration.GTKSpecific;
+using FormsRectangle = Xamarin.Forms.Shapes.Rectangle;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class RectangleRenderer : ShapeRenderer<FormsRectangle, RectangleView>
+	{
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/ShapeRenderer.cs
@@ -24,6 +24,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 				UpdateFill();
 				UpdateStroke();
+				UpdateStrokeThickness();
+				UpdateStrokeDashArray();
+				UpdateStrokeDashOffset();
+				UpdateStrokeLineCap();
+				UpdateStrokeLineJoin();
+				UpdateStrokeMiterLimit();
 
 				UpdateSize();
 			}
@@ -97,7 +103,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 		void UpdateStrokeDashOffset()
 		{
-			Control.UpdateStrokeDashOffset((float)Element.StrokeDashOffset);
+			Control.UpdateStrokeDashOffset(Element.StrokeDashOffset);
 		}
 
 		void UpdateStrokeLineCap()

--- a/Xamarin.Forms.Platform.GTK/Renderers/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/Shapes/ShapeRenderer.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using System.Linq;
+using System.ComponentModel;
+using Xamarin.Forms.Platform.GTK.Controls;
+using Xamarin.Forms.Platform.GTK.Extensions;
+using Xamarin.Forms.PlatformConfiguration.GTKSpecific;
+using Xamarin.Forms.Shapes;
+using Cairo;
+
+namespace Xamarin.Forms.Platform.GTK.Renderers
+{
+	public class ShapeRenderer<TShape, TNativeShape> : ViewRenderer<TShape, TNativeShape>
+		where TShape : Shape
+		where TNativeShape : ShapeView, new()
+	{
+		protected override void OnElementChanged(ElementChangedEventArgs<TShape> e)
+		{
+			if (e.NewElement != null)
+			{
+				if (Control == null)
+				{
+					SetNativeControl(new TNativeShape());
+				}
+
+				UpdateFill();
+				UpdateStroke();
+
+				UpdateSize();
+			}
+
+			base.OnElementChanged(e);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == Shape.FillProperty.PropertyName)
+				UpdateFill();
+			else if (e.PropertyName == Shape.StrokeProperty.PropertyName)
+				UpdateStroke();
+			else if (e.PropertyName == Shape.StrokeThicknessProperty.PropertyName)
+				UpdateStrokeThickness();
+			else if (e.PropertyName == Shape.StrokeDashArrayProperty.PropertyName)
+				UpdateStrokeDashArray();
+			else if (e.PropertyName == Shape.StrokeDashOffsetProperty.PropertyName)
+				UpdateStrokeDashOffset();
+			else if (e.PropertyName == Shape.StrokeLineCapProperty.PropertyName)
+				UpdateStrokeLineCap();
+			else if (e.PropertyName == Shape.StrokeLineJoinProperty.PropertyName)
+				UpdateStrokeLineJoin();
+			else if (e.PropertyName == Shape.StrokeMiterLimitProperty.PropertyName)
+				UpdateStrokeMiterLimit();
+		}
+
+		protected override void OnSizeAllocated(Gdk.Rectangle allocation)
+		{
+			UpdateSize();
+
+			base.OnSizeAllocated(allocation);
+		}
+
+
+		void UpdateFill()
+		{
+			if (Element == null || Control == null)
+				return;
+
+			Control.UpdateFill(Element.Fill);
+		}
+
+		void UpdateStroke()
+		{
+			if (Element == null || Control == null)
+				return;
+
+			Control.UpdateStroke(Element.Stroke);
+		}
+
+		void UpdateSize()
+		{
+			int height = HeightRequest;
+			int width = WidthRequest;
+
+			Control.UpdateSize(height, width);
+		}
+
+		void UpdateStrokeThickness()
+		{
+			Control.UpdateStrokeThickness(Element.StrokeThickness);
+		}
+
+		void UpdateStrokeDashArray()
+		{
+			Control.UpdateStrokeDashArray(Element.StrokeDashArray.ToArray());
+		}
+
+		void UpdateStrokeDashOffset()
+		{
+			Control.UpdateStrokeDashOffset((float)Element.StrokeDashOffset);
+		}
+
+		void UpdateStrokeLineCap()
+		{
+			PenLineCap lineCap = Element.StrokeLineCap;
+			LineCap cairoStrokeCap = LineCap.Butt;
+			switch (lineCap)
+			{
+				case PenLineCap.Flat:
+					cairoStrokeCap = LineCap.Butt;
+					break;
+				case PenLineCap.Square:
+					cairoStrokeCap = LineCap.Square;
+					break;
+				case PenLineCap.Round:
+					cairoStrokeCap = LineCap.Round;
+					break;
+			}
+			Control.UpdateStrokeLineCap(cairoStrokeCap);
+		}
+
+		void UpdateStrokeLineJoin()
+		{
+			PenLineJoin lineJoin = Element.StrokeLineJoin;
+			LineJoin cairoStrokeJoin = LineJoin.Miter;
+			switch (lineJoin)
+			{
+				case PenLineJoin.Miter:
+					cairoStrokeJoin = LineJoin.Miter;
+					break;
+				case PenLineJoin.Bevel:
+					cairoStrokeJoin = LineJoin.Bevel;
+					break;
+				case PenLineJoin.Round:
+					cairoStrokeJoin = LineJoin.Round;
+					break;
+			}
+			Control.UpdateStrokeLineJoin(cairoStrokeJoin);
+		}
+
+		void UpdateStrokeMiterLimit()
+		{
+			Control.UpdateStrokeMiterLimit((float)Element.StrokeMiterLimit);
+		}
+
+	}
+}

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -121,6 +121,8 @@
     <Compile Include="Controls\ActivityIndicator.cs" />
     <Compile Include="Controls\Shapes\EllipseView.cs" />
     <Compile Include="Controls\Shapes\PathView.cs" />
+    <Compile Include="Controls\Shapes\PolylineView.cs" />
+    <Compile Include="Controls\Shapes\PolygonView.cs" />
     <Compile Include="Controls\Shapes\RectangleView.cs" />
     <Compile Include="Controls\BoxView.cs" />
     <Compile Include="Controls\Carousel.cs" />
@@ -194,6 +196,8 @@
     <Compile Include="Renderers\ActivityIndicatorRenderer.cs" />
     <Compile Include="Renderers\Shapes\EllipseRenderer.cs" />
     <Compile Include="Renderers\Shapes\PathRenderer.cs" />
+    <Compile Include="Renderers\Shapes\PolylineRenderer.cs" />
+    <Compile Include="Renderers\Shapes\PolygonRenderer.cs" />
     <Compile Include="Renderers\Shapes\ShapeRenderer.cs" />
     <Compile Include="Renderers\Shapes\RectangleRenderer.cs" />
     <Compile Include="Renderers\BoxViewRenderer.cs" />

--- a/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
+++ b/Xamarin.Forms.Platform.GTK/Xamarin.Forms.Platform.GTK.csproj
@@ -119,6 +119,9 @@
     <Compile Include="Cells\ViewCell.cs" />
     <Compile Include="Cells\ViewCellRenderer.cs" />
     <Compile Include="Controls\ActivityIndicator.cs" />
+    <Compile Include="Controls\Shapes\EllipseView.cs" />
+    <Compile Include="Controls\Shapes\PathView.cs" />
+    <Compile Include="Controls\Shapes\RectangleView.cs" />
     <Compile Include="Controls\BoxView.cs" />
     <Compile Include="Controls\Carousel.cs" />
     <Compile Include="Controls\CustomComboBox.cs" />
@@ -139,6 +142,7 @@
     <Compile Include="Controls\ScrolledTextView.cs" />
     <Compile Include="Controls\PageContainer.cs" />
     <Compile Include="Controls\SearchEntry.cs" />
+    <Compile Include="Controls\Shapes\ShapeView.cs" />
     <Compile Include="Controls\TabbedPageHeader.cs" />
     <Compile Include="Controls\TableView.cs" />
     <Compile Include="Controls\TimePicker.cs" />
@@ -188,6 +192,10 @@
     <Compile Include="RendererFactory.cs" />
     <Compile Include="Renderers\AbstractPageRenderer.cs" />
     <Compile Include="Renderers\ActivityIndicatorRenderer.cs" />
+    <Compile Include="Renderers\Shapes\EllipseRenderer.cs" />
+    <Compile Include="Renderers\Shapes\PathRenderer.cs" />
+    <Compile Include="Renderers\Shapes\ShapeRenderer.cs" />
+    <Compile Include="Renderers\Shapes\RectangleRenderer.cs" />
     <Compile Include="Renderers\BoxViewRenderer.cs" />
     <Compile Include="Renderers\ButtonRenderer.cs" />
     <Compile Include="Renderers\CarouselPageRenderer.cs" />


### PR DESCRIPTION
### Description of Change ###

Supported Shapes:
  - Ellipse
  - Rectangle
  - Path

Supported Path Segments:
  - Arc
  - Line

Supported Brushes:
  - SolidColorBrush

(Strokes implementation will come in a 2nd PR.)

Co-authored-by: Afshin Arani &lt;afshinarani79@gmail.com&gt;

### API Changes ###
NOTE: even if this could be considered an enhancement, any code that used Shapes with XamarinForms5.0 (or older) running on Gtk would have crashed or contained bugs (obviously), so this is essentially a bugfix. So: None, no API changes.

### Platforms Affected ### 
- GTK

### Testing Procedure ###
Manual with our own app.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
