### PR TITLE
[Android] Fix issue interacting with a SwipeView inside a ScrollView on a TabbedPage

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14897.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14897.xaml
@@ -1,0 +1,48 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<controls:TestTabbedPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14897"
+    xmlns:android="clr-namespace:Xamarin.Forms.PlatformConfiguration.AndroidSpecific;assembly=Xamarin.Forms.Core"
+    android:TabbedPage.IsSwipePagingEnabled="False"
+    Title="Issue 14897">
+      <ContentPage
+          Title="Page 1">
+        <StackLayout
+            HorizontalOptions="CenterAndExpand"
+            VerticalOptions="CenterAndExpand">
+            <Label
+                Margin="12"
+                Text="Interact with the SwipeView available in Page 2 and then, try to swipe to move between tabs. If the page not swipe, the test has passed." />
+        </StackLayout>
+    </ContentPage>
+    <ContentPage
+        Title="Page 2">
+        <ScrollView>
+            <SwipeView
+                Padding="50"
+                BackgroundColor="Blue"
+                VerticalOptions="CenterAndExpand">
+            <Grid
+                BackgroundColor="White"
+                HeightRequest="50">
+                <Label
+                    HorizontalOptions="Center"
+                    Text="Swipe Left or Right"
+                    VerticalOptions="Center" />
+            </Grid>
+            <SwipeView.LeftItems>
+                <SwipeItems>
+                    <SwipeItem BackgroundColor="Red" Text="Left SwipeItem" />
+                </SwipeItems>
+            </SwipeView.LeftItems>
+            <SwipeView.RightItems>
+                <SwipeItems>
+                    <SwipeItem BackgroundColor="Green" Text="Right SwipeItem" />
+                </SwipeItems>
+            </SwipeView.RightItems>
+        </SwipeView>
+        </ScrollView>
+    </ContentPage>
+</controls:TestTabbedPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14897.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14897.xaml.cs
@@ -1,0 +1,32 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14897, "[Bug] [5.0.0.2244] [Android] Interacting with a SwipeView inside a ScrollView on a TabbedPage with IsSwipePagingEnabled=false re-enables page swiping",
+		PlatformAffected.Android)]
+#if UITEST
+	[Category(UITestCategories.SwipeView)]
+#endif
+	public sealed partial class Issue14897 : TestTabbedPage
+	{
+		public Issue14897()
+		{
+#if APP
+			this.InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1824,6 +1824,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14505-II.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue6387.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14757.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14897.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2341,6 +2342,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue6387.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14897.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SwipeViewRenderer.cs
@@ -151,6 +151,9 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (Element != null)
 			{
+				if (_pageParent == null)
+					_pageParent = Element.FindParentOfType<TabbedPage>();
+
 				if (_scrollParent == null)
 				{
 					_scrollParent = Element.FindParentOfType<ScrollView>();
@@ -176,9 +179,6 @@ namespace Xamarin.Forms.Platform.Android
 						collectionView.Scrolled += OnParentScrolled;
 					}
 				}
-
-				if (_pageParent == null)
-					_pageParent = Element.FindParentOfType<TabbedPage>();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

Fix issue interacting with a SwipeView inside a ScrollView on a TabbedPage.  With IsSwipePagingEnabled="false" was re-enabling page swiping. This PR introduce changes to fix the issue.

### Issues Resolved ### 

- fixes #14897 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Launch Core Gallery and navigate to the issue 14897. Interact with the SwipeView available in Page 2 and then, try to swipe to move between tabs. If the page not swipe, the test has passed.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
