### PR TITLE
Allow 1 modifier key to be added on macOS

### DIFF
--- a/Xamarin.Forms.Platform.MacOS/Extensions/NSMenuExtensions.cs
+++ b/Xamarin.Forms.Platform.MacOS/Extensions/NSMenuExtensions.cs
@@ -95,7 +95,7 @@ namespace Xamarin.Forms.Platform.macOS.Extensions
 			if (accelerator == null)
 				return;
 
-			bool hasModifierMask = accelerator.Modifiers?.Count() > 1;
+			bool hasModifierMask = accelerator.Modifiers?.Count() >= 1;
 
 			if (hasModifierMask)
 			{


### PR DESCRIPTION
### Description of Change ###

Because of a faulty if statement in the code it was not possible to add just 1 modifier key to trigger a menu item on macOS, this is now fixed.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #1749

### API Changes ###
 
 None

### Platforms Affected ### 
- macOS

### Behavioral/Visual Changes ###
Now 1 modifier key can be added to trigger a `MenuItem` instead of having to use multiple

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
