### PR TITLE
[iOS] Fix inability to check an initially disabled RadioButton after enabling it

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14544.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14544.cs
@@ -1,0 +1,84 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.RadioButton)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14544, "RadioButton does not respond to taps after changing IsEnabled from false to true", PlatformAffected.iOS)]
+	public class Issue14544 : TestContentPage 
+	{
+		StackLayout _layout;
+		RadioButton _radioButton;
+		Button _button;
+		Label _statusLabel;
+
+		const string RadioButtonID = "DisabledRadioButton";
+		const string ToggleButtonID = "ToggleButton";
+		const string StatusLabelID = "StatusLabel";
+
+		const string CheckedLabel = "Checked";
+		const string UncheckedLabel = "Unchecked";
+
+		protected override void Init()
+		{
+			_statusLabel = new Label { Text = UncheckedLabel, AutomationId = StatusLabelID };
+
+			_radioButton = new RadioButton
+			{
+				AutomationId = RadioButtonID,
+				Content = "Disabled Radio Button",
+				IsEnabled = false,
+			};
+			_radioButton.CheckedChanged += (s, e) => _statusLabel.Text = e.Value ? CheckedLabel : UncheckedLabel;
+
+			_button = new Button()
+			{
+				AutomationId = ToggleButtonID,
+				Text = "Enable Radio Button",
+				Command = new Command(() => _radioButton.IsEnabled = true)
+			};
+
+			_button.Command.Execute(null);
+
+			Content = new StackLayout
+			{
+				Orientation = StackOrientation.Vertical,
+				Children =
+				{
+					_radioButton,
+					_button,
+					_statusLabel
+				}
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void Issue14544Test()
+		{
+			RunningApp.WaitForElement(RadioButtonID);
+
+			//Radio button should be unchecked initially
+			var labelElem = RunningApp.Query(c => c.Marked(StatusLabelID))[0];
+			Assert.AreEqual(UncheckedLabel, labelElem.Text);
+
+			RunningApp.Tap(ToggleButtonID);
+			RunningApp.Tap(RadioButtonID);
+
+			labelElem = RunningApp.Query(c => c.Marked(StatusLabelID))[0];
+			Assert.AreEqual(CheckedLabel, labelElem.Text);
+
+			RunningApp.Screenshot("Checked RadioButton");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14544.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14544.cs
@@ -29,8 +29,16 @@ namespace Xamarin.Forms.Controls.Issues
 
 		protected override void Init()
 		{
-			_statusLabel = new Label { Text = UncheckedLabel, AutomationId = StatusLabelID };
+			var descriptionLabel = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "Initially the RadioButton should not respond, then tap the button to enable the RadioButton. If the RadioButton now responds (it selects) the test succeeded."
+			};
 
+			_statusLabel = new Label { Text = UncheckedLabel, AutomationId = StatusLabelID };
+			
 			_radioButton = new RadioButton
 			{
 				AutomationId = RadioButtonID,
@@ -46,13 +54,12 @@ namespace Xamarin.Forms.Controls.Issues
 				Command = new Command(() => _radioButton.IsEnabled = true)
 			};
 
-			_button.Command.Execute(null);
-
 			Content = new StackLayout
 			{
 				Orientation = StackOrientation.Vertical,
 				Children =
 				{
+					descriptionLabel,
 					_radioButton,
 					_button,
 					_statusLabel
@@ -70,9 +77,18 @@ namespace Xamarin.Forms.Controls.Issues
 			var labelElem = RunningApp.Query(c => c.Marked(StatusLabelID))[0];
 			Assert.AreEqual(UncheckedLabel, labelElem.Text);
 
+			// Tap RadioButton
+			RunningApp.Tap(RadioButtonID);
+
+			// Should be still unchecked
+			labelElem = RunningApp.Query(c => c.Marked(StatusLabelID))[0];
+			Assert.AreEqual(UncheckedLabel, labelElem.Text);
+
+			// Tap toggle button, then RadioButton
 			RunningApp.Tap(ToggleButtonID);
 			RunningApp.Tap(RadioButtonID);
 
+			// RadioButton should now be selected
 			labelElem = RunningApp.Query(c => c.Marked(StatusLabelID))[0];
 			Assert.AreEqual(CheckedLabel, labelElem.Text);
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14544.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14544.cs
@@ -16,7 +16,6 @@ namespace Xamarin.Forms.Controls.Issues
 	[Issue(IssueTracker.Github, 14544, "RadioButton does not respond to taps after changing IsEnabled from false to true", PlatformAffected.iOS)]
 	public class Issue14544 : TestContentPage 
 	{
-		StackLayout _layout;
 		RadioButton _radioButton;
 		Button _button;
 		Label _statusLabel;

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -921,6 +921,7 @@
       <DependentUpon>VisualGallery.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14544.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Core/RadioButton.cs
+++ b/Xamarin.Forms.Core/RadioButton.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Runtime.CompilerServices;
+
 using Xamarin.Forms.Internals;
 using Xamarin.Forms.Shapes;
 
@@ -217,6 +219,14 @@ namespace Xamarin.Forms
 		bool IBorderElement.IsBackgroundSet() => IsSet(BackgroundProperty);
 		bool IBorderElement.IsBorderColorSet() => IsSet(BorderElement.BorderColorProperty);
 		bool IBorderElement.IsBorderWidthSet() => IsSet(BorderElement.BorderWidthProperty);
+
+		protected override void OnPropertyChanged([CallerMemberName] string propertyName = null)
+		{
+			base.OnPropertyChanged(propertyName);
+
+			if (propertyName == nameof(IsEnabled))
+				UpdateIsEnabled();
+		}
 
 		protected internal override void ChangeVisualState()
 		{


### PR DESCRIPTION
### Description of Change ###

The RadioButton control used on iOS was not listening for changes to the IsEnabled state to add the tap gesture recogniser needed to toggle the control's checked state.

UpdateIsEnabled was previously only called once when the control was first created, so if a RadioButton was created in an initially disabled state, there was nothing in place to add the tap gesture recogniser at a later point. This PR listens for changes to IsEnabled via OnPropertyChanged to call UpdateIsEnabled which will add/remove the tap gesture recogniser based on the enabled state.

This doesn't affect Android as that uses the built in radio button views rather than the Xamarin Forms implementation of one.

### Issues Resolved ### 
Fixes #14544 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###

Before, adding a RadioButton control to a page with IsEnabled set to false meant that RadioButton did not respond to taps after changing IsEnabled to true. After this change, setting IsEnabled to true allows the RadioButton to respond to taps as expected to toggle the checked state.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
- Add a RadioButton to a page with IsEnabled set to false.
- After the page has loaded, change IsEnabled to true (via a button click etc.)
- Verify that the RadioButton's checked state can now be updated via tap gestures.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
