### PR TITLE
[Core] Fix exception navigating using Shell

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -163,7 +163,10 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+				await Device.InvokeOnMainThreadAsync(() =>
+				{
+					return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+				});
 			}
 
 			(_shell as IShellController).UpdateCurrentState(source);


### PR DESCRIPTION
### Description of Change ###

Fix Exception "Can only be called on ui thread!" navigating using Shell.

### Issues Resolved ### 

- fixes #14366

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
