### PR TITLE
[Android] Fix TabbedPage Disappearing events for swipe gestures

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8804.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8804.xaml
@@ -1,0 +1,33 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<local:TestTabbedPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    xmlns:local="using:Xamarin.Forms.Controls"
+    mc:Ignorable="d"
+    Title="Test 8804"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue8804"
+    xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+    android:TabbedPage.IsSwipePagingEnabled="True">
+    <ContentPage
+        Title="Page 1" Disappearing="ContentPage1_Disappearing">
+        <StackLayout
+            VerticalOptions="CenterAndExpand"
+            HorizontalOptions="CenterAndExpand">
+            <Label
+                Text="Swipe to Page 2. You should see an alert confirming that Page 1 is Disappearing. If you see the alert, the test has passed."
+                Margin="12"/>
+        </StackLayout>
+    </ContentPage>
+    <ContentPage
+        Title="Page 2" Disappearing="ContentPage2_Disappearing">
+        <StackLayout
+            VerticalOptions="CenterAndExpand"
+            HorizontalOptions="CenterAndExpand">
+            <Label
+                Text="Swipe to Page 1. You should see an alert confirming that Page 2 is Disappearing. If you see the alert, the test has passed."
+                Margin="12"/>
+        </StackLayout>
+    </ContentPage>
+</local:TestTabbedPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8804.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8804.xaml.cs
@@ -1,0 +1,40 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8804,
+		"[Bug] Android TabbedPage Swipe Gesture triggering wrong OnDisappearing",
+		PlatformAffected.Android)]
+	public partial class Issue8804 : TestTabbedPage
+	{
+		public Issue8804()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+
+		private async void ContentPage1_Disappearing(object sender, System.EventArgs e)
+		{
+			await DisplayAlert("", "Page 1 Disappearing", "OK");
+		}
+
+		private async void ContentPage2_Disappearing(object sender, System.EventArgs e)
+		{
+			await DisplayAlert("", "Page 2 Disappearing", "OK");
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -44,6 +44,9 @@
       <DependentUpon>Issue14765.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue14764.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">
+      <DependentUpon>Issue8804.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -1810,7 +1813,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14697.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13577.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
@@ -2323,7 +2326,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-	<EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13577.xaml">
@@ -2923,6 +2926,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14765.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8804.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/TabbedPageRenderer.cs
@@ -130,13 +130,15 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 
 		void ViewPager.IOnPageChangeListener.OnPageSelected(int position)
 		{
-			if (_previousPage != Element.CurrentPage)
+			var selectedPage = Element.Children[position];
+			if (_previousPage != selectedPage)
 			{
 				_previousPage?.SendDisappearing();
-				_previousPage = Element.CurrentPage;
 			}
-			Element.CurrentPage = Element.Children[position];
+			Element.CurrentPage = selectedPage;
 			Element.CurrentPage.SendAppearing();
+
+			_previousPage = Element.CurrentPage;
 
 			if (IsBottomTabPlacement)
 				_bottomNavigationView.SelectedItemId = position;


### PR DESCRIPTION
### Description of Change ###

Fix TabbedPage Disappearing events for swipe gestures on Android

### Issues Resolved ### 

- fixes #8804

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![Screenshot_1636756492](https://user-images.githubusercontent.com/6692379/141567784-ee7374d9-33d6-465d-9f15-ef26cfa218d6.png)

### Testing Procedure ###

Launch Core Gallery and navigate to the issue 8804. Swipe to Page 2. You should see an alert confirming that Page 1 is Disappearing. If you see the alert, the test has passed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
