### PR TITLE
[Android] Fix issue clipping shapes 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14556.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14556.xaml
@@ -1,0 +1,29 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 14556" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14556">
+    <StackLayout
+        Padding="12">
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If you see a triangle (clip) instead of a rectangle, the test has passed."/>
+        <StackLayout>
+            <Path
+                Clip="M0,1.71815 L6.65685,6.375 L0,11.0319 z"
+                Data="M0,0 L7,0 L7,13 L0,13 z"
+                Fill="Gray"
+                HorizontalOptions="Center"
+                VerticalOptions ="Center"
+                HeightRequest="50"
+                WidthRequest="50"
+                Aspect="Fill" />
+        </StackLayout>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14556.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14556.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Shape)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14556,
+		"[Bug] Clip is not work on Shapes.Path",
+		PlatformAffected.Android)]
+	public partial class Issue14556 : TestContentPage
+	{
+		public Issue14556()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1760,6 +1760,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13684.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12300.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue12150.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14556.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2193,6 +2194,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13684.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14556.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Extensions/CanvasExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Extensions/CanvasExtensions.cs
@@ -5,6 +5,14 @@ namespace Xamarin.Forms.Platform.Android
 {
 	public static class CanvasExtensions
 	{
+		public static void ClipShape(this Canvas canvas, Path path)
+		{
+			if (canvas == null || path == null)
+				return;
+
+			canvas.ClipPath(path);
+		}
+
 		public static void ClipShape(this Canvas canvas, Context context, VisualElement element)
 		{
 			if (canvas == null || element == null)

--- a/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Shapes/ShapeRenderer.cs
@@ -4,6 +4,7 @@ using Android.Content;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.Graphics.Drawables.Shapes;
+using Android.Views;
 using Xamarin.Forms.Shapes;
 using AColor = Android.Graphics.Color;
 using AMatrix = Android.Graphics.Matrix;
@@ -41,6 +42,7 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateStrokeLineCap();
 				UpdateStrokeLineJoin();
 				UpdateStrokeMiterLimit();
+				UpdateClip();
 
 				if (!args.NewElement.Bounds.IsEmpty)
 				{
@@ -83,6 +85,8 @@ namespace Xamarin.Forms.Platform.Android
 				UpdateStrokeLineJoin();
 			else if (args.PropertyName == Shape.StrokeMiterLimitProperty.PropertyName)
 				UpdateStrokeMiterLimit();
+			else if (args.PropertyName == VisualElement.ClipProperty.PropertyName)
+				UpdateClip();
 		}
 
 		public override SizeRequest GetDesiredSize(int widthConstraint, int heightConstraint)
@@ -176,6 +180,18 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			Control.UpdateStrokeMiterLimit((float)Element.StrokeMiterLimit);
 		}
+
+		void UpdateClip()
+		{
+			var geometry = Element.Clip;
+
+			if (geometry == null)
+				return;
+
+			var path = geometry.ToAPath(Context);
+
+			Control.UpdateClip(path);
+		}
 	}
 
 	public class ShapeView : AView
@@ -202,6 +218,8 @@ namespace Xamarin.Forms.Platform.Android
 		AMatrix _transform;
 		AMatrix _transformMatrix;
 
+		APath _clip;
+
 		public ShapeView(Context context) : base(context)
 		{
 			_drawable = new ShapeDrawable(null);
@@ -217,6 +235,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void OnDraw(Canvas canvas)
 		{
+			if (_clip != null)
+				canvas.ClipShape(_clip);
+
 			base.OnDraw(canvas);
 
 			if (_path == null)
@@ -299,6 +320,13 @@ namespace Xamarin.Forms.Platform.Android
 			inverseTransformMatrix.MapRect(_pathFillBounds);
 			inverseTransformMatrix.MapRect(_pathStrokeBounds);
 			inverseTransformMatrix.Dispose();
+		}
+
+		public void UpdateClip(APath clip)
+		{
+			_clip = clip;
+
+			Invalidate();
 		}
 
 		public void UpdateShape(APath path)


### PR DESCRIPTION
### Description of Change ###

Allow to Clip shapes like:
`<Path Clip="M0,1.71815 L6.65685,6.375 L0,11.0319 z" Data="M0,0 L7,0 L7,13 L0,13 z" Fill="Gray" HorizontalOptions="Center" HeightRequest="13" Margin="2,1,0,1" Aspect="Fill" VerticalOptions="Center" WidthRequest="7"/>`

### Issues Resolved ### 

- fixes #14556 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14556. If you see a triangle (clip) instead of a rectangle, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
