### PR TITLE
[iOS] Fix crash/closing wrong modal with FormSheet and tap outside

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12300.cs
@@ -81,16 +81,5 @@ namespace Xamarin.Forms.Controls.Issues
 				Navigation.PopModalAsync();
 			}
 		}
-
-#if UITEST && __IOS__
-		[Test]
-		public void RefreshControlTurnsOffSuccessfully()
-		{
-			RunningApp.WaitForElement(_testReady);
-
-			RunningApp.WaitForNoElement("RefreshControl");
-		}
-#endif
-
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12300.cs
@@ -1,0 +1,96 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.PlatformConfiguration;
+using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using NavigationPage = Xamarin.Forms.NavigationPage;
+using Page = Xamarin.Forms.Page;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12300, "Crash when dismissing modally presented page on iOS", PlatformAffected.iOS)]
+	public class Issue12300 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var button = new Button()
+			{
+				Text = "Show Modal Page",
+				HorizontalOptions = LayoutOptions.Center,
+				VerticalOptions = LayoutOptions.CenterAndExpand,
+			};
+
+			button.Clicked += (s, a) =>
+			{
+				Navigation.PushModalAsync(new OTNavigationPage(new ModalPage()));
+			};
+
+			Content = new StackLayout()
+			{
+				Children =
+				{
+					button
+				}
+			};
+		}
+
+		public class OTNavigationPage : NavigationPage
+		{
+			public OTNavigationPage(Page page) : base(page)
+			{
+				On<iOS>().SetModalPresentationStyle(UIModalPresentationStyle.PageSheet);
+			}
+		}
+
+		public class ModalPage : ContentPage
+		{
+			public ModalPage()
+			{
+				var button = new Button()
+				{
+					Text = "Hide Modal Page",
+					HorizontalOptions = LayoutOptions.Center,
+					VerticalOptions = LayoutOptions.CenterAndExpand,
+				};
+
+				button.Clicked += (s, a) =>
+				{
+					Navigation.PopModalAsync();
+				};
+
+				Content = new StackLayout()
+				{
+					Children =
+					{
+						button
+					}
+				};
+			}
+
+			private void ButtonClicked(object sender, EventArgs e)
+			{
+				Navigation.PopModalAsync();
+			}
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public void RefreshControlTurnsOffSuccessfully()
+		{
+			RunningApp.WaitForElement(_testReady);
+
+			RunningApp.WaitForNoElement("RefreshControl");
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1749,6 +1749,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13616.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13670.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12300.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
+++ b/Xamarin.Forms.Platform.iOS/ModalWrapper.cs
@@ -60,17 +60,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override void DismissViewController(bool animated, Action completionHandler)
 		{
-			if (PresentedViewController == null)
-			{
-				// After dismissing a UIDocumentMenuViewController, (for instance, if a WebView with an Upload button
-				// is asking the user for a source (camera roll, etc.)), the view controller accidentally calls dismiss
-				// again on itself before presenting the UIImagePickerController; this leaves the UIImagePickerController
-				// without an anchor to the view hierarchy and it doesn't show up. This appears to be an iOS bug.
-
-				// We can work around it by ignoring the dismiss call when PresentedViewController is null.
-				return;
-			}
-
 			base.DismissViewController(animated, completionHandler);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Removed some ancient workaround for a (presumed) bug in iOS. As far as I can tell this was implemented for [this test case](https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Bugzilla44500.cs), which still works fine after removing this code. This is what is causing the weird behavior with the new modals today. I don't think there is much risk in removing this.

Original Bugzilla ticket [here](https://bugzilla.xamarin.com/44/44500/bug.html) and PR implementing this [here](https://github.com/xamarin/Xamarin.Forms/pull/951).

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #12300

### API Changes ###
 
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Before there was a crash/unexpected behavior (closing underlaying modal as well as the top one) when there was a tap outside of the modal FormSheet or PageSheet and then closing the modal.

This change closes the top most modal immediately with a tap outside as is the expected behavior.

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
