### PR TITLE
Block keyboard for iOS 15 time picker

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -40,6 +40,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS12OrNewer;
 		static bool? s_isiOS13OrNewer;
 		static bool? s_isiOS14OrNewer;
+		static bool? s_isiOS15OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
 
 		internal static bool IsiOS9OrNewer
@@ -100,6 +101,16 @@ namespace Xamarin.Forms
 				if (!s_isiOS14OrNewer.HasValue)
 					s_isiOS14OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(14, 0);
 				return s_isiOS14OrNewer.Value;
+			}
+		}
+
+		internal static bool IsiOS15OrNewer
+		{
+			get
+			{
+				if (!s_isiOS15OrNewer.HasValue)
+					s_isiOS15OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(15, 0);
+				return s_isiOS15OrNewer.Value;
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -56,6 +56,12 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					_picker.RemoveFromSuperview();
 					_picker.ValueChanged -= OnValueChanged;
+
+					if (Forms.IsiOS15OrNewer)
+					{
+						_picker.EditingDidBegin -= PickerEditingDidBegin;
+					}
+
 					_picker.Dispose();
 					_picker = null;
 				}
@@ -64,11 +70,6 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Control.EditingDidBegin -= OnStarted;
 					Control.EditingDidEnd -= OnEnded;
-
-					if (Forms.IsiOS15OrNewer)
-					{
-						_picker.EditingDidBegin -= PickerEditingDidBegin;
-					}
 				}
 			}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TimePickerRenderer.cs
@@ -64,6 +64,11 @@ namespace Xamarin.Forms.Platform.iOS
 				{
 					Control.EditingDidBegin -= OnStarted;
 					Control.EditingDidEnd -= OnEnded;
+
+					if (Forms.IsiOS15OrNewer)
+					{
+						_picker.EditingDidBegin -= PickerEditingDidBegin;
+					}
 				}
 			}
 
@@ -89,6 +94,11 @@ namespace Xamarin.Forms.Platform.iOS
 					if (Forms.IsiOS14OrNewer)
 					{
 						_picker.PreferredDatePickerStyle = UIKit.UIDatePickerStyle.Wheels;
+					}
+
+					if (Forms.IsiOS15OrNewer)
+					{
+						_picker.EditingDidBegin += PickerEditingDidBegin;
 					}
 
 					var width = UIScreen.MainScreen.Bounds.Width;
@@ -160,6 +170,11 @@ namespace Xamarin.Forms.Platform.iOS
 		void OnStarted(object sender, EventArgs eventArgs)
 		{
 			ElementController.SetValueFromRenderer(VisualElement.IsFocusedPropertyKey, true);
+		}
+
+		void PickerEditingDidBegin(object sender, EventArgs eventArgs)
+		{
+			_picker.ResignFirstResponder();
 		}
 
 		void OnValueChanged(object sender, EventArgs e)


### PR DESCRIPTION
### Description of Change ###

This changes blocks showing the keyboard input when you tap the time picker on an iPad. While ideally we should allow the user to input a time with a numeric keyboard, this blocks the keyboard as a whole as an intermediate solution. Effectively this reverts the functionality to what it was before iOS 15 so nothing was lost nor added.

Note: only happens on iOS 15 and an iPad

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #14673 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
Right now when you tap on a time in the TimePicker you will get a full keyboard in a too small popup making it look weird. On top of that, it's not even functional. 

With this change when you tap a time in the TimePicker, nothing happens as it was before.

### Before/After Screenshots ### 

**Before**
![image](https://user-images.githubusercontent.com/939291/135862106-10d58258-8907-4663-988e-fe12243858be.png)

**After**
![image](https://user-images.githubusercontent.com/939291/135861780-cf8d5bc7-88d9-4d31-88c9-b336b3c24e33.png)


### Testing Procedure ###
Go to the TimePicker in the gallery, pick any property, open the TimePicker wheels and tap on the selected time. Nothing should happen. When testing on the Simulator, make sure the soft-keyboard is on (CMD + Shift + K)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
