### PR TITLE
[Android] Fix CollectionView threw ArgumentOutOfRangeException

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/SpacingItemDecoration.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/SpacingItemDecoration.cs
@@ -86,14 +86,14 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (_orientation == ItemsLayoutOrientation.Vertical)
 			{
-				outRect.Left = spanIndex == 0 ? 0 : _adjustedHorizontalSpacing;
-				outRect.Top = spanGroupIndex == 0 ? 0 : _adjustedVerticalSpacing;
+				outRect.Left = spanIndex > 0 ? _adjustedHorizontalSpacing : 0;
+				outRect.Top = spanGroupIndex > 0 ? _adjustedVerticalSpacing : 0;
 			}
 
 			if (_orientation == ItemsLayoutOrientation.Horizontal)
 			{
-				outRect.Top = spanIndex == 0 ? 0 : _adjustedVerticalSpacing;
-				outRect.Left = spanGroupIndex == 0 ? 0 : _adjustedHorizontalSpacing;
+				outRect.Top = spanIndex > 0 ? _adjustedVerticalSpacing : 0;
+				outRect.Left = spanGroupIndex > 0 ? _adjustedHorizontalSpacing : 0;
 			}
 		}
 
@@ -101,7 +101,7 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			var position = parent.GetChildAdapterPosition(view);
 
-			if (_spanCount > 1)
+			if (_spanCount > 1 && position != RecyclerView.NoPosition)
 			{
 				if (parent.GetLayoutManager() is GridLayoutManager gridLayoutManager)
 				{


### PR DESCRIPTION
### Description of Change ###

CollectionView threw ArgumentOutOfRangeException when removing the item if there is only one item in only one group.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- #13562

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
