### PR TITLE
[Android] Allow cached screen density to be reset (#7239)

### DIFF
--- a/Xamarin.Forms.Platform.Android/ContextExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/ContextExtensions.cs
@@ -86,6 +86,11 @@ namespace Xamarin.Forms.Platform.Android
 				s_displayDensity = metrics.Density;
 		}
 
+		public static void ResetDensity()
+		{
+			s_displayDensity = float.MinValue;
+		}
+
 		public static AActivity GetActivity(this Context context)
 		{
 			if (context == null)


### PR DESCRIPTION
### Description of Change ###

Added a method to reset the variable that caches screen density used in pixel calculations. As documented in the related issue, changing the screen density will result in display problems. Elements do not have their actual sizes updated when screen density changes.

Rebuilding the application MainPage after the density changes does not resolve the display issues because the density used in the pixel calculations is cached based on the density of the screen the application is launched on. Resetting the density allows new UI elements to be created with the correct screen density. As a result, rebuilding the application MainPage after resetting the density resolves the display issues.

The change is very simple with zero impact on existing projects while allowing our company to go to production without a custom build of Xamarin Forms. We would love to see this change implemented in the next service release of Xamarin Forms and in MAUI since the issue still is still present.

### Issues Resolved ### 

- workaround #7239

### API Changes ###

Xamarin.Forms.Platform.Android.ContextExtensions

Added:
 - void ResetDensity()

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

Steps to reproduce are documented in related issue.
Our company is testing via Samsung Dex.
Docking and undocking our Xamarin application will result in display issues as the screen density changes.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
