### PR TITLE
[UWP] Validate CarouselView DivideByZeroException

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13818.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13818.xaml
@@ -1,0 +1,42 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 13818" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13818">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Without exceptions, the test has passed."/>
+        <CarouselView 
+            HeightRequest="200"
+            ItemsSource="{Binding Numbers}"
+            Position="{Binding Position}" 
+            Margin="24">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Label
+                        Text="{Binding .}" />
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+        <CarouselView
+            HeightRequest="200"
+            Loop="True"
+            ItemsSource="{Binding Numbers}"
+            Position="{Binding Position}" 
+            Margin="24">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Label
+                        Text="{Binding .}" />
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13818.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13818.xaml.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 13818,
+		"[Bug] System.DivideByZeroException: Attempted to divide by zero. exception when opening the CarouselView in UWP",
+		PlatformAffected.UWP)]
+	public partial class Issue13818 : TestContentPage
+	{
+		Issue13818ViewModel _context = new Issue13818ViewModel();
+
+		public Issue13818()
+		{
+#if APP
+			InitializeComponent();
+			BindingContext = _context;
+#endif
+		}
+
+		protected override void Init()
+		{
+			_context.Init();
+		}
+	}
+
+	public class Issue13818ViewModel : BindableObject
+	{
+		int _position = 0;
+
+		public void Init()
+		{
+			for (int i = 0; i < 10; i++)
+			{
+				Numbers.Add(i);
+			}
+
+			Position = 4;
+
+		}
+
+		public int Position
+		{
+			get
+			{
+				return _position;
+			}
+			set
+			{
+				_position = value;
+				OnPropertyChanged();
+			}
+		}
+
+		public ObservableCollection<int> Numbers { get; set; } = new ObservableCollection<int>();
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1770,6 +1770,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13818.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2218,6 +2219,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14286.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13818.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>


### PR DESCRIPTION
### Description of Change ###

Cannot reproduce the issues in 5.0.0 branch. Added sample to validate UWP CarouselView DivideByZeroException.

### Issues Resolved ### 

- fixes #13818

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13818. Without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
