### PR TITLE
[iOS] Avoid setting embedding view controller background color

### DIFF
--- a/EmbeddingTestBeds/Embedding.XF/TransparentPage.xaml
+++ b/EmbeddingTestBeds/Embedding.XF/TransparentPage.xaml
@@ -1,0 +1,13 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Embedding.XF.TransparentPage"
+             BackgroundColor="Transparent">
+    <ContentPage.Content>
+        <StackLayout Margin="80">
+            <BoxView HeightRequest="100" BackgroundColor="#77ff0000" />
+            <Label Text="This page has a transparent background. The containing view background should be yellow and should be visible" />
+            <BoxView HeightRequest="100" BackgroundColor="#770000ff" />
+        </StackLayout>
+    </ContentPage.Content>
+</ContentPage>

--- a/EmbeddingTestBeds/Embedding.XF/TransparentPage.xaml.cs
+++ b/EmbeddingTestBeds/Embedding.XF/TransparentPage.xaml.cs
@@ -1,0 +1,14 @@
+﻿using Xamarin.Forms;
+using Xamarin.Forms.Xaml;
+
+namespace Embedding.XF
+{
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+	public partial class TransparentPage : ContentPage
+	{
+		public TransparentPage()
+		{
+			InitializeComponent();
+		}
+	}
+}

--- a/EmbeddingTestBeds/Embedding.iOS/AppDelegate.cs
+++ b/EmbeddingTestBeds/Embedding.iOS/AppDelegate.cs
@@ -16,6 +16,7 @@ namespace Embedding.iOS
 		UIViewController _hello;
 		UIViewController _alertsAndActionSheets;
 		UIViewController _webview;
+		UIViewController _containingController;
 
 		UIBarButtonItem _helloButton;
 
@@ -90,6 +91,16 @@ namespace Embedding.iOS
 			}
 
 			_navigation.PushViewController(_webview, true);
+		}
+
+		public void ShowTransparent()
+		{
+			if (_containingController == null)
+			{
+				_containingController = new ContainingViewController();
+			}
+
+			_navigation.PushViewController(_containingController, true);
 		}
 	}
 }

--- a/EmbeddingTestBeds/Embedding.iOS/ContainingViewController.cs
+++ b/EmbeddingTestBeds/Embedding.iOS/ContainingViewController.cs
@@ -1,0 +1,21 @@
+﻿using UIKit;
+using Embedding.XF;
+using Xamarin.Forms.Platform.iOS;
+
+namespace Embedding.iOS
+{
+    public class ContainingViewController : UIViewController
+    {
+        public override void ViewDidLoad()
+        {
+            base.ViewDidLoad();
+            View.BackgroundColor = UIColor.Yellow;
+
+            var tansparentController = new TransparentPage().CreateViewController();
+            AddChildViewController(tansparentController);
+            tansparentController.View.Frame = View.Bounds;
+            View.AddSubview(tansparentController.View);
+            tansparentController.DidMoveToParentViewController(this);
+        }
+    }
+}

--- a/EmbeddingTestBeds/Embedding.iOS/Embedding.iOS.csproj
+++ b/EmbeddingTestBeds/Embedding.iOS/Embedding.iOS.csproj
@@ -68,6 +68,7 @@
     <Compile Include="ViewController.designer.cs">
       <DependentUpon>ViewController.cs</DependentUpon>
     </Compile>
+    <Compile Include="ContainingViewController.cs" />
   </ItemGroup>
   <ItemGroup>
     <InterfaceDefinition Include="Resources\LaunchScreen.xib" />

--- a/EmbeddingTestBeds/Embedding.iOS/Main.storyboard
+++ b/EmbeddingTestBeds/Embedding.iOS/Main.storyboard
@@ -1,39 +1,53 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="198">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="18122" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="198">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="18093"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
+        <!--View Controller-->
         <scene sceneID="197">
             <objects>
-                <viewController id="198" sceneMemberID="viewController" customClass="ViewController">
+                <viewController id="198" customClass="ViewController" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="195"/>
                         <viewControllerLayoutGuide type="bottom" id="196"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="199">
-                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="calibratedWhite"/>
                         <subviews>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="209" translatesAutoresizingMaskIntoConstraints="NO" fixedFrame="YES">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="209">
                                 <rect key="frame" x="113" y="167" width="205" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Show Web View">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" id="210" translatesAutoresizingMaskIntoConstraints="NO" fixedFrame="YES">
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="210">
                                 <rect key="frame" x="96" y="257" width="239" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <state key="normal" title="Show Alerts And ActionSheets">
-                                    <color key="titleShadowColor" white="0.5" alpha="1" colorSpace="calibratedWhite"/>
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                            </button>
+                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZYx-Eg-NIM">
+                                <rect key="frame" x="96" y="347" width="239" height="30"/>
+                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <state key="normal" title="Show Transparent">
+                                    <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 </state>
                             </button>
                         </subviews>
+                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>
                     <connections>
-                        <outlet property="UIViewController" destination="199" id="name-outlet-199"/>
                         <outlet property="ShowAlertsAndActionSheets" destination="210" id="name-outlet-210"/>
+                        <outlet property="ShowTransparent" destination="ZYx-Eg-NIM" id="6k8-bj-ams"/>
                         <outlet property="ShowWebView" destination="209" id="name-outlet-209"/>
+                        <outlet property="UIViewController" destination="199" id="name-outlet-199"/>
                     </connections>
                 </viewController>
                 <placeholder placeholderIdentifier="IBFirstResponder" id="200" userLabel="First Responder" sceneMemberID="firstResponder"/>

--- a/EmbeddingTestBeds/Embedding.iOS/ViewController.cs
+++ b/EmbeddingTestBeds/Embedding.iOS/ViewController.cs
@@ -15,6 +15,7 @@ namespace Embedding.iOS
 			base.ViewDidLoad();
 			ShowWebView.TouchUpInside += (sender, e) => AppDelegate.Shared.ShowWebView();
 			ShowAlertsAndActionSheets.TouchUpInside += (sender, e) => AppDelegate.Shared.ShowAlertsAndActionSheets();
+			ShowTransparent.TouchUpInside += (sender, e) => AppDelegate.Shared.ShowTransparent();
 		}
     }
 }

--- a/EmbeddingTestBeds/Embedding.iOS/ViewController.designer.cs
+++ b/EmbeddingTestBeds/Embedding.iOS/ViewController.designer.cs
@@ -23,6 +23,10 @@ namespace Embedding.iOS
         UIKit.UIButton ShowWebView { get; set; }
 
         [Outlet]
+        [GeneratedCode("iOS Designer", "1.0")]
+        UIKit.UIButton ShowTransparent { get; set; }
+
+        [Outlet]
         [GeneratedCode ("iOS Designer", "1.0")]
         UIKit.UIView UIViewController { get; set; }
 
@@ -36,6 +40,11 @@ namespace Embedding.iOS
             if (ShowWebView != null) {
                 ShowWebView.Dispose ();
                 ShowWebView = null;
+            }
+
+            if (ShowTransparent != null) {
+                ShowTransparent.Dispose ();
+                ShowTransparent = null;
             }
 
             if (UIViewController != null) {

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -95,6 +95,11 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 
 			base.ViewWillAppear(animated);
+
+			if (!_disposed)
+			{
+				View.BackgroundColor = UIColor.Clear;
+			}
 		}
 
 		public override void ViewDidLoad()

--- a/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/PlatformRenderer.cs
@@ -91,7 +91,6 @@ namespace Xamarin.Forms.Platform.iOS
 			// while it's being replaced on the Window.RootViewController with a new MainPage
 			if (!_disposed)
 			{
-				View.BackgroundColor = ColorExtensions.BackgroundColor;
 				Platform.WillAppear();
 			}
 


### PR DESCRIPTION
### Description of Change ###

Changes the `UIViewController` created when embedding a `Page` on iOS to not explicitly set a background color (it was preventing embedding a transparent page).

### Issues Resolved ### 
- fixes #13934
 

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
Pages that are transparent and embedded in iOS will now appear transparent.

### Testing Procedure ###
An option has been added to the iOS embedding test bed to display a transparent page. This also contains some semi-transparent boxes. It is shown over a yellow background that should be visible.

Additionally, other pages should be unaffected.

![Simulator Screen Shot - iPod touch (7th generation) - 2021-10-25 at 19 26 50](https://user-images.githubusercontent.com/475450/138750077-d3f2a957-ce43-4f9f-a077-df7341c4baba.png)

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
