### PR TITLE
[iOS] Fix issue using FormattedString and LineBreakMode

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12590.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12590.xaml
@@ -1,0 +1,40 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 12590" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue12590">
+    <StackLayout
+        Padding="12">
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the string is trimmed in in both cases,the test has passed."/>
+        <Label
+            FontSize="Micro"
+            Text="Text"/>
+        <Label
+            MaxLines="1"
+            LineBreakMode="TailTruncation"
+            Text="Some long string. Some long string. Some long string. Some long string. Some long string. Some long string" />
+        <Label
+            FontSize="Micro"
+            Text="FormattedString"/>
+        <Label
+            MaxLines="1"
+            LineBreakMode="TailTruncation">
+            <Label.FormattedText>
+                <FormattedString>
+                    <FormattedString.Spans>
+                        <Span Text="Some long string. Some long string. Some long string. Some long string. Some long string. Some long string" />
+                        <Span Text="Some long string. Some long string. Some long string. Some long string. Some long string. Some long string" />
+                    </FormattedString.Spans>
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12590.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12590.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 12590,
+		"[Bug] LineBreakMode=TailTruncation doesn't work with Label.FormattedText",
+		PlatformAffected.iOS)]
+	public partial class Issue12590 : TestContentPage
+	{
+		public Issue12590()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1753,6 +1753,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12150.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue12590.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2186,6 +2187,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13684.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue12590.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -289,6 +289,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			Control.AttributedStringValue = newAttributedText;
 #endif
 			UpdateCharacterSpacing();
+
 			_perfectSizeValid = false;
 		}
 
@@ -468,6 +469,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			_perfectSizeValid = false;
 
 			UpdateHorizontalTextAlignment();
+			UpdateLineBreakMode();
 		}
 
 		void UpdateTextHtml()


### PR DESCRIPTION
### Description of Change ###

Fix issue using FormattedString and LineBreakMode on iOS.

### Issues Resolved ### 

- fixes #12590 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="315" alt="fix-12590" src="https://user-images.githubusercontent.com/6755973/131992091-e64c50a3-6785-4a30-bf65-7d045659f1b7.png">

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 12590. If the string is trimmed in in both cases,the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
