### PR TITLE
[iOS] Fix SwipeView Background behavior

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14444.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14444.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 14444" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14444"
+    BackgroundColor="LightGray">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the SwipeView background is transparent, the test has passed."/>
+        <StackLayout
+            Padding="12">
+            <SwipeView
+                BackgroundColor="Transparent">
+                <SwipeView.LeftItems>
+                    <SwipeItemView WidthRequest="50">
+                        <BoxView
+                            HeightRequest="50"
+                            HorizontalOptions="FillAndExpand"
+                            BackgroundColor="Red"/>
+                    </SwipeItemView>
+                </SwipeView.LeftItems>
+                <BoxView
+                    HeightRequest="50"
+                    HorizontalOptions="FillAndExpand"
+                    BackgroundColor="Gray"
+                    CornerRadius="16"/>
+            </SwipeView>
+        </StackLayout>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14444.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14444.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 14444,
+		"[Bug] SwipeView backgrownd color is set to white on iOS",
+		PlatformAffected.iOS)]
+	public partial class Issue14444 : TestContentPage
+	{
+		public Issue14444()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1766,6 +1766,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue12590.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14444.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2208,6 +2209,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue11795.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14444.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -171,20 +171,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		protected override void SetBackgroundColor(Color color)
 		{
-			UIColor backgroundColor = ColorExtensions.BackgroundColor;
+			Color backgroundColor = Element.BackgroundColor;
 
-			if (Element.BackgroundColor != Color.Default)
-			{
-				BackgroundColor = Element.BackgroundColor.ToUIColor();
+			if (Element.BackgroundColor == Color.Default)
+				return;
 
-				if (_contentView != null && (Element.Content == null || (Element.Content != null && Element.Content.BackgroundColor == Color.Default)))
-					_contentView.BackgroundColor = Element.BackgroundColor.ToUIColor();
-			}
-			else
-				BackgroundColor = backgroundColor;
+			BackgroundColor = backgroundColor.ToUIColor();
 
-			if (_contentView != null && _contentView.BackgroundColor == UIColor.Clear)
-				_contentView.BackgroundColor = backgroundColor;
+			if (_contentView != null && (Element.Content == null || (Element.Content != null && Element.Content.BackgroundColor == Color.Default)))
+				_contentView.BackgroundColor = backgroundColor.ToUIColor();
 		}
 
 		protected override void SetBackground(Brush brush)


### PR DESCRIPTION
### Description of Change ###

Avoid setting default color value in the iOS SwipeView background under some conditions.

### Issues Resolved ### 

- fixes #14444 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<img width="317" alt="fix14444" src="https://user-images.githubusercontent.com/6755973/132327353-1f21f074-a8c5-437c-bd07-f9508fef11e5.png">


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14444. If the SwipeView background is transparent, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
