### PR TITLE
Fix 15066

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15066.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15066.cs
@@ -1,0 +1,45 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15066, "[Bug] StackLayout's layout inside ScrollView is not updated properly when adding children", PlatformAffected.Android)]
+	public class Issue15066 : TestContentPage
+	{
+		protected override void Init()
+		{
+			Button addButton = new Button()
+			{
+				Text = "Add",
+			};
+			Label testInstructionsLabel = new Label()
+			{
+				Text = "Click the 'Add' button until the height of the dark green StackLayout is larger than the height of the page. " +
+					"Then scroll to the end of the page. " +
+					"If there is a dark blue gap at the end of the page, the test has failed.",
+				HorizontalTextAlignment = TextAlignment.Center,
+			};
+			StackLayout containerStackLayout = new StackLayout()
+			{
+				BackgroundColor = Color.DarkGreen,
+				Children = { addButton, testInstructionsLabel },
+			};
+			addButton.Clicked += (_, __) =>
+				containerStackLayout.Children.Add(new StackLayout() { BackgroundColor = Color.Gray, HeightRequest = 40.0 });
+			Content = new ScrollView()
+			{
+				BackgroundColor = Color.DarkBlue,
+				Content = containerStackLayout,
+			};
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1858,6 +1858,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11954.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13918.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15066.cs" />
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">

--- a/Xamarin.Forms.Core/Device.cs
+++ b/Xamarin.Forms.Core/Device.cs
@@ -90,8 +90,6 @@ namespace Xamarin.Forms
 			set { s_platformServices = value; }
 		}
 
-		public static IPlatformInvalidate PlatformInvalidator { get; set; }
-
 		[EditorBrowsable(EditorBrowsableState.Never)]
 		public static IReadOnlyList<string> Flags { get; private set; }
 
@@ -286,11 +284,6 @@ namespace Xamarin.Forms
 			public static readonly Style ListItemDetailTextStyle = new Style(typeof(Label)) { BaseResourceKey = ListItemDetailTextStyleKey };
 
 			public static readonly Style CaptionStyle = new Style(typeof(Label)) { BaseResourceKey = CaptionStyleKey };
-		}
-
-		public static void Invalidate(VisualElement visualElement)
-		{
-			PlatformInvalidator?.Invalidate(visualElement);
 		}
 	}
 }

--- a/Xamarin.Forms.Core/IPlatformInvalidate.cs
+++ b/Xamarin.Forms.Core/IPlatformInvalidate.cs
@@ -1,8 +1,0 @@
-﻿namespace Xamarin.Forms.Internals
-{
-	public interface IPlatformInvalidate
-
-	{
-		void Invalidate(VisualElement visualElement);
-	}
-}

--- a/Xamarin.Forms.Core/Layout.cs
+++ b/Xamarin.Forms.Core/Layout.cs
@@ -327,7 +327,7 @@ namespace Xamarin.Forms
 
 			s_resolutionList.Add(new KeyValuePair<Layout, int>(this, GetElementDepth(this)));
 
-			if (Device.PlatformInvalidator == null && !s_relayoutInProgress)
+			if (!s_relayoutInProgress)
 			{
 				// Rather than recomputing the layout for each change as it happens, we accumulate them in
 				// s_resolutionList and schedule a single layout update operation to handle them all at once.
@@ -345,15 +345,9 @@ namespace Xamarin.Forms
 					Device.BeginInvokeOnMainThread(ResolveLayoutChanges);
 				}
 			}
-			else
-			{
-				// If the platform supports PlatformServices2, queueing is unnecessary; the layout changes
-				// will be handled during the Layout's next Measure/Arrange pass
-				Device.Invalidate(this);
-			}
 		}
 
-		public void ResolveLayoutChanges()
+		internal void ResolveLayoutChanges()
 		{
 			s_relayoutInProgress = false;
 

--- a/Xamarin.Forms.Core/VisualElement.cs
+++ b/Xamarin.Forms.Core/VisualElement.cs
@@ -677,7 +677,6 @@ namespace Xamarin.Forms
 			if (!Batched)
 			{
 				BatchCommitted?.Invoke(this, new EventArg<VisualElement>(this));
-				Device.Invalidate(this);
 			}
 		}
 

--- a/Xamarin.Forms.Platform.Android/Forms.cs
+++ b/Xamarin.Forms.Platform.Android/Forms.cs
@@ -308,10 +308,7 @@ namespace Xamarin.Forms
 			// because AndroidPlatformServices needs a current activity to launch URIs from
 			Profile.FramePartition("Device.PlatformServices");
 
-			var androidServices = new AndroidPlatformServices(activity);
-
-			Device.PlatformServices = androidServices;
-			Device.PlatformInvalidator = androidServices;
+			Device.PlatformServices = new AndroidPlatformServices(activity);
 
 			// use field and not property to avoid exception in getter
 			if (Device.info != null)
@@ -645,7 +642,7 @@ namespace Xamarin.Forms
 			}
 		}
 
-		class AndroidPlatformServices : IPlatformServices, IPlatformInvalidate
+		class AndroidPlatformServices : IPlatformServices
 		{
 			double _buttonDefaultSize;
 			double _editTextDefaultSize;
@@ -950,18 +947,6 @@ namespace Xamarin.Forms
 			public SizeRequest GetNativeSize(VisualElement view, double widthConstraint, double heightConstraint)
 			{
 				return Platform.Android.Platform.GetNativeSize(view, widthConstraint, heightConstraint);
-			}
-
-			public void Invalidate(VisualElement visualElement)
-			{
-				var renderer = visualElement.GetRenderer();
-				if (renderer == null || renderer.View.IsDisposed())
-				{
-					return;
-				}
-
-				renderer.View.Invalidate();
-				renderer.View.RequestLayout();
 			}
 
 			public OSAppTheme RequestedTheme

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -505,15 +505,5 @@ namespace Xamarin.Forms.Platform.Android
 
 		void IVisualElementRenderer.SetLabelFor(int? id)
 			=> ViewCompat.SetLabelFor(this, id ?? ViewCompat.GetLabelFor(this));
-
-		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
-		{
-			if (Element is Layout layout)
-			{
-				layout.ResolveLayoutChanges();
-			}
-
-			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
-		}
 	}
 }

--- a/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementTracker.cs
@@ -336,9 +336,6 @@ namespace Xamarin.Forms.Platform.Android
 				aview.Visibility = ViewStates.Visible;
 			if (!view.IsVisible && aview.Visibility != ViewStates.Gone)
 				aview.Visibility = ViewStates.Gone;
-
-			aview.Invalidate();
-			aview.RequestLayout();
 		}
 
 		void UpdateNativeView(object sender, EventArgs e)

--- a/Xamarin.Forms.Platform.UAP/Forms.cs
+++ b/Xamarin.Forms.Platform.UAP/Forms.cs
@@ -58,11 +58,8 @@ namespace Xamarin.Forms
 			Device.SetIdiom(TargetIdiom.Tablet);
 			Device.SetFlowDirection(GetFlowDirection());
 
-			var platformServices = new WindowsPlatformServices(Window.Current.Dispatcher);
+			Device.PlatformServices = new WindowsPlatformServices(Window.Current.Dispatcher);
 
-			Device.PlatformServices = platformServices;
-			Device.PlatformInvalidator = platformServices;
-			
 			Device.SetFlags(s_flags);
 			Device.Info = new WindowsDeviceInfo();
 

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -296,11 +296,6 @@ namespace Xamarin.Forms.Platform.UWP
 			if (Element == null || availableSize.Width * availableSize.Height == 0)
 				return new Windows.Foundation.Size(0, 0);
 
-			if (Element is Layout layout)
-			{
-				layout.ResolveLayoutChanges();
-			}
-
 			Element.IsInNativeLayout = true;
 
 			for (var i = 0; i < ElementController.LogicalChildren.Count; i++)

--- a/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
+++ b/Xamarin.Forms.Platform.UAP/WindowsBasePlatformServices.cs
@@ -25,7 +25,7 @@ using IOPath = System.IO.Path;
 
 namespace Xamarin.Forms.Platform.UWP
 {
-	internal abstract class WindowsBasePlatformServices : IPlatformServices, IPlatformInvalidate
+	internal abstract class WindowsBasePlatformServices : IPlatformServices
 	{
 		const string WrongThreadError = "RPC_E_WRONG_THREAD";
 		readonly CoreDispatcher _dispatcher;
@@ -254,17 +254,6 @@ namespace Xamarin.Forms.Platform.UWP
 			});
 
 			return await taskCompletionSource.Task;
-		}
-
-		public void Invalidate(VisualElement visualElement)
-		{
-			var renderer = Platform.GetRenderer(visualElement);
-			if (renderer == null)
-			{
-				return;
-			}
-
-			renderer.ContainerElement.InvalidateMeasure();
 		}
 
 		public OSAppTheme RequestedTheme => Windows.UI.Xaml.Application.Current.RequestedTheme == ApplicationTheme.Dark ? OSAppTheme.Dark : OSAppTheme.Light;

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -214,12 +214,9 @@ namespace Xamarin.Forms
 			}
 #endif
 			Device.SetFlags(s_flags);
-			var platformServices = new IOSPlatformServices();
-
-			Device.PlatformServices = platformServices;
+			Device.PlatformServices = new IOSPlatformServices();
 
 #if __MOBILE__
-			Device.PlatformInvalidator = platformServices;
 			Device.Info = new IOSDeviceInfo();
 #else
 			Device.Info = new Platform.macOS.MacDeviceInfo();
@@ -265,9 +262,6 @@ namespace Xamarin.Forms
 		}
 
 		class IOSPlatformServices : IPlatformServices
-#if __MOBILE__
-			, IPlatformInvalidate
-#endif
 		{
 			readonly double _fontScalingFactor = 1;
 			public IOSPlatformServices()
@@ -823,18 +817,6 @@ namespace Xamarin.Forms
 					throw new InvalidOperationException("Could not find current view controller.");
 
 				return viewController;
-			}
-
-			public void Invalidate(VisualElement visualElement)
-			{
-				var renderer = Platform.iOS.Platform.GetRenderer(visualElement);
-
-				if (renderer == null)
-				{
-					return;
-				}
-
-				renderer.NativeView.SetNeedsLayout();
 			}
 #endif
 		}

--- a/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementRenderer.cs
@@ -313,24 +313,13 @@ namespace Xamarin.Forms.Platform.MacOS
 
 #if __MOBILE__
 
-		void ResolveLayoutChanges()
-		{
-			if (Element is Layout layout)
-			{
-				layout.ResolveLayoutChanges();
-			}
-		}
-
 		public override SizeF SizeThatFits(SizeF size)
 		{
-			ResolveLayoutChanges();
 			return new SizeF(0, 0);
 		}
 
 		public override void LayoutSubviews()
 		{
-			ResolveLayoutChanges();
-
 			base.LayoutSubviews();
 
 			if (_blur != null && Superview != null)


### PR DESCRIPTION
### Description of Change ###

fix #15066 
revert the commit [e8d06f357eae3021a31272db272d4873356870b6](https://github.com/xamarin/Xamarin.Forms/commit/e8d06f357eae3021a31272db272d4873356870b6) which introduced this bug

### Issues Resolved ###

- fixes #15066 

### API Changes ###
 
 None

### Platforms Affected ###

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###

The layout of a StackLayout or a Grid which is inside a ScrollView is updated properly when child elements are added to the StackLayout/Grid.

### Before/After Screenshots ###

![Screenshot_20220117_181613_com companyname xamarinformslayoutchangesbug](https://user-images.githubusercontent.com/9087189/149823388-dd3fe36a-3f71-475b-9fbd-05ffde06bab7.jpg)
![Screenshot_20220117_181651_com companyname xamarinformslayoutchangesbug](https://user-images.githubusercontent.com/9087189/149823428-f3880079-330d-436a-9182-d8de61ea993a.jpg)

### Testing Procedure ###
Android: description can be seen in Issue15066.cs
iOS: not able to test this
UWP: bug was not present before this fix

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
