### PR TITLE
[iOS] RemoveObserver only if previously was added

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -39,6 +39,7 @@ namespace Xamarin.Forms.Platform.iOS
 		bool _useLegacyColorManagement;
 
 		bool _disposed;
+		bool _observedSublayers;
 		IDisposable _selectedTextRangeObserver;
 		bool _nativeSelectionIsUpdating;
 
@@ -93,7 +94,11 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.ShouldChangeCharacters -= ShouldChangeCharacters;
 					_selectedTextRangeObserver?.Dispose();
 
-					ClearButton?.Layer?.RemoveObserver(this, new NSString("sublayers"));
+					if (_observedSublayers)
+					{
+						ClearButton?.Layer?.RemoveObserver(this, new NSString("sublayers"));
+						_observedSublayers = false;
+					}
 				}
 			}
 
@@ -129,6 +134,7 @@ namespace Xamarin.Forms.Platform.iOS
 				_selectedTextRangeObserver = textField.AddObserver("selectedTextRange", NSKeyValueObservingOptions.New, UpdateCursorFromControl);
 
 				ClearButton?.Layer.AddObserver(this, new NSString("sublayers"), NSKeyValueObservingOptions.New, IntPtr.Zero);
+				_observedSublayers = true;
 			}
 
 			// When we set the control text, it triggers the UpdateCursorFromControl event, which updates CursorPosition and SelectionLength;


### PR DESCRIPTION
### Description of Change ###

Avoid possible exception with custom Entry renderer. If create a Custom Renderer will not register the sublayers observer but will try to remove it disposing the renderer. This PR include changes to avoid remove the observer if previously was not added.

Fixes

`Cannot remove an observer X for the key path "Y" from Z because it is not registered as an observer.`

### Issues Resolved ### 

- fixes #14788

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
