### PR TITLE
Support CSS styles and classes for `Span`

### DIFF
--- a/Xamarin.Forms.Core/Element_StyleSheets.cs
+++ b/Xamarin.Forms.Core/Element_StyleSheets.cs
@@ -78,6 +78,12 @@ namespace Xamarin.Forms
 				}
 				ApplyStyleSheets(mergedSheets, child);
 			}
+
+			if (element is Label label && label.FormattedText?.Spans?.Count > 0)
+			{
+				foreach (var child in label.FormattedText.Spans)
+					ApplyStyleSheets(sheets, child);
+			}
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
+++ b/Xamarin.Forms.Core/Properties/AssemblyInfo.cs
@@ -44,6 +44,7 @@ using Xamarin.Forms.StyleSheets;
 [assembly: XmlnsPrefix("http://xamarin.com/schemas/2014/forms/design", "d")]
 
 [assembly: StyleProperty("background-color", typeof(VisualElement), nameof(VisualElement.BackgroundColorProperty))]
+[assembly: StyleProperty("background-color", typeof(Span), nameof(Span.BackgroundColorProperty))]
 [assembly: StyleProperty("background", typeof(VisualElement), nameof(VisualElement.BackgroundProperty))]
 [assembly: StyleProperty("background-image", typeof(Page), nameof(Page.BackgroundImageSourceProperty))]
 [assembly: StyleProperty("border-color", typeof(IBorderElement), nameof(BorderElement.BorderColorProperty))]

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -1,11 +1,14 @@
 using System;
 using System.ComponentModel;
+using System.Reflection;
 using Xamarin.Forms.Internals;
+using Xamarin.Forms.StyleSheets;
 
 namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
-	public class Span : GestureElement, IFontElement, IStyleElement, ITextElement, ILineHeightElement, IDecorableTextElement
+	public class Span : GestureElement, IFontElement, IStyleElement, ITextElement,
+		ILineHeightElement, IDecorableTextElement, IStylable
 	{
 		internal readonly MergedStyle _mergedStyle;
 
@@ -184,6 +187,46 @@ namespace Xamarin.Forms
 
 		void ILineHeightElement.OnLineHeightChanged(double oldValue, double newValue)
 		{
+		}
+
+		BindableProperty IStylable.GetProperty(string key, bool inheriting)
+		{
+			if (!Internals.Registrar.StyleProperties.TryGetValue(key, out var attrList))
+				return null;
+
+			StylePropertyAttribute styleAttribute = null;
+			for (int i = 0; i < attrList.Count; i++)
+			{
+				styleAttribute = attrList[i];
+				if (styleAttribute.TargetType.GetTypeInfo().IsAssignableFrom(GetType().GetTypeInfo()))
+					break;
+				styleAttribute = null;
+			}
+
+			if (styleAttribute == null)
+				return null;
+
+			//do not inherit non-inherited properties
+			if (inheriting && !styleAttribute.Inherited)
+				return null;
+
+			if (styleAttribute.BindableProperty != null)
+				return styleAttribute.BindableProperty;
+
+			var propertyOwnerType = styleAttribute.PropertyOwnerType ?? GetType();
+#if NETSTANDARD1_0
+			var bpField = propertyOwnerType.GetField(styleAttribute.BindablePropertyName);
+#else
+			var bpField = propertyOwnerType.GetField(styleAttribute.BindablePropertyName,
+													  BindingFlags.Public
+													| BindingFlags.NonPublic
+													| BindingFlags.Static
+													| BindingFlags.FlattenHierarchy);
+#endif
+			if (bpField == null)
+				return null;
+
+			return (styleAttribute.BindableProperty = bpField.GetValue(null) as BindableProperty);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/Span.cs
+++ b/Xamarin.Forms.Core/Span.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.ComponentModel;
 using System.Reflection;
 using Xamarin.Forms.Internals;
@@ -8,7 +9,7 @@ namespace Xamarin.Forms
 {
 	[ContentProperty("Text")]
 	public class Span : GestureElement, IFontElement, IStyleElement, ITextElement,
-		ILineHeightElement, IDecorableTextElement, IStylable
+		ILineHeightElement, IDecorableTextElement, IStylable, IStyleSelectable
 	{
 		internal readonly MergedStyle _mergedStyle;
 
@@ -29,6 +30,25 @@ namespace Xamarin.Forms
 			get { return (Style)GetValue(StyleProperty); }
 			set { SetValue(StyleProperty, value); }
 		}
+
+		[TypeConverter(typeof(ListStringTypeConverter))]
+		public IList<string> StyleClass
+		{
+			get { return @class; }
+			set { @class = value; }
+		}
+
+		[TypeConverter(typeof(ListStringTypeConverter))]
+		public IList<string> @class
+		{
+			get { return _mergedStyle.StyleClass; }
+			set
+			{
+				_mergedStyle.StyleClass = value;
+			}
+		}
+
+		IList<string> IStyleSelectable.Classes => StyleClass;
 
 		public static readonly BindableProperty BackgroundColorProperty
 			= BindableProperty.Create(nameof(BackgroundColor), typeof(Color), typeof(Span), default(Color), defaultBindingMode: BindingMode.OneWay);

--- a/Xamarin.Forms.Core/StyleSheets/Style.cs
+++ b/Xamarin.Forms.Core/StyleSheets/Style.cs
@@ -82,10 +82,41 @@ namespace Xamarin.Forms.StyleSheets
 
 			foreach (var child in styleable.LogicalChildrenInternal)
 			{
-				var ve = child as VisualElement;
-				if (ve == null)
+				switch (child)
+				{
+					case VisualElement ve:
+						Apply(ve, inheriting: true);
+
+						break;
+					case Span span:
+						Apply(span, inheriting: true);
+
+						break;
+					default:
+						break;
+				}
+			}
+		}
+
+		public void Apply(Span styleable, bool inheriting = false)
+		{
+			if (styleable == null)
+				throw new ArgumentNullException(nameof(styleable));
+
+			foreach (var decl in Declarations)
+			{
+				var property = ((IStylable)styleable).GetProperty(decl.Key, inheriting);
+				if (property == null)
 					continue;
-				Apply(ve, inheriting: true);
+				if (string.Equals(decl.Value, "initial", StringComparison.OrdinalIgnoreCase))
+					styleable.ClearValue(property, fromStyle: true);
+				else
+				{
+					object value;
+					if (!convertedValues.TryGetValue(decl, out value))
+						convertedValues[decl] = (value = Convert(styleable, decl.Value, property));
+					styleable.SetValue(property, value, fromStyle: true);
+				}
 			}
 		}
 

--- a/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
+++ b/Xamarin.Forms.Core/StyleSheets/StyleSheet.cs
@@ -112,15 +112,27 @@ namespace Xamarin.Forms.StyleSheets
 
 		void Apply(Element styleable)
 		{
-			if (!(styleable is VisualElement visualStylable))
+			if (!(styleable is IStylable))
 				return;
+
 			foreach (var kvp in Styles)
 			{
 				var selector = kvp.Key;
 				var style = kvp.Value;
 				if (!selector.Matches(styleable))
 					continue;
-				style.Apply(visualStylable);
+
+				switch (styleable)
+				{
+					case VisualElement ve:
+						style.Apply(ve);
+						break;
+					case Span span:
+						style.Apply(span);
+						break;
+					default:
+						break;
+				}
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

This implements #10277. To accomplish that, it first implements CSS styles altogether for Span, and maps the Span's `BackgroundColor` property (most other CSS properties are already mapped).

### Issues Resolved ### 

- fixes #10277

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ###
Given the following XAML:

```xml
        <Label>
            <Label.FormattedText>
                <FormattedString>
                    <Span Text="No class" />
                    <Span Text="Big stuff" StyleClass="big" />
                    <Span Text="Small and fun" StyleClass="small" />
                </FormattedString>
            </Label.FormattedText>
        </Label>
```

And the following CSS:

```css
span {
    background-color: saddlebrown;
    font-size: 16;
    color: white;
}

    span.big {
        background-color: lightyellow;
        font-size: 24;
        color: darkslategray;
    }

    span.small {
        background-color: lightyellow;
        font-size: 10;
        letter-spacing: 3;
        color: darkslategray;
        font-style: italic;
    }
```

This produces three differently-styled spans due to their classes:

<img width="226" alt="image" src="https://user-images.githubusercontent.com/20194/120088187-802b4180-c0ee-11eb-8b43-30bdf889d877.png">

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
