### PR TITLE
[iOS] Allow empty image to hide back nav button

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -1216,7 +1216,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 			UIImage GetEmptyBackIndicatorImage()
 			{
-				var rect = RectangleF.Empty;
+				var rect = new RectangleF(0, 0, 1, 1);
 				var size = rect.Size;
 
 				UIGraphics.BeginImageContext(size);


### PR DESCRIPTION
### Description of Change ###

Allow empty image to hide back nav button.

### Issues Resolved ### 

- fixes #14331

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
