### PR TITLE
UWP TitleView Width not updated after push/pop Modal

### DIFF
--- a/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
+++ b/Xamarin.Forms.Platform.UAP/TitleViewManager.cs
@@ -52,6 +52,17 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				CommandBar.LayoutUpdated -= commandLayoutUpdated;
 				CommandBar.Unloaded -= commandBarUnloaded;
+				CommandBar.Loaded += CommandBar_Loaded;
+			}
+		}
+
+		private void CommandBar_Loaded(object sender, RoutedEventArgs e)
+		{
+			if (CommandBar != null)
+			{
+				CommandBar.LayoutUpdated += commandLayoutUpdated;
+				CommandBar.Unloaded += commandBarUnloaded;
+				CommandBar.Loaded -= CommandBar_Loaded;
 			}
 		}
 


### PR DESCRIPTION
[Takeover from #10849]

TitleViewManager is unregistered at CommandBar unload from the page calling PushModal. After the page gets visible again by a PopModal
the CommandBar is reloaded again but the TitleViewManager is not re-registered.

This is a fix for that problem.
### Description of Change ###

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- closes #10849
- fixes #12382

### API Changes ###
 
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
