### PR TITLE
Refactor Entry ClearButton observer lifecycle to prevent NRE on older iOS versions

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -40,6 +40,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		bool _disposed;
 		IDisposable _selectedTextRangeObserver;
+		IDisposable _clearButtonSublayerObserver;
 		bool _nativeSelectionIsUpdating;
 
 		bool _cursorPositionChangePending;
@@ -92,8 +93,7 @@ namespace Xamarin.Forms.Platform.iOS
 					Control.EditingDidEnd -= OnEditingEnded;
 					Control.ShouldChangeCharacters -= ShouldChangeCharacters;
 					_selectedTextRangeObserver?.Dispose();
-
-					ClearButton?.Layer?.RemoveObserver(this, new NSString("sublayers"));
+					_clearButtonSublayerObserver?.Dispose();
 				}
 			}
 
@@ -128,7 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 				textField.ShouldChangeCharacters += ShouldChangeCharacters;
 				_selectedTextRangeObserver = textField.AddObserver("selectedTextRange", NSKeyValueObservingOptions.New, UpdateCursorFromControl);
 
-				ClearButton?.Layer.AddObserver(this, new NSString("sublayers"), NSKeyValueObservingOptions.New, IntPtr.Zero);
+				_clearButtonSublayerObserver = ClearButton?.Layer.AddObserver(new NSString("sublayers"), NSKeyValueObservingOptions.New, UpdateClearButtonSublayer);
 			}
 
 			// When we set the control text, it triggers the UpdateCursorFromControl event, which updates CursorPosition and SelectionLength;
@@ -157,12 +157,6 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateIsReadOnly();
 
 			if (Element.ClearButtonVisibility != ClearButtonVisibility.Never)
-				UpdateClearButtonVisibility();
-		}
-
-		public override void ObserveValue(NSString keyPath, NSObject ofObject, NSDictionary change, IntPtr context)
-		{
-			if (keyPath == new NSString("sublayers") && _defaultClearImage == null)
 				UpdateClearButtonVisibility();
 		}
 
@@ -438,6 +432,15 @@ namespace Xamarin.Forms.Platform.iOS
 						SetSelectionLengthFromRenderer(selectionLength);
 				}
 			}
+		}
+
+		void UpdateClearButtonSublayer(NSObservedChange obj)
+		{
+			if (Control == null || Element == null)
+				return;
+
+			if (_defaultClearImage == null)
+				UpdateClearButtonVisibility();
 		}
 
 		void UpdateCursorSelection()


### PR DESCRIPTION
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### Issues Resolved ### 

- fixes #14804
- fixes #14788
- closes #14790
- Refactors #14526 

### API Changes ###
 None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
No more crash on older iOS versions

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
