### PR TITLE
[Core] Fix wrong orientation issue using OrientationStateTrigger

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14472.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14472.xaml
@@ -1,0 +1,70 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 14472" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14472">
+    <StackLayout
+        Padding="12">
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If can see a Green Background Color in PortraitDown orientation, the test has passed."/>
+        <StackLayout
+            VerticalOptions="FillAndExpand"
+            HorizontalOptions="Fill">
+            <VisualStateManager.VisualStateGroups>
+                <VisualStateGroup>
+                    <VisualState x:Name="Landscape">
+                        <VisualState.StateTriggers>
+                            <OrientationStateTrigger
+                                Orientation="Landscape" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor"
+                                    Value="Red" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PortraitUp">
+                        <VisualState.StateTriggers>
+                            <OrientationStateTrigger
+                                Orientation="PortraitUp" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor"
+                                    Value="Blue" />
+                        </VisualState.Setters>
+                    </VisualState>
+                    <VisualState x:Name="PortraitDown">
+                        <VisualState.StateTriggers>
+                            <OrientationStateTrigger
+                                Orientation="PortraitDown" />
+                        </VisualState.StateTriggers>
+                        <VisualState.Setters>
+                            <Setter Property="BackgroundColor"
+                                    Value="Green" />
+                        </VisualState.Setters>
+                    </VisualState>
+                </VisualStateGroup>
+            </VisualStateManager.VisualStateGroups>
+            <StackLayout
+                Orientation="Horizontal"
+                HorizontalOptions="Center"
+                VerticalOptions="Center">
+                <ContentView
+                    Padding="0,40,0,40"
+                    VerticalOptions="FillAndExpand">
+                    <Label
+                        Text="Issue 14472"
+                        TextColor="White"
+                        VerticalOptions="Center"
+                        HeightRequest="64" />
+                </ContentView>
+            </StackLayout>
+        </StackLayout>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14472.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14472.xaml.cs
@@ -1,0 +1,35 @@
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.ComponentModel;
+using System.Linq;
+using System.Runtime.CompilerServices;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14472,
+		"[Bug] [iOS] OrientationStateTrigger PortraitUp not Triggered Correctly",
+		PlatformAffected.iOS)]
+	public partial class Issue14472 : TestContentPage
+	{
+		public Issue14472()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1796,6 +1796,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue13577.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14472.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2277,6 +2278,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13577.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14472.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Core/OrientationStateTrigger.cs
+++ b/Xamarin.Forms.Core/OrientationStateTrigger.cs
@@ -57,19 +57,29 @@ namespace Xamarin.Forms
 			switch (Orientation)
 			{
 				case DeviceOrientation.Landscape:
-				case DeviceOrientation.LandscapeLeft:
-				case DeviceOrientation.LandscapeRight:
-					SetActive(
-						currentOrientation == DeviceOrientation.Landscape ||
+					SetActive(currentOrientation == DeviceOrientation.Landscape ||
 						currentOrientation == DeviceOrientation.LandscapeLeft ||
 						currentOrientation == DeviceOrientation.LandscapeRight);
 					break;
+				case DeviceOrientation.LandscapeLeft:
+					SetActive(currentOrientation == DeviceOrientation.Landscape ||
+						currentOrientation == DeviceOrientation.LandscapeLeft);
+					break;
+				case DeviceOrientation.LandscapeRight:
+					SetActive(currentOrientation == DeviceOrientation.Landscape ||
+						currentOrientation == DeviceOrientation.LandscapeRight);
+					break;
 				case DeviceOrientation.Portrait:
-				case DeviceOrientation.PortraitDown:
-				case DeviceOrientation.PortraitUp:
-					SetActive(
-						currentOrientation == DeviceOrientation.Portrait ||
+					SetActive(currentOrientation == DeviceOrientation.Portrait ||
 						currentOrientation == DeviceOrientation.PortraitDown ||
+						currentOrientation == DeviceOrientation.PortraitUp);
+					break;
+				case DeviceOrientation.PortraitDown:
+					SetActive(currentOrientation == DeviceOrientation.Portrait ||
+						currentOrientation == DeviceOrientation.PortraitDown);
+					break;
+				case DeviceOrientation.PortraitUp:
+					SetActive(currentOrientation == DeviceOrientation.Portrait ||
 						currentOrientation == DeviceOrientation.PortraitUp);
 					break;
 			}


### PR DESCRIPTION
### Description of Change ###

Fix wrong orientation issue using `OrientationStateTrigger`.

### Issues Resolved ### 

- fixes #14472 
- fixes #9651

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)


### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14472. If can see a Green Background Color in PortraitDown orientation, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
