### PR TITLE
Fix CoerceValue() method

### DIFF
--- a/Xamarin.Forms.Core/BindableObject.cs
+++ b/Xamarin.Forms.Core/BindableObject.cs
@@ -598,16 +598,15 @@ namespace Xamarin.Forms
 			if (checkAccess && property.IsReadOnly)
 				throw new InvalidOperationException($"The BindableProperty \"{property.PropertyName}\" is readonly.");
 
+			if (property.CoerceValue == null)
+				return;
+
 			BindablePropertyContext bpcontext = GetContext(property);
 			if (bpcontext == null)
 				return;
 
-			object currentValue = bpcontext.Value;
-
-			if (property.ValidateValue != null && !property.ValidateValue(this, currentValue))
-				throw new ArgumentException($"Value is an invalid value for {property.PropertyName}", nameof(currentValue));
-
-			property.CoerceValue?.Invoke(this, currentValue);
+			object coercedValue = property.CoerceValue.Invoke(this, bpcontext.Value);
+			SetValueCore(property, coercedValue, SetValueFlags.None, checkAccess ? SetValuePrivateFlags.CheckAccess : 0);
 		}
 
 		[Flags]


### PR DESCRIPTION
### Description of Change ###
Fixes `CoerceValue()` so it actually sets the value of the bindable object.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15024

### API Changes ###
 
 None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
CoerceValue() updates the value of the object now.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
See reproduction and expected/actual behavior in #15024

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
