### PR TITLE
[iOS] Fix TabbedPage BackgroundColor issue

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14917.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14917.xaml
@@ -1,0 +1,43 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<TabbedPage 
+    xmlns="http://xamarin.com/schemas/2014/forms" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    x:Class="Xamarin.Forms.Controls.Issues.Issue14917"
+    Title="Issue 14917"
+    BackgroundColor="Yellow">
+    <ContentPage
+        Title="Tab 1"
+        BackgroundColor="Transparent" >
+        <Grid
+            Margin="60">
+          <Label
+              HorizontalOptions="Center"
+              VerticalOptions="Center"
+              Text="Tab 1"/>
+      </Grid>
+    </ContentPage>
+    <ContentPage
+        Title="Tab 2"
+        BackgroundColor="Red"
+        Opacity="0.1">
+      <Grid
+
+        Margin="60">
+          <Label
+              HorizontalOptions="Center"
+              VerticalOptions="Center"
+              Text="Tab 2"/>
+      </Grid>
+    </ContentPage>
+    <ContentPage
+        Title="Tab 3"
+        BackgroundColor="Blue">
+        <Grid
+            Margin="60">
+          <Label
+              HorizontalOptions="Center"
+              VerticalOptions="Center"
+              Text="Tab 3"/>
+      </Grid>
+    </ContentPage>
+</TabbedPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14917.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue14917.xaml.cs
@@ -1,0 +1,26 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.UITest;
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.TabbedPage)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 14917, "TabbedPage backgrouncolor on Ios not set in IoS 15", PlatformAffected.iOS)]
+	public partial class Issue14917 : TabbedPage
+	{
+		public Issue14917()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1832,6 +1832,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14897.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11954.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue14917.xaml.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2358,6 +2359,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14897.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14917.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -82,6 +82,7 @@ namespace Xamarin.Forms.Platform.iOS
 			//disable edit/reorder of tabs
 			CustomizableViewControllers = null;
 
+			UpdateBackgroundColor();
 			UpdateBarBackgroundColor();
 			UpdateBarBackground();
 			UpdateBarTextColor();
@@ -222,6 +223,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (controller != null && controller != base.SelectedViewController)
 				base.SelectedViewController = controller;
 
+			UpdateBackgroundColor();
 			UpdateBarBackgroundColor();
 			UpdateBarTextColor();
 			UpdateSelectedTabColors();
@@ -240,6 +242,7 @@ namespace Xamarin.Forms.Platform.iOS
 					return;
 
 				SelectedViewController = controller;
+				UpdateBackgroundColor();
 			}
 			else if (e.PropertyName == TabbedPage.BarBackgroundColorProperty.PropertyName)
 				UpdateBarBackgroundColor();
@@ -345,6 +348,19 @@ namespace Xamarin.Forms.Platform.iOS
 			page.PropertyChanged -= OnPagePropertyChanged;
 
 			Platform.SetRenderer(page, null);
+		}
+
+		void UpdateBackgroundColor()
+		{
+			if (Tabbed == null || SelectedViewController == null || SelectedViewController.View == null)
+				return;
+
+			var parent = SelectedViewController.View.Superview;
+
+			if (parent == null)
+				return;
+
+			parent.BackgroundColor = Tabbed.BackgroundColor.ToUIColor();
 		}
 
 		void UpdateBarBackgroundColor()

--- a/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/TabbedRenderer.cs
@@ -360,7 +360,8 @@ namespace Xamarin.Forms.Platform.iOS
 			if (parent == null)
 				return;
 
-			parent.BackgroundColor = Tabbed.BackgroundColor.ToUIColor();
+			if (Tabbed.BackgroundColor != Color.Default)
+				parent.BackgroundColor = Tabbed.BackgroundColor.ToUIColor();
 		}
 
 		void UpdateBarBackgroundColor()


### PR DESCRIPTION
### Description of Change ###

Fix TabbedPage BackgroundColor issue.

### Issues Resolved ### 

- fixes #14917 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

![fix14917](https://user-images.githubusercontent.com/6755973/143571903-2c964888-9022-45b7-b681-aa48447eb156.gif)


### Testing Procedure ###
Launch Core Gallery and navigate to the issue 14917. If the first tab background is Yellow, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
