### PR TITLE
[Windows] Avoid override NavigationViewItemOnLeftMinHeight

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Shell/ShellFlyoutItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellFlyoutItemRenderer.cs
@@ -136,7 +136,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 			Size request = _content.Measure(width, height, MeasureFlags.IncludeMargins).Request;
 
-			var minSize = (double)Windows.UI.Xaml.Application.Current.Resources["NavigationViewItemOnLeftMinHeight"];
+			double minSize = 0;
 
 			if (request.Height < minSize)
 			{

--- a/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellStyles.xaml
@@ -8,7 +8,6 @@
     xmlns:contract7NotPresent="http://schemas.microsoft.com/winfx/2006/xaml/presentation?IsApiContractNotPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:primitiveContract7Present="using:Microsoft.UI.Xaml.Controls.Primitives?IsApiContractPresent(Windows.Foundation.UniversalApiContract,7)"
     xmlns:xf="using:Xamarin.Forms.Platform.UWP">
-    <x:Double x:Key="NavigationViewItemOnLeftMinHeight">0</x:Double>
     <DataTemplate x:Key="ShellFlyoutBaseShellItemTemplate">
         <winui:NavigationViewItem x:Name="navItem" AutomationProperties.AutomationId="{Binding AutomationId}">
             <xf:ShellFlyoutItemRenderer IsSelected="{Binding IsSelected, ElementName=navItem, Mode=TwoWay}"></xf:ShellFlyoutItemRenderer>


### PR DESCRIPTION
### Description of Change ###

By overriding `NavigationViewItemOnLeftMinHeight `, any native application referencing Xamarin.Forms could be affected. Also, in the case of Shell, the `ShellNavigationView `style is used, which already set the `NavigationViewItemOnLeftMinHeight` property to zero.

### Issues Resolved ### 

- fixes #13457 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery and open the Shell Store sample. Then, open the Flyout. 

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
