### PR TITLE
[Android] Fix crash trying to update a removed tab menu item

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -537,13 +537,19 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 				if (IsBottomTabPlacement)
 				{
-					IMenuItem tab = _bottomNavigationView.Menu.GetItem(index);
-					tab.SetTitle(page.Title);
+					if (_bottomNavigationView.Menu.Size() > index)
+					{
+						IMenuItem tab = _bottomNavigationView.Menu.GetItem(index);
+						tab.SetTitle(page.Title);
+					}
 				}
 				else
 				{
-					TabLayout.Tab tab = _tabLayout.GetTabAt(index);
-					tab.SetText(page.Title);
+					if (_tabLayout.TabCount > index)
+					{
+						TabLayout.Tab tab = _tabLayout.GetTabAt(index);
+						tab.SetText(page.Title);
+					}
 				}
 			}
 			else if (e.PropertyName == Page.IconImageSourceProperty.PropertyName)
@@ -552,16 +558,22 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				var index = Element.Children.IndexOf(page);
 				if (IsBottomTabPlacement)
 				{
-					var menuItem = _bottomNavigationView.Menu.GetItem(index);
-					_ = this.ApplyDrawableAsync(page, Page.IconImageSourceProperty, Context, icon =>
+					if (_bottomNavigationView.Menu.Size() > index)
 					{
-						menuItem.SetIcon(icon);
-					});
+						var menuItem = _bottomNavigationView.Menu.GetItem(index);
+						_ = this.ApplyDrawableAsync(page, Page.IconImageSourceProperty, Context, icon =>
+						{
+							menuItem.SetIcon(icon);
+						});
+					}
 				}
 				else
 				{
-					TabLayout.Tab tab = _tabLayout.GetTabAt(index);
-					SetTabIconImageSource(page, tab);
+					if (_tabLayout.TabCount > index)
+					{
+						TabLayout.Tab tab = _tabLayout.GetTabAt(index);
+						SetTabIconImageSource(page, tab);
+					}
 				}
 			}
 		}


### PR DESCRIPTION
### Description of Change ###

In https://github.com/xamarin/Xamarin.Forms/issues/11301 clearing the pages was invoking this code https://github.com/xamarin/Xamarin.Forms/blob/5.0.0/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs#L540 also in the removed page. Trying to update and get the item, the index does not fit with the collection count.

Added some validations to svoid update the items title or icon if, the index is out of range.

### Issues Resolved ### 

- fixes #11301

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
  
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use the NuGet package from this PR in the sample from https://github.com/xamarin/Xamarin.Forms/issues/11301#issue-650557548. If doing logout everything continue working without exceptions, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
