### PR TITLE
Only check for netfx when not in a wapproj

### DIFF
--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -48,9 +48,9 @@
 
 	<Target Name="_ValidateNETFrameworkVersion"
 			BeforeTargets="_CheckForInvalidConfigurationAndPlatform"
-			Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '4.6.1' AND '$(XFDisableFrameworkVersionValidation)' != 'True'">
+			Condition="'$(TargetFrameworkIdentifier)' == '.NETFramework' AND '$(TargetFrameworkVersion.Substring(1))' &lt; '4.6.1' AND '$(ProjectExt)' != '.wapproj' AND '$(XFDisableFrameworkVersionValidation)' != 'True'">
 		<Error Code="XF004"
-			Text="XF requires .NETFramework >= v4.6.1. You have '$(TargetFrameworkVersion)'" />
+			Text="Xamarin.Forms requires .NETFramework >= v4.6.1. You have '$(TargetFrameworkVersion)'" />
 	</Target>
 
 	<!-- XamlG -->


### PR DESCRIPTION
### Description of Change ###

The UWP/WinUI .wapproj also uses netfx, but actually does not build with Xamarin.Forms. So skip the check here as well.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #13957

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
