### PR TITLE
[UWP] Fix incorrect Button rendering inside CollectionView ItemTemplate

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13588.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13588.xaml
@@ -1,0 +1,80 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue13588"
+    Title="Issue 13588">
+    <Grid
+        RowSpacing="0">
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto" />
+            <RowDefinition Height="*" />
+        </Grid.RowDefinitions>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If Buttons inside CollectionView renders correctly, the test has passed."/>
+        <CollectionView
+            Grid.Row="1">
+            <CollectionView.ItemsSource>
+                <x:Array Type="{x:Type x:String}">
+                    <x:String>mono</x:String>
+                    <x:String>monodroid</x:String>
+                    <x:String>monotouch</x:String>
+                    <x:String>monorail</x:String>
+                    <x:String>monodevelop</x:String>
+                    <x:String>monotone</x:String>
+                    <x:String>monopoly</x:String>
+                    <x:String>monomodal</x:String>
+                    <x:String>mononucleosis</x:String>
+                </x:Array>
+            </CollectionView.ItemsSource>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="*" />
+                            <ColumnDefinition Width="40" />
+                        </Grid.ColumnDefinitions>
+                        <Label
+                            Margin="10,5,10,0"
+                            FontAttributes="Bold"
+                            VerticalOptions="Center"
+                            HorizontalOptions="StartAndExpand"
+                            Text="{Binding}"
+                            LineBreakMode="WordWrap" >
+                        </Label>
+                        <Label 
+                            Margin="10,0,10,0"
+                            Grid.Column="1"
+                            VerticalOptions="Center"
+                            HorizontalOptions="Start"
+                            LineBreakMode="WordWrap"
+                            Text="Status" />
+                        <!-- Button having the display issue-->
+                        <Button 
+                            Grid.Column="3"
+                            Text="X"
+                            VerticalOptions="Center"
+                            HorizontalOptions="End">
+                        </Button>
+                        <!-- Button having the display issue-->
+                        <Button 
+                            Grid.Column="2"
+                            Text="Retry"
+                            VerticalOptions="Center"
+                            HorizontalOptions="Center">
+                        </Button>
+                    </Grid>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13588.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13588.xaml.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Windows.Input;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.UITest;
+using Xamarin.UITest.Queries;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.CollectionView)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13588, "[Bug] Button inside collectionview not appearing until UWP window is resized #13552", PlatformAffected.UWP)]
+	public partial class Issue13588 : TestContentPage
+	{
+		public Issue13588()
+		{
+#if APP
+			Title = "Issue 13588";
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1770,6 +1770,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13588.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2218,6 +2219,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14286.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13588.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -319,6 +319,7 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				_button.Click -= OnButtonClick;
 				_button.RemoveHandler(PointerPressedEvent, _pointerPressedHandler);
+				_button.Loading -= ButtonOnLoading;
 				_button.Loaded -= ButtonOnLoaded;				
 
 				_pointerPressedHandler = null;

--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -30,6 +30,7 @@ namespace Xamarin.Forms.Platform.UWP
 					_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
 					_button.Click += OnButtonClick;
 					_button.AddHandler(PointerPressedEvent, _pointerPressedHandler, true);
+					_button.Loading += ButtonOnLoading;
 					_button.Loaded += ButtonOnLoaded;
 
 					SetNativeControl(_button);
@@ -69,6 +70,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 				UpdateFont();
 			}
+		}
+
+		void ButtonOnLoading(object o, RoutedEventArgs routedEventArgs)
+		{
+			Element.IsNativeStateConsistent = false;
 		}
 
 		void ButtonOnLoaded(object o, RoutedEventArgs routedEventArgs)


### PR DESCRIPTION
### Description of Change ###

Fix incorrect Button rendering inside CollectionView ItemTemplate on UWP.

### Issues Resolved ### 

- fixes #13588 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 13588. If Buttons inside CollectionView renders correctly, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
