### PR TITLE
[Android] Avoid update native control enabled if is already disposed

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/VisualElementRenderer.cs
@@ -42,6 +42,9 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 			if (_disposed)
 				return;
 
+			if (Control.IsDisposed())
+				return;
+
 			Control.UpdateFlowDirection(Element);
 		}
 
@@ -106,9 +109,10 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 		void UpdateIsEnabled()
 		{
 			if (Element == null || _disposed)
-			{
 				return;
-			}
+
+			if (Control.IsDisposed())
+				return;
 
 			Control.Enabled = Element.IsEnabled;
 		}


### PR DESCRIPTION
### Description of Change ###

Avoid update native control enabled if is already disposed on Android.

### Issues Resolved ### 

- fixes #14738 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
