### PR TITLE
Don't set the width of the TitleView to the width of the status bar

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
@@ -22,6 +22,35 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		protected override void Init()
 		{
+			SetupMeasuringTest1();
+		}
+
+		void SetupMeasuringTest2()
+		{
+			ContentPage contentPage = new ContentPage();
+			AddFlyoutItem(contentPage, "Width Measure (13949)");
+
+			Grid grid = new Grid();
+			grid.ColumnDefinitions.Add(new ColumnDefinition());
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			grid.AddChild(new Label() { Text = "Text" }, 0, 0);
+			grid.AddChild(new Button() { Text = "B1" }, 1, 0);
+			grid.AddChild(new Label() { Text = "B2" }, 2, 0);
+
+			Shell.SetTitleView(contentPage, grid);
+
+			contentPage.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label() { Text = "TitleView should have one label and two buttons"}
+				}
+			};
+		}
+
+		void SetupMeasuringTest1()
+		{
 			AddTopTab(createContentPage("title 1"), "page 1");
 			AddTopTab(createContentPage(null), "page 2");
 			AddTopTab(createContentPage("title 3"), "page 3");
@@ -38,7 +67,7 @@ namespace Xamarin.Forms.Controls.Issues
 						{
 							new Label()
 							{
-								Text = "Tab 1,3, and 4 should have a single visible TitleView. If the TitleView is duplicated or not visible the test has failed.",
+								Text = "Tab 1, 3, and 4 should have a single visible TitleView. If the TitleView is duplicated or not visible the test has failed.",
 								AutomationId = "Instructions"
 							},
 							safeArea
@@ -60,10 +89,19 @@ namespace Xamarin.Forms.Controls.Issues
 
 				return page;
 			}
+
 		}
 
-
 #if UITEST
+
+		[Test]
+		public void TitleWidthMeasuresCorrectly_13949()
+		{
+			this.TapInFlyout("Width Measure (13949)");
+			RunningApp.WaitForElement("Text");
+			RunningApp.WaitForElement("B1");
+			RunningApp.WaitForElement("B2");
+		}
 
 		[Test]
 		public void TitleViewPositionsCorrectly()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
@@ -26,6 +26,7 @@ namespace Xamarin.Forms.Controls.Issues
 			SetupMeasuringTest2();
 			SetupMeasuringTest3();
 		}
+		
 		void SetupMeasuringTest3()
 		{
 			ContentPage contentPage = new ContentPage();
@@ -133,7 +134,7 @@ namespace Xamarin.Forms.Controls.Issues
 		[Test]
 		public void TitleWidthWithToolBarItemMeasuresCorrectly_13949()
 		{
-			this.TapInFlyout("Width Measure and ToolBarItem(13949)");
+			this.TapInFlyout("Width Measure and ToolBarItem (13949)");
 			RunningApp.WaitForElement("Text");
 			RunningApp.WaitForElement("B1");
 			RunningApp.WaitForElement("B2");

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/ShellTitleView.cs
@@ -23,6 +23,33 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 			SetupMeasuringTest1();
+			SetupMeasuringTest2();
+			SetupMeasuringTest3();
+		}
+		void SetupMeasuringTest3()
+		{
+			ContentPage contentPage = new ContentPage();
+			AddFlyoutItem(contentPage, "Width Measure and ToolBarItem (13949)");
+
+			Grid grid = new Grid();
+			grid.ColumnDefinitions.Add(new ColumnDefinition());
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
+			grid.AddChild(new Label() { Text = "Text" }, 0, 0);
+			grid.AddChild(new Button() { Text = "B1" }, 1, 0);
+			grid.AddChild(new Button() { Text = "B2" }, 2, 0);
+
+			Shell.SetTitleView(contentPage, grid);
+
+			contentPage.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Label() { Text = "TitleView should have one label and two buttons"}
+				}
+			};
+
+			contentPage.ToolbarItems.Add(new ToolbarItem() { Text = "Item" });
 		}
 
 		void SetupMeasuringTest2()
@@ -36,7 +63,7 @@ namespace Xamarin.Forms.Controls.Issues
 			grid.ColumnDefinitions.Add(new ColumnDefinition() { Width = GridLength.Auto });
 			grid.AddChild(new Label() { Text = "Text" }, 0, 0);
 			grid.AddChild(new Button() { Text = "B1" }, 1, 0);
-			grid.AddChild(new Label() { Text = "B2" }, 2, 0);
+			grid.AddChild(new Button() { Text = "B2" }, 2, 0);
 
 			Shell.SetTitleView(contentPage, grid);
 
@@ -55,7 +82,7 @@ namespace Xamarin.Forms.Controls.Issues
 			AddTopTab(createContentPage(null), "page 2");
 			AddTopTab(createContentPage("title 3"), "page 3");
 			AddTopTab(createContentPage("title 4"), "page 4");
-
+			Items[0].Title = "Duplicate Test";
 			ContentPage createContentPage(string titleView)
 			{
 				Label safeArea = new Label();
@@ -103,6 +130,15 @@ namespace Xamarin.Forms.Controls.Issues
 			RunningApp.WaitForElement("B2");
 		}
 
+		[Test]
+		public void TitleWidthWithToolBarItemMeasuresCorrectly_13949()
+		{
+			this.TapInFlyout("Width Measure and ToolBarItem(13949)");
+			RunningApp.WaitForElement("Text");
+			RunningApp.WaitForElement("B1");
+			RunningApp.WaitForElement("B2");
+		}
+		
 		[Test]
 		public void TitleViewPositionsCorrectly()
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -195,17 +195,6 @@ namespace Xamarin.Forms.Platform.iOS
 			else
 			{
 				var view = new TitleViewContainer(titleView);
-
-				if (Forms.IsiOS11OrNewer)
-				{
-					view.TranslatesAutoresizingMaskIntoConstraints = false;
-				}
-				else
-				{
-					view.TranslatesAutoresizingMaskIntoConstraints = true;
-					view.AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
-				}
-
 				NavigationItem.TitleView = view;
 			}
 		}
@@ -399,6 +388,16 @@ namespace Xamarin.Forms.Platform.iOS
 			public TitleViewContainer(View view) : base(view)
 			{
 				MatchHeight = true;
+
+				if (Forms.IsiOS11OrNewer)
+				{
+					TranslatesAutoresizingMaskIntoConstraints = false;
+				}
+				else
+				{
+					TranslatesAutoresizingMaskIntoConstraints = true;
+					AutoresizingMask = UIViewAutoresizing.FlexibleHeight | UIViewAutoresizing.FlexibleWidth;
+				}
 			}
 
 			public override CGRect Frame
@@ -424,7 +423,6 @@ namespace Xamarin.Forms.Platform.iOS
 						Frame = new CGRect(Frame.X, newSuper.Bounds.Y, Frame.Width, newSuper.Bounds.Height);
 
 					Height = newSuper.Bounds.Height;
-					Width = newSuper.Bounds.Width;
 				}
 
 				base.WillMoveToSuperview(newSuper);
@@ -435,6 +433,11 @@ namespace Xamarin.Forms.Platform.iOS
 			public override CGSize SizeThatFits(CGSize size)
 			{
 				return size;
+			}
+
+			public override void LayoutSubviews()
+			{
+				base.LayoutSubviews();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -434,11 +434,6 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				return size;
 			}
-
-			public override void LayoutSubviews()
-			{
-				base.LayoutSubviews();
-			}
 		}
 
 		#region SearchHandler


### PR DESCRIPTION
### Description of Change ###

Shell's Title View is incorrectly setting the width of the titleview to the width of the status bar so the content is overflowing. 

Regression here
https://github.com/xamarin/Xamarin.Forms/commit/0e708d0f5e2b1177d5414798075e31c84b7a1124#diff-2f88e95da9bc5f5ca84db7e94d89f0382947623bd11d414cc4cd02ce452fe558R427


### Issues Resolved ### 
- fixes #13949
- fixes #13795

### Platforms Affected ### 
- iOS

### Testing Procedure ###
- UI Tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
