### PR TITLE
Remove UIActivityIndicatorViewDelegate and instead override ViewRenderer to fix #14119

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ActivityIndicatorRenderer.cs
@@ -6,33 +6,6 @@ using RectangleF = CoreGraphics.CGRect;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public sealed class UIActivityIndicatorViewDelegate : UIActivityIndicatorView
-    {
-        ActivityIndicator _element;
-        public UIActivityIndicatorViewDelegate(RectangleF point, ActivityIndicator element) : base(point)
-            => _element = element;
-
-        public override void Draw(CGRect rect)
-        {
-            base.Draw(rect);
-            if (_element?.IsRunning == true)
-                StartAnimating();
-        }
-
-        public override void LayoutSubviews()
-        {
-            base.LayoutSubviews();
-            if (_element?.IsRunning == true)
-                StartAnimating();
-        }
-
-        protected override void Dispose(bool disposing)
-        {
-            base.Dispose(disposing);
-            _element = null;
-        }
-    }
-	
 	public class ActivityIndicatorRenderer : ViewRenderer<ActivityIndicator, UIActivityIndicatorView>
 	{
 		[Internals.Preserve(Conditional = true)]
@@ -47,10 +20,10 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				if (Control == null)
 				{
-					if(Forms.IsiOS13OrNewer)
-						SetNativeControl(new UIActivityIndicatorViewDelegate(RectangleF.Empty, e.NewElement) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium });
+					if (Forms.IsiOS13OrNewer)
+						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Medium });
 					else
-						SetNativeControl(new UIActivityIndicatorViewDelegate(RectangleF.Empty, e.NewElement) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
+						SetNativeControl(new UIActivityIndicatorView(RectangleF.Empty) { ActivityIndicatorViewStyle = UIActivityIndicatorViewStyle.Gray });
 				}
 
 				UpdateColor();
@@ -77,9 +50,12 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void UpdateIsRunning()
 		{
-			if (Control?.Superview == null)
-                return;
-				
+			// You can't call StartAnimating until it has been added to the top UIView (its Superview), otherwise it doesn't do
+			// anything.It seems to affect any cell based view, where the cell might not be visible, when the Activity starts its animation.
+			// See https://github.com/xamarin/Xamarin.Forms/pull/11339
+			if (Superview == null || Control?.Superview == null)
+				return;
+
 			if (Element.IsRunning)
 				Control.StartAnimating();
 			else
@@ -88,8 +64,28 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal void PreserveState()
 		{
-			if (Control != null && !Control.IsAnimating && Element != null && Element.IsRunning)
-				Control.StartAnimating();
+			// Re-apply is running state in case animation was stopped by external means/events and/or Superview changes
+			// (e.g. in UITableView, see ListViewRenderer).
+			// NOTE: not sure if this is still needed after PR11339
+			UpdateIsRunning();
+		}
+
+		public override void Draw(CGRect rect)
+		{
+			base.Draw(rect);
+
+			// Ensure running state is applied when Superview has changed
+			// See https://github.com/xamarin/Xamarin.Forms/pull/11339
+			UpdateIsRunning();
+		}
+
+		public override void LayoutSubviews()
+		{
+			base.LayoutSubviews();
+
+			// Ensure running state is applied when Superview has changed
+			// See https://github.com/xamarin/Xamarin.Forms/pull/11339
+			UpdateIsRunning();
 		}
 	}
 }


### PR DESCRIPTION


### Description of Change ###
PR #11339 introduced ``UIActivityIndicatorViewDelegate`` to cope with changing Superview and start/stop UIActivityIndicatorView accordingly. However this conflicts with UIAppearance/theming of ``UIActivityIndicatorView``. It seems that on iOS 11 (and maybe other versions) sub-classes of ``UIActivityIndicatorView`` do not receive correct default theme/appearance leading to activity indicator showing all-black as reported in #14119.

This PR attempts to fix this by removing ``UIActivityIndicatorViewDelegate`` and instead handling ``LayoutSubviews()``/``Draw()``
through overriding ``ViewRenderer``. This way the native ``UIActivityIndicatorView`` is managed by ``ViewRenderer`` and thus
appearance works on older iOS versions as well.

### Issues Resolved ### 

- fixes #14119 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

**BEFORE (iOS 11)**
![IMG_0013](https://user-images.githubusercontent.com/22767700/144709597-24169359-850c-4749-8aff-c8e7ab984251.png)


**AFTER(iOS 11)**
![IMG_0015](https://user-images.githubusercontent.com/22767700/144709602-4c4780c4-4cf3-44bb-9d7f-9e4ec2e431ec.png)


### Testing Procedure ###

Can be tested with XF control gallery (ActivityIndicator Gallery):

I tested on iOS 11, 12.4, and 15
Tested for regressions using test case B44980 (which should cover #1989).
Could not re-test #11339 since there I found no test case.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
