### PR TITLE
[iOS] Fix gradient background issue on Image

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14397.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14397.cs
@@ -1,0 +1,64 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14397, "[Bug] iOS Background appears in front of image",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Image)]
+#endif
+	public class Issue14397 : TestContentPage
+	{
+		public Issue14397()
+		{
+			Title = "Issue 14397";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				Text = "If can see the icon with the gradient background, the test has passed."
+			};
+
+			var image = new Image
+			{
+				HorizontalOptions = LayoutOptions.Start,
+				HeightRequest = 100,
+				WidthRequest = 100,
+				Source = "coffee.png",
+				Margin = new Thickness(12, 0)
+			};
+
+			image.Background = new LinearGradientBrush
+			{
+				StartPoint = new Point(0, 0),
+				EndPoint = new Point(1, 0),
+				GradientStops = new GradientStopCollection
+				{
+					new GradientStop { Color = Color.OrangeRed, Offset = 0.0f },
+					new GradientStop { Color = Color.PaleVioletRed, Offset = 0.9f },
+				}
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(image);
+
+			Content = layout;
+		}
+
+		protected override void Init()
+		{
+			
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1814,6 +1814,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6387.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14757.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14397.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Drawing;
 using System.ComponentModel;
 using System.IO;
 using System.Threading;
@@ -72,6 +71,7 @@ namespace Xamarin.Forms.Platform.iOS
 				}
 
 				await TrySetImage(e.OldElement as Image);
+				UpdateBackground();
 			}
 
 			base.OnElementChanged(e);
@@ -83,6 +83,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.PropertyName == Image.SourceProperty.PropertyName)
 				await TrySetImage().ConfigureAwait(false);
+			else if (e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
+				UpdateBackground();
 		}
 
 		protected virtual async Task TrySetImage(Image previous = null)
@@ -115,8 +117,17 @@ namespace Xamarin.Forms.Platform.iOS
 		bool IImageVisualElementRenderer.IsDisposed => _isDisposed;
 
 		UIImageView IImageVisualElementRenderer.GetImage() => Control;
-	}
 
+		void UpdateBackground()
+		{
+			var parent = Control.Superview;
+
+			if (parent == null)
+				return;
+
+			parent.UpdateBackground(Element.Background);
+		}
+	}
 
 	public interface IImageSourceHandler : IRegisterable
 	{

--- a/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/ViewRenderer.cs
@@ -215,6 +215,10 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (IsElementOrControlEmpty)
 				return;
 
+			// Updated in the ImageRenderer
+			if (Element is Image)
+				return;
+
 			Control.UpdateBackground(brush);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix gradient background issue on Image on iOS.

### Issues Resolved ### 

- fixes #14397 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="341" alt="Captura de pantalla 2021-10-26 a las 13 58 42" src="https://user-images.githubusercontent.com/6755973/138876109-66a8dabf-c0c0-4de0-8ff4-677d25b7b9b9.png">


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14397. If can see the icon with the gradient background, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
