### PR TITLE
CSS: Support omitting semicolon from last property

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/StyleSheets/StyleParserTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/StyleSheets/StyleParserTests.cs
@@ -1,0 +1,24 @@
+﻿using System.IO;
+using NUnit.Framework;
+
+namespace Xamarin.Forms.StyleSheets.UnitTests
+{
+	[TestFixture]
+	public class StyleParserTests
+	{
+		[TestCase("font-size: 10", 1)]
+		[TestCase("font-size: 10;", 1)]
+		[TestCase("font-size: 10 background-color: blue", 0)]
+		[TestCase("font-size: 10; background-color: blue", 2)]
+		[TestCase("font-size: 10; background-color: blue;", 2)]
+		public void TestCase(string css, int propertyCount)
+		{
+			using (var reader = new StringReader(css))
+			{
+				var parser = Style.Parse(new CssReader(reader));
+
+				Assert.AreEqual(propertyCount, parser.Declarations.Count);
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -249,6 +249,7 @@
     <Compile Include="PathSegmentTests.cs" />
     <Compile Include="GeometryTests.cs" />
     <Compile Include="ShellParameterPassingTests.cs" />
+    <Compile Include="StyleSheets\StyleParserTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Core/StyleSheets/TextReaderExtensions.cs
+++ b/Xamarin.Forms.Core/StyleSheets/TextReaderExtensions.cs
@@ -55,15 +55,20 @@ namespace Xamarin.Forms.StyleSheets
 			return sb.ToString();
 		}
 
-		public static string ReadUntil(this TextReader reader, params char[] limit)
+		public static string ReadUntil(this TextReader reader, out char? limitedBy, params char[] limit)
 		{
+			limitedBy = null;
+
 			var sb = new StringBuilder();
 			int p;
 			while ((p = reader.Peek()) > 0)
 			{
 				var c = unchecked((char)p);
 				if (limit != null && limit.Contains(c))
+				{
+					limitedBy = c;
 					break;
+				}
 				reader.Read();
 				sb.Append(c);
 			}


### PR DESCRIPTION
### Description of Change ###

[ `main` may be the more appropriate branch, but it's a relatively small change. ]

The current CSS parser doesn't support declarations like `label {font-size: 18; background-color: red}` where the final semicolon is omitted. These are, however, valid CSS.

This fixes that behavior and introduces a few unit tests to check for such edge cases.

### Issues Resolved ### 

- fixes #2588

### Testing Procedure ###

Run all tests in the `Xamarin.Forms.Core.UnitTests.StyleSheets` and `Xamarin.Forms.StyleSheets.UnitTests` namespaces.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
