### PR TITLE
Fix layout size when iOS swipe-back gesture is aborted, fixes #14763

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14763.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14763.cs
@@ -1,0 +1,66 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14763, "[iOS] Resize on back-swipe stays when going back is cancelled", PlatformAffected.iOS)]
+	public class Issue14763 : NavigationPage
+	{
+		public Issue14763() : base(new HomePage())
+		{ }
+
+		class HomePage : ContentPage
+		{
+			public HomePage()
+			{
+				Title = "Home";
+				var grd = new Grid { BackgroundColor = Color.Brown };
+				grd.RowDefinitions.Add(new RowDefinition());
+				grd.RowDefinitions.Add(new RowDefinition());
+				grd.RowDefinitions.Add(new RowDefinition());
+
+				NavigationPage.SetHasNavigationBar(this, false);
+
+				var boxView = new BoxView { BackgroundColor = Color.Blue };
+				grd.Children.Add(boxView, 0, 0);
+				var stackLayout = new StackLayout()
+				{
+					BackgroundColor = Color.Yellow
+				};
+				var btnPop = new Button {
+					Text = "Back (I get cut off)", AutomationId = "PopButtonId", Command = new Command(async () => await Navigation.PopAsync()),
+					BackgroundColor = Color.Red
+				};
+				stackLayout.Children.Add(btnPop);
+				btnPop.VerticalOptions = new LayoutOptions(LayoutAlignment.End, expands: true);
+				var btn = new Button()
+				{
+					BackgroundColor = Color.Pink,
+					Text = "NextButtonID",
+					AutomationId = "NextButtonID",
+					
+					Command = new Command(async () =>
+					{
+						
+						var page = new ContentPage
+						{
+							Title = "Detail",
+							Content = stackLayout
+						};
+
+						NavigationPage.SetHasNavigationBar(page, true);
+						await Navigation.PushAsync(page);
+					})
+				};
+
+				grd.Children.Add(btn, 0, 1);
+				var image = new Image() { Source = "coffee.png", AutomationId = "CoffeeImageId", BackgroundColor = Color.Yellow };
+				image.VerticalOptions = LayoutOptions.End;
+				grd.Children.Add(image, 0, 2);
+				Content = grd;
+
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14763.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14763.cs
@@ -1,13 +1,23 @@
 ﻿using Xamarin.Forms.CustomAttributes;
 using Xamarin.Forms.Internals;
+using System.Linq;
+using System.Threading.Tasks;
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
 
 namespace Xamarin.Forms.Controls.Issues
 {
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github10000)]
+#endif
 	[Preserve(AllMembers = true)]
 	[Issue(IssueTracker.Github, 14763, "[iOS] Resize on back-swipe stays when going back is cancelled", PlatformAffected.iOS)]
-	public class Issue14763 : NavigationPage
+	public class Issue14763 : TestNavigationPage
 	{
-		public Issue14763() : base(new HomePage())
+		public Issue14763() : base()
 		{ }
 
 		class HomePage : ContentPage
@@ -26,7 +36,8 @@ namespace Xamarin.Forms.Controls.Issues
 				grd.Children.Add(boxView, 0, 0);
 				var stackLayout = new StackLayout()
 				{
-					BackgroundColor = Color.Yellow
+					BackgroundColor = Color.Yellow,
+					AutomationId = "ChildLayout"
 				};
 				var btnPop = new Button {
 					Text = "Back (I get cut off)", AutomationId = "PopButtonId", Command = new Command(async () => await Navigation.PopAsync()),
@@ -46,11 +57,12 @@ namespace Xamarin.Forms.Controls.Issues
 						var page = new ContentPage
 						{
 							Title = "Detail",
-							Content = stackLayout
+							Content = stackLayout,
+							AutomationId = "ChildPage"
 						};
 
 						NavigationPage.SetHasNavigationBar(page, true);
-						await Navigation.PushAsync(page);
+						await Navigation.PushAsync(page, false);
 					})
 				};
 
@@ -62,5 +74,35 @@ namespace Xamarin.Forms.Controls.Issues
 
 			}
 		}
+
+		protected override void Init()
+		{
+			PushAsync(new HomePage());
+		}
+
+#if UITEST && __IOS__
+		[Test]
+		public async Task PopButtonStillVisibleAfterSwipeBack()
+		{
+			RunningApp.WaitForElement("NextButtonID");
+			// Navigate to child page
+			RunningApp.Tap("NextButtonID");
+			var childLayout = RunningApp.WaitForElement("ChildLayout").First();
+			RunningApp.WaitForElement("PopButtonId");
+			await Task.Delay(1000);
+			var origLayoutRect = childLayout.Rect;
+
+			// Swipe-back/Swipe in from left across 1/2 of screen width to start back nav without completing it
+			var screenBounds = RunningApp.ScreenBounds();
+			RunningApp.DragCoordinates(0, screenBounds.CenterY, screenBounds.CenterX, screenBounds.CenterY);			
+			// Wait for swipe-back and UI to settle
+			await Task.Delay(3000);
+			childLayout = RunningApp.WaitForElement("ChildLayout").First();
+			var newLayoutRect = childLayout.Rect;
+
+			// Assert that child page has same height as before
+			Assert.That(newLayoutRect.Height, Is.EqualTo(origLayoutRect.Height));
+		}
+#endif
 	}
 }

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -31,6 +31,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14095.xaml.cs">
       <DependentUpon>Issue14095.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14763.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14523.xaml.cs">
       <DependentUpon>Issue14523.xaml</DependentUpon>
     </Compile>
@@ -1809,7 +1810,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14697.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml.cs" />
-	<Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8384.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13577.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
@@ -2322,7 +2323,7 @@
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8383-2.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
-	<EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8384.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13577.xaml">

--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -173,10 +173,10 @@ namespace Xamarin.Forms.Platform.iOS
 			var toolbar = _secondaryToolbar;
 
 			//save the state of the Current page we are calculating, this will fire before Current is updated
-			_hasNavigationBar = NavigationPage.GetHasNavigationBar(Current);
+			_hasNavigationBar = NavigationPage.GetHasNavigationBar(Current) && !(NavigationBarHidden || NavigationBar.Translucent);
 
 			// Use 0 if the NavBar is hidden or will be hidden
-			var toolbarY = NavigationBarHidden || NavigationBar.Translucent || !_hasNavigationBar ? 0 : navBarFrameBottom;
+			var toolbarY = !_hasNavigationBar ? 0 : navBarFrameBottom;
 			toolbar.Frame = new RectangleF(0, toolbarY, View.Frame.Width, toolbar.Frame.Height);
 
 			double trueBottom = toolbar.Hidden ? toolbarY : toolbar.Frame.Bottom;
@@ -1385,6 +1385,11 @@ namespace Xamarin.Forms.Platform.iOS
 					current.IgnoresContainerArea = !hasNavBar;
 					NavigationController.SetNavigationBarHidden(!hasNavBar, animated);
 				}
+				
+				// Esnure correct nav bar state and layout dimension after swipe-back gesture was
+				// aborted, see  https://github.com/xamarin/Xamarin.Forms/issues/14763.
+				if (_navigation.TryGetTarget(out var n))
+					n.ValidateNavbarExists(current);
 			}
 
 			void UpdateToolbarItems()


### PR DESCRIPTION
### Description of Change ###

Consider two pages on nav stack: **Home page without nav bar** (HasNavigationBar = false) and **SubPage with
nav bar** (HasNavigationBar = true). Currently SubPage is visible.

The user can navigate back to Home page using swipe-back gesture (see screen video). During swipe-back gesture, the next view (Home) starts to appear (ViewWillAppear called) but if the user aborts or reverts the swipe then transition to next view will be aborted (ViewDidAppear not called). In this case SubPage remains the current page. 

In the transition phase caused by the active swipe-back gesture, ``NavigationController.NavigationBarHidden`` will already be set based on the next page HasNavigationBar property (false in our example). But if the user cancels the swipe the App remains on (or kind of returns to) the current page (SubPage) - which has the navigation bar enabled.

In the above scenario we we need to ensure that navigation bar state is correct and consistent with layout and dimensions of our current page. Otherwise SubPage assumes that it has full height available. This PR does this by calling ``NavigationRenderer.ValidateNavbarExists`` from (``ParentViewController.UpdateNavigationBarVisibility``). For this to work I had to adapt the semantics of ``_hasNavigationBar``.

PR also contains a test to reproduce the issue and verify the fix (under test cases for controls).

### Issues Resolved ### 

- fixes #14763 

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

See screen videos.

### Before/After Screenshots ### 

**BEFORE fix:**
https://user-images.githubusercontent.com/22767700/142003062-8af4d5ab-ae3b-4f19-a3a7-0dcd7205f90e.MP4

**AFTER fix:**
https://user-images.githubusercontent.com/22767700/142003089-1a2a5e02-ed56-4537-b1e2-bcdc9801a7cd.MP4

### Testing Procedure ###
Launch Xamarin.Forms.ControlGallery.Android, go to test cases and navigate to issue 14763. Go to next page and go back using swipe-back gesture. When aborting swipe-back gesture the back button at the bottom should correctly appear on the bottom.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [] Targets the correct branch
- [] Tests are passing (or failures are unrelated)
