### PR TITLE
[Android] Fix Frame black background issue (with zero CornerRadius)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FrameBackgroundIssue.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FrameBackgroundIssue.xaml
@@ -1,0 +1,87 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Frame Backgrund Issue" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.FrameBackgroundIssue">
+    <ScrollView>
+        <StackLayout
+            Padding="12">
+            <Frame
+                HasShadow="False"
+                WidthRequest="150"
+                BackgroundColor="LightGray"
+                BorderColor="DarkGreen"
+                CornerRadius="0"
+                Padding="0">
+                <StackLayout>
+                    <BoxView
+                        BackgroundColor="GreenYellow" />
+                    <Label
+                        Margin="8"
+                        Text="Frame using BackgroundColor"
+                        TextColor="Black" />
+                </StackLayout>
+            </Frame>
+            <Frame
+                HasShadow="False"
+                WidthRequest="150"
+                BackgroundColor="LightGray"
+                BorderColor="DarkGreen"
+                CornerRadius="{Binding Source={x:Reference CornerRadiusSlider}, Path=Value}"
+                Padding="0">
+                <StackLayout>
+                    <BoxView
+                        BackgroundColor="GreenYellow" />
+                    <Label
+                        Margin="8"
+                        Text="Frame using BackgroundColor"
+                        TextColor="Black" />
+                </StackLayout>
+            </Frame>
+            <Frame
+                HasShadow="False"
+                WidthRequest="150"
+                Background="LightGray"
+                BorderColor="DeepPink"
+                CornerRadius="0"
+                Padding="0">
+                <StackLayout>
+                    <BoxView
+                        Background="LightPink" />
+                    <Label
+                        Margin="8"
+                        Text="Frame using Background"
+                        TextColor="Black" />
+                </StackLayout>
+            </Frame>
+            <Frame
+                HasShadow="False"
+                WidthRequest="150"
+                Background="LightGray"
+                BorderColor="DeepPink"
+                CornerRadius="{Binding Source={x:Reference CornerRadiusSlider}, Path=Value}"
+                Padding="0">
+                <StackLayout>
+                    <BoxView
+                        Background="LightPink" />
+                    <Label
+                        Margin="8"
+                        Text="Frame using Background"
+                        TextColor="Black" />
+                </StackLayout>
+            </Frame>
+            <Label
+                FontSize="Micro"
+                Text="Frame CornerRadius"/>
+            <Slider
+                x:Name="CornerRadiusSlider"
+                Minimum="0"
+                Maximum="48"
+                Value="12"/>
+        </StackLayout>
+    </ScrollView>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FrameBackgroundIssue.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/FrameBackgroundIssue.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Frame)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 0,
+		"[Bug] Frame Background not working",
+		PlatformAffected.Android)]
+	public partial class FrameBackgroundIssue : TestContentPage
+	{
+		public FrameBackgroundIssue()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1770,6 +1770,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13726.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)FrameBackgroundIssue.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2218,6 +2219,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14286.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)FrameBackgroundIssue.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/FrameRenderer.cs
@@ -2,6 +2,7 @@ using System;
 using System.ComponentModel;
 using Android.Content;
 using Android.Graphics;
+using Android.Graphics.Drawables;
 using Android.Graphics.Drawables.Shapes;
 using Android.Views;
 using AndroidX.CardView.Widget;
@@ -22,7 +23,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		bool _hasLayoutOccurred;
 		bool _disposed;
 		Frame _element;
-		GradientStrokeDrawable _backgroundDrawable;
+		GradientDrawable _backgroundDrawable;
 
 		VisualElementPackager _visualElementPackager;
 		VisualElementTracker _visualElementTracker;
@@ -176,10 +177,8 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (e.NewElement != null)
 			{
 				this.EnsureId();
-				_backgroundDrawable = new GradientStrokeDrawable
-				{
-					Shape = new RectShape()
-				};
+
+				_backgroundDrawable = new GradientDrawable();
 				this.SetBackground(_backgroundDrawable);
 
 				if (_visualElementTracker == null)
@@ -299,10 +298,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				_backgroundDrawable = null;
 				this.SetBackground(null);
 
-				_backgroundDrawable = new GradientStrokeDrawable
-				{
-					Shape = new RectShape()
-				};
+				_backgroundDrawable = new GradientDrawable();
 
 				this.SetBackground(_backgroundDrawable);
 				UpdateBorderColor();
@@ -318,7 +314,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				_height = Control.Height;
 				_width = Control.Width;
 
-				_backgroundDrawable.UpdateBackground(background);
+				_backgroundDrawable.UpdateBackground(background, _height, _width);
 			}
 		}
 
@@ -357,9 +353,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 				return;
 
 			if (_defaultCornerRadius == -1f)
-			{
 				_defaultCornerRadius = Radius;
-			}
 
 			float cornerRadius = Element.CornerRadius;
 


### PR DESCRIPTION
### Description of Change ###

Fix Frame black background issue (with zero CornerRadius) on Android.

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Launch Core Gallery and navigate to the issue called "Frame Background issue". If the Frame background is not black in all the conditions (using Background and BackgroundColor, different CornerRadius etc), the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
