### PR TITLE
[Android] Fix CollectionView item renderer disposal on Android (Memory Leak)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14880.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14880.xaml
@@ -1,0 +1,34 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:d="http://xamarin.com/schemas/2014/forms/design"
+    xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+    mc:Ignorable="d"
+    xmlns:local="clr-namespace:Xamarin.Forms.Controls.Issues"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14880"
+    Title="Issue 14880">
+    <Grid>
+        <Grid.RowDefinitions>
+            <RowDefinition Height="Auto"/>
+            <RowDefinition Height="*"/>
+        </Grid.RowDefinitions>
+        <StackLayout Orientation="Vertical" Spacing="5" Grid.Row="0" VerticalOptions="Center">
+            <Label LineBreakMode="WordWrap" Text="Place a breakpoint in the Dispose method of CheckBoxRendererBase.cs for the Android platform, then click the Back button. Does the breakpoint halt the program? If so, good. The Dispose method was called and the test passed." HorizontalTextAlignment="Start" VerticalTextAlignment="Center" Padding="30,10,30,10"/>
+        </StackLayout>
+        <CollectionView Grid.Row="1" ItemsSource="{Binding Items}">
+            <CollectionView.ItemsLayout>
+                <LinearItemsLayout Orientation="Vertical" ItemSpacing="5"/>
+            </CollectionView.ItemsLayout>
+            <CollectionView.ItemTemplate>
+                <DataTemplate>
+                    <StackLayout Orientation="Horizontal" Spacing="10" BackgroundColor="Beige" Padding="10">
+                        <CheckBox/>
+                        <Label Text="{Binding Text}" HorizontalTextAlignment="Start" VerticalTextAlignment="Center" />
+                    </StackLayout>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
+    </Grid>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14880.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14880.xaml.cs
@@ -1,0 +1,57 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14880, "[Bug] CollectionView item renderers never get disposed on Android (Memory Leak)", PlatformAffected.Android)]
+	public partial class Issue14880 : TestContentPage
+	{
+		public Issue14880()
+		{
+#if APP
+			InitializeComponent();
+			BindingContext = new Issue14880ViewModel();
+#endif
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue14880ViewModel
+	{
+		public ObservableCollection<Issue14880Model> Items { get; set; }
+
+		public Issue14880ViewModel()
+		{
+			var collection = new ObservableCollection<Issue14880Model>();
+			var pageSize = 5;
+
+			for (var i = 0; i < pageSize; i++)
+			{
+				collection.Add(new Issue14880Model()
+				{
+					Text = "Item " + i,
+				});
+			}
+
+			Items = collection;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class Issue14880Model
+	{
+		public string Text { get; set; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -44,6 +44,10 @@
       <DependentUpon>Issue14765.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue14764.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14880.xaml.cs">
+      <DependentUpon>Issue14880.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)RadioButtonTemplateFromStyle.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellSearchHandlerItemSizing.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)ShellWithCustomRendererDisabledAnimations.cs" />
@@ -1810,7 +1814,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14697.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13577.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
@@ -2323,7 +2327,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-	<EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13577.xaml">
@@ -2923,6 +2927,12 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14765.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:Compile</Generator>
+    </EmbeddedResource>
+  </ItemGroup>
+  <ItemGroup>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14880.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemContentView.cs
@@ -53,6 +53,8 @@ namespace Xamarin.Forms.Platform.Android
 				RemoveView(Content.View);
 			}
 
+			Content?.Dispose();
+
 			Content = null;
 			_size = null;
 		}

--- a/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/ItemsViewAdapter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using Android.Content;
 using Android.Widget;
 using AndroidX.RecyclerView.Widget;
@@ -12,6 +13,7 @@ namespace Xamarin.Forms.Platform.Android
 		where TItemsViewSource : IItemsViewSource
 	{
 		protected readonly TItemsView ItemsView;
+		protected readonly List<ItemContentView> ContentViews;
 		readonly Func<View, Context, ItemContentView> _createItemContentView;
 		protected internal TItemsViewSource ItemsSource;
 
@@ -21,6 +23,7 @@ namespace Xamarin.Forms.Platform.Android
 		protected internal ItemsViewAdapter(TItemsView itemsView, Func<View, Context, ItemContentView> createItemContentView = null)
 		{
 			ItemsView = itemsView ?? throw new ArgumentNullException(nameof(itemsView));
+			ContentViews = new List<ItemContentView>();
 
 			UpdateUsingItemTemplate();
 
@@ -87,6 +90,8 @@ namespace Xamarin.Forms.Platform.Android
 
 			var itemContentView = _createItemContentView.Invoke(ItemsView, context);
 
+			ContentViews.Add(itemContentView);
+
 			return new TemplatedItemViewHolder(itemContentView, ItemsView.ItemTemplate);
 		}
 
@@ -109,6 +114,12 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (disposing)
 				{
+					foreach (var contentView in ContentViews)
+					{
+						contentView.Recycle();
+					}
+					ContentViews.Clear();
+
 					ItemsSource?.Dispose();
 					ItemsView.PropertyChanged -= ItemsViewPropertyChanged;
 				}


### PR DESCRIPTION
### Description of Change ###

Fix CollectionView item renderer disposal on Android (Memory Leak)

### Issues Resolved ### 

- fixes #14880 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img width="1202" alt="pull_screenshot" src="https://user-images.githubusercontent.com/6692379/141660465-68aa6ee9-bb08-45a6-823f-afe298561a50.png">

### Testing Procedure ###
Launch Control Gallery and navigate to the issue 14880. Place a breakpoint in the Dispose method of CheckBoxRendererBase.cs for the Android platform, then click the Back button. Does the breakpoint halt the program? If so, good. The Dispose method was called and the test passed.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
