### PR TITLE
Revert "Fix crash navigating in Shell (#14577)"

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -163,10 +163,7 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				await Device.InvokeOnMainThreadAsync(() =>
-				{
-					return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
-				});
+				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
 			}
 
 			(_shell as IShellController).UpdateCurrentState(source);


### PR DESCRIPTION
Reverts the changes for this PR as it caused the test scenario in Issue12126 to NRE. The original issue this was supposed to fix has a workaround, so I rather have that atm until we figure out the correct fix for this one.