### PR TITLE
[iOS] Remove usage of System.Drawing types

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Cells/SwitchCellRenderer.cs
@@ -3,6 +3,7 @@ using System.ComponentModel;
 using System.Drawing;
 using Foundation;
 using UIKit;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
@@ -3,6 +3,7 @@ using Foundation;
 using System.Collections.Generic;
 using System.Drawing;
 using Xamarin.Forms.Internals;
+using SizeF = CoreGraphics.CGSize;
 #if __MOBILE__
 using UIKit;
 using NativeLabel = UIKit.UILabel;

--- a/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
@@ -4,6 +4,7 @@ using System.Drawing;
 using System.Linq;
 using static System.String;
 using Xamarin.Forms.Internals;
+using SizeF = CoreGraphics.CGSize;
 #if __MOBILE__
 using UIKit;
 namespace Xamarin.Forms.Platform.iOS

--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -2,6 +2,7 @@ using CoreGraphics;
 using System.ComponentModel;
 using System.Drawing;
 using UIKit;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -7,6 +7,7 @@ using Foundation;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using Specifics = Xamarin.Forms.PlatformConfiguration.iOSSpecific.Entry;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FrameRenderer.cs
@@ -2,6 +2,7 @@ using System.ComponentModel;
 using System.Drawing;
 using CoreGraphics;
 using UIKit;
+using SizeF = CoreGraphics.CGSize;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SearchBarRenderer.cs
@@ -5,6 +5,7 @@ using CoreGraphics;
 using Foundation;
 using UIKit;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SliderRenderer.cs
@@ -198,7 +198,7 @@ namespace Xamarin.Forms.Platform.iOS
 							if (control != null)
 							{
 								var tappedLocation = recognizer.LocationInView(control);
-								if (tappedLocation != null)
+								if (tappedLocation != default)
 								{
 									var val = (tappedLocation.X - control.Frame.X) * control.MaxValue / control.Frame.Size.Width;
 									Element.SetValueFromRenderer(Slider.ValueProperty, val);

--- a/Xamarin.Forms.Platform.iOS/Renderers/StepperRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/StepperRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.Drawing;
 using System.ComponentModel;
 using UIKit;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwitchRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using System.Drawing;
 using UIKit;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -9,6 +9,7 @@ using static Xamarin.Forms.PlatformConfiguration.iOSSpecific.Page;
 using PageUIStatusBarAnimation = Xamarin.Forms.PlatformConfiguration.iOSSpecific.UIStatusBarAnimation;
 using TabbedPageConfiguration = Xamarin.Forms.PlatformConfiguration.iOSSpecific.TabbedPage;
 using TranslucencyMode = Xamarin.Forms.PlatformConfiguration.iOSSpecific.TranslucencyMode;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -133,7 +134,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!Element.Bounds.IsEmpty)
 			{
-				View.Frame = new System.Drawing.RectangleF((float)Element.X, (float)Element.Y, (float)Element.Width, (float)Element.Height);
+				View.Frame = new RectangleF((float)Element.X, (float)Element.Y, (float)Element.Width, (float)Element.Height);
 			}
 
 			var frame = View.Frame;

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -16,6 +16,7 @@ using WebKit;
 using Xamarin.Forms.Internals;
 using PreserveAttribute = Foundation.PreserveAttribute;
 using Uri = System.Uri;
+using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -5,6 +5,8 @@ using System.Threading;
 using CoreAnimation;
 using CoreGraphics;
 using Xamarin.Forms.Internals;
+using RectangleF = CoreGraphics.CGRect;
+using PointF = CoreGraphics.CGPoint;
 
 #if __MOBILE__
 using UIKit;


### PR DESCRIPTION
### Description of Change ###

Avoid using types from System.Drawing in the iOS platform code. This was already done in half of the files but some of them were missing. Due to some legacy incompatibilities the references to these types were incorrectly resolved to System.Drawing.Common where they don't really exist outside of legacy Xamarin platforms. This allows limited usage of the Xamarin.Forms on net6.0 platforms as a transition step to migrating to MAUI.

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Manually recompiled the platform assembly, verified that there are no more references to System.Drawing.Common. The assembly now loads on net6.0-ios without an error.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
