### PR TITLE
[Android] Fix crash dropping item using ListView (happens occasionally)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14552.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14552.xaml
@@ -1,0 +1,50 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 14552" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14552">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="Using a Device, drag and drop several times elements. Without exceptions, the test has passed."/>
+        <Grid>
+            <ListView
+                ItemsSource="{Binding ViewModel.Items}"
+                SelectionMode="None">
+                <ListView.ItemTemplate>
+                    <DataTemplate>
+                        <ViewCell
+                            Tapped="IsSelected_Tapped">
+                            <StackLayout
+                                Orientation="Horizontal"
+                                Spacing="1">
+                                <CheckBox
+                                    IsChecked="{Binding IsSelected, Mode=TwoWay}"
+                                    IsEnabled="{Binding IsEnabled}" />
+                                <Label
+                                    Text="{Binding Name}"
+                                    VerticalOptions="Center">
+                                    <Label.GestureRecognizers>
+                                        <DragGestureRecognizer
+                                            CanDrag="True"
+                                            DragStarting="OnDragStarting" />
+                                        <DropGestureRecognizer
+                                            AllowDrop="True"
+                                            Drop="OnDropped"
+                                            DragOver="OnDragOver" />
+                                    </Label.GestureRecognizers>
+                                </Label>
+                            </StackLayout>
+                        </ViewCell>
+                    </DataTemplate>
+                </ListView.ItemTemplate>
+            </ListView>
+        </Grid>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14552.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14552.xaml.cs
@@ -1,0 +1,124 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Globalization;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 14552,
+		"[Bug] NullReferenceException in DragAndDropGestureHandler.<OnLongPress> on Android",
+		PlatformAffected.Android)]
+	public partial class Issue14552 : TestContentPage
+	{
+		public Issue14552()
+		{
+#if APP
+			InitializeComponent();
+
+            BindingContext = this;
+
+            for (int i = 0; i < 25; i++)
+                ViewModel.Items.Add(new Issue14552Item { Name = $"Item{i}" });
+#endif
+        }
+
+        public Issue14552ViewModel ViewModel { get; } = new Issue14552ViewModel();
+
+        protected override void Init()
+		{
+		}
+
+        void OnDragStarting(object sender, DragStartingEventArgs args)
+        {
+            Issue14552Item item = (Issue14552Item)((Element)sender).BindingContext;
+
+            int index = ViewModel.Items.IndexOf(item);
+            if (index != -1)
+            {
+                // TODO - Xamarin - ideally we'd assign item directly into the property bag, but that crashes
+                args.Data.Text = index.ToString(CultureInfo.InvariantCulture);
+                args.Handled = true;
+            }
+        }
+
+        void OnDragOver(object sender, DragEventArgs args)
+        {
+            Issue14552Item draggedOver = (Issue14552Item)((Element)sender).BindingContext;
+
+            args.AcceptedOperation = DataPackageOperation.None;
+
+            if (Int32.TryParse(args.Data.Text, NumberStyles.Integer, CultureInfo.InvariantCulture, out int draggedIndex) && draggedIndex >= 0 && draggedIndex < this.ViewModel.Items.Count)
+            {
+                Issue14552Item dropped = this.ViewModel.Items[draggedIndex];
+                if (!ReferenceEquals(dropped, draggedOver))
+                    args.AcceptedOperation = DataPackageOperation.Copy;
+            }
+        }
+    }
+    public class Issue14552Item : Observable
+    {
+        string _name;
+        public string Name
+        {
+            get => _name;
+            set => Set(ref _name, value);
+        }
+
+        bool _isSelected;
+        public bool IsSelected
+        {
+            get => _isSelected;
+            set => Set(ref _isSelected, value);
+        }
+
+        bool _isEnabled = true;
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set => Set(ref _isEnabled, value);
+        }
+    }
+
+    public class Issue14552ViewModel
+    {
+        public ObservableCollection<Issue14552Item> Items { get; } = new ObservableCollection<Issue14552Item>();
+    }
+
+
+    public abstract class Observable : INotifyPropertyChanged
+    {
+        public event PropertyChangedEventHandler PropertyChanged;
+
+        protected bool Set<T>(ref T storage, T value, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+                return false;
+
+            storage = value;
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        protected bool Set<T>(T storage, T value, Action<T> assign, [CallerMemberName] string propertyName = null)
+        {
+            if (Equals(storage, value))
+                return false;
+
+            assign(value);
+
+            OnPropertyChanged(propertyName);
+            return true;
+        }
+
+        public void OnPropertyChanged(string propertyName) => this.PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1771,6 +1771,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)FrameBackgroundIssue.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14552.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2222,6 +2223,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)FrameBackgroundIssue.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14552.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/DragAndDropGestureHandler.cs
+++ b/Xamarin.Forms.Platform.Android/DragAndDropGestureHandler.cs
@@ -251,9 +251,9 @@ namespace Xamarin.Forms.Platform.Android
 
 				var element = GetView();
 				var renderer = Platform.GetRenderer(element);
-				var v = renderer.View;
+				var v = renderer?.View;
 
-				if (v.Handle == IntPtr.Zero)
+				if (v == null || v.Handle == IntPtr.Zero)
 					return;
 
 				var args = rec.SendDragStarting(element);


### PR DESCRIPTION
### Description of Change ###

Fix crash dropping item using ListView on Android.

### Issues Resolved ### 

- fixes #14552

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery using an Android device and navigate to the issue 14552. Drag and drop several times elements. Without exceptions, the test has passed

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
