### PR TITLE
Make sure ScrollViewRenderer on Android is resolving layout changes

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15066.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15066.cs
@@ -1,0 +1,42 @@
+﻿using Xamarin.Forms.CustomAttributes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Issue(IssueTracker.Github, 15066, "StackLayout's layout inside ScrollView is not updated properly when adding children", 
+		PlatformAffected.Android)]
+	public class Issue15066 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var instructions = new Label 
+			{ 
+				BackgroundColor = Color.AntiqueWhite,
+				Padding = 3,
+				Text = "Tap the 'Add' button until the added items are past the bottom of the screen." +
+					" Then scroll down - if there is any blue visible at the bottom, this test has failed."
+			};
+
+			var scrollView = new ScrollView() { BackgroundColor = Color.DarkBlue };
+
+			var layout = new StackLayout() { BackgroundColor = Color.DarkGreen };
+
+			var button = new Button() { Text = "Add" };
+
+			button.Clicked += (sender, args) => {
+				layout.Children.Add(new StackLayout() { BackgroundColor = Color.Gray, HeightRequest = 40.0 });
+			};
+
+			layout.Children.Add(instructions);
+			layout.Children.Add(button);
+
+			for (int n = 0; n < 8; n++)
+			{
+				layout.Children.Add(new StackLayout() { BackgroundColor = Color.Gray, HeightRequest = 40.0 });
+			}
+
+			scrollView.Content = layout;
+
+			Content = scrollView;
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14801.xaml.cs">
       <DependentUpon>Issue14801.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15066.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">
       <DependentUpon>Issue8804.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -287,6 +287,16 @@ namespace Xamarin.Forms.Platform.Android
 			_checkedForRtlScroll = true;
 		}
 
+		protected override void OnMeasure(int widthMeasureSpec, int heightMeasureSpec)
+		{
+			if (Element is Layout layout)
+			{
+				layout.ResolveLayoutChanges();
+			}
+
+			base.OnMeasure(widthMeasureSpec, heightMeasureSpec);
+		}
+
 		protected override void OnScrollChanged(int l, int t, int oldl, int oldt)
 		{
 			_checkedForRtlScroll = true;


### PR DESCRIPTION
Since ScrollViewRenderer does not inherit from VisualElementRenderer, it was not inheriting the override which resolves layout changes before a measure/layout pass.

This change overrides OnMeasure to handle that.

Fixes #15066 
Proposing this as an alternative to #15067.



