### PR TITLE
fix #8293 and partially 14323

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8293.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8293.cs
@@ -1,0 +1,62 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System;
+using System.Threading;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8293, "[Bug] Font Icon Disappears when Minimizing Window in UWP", PlatformAffected.UWP)]
+	public class Issue8293 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout
+			{
+				AutomationId = "Issue8293Label"
+			};
+
+			var iconColor = Color.White;
+			var fontImageSource = new FontImageSource { Size = 24, Color = Color.White, FontFamily = GetFontFamily("materialdesignicons-webfont.ttf", "Material Design Icons"), Glyph = GetGlyph("f625") };
+
+			List<Func<FontImageSource, View>> affectedViewsCreators = new List<Func<FontImageSource, View>>
+			{
+				(fontImageSource) => new Button { ImageSource = fontImageSource },
+				(fontImageSource) => new ImageButton { WidthRequest=39,HeightRequest=39, Source = fontImageSource, BackgroundColor = Color.FromHex("#333333")},
+				(fontImageSource) => new Frame{Content = new Image {  Source = fontImageSource}, BorderColor=iconColor, Padding=0,  }
+			};
+
+			foreach (var affectedViewCreator in affectedViewsCreators)
+			{
+				var affectedView = affectedViewCreator(fontImageSource);
+				stackLayout.Children.Add(affectedView);
+			}
+
+			Content = stackLayout;
+
+		}
+
+		private string GetFontFamily(string fileName, string fontName)
+		{
+			return $"Assets/Fonts/{fileName}#{fontName}";
+		}
+
+		private static string GetGlyph(string codePoint)
+		{
+			int p = int.Parse(codePoint, System.Globalization.NumberStyles.HexNumber);
+			return char.ConvertFromUtf32(p);
+		}
+	}
+
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -975,6 +975,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14544.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Github7996.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue14657.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8293.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)_TemplateMarkup.xaml.cs">
       <DependentUpon>_TemplateMarkup.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -16,7 +16,14 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _fontApplied;
 
 		FormsButton _button;
-		PointerEventHandler _pointerPressedHandler;		
+		PointerEventHandler _pointerPressedHandler;
+		Window _window;
+
+		public ButtonRenderer()
+		{
+			_window = Window.Current;
+			_window.Activated += Window_Activated;
+		}
 
 		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
 		{
@@ -70,6 +77,16 @@ namespace Xamarin.Forms.Platform.UWP
 
 				UpdateFont();
 			}
+		}
+
+		void Window_Activated(object sender, Windows.UI.Core.WindowActivatedEventArgs e)
+		{
+			if (Control == null | Element == null)
+				return;
+
+			if(Element.ImageSource is FontImageSource)
+				UpdateContent();
+			
 		}
 
 		void ButtonOnLoading(FrameworkElement sender, object args)
@@ -321,6 +338,10 @@ namespace Xamarin.Forms.Platform.UWP
 		{
 			if (_isDisposed)
 				return;
+			if(_window != null)
+			{
+				_window.Activated -= Window_Activated;
+			}
 			if (_button != null)
 			{
 				_button.Click -= OnButtonClick;

--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -49,6 +49,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (disposing)
 			{
+				if (_window != null)
+				{
+					_window.Activated -= Window_Activated;
+				}
+
 				ImageElementManager.Dispose(this);
 				if (Control != null)
 				{

--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -18,10 +18,24 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _disposed;
 		WImage _image;
 		FormsButton _formsButton;
+		Window _window;
 
 		public ImageButtonRenderer() : base()
 		{
 			ImageElementManager.Init(this);
+			_window = Window.Current;
+			_window.Activated += Window_Activated;
+		}
+
+		async void Window_Activated(object sender, Windows.UI.Core.WindowActivatedEventArgs e)
+		{
+			if (Control == null | Element == null)
+				return;
+
+			if (Element.Source is FontImageSource)
+			{
+				await TryUpdateSource();
+			}
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -53,6 +53,11 @@ namespace Xamarin.Forms.Platform.UWP
 
 			if (disposing)
 			{
+				if (_window != null)
+				{
+					_window.Activated -= Window_Activated;
+				}
+
 				ImageElementManager.Dispose(this);
 				if (Control != null)
 				{

--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -10,11 +10,24 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		bool _measured;
 		bool _disposed;
-
+		Window _window;
 		public ImageRenderer() : base()
 		{
 			ImageElementManager.Init(this);
+			_window = Window.Current;
+			_window.Activated += Window_Activated;
 			Windows.UI.Xaml.Application.Current.Resuming += OnResumingAsync;
+		}
+
+		async void Window_Activated(object sender, Windows.UI.Core.WindowActivatedEventArgs e)
+		{
+			if (Control == null | Element == null)
+				return;
+
+			if(Element.Source is FontImageSource)
+			{
+				await TryUpdateSource();
+			}
 		}
 
 		bool IImageVisualElementRenderer.IsDisposed => _disposed;


### PR DESCRIPTION
### Description of Change ###

Handles Window.Activated to re-render the FontImageSource in renderers ButtonRenderer, ImageButtonRenderer and ImageRenderer.

### Issues Resolved ### 

- fixes #8293
- partially fixes #14323

partially because the event is not raised immediately and there is a flash.  So not the best of solutions but certainly better that the current situation where Xamarin Forms cannot be considered cross platform if using UWP.  

**!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!**
There is an alternative though that works for minmize and screen lock without the flash. 

As I have [outlined](https://github.com/xamarin/Xamarin.Forms/issues/8293#issuecomment-1012386033) and demonstrated with an effect, we can **turn the FontImageSource in to a TextBlock and render that as the Button Content** instead of an Image with a CanvasImageSource.  This solution does not work for an Image / ImageRenderer but a Label may be sufficient for most people.  For an ImageButton / ImageButtonRenderer we can do the same but the image does size differently and would have to be looked into further.

Below, two rows containing 4 Button elements all with FontImageSource with different font families Ionicicons, Font Awesome, Material ( old ) and Material Current.  Top row normal rendering ( with corrected FontImageSourceHandler from https://github.com/xamarin/Xamarin.Forms/pull/15047/files ) and bottom row TextBlock button content from effect.  As you can see they look approximately the same.

![image](https://user-images.githubusercontent.com/11292998/149981751-158b981d-8b58-4954-bcf5-85f0ebe3d773.png)



The effect just replaces the Image with the TextBlock and is easy to replicate in the ButtonRendererer.
( The additional classes are copies of Xamarin internals )

@jfversluis Your thoughts appreciated.

```
using System.ComponentModel;
using Windows.UI.Xaml;
using Windows.UI.Xaml.Controls;
using Windows.UI.Xaml.Media.Imaging;
using Windows.UI.Xaml.Input;
using Xamarin.Forms.Internals;
using WBrush = Windows.UI.Xaml.Media.Brush;
using WImage = Windows.UI.Xaml.Controls.Image;
using WStretch = Windows.UI.Xaml.Media.Stretch;
using WThickness = Windows.UI.Xaml.Thickness;
using System.Runtime.CompilerServices;
using System.Threading.Tasks;
using System;
using System.Threading;
using Microsoft.Graphics.Canvas.UI.Xaml;
using Xamarin.Forms.PlatformConfiguration.WindowsSpecific;
using UwpScrollBarVisibility = Windows.UI.Xaml.Controls.ScrollBarVisibility;
using Windows.Foundation;
using Windows.UI.Xaml.Media;
using System.Linq;
using System.Reflection;
using System.Collections.Generic;
using WBinding = Windows.UI.Xaml.Data.Binding;
using WBindingExpression = Windows.UI.Xaml.Data.BindingExpression;
using System.Collections.Concurrent;

namespace DisapeeraingButtonSolution
{
    internal class InterceptVisualStateManager : Windows.UI.Xaml.VisualStateManager
	{
		static InterceptVisualStateManager s_instance;

		public static readonly DependencyProperty FormsElementProperty = DependencyProperty.RegisterAttached(
				"FormsElement", typeof(VisualElement), typeof(Control), new PropertyMetadata(null));

		public static void SetFormsElement(Control frameworkElement, VisualElement value)
		{
			frameworkElement.SetValue(FormsElementProperty, value);
		}

		public static VisualElement GetFormsElement(Control frameworkElement)
		{
			return (VisualElement)frameworkElement.GetValue(FormsElementProperty);
		}

		internal static InterceptVisualStateManager Instance
		{
			get
			{
				s_instance = s_instance ?? new InterceptVisualStateManager();
				return s_instance;
			}
		}

		// For most of the UWP controls, this custom VisualStateManager is injected to prevent the default Windows
		// VSM from handling states which the Forms VSM is already managing. 
		// The exception are the controls which are built on TextBox (SearchBar, Entry, Editor); there's a UWP
		// bug wherein the GoToStateCore override for those controls is never called (Item 10976357 in VSTS)
		// So until that's resolved, the FormsTextBox control is doing that work as best it can. 

		protected override bool GoToStateCore(Control control, FrameworkElement templateRoot, string stateName,
			Windows.UI.Xaml.VisualStateGroup @group, Windows.UI.Xaml.VisualState state, bool useTransitions)
		{
			// If this custom VSM is in play, it's because the control is using the Forms VSM or the user has disabled
			// legacy color handling. Either way, we may need to prevent the Windows VSM from transitioning to the new
			// state. So we intercept the transition here.

			if (ShouldIntercept(control, state, stateName))
			{
				return false;
			}

			return base.GoToStateCore(control, templateRoot, stateName, @group, state, useTransitions);
		}

		static bool ShouldIntercept(Control control, Windows.UI.Xaml.VisualState state, string stateName)
		{
			if (state == null || state.Name == "Normal")
			{
				// We don't intercept the "Normal" state, that's the base state onto which Forms applies properties
				return false;
			}

			// Retrieve the VisualElement we're managing states for
			var visualElement = GetFormsElement(control);

			if (visualElement == null)
			{
				return false;
			}

			// Retrieve the set of VisualStateGroups for the VisualElement
			var groups = VisualStateManager.GetVisualStateGroups(visualElement);

			if (groups == null)
			{
				// No groups? 
				// Then the user disabled legacy color management through the platform specific, not by using the XFVSM
				// So our ignored states lists is effectively "Disabled" and "Focused"
				if (state.Name == "Disabled" || state.Name == "Focused")
				{
					return true;
				}
			}
			else
			{
				// Check the states the XFVSM is managing
				foreach (VisualStateGroup vsg in groups)
				{
					foreach (VisualState vs in vsg.States)
					{
						if (vs.Name == stateName)
						{
							// The XFVSM is already handling this state, so don't let the Windows VSM do it
							return true;
						}
					}
				}
			}

			return false;
		}

		internal static void Hook(FrameworkElement rootElement, Control control, VisualElement visualElement)
		{
			if (rootElement == null)
			{
				return;
			}

			// Set this as the custom VSM for that root element, 
			// and associate the VisualElement with this UWP Control 
			SetCustomVisualStateManager(rootElement, Instance);
			SetFormsElement(control, visualElement);
		}
	}
	public static class ElementExtensions
	{
		internal static T FindParent<T>(this Element self)
			where T : class
		{
			T returnvalue = default(T);

			do
			{
				self = self?.RealParent;
				returnvalue = self as T;
			}
			while (returnvalue == null && self != null);

			return returnvalue;
		}
	}
	internal static class FrameworkElementExtensions
	{
		static readonly Lazy<ConcurrentDictionary<Type, DependencyProperty>> ForegroundProperties =
			new Lazy<ConcurrentDictionary<Type, DependencyProperty>>(() => new ConcurrentDictionary<Type, DependencyProperty>());

		public static WBrush GetForeground(this FrameworkElement element)
		{
			if (element == null)
				throw new ArgumentNullException("element");

			return (WBrush)element.GetValue(GetForegroundProperty(element));
		}

		public static WBinding GetForegroundBinding(this FrameworkElement element)
		{
			WBindingExpression expr = element.GetBindingExpression(GetForegroundProperty(element));
			if (expr == null)
				return null;

			return expr.ParentBinding;
		}

		public static object GetForegroundCache(this FrameworkElement element)
		{
			WBinding binding = GetForegroundBinding(element);
			if (binding != null)
				return binding;

			return GetForeground(element);
		}

		public static void RestoreForegroundCache(this FrameworkElement element, object cache)
		{
			var binding = cache as WBinding;
			if (binding != null)
				SetForeground(element, binding);
			else
				SetForeground(element, (WBrush)cache);
		}

		public static void SetForeground(this FrameworkElement element, WBrush foregroundBrush)
		{
			if (element == null)
				throw new ArgumentNullException("element");

			element.SetValue(GetForegroundProperty(element), foregroundBrush);
		}

		public static void SetForeground(this FrameworkElement element, WBinding binding)
		{
			if (element == null)
				throw new ArgumentNullException("element");

			element.SetBinding(GetForegroundProperty(element), binding);
		}

		internal static IEnumerable<T> GetDescendantsByName<T>(this DependencyObject parent, string elementName) where T : DependencyObject
		{
			int myChildrenCount = VisualTreeHelper.GetChildrenCount(parent);
			for (int i = 0; i < myChildrenCount; i++)
			{
				var child = VisualTreeHelper.GetChild(parent, i);
				var controlName = child.GetValue(FrameworkElement.NameProperty) as string;
				if (controlName == elementName && child is T)
					yield return child as T;
				else
				{
					foreach (var subChild in child.GetDescendantsByName<T>(elementName))
						yield return subChild;
				}
			}
		}

		internal static T GetFirstDescendant<T>(this DependencyObject element) where T : FrameworkElement
		{
			int count = VisualTreeHelper.GetChildrenCount(element);
			for (var i = 0; i < count; i++)
			{
				DependencyObject child = VisualTreeHelper.GetChild(element, i);

				T target = child as T ?? GetFirstDescendant<T>(child);
				if (target != null)
					return target;
			}

			return null;
		}

		static DependencyProperty GetForegroundProperty(FrameworkElement element)
		{
			if (element is Control)
				return Control.ForegroundProperty;
			if (element is TextBlock)
				return TextBlock.ForegroundProperty;

			Type type = element.GetType();

			DependencyProperty foregroundProperty;
			if (!ForegroundProperties.Value.TryGetValue(type, out foregroundProperty))
			{
				FieldInfo field = ReflectionExtensions.GetFields(type).FirstOrDefault(f => f.Name == "ForegroundProperty");
				if (field == null)
					throw new ArgumentException("type is not a Foregroundable type");

				var property = (DependencyProperty)field.GetValue(null);
				ForegroundProperties.Value.TryAdd(type, property);

				return property;
			}

			return foregroundProperty;
		}

		internal static IEnumerable<T> GetChildren<T>(this DependencyObject parent) where T : DependencyObject
		{
			int myChildrenCount = VisualTreeHelper.GetChildrenCount(parent);
			for (int i = 0; i < myChildrenCount; i++)
			{
				var child = VisualTreeHelper.GetChild(parent, i);
				if (child is T)
					yield return child as T;
				else
				{
					foreach (var subChild in child.GetChildren<T>())
						yield return subChild;
				}
			}
		}
	}
	internal static class Extensions
	{
		public static ConfiguredTaskAwaitable<T> DontSync<T>(this IAsyncOperation<T> self)
		{
			return self.AsTask().ConfigureAwait(false);
		}

		public static ConfiguredTaskAwaitable DontSync(this IAsyncAction self)
		{
			return self.AsTask().ConfigureAwait(false);
		}

		public static void SetBinding(this FrameworkElement self, DependencyProperty property, string path)
		{
			self.SetBinding(property, new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath(path) });
		}

		public static void SetBinding(this FrameworkElement self, DependencyProperty property, string path, Windows.UI.Xaml.Data.IValueConverter converter)
		{
			self.SetBinding(property, new Windows.UI.Xaml.Data.Binding { Path = new PropertyPath(path), Converter = converter });
		}

		internal static InputScopeNameValue GetKeyboardButtonType(this ReturnType returnType)
		{
			switch (returnType)
			{
				case ReturnType.Default:
				case ReturnType.Done:
				case ReturnType.Go:
				case ReturnType.Next:
				case ReturnType.Send:
					return InputScopeNameValue.Default;
				case ReturnType.Search:
					return InputScopeNameValue.Search;
				default:
					throw new System.NotImplementedException($"ReturnType {returnType} not supported");
			}
		}

		internal static InputScope ToInputScope(this ReturnType returnType)
		{
			var scopeName = new InputScopeName()
			{
				NameValue = GetKeyboardButtonType(returnType)
			};

			var inputScope = new InputScope
			{
				Names = { scopeName }
			};

			return inputScope;
		}

		internal static UwpScrollBarVisibility ToUwpScrollBarVisibility(this ScrollBarVisibility visibility)
		{
			switch (visibility)
			{
				case ScrollBarVisibility.Always:
					return UwpScrollBarVisibility.Visible;
				case ScrollBarVisibility.Default:
					return UwpScrollBarVisibility.Auto;
				case ScrollBarVisibility.Never:
					return UwpScrollBarVisibility.Hidden;
				default:
					return UwpScrollBarVisibility.Auto;
			}
		}

		public static T Clamp<T>(this T value, T min, T max) where T : IComparable<T>
		{
			if (value.CompareTo(min) < 0)
				return min;
			if (value.CompareTo(max) > 0)
				return max;
			return value;
		}


		internal static int ToEm(this double pt)
		{
			return Convert.ToInt32(pt * 0.0624f * 1000); //Coefficient for converting Pt to Em. The value is uniform spacing between characters, in units of 1/1000 of an em.
		}
	}
	public static class VisualElementExtensions
	{
		public static IVisualElementRenderer GetOrCreateRenderer(this VisualElement self)
		{
			if (self == null)
				throw new ArgumentNullException("self");

			IVisualElementRenderer renderer = Platform.GetRenderer(self);
			if (renderer == null)
			{
#pragma warning disable 618
				renderer = RendererFactory.CreateRenderer(self);
#pragma warning restore 618
				Platform.SetRenderer(self, renderer);
			}

			return renderer;
		}

		internal static void Cleanup(this VisualElement self)
		{
			if (self == null)
				throw new ArgumentNullException("self");

			IVisualElementRenderer renderer = Platform.GetRenderer(self);

			foreach (Element element in self.Descendants())
			{
				var visual = element as VisualElement;
				if (visual == null)
					continue;

				IVisualElementRenderer childRenderer = Platform.GetRenderer(visual);
				if (childRenderer != null)
				{
					childRenderer.Dispose();
					Platform.SetRenderer(visual, null);
				}
			}

			if (renderer != null)
			{
				renderer.Dispose();
				Platform.SetRenderer(self, null);
			}
		}

		internal static bool UseFormsVsm<T>(this T element) where T : VisualElement, IElementConfiguration<T>
		{
			// Determine whether we're letting the VSM handle the colors or doing it the old way
			// or disabling the legacy color management and doing it the old-old (pre 2.0) way
			return element.HasVisualStateGroups()
					|| !element.OnThisPlatform().GetIsLegacyColorModeEnabled();
		}
	}
	internal static class ImageExtensions2
	{
		public static Size GetImageSourceSize(this Windows.UI.Xaml.Media.ImageSource source)
		{
			if (source is null)
			{
				return Size.Zero;
			}
			else if (source is BitmapSource bitmap)
			{
				return new Size
				{
					Width = bitmap.PixelWidth,
					Height = bitmap.PixelHeight
				};
			}
			else if (source is CanvasImageSource canvas)
			{
				return new Size
				{
					Width = canvas.Size.Width,
					Height = canvas.Size.Height
				};
			}

			throw new InvalidCastException($"\"{source.GetType().FullName}\" is not supported.");
		}
	}
	public static class ImageExtensions
	{
		public static WStretch ToStretch(this Aspect aspect)
		{
			switch (aspect)
			{
				case Aspect.Fill:
					return WStretch.Fill;
				case Aspect.AspectFill:
					return WStretch.UniformToFill;
				default:
				case Aspect.AspectFit:
					return WStretch.Uniform;
			}
		}

		public static async Task<Windows.UI.Xaml.Media.ImageSource> ToWindowsImageSourceAsync(this ImageSource source, CancellationToken cancellationToken = default(CancellationToken))
		{
			if (source == null || source.IsEmpty)
				return null;

			var handler = Registrar.Registered.GetHandlerForObject<IImageSourceHandler>(source);
			if (handler == null)
				return null;

			try
			{
				return await handler.LoadImageAsync(source, cancellationToken);
			}
			catch (OperationCanceledException)
			{
				Log.Warning("Image loading", "Image load cancelled");
			}
			catch (Exception ex)
			{
				Log.Warning("Image loading", $"Image load failed: {ex}");
			}

			return null;
		}
	}
	internal static class PropertyChangedEventArgsExtensions
	{
		[MethodImpl(MethodImplOptions.AggressiveInlining)]
		public static bool Is(this PropertyChangedEventArgs args, BindableProperty property)
		{
			return args.PropertyName == property.PropertyName;
		}

		[MethodImpl(MethodImplOptions.AggressiveInlining)]
		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1)
		{
			return args.PropertyName == p0.PropertyName ||
				args.PropertyName == p1.PropertyName;
		}

		[MethodImpl(MethodImplOptions.AggressiveInlining)]
		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2)
		{
			return args.PropertyName == p0.PropertyName ||
				args.PropertyName == p1.PropertyName ||
				args.PropertyName == p2.PropertyName;
		}

		[MethodImpl(MethodImplOptions.AggressiveInlining)]
		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3)
		{
			return args.PropertyName == p0.PropertyName ||
				args.PropertyName == p1.PropertyName ||
				args.PropertyName == p2.PropertyName ||
				args.PropertyName == p3.PropertyName;
		}

		[MethodImpl(MethodImplOptions.AggressiveInlining)]
		public static bool IsOneOf(this PropertyChangedEventArgs args, BindableProperty p0, BindableProperty p1, BindableProperty p2, BindableProperty p3, BindableProperty p4)
		{
			return args.PropertyName == p0.PropertyName ||
				args.PropertyName == p1.PropertyName ||
				args.PropertyName == p2.PropertyName ||
				args.PropertyName == p3.PropertyName ||
				args.PropertyName == p4.PropertyName;
		}
	}

    internal static class FontImageSourceExtensions
    {
		public static TextBlock ToTextBlock(this FontImageSource fontImageSource)
        {
			var fontFamily = fontImageSource.FontFamily;
			var iconColor = fontImageSource.Color != Color.Default ? fontImageSource.Color : Color.White;
			var textBlock = new TextBlock() { Text = fontImageSource.Glyph, Foreground = iconColor.ToBrush() };
			var font = Font.OfSize(fontFamily, fontImageSource.Size);
			textBlock.ApplyFont(font);
			return textBlock;
		}
    }


	public class MyButtonRenderer : ViewRenderer<Button, FormsButton>
	{
                bool _fontApplied;

		FormsButton _button;
		PointerEventHandler _pointerPressedHandler;

		protected override void OnElementChanged(ElementChangedEventArgs<Button> e)
		{
			base.OnElementChanged(e);

			if (e.NewElement != null)
			{
				if (Control == null)
				{
					_button = new FormsButton();
					_pointerPressedHandler = new PointerEventHandler(OnPointerPressed);
					_button.Click += OnButtonClick;
					_button.AddHandler(PointerPressedEvent, _pointerPressedHandler, true);
					_button.Loading += ButtonOnLoading;
					_button.Loaded += ButtonOnLoaded;

					SetNativeControl(_button);
				}
				else
				{
					WireUpFormsVsm();
				}

				UpdateContent();

				//TODO: We may want to revisit this strategy later. If a user wants to reset any of these to the default, the UI won't update.
				if (Element.IsSet(VisualElement.BackgroundColorProperty) && Element.BackgroundColor != (Color)VisualElement.BackgroundColorProperty.DefaultValue)
					UpdateBackgroundBrush();

				if (Element.IsSet(VisualElement.BackgroundProperty) && (Element.Background != null && !Element.Background.IsEmpty))
					UpdateBackgroundBrush();

				if (Element.IsSet(Button.TextColorProperty) && Element.TextColor != (Color)Button.TextColorProperty.DefaultValue)
					UpdateTextColor();

				if (Element.IsSet(Button.BorderColorProperty) && Element.BorderColor != (Color)Button.BorderColorProperty.DefaultValue)
					UpdateBorderColor();

				if (Element.IsSet(Button.CharacterSpacingProperty))
					UpdateCharacterSpacing();

				if (Element.IsSet(Button.BorderWidthProperty) && Element.BorderWidth != (double)Button.BorderWidthProperty.DefaultValue)
					UpdateBorderWidth();

				if (Element.IsSet(Button.CornerRadiusProperty) && Element.CornerRadius != (int)Button.CornerRadiusProperty.DefaultValue)
					UpdateBorderRadius();

				// By default Button loads width padding 8, 4, 8 ,4
				if (Element.IsSet(Button.PaddingProperty))
					UpdatePadding();

				UpdateFont();
			}
		}

		void ButtonOnLoading(FrameworkElement sender, object args)
		{
			// HACK: Update IsNativeStateConsistent to fix issue rendering Buttons inside a CollectionView
			var collectionViewParent = Element.FindParent<CollectionView>();

			if (collectionViewParent == null)
				return;

			Element.IsNativeStateConsistent = false;
		}

		void ButtonOnLoaded(object o, RoutedEventArgs routedEventArgs)
		{
			WireUpFormsVsm();
		}

		void WireUpFormsVsm()
		{
			if (Element.UseFormsVsm())
			{
				InterceptVisualStateManager.Hook(Control.GetFirstDescendant<Windows.UI.Xaml.Controls.Grid>(), Control, Element);
			}
		}

		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
		{
			base.OnElementPropertyChanged(sender, e);

			if (e.IsOneOf(Button.TextProperty, Button.ImageSourceProperty, Button.TextTransformProperty))
			{
				UpdateContent();
			}
			else if (e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
			{
				UpdateCharacterSpacing();
			}
			else if (e.PropertyName == VisualElement.BackgroundColorProperty.PropertyName || e.PropertyName == VisualElement.BackgroundProperty.PropertyName)
			{
				UpdateBackgroundBrush();
			}
			else if (e.PropertyName == Button.TextColorProperty.PropertyName)
			{
				UpdateTextColor();
			}
			else if (e.PropertyName == Button.FontProperty.PropertyName)
			{
				UpdateFont();
			}
			else if (e.PropertyName == Button.BorderColorProperty.PropertyName)
			{
				UpdateBorderColor();
			}
			else if (e.PropertyName == Button.BorderWidthProperty.PropertyName)
			{
				UpdateBorderWidth();
			}
			else if (e.PropertyName == Button.CornerRadiusProperty.PropertyName)
			{
				UpdateBorderRadius();
			}
			else if (e.PropertyName == Button.PaddingProperty.PropertyName)
			{
				UpdatePadding();
			}
		}

		protected override void UpdateBackgroundColor()
		{
			// Button is a special case; we don't want to set the Control's background
			// because it goes outside the bounds of the Border/ContentPresenter, 
			// which is where we might change the BorderRadius to create a rounded shape.
			return;
		}

		protected override void UpdateBackground()
		{
			return;
		}

		protected override bool PreventGestureBubbling { get; set; } = true;

		void OnButtonClick(object sender, RoutedEventArgs e)
		{
			((IButtonController)Element)?.SendReleased();
			((IButtonController)Element)?.SendClicked();
		}

		void OnPointerPressed(object sender, RoutedEventArgs e)
		{
			((IButtonController)Element)?.SendPressed();
		}

		void UpdateBackgroundBrush()
		{
			if (Brush.IsNullOrEmpty(Element.Background))
				Control.BackgroundColor = Element.BackgroundColor != Color.Default ? Element.BackgroundColor.ToBrush() : (WBrush)Windows.UI.Xaml.Application.Current.Resources["ButtonBackgroundThemeBrush"];
			else
				Control.BackgroundColor = Element.Background.ToBrush();
		}

		void UpdateBorderColor()
		{
			Control.BorderBrush = Element.BorderColor != Color.Default ? Element.BorderColor.ToBrush() : (WBrush)Windows.UI.Xaml.Application.Current.Resources["ButtonBorderThemeBrush"];
		}

		void UpdateBorderRadius()
		{
			Control.BorderRadius = Element.CornerRadius;
		}

		void UpdateBorderWidth()
		{
			Control.BorderThickness = Element.BorderWidth == (double)Button.BorderWidthProperty.DefaultValue ? new WThickness(3) : new WThickness(Element.BorderWidth);
		}

		void UpdateCharacterSpacing()
		{
			Control.UpdateCharacterSpacing(Element.CharacterSpacing.ToEm());
		}

		async void UpdateContent()
		{
			var text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
			
			if(Element.ImageSource == null)
            {
				Control.Content = text;
				Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.RendererReady);
				return;
			}
			FrameworkElement icon = null;
			
			if (Element.ImageSource is FontImageSource fontImageSource)
            {
				icon = fontImageSource.ToTextBlock();
            }
            else
            {
				var elementImage = await Element.ImageSource.ToWindowsImageSourceAsync();
				var size = elementImage.GetImageSourceSize();
				var image = new WImage
				{
					Source = elementImage,
					VerticalAlignment = VerticalAlignment.Center,
					HorizontalAlignment = HorizontalAlignment.Center,
					Stretch = WStretch.Uniform,
					Width = size.Width,
					Height = size.Height,
				};

				// BitmapImage is a special case that has an event when the image is loaded
				// when this happens, we want to resize the button
				if (elementImage is BitmapImage bmp)
				{
					bmp.ImageOpened += (sender, args) => {
						var actualSize = bmp.GetImageSourceSize();
						image.Width = actualSize.Width;
						image.Height = actualSize.Height;
						Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.RendererReady);
					};
				}
				icon = image;
			}

			// No text, just the icon
			if (string.IsNullOrEmpty(text))
			{
				Control.Content = icon;
				Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.RendererReady);
				return;
			}

			// Both icon and text, so we need to build a container for them
			Control.Content = CreateContentContainer(Element.ContentLayout, icon , text);
			Element?.InvalidateMeasureNonVirtual(InvalidationTrigger.RendererReady);
		}

		static StackPanel CreateContentContainer(Button.ButtonContentLayout layout, FrameworkElement icon,string text)
		{
			var container = new StackPanel();
			var textBlock = new TextBlock
			{
				Text = text,
				VerticalAlignment = VerticalAlignment.Center,
				HorizontalAlignment = HorizontalAlignment.Center
			};

			var spacing = layout.Spacing;

			container.HorizontalAlignment = HorizontalAlignment.Center;
			container.VerticalAlignment = VerticalAlignment.Center;

			switch (layout.Position)
			{
				case Button.ButtonContentLayout.ImagePosition.Top:
					container.Orientation = Orientation.Vertical;
					icon.Margin = new WThickness(0, 0, 0, spacing);
					container.Children.Add(icon);
					container.Children.Add(textBlock);
					break;
				case Button.ButtonContentLayout.ImagePosition.Bottom:
					container.Orientation = Orientation.Vertical;
					icon.Margin = new WThickness(0, spacing, 0, 0);
					container.Children.Add(textBlock);
					container.Children.Add(icon);
					break;
				case Button.ButtonContentLayout.ImagePosition.Right:
					container.Orientation = Orientation.Horizontal;
					icon.Margin = new WThickness(spacing, 0, 0, 0);
					container.Children.Add(textBlock);
					container.Children.Add(icon);
					break;
				default:
					// Defaults to image on the left
					container.Orientation = Orientation.Horizontal;
					icon.Margin = new WThickness(0, 0, spacing, 0);
					container.Children.Add(icon);
					container.Children.Add(textBlock);
					break;
			}

			return container;
		}

		void UpdateFont()
		{
			if (Control == null || Element == null)
				return;

			if (Element.Font == Font.Default && !_fontApplied)
				return;

			Font fontToApply = Element.Font == Font.Default ? Font.SystemFontOfSize(NamedSize.Medium) : Element.Font;

			Control.ApplyFont(fontToApply);
			_fontApplied = true;
		}

		void UpdateTextColor()
		{
			Control.Foreground = Element.TextColor != Color.Default ? Element.TextColor.ToBrush() : (WBrush)Windows.UI.Xaml.Application.Current.Resources["DefaultTextForegroundThemeBrush"];
		}

		void UpdatePadding()
		{
			Control.Padding = new WThickness(
				Element.Padding.Left,
				Element.Padding.Top,
				Element.Padding.Right,
				Element.Padding.Bottom
			);
		}

		bool _isDisposed;
		protected override void Dispose(bool disposing)
		{
			if (_isDisposed)
				return;
			if (_button != null)
			{
				_button.Click -= OnButtonClick;
				_button.RemoveHandler(PointerPressedEvent, _pointerPressedHandler);
				_button.Loading -= ButtonOnLoading;
				_button.Loaded -= ButtonOnLoaded;

				_pointerPressedHandler = null;
			}

			_isDisposed = true;

			base.Dispose(disposing);
		}
	}
}
```

### API Changes ###
None


### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
When minimizing the app the icon will no longer have disappeared.


### Before/After Screenshots ### 
None

### Testing Procedure ###
TestContentPage and manual review.



### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
