### PR TITLE
Tablet/Desktop support for non-Duo interfaces in the DualScreen design pattern.

### DIFF
--- a/Xamarin.Forms.Core/DualScreen/IDualScreenService.cs
+++ b/Xamarin.Forms.Core/DualScreen/IDualScreenService.cs
@@ -9,6 +9,7 @@ namespace Xamarin.Forms.DualScreen
 	internal interface IDualScreenService
 	{
 		event EventHandler OnScreenChanged;
+		bool IsDuo { get; }
 		bool IsSpanned { get; }
 		bool IsLandscape { get; }
 		Rectangle GetHinge();

--- a/Xamarin.Forms.DualScreen.UnitTests/TestDualScreenService.cs
+++ b/Xamarin.Forms.DualScreen.UnitTests/TestDualScreenService.cs
@@ -22,6 +22,8 @@ namespace Xamarin.Forms.DualScreen.UnitTests
 
 		public Size ScaledScreenSize => DeviceInfo.ScaledScreenSize;
 
+		public bool IsDuo { get; set; }
+
 		public event EventHandler OnScreenChanged;
 
 		public void Dispose()

--- a/Xamarin.Forms.DualScreen/DualScreenService.android.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenService.android.cs
@@ -32,7 +32,7 @@ namespace Xamarin.Forms.DualScreen
 		{
 			ScreenHelper _helper;
 			bool _isDuo = false;
-			bool IsDuo => (_helper == null || _HingeService == null || _mainActivity == null || _singleUseHingeSensor == null) ? false : _isDuo;
+			public bool IsDuo => (_helper == null || _HingeService == null || _mainActivity == null || _singleUseHingeSensor == null) ? false : _isDuo;
 			HingeSensor _singleUseHingeSensor;
 			static Activity _mainActivity;
 			static DualScreenServiceImpl _HingeService;

--- a/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
+++ b/Xamarin.Forms.DualScreen/DualScreenService.uwp.cs
@@ -80,6 +80,19 @@ namespace Xamarin.Forms.DualScreen
             }
 		}
 
+		private bool _IsDuo;
+		public bool IsDuo
+		{
+			get
+			{
+				return _IsDuo;
+			}
+			set
+			{
+				_IsDuo = value;
+			}
+		}
+
 		public DeviceInfo DeviceInfo => Device.info;
 
 		public bool IsLandscape

--- a/Xamarin.Forms.DualScreen/NoDualScreenServiceImpl.shared.cs
+++ b/Xamarin.Forms.DualScreen/NoDualScreenServiceImpl.shared.cs
@@ -18,11 +18,13 @@ namespace Xamarin.Forms.DualScreen
 
 		}
 
+		public bool IsDuo => false;
+
 		public Task<int> GetHingeAngleAsync() => Task.FromResult(0);
 
-		public bool IsSpanned => false;
+		public bool IsSpanned => Device.Idiom != TargetIdiom.Phone;
 
-        public bool IsLandscape => Device.info.CurrentOrientation.IsLandscape();
+		public bool IsLandscape => Device.info.CurrentOrientation.IsLandscape();
 
 		public DeviceInfo DeviceInfo => Device.info;
 

--- a/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs
+++ b/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs
@@ -26,11 +26,12 @@ namespace Xamarin.Forms.DualScreen
 		public event PropertyChangedEventHandler PropertyChanged;
 		List<string> _pendingPropertyChanges = new List<string>();
 		Rectangle _absoluteLayoutPosition;
-		object _watchHandle = null;
+		object _watchHandle;
+		Action _layoutChangedReference;
 
 		TwoPaneViewLayoutGuide()
 		{
-
+			
 		}
 
 		public TwoPaneViewLayoutGuide(VisualElement layout) : this(layout, null)
@@ -55,39 +56,63 @@ namespace Xamarin.Forms.DualScreen
 		void OnLayoutPropertyChanging(object sender, PropertyChangingEventArgs e)
 		{
 			if (e.PropertyName == "Renderer")
+			{
 				StopWatchingForChanges();
+			}
 		}
 
 		void OnLayoutPropertyChanged(object sender, PropertyChangedEventArgs e)
 		{
 			if (e.PropertyName == "Renderer")
+			{
 				WatchForChanges();
+			}
 		}
 
 		public void WatchForChanges()
 		{
-			StopWatchingForChanges();
-
-			if (_layout != null)
+			if (_layout != null && _watchHandle == null)
 			{
-				_watchHandle = DualScreenService.WatchForChangesOnLayout(_layout, () => OnScreenChanged(DualScreenService, EventArgs.Empty));
+				_layoutChangedReference = OnLayoutChanged;
+				var layoutHandle = DualScreenService.WatchForChangesOnLayout(_layout, _layoutChangedReference);
 
-				if (_watchHandle == null)
+				if (layoutHandle == null)
+				{
+					_layoutChangedReference = null;
 					return;
-			}
+				}
 
-			DualScreenService.OnScreenChanged += OnScreenChanged;
+				_watchHandle = layoutHandle;
+				OnScreenChanged(DualScreenService, EventArgs.Empty);
+				DualScreenService.OnScreenChanged += OnScreenChanged;
+			}
+			else
+			{
+				DualScreenService.OnScreenChanged += OnScreenChanged;
+			}
 		}
 
 		public void StopWatchingForChanges()
 		{
 			DualScreenService.OnScreenChanged -= OnScreenChanged;
-
 			if (_layout != null)
 			{
 				DualScreenService.StopWatchingForChangesOnLayout(_layout, _watchHandle);
-				_watchHandle = null;
 			}
+
+			_layoutChangedReference = null;
+			_watchHandle = null;
+		}
+
+		void OnLayoutChanged()
+		{
+			if (_watchHandle == null)
+			{
+				StopWatchingForChanges();
+				return;
+			}
+
+			OnScreenChanged(DualScreenService, EventArgs.Empty);
 		}
 
 		void OnScreenChanged(object sender, EventArgs e)
@@ -98,9 +123,18 @@ namespace Xamarin.Forms.DualScreen
 				return;
 			}
 
+			if(_layout != null && _watchHandle == null)
+			{
+				StopWatchingForChanges();
+				return;
+			}
+
 			var screenPosition = DualScreenService.GetLocationOnScreen(_layout);
 			if (screenPosition == null)
+			{
+				UpdateLayouts();
 				return;
+			}
 
 			var newPosition = new Rectangle(screenPosition.Value, _layout.Bounds.Size);
 

--- a/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs.rej
+++ b/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs.rej
@@ -1,0 +1,20 @@
+diff a/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs b/Xamarin.Forms.DualScreen/TwoPaneViewLayoutGuide.shared.cs	(rejected hunks)
+@@ -98,18 +98,9 @@
+ 				return;
+ 			}
+ 
+-			if(_layout != null && _watchHandle == null)
+-			{
+-				StopWatchingForChanges();
+-				return;
+-			}
+-
+ 			var screenPosition = DualScreenService.GetLocationOnScreen(_layout);
+ 			if (screenPosition == null)
+-			{
+-				UpdateLayouts();
+ 				return;
+-			}
+ 
+ 			var newPosition = new Rectangle(screenPosition.Value, _layout.Bounds.Size);
+ 


### PR DESCRIPTION
### Description of Change ###

Extended the DualScreen pattern to support both Desktop & Tablets with non-Duo devices.  This gives developers the ability to show extended information in large real estate devices while not changing the functionality for phones.

### API Changes ###

Added:
 - bool IsDuo to IDualScreenServices
 - bool IsDuo to false for NoDualScreenImpl
 - void FakeControl.Clear ();

Changed:
 - IsDuo on Android interface to public 
 - IsSpanned to detect non-phone
 
### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
It will allow desktop and tablets to show split content spanned across the interface instead of a single pane view.  

### Before/After Screenshots ### 
Before
https://p22.f4.n0.cdn.getcloudapp.com/items/qGu5LQQO/ab854e9a-4ab4-472a-b293-2c8a4cc4f7d2.jpeg?v=7309047bd85c3b72e800a2fac7fcd9ad

After
https://p22.f4.n0.cdn.getcloudapp.com/items/YEuZ07Lq/726ba9b8-34c8-4167-9def-1184aba2d252.jpeg?source=viewer&v=410412c218067f1cf27c24b0e1bc21cc

### Testing Procedure ###
I test these on Phone, Tablet/Desktop with and without Surface Duo

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
