### PR TITLE
RefreshView: add new internal property IsRefreshAllowed to fix #14350

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14350.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14350.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+             xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             mc:Ignorable="d"
+			 Title="Test 14350"
+             x:Class="Xamarin.Forms.Controls.Issues.Issue14350">
+
+    <RefreshView IsRefreshing="{Binding IsRefreshing}" Command="{Binding Refresh}" IsEnabled="{Binding IsRefreshAllowed}">
+        <ScrollView>
+            <StackLayout>
+                <Label Text="Test for issue #14350" />
+                <Label Text="Refreshing ..." IsVisible="{Binding IsRefreshing}" BackgroundColor="Orange"/>
+                <Label Text="Enable refresh:" IsVisible="{Binding IsRefreshAllowed}" TextColor="Green"/>
+                <StackLayout>
+                    <StackLayout Orientation="Horizontal">
+                        <Label Text="Refresh enabled:" HorizontalOptions="FillAndExpand"/>
+                        <Switch IsToggled="{Binding IsRefreshAllowed}" />
+                    </StackLayout>
+                </StackLayout>
+                <StackLayout>
+                    <Label Text="Test steps (Android):" />
+                    <Label Text="1. Swipe to refresh" />
+                    <Label Text="2. Refresh/busy indicator appears at the top" />
+                    <Label Text="3. Refresh/busy indicator should remain visible until content changes (refresh is finished).
+					   due to issue #14350 the indicator vanishes too early if Command.CanExecute toggles (in this test after 1 second)." />
+                    <Label Text="4. Repeat steps 1 to 3 multiple times" />
+                </StackLayout>
+            </StackLayout>
+        </ScrollView>
+    </RefreshView>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14350.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14350.xaml
@@ -6,28 +6,31 @@
              mc:Ignorable="d"
 			 Title="Test 14350"
              x:Class="Xamarin.Forms.Controls.Issues.Issue14350">
-
-    <RefreshView IsRefreshing="{Binding IsRefreshing}" Command="{Binding Refresh}" IsEnabled="{Binding IsRefreshAllowed}">
-        <ScrollView>
-            <StackLayout>
-                <Label Text="Test for issue #14350" />
-                <Label Text="Refreshing ..." IsVisible="{Binding IsRefreshing}" BackgroundColor="Orange"/>
-                <Label Text="Enable refresh:" IsVisible="{Binding IsRefreshAllowed}" TextColor="Green"/>
+    <StackLayout>
+        <Label Text="Test for issue #14350" />
+        <Label Text="Refresh enabled" IsVisible="{Binding IsRefreshAllowed}" TextColor="Green"/>
+        <Button Text="Refresh now" Command="{Binding Refresh}" />
+        <StackLayout>
+            <StackLayout Orientation="Horizontal">
+                <Label Text="Enable refresh:" HorizontalOptions="FillAndExpand"/>
+                <Switch IsToggled="{Binding IsRefreshAllowed}" />
+            </StackLayout>
+        </StackLayout>
+        <RefreshView IsRefreshing="{Binding IsRefreshing}" Command="{Binding Refresh}" IsEnabled="{Binding IsRefreshAllowed}">
+            <ScrollView>
                 <StackLayout>
-                    <StackLayout Orientation="Horizontal">
-                        <Label Text="Refresh enabled:" HorizontalOptions="FillAndExpand"/>
-                        <Switch IsToggled="{Binding IsRefreshAllowed}" />
+                    <Label Text="Pull-to-refresh here" />
+                    <Label Text="Refreshing ..." IsVisible="{Binding IsRefreshing}" TextColor="Orange"/>
+                    <BoxView HeightRequest="30" />
+                    <StackLayout>
+                        <Label Text="Test steps:" />
+                        <Label Text="1. Swipe to refresh" />
+                        <Label Text="2. Refresh/busy indicator appears at the top" />
+                        <Label Text="3. Refresh/busy indicator should remain visible until content changes (refresh is finished). Due to issue #14350 the indicator vanishes too early if Command.CanExecute toggles (in this test after 1 second)." />
+                        <Label Text="4. Repeat steps 1 to 3 multiple times" />
                     </StackLayout>
                 </StackLayout>
-                <StackLayout>
-                    <Label Text="Test steps (Android):" />
-                    <Label Text="1. Swipe to refresh" />
-                    <Label Text="2. Refresh/busy indicator appears at the top" />
-                    <Label Text="3. Refresh/busy indicator should remain visible until content changes (refresh is finished).
-					   due to issue #14350 the indicator vanishes too early if Command.CanExecute toggles (in this test after 1 second)." />
-                    <Label Text="4. Repeat steps 1 to 3 multiple times" />
-                </StackLayout>
-            </StackLayout>
-        </ScrollView>
-    </RefreshView>
+            </ScrollView>
+        </RefreshView>
+    </StackLayout>
 </ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14350.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14350.xaml.cs
@@ -1,0 +1,26 @@
+﻿using System.ComponentModel;
+
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	// Learn more about making custom code visible in the Xamarin.Forms previewer
+	// by visiting https://aka.ms/xamarinforms-previewer
+	[DesignTimeVisible(false)]
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14350,
+		"[Bug] RefreshView to completes instantly when using AsyncCommand or Command with CanExecute functionality",
+		PlatformAffected.Android)]
+	public partial class Issue14350 : ContentPage
+	{
+		public Issue14350()
+		{
+#if APP
+			InitializeComponent();
+			BindingContext = new ViewModelIssue8384();
+#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8384.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8384.xaml.cs
@@ -55,6 +55,7 @@ namespace Xamarin.Forms.Controls.Issues
 
 		private List<string> _items;
 		private bool _isRefreshing;
+		private bool _isRefreshAllowed = true;
 		private MyCommand _refresh;
 
 		static readonly List<string> FIRST_LIST = new List<string>() {
@@ -75,6 +76,19 @@ namespace Xamarin.Forms.Controls.Issues
 			{
 				_isRefreshing = value;
 				OnPropertyChanged("IsRefreshing");
+			}
+		}
+
+		public bool IsRefreshAllowed
+		{
+			get
+			{
+				return _isRefreshAllowed;
+			}
+			set
+			{
+				_isRefreshAllowed = value;
+				OnPropertyChanged("IsRefreshAllowed");
 			}
 		}
 

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1795,6 +1795,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11795.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14528.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14286.xaml.cs" />
+	<Compile Include="$(MSBuildThisFileDirectory)Issue14350.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14613.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13930.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11211.xaml.cs" />
@@ -2281,6 +2282,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14286.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+	<EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14350.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14613.xaml">

--- a/Xamarin.Forms.Core.UnitTests/RefreshViewTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/RefreshViewTests.cs
@@ -35,22 +35,25 @@ namespace Xamarin.Forms.Core.UnitTests
 		{
 			RefreshView refreshView = new RefreshView();
 			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsRefreshAllowed);
 		}
 
 		[Test]
-		public void CanExecuteDisablesRefreshView()
+		public void CanExecuteDisablesRefresh()
 		{
 			RefreshView refreshView = new RefreshView();
 			refreshView.Command = new Command(() => { }, () => false);
-			Assert.IsFalse(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsFalse(refreshView.IsRefreshAllowed);
 		}
 
 		[Test]
-		public void CanExecuteEnablesRefreshView()
+		public void CanExecuteEnablesRefresh()
 		{
 			RefreshView refreshView = new RefreshView();
 			refreshView.Command = new Command(() => { }, () => true);
 			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsRefreshAllowed);
 		}
 
 		[Test]
@@ -64,16 +67,18 @@ namespace Xamarin.Forms.Core.UnitTests
 
 			canExecute = false;
 			command.ChangeCanExecute();
-			Assert.IsFalse(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsFalse(refreshView.IsRefreshAllowed);
 
 
 			canExecute = true;
 			command.ChangeCanExecute();
 			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsRefreshAllowed);
 		}
 
 		[Test]
-		public void CommandPropertyChangesEnabled()
+		public void CommandPropertyChangesRefreshEnabled()
 		{
 			RefreshView refreshView = new RefreshView();
 
@@ -82,26 +87,40 @@ namespace Xamarin.Forms.Core.UnitTests
 			refreshView.CommandParameter = true;
 			refreshView.Command = command;
 
-			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsRefreshAllowed);
 			refreshView.CommandParameter = false;
-			Assert.IsFalse(refreshView.IsEnabled);
+			Assert.IsFalse(refreshView.IsRefreshAllowed);
 			refreshView.CommandParameter = true;
+			Assert.IsTrue(refreshView.IsRefreshAllowed);
+		}
+
+		[Test]
+		public void CanExecuteDoesNotDisableRefreshView()
+		{
+			// NOTE: RefreshView.IsEnabled should NOT be set to false based on CanExec to avoid problems like:
+			// https://github.com/xamarin/Xamarin.Forms/issues/14350
+			RefreshView refreshView = new RefreshView();
+			Assert.IsTrue(refreshView.IsEnabled);
+			refreshView.Command = new Command(() => { }, () => false);
 			Assert.IsTrue(refreshView.IsEnabled);
 		}
 
 		[Test]
-		public void RemovedCommandEnablesRefreshView()
+		public void RemovedCommandEnablesRefresh()
 		{
 			RefreshView refreshView = new RefreshView();
 
 			bool canExecute = true;
 			var command = new Command(() => { }, () => false);
 			refreshView.Command = command;
-			Assert.IsFalse(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsFalse(refreshView.IsRefreshAllowed);
 			refreshView.Command = null;
 			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsRefreshAllowed);
 			refreshView.Command = command;
-			Assert.IsFalse(refreshView.IsEnabled);
+			Assert.IsTrue(refreshView.IsEnabled);
+			Assert.IsFalse(refreshView.IsRefreshAllowed);
 		}
 
 		[Test]

--- a/Xamarin.Forms.Core/RefreshView.cs
+++ b/Xamarin.Forms.Core/RefreshView.cs
@@ -103,7 +103,7 @@ namespace Xamarin.Forms
 		}
 
 		public static readonly BindableProperty IsRefreshAllowedProperty =
-			BindableProperty.Create(nameof(IsRefreshAllowed), typeof(bool), typeof(RefreshView), false, BindingMode.TwoWay);
+			BindableProperty.Create(nameof(IsRefreshAllowed), typeof(bool), typeof(RefreshView), true, BindingMode.TwoWay);
 
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public bool IsRefreshAllowed

--- a/Xamarin.Forms.Core/RefreshView.cs
+++ b/Xamarin.Forms.Core/RefreshView.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.ComponentModel;
 using System.Runtime.CompilerServices;
 using System.Windows.Input;
 using Xamarin.Forms.Platform;
@@ -47,6 +48,9 @@ namespace Xamarin.Forms
 				return value;
 
 			if (!view.IsEnabled)
+				return false;
+
+			if (!view.IsRefreshAllowed)
 				return false;
 
 			if (view.Command == null)
@@ -98,12 +102,22 @@ namespace Xamarin.Forms
 			set { SetValue(CommandParameterProperty, value); }
 		}
 
+		public static readonly BindableProperty IsRefreshAllowedProperty =
+			BindableProperty.Create(nameof(IsRefreshAllowed), typeof(bool), typeof(RefreshView), false, BindingMode.TwoWay);
+
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public bool IsRefreshAllowed
+		{
+			get { return (bool)GetValue(IsRefreshAllowedProperty); }
+			set { SetValue(IsRefreshAllowedProperty, value); }
+		}
+
 		void RefreshCommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{
 			if (Command != null)
-				SetValueCore(IsEnabledProperty, Command.CanExecute(CommandParameter));
+				SetValueCore(IsRefreshAllowedProperty, Command.CanExecute(CommandParameter));
 			else
-				SetValueCore(IsEnabledProperty, true);
+				SetValueCore(IsRefreshAllowedProperty, true);
 		}
 
 		public static readonly BindableProperty RefreshColorProperty =

--- a/Xamarin.Forms.Platform.UAP/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/RefreshViewRenderer.cs
@@ -105,6 +105,8 @@ namespace Xamarin.Forms.Platform.UWP
 				UpdateContent();
 			else if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled();
+			else if (e.PropertyName == RefreshView.IsRefreshAllowedProperty.PropertyName)
+				UpdateIsEnabled();
 			else if (e.PropertyName == RefreshView.IsRefreshingProperty.PropertyName)
 				UpdateIsRefreshing();
 			else if (e.PropertyName == RefreshView.RefreshColorProperty.PropertyName)
@@ -135,7 +137,7 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void UpdateIsEnabled()
 		{
-			Control.IsEnabled = Element.IsEnabled;
+			Control.IsEnabled = Element.IsEnabled && Element.IsRefreshAllowed;
 		}
 
 		void UpdateIsRefreshing()

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -38,6 +38,9 @@ namespace Xamarin.Forms.Platform.iOS
 						TryOffsetRefresh(this, IsRefreshing);
 					}
 				}
+
+				// Allow to disable UIRefreshControl layout AFTER refresh is done
+				UpdateIsEnabled();
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/RefreshViewRenderer.cs
@@ -81,6 +81,8 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (e.PropertyName == VisualElement.IsEnabledProperty.PropertyName)
 				UpdateIsEnabled();
+			else if (e.PropertyName == RefreshView.IsRefreshAllowedProperty.PropertyName)
+				UpdateIsEnabled();
 			else if (e.PropertyName == RefreshView.IsRefreshingProperty.PropertyName)
 				UpdateIsRefreshing();
 			else if (e.IsOneOf(RefreshView.RefreshColorProperty, VisualElement.BackgroundColorProperty))
@@ -252,7 +254,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateIsEnabled()
 		{
-			bool isRefreshViewEnabled = Element.IsEnabled;
+			bool isRefreshViewEnabled = Element.IsEnabled && Element.IsRefreshAllowed;
 			_refreshControl.Enabled = isRefreshViewEnabled;
 
 			UserInteractionEnabled = true;


### PR DESCRIPTION
### Description of Change ###
Add new internal property ``IsRefreshAllowed`` to ``RefreshView`` to avoid that change in ``Command.CanExecute`` cancels refresh animation.

Implementations of ``ICommand`` - like ``AsyncCommand`` - usually set CanExecute() based on command state. If command execution starts CanExecute() is often set to false to avoid that command is executed multiple times in parallel. If such a command is used for ``RefreshView.RefreshCommand`` then the refresh indication is stopped immediately - even if refresh command is still running.

``RefreshView`` sets its ``IsEnabled`` property depending on ``RefreshCommand.CanExecute()``. Two things happen regarding refresh indicator when ``IsEnabled`` is set to false:
1. ``RefreshView`` sets ``IsRefreshing`` to false, thereby stopping the refresh indicator
2. On Android, disabling the RefreshView (through ``IsEnabled = false``) also immediately stops the refresh indicator
 since the Android ``SwipeRefreshLayout`` is also disabled (this happens through standard XF view/renderer interactions). 

Idea is to introduce a new property ``RefreshView.IsRefreshAllowed`` instead of setting ``RefreshView.IsEnabled`` - similar to ``ListView``.
``RefreshView.IsRefreshAllowed`` is set depending on ``RefreshCommand.CanExecute()``. Platform renderers need to consider 
``IsRefreshAllowed`` and disable swipe to refresh AFTER finishing current refresh activity/indication.


### Issues Resolved ### 

- fixes #14350

### API Changes ###
Added:
 - bool RefreshView.IsRefreshAllowed { get; set; } // INTERNAL bindable Property

### Platforms Affected ### 
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Launch Xamarin.Forms.ControlGallery.Android and navigate to issue 14350. Follow the steps there to test the issue.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
