### PR TITLE
[Android] Set TextColor to search icon in SearchBar

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9266.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9266.xaml
@@ -1,0 +1,31 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    Title="Test 9266" xmlns:local="using:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue9266">
+    <StackLayout>
+        <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the Search icon color is Yellow, the test has passed."/>
+        <StackLayout
+            Padding="12">
+            <Label 
+                Text="Entry"/>
+            <Entry
+                TextColor="Yellow"
+                BackgroundColor="Red"
+                ClearButtonVisibility="WhileEditing"/>
+            <Label 
+                Text="SearchBar"/>
+            <SearchBar
+                TextColor="Yellow"
+                BackgroundColor="Red"/>
+        </StackLayout>
+    </StackLayout>
+</local:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9266.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue9266.xaml.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Threading.Tasks;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 9266,
+		"[Bug] Search icon color wrong with 4.4",
+		PlatformAffected.iOS)]
+	public partial class Issue9266 : TestContentPage
+	{
+		public Issue9266()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -40,6 +40,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14426.xaml.cs">
       <DependentUpon>Issue14426.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue9266.xaml.cs">
+      <DependentUpon>Issue9266.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -2903,6 +2906,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14095.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue9266.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -5,12 +5,14 @@ using System.Linq;
 using Android.Content;
 using Android.Content.Res;
 using Android.Graphics;
+using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Text;
 using Android.Text.Method;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
+using AndroidX.Core.Content;
 using AView = Android.Views.View;
 
 namespace Xamarin.Forms.Platform.Android
@@ -288,6 +290,31 @@ namespace Xamarin.Forms.Platform.Android
 		void UpdateTextColor()
 		{
 			_textColorSwitcher?.UpdateTextColor(_editText, Element.TextColor);
+
+			UpdateSearchButtonColor();
+			UpdateClearButtonColor();
+		}
+
+		void UpdateSearchButtonColor()
+		{
+			var resource = Control?.FindViewById(Context.Resources.GetIdentifier("android:id/search_mag_icon", null, null));
+			var icon = resource as ImageView;
+
+			if (!Element.TextColor.IsDefault)
+				icon?.SetColorFilter(Element.TextColor.ToAndroid());
+			else
+				icon?.ClearColorFilter();
+		}
+
+		void UpdateClearButtonColor()
+		{
+			var resource = Control?.FindViewById(Context.Resources.GetIdentifier("android:id/search_close_btn", null, null));
+			var icon = resource as ImageView;
+
+			if (!Element.TextColor.IsDefault)
+				icon?.SetColorFilter(Element.TextColor.ToAndroid());
+			else
+				icon?.ClearColorFilter();
 		}
 
 		void UpdateMaxLength()


### PR DESCRIPTION
### Description of Change ###

Set TextColor to search icon in SearchBar. In this way, is easy to manage the desire color. Until now this color depended on `AndroidProject/Resources/values/styles.xml` and the styles used. Without setting a TextColor this will be the fallback behavior.

@jfversluis What is your opinion in this case?

### Issues Resolved ### 

- fixes #9266 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![image](https://user-images.githubusercontent.com/6755973/138072202-d67c9c5c-6d5d-4892-acb2-dbea23eae1a5.png)


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 9266. If the Search icon color is Yellow, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
