### PR TITLE
fix #8293 and #14323 idea

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8293.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8293.cs
@@ -1,0 +1,60 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System;
+using System.Threading;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8293, "[Bug] Font Icon Disappears when Minimizing Window in UWP", PlatformAffected.UWP)]
+	public class Issue8293 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout
+			{
+				AutomationId = "Issue8293Label"
+			};
+
+			var iconColor = Color.White;
+			var fontImageSource = new FontImageSource { Size = 24, Color = Color.White, FontFamily = GetFontFamily("materialdesignicons-webfont.ttf", "Material Design Icons"), Glyph = GetGlyph("f625") };
+
+			List<Func<FontImageSource, View>> affectedViewsCreators = new List<Func<FontImageSource, View>>
+			{
+				(fontImageSource) => new Button { ImageSource = fontImageSource },
+			};
+
+			foreach (var affectedViewCreator in affectedViewsCreators)
+			{
+				var affectedView = affectedViewCreator(fontImageSource);
+				stackLayout.Children.Add(affectedView);
+			}
+
+			Content = stackLayout;
+
+		}
+
+		private string GetFontFamily(string fileName, string fontName)
+		{
+			return $"Assets/Fonts/{fileName}#{fontName}";
+		}
+
+		private static string GetGlyph(string codePoint)
+		{
+			int p = int.Parse(codePoint, System.Globalization.NumberStyles.HexNumber);
+			return char.ConvertFromUtf32(p);
+		}
+	}
+
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14801.xaml.cs">
       <DependentUpon>Issue14801.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8293.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">
       <DependentUpon>Issue8804.xaml</DependentUpon>
     </Compile>


### PR DESCRIPTION

### Description of Change ###

ButtonRenderer to render a FontIcon for FontImageSource instead of an Image with CanvasImageSource that is the cause of these issues.

### Issues Resolved ### 
possible fix of #8293 and #14323


 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
Icon does not disappear

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Manual Xamarin.Forms.Controls.Issues

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)

To be discussed with https://github.com/xamarin/Xamarin.Forms/pull/15070
