### PR TITLE
Call Dispose on the VisualElementRenderer, rather than the Android View

### DIFF
--- a/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Cells/ViewCellRenderer.cs
@@ -216,7 +216,7 @@ namespace Xamarin.Forms.Platform.Android
 				RemoveView(_view.View);
 				Platform.SetRenderer(_viewCell.View, null);
 				_viewCell.View.IsPlatformEnabled = false;
-				_view.View.Dispose();
+				_view.Dispose();
 
 				_viewCell = cell;
 				_view = Platform.CreateRenderer(_viewCell.View, Context);


### PR DESCRIPTION
### Description of Change ###

When switching to a new renderer for the ViewCell, Dispose() is called on the Android View but not on the IVisualElementRenderer itself. 

This change calls Dispose on the IVisualElementRenderer, giving it an opportunity to handle full cleanup before it's released.

### Issues Resolved ### 

Possibly a memory leak or two.

### API Changes ###

None

### Platforms Affected ### 
- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

None

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
