### PR TITLE
Fix TabBar icon colors for iOS 15 iPad

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/SafeShellTabBarAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SafeShellTabBarAppearanceTracker.cs
@@ -66,9 +66,10 @@ namespace Xamarin.Forms.Platform.iOS
 			// Set TabBarTitleColor
 			var tabBarTitleColor = appearanceElement.EffectiveTabBarTitleColor;
 
+			// Update colors for all variations of the appearance to also make it work for iPads, etc. which use different layouts for the tabbar
+			// Also, set ParagraphStyle explicitly. This seems to be an iOS bug. If we don't do this, tab titles will be truncat...
 			if (!tabBarTitleColor.IsDefault)
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = tabBarTitleColor.ToUIColor(), ParagraphStyle = NSParagraphStyle.Default };
 				tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = tabBarTitleColor.ToUIColor();
 
@@ -84,7 +85,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!tabBarUnselectedColor.IsDefault)
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = tabBarUnselectedColor.ToUIColor(), ParagraphStyle = NSParagraphStyle.Default };
 				tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = tabBarUnselectedColor.ToUIColor();
 
@@ -100,7 +100,6 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (!tabBarDisabledColor.IsDefault)
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				tabBarAppearance.StackedLayoutAppearance.Disabled.TitleTextAttributes = new UIStringAttributes { ForegroundColor = tabBarDisabledColor.ToUIColor(), ParagraphStyle = NSParagraphStyle.Default };
 				tabBarAppearance.StackedLayoutAppearance.Disabled.IconColor = tabBarDisabledColor.ToUIColor();
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -562,10 +562,12 @@ namespace Xamarin.Forms.Platform.iOS
 				ForegroundColor = isDefaultBarTextColor ? _defaultBarTextColor : barTextColor.ToUIColor()
 			};
 
+			// Update colors for all variations of the appearance to also make it work for iPads, etc. which use different layouts for the tabbar
+			// Also, set ParagraphStyle explicitly. This seems to be an iOS bug. If we don't do this, tab titles will be truncat...
+
 			// Set SelectedTabColor
 			if (Tabbed.IsSet(TabbedPage.SelectedItemProperty) && Tabbed.SelectedTabColor != Color.Default)
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				var foregroundColor = Tabbed.SelectedTabColor.ToUIColor();
 				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
@@ -578,7 +580,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				var foregroundColor = UITabBar.Appearance.TintColor;
 				_tabBarAppearance.StackedLayoutAppearance.Selected.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Selected.IconColor = foregroundColor;
@@ -593,7 +594,6 @@ namespace Xamarin.Forms.Platform.iOS
 			// Set UnselectedTabColor
 			if (Tabbed.IsSet(TabbedPage.UnselectedTabColorProperty) && Tabbed.UnselectedTabColor != Color.Default)
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				var foregroundColor = Tabbed.UnselectedTabColor.ToUIColor();
 				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foregroundColor, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foregroundColor;
@@ -606,7 +606,6 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 			else
 			{
-				// Update colors for all variations of the appearance to also make it work for iPads, etc.
 				var foreground = UITabBar.Appearance.TintColor;
 				_tabBarAppearance.StackedLayoutAppearance.Normal.TitleTextAttributes = new UIStringAttributes { ForegroundColor = foreground, ParagraphStyle = NSParagraphStyle.Default };
 				_tabBarAppearance.StackedLayoutAppearance.Normal.IconColor = foreground;


### PR DESCRIPTION
### Description of Change ###

Fixes bug for setting icon and text colors on iPad's running iOS 15

### Issues Resolved ### 

- fixes #14771

### API Changes ###
 
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Before the colors would have no effect on the TabBar, these will now be applied again as before

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
