### PR TITLE
[iOS] Add consistency in date format between platforms

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13918.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13918.xaml
@@ -1,0 +1,19 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13918"
+    Title="Issue 13918">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If can see the century in the DatePicker, the test has passed." /> 
+        <DatePicker />
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13918.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13918.xaml.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13918, "[Bug] iOS DatePicker only displays the last two digits of the year",
+		PlatformAffected.iOS)]
+	public partial class Issue13918 : TestContentPage
+	{
+		public Issue13918()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1840,6 +1840,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14897.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11954.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13918.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2369,6 +2370,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14897.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13918.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/DatePickerRenderer.cs
@@ -166,29 +166,12 @@ namespace Xamarin.Forms.Platform.iOS
 		{
 			if (_picker.Date.ToDateTime().Date != Element.Date.Date)
 				_picker.SetDate(Element.Date.ToNSDate(), animate);
-
-			// Can't use Element.Format because it won't display the correct format if the region and language are set differently
-			if (Element.Format.Equals("d") || Element.Format.Equals("D"))
+						
+			if (string.IsNullOrWhiteSpace(Element.Format))
 			{
-				NSDateFormatter dateFormatter = new NSDateFormatter
-				{
-					TimeZone = NSTimeZone.FromGMT(0)
-				};
-
-				if (Element.Format?.Equals("D") == true)
-				{
-					dateFormatter.DateStyle = NSDateFormatterStyle.Long;
-					var strDate = dateFormatter.StringFor(_picker.Date);
-					Control.Text = strDate;
-				}
-				else
-				{
-					dateFormatter.DateStyle = NSDateFormatterStyle.Short;
-					var strDate = dateFormatter.StringFor(_picker.Date);
-					Control.Text = strDate;
-				}
+				Control.Text = Element.Date.ToShortDateString();
 			}
-			else if (Element.Format.Contains("/"))
+			else if (Element.Format.Contains('/'))
 			{
 				Control.Text = Element.Date.ToString(Element.Format, CultureInfo.InvariantCulture);
 			}


### PR DESCRIPTION
### Description of Change ###

Add consistency in date format between platforms.

### Issues Resolved ### 

- fixes #13918

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the sample 13918. If can see the century in the DatePicker, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
