### PR TITLE
[UWP] CollectionView Memory Leak

### DIFF
--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -127,6 +127,13 @@ namespace Xamarin.Forms.Platform.UWP
 				CollectionViewSource = null;
 			}
 
+			var itemContentControls = ListViewBase.GetChildren<ItemContentControl>();
+			foreach (ItemContentControl itemContentControl in itemContentControls)
+			{
+				itemContentControl.FormsDataContext = null;
+				itemContentControl.DataContext = null;
+			}
+
 			if (Element?.ItemsSource == null)
 			{
 				ListViewBase.ItemsSource = null;

--- a/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/ItemsViewRenderer.cs
@@ -213,10 +213,11 @@ namespace Xamarin.Forms.Platform.UWP
 				return;
 			}
 
-			if (Layout != null)
+			if (oldElement is StructuredItemsView oldStructuredItemsView)
 			{
 				// Stop tracking the old layout
-				Layout.PropertyChanged -= LayoutPropertyChanged;
+				oldStructuredItemsView.ItemsLayout.PropertyChanged -= LayoutPropertyChanged;
+				oldStructuredItemsView.ItemsLayout = null;
 			}
 
 			// Stop listening for ScrollTo requests
@@ -604,7 +605,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 				default:
 					return elementBounds.Left < containerBounds.Right && elementBounds.Right > containerBounds.Left;
-			};
+			}
 		}
 
 		void OnScrollViewChanged(object sender, ScrollViewerViewChangedEventArgs e)

--- a/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/CollectionView/SelectableItemsViewRenderer.cs
@@ -22,9 +22,9 @@ namespace Xamarin.Forms.Platform.UWP
 				oldListViewBase.SelectionChanged -= NativeSelectionChanged;
 			}
 
-			if (ItemsView != null)
+			if (oldElement is TItemsView oldItemsView)
 			{
-				ItemsView.SelectionChanged -= FormsSelectionChanged;
+				oldItemsView.SelectionChanged -= FormsSelectionChanged;
 			}
 
 			base.TearDownOldElement(oldElement);


### PR DESCRIPTION
### Description of Change ###
Unsubscribe from `oldElement` on `TearDownOldElement` instead of current `Layout/ItemsView`that is already null.

### Issues Resolved ### 
- fixes 
  - #14721
  - #8928

### API Changes ###
 None

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ###
Not applicable

### Testing Procedure ###
**Case 1: Nav back from CollectionView**
1. Take a `Memory Snapshot`
2. Navigate to a View that contains a `CollectionView`
3. Go back
4. Take another `Memory Snapshot` and compare it with the first one
5. Check that the `CollectionView`, BindingContext VM, Items VM are released

**Case 2: Change ItemsSource of CollectionView**
1. Take a `Memory Snapshot`
2. Add items to the `CollectionView`
3. Replace the `ItemsSource` with an empty collection
4. Take another `Memory Snapshot` and compare it with the first one
5. Check that the Items VM are released

Simple project available here: https://github.com/MADSENSE/Madsense.XamarinForms.Sample/tree/collectionview-memory-leak

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
