### PR TITLE
[Android] Fix content pages not Garbage collected

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14657.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14657.cs
@@ -1,0 +1,136 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Github10000)]
+	[Category(UITestCategories.Shell)]
+	[Category(UITestCategories.TitleView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14657, "Shell pages are not released from memory", PlatformAffected.Android)]
+	public class Issue14657 : TestShell 
+	{
+		static int pageCount = 0;
+		protected override void Init()
+		{
+			Routing.RegisterRoute(nameof(Issue14657_ChildPage), typeof(Issue14657_ChildPage));
+			
+			var rootPage = CreateRootPage();
+
+			AddContentPage(rootPage);
+		}
+
+		ContentPage CreateRootPage()
+		{
+			var rootPage = CreateContentPage("Home page");
+			rootPage.Content = new StackLayout()
+			{
+				Children =
+				{
+					new Button()
+					{
+						Command = new Command(CollectMemory),
+						Text = "Force GC",
+						AutomationId = "GC_14657"
+					},
+					new Button()
+					{
+						Command = new Command(async () => await GoToChild()),
+						Text = "Go to child page",
+						AutomationId = "GoToChild_14657"
+					}
+				}
+			};
+			Shell.SetTitleView(rootPage, new StackLayout()
+			{
+				Orientation = StackOrientation.Horizontal,
+				Children = { new Label { Text = "Root Page" } }
+			});
+
+			return rootPage;
+		}
+
+		public class Issue14657_ChildPage : ContentPage
+		{
+			public Issue14657_ChildPage()
+			{
+				Interlocked.Increment(ref pageCount);
+
+				Content = new StackLayout
+				{
+					Children =
+					{
+						new Label()
+						{
+							Text = $"{pageCount}",
+							AutomationId = "CountLabel",
+							TextColor = Color.Black
+						},
+						new Button()
+						{
+							Command = new Command(CollectMemory),
+							Text = "Force GC",
+							AutomationId = "GC_14657"
+						}
+					}
+				};
+			}
+
+			~Issue14657_ChildPage()
+			{
+				Interlocked.Decrement(ref pageCount);
+			}
+		}
+
+		async Task GoToChild()
+		{
+			await GoToAsync(nameof(Issue14657_ChildPage));
+		}
+
+		static void CollectMemory()
+		{
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+			GC.WaitForPendingFinalizers();
+			GC.WaitForPendingFinalizers();
+			GC.Collect();
+		}
+
+#if UITEST
+		[Test]
+		public void Issue14657Test()
+		{
+			RunningApp.Tap("GoToChild_14657");
+			RunningApp.WaitForFirstElement("CountLabel")
+				.AssertHasText("1");
+			RunningApp.NavigateBack();
+			RunningApp.Tap("GC_14657");
+
+			RunningApp.Tap("GoToChild_14657");
+			RunningApp.WaitForFirstElement("CountLabel")
+				.AssertHasText("1");
+			RunningApp.NavigateBack();
+			RunningApp.Tap("GC_14657");
+
+			RunningApp.Tap("GoToChild_14657");
+			RunningApp.WaitForFirstElement("CountLabel")
+				.AssertHasText("1");
+			RunningApp.NavigateBack();
+		}
+
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -943,6 +943,7 @@
       <SubType>Code</SubType>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue14544.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14657.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ContainerView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ContainerView.cs
@@ -52,6 +52,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (disposing)
 			{
+				RemoveAllViews();
 				_shellViewRenderer?.TearDown();
 				_view = null;
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -165,6 +165,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		void Destroy()
 		{
+			if (_page != null)
+			{
+				var titleView = Shell.GetTitleView(_page);
+				if (titleView != null)
+				{
+					Shell.SetTitleView(_page, null);
+				}
+			}
+
 			((IShellController)_shellContext.Shell).RemoveAppearanceObserver(this);
 
 			if (_shellContent != null)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellContentFragment.cs
@@ -180,6 +180,8 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (_root is ViewGroup vg)
 					vg.RemoveView(_shellPageContainer);
+
+				_shellPageContainer.Dispose();
 			}
 
 			_renderer?.Dispose();
@@ -194,6 +196,7 @@ namespace Xamarin.Forms.Platform.Android
 			_root = null;
 			_renderer = null;
 			_shellContent = null;
+			_shellPageContainer = null;
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -176,6 +176,7 @@ namespace Xamarin.Forms.Platform.Android
 				_currentMenuItems?.Clear();
 				_currentToolbarItems?.Clear();
 
+				_drawerLayout.RemoveDrawerListener(_drawerToggle);
 				_drawerToggle?.Dispose();
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -178,6 +178,8 @@ namespace Xamarin.Forms.Platform.Android
 
 				_drawerLayout.RemoveDrawerListener(_drawerToggle);
 				_drawerToggle?.Dispose();
+
+				_toolbar.RemoveAllViews();
 			}
 
 			_currentMenuItems = null;


### PR DESCRIPTION
### Description of Change ###

Changes I am certail of that fixes (at least sometimes, read next paragraph) content page instances not garbage collected:
* `ShellToolbarTracker` - calling `RemoveDrawerListener(...)` in dispose method
    * after adding this the simplest content page with no content were garbage collected
* `ShellContentFragment` - explicitly setting page TitleView to `null`
    * this change allows pages to be collected when a page has set custom content via `Shell.TitleView` (you need to add at least some layout with content, e.g. `StackLayout` with `Label`)
    * This is my first time browsing throught Xamarin.Forms codebase and I have no idea if this is the best place to set title to null, I would appreciate other devs feedback but it certainly fixed my issue

Those changes allow _simple_ pages to be collected by GC. By _simple_ I mean pages with default controls (buttons, labels, etc.) and with custom TitleView, but in my application I have used third-party controls (Syncfusion) and those pages are still not collected. I am certain it is a Shell issue because using those controls in non-Shell application seems fine.

Other changes don't necessarily affect my issue but are something I noticed when debugging Xamarin Forms. Calling `_shellPageContainer.Dispose();` is must-have in my opinion but calling RemoveView/RemoveAllViews is something I need more feedback from other devs if it is necessary or not.

### Issues Resolved ### 

#14657 - It doesn't fix the issue completely, more investigation is still required.

### API Changes ###

None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Applications should use less memory because _simple_ page instances will be garbage collected.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I was able to test only Android platform (Android 10 and 11).

In generall, just implement a finalizer on any page that is created and destroyed on the fly, i.e. a page when navigated to, a new instance is created unlike a pages which are added to flyout menu, those are usually have single instance for the lifetime of application. That finalizer is never called.

Also I have created automatic test to demonstrated the issue. Callign 

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
