### PR TITLE
[Android] Avoid reset ListView adapter in TabbedPage if is already disposed

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -615,7 +615,11 @@ namespace Xamarin.Forms.Platform.Android
 				// In a TabbedPage page with two pages, Page A and Page B with ListView, if A changes B's ListView,
 				// we need to reset the ListView's adapter to reflect the changes on page B
 				// If there header and footer are present at the reset time of the adapter
-				// they will be DOUBLE added to the ViewGround (the ListView) causing indexes to be off by one. 
+				// they will be DOUBLE added to the ViewGround (the ListView) causing indexes to be off by one.
+
+				if (_realListView.IsDisposed())
+					return;
+
 				_realListView.RemoveHeaderView(HeaderView);
 				_realListView.RemoveFooterView(FooterView);
 				_realListView.Adapter = _realListView.Adapter;


### PR DESCRIPTION
### Description of Change ###

Avoid reset ListView adapter in TabbedPage if ListView is already disposed.

### Issues Resolved ### 

- fixes #14194 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
