### PR TITLE
fix the calculations of the needed size of a ScollView on Android (Issue 15100)

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15100.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15100.xaml
@@ -1,0 +1,21 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage xmlns="http://xamarin.com/schemas/2014/forms"
+                          xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+                          xmlns:controls="clr-namespace:Xamarin.Forms.Controls" 
+                          x:Class="Xamarin.Forms.Controls.Issues.Issue15100"
+                          x:Name="page">
+    <ScrollView BackgroundColor="DarkBlue" Orientation="Both" Padding="5.0">
+        <Frame BackgroundColor="DarkGreen"
+               BorderColor="White"
+               CornerRadius="0.0"
+               HeightRequest="{Binding Path=Height, Source={x:Reference page}}"
+               Margin="30.0"
+               Padding="0.0"
+               WidthRequest="{Binding Path=Width, Source={x:Reference page}}">
+            <Label HorizontalTextAlignment="Center"
+                   TextColor="#FFAAAAAA"
+                   Padding="3.0"
+                   Text="Scroll to the bottom right of the page.&#x0a;If the white frame or the dark blue margin is not visible&#x0a;or the margin is thinner than the margin at the top left of the page,&#x0a;the test has failed." />
+        </Frame>
+    </ScrollView>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15100.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15100.xaml.cs
@@ -17,7 +17,9 @@ namespace Xamarin.Forms.Controls.Issues
 	{
 		public Issue15100()
 		{
+#if APP
 			InitializeComponent();
+#endif
 		}
 
 		protected override void Init()

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15100.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15100.xaml.cs
@@ -1,0 +1,27 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15100, "[Bug] ScrollView's size does not consider all Margins and Paddings on Android", PlatformAffected.Android)]
+	public partial class Issue15100 : TestContentPage
+	{
+		public Issue15100()
+		{
+			InitializeComponent();
+		}
+
+		protected override void Init()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1874,6 +1874,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue15287.xaml.cs">
       <DependentUpon>Issue15287.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15100.xaml.cs">
+      <DependentUpon>Issue15100.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2429,6 +2432,8 @@
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue15287.xaml">
       <SubType>Designer</SubType>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue15100.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewContainer.cs
@@ -75,7 +75,7 @@ namespace Xamarin.Forms.Platform.Android
 			// we need to make sure we are big enough to be laid out at 0,0
 			if (_childView != null)
 			{
-				SetMeasuredDimension((int)Context.ToPixels(_childView.Bounds.Right + _parent.Padding.Right), (int)Context.ToPixels(_childView.Bounds.Bottom + _parent.Padding.Bottom));
+				SetMeasuredDimension((int)Context.ToPixels(_childView.Bounds.Right + _childView.Margin.Right + _parent.Padding.Right), (int)Context.ToPixels(_childView.Bounds.Bottom + _childView.Margin.Bottom + _parent.Padding.Bottom));
 			}
 			else
 				SetMeasuredDimension((int)Context.ToPixels(_parent.Padding.Right), (int)Context.ToPixels(_parent.Padding.Bottom));

--- a/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ScrollViewRenderer.cs
@@ -271,7 +271,10 @@ namespace Xamarin.Forms.Platform.Android
 				MeasureSpecFactory.MakeMeasureSpec(bottom - top, MeasureSpecMode.Unspecified));
 			base.OnLayout(changed, left, top, right, bottom);
 			if (_view.Content != null && _hScrollView != null)
-				_hScrollView.Layout(0, 0, right - left, Math.Max(bottom - top, (int)Context.ToPixels(_view.Content.Height)));
+			{
+				double scrollViewHeight = _view.Content.Height + _view.Padding.Top + _view.Padding.Bottom + _view.Content.Margin.Top + _view.Content.Margin.Bottom;
+				_hScrollView.Layout(0, 0, right - left, Math.Max(bottom - top, (int)Context.ToPixels(scrollViewHeight)));
+			}
 			else if (_view.Content != null && requestContainerLayout)
 				_container?.RequestLayout();
 


### PR DESCRIPTION
### Description of Change ###

The calculations of the needed size of a ScollView on Android do now always consider all Margins of its child view and all Paddings of the ScrollView.

### Issues Resolved ### 

- fixes #15100 

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Now a ScrollView takes up all the space needed by the size of its child view, the Margins of the child view and the Paddings of the ScrollView.
So it is possible to see the complete child view and the complete Padding/Margin surrounding the child view.

### Before/After Screenshots ### 

![Screenshot_20220127_142147_com companyname xamarinformsscrollviewsizebug_shrinked](https://user-images.githubusercontent.com/9087189/151373595-4feea61c-8862-4c7e-8524-6332ef69b944.jpg)
![Screenshot_20220127_144226_com companyname xamarinformsscrollviewsizebug_shrinked](https://user-images.githubusercontent.com/9087189/151392667-74489f9a-8055-4ef6-8702-6174ea9c7938.jpg)

### Testing Procedure ###

- Android: description can be seen in Issue15100.cs
- iOS: not able to test this
- UWP: bug is not present

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
