### PR TITLE
[iOS] Fix: CollectionView was not updating when it was invisible

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -618,6 +618,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (CollectionView.Hidden)
 				{
+					CollectionView.ReloadData();
 					CollectionView.Hidden = false;
 					Layout.InvalidateLayout();
 					CollectionView.LayoutIfNeeded();

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -141,9 +141,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
-			if (_collectionView.Hidden)
-				return;
-
 			switch (args.Action)
 			{
 				case NotifyCollectionChangedAction.Add:
@@ -202,7 +199,7 @@ namespace Xamarin.Forms.Platform.iOS
 			ResetGroupTracking();
 
 			// Queue up the updates to the UICollectionView
-			_collectionView.InsertSections(CreateIndexSetFrom(startIndex, count));
+			Update(() => _collectionView.InsertSections(CreateIndexSetFrom(startIndex, count)));
 		}
 
 		void Remove(NotifyCollectionChangedEventArgs args)
@@ -231,7 +228,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var count = args.OldItems.Count;
 
 			// Queue up the updates to the UICollectionView
-			_collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count));
+			Update(() => _collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count)));
 		}
 
 		void Replace(NotifyCollectionChangedEventArgs args)
@@ -245,7 +242,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
 
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
-				_collectionView.ReloadSections(CreateIndexSetFrom(startIndex, newCount));
+				Update(() => _collectionView.ReloadSections(CreateIndexSetFrom(startIndex, newCount)));
 				return;
 			}
 
@@ -263,14 +260,14 @@ namespace Xamarin.Forms.Platform.iOS
 			if (count == 1)
 			{
 				// For a single item, we can use MoveSection and get the animation
-				_collectionView.MoveSection(args.OldStartingIndex, args.NewStartingIndex);
+				Update(() => _collectionView.MoveSection(args.OldStartingIndex, args.NewStartingIndex));
 				return;
 			}
 
 			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
 			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
 
-			_collectionView.ReloadSections(CreateIndexSetFrom(start, end));
+			Update(() => _collectionView.ReloadSections(CreateIndexSetFrom(start, end)));
 		}
 
 		int GetGroupCount(int groupIndex)
@@ -344,6 +341,16 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return NotLoadedYet()
 				|| _collectionView.NumberOfSections() == 0;
+		}
+
+		void Update(Action update) 
+		{
+			if (_collectionView.Hidden)
+			{
+				return;
+			}
+
+			update();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -141,6 +141,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
+			if (_collectionView.Hidden)
+				return;
+
 			switch (args.Action)
 			{
 				case NotifyCollectionChangedAction.Add:
@@ -199,7 +202,7 @@ namespace Xamarin.Forms.Platform.iOS
 			ResetGroupTracking();
 
 			// Queue up the updates to the UICollectionView
-			Update(() => _collectionView.InsertSections(CreateIndexSetFrom(startIndex, count)));
+			_collectionView.InsertSections(CreateIndexSetFrom(startIndex, count));
 		}
 
 		void Remove(NotifyCollectionChangedEventArgs args)
@@ -228,7 +231,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var count = args.OldItems.Count;
 
 			// Queue up the updates to the UICollectionView
-			Update(() => _collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count)));
+			_collectionView.DeleteSections(CreateIndexSetFrom(startIndex, count));
 		}
 
 		void Replace(NotifyCollectionChangedEventArgs args)
@@ -242,7 +245,7 @@ namespace Xamarin.Forms.Platform.iOS
 				var startIndex = args.NewStartingIndex > -1 ? args.NewStartingIndex : _groupSource.IndexOf(args.NewItems[0]);
 
 				// We are replacing one set of items with a set of equal size; we can do a simple item range update
-				Update(() => _collectionView.ReloadSections(CreateIndexSetFrom(startIndex, newCount)));
+				_collectionView.ReloadSections(CreateIndexSetFrom(startIndex, newCount));
 				return;
 			}
 
@@ -260,14 +263,14 @@ namespace Xamarin.Forms.Platform.iOS
 			if (count == 1)
 			{
 				// For a single item, we can use MoveSection and get the animation
-				Update(() => _collectionView.MoveSection(args.OldStartingIndex, args.NewStartingIndex));
+				_collectionView.MoveSection(args.OldStartingIndex, args.NewStartingIndex);
 				return;
 			}
 
 			var start = Math.Min(args.OldStartingIndex, args.NewStartingIndex);
 			var end = Math.Max(args.OldStartingIndex, args.NewStartingIndex) + count;
 
-			Update(() => _collectionView.ReloadSections(CreateIndexSetFrom(start, end)));
+			_collectionView.ReloadSections(CreateIndexSetFrom(start, end));
 		}
 
 		int GetGroupCount(int groupIndex)
@@ -341,16 +344,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return NotLoadedYet()
 				|| _collectionView.NumberOfSections() == 0;
-		}
-
-		void Update(Action update) 
-		{
-			if (_collectionView.Hidden)
-			{
-				return;
-			}
-
-			update();
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -111,8 +111,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
-			// Force UICollectionView to get the internal accounting straight 
-			CollectionView.NumberOfItemsInSection(_section);
+			// Force UICollectionView to get the internal accounting straight
+			if(!CollectionView.Hidden)
+				CollectionView.NumberOfItemsInSection(_section);
 
 			switch (args.Action)
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -111,9 +111,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
-			if (CollectionView.Hidden)
-				return;
-
 			// Force UICollectionView to get the internal accounting straight 
 			CollectionView.NumberOfItemsInSection(_section);
 
@@ -271,6 +268,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Update(Action update, NotifyCollectionChangedEventArgs args)
 		{
+			if (CollectionView.Hidden)
+			{
+				return;
+			}
+
 			OnCollectionViewUpdating(args); 
 			update(); 
 			OnCollectionViewUpdated(args); 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -111,6 +111,9 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void CollectionChanged(NotifyCollectionChangedEventArgs args)
 		{
+			if (CollectionView.Hidden)
+				return;
+
 			// Force UICollectionView to get the internal accounting straight 
 			CollectionView.NumberOfItemsInSection(_section);
 
@@ -268,11 +271,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void Update(Action update, NotifyCollectionChangedEventArgs args)
 		{
-			if (CollectionView.Hidden)
-			{
-				return;
-			}
-
 			OnCollectionViewUpdating(args); 
 			update(); 
 			OnCollectionViewUpdated(args); 


### PR DESCRIPTION
### Description of Change ###
If a CollectionView is not visible and an ObservableCollection notifies about changes the CollectionView doesn't react.
Also, after changing the CollectionView's visibility to visible and making any changes in the ObservableCollection we can get exceptions like this: https://github.com/xamarin/Xamarin.Forms/issues/14045#issuecomment-869204559

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #14045 (not sure about this, but it looks similar)

### API Changes ###
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Create a page with CollectionView and bind ItemsSource to ObservableCollection
- Set IsVisible to false for the CollectionView
- Add some items into the ObservableCollection
- Set IsVisible to true for CollectionView
- You will se, that the CollectionView doesn't show new items

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
