### PR TITLE
Route Shell Modal Navigation through ShellSection

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/ShellModalTests.cs
@@ -431,6 +431,34 @@ namespace Xamarin.Forms.Core.UnitTests
 			Assert.AreEqual(0, shell.Navigation.ModalStack.Count);
 		}
 
+		[Test]
+		public async Task PopModalFromShellNavigationProxy()
+		{
+			Routing.RegisterRoute("ModalTestPage", typeof(ModalTestPage));
+			Shell shell = new Shell();
+			shell.Items.Add(CreateShellItem(shellItemRoute: "NewRoute"));
+
+			await shell.GoToAsync("ModalTestPage");
+			await shell.Navigation.PopModalAsync();
+
+			Assert.AreEqual("//NewRoute", shell.CurrentState.Location.ToString());
+		}
+
+		[Test]
+		public async Task PushModalFromShellNavigationProxy()
+		{
+			ModalTestPage modalTestPage = new ModalTestPage();
+			Routing.SetRoute(modalTestPage, "ModalTestPage");
+
+			Routing.RegisterRoute("ModalTestPage", typeof(ModalTestPage));
+			Shell shell = new Shell();
+			shell.Items.Add(CreateShellItem(shellItemRoute: "NewRoute"));
+			await shell.Navigation.PushModalAsync(modalTestPage);
+
+			Assert.AreEqual("//NewRoute/ModalTestPage", shell.CurrentState.Location.ToString());
+		}
+
+
 		[QueryProperty("SomeQueryParameter", "SomeQueryParameter")]
 		public class ModalTestPageBase : ShellLifeCycleTests.LifeCyclePage
 		{

--- a/Xamarin.Forms.Core/Shell/Shell.cs
+++ b/Xamarin.Forms.Core/Shell/Shell.cs
@@ -1308,6 +1308,13 @@ namespace Xamarin.Forms
 
 			protected override async Task<Page> OnPopModal(bool animated)
 			{
+				if (!_shell.NavigationManager.AccumulateNavigatedEvents)
+				{
+					var page = _shell.CurrentPage;
+					await _shell.GoToAsync("..", animated);
+					return page;
+				}
+
 				if (ModalStack.Count > 0)
 					ModalStack[ModalStack.Count - 1].SendDisappearing();
 
@@ -1327,6 +1334,14 @@ namespace Xamarin.Forms
 
 			protected override async Task OnPushModal(Page modal, bool animated)
 			{
+				if (!_shell.NavigationManager.AccumulateNavigatedEvents)
+				{
+					// This will route the modal push through the shell section which is setup
+					// to update the shell state after a modal push
+					await _shell.CurrentItem.CurrentItem.Navigation.PushModalAsync(modal, animated);
+					return;
+				}
+
 				if (ModalStack.Count == 0)
 					_shell.CurrentItem.SendDisappearing();
 


### PR DESCRIPTION
### Description of Change ###

All Navigation needs to get routed through the ShellSection. This PR routes any calls that start inside the Shell NavigationProxy to the ShellSection so that it can handle the navigation properly

### Issues Resolved ### 
- fixes #14968 

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Testing Procedure ###
- unit tests included

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
