### PR TITLE
[iOS] Fix backwards navigation fails using Shell

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14805.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14805.cs
@@ -1,0 +1,97 @@
+﻿using System.Diagnostics;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14805, "[Bug] Xamarin.Forms.Shell v5.0.0.2196 Backwards Navigation not working in iOS 15.0",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(Core.UITests.UITestCategories.Github5000)]
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+#endif
+	public class Issue14805 : TestShell
+	{
+		static int PushCount = 1;
+		static int PopCount = 1;
+
+		protected override void Init()
+		{
+			AddFlyoutItem(CreateContentPage(), "Push Me");
+		}
+
+		ContentPage CreateContentPage()
+		{
+			StackLayout layout = new StackLayout();
+
+			Label titleLabel = new Label()
+			{
+				Text = $"Page {PushCount - PopCount + 1}"
+			};
+
+			Button pushButton = new Button()
+			{
+				Text = "Push",
+				AutomationId = $"Push{PushCount}",
+				Command = new Command(async () =>
+				{
+					PushCount++;
+					Debug.WriteLine($"Push {PushCount}");
+					await Navigation.PushAsync(CreateContentPage());
+				})
+			};
+
+			Button popButton = new Button()
+			{
+				Text = "Pop",
+				AutomationId = $"Pop{PopCount}",
+				Command = new Command(async () =>
+				{
+					PopCount++;
+					Debug.WriteLine($"Pop {PopCount}");
+					await Navigation.PopAsync();
+				})
+			};
+
+			Label label = new Label()
+			{
+				Text = "Success",
+				AutomationId = "Success"
+			};
+
+			layout.Children.Add(titleLabel);
+			layout.Children.Add(pushButton);
+			layout.Children.Add(popButton);
+
+			if (PopCount == 3)
+				layout.Children.Add(label);
+
+			return new ContentPage()
+			{
+				Content = layout
+			};
+		}
+
+#if UITEST
+		[Test]
+		public void PushingPagesAndThenPopNotWorking()
+		{
+			RunningApp.Tap("Push1");
+			RunningApp.Tap("Push2");
+			RunningApp.Tap("Pop1");
+			RunningApp.Tap("Push3");
+			RunningApp.Tap("Pop2");
+			RunningApp.Tap("Push4");
+			RunningApp.WaitForElement("Success");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1824,6 +1824,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6387.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14757.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/Shell/ShellSection.cs
+++ b/Xamarin.Forms.Core/Shell/ShellSection.cs
@@ -116,6 +116,8 @@ namespace Xamarin.Forms
 			await poppingCompleted;
 
 			RemovePage(page);
+
+			(Parent?.Parent as IShellController)?.UpdateCurrentState(ShellNavigationSource.Pop);
 		}
 
 		async void IShellSectionController.SendPoppingToRoot(Task finishedPopping)


### PR DESCRIPTION
### Description of Change ###

Fix backwards navigation fails using Shell on iOS.

### Issues Resolved ### 

- fixes #14805 
- fixes #14830

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Use the package from this PR with https://github.com/DiogoSemedo/xamarin or, launch Core Gallery and pass the UITest from Issue 4805.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
