### PR TITLE
[UWP] Fix MultiWindow crash using default brushes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
@@ -33,6 +33,8 @@ namespace Xamarin.Forms.Controls.Issues
 		protected override void Init()
 		{
 			var layout = new StackLayout();
+			
+			layout.Background = Brush.LightGray;
 
 			var instructions = new Label
 			{

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -216,7 +216,11 @@ namespace Xamarin.Forms
 		{
 			if (Background != null)
 			{
-				Background.Parent = this;
+				Device.InvokeOnMainThreadAsync(() =>
+				{
+					Background.Parent = this;
+				});
+
 				Background.PropertyChanged += OnBackgroundChanged;
 
 				if (Background is GradientBrush gradientBrush)


### PR DESCRIPTION
### Description of Change ###

 Fix MultiWindow crash using default brushes on UWP.

### Issues Resolved ### 

- fixes #14210

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch Core Gallery on Windows. Launch several times (more than one time) a new Window (tap the "Open Secondary Window" Button). Without exceptions, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
