### PR TITLE
Fix Entry crashing on iOS < 14 

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -50,6 +50,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 		UIImage _defaultClearImage;
 
+		UIButton ClearButton => Control?.ValueForKey(new NSString("clearButton")) as UIButton;
+
 		public EntryRendererBase()
 		{
 		}
@@ -90,6 +92,8 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EditingDidEnd -= OnEditingEnded;
 					Control.ShouldChangeCharacters -= ShouldChangeCharacters;
 					_selectedTextRangeObserver?.Dispose();
+
+					ClearButton?.Layer?.RemoveObserver(this, new NSString("sublayers"));
 				}
 			}
 
@@ -123,6 +127,8 @@ namespace Xamarin.Forms.Platform.iOS
 				textField.EditingDidEnd += OnEditingEnded;
 				textField.ShouldChangeCharacters += ShouldChangeCharacters;
 				_selectedTextRangeObserver = textField.AddObserver("selectedTextRange", NSKeyValueObservingOptions.New, UpdateCursorFromControl);
+
+				ClearButton?.Layer.AddObserver(this, new NSString("sublayers"), NSKeyValueObservingOptions.New, IntPtr.Zero);
 			}
 
 			// When we set the control text, it triggers the UpdateCursorFromControl event, which updates CursorPosition and SelectionLength;
@@ -151,6 +157,12 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateIsReadOnly();
 
 			if (Element.ClearButtonVisibility != ClearButtonVisibility.Never)
+				UpdateClearButtonVisibility();
+		}
+
+		public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
+		{
+			if (keyPath == new NSString("sublayers") && _defaultClearImage == null)
 				UpdateClearButtonVisibility();
 		}
 
@@ -564,24 +576,27 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateClearButtonColor()
 		{
-			if (Control.ValueForKey(new NSString("clearButton")) is UIButton clearButton)
+			if (ClearButton != null)
 			{
-				clearButton.TintColor = Element.TextColor.ToUIColor();
-
+				ClearButton.TintColor = Element.TextColor.ToUIColor();
+				
 				if(_defaultClearImage == null)
-					_defaultClearImage = clearButton.ImageForState(UIControlState.Highlighted);
+					_defaultClearImage = ClearButton.ImageForState(UIControlState.Highlighted);
+
+				if (_defaultClearImage == null)
+					return;
 
 				if(Element.TextColor == Color.Default)
 				{
-					clearButton.SetImage(_defaultClearImage, UIControlState.Normal);
-					clearButton.SetImage(_defaultClearImage, UIControlState.Highlighted);
+					ClearButton.SetImage(_defaultClearImage, UIControlState.Normal);
+					ClearButton.SetImage(_defaultClearImage, UIControlState.Highlighted);
 				}
 				else
 				{
 					var tintedClearImage = GetClearButtonTintImage(_defaultClearImage, Element.TextColor.ToUIColor());
 
-					clearButton.SetImage(tintedClearImage, UIControlState.Normal);
-					clearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
+					ClearButton.SetImage(tintedClearImage, UIControlState.Normal);
+					ClearButton.SetImage(tintedClearImage, UIControlState.Highlighted);
 				}
 			}
 		}


### PR DESCRIPTION
<!-- WAIT! 

After July 15, 2020, feature related pull requests cannot be guaranteed to merge by Xamarin.Forms 5.0. They will be labeled "maui" for transition to dotnet/maui. See the [transition to .NET MAUI](https://github.com/xamarin/Xamarin.Forms/wiki/Feature-Roadmap#transition-to-net-maui) for more information.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/main/.github/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

Fixing crashes on iOS < 14 if ClearButtonVisibility of Entry is WhileEditing

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

Fixes:
- #14479 
- #14510

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

- Use iOS simulator with iOS 13 or lower
- Set ClearButtonVisibility of Entry to WhileEditing
- The app must not crash when a page is opening

### PR Checklist ###
<!-- To be completed by reviewers -->

- [X] Targets the correct branch
- [X] Tests are passing (or failures are unrelated)
