### PR TITLE
[UWP] Fix issue setting incorrectly the origin in RadialGradientBrush

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14801.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14801.xaml
@@ -1,0 +1,89 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage 
+    xmlns="http://xamarin.com/schemas/2014/forms"  
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14801"
+    Title="Issue 14801">
+    <ScrollView>
+        <StackLayout>
+            <Label
+            Padding="12"
+            BackgroundColor="Black"
+            TextColor="White"
+            Text="If the RadialGradientBrush is rendered in all cases, the test passed."/>
+            <ScrollView>
+                <StackLayout
+                Margin="12">
+                    <Label
+                    Text="RadialGradientBrush (Upper left)"
+                    FontAttributes="Bold" />
+                    <Frame 
+                    Margin="0,12,0,0"
+                    BorderColor="LightGray"
+                    HasShadow="True"
+                    CornerRadius="12"
+                    HeightRequest="60"
+                    WidthRequest="120">
+                        <Frame.Background>
+                            <RadialGradientBrush
+                            Center="0.1,0.1"
+                            Radius="0.5">
+                                <RadialGradientBrush.GradientStops>
+                                    <GradientStop Offset="0.0" Color="Red"/>
+                                    <GradientStop Offset="0.5" Color="Green"/>
+                                    <GradientStop Offset="1.0" Color="Blue"/>
+                                </RadialGradientBrush.GradientStops>
+                            </RadialGradientBrush>
+                        </Frame.Background>
+                    </Frame>
+                    <Label
+                    Margin="0,12,0,0"
+                    Text="RadialGradientBrush (Center)"
+                    FontAttributes="Bold" />
+                    <Frame 
+                    Margin="0,12,0,0"
+                    BorderColor="LightGray"
+                    HasShadow="True"
+                    CornerRadius="12"
+                    HeightRequest="60"
+                    WidthRequest="120">
+                        <Frame.Background>
+                            <RadialGradientBrush
+                            Center="0.5,0.5"
+                            Radius="0.5">
+                                <RadialGradientBrush.GradientStops>
+                                    <GradientStop Offset="0.0" Color="Red"/>
+                                    <GradientStop Offset="0.5" Color="Green"/>
+                                    <GradientStop Offset="1.0" Color="Blue"/>
+                                </RadialGradientBrush.GradientStops>
+                            </RadialGradientBrush>
+                        </Frame.Background>
+                    </Frame>
+                    <Label
+                    Margin="0,12,0,0"
+                    Text="RadialGradientBrush (Lower right)"
+                    FontAttributes="Bold" />
+                    <Frame
+                    Margin="0,12,0,0"
+                    BorderColor="LightGray"
+                    HasShadow="True"
+                    CornerRadius="12"
+                    HeightRequest="60"
+                    WidthRequest="120">
+                        <Frame.Background>
+                            <RadialGradientBrush
+                            Center="0.9,0.9"
+                            Radius="0.5">
+                                <RadialGradientBrush.GradientStops>
+                                    <GradientStop Offset="0.0" Color="Red"/>
+                                    <GradientStop Offset="0.5" Color="Green"/>
+                                    <GradientStop Offset="1.0" Color="Blue"/>
+                                </RadialGradientBrush.GradientStops>
+                            </RadialGradientBrush>
+                        </Frame.Background>
+                    </Frame>
+                </StackLayout>
+            </ScrollView>
+        </StackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14801.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14801.xaml.cs
@@ -1,0 +1,21 @@
+﻿using System;
+using System.Collections.Generic;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14801, "[Bug] RadialGradientBrush behavior is wrong on UWP", PlatformAffected.UWP)]
+	public partial class Issue14801 : ContentPage
+	{
+		public Issue14801()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+	}
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1834,7 +1834,6 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
-	  <Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13577.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -44,6 +44,9 @@
       <DependentUpon>Issue14765.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue14764.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14801.xaml.cs">
+      <DependentUpon>Issue14801.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -1809,7 +1812,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14697.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13577.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
@@ -2322,7 +2325,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-	<EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13577.xaml">
@@ -2920,6 +2923,12 @@
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14765.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14801.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.UAP/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/BrushExtensions.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (brush == null)
 				return null;
-			
+
 			if (brush is SolidColorBrush solidColorBrush)
 			{
 				return solidColorBrush.Color.ToBrush();
@@ -44,7 +44,8 @@ namespace Xamarin.Forms.Platform.UWP
 			if (brush is RadialGradientBrush radialGradientBrush)
 			{
 				var wRadialGradientBrush = new WRadialGradientBrush()
-				{
+				{ 
+					GradientOrigin = new WPoint(radialGradientBrush.Center.X, radialGradientBrush.Center.Y),
 					Center = new WPoint(radialGradientBrush.Center.X, radialGradientBrush.Center.Y),
 					RadiusX = radialGradientBrush.Radius,
 					RadiusY = radialGradientBrush.Radius


### PR DESCRIPTION
### Description of Change ###

Fix issue setting incorrectly the origin in RadialGradientBrush on UWP.

### Issues Resolved ### 

- fixes #14801 

### API Changes ###
 
 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
![image](https://user-images.githubusercontent.com/6755973/140710278-a4963a67-bac8-4ff8-9946-2bcb103af515.png)

### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14801. If the RadialGradientBrush is rendered in all cases, the test passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
