### PR TITLE
[UWP] Fix issue with invisible CollectionView and layouts

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9079.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9079.xaml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9079"
+    Title="Issue 9079">
+    <ContentPage.Content>
+        <StackLayout>
+            <Button 
+                Text="Show/Hide CollectionView" 
+                Clicked="Button_Clicked" />
+            <CollectionView
+                x:Name="collectionView" 
+                IsVisible="False">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout 
+                        Orientation="Vertical"
+                        Span="3" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate>
+                        <Label 
+                            VerticalTextAlignment="Center" 
+                            Text="{Binding}" />
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </StackLayout>
+    </ContentPage.Content>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9079.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9079.xaml.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Diagnostics;
+using System.Collections.Generic;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 9079,
+		"[Bug] [UWP] CollectionView ItemsLayout not working when initially invisible",
+		PlatformAffected.UWP)]
+	public partial class Issue9079 : TestContentPage
+	{
+		public Issue9079()
+		{
+#if APP
+			InitializeComponent();
+			GenerateItems();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+#if APP
+		void GenerateItems()
+		{
+			List<string> items = new List<string>();
+			for (int i = 0; i < 100; i++)
+				items.Add($"Hello world {i}!");
+
+			collectionView.ItemsSource = items;
+		}
+
+		void Button_Clicked(object sender, EventArgs e)
+		{
+			collectionView.IsVisible = !collectionView.IsVisible;
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1770,6 +1770,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9079.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2218,6 +2219,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14286.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9079.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/StructuredItemsViewRenderer.cs
@@ -45,7 +45,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				UpdateFooter();
 			}
-			else if (changedProperty.Is(StructuredItemsView.ItemsLayoutProperty))
+			else if (changedProperty.IsOneOf(VisualElement.IsVisibleProperty, StructuredItemsView.ItemsLayoutProperty))
 			{
 				UpdateItemsLayout();
 			}


### PR DESCRIPTION
### Description of Change ###

Fix issue with invisible CollectionView and wrong layout on UWP.

### Issues Resolved ### 

- fixes #9079

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![fix-9079](https://user-images.githubusercontent.com/6755973/132715730-f1b331c2-3f72-4a31-a006-a12b2d5fb74f.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 9079. Tap the button to hide/show the CollectionView. If the CollectionView layout is always correct, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
