### PR TITLE
[Core] Make BindableLayout handle collection changed on the main thread

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindableLayoutTests.cs
@@ -5,6 +5,7 @@ using System.Collections.ObjectModel;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 
 namespace Xamarin.Forms.Core.UnitTests
@@ -137,6 +138,144 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			itemsSource.Clear();
 			Assert.IsTrue(IsLayoutWithItemsSource(itemsSource, layout));
+		}
+
+		[Test]
+		public async Task TracksAddOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>();
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.Add(1));
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+		}
+
+		[Test]
+		public async Task TracksInsertOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1, 2, 3, 4 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.Insert(2, 5));
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+		}
+
+		[Test]
+		public async Task TracksRemoveOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.RemoveAt(0));
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.Remove(1));
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+		}
+
+		[Test]
+		public async Task TracksRemoveAllOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableRangeCollection<int>(Enumerable.Range(0, 10));
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.RemoveAll());
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+		}
+
+		[Test]
+		public async Task TracksReplaceOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1, 2 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource[0] = 3);
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource[1] = 4);
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource[2] = 5);
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+		}
+
+		[Test]
+		public async Task TracksMoveOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.Move(0, 1));
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.Move(1, 0));
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
+		}
+
+		[Test]
+		public async Task TracksClearOnBackgroundThread()
+		{
+			var invokeOnMainThreadWasCalled = false;
+			Device.PlatformServices = new MockPlatformServices(x => invokeOnMainThreadWasCalled = true, isInvokeRequired: true);
+			var layout = new StackLayout
+			{
+				IsPlatformEnabled = true,
+			};
+
+			var itemsSource = new ObservableCollection<int>() { 0, 1 };
+			BindableLayout.SetItemsSource(layout, itemsSource);
+
+			invokeOnMainThreadWasCalled = false;
+			await Task.Run(() => itemsSource.Clear());
+			Assert.IsTrue(invokeOnMainThreadWasCalled);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/BindableLayout.cs
+++ b/Xamarin.Forms.Core/BindableLayout.cs
@@ -297,14 +297,17 @@ namespace Xamarin.Forms
 				return;
 			}
 
-			e.Apply(
-				insert: (item, index, _) => layout.Children.Insert(index, CreateItemView(item, layout)),
-				removeAt: (item, index) => layout.Children.RemoveAt(index),
-				reset: CreateChildren);
+			Device.BeginInvokeOnMainThread(() =>
+			{
+				e.Apply(
+					insert: (item, index, _) => layout.Children.Insert(index, CreateItemView(item, layout)),
+					removeAt: (item, index) => layout.Children.RemoveAt(index),
+					reset: CreateChildren);
 
-			// UpdateEmptyView is called from within CreateChildren, therefor skip it for Reset
-			if (e.Action != NotifyCollectionChangedAction.Reset)
-				UpdateEmptyView(layout);
+				// UpdateEmptyView is called from within CreateChildren, therefor skip it for Reset
+				if (e.Action != NotifyCollectionChangedAction.Reset)
+					UpdateEmptyView(layout);
+			});
 		}
 	}
 }


### PR DESCRIPTION

### Description of Change ###

Changes the `BindableLayout.ItemsSourceCollectionChanged` method to handle changes on the main thread.

### Issues Resolved ### 

- fixes #14039

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

There are unit tests that just confirm that BeginInvokeOnMainThread is called.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
