### PR TITLE
Fix NRE when using Line on iOS with Xcode 13.2

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
@@ -386,8 +386,15 @@ namespace Xamarin.Forms.Platform.MacOS
                 viewBounds.Width -= _strokeWidth;
                 viewBounds.Height -= _strokeWidth;
 
-                nfloat widthScale = viewBounds.Width / _pathFillBounds.Width;
-                nfloat heightScale = viewBounds.Height / _pathFillBounds.Height;
+                if (viewBounds.Width < 0)
+                    viewBounds.Width = 0;
+
+                if (viewBounds.Height < 0)
+                    viewBounds.Height = 0;
+
+                nfloat widthScale = nfloat.IsNaN(viewBounds.Width / _pathFillBounds.Width) ? 0 : viewBounds.Width / _pathFillBounds.Width;
+                nfloat heightScale = nfloat.IsNaN(viewBounds.Height / _pathFillBounds.Height) ? 0 : viewBounds.Height / _pathFillBounds.Height;
+
                 var stretchTransform = CGAffineTransform.MakeIdentity();
 
                 switch (_stretch)
@@ -441,11 +448,15 @@ namespace Xamarin.Forms.Platform.MacOS
 
                     if (_pathStrokeBounds.Width > Bounds.Width)
                         width = Bounds.Width - adjustX;
-                    if (_pathStrokeBounds.Height > Bounds.Height)
+                    if (_pathStrokeBounds.Height > Bounds.Height) 
                         height = Bounds.Height - adjustY;
 
                     Frame = new CGRect(adjustX, adjustY, width, height);
-                    var transform = new CGAffineTransform(Bounds.Width / width, 0, 0, Bounds.Height / height, -adjustX, -adjustY);
+
+                    var calculatedWidth = nfloat.IsNaN(Bounds.Width / width) ? 0 : Bounds.Width / width;
+                    var calculatedHeight = nfloat.IsNaN(Bounds.Height / height) ? 0 : Bounds.Height / height;
+
+                    var transform = new CGAffineTransform(calculatedWidth, 0, 0, calculatedHeight, -adjustX, -adjustY);
                     _renderPath = _path.CopyByTransformingPath(transform);
                 }
                 else

--- a/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Shapes/ShapeRenderer.cs
@@ -392,8 +392,11 @@ namespace Xamarin.Forms.Platform.MacOS
                 if (viewBounds.Height < 0)
                     viewBounds.Height = 0;
 
-                nfloat widthScale = nfloat.IsNaN(viewBounds.Width / _pathFillBounds.Width) ? 0 : viewBounds.Width / _pathFillBounds.Width;
-                nfloat heightScale = nfloat.IsNaN(viewBounds.Height / _pathFillBounds.Height) ? 0 : viewBounds.Height / _pathFillBounds.Height;
+                var calculatedWidth = viewBounds.Width / _pathFillBounds.Width;
+                var calculatedHeight = viewBounds.Height / _pathFillBounds.Height;
+
+                nfloat widthScale = nfloat.IsNaN(calculatedWidth) ? 0 : calculatedWidth;
+                nfloat heightScale = nfloat.IsNaN(calculatedHeight) ? 0 : calculatedHeight;
 
                 var stretchTransform = CGAffineTransform.MakeIdentity();
 
@@ -453,10 +456,10 @@ namespace Xamarin.Forms.Platform.MacOS
 
                     Frame = new CGRect(adjustX, adjustY, width, height);
 
-                    var calculatedWidth = nfloat.IsNaN(Bounds.Width / width) ? 0 : Bounds.Width / width;
-                    var calculatedHeight = nfloat.IsNaN(Bounds.Height / height) ? 0 : Bounds.Height / height;
+                    var calculatedWidth = Bounds.Width / width;
+                    var calculatedHeight = Bounds.Height / height;
 
-                    var transform = new CGAffineTransform(calculatedWidth, 0, 0, calculatedHeight, -adjustX, -adjustY);
+                    var transform = new CGAffineTransform(nfloat.IsNaN(calculatedWidth) ? 0 : calculatedWidth, 0, 0, nfloat.IsNaN(calculatedHeight) ? 0: calculatedHeight, -adjustX, -adjustY);
                     _renderPath = _path.CopyByTransformingPath(transform);
                 }
                 else


### PR DESCRIPTION
### Description of Change ###

As of Xcode 13.2 something seems changed in the Apple iOS APIs that causes a NRE on our side. Not sure if this fix is perfect. I wonder if something in `CGAffineTransform` is changed that doesn't accept invalid values anymore, where it did before, or maybe something in the iOS APIs changed in the measurements which causes invalid values to come in in the first place.

Any views on that are appreciated :)

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #14986

### API Changes ###
None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

No more crash when using a `Line`

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Go to the Shapes Gallery and open the Line Gallery. If it doesn't crash and you can see lines, then it is all OK!

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
