### PR TITLE
[iOS] Fix crash navigating in Shell and trying to get the navbar visibility

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellSectionRenderer.cs
@@ -703,11 +703,15 @@ namespace Xamarin.Forms.Platform.iOS
 				System.Diagnostics.Debug.Write($"WillShowViewController {viewController.GetHashCode()}");
 				var element = _self.ElementForViewController(viewController);
 
-				bool navBarVisible;
-				if (element is ShellSection)
-					navBarVisible = _self._renderer.ShowNavBar;
-				else
-					navBarVisible = Shell.GetNavBarIsVisible(element);
+				bool navBarVisible = false;
+
+				if (element != null)
+				{
+					if (element is ShellSection)
+						navBarVisible = _self._renderer.ShowNavBar;
+					else
+						navBarVisible = Shell.GetNavBarIsVisible(element);
+				}
 
 				navigationController.SetNavigationBarHidden(!navBarVisible, true);
 


### PR DESCRIPTION
### Description of Change ###

Fix crash navigating in Shell and trying to get the NavBar visibility.

### Issues Resolved ### 

- fixes #13510
- fixes #14125
- fixes #14122

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Try the NuGet package from this PR in this sample: https://github.com/Kukkimonsuta/xamarin-forms-14125

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
