### PR TITLE
CSS: allow styling Cells

### DIFF
--- a/Xamarin.Forms.Core/Element_StyleSheets.cs
+++ b/Xamarin.Forms.Core/Element_StyleSheets.cs
@@ -68,16 +68,32 @@ namespace Xamarin.Forms
 
 			foreach (Element child in element.AllChildren)
 			{
-				var mergedSheets = sheets;
-				var resourceProvider = child as IResourcesProvider;
-				var childSheets = resourceProvider?.GetStyleSheets();
-				if (childSheets?.Any() ?? false)
-				{
-					mergedSheets = new List<StyleSheet>(childSheets);
-					mergedSheets.AddRange(sheets);
-				}
-				ApplyStyleSheets(mergedSheets, child);
+				ApplyStyleSheetsToChildElement(sheets, child);
 			}
+
+			if (element is TableView tableView && tableView.Root != null)
+			{
+				foreach (var section in tableView.Root)
+				{
+					foreach (var cell in section)
+					{
+						ApplyStyleSheetsToChildElement(sheets, cell);
+					}
+				}
+			}
+		}
+
+		private void ApplyStyleSheetsToChildElement(List<StyleSheet> sheets, Element child)
+		{
+			var mergedSheets = sheets;
+			var resourceProvider = child as IResourcesProvider;
+			var childSheets = resourceProvider?.GetStyleSheets();
+			if (childSheets?.Any() ?? false)
+			{
+				mergedSheets = new List<StyleSheet>(childSheets);
+				mergedSheets.AddRange(sheets);
+			}
+			ApplyStyleSheets(mergedSheets, child);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -53,6 +53,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: StyleProperty("border-radius", typeof(ImageButton), nameof(BorderElement.CornerRadiusProperty))]
 [assembly: StyleProperty("border-width", typeof(IBorderElement), nameof(BorderElement.BorderWidthProperty))]
 [assembly: StyleProperty("color", typeof(IColorElement), nameof(ColorElement.ColorProperty), Inherited = true)]
+[assembly: StyleProperty("color", typeof(TextCell), nameof(TextCell.TextColorProperty), Inherited = true)]
 [assembly: StyleProperty("color", typeof(ITextElement), nameof(TextElement.TextColorProperty), Inherited = true)]
 [assembly: StyleProperty("text-transform", typeof(ITextElement), nameof(TextElement.TextTransformProperty), Inherited = true)]
 [assembly: StyleProperty("color", typeof(ProgressBar), nameof(ProgressBar.ProgressColorProperty))]

--- a/Xamarin.Forms.Core/StyleSheets/Style.cs
+++ b/Xamarin.Forms.Core/StyleSheets/Style.cs
@@ -82,10 +82,58 @@ namespace Xamarin.Forms.StyleSheets
 
 			foreach (var child in styleable.LogicalChildrenInternal)
 			{
-				var ve = child as VisualElement;
-				if (ve == null)
+				switch (child)
+				{
+					case VisualElement ve:
+						Apply(ve, inheriting: true);
+
+						break;
+					case Cell cell:
+						Apply(cell, inheriting: true);
+
+						break;
+					default:
+						break;
+				}
+			}
+		}
+
+		public void Apply(Cell styleable, bool inheriting = false)
+		{
+			if (styleable == null)
+				throw new ArgumentNullException(nameof(styleable));
+
+			foreach (var decl in Declarations)
+			{
+				var property = ((IStylable)styleable).GetProperty(decl.Key, inheriting);
+				if (property == null)
 					continue;
-				Apply(ve, inheriting: true);
+				if (string.Equals(decl.Value, "initial", StringComparison.OrdinalIgnoreCase))
+					styleable.ClearValue(property, fromStyle: true);
+				else
+				{
+					object value;
+					if (!convertedValues.TryGetValue(decl, out value))
+						convertedValues[decl] = (value = Convert(styleable, decl.Value, property));
+					styleable.SetValue(property, value, fromStyle: true);
+				}
+			}
+
+			foreach (var child in styleable.LogicalChildrenInternal)
+			{
+				switch (child)
+				{
+					case VisualElement ve:
+						Apply(ve, inheriting: true);
+
+						break;
+					case Cell cell:
+						Apply(cell, inheriting: true);
+
+						break;
+					default:
+						break;
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -112,15 +112,27 @@ namespace Xamarin.Forms.StyleSheets
 
 		void Apply(Element styleable)
 		{
-			if (!(styleable is VisualElement visualStylable))
+			if (!(styleable is IStylable))
 				return;
+
 			foreach (var kvp in Styles)
 			{
 				var selector = kvp.Key;
 				var style = kvp.Value;
 				if (!selector.Matches(styleable))
 					continue;
-				style.Apply(visualStylable);
+
+				switch (styleable)
+				{
+					case VisualElement visualStylable:
+						style.Apply(visualStylable);
+						break;
+					case Cell cell:
+						style.Apply(cell);
+						break;
+					default:
+						return;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

This PR

* makes `Cell` implement `IStylable` the same way VisualElement does. For `ViewCell`, this means style information gets propagated as expected, which fixes #6563.
* makes `TextCell` in particular map `color` to `TextColorProperty`.

### Issues Resolved ### 

- fixes #6563, which failed because `ViewCell`s were previously ignored in the hierarchy and therefore couldn't propagate style information to the child views

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

Styling information that did not previously affect the view hierarchy inside cells will now have an effect. A selector might hypothetically be too broad. For example, if you had:

```css
label
{
    color: red;
}
```

And also:

```xml
<ViewCell><Label>This was previously black</Label></ViewCell>
```

You might be surprised to find this will now become red.

### Testing Procedure ###

The test case from #6563 should be a good starting point.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
