### PR TITLE
[macOS] Fix TextColor Label issue 

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10101.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10101.xaml
@@ -1,0 +1,49 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 10101" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue10101">
+    <local:TestContentPage.Resources>
+         <ResourceDictionary>
+             <!-- FONTS -->
+             <OnPlatform x:TypeArguments="Font" x:Key="FontNormal">
+                 <On Platform="macOS" Value="Roboto Bold, 15" />
+             </OnPlatform>
+             <!-- LABELS -->
+             <Style TargetType="Label" ApplyToDerivedTypes="True">
+                 <Setter Property="Font" Value="{StaticResource FontNormal}" />
+                 <Setter Property="TextColor" Value="Red" />
+             </Style>
+         </ResourceDictionary>
+     </local:TestContentPage.Resources>
+
+     <StackLayout>
+         <Label
+             x:Name="label1"
+             Text="I should keep my color" />
+          <Label
+              x:Name="label2"
+              LineBreakMode="WordWrap">
+            <Label.FormattedText>
+                <FormattedString>
+                    <Span Text="I should" TextColor="Red" FontAttributes="Bold" />
+                    <Span Text=" keep my color" TextColor="Red" />
+                </FormattedString>
+            </Label.FormattedText>
+        </Label>
+         <Button x:Name="button" Text="Change text on label"  Clicked="button_Clicked" />
+
+         <Label x:Name="labelColor" Text="Welcome to Xamarin.Forms!" HorizontalOptions="Center"
+                VerticalOptions="CenterAndExpand">
+             <Label.GestureRecognizers>
+                 <TapGestureRecognizer Tapped="OnTapped" />
+             </Label.GestureRecognizers>
+         </Label>
+         <Label x:Name="labelText" Text="" HorizontalOptions="Center"
+                VerticalOptions="CenterAndExpand" />
+     </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10101.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue10101.xaml.cs
@@ -1,0 +1,79 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 10101, "Changing text on a Label on macOS resets font color to Black", PlatformAffected.macOS)]
+	public partial class Issue10101 : TestContentPage
+	{
+		class ColorItem
+		{
+			public Color Color { get; set; } = Color.Red;
+			public string Name { get; set; }
+		}
+
+		readonly Random _random = new Random();
+
+		static List<ColorItem> GetSystemColorList() =>
+			new List<ColorItem>
+			{
+				new ColorItem() {Color = Color.Accent, Name = "Accent"},
+				new ColorItem() {Color = Color.AliceBlue, Name = "AliceBlue"},
+				new ColorItem() {Color = Color.MintCream, Name = "MintCream"},
+				new ColorItem() {Color = Color.MistyRose, Name = "MistyRose"},
+				new ColorItem() {Color = Color.Moccasin, Name = "Moccasin"},
+				new ColorItem() {Color = Color.NavajoWhite, Name = "NavajoWhite"},
+				new ColorItem() {Color = Color.Navy, Name = "Navy"},
+				new ColorItem() {Color = Color.OldLace, Name = "OldLace"},
+				new ColorItem() {Color = Color.MidnightBlue, Name = "MidnightBlue"},
+				new ColorItem() {Color = Color.Olive, Name = "Olive"},
+				new ColorItem() {Color = Color.Orange, Name = "Orange"},
+				new ColorItem() {Color = Color.OrangeRed, Name = "OrangeRed"},
+				new ColorItem() {Color = Color.Orchid, Name = "Orchid"},
+				new ColorItem() {Color = Color.PaleGoldenrod, Name = "PaleGoldenrod"},
+				new ColorItem() {Color = Color.PaleGreen, Name = "PaleGreen"},
+				new ColorItem() {Color = Color.PaleTurquoise, Name = "PaleTurquoise"},
+				new ColorItem() {Color = Color.OliveDrab, Name = "OliveDrab"}
+			};
+
+		protected override void Init()
+		{
+
+		}
+
+#if APP
+		public Issue10101()
+		{
+			InitializeComponent();
+			OnTapped(null, null);
+		}
+
+		ColorItem RandomColor()
+		{
+			var colors = GetSystemColorList();
+			return colors[_random.Next(0, colors.Count - 1)];
+		}
+
+		void OnTapped(object sender, EventArgs e)
+		{
+			var color = RandomColor();
+
+			labelText.TextColor = color.Color;
+			labelColor.TextColor = color.Color;
+
+			labelText.Text = $"TextColor should be {color.Name}";
+			labelColor.Text = $"TextColor should be {color.Name}";
+		}
+
+		void button_Clicked(System.Object sender, System.EventArgs e)
+		{
+			label1.Text = "This text should still be red";
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1770,6 +1770,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue10101.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2218,6 +2219,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14286.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue10101.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -201,6 +201,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			else if (e.PropertyName == Label.TextProperty.PropertyName)
 			{
 				UpdateText();
+				UpdateTextColor();
 				UpdateTextDecorations();
 				UpdateCharacterSpacing();
 			}


### PR DESCRIPTION
### Description of Change ###

Fix TextColor Label issue .

### Issues Resolved ### 

- fixes #10101 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 10101. Tap the Button, if the Label Red color continue, the test passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
