### PR TITLE
Fix iOS so if you remove more than one page it's able to remove them successfully

### DIFF
--- a/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
+++ b/Xamarin.Forms.ControlGallery.iOS/Xamarin.Forms.ControlGallery.iOS.csproj
@@ -390,7 +390,7 @@
     </PackageReference>
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
     <PackageReference Include="Xamarin.Insights" Version="1.12.3" />
-    <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.22.1" />
+    <PackageReference Include="Xamarin.TestCloud.Agent" Version="0.22.2" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.storyboard" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13916.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13916.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13916, "[iOS] iOS Application crashes on Back press when navigated to using GoToAsync with \"//\" or \"///\" route if 2 or more things are removed from the navigation stack",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue13916 : TestShell
+	{
+		static int pageCount = 1;
+		protected override void Init()
+		{
+			Routing.RegisterRoute(nameof(Issue13916SuccessPage), typeof(Issue13916SuccessPage));
+
+			AddFlyoutItem(CreateContentPage(), "Push Me");
+		}
+
+
+		public class Issue13916SuccessPage : ContentPage
+		{
+			public Issue13916SuccessPage()
+			{
+				StackLayout layout = new StackLayout();
+				Label label = new Label()
+				{
+					Text = "Success",
+					AutomationId = "Success"
+				};
+				layout.Children.Add(label);
+				Content = layout;
+			}
+		}
+
+		ContentPage CreateContentPage()
+		{
+			StackLayout layout = new StackLayout();
+			Button button = new Button()
+			{
+				Text = "Click Me",
+				AutomationId = $"ClickMe{pageCount}",
+				Command = new Command(async () =>
+				{
+					if (Navigation.NavigationStack.Count >= 3)
+					{
+						await GoToAsync($"../../{nameof(Issue13916SuccessPage)}");
+					}
+					else
+					{
+						await Navigation.PushAsync(CreateContentPage());
+					}
+				})
+			};
+			pageCount++;
+
+			layout.Children.Add(button);
+
+			return new ContentPage()
+			{
+				Content = layout
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void RemovingMoreThanOneInnerPageAndThenPushingAPageCrashes()
+		{
+			RunningApp.Tap("ClickMe1");
+			RunningApp.Tap("ClickMe2");
+			RunningApp.Tap("ClickMe3");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -21,6 +21,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13126.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13126_2.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13916.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />

--- a/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
+++ b/Xamarin.Forms.Core.Android.UITests/Xamarin.Forms.Core.Android.UITests.csproj
@@ -48,7 +48,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.14" />
+    <PackageReference Include="Xamarin.UITest" Version="3.1.0" />
     <PackageReference Include="NUnit3TestAdapter">
       <Version>3.17.0</Version>
     </PackageReference>

--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatedArgsTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatedArgsTests.cs
@@ -1,0 +1,211 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading.Tasks;
+using NUnit.Framework;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Core.UnitTests
+{
+	[TestFixture]
+	public class ShellNavigatedArgsTests : ShellTestBase
+	{
+		[TearDown]
+		public override void TearDown()
+		{
+			base.TearDown();
+			Routing.Clear();
+		}
+
+		[Test]
+		public async Task RemoveInnerPagesNavigatingArgs()
+		{
+			Routing.RegisterRoute("SecondPageView", typeof(ContentPage));
+			Routing.RegisterRoute("ThirdPageView", typeof(ContentPage));
+			Routing.RegisterRoute("FourthPage", typeof(ContentPage));
+
+			var shell = new TestShell(CreateShellItem<FlyoutItem>(shellContentRoute: "HomePageView"));
+
+			await shell.GoToAsync("//HomePageView/SecondPageView/ThirdPageView");
+			await shell.GoToAsync("//HomePageView/FourthPage");
+
+			shell.TestNavigatedArgs(ShellNavigationSource.Pop, "//HomePageView/SecondPageView/ThirdPageView", "//HomePageView/FourthPage");
+			Assert.AreEqual(3, shell.NavigatedCount);
+		}
+
+		[Test]
+		public async Task PopToRootSetsCorrectNavigationSource()
+		{
+			var shell = new TestShell(CreateShellItem());
+			await shell.Navigation.PushAsync(new ContentPage());
+			await shell.Navigation.PushAsync(new ContentPage());
+			await shell.Navigation.PopToRootAsync();
+			Assert.AreEqual(ShellNavigationSource.PopToRoot, shell.LastShellNavigatingEventArgs.Source);
+
+			await shell.Navigation.PushAsync(new ContentPage());
+			await shell.Navigation.PushAsync(new ContentPage());
+
+			await shell.Navigation.PopAsync();
+			Assert.AreEqual(ShellNavigationSource.Pop, shell.LastShellNavigatingEventArgs.Source);
+
+			await shell.Navigation.PopAsync();
+			Assert.AreEqual(ShellNavigationSource.PopToRoot, shell.LastShellNavigatingEventArgs.Source);
+		}
+
+		[Test]
+		public async Task PushingSetsCorrectNavigationSource()
+		{
+			var shell = new TestShell(CreateShellItem(shellItemRoute: "item1"));
+			shell.RegisterPage(nameof(PushingSetsCorrectNavigationSource));
+			await shell.GoToAsync(nameof(PushingSetsCorrectNavigationSource));
+
+			shell.TestNavigatingArgs(ShellNavigationSource.Push,
+				"//item1", $"{nameof(PushingSetsCorrectNavigationSource)}");
+
+			shell.TestNavigatedArgs(ShellNavigationSource.Push,
+				"//item1", $"//item1/{nameof(PushingSetsCorrectNavigationSource)}");
+		}
+
+		[Test]
+		public async Task ChangingShellItemSetsCorrectNavigationSource()
+		{
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item1"),
+				CreateShellItem(shellItemRoute: "item2")
+			);
+
+			await shell.GoToAsync("//item2");
+
+			shell.TestNavigationArgs(ShellNavigationSource.ShellItemChanged,
+				"//item1", "//item2");
+		}
+
+		[Test]
+		public async Task ChangingShellSectionSetsCorrectNavigationSource()
+		{
+			var shell = new TestShell(
+				CreateShellItem(shellSectionRoute: "item1")
+			);
+
+			shell.Items[0].Items.Add(CreateShellSection(shellContentRoute: "item2"));
+
+			await shell.GoToAsync("//item2");
+
+			shell.TestNavigationArgs(ShellNavigationSource.ShellSectionChanged,
+				"//item1", "//item2");
+		}
+
+		[Test]
+		public async Task PoppingSamePageSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("detailspage", typeof(ContentPage));
+			var shell = new TestShell(CreateShellItem(shellItemRoute: "item1"));
+			await shell.GoToAsync("detailspage/detailspage");
+			await shell.Navigation.PopAsync();
+
+
+			shell.TestNavigatingArgs(ShellNavigationSource.Pop,
+				"//item1/detailspage/detailspage", $"..");
+
+			shell.TestNavigatedArgs(ShellNavigationSource.Pop,
+				"//item1/detailspage/detailspage", $"//item1/detailspage");
+		}
+
+		[Test]
+		public async Task ChangingShellContentSetsCorrectNavigationSource()
+		{
+			var shell = new TestShell(
+				CreateShellItem(shellContentRoute: "item1")
+			);
+
+			shell.Items[0].Items[0].Items.Add(CreateShellContent(shellContentRoute: "item2"));
+
+			await shell.GoToAsync("//item2");
+
+			shell.TestNavigationArgs(ShellNavigationSource.ShellContentChanged,
+				"//item1", "//item2");
+		}
+
+		[Test]
+		public async Task InsertPageSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
+
+			await shell.GoToAsync("//item/page");
+			await shell.GoToAsync("//item/pagemiddle/page");
+
+			shell.TestNavigationArgs(ShellNavigationSource.Insert,
+				"//item/page", "//item/pagemiddle/page");
+		}
+
+
+		[Test]
+		public async Task InsertPageFromINavigationSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
+
+			await shell.GoToAsync("//item/page");
+			ContentPage contentPage = new ContentPage();
+			Routing.SetRoute(contentPage, "pagemiddle");
+			shell.Navigation.InsertPageBefore(contentPage, shell.Navigation.NavigationStack.Last());
+
+			shell.TestNavigationArgs(ShellNavigationSource.Insert,
+				"//item/page", "//item/pagemiddle/page");
+		}
+
+
+		[Test]
+		public async Task RemovePageFromINavigationSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
+
+			await shell.GoToAsync("//item/pagemiddle/page");
+			shell.Navigation.RemovePage(shell.Navigation.NavigationStack[1]);
+
+			shell.TestNavigationArgs(ShellNavigationSource.Remove,
+				"//item/pagemiddle/page", "//item/page");
+		}
+
+		[Test]
+		public async Task RemovePageSetsCorrectNavigationSource()
+		{
+			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
+			Routing.RegisterRoute("page", typeof(ContentPage));
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
+
+			await shell.GoToAsync("//item/pagemiddle/page");
+			await shell.GoToAsync("//item/page");
+
+
+			shell.TestNavigationArgs(ShellNavigationSource.Remove,
+				"//item/pagemiddle/page", "//item/page");
+		}
+
+		[Test]
+		public async Task InitialNavigatingArgs()
+		{
+			var shell = new TestShell(
+				CreateShellItem(shellItemRoute: "item")
+			);
+
+			shell.TestNavigationArgs(ShellNavigationSource.ShellItemChanged,
+				null, "//item");
+		}
+	}
+}

--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -294,6 +294,38 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
+		public async Task RemoveInnerPagesNavigatingArgs()
+		{
+			Routing.RegisterRoute("SecondPageView", typeof(ContentPage));
+			Routing.RegisterRoute("ThirdPageView", typeof(ContentPage));
+			Routing.RegisterRoute("FourthPage", typeof(ContentPage));
+
+			var shell = new TestShell(
+				new FlyoutItem
+				{
+					Items =
+					{
+						new ShellContent()
+						{
+							Route = "HomePageView"
+						}
+					}
+				}
+			);
+
+			await shell.GoToAsync("//HomePageView/SecondPageView/ThirdPageView");
+			await shell.GoToAsync("//HomePageView/FourthPage");
+
+			Assert.That(shell.CurrentState.Location.ToString(),
+				Is.EqualTo("//HomePageView/FourthPage"));
+
+			Assert.That(shell.LastShellNavigatedEventArgs.Current.Location.ToString(),
+				Is.EqualTo("//HomePageView/FourthPage"));
+
+			Assert.AreEqual(2, shell.NavigatedCount);
+		}
+
+		[Test]
 		public async Task NavigationPushAndPopBasic()
 		{
 			var flyoutItem =

--- a/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellNavigatingTests.cs
@@ -294,38 +294,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task RemoveInnerPagesNavigatingArgs()
-		{
-			Routing.RegisterRoute("SecondPageView", typeof(ContentPage));
-			Routing.RegisterRoute("ThirdPageView", typeof(ContentPage));
-			Routing.RegisterRoute("FourthPage", typeof(ContentPage));
-
-			var shell = new TestShell(
-				new FlyoutItem
-				{
-					Items =
-					{
-						new ShellContent()
-						{
-							Route = "HomePageView"
-						}
-					}
-				}
-			);
-
-			await shell.GoToAsync("//HomePageView/SecondPageView/ThirdPageView");
-			await shell.GoToAsync("//HomePageView/FourthPage");
-
-			Assert.That(shell.CurrentState.Location.ToString(),
-				Is.EqualTo("//HomePageView/FourthPage"));
-
-			Assert.That(shell.LastShellNavigatedEventArgs.Current.Location.ToString(),
-				Is.EqualTo("//HomePageView/FourthPage"));
-
-			Assert.AreEqual(2, shell.NavigatedCount);
-		}
-
-		[Test]
 		public async Task NavigationPushAndPopBasic()
 		{
 			var flyoutItem =
@@ -521,22 +489,6 @@ namespace Xamarin.Forms.Core.UnitTests
 		}
 
 		[Test]
-		public async Task PoppingSamePageSetsCorrectNavigationSource()
-		{
-			Routing.RegisterRoute("detailspage", typeof(ContentPage));
-			var shell = new TestShell(CreateShellItem(shellItemRoute: "item1"));
-			await shell.GoToAsync("detailspage/detailspage");
-			await shell.Navigation.PopAsync();
-
-
-			shell.TestNavigatingArgs(ShellNavigationSource.Pop,
-				"//item1/detailspage/detailspage", $"..");
-
-			shell.TestNavigatedArgs(ShellNavigationSource.Pop,
-				"//item1/detailspage/detailspage", $"//item1/detailspage");
-		}
-
-		[Test]
 		public async Task PoppingSetsCorrectNavigationSource()
 		{
 			var shell = new TestShell(CreateShellItem(shellContentRoute: "item1"));
@@ -552,127 +504,6 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			shell.TestNavigatedArgs(ShellNavigationSource.Pop,
 				"//item1/page1/page2", $"//item1/page1");
-		}
-
-		[Test]
-		public async Task PopToRootSetsCorrectNavigationSource()
-		{
-			var shell = new TestShell(CreateShellItem());
-			await shell.Navigation.PushAsync(new ContentPage());
-			await shell.Navigation.PushAsync(new ContentPage());
-			await shell.Navigation.PopToRootAsync();
-			Assert.AreEqual(ShellNavigationSource.PopToRoot, shell.LastShellNavigatingEventArgs.Source);
-
-			await shell.Navigation.PushAsync(new ContentPage());
-			await shell.Navigation.PushAsync(new ContentPage());
-
-			await shell.Navigation.PopAsync();
-			Assert.AreEqual(ShellNavigationSource.Pop, shell.LastShellNavigatingEventArgs.Source);
-
-			await shell.Navigation.PopAsync();
-			Assert.AreEqual(ShellNavigationSource.PopToRoot, shell.LastShellNavigatingEventArgs.Source);
-		}
-
-		[Test]
-		public async Task PushingSetsCorrectNavigationSource()
-		{
-			var shell = new TestShell(CreateShellItem(shellItemRoute: "item1"));
-			shell.RegisterPage(nameof(PushingSetsCorrectNavigationSource));
-			await shell.GoToAsync(nameof(PushingSetsCorrectNavigationSource));
-
-			shell.TestNavigatingArgs(ShellNavigationSource.Push,
-				"//item1", $"{nameof(PushingSetsCorrectNavigationSource)}");
-
-			shell.TestNavigatedArgs(ShellNavigationSource.Push,
-				"//item1", $"//item1/{nameof(PushingSetsCorrectNavigationSource)}");
-		}
-
-		[Test]
-		public async Task ChangingShellItemSetsCorrectNavigationSource()
-		{
-			var shell = new TestShell(
-				CreateShellItem(shellItemRoute: "item1"),
-				CreateShellItem(shellItemRoute: "item2")
-			);
-
-			await shell.GoToAsync("//item2");
-
-			shell.TestNavigationArgs(ShellNavigationSource.ShellItemChanged,
-				"//item1", "//item2");
-		}
-
-		[Test]
-		public async Task ChangingShellSectionSetsCorrectNavigationSource()
-		{
-			var shell = new TestShell(
-				CreateShellItem(shellSectionRoute: "item1")
-			);
-
-			shell.Items[0].Items.Add(CreateShellSection(shellContentRoute: "item2"));
-
-			await shell.GoToAsync("//item2");
-
-			shell.TestNavigationArgs(ShellNavigationSource.ShellSectionChanged,
-				"//item1", "//item2");
-		}
-
-		[Test]
-		public async Task ChangingShellContentSetsCorrectNavigationSource()
-		{
-			var shell = new TestShell(
-				CreateShellItem(shellContentRoute: "item1")
-			);
-
-			shell.Items[0].Items[0].Items.Add(CreateShellContent(shellContentRoute: "item2"));
-
-			await shell.GoToAsync("//item2");
-
-			shell.TestNavigationArgs(ShellNavigationSource.ShellContentChanged,
-				"//item1", "//item2");
-		}
-
-		[Test]
-		public async Task InsertPageSetsCorrectNavigationSource()
-		{
-			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
-			Routing.RegisterRoute("page", typeof(ContentPage));
-			var shell = new TestShell(
-				CreateShellItem(shellItemRoute: "item")
-			);
-
-			await shell.GoToAsync("//item/page");
-			await shell.GoToAsync("//item/pagemiddle/page");
-
-			shell.TestNavigationArgs(ShellNavigationSource.Insert,
-				"//item/page", "//item/pagemiddle/page");
-		}
-
-		[Test]
-		public async Task RemovePageSetsCorrectNavigationSource()
-		{
-			Routing.RegisterRoute("pagemiddle", typeof(ContentPage));
-			Routing.RegisterRoute("page", typeof(ContentPage));
-			var shell = new TestShell(
-				CreateShellItem(shellItemRoute: "item")
-			);
-
-			await shell.GoToAsync("//item/pagemiddle/page");
-			await shell.GoToAsync("//item/page");
-
-
-			shell.TestNavigationArgs(ShellNavigationSource.Remove,
-				"//item/pagemiddle/page", "//item/page");
-		}
-
-		[Test]
-		public async Task InitialNavigatingArgs()
-		{
-			var shell = new TestShell(
-				CreateShellItem(shellItemRoute: "item")
-			);
-
-			shell.TestNavigationArgs(ShellNavigationSource.ShellItemChanged,
-				null, "//item");
 		}
 
 

--- a/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellTestBase.cs
@@ -374,8 +374,6 @@ namespace Xamarin.Forms.Core.UnitTests
 				OnNavigatingCount++;
 			}
 
-
-
 			public void TestNavigationArgs(ShellNavigationSource source, string from, string to)
 			{
 				TestNavigatingArgs(source, from, to);
@@ -392,6 +390,7 @@ namespace Xamarin.Forms.Core.UnitTests
 					Assert.AreEqual(from, this.LastShellNavigatedEventArgs.Previous.Location.ToString());
 
 				Assert.AreEqual(to, this.LastShellNavigatedEventArgs.Current.Location.ToString());
+				Assert.AreEqual(to, this.CurrentState.Location.ToString());
 			}
 
 			public void TestNavigatingArgs(ShellNavigationSource source, string from, string to)

--- a/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
+++ b/Xamarin.Forms.Core.UnitTests/Xamarin.Forms.Core.UnitTests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="ShellFlyoutItemGroupTests.cs" />
     <Compile Include="ShellFlyoutItemTemplateTests.cs" />
     <Compile Include="ShellModalTests.cs" />
+    <Compile Include="ShellNavigatedArgsTests.cs" />
     <Compile Include="ShellNavigationStateTests.cs" />
     <Compile Include="ShellNavigatingTests.cs" />
     <Compile Include="ShellTestBase.cs" />

--- a/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
+++ b/Xamarin.Forms.Core.Windows.UITests/Xamarin.Forms.Core.Windows.UITests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="Selenium.Support" Version="3.141.0" />
     <PackageReference Include="Selenium.WebDriver" Version="3.141.0" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.14" />
+    <PackageReference Include="Xamarin.UITest" Version="3.1.0" />
     <PackageReference Include="NUnit3TestAdapter">
       <Version>3.17.0</Version>
     </PackageReference>

--- a/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
+++ b/Xamarin.Forms.Core.iOS.UITests/Xamarin.Forms.Core.iOS.UITests.csproj
@@ -49,7 +49,7 @@
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="NUnit" Version="3.13.1" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.14" />
+    <PackageReference Include="Xamarin.UITest" Version="3.1.0" />
     <PackageReference Include="NUnit3TestAdapter">
       <Version>3.17.0</Version>
     </PackageReference>

--- a/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
+++ b/Xamarin.Forms.Core.macOS.UITests/Xamarin.Forms.Core.macOS.UITests.csproj
@@ -53,7 +53,7 @@
     <PackageReference Include="ServiceStack.Interfaces" Version="4.5.12" />
     <PackageReference Include="ServiceStack.Text" Version="4.5.12" />
     <PackageReference Include="Xam.Plugin.DeviceInfo" Version="3.0.2" />
-    <PackageReference Include="Xamarin.UITest" Version="3.0.14" />
+    <PackageReference Include="Xamarin.UITest" Version="3.1.0" />
     <PackageReference Include="Xamarin.UITest.Desktop" Version="0.0.7" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -468,9 +468,11 @@ namespace Xamarin.Forms
 			var modalStack = shellSection?.Navigation?.ModalStack;
 			var result = ShellNavigationManager.GetNavigationState(shellItem, shellSection, shellContent, stack, modalStack);
 
-			SetValueFromRenderer(CurrentStatePropertyKey, result);
-
-			_navigationManager.HandleNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
+			if (result?.Location != oldState?.Location)
+			{
+				SetValueFromRenderer(CurrentStatePropertyKey, result);
+				_navigationManager.HandleNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
+			}
 		}
 		ReadOnlyCollection<ShellItem> IShellController.GetItems() =>
 			new ReadOnlyCollection<ShellItem>(((ShellItemCollection)Items).VisibleItemsReadOnly.ToList());

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -474,6 +474,7 @@ namespace Xamarin.Forms
 				_navigationManager.HandleNavigated(new ShellNavigatedEventArgs(oldState, CurrentState, source));
 			}
 		}
+
 		ReadOnlyCollection<ShellItem> IShellController.GetItems() =>
 			new ReadOnlyCollection<ShellItem>(((ShellItemCollection)Items).VisibleItemsReadOnly.ToList());
 

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -166,6 +166,7 @@ namespace Xamarin.Forms
 				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
 			}
 
+			(_shell as IShellController).UpdateCurrentState(source);
 			_accumulateNavigatedEvents = false;
 
 			// this can be null in the event that no navigation actually took place!

--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -11,7 +11,7 @@ namespace Xamarin.Forms
 		readonly Shell _shell;
 		ShellNavigatedEventArgs _accumulatedEvent;
 		bool _accumulateNavigatedEvents;
-
+		public bool AccumulateNavigatedEvents => _accumulateNavigatedEvents;
 		public event EventHandler<ShellNavigatedEventArgs> Navigated;
 		public event EventHandler<ShellNavigatingEventArgs> Navigating;
 

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -116,7 +116,6 @@ namespace Xamarin.Forms
 			await poppingCompleted;
 
 			RemovePage(page);
-			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		async void IShellSectionController.SendPoppingToRoot(Task finishedPopping)
@@ -135,8 +134,6 @@ namespace Xamarin.Forms
 
 			for (int i = 1; i < oldStack.Count; i++)
 				RemovePage(oldStack[i]);
-
-			//SendUpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
 
 		[Obsolete]
@@ -151,8 +148,6 @@ namespace Xamarin.Forms
 			_navStack.Remove(last);
 
 			RemovePage(last);
-
-			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		// we want the list returned from here to remain point in time accurate
@@ -178,7 +173,6 @@ namespace Xamarin.Forms
 				_navStack.Remove(page);
 
 			RemovePage(page);
-			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 
@@ -724,8 +718,6 @@ namespace Xamarin.Forms
 			};
 
 			_navigationRequested?.Invoke(this, args);
-
-			//SendUpdateCurrentState(ShellNavigationSource.Insert);
 		}
 
 		protected async virtual Task<Page> OnPopAsync(bool animated)
@@ -761,8 +753,6 @@ namespace Xamarin.Forms
 			if (args.Task != null)
 				await args.Task;
 			RemovePage(page);
-
-			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 
 			return page;
 		}
@@ -804,7 +794,6 @@ namespace Xamarin.Forms
 			}
 
 			PresentedPageAppearing();
-			//SendUpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
 
 		protected virtual Task OnPushAsync(Page page, bool animated)
@@ -833,8 +822,6 @@ namespace Xamarin.Forms
 			PresentedPageAppearing();
 			AddPage(page);
 			_navigationRequested?.Invoke(this, args);
-
-			////SendUpdateCurrentState(ShellNavigationSource.Push);
 
 			if (args.Task == null)
 				return Task.FromResult(true);
@@ -867,8 +854,6 @@ namespace Xamarin.Forms
 					bool isAnimated = animated ?? (Shell.GetPresentationMode(pageToPop) & PresentationMode.NotAnimated) != PresentationMode.NotAnimated;
 					await Navigation.PopModalAsync(isAnimated);
 				}
-
-				//((IShellController)Shell).UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
 			}
 			finally
 			{
@@ -911,8 +896,6 @@ namespace Xamarin.Forms
 				RequestType = NavigationRequestType.Remove
 			};
 			_navigationRequested?.Invoke(this, args);
-
-			//SendUpdateCurrentState(ShellNavigationSource.Remove);
 		}
 
 		internal bool IsVisibleSection => Parent?.Parent is Shell shell && shell.CurrentItem?.CurrentItem == this;
@@ -1012,14 +995,6 @@ namespace Xamarin.Forms
 		}
 
 		void SendAppearanceChanged() => ((IShellController)Parent?.Parent)?.AppearanceChanged(this, false);
-
-		//void SendUpdateCurrentState(ShellNavigationSource source)
-		//{
-		//	if (Parent?.Parent is IShellController shell)
-		//	{
-		//		shell.UpdateCurrentState(source);
-		//	}
-		//}
 
 		protected override void OnBindingContextChanged()
 		{

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -116,7 +116,7 @@ namespace Xamarin.Forms
 			await poppingCompleted;
 
 			RemovePage(page);
-			SendUpdateCurrentState(ShellNavigationSource.Pop);
+			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		async void IShellSectionController.SendPoppingToRoot(Task finishedPopping)
@@ -136,7 +136,7 @@ namespace Xamarin.Forms
 			for (int i = 1; i < oldStack.Count; i++)
 				RemovePage(oldStack[i]);
 
-			SendUpdateCurrentState(ShellNavigationSource.PopToRoot);
+			//SendUpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
 
 		[Obsolete]
@@ -152,7 +152,7 @@ namespace Xamarin.Forms
 
 			RemovePage(last);
 
-			SendUpdateCurrentState(ShellNavigationSource.Pop);
+			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		// we want the list returned from here to remain point in time accurate
@@ -178,7 +178,7 @@ namespace Xamarin.Forms
 				_navStack.Remove(page);
 
 			RemovePage(page);
-			SendUpdateCurrentState(ShellNavigationSource.Pop);
+			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 
@@ -572,7 +572,7 @@ namespace Xamarin.Forms
 
 			if (Parent?.Parent is IShellController shell)
 			{
-				shell.UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
+				//shell.UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
 			}
 		}
 
@@ -725,7 +725,7 @@ namespace Xamarin.Forms
 
 			_navigationRequested?.Invoke(this, args);
 
-			SendUpdateCurrentState(ShellNavigationSource.Insert);
+			//SendUpdateCurrentState(ShellNavigationSource.Insert);
 		}
 
 		protected async virtual Task<Page> OnPopAsync(bool animated)
@@ -762,7 +762,7 @@ namespace Xamarin.Forms
 				await args.Task;
 			RemovePage(page);
 
-			SendUpdateCurrentState(ShellNavigationSource.Pop);
+			//SendUpdateCurrentState(ShellNavigationSource.Pop);
 
 			return page;
 		}
@@ -804,7 +804,7 @@ namespace Xamarin.Forms
 			}
 
 			PresentedPageAppearing();
-			SendUpdateCurrentState(ShellNavigationSource.PopToRoot);
+			//SendUpdateCurrentState(ShellNavigationSource.PopToRoot);
 		}
 
 		protected virtual Task OnPushAsync(Page page, bool animated)
@@ -834,7 +834,7 @@ namespace Xamarin.Forms
 			AddPage(page);
 			_navigationRequested?.Invoke(this, args);
 
-			SendUpdateCurrentState(ShellNavigationSource.Push);
+			////SendUpdateCurrentState(ShellNavigationSource.Push);
 
 			if (args.Task == null)
 				return Task.FromResult(true);
@@ -868,7 +868,7 @@ namespace Xamarin.Forms
 					await Navigation.PopModalAsync(isAnimated);
 				}
 
-				((IShellController)Shell).UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
+				//((IShellController)Shell).UpdateCurrentState(ShellNavigationSource.ShellSectionChanged);
 			}
 			finally
 			{
@@ -912,7 +912,7 @@ namespace Xamarin.Forms
 			};
 			_navigationRequested?.Invoke(this, args);
 
-			SendUpdateCurrentState(ShellNavigationSource.Remove);
+			//SendUpdateCurrentState(ShellNavigationSource.Remove);
 		}
 
 		internal bool IsVisibleSection => Parent?.Parent is Shell shell && shell.CurrentItem?.CurrentItem == this;
@@ -1013,13 +1013,13 @@ namespace Xamarin.Forms
 
 		void SendAppearanceChanged() => ((IShellController)Parent?.Parent)?.AppearanceChanged(this, false);
 
-		void SendUpdateCurrentState(ShellNavigationSource source)
-		{
-			if (Parent?.Parent is IShellController shell)
-			{
-				shell.UpdateCurrentState(source);
-			}
-		}
+		//void SendUpdateCurrentState(ShellNavigationSource source)
+		//{
+		//	if (Parent?.Parent is IShellController shell)
+		//	{
+		//		shell.UpdateCurrentState(source);
+		//	}
+		//}
 
 		protected override void OnBindingContextChanged()
 		{


### PR DESCRIPTION
### Description of Change ###

When you set the ViewControllers property on UINavigationController it doesn't take right away. If you retrieve the ViewControllers it will still contain the ViewController you just removed. This means if you do something like

```C#
ViewControllers = ViewControllers.Remove(vc1)
ViewControllers = ViewControllers.Remove(vc2)  // This will add back in vc1 
```

So when processing a navigation with removes/inserts we now save local copy of pending changes.

### Issues Resolved ### 
- fixes #13916

### Platforms Affected ### 
- Core/XAML (all platforms)
- iOS

### Testing Procedure ###
- unit tests included
- UI Tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
