### PR TITLE
[iOS] Fix Frame Background issue with transparent color

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14426.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14426.xaml
@@ -1,0 +1,74 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 14426" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14426"
+    BackgroundColor="Red">
+    <StackLayout
+        Padding="12">
+        <Label
+            Text="If the first Frame Background is transparent, the test has passed."/>
+        <Frame 
+            HasShadow="False">
+            <Frame.Background>
+                <SolidColorBrush 
+                    Color="Transparent" />
+            </Frame.Background>
+            <Label 
+                Text="Transparent Background" />
+        </Frame>
+        <Frame 
+            HasShadow="False">
+            <Frame.Background>
+                <SolidColorBrush 
+                    Color="Green" />
+            </Frame.Background>
+            <Label 
+                TextColor="White"
+                Text="Green SolidColor" />
+        </Frame>
+        <Frame 
+            HasShadow="False">
+            <Frame.Background>
+                <LinearGradientBrush 
+                    StartPoint="0,0"
+                    EndPoint="1,0">
+                    <LinearGradientBrush.GradientStops>
+                        <GradientStop 
+                            Color="Yellow"
+                            Offset="0.1" />
+                        <GradientStop 
+                            Color="Green"
+                            Offset="1.0" />
+                    </LinearGradientBrush.GradientStops>
+                </LinearGradientBrush>
+            </Frame.Background>
+            <Label 
+                 TextColor="White"
+                Text="LinearGradient" />
+        </Frame>
+        <Frame 
+            HasShadow="False">
+            <Frame.Background>
+                <RadialGradientBrush
+                    Center="0.1,0.1"
+                    Radius="0.5">
+                    <RadialGradientBrush.GradientStops>
+                        <GradientStop
+                            Color="Red"
+                            Offset="0.1" />
+                        <GradientStop
+                            Color="DarkBlue"
+                            Offset="1.0" />
+                    </RadialGradientBrush.GradientStops>
+                </RadialGradientBrush>
+            </Frame.Background>
+            <Label 
+                Text="RadialGradient" />
+        </Frame>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14426.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14426.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14426,
+		"[Bug] [Regression] iOS Frame.Background not working",
+		PlatformAffected.iOS)]
+	public partial class Issue14426 : TestContentPage
+	{
+		public Issue14426()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -23,6 +23,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13551.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13819.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13916.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14426.xaml.cs">
+      <DependentUpon>Issue14426.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -2683,8 +2686,8 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6742.xaml">
-        <SubType>Designer</SubType>
-        <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10897.xaml">
       <SubType>Designer</SubType>
@@ -2723,8 +2726,8 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue4143.xaml">
-        <SubType>Designer</SubType>
-        <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
@@ -2733,6 +2736,12 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)VisualGallery.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14426.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -93,7 +93,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					_actualView.Layer.BackgroundColor = UIColor.Clear.CGColor;
 
-					backgroundLayer.BackgroundColor = ColorExtensions.BackgroundColor.CGColor;
 					backgroundLayer.CornerRadius = cornerRadius;
 
 					Layer.InsertBackgroundLayer(backgroundLayer, 0);


### PR DESCRIPTION
### Description of Change ###

Fix Frame Background issue with transparent color.

### Issues Resolved ### 

- fixes #14426 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="383" alt="fix-14426" src="https://user-images.githubusercontent.com/6755973/131831652-2976c9c5-71c5-447f-81c7-adea01548990.png">


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14426. If the first Frame Background is transparent, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
