### PR TITLE
[iOS] Fix setting text decorations and text at the same time and respect changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11954.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue11954.cs
@@ -1,0 +1,94 @@
+﻿using System;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.CustomAttributes;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Label)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 11954,
+		"[Bug] iOS label can't un-set text decorations when updating text at the same time",
+		PlatformAffected.iOS)]
+	public class Issue11954 : TestContentPage
+	{
+		public Issue11954()
+		{
+			UpdateLabel();
+		}
+
+		private Label NiceLabel;
+
+		protected override void Init()
+		{
+			Title = "Issue 11954";
+
+			var layout = new StackLayout();
+
+			var instructions = new Label
+			{
+				Padding = 12,
+				BackgroundColor = Color.Black,
+				TextColor = Color.White,
+				Text = "If press the toggle button and the label enables and disables strikethrough correctly, the test has passed"
+			};
+
+			NiceLabel = new Label
+			{
+				FontSize = 16,
+				Padding = new Thickness(30,24,30,0),
+				Text = "Default text"
+			};
+
+			var button = new Button
+			{
+				Text = "Toggle"
+			};
+
+			button.Clicked += Button_Clicked;
+
+			layout.Children.Add(NiceLabel);
+			layout.Children.Add(button);
+
+			Content = layout;
+		}
+
+		private bool _isStrikethrough;
+
+		private void Button_Clicked(object sender, EventArgs e)
+		{
+			// Toggle strike-through and update label
+			_isStrikethrough = !_isStrikethrough;
+			UpdateLabel();
+		}
+
+		private void UpdateLabel()
+		{
+			NiceLabel.TextDecorations = _isStrikethrough ? TextDecorations.Strikethrough : TextDecorations.None;
+
+			// Comment out the next line and it starts working again
+			NiceLabel.Text = "Is it strikethrough? " + _isStrikethrough.ToString();
+		}
+
+#if UITEST
+		[Test]
+		[Category(UITestCategories.ManualReview)]
+		public void Issue11954Test()
+		{
+			RunningApp.Tap("Toggle");
+			RunningApp.Screenshot("Label should have strikethrough");
+			RunningApp.Tap("Toggle");
+			RunningApp.Screenshot("Label should NOT have strikethrough");
+
+			Assert.Inconclusive("For visual review only");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1720,7 +1720,7 @@
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue10623.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11829.cs" />
-    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs" >
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11496.xaml.cs">
       <DependentUpon>Issue11496.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue11209.xaml.cs">
@@ -1828,6 +1828,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14757.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14897.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue11954.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2731,7 +2732,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue7671.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
@@ -2946,7 +2947,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14765.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13573.xaml">
       <SubType>Designer</SubType>

--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -455,7 +455,7 @@ namespace Xamarin.Forms.Platform.MacOS
 			{
 				var text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
 #if __MOBILE__
-				Control.Text = text;
+				Control.AttributedText = new NSAttributedString(text);
 #else
 				Control.StringValue = text ?? "";
 #endif


### PR DESCRIPTION
### Description of Change ###

Instead of using the UILabel.Text property, we now only use the UILabel.AttributedText property. This makes sure that no formatting or markup is left behind. The label is drawn differently depending on which property you set. This change is the last reference to UILabel.Text.

We should test very well if this doesn't break anywhere!11!!

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #11954 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
Go to issue 11954 and follow the instructions. Label should successfully enable/disable strikethrough

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
