### PR TITLE
[Core] Update Parent of NavPage childrens doing PopModalAsync

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12300.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue12300.cs
@@ -7,6 +7,7 @@ using Xamarin.Forms.PlatformConfiguration;
 using Xamarin.Forms.PlatformConfiguration.iOSSpecific;
 using NavigationPage = Xamarin.Forms.NavigationPage;
 using Page = Xamarin.Forms.Page;
+using System.Diagnostics;
 
 #if UITEST
 using Xamarin.UITest;
@@ -79,6 +80,13 @@ namespace Xamarin.Forms.Controls.Issues
 			private void ButtonClicked(object sender, EventArgs e)
 			{
 				Navigation.PopModalAsync();
+			}
+
+			protected override void OnParentSet()
+			{
+				base.OnParentSet();
+
+				Debug.WriteLine($"OnParentSet: {Parent == null}");
 			}
 		}
 	}

--- a/Xamarin.Forms.Core/Application.cs
+++ b/Xamarin.Forms.Core/Application.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.ComponentModel;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Xamarin.Forms.Internals;
@@ -434,7 +435,17 @@ namespace Xamarin.Forms
 					return null;
 				}
 				Page result = await base.OnPopModal(animated);
+
+				if(result is NavigationPage navigationPage)
+				{
+					var pages = navigationPage.Pages.Reverse();
+
+					foreach (var page in pages)
+						page.Parent = null;
+				}
+
 				result.Parent = null;
+
 				_owner.OnModalPopped(result);
 				return result;
 			}


### PR DESCRIPTION
### Description of Change ###

Update Parent of NavPage childrens doing PopModalAsync.

### Issues Resolved ### 

- fixes #12703

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Can use Issue 1230. If OnParentSet method is invoked and Parent is null, the test has passed. 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
