### PR TITLE
Prevent CollectionView.EmptyView from showing up while it shouldn't on iOS

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/MyCollectionView.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/MyCollectionView.xaml
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<!-- Used in Issue13794 -->
+<CollectionView
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.Issues.MyCollectionView"
+    ItemsSource="{Binding Data}"
+    SelectionMode="Single"
+    SelectionChanged="CollectionView_SelectionChanged">
+
+    <CollectionView.EmptyView>
+        <Label Text="The collection is empty" BackgroundColor="Transparent" VerticalOptions="CenterAndExpand" HorizontalOptions="FillAndExpand" HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
+    </CollectionView.EmptyView>
+
+    <CollectionView.Footer>
+        <Grid HeightRequest="50" BackgroundColor="LightGray">
+            <Label Text="Footer" VerticalOptions="Center" HorizontalOptions="Center"  />
+        </Grid>
+    </CollectionView.Footer>
+
+    <CollectionView.ItemTemplate>
+        <DataTemplate>
+            <SwipeView>
+                  <SwipeView.RightItems>
+                    <SwipeItems>
+                        <SwipeItem Text="Delete" BackgroundColor="Red" Invoked="DeleteItem_Invoked" />
+                    </SwipeItems>
+                </SwipeView.RightItems>
+
+                
+                <Label Text="{Binding .}" Padding="20" />
+
+            </SwipeView>
+        </DataTemplate>
+    </CollectionView.ItemTemplate>
+
+</CollectionView>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/MyCollectionView.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Controls/MyCollectionView.xaml.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.ObjectModel;
+using System.Linq;
+using Xamarin.Forms;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+    public partial class MyCollectionView : CollectionView
+    {
+        public ObservableCollection<string> Data { get; private set; }
+
+        public MyCollectionView(ObservableCollection<string> data)
+        {
+            InitializeComponent();
+            BindingContext = this;
+
+            // Moving this above InitializeComponent fixes the problem.
+            Data = data;
+        }
+
+        void CollectionView_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (e.CurrentSelection == null || e.CurrentSelection.Count == 0)
+            {
+                return;
+            }
+
+            SelectedItem = null;
+
+            if (e.CurrentSelection.FirstOrDefault() is String data)
+            {
+                Console.WriteLine($"Selected: {data}");
+            }
+        }
+
+        void DeleteItem_Invoked(System.Object sender, System.EventArgs e)
+        {
+            if (sender is SwipeItem swipeItem && swipeItem.BindingContext is String dataItem)
+            {
+                Data.Remove(dataItem);
+            }
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13794.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13794.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 13794, "[Bug] CollectionView iOS draws both EmptyView and Items/ItemTemplate", PlatformAffected.iOS)]
+	public class Issue13794 : TestContentPage
+	{
+		ObservableCollection<string> _data;
+		MyCollectionView _myCollectionView;
+
+		public Issue13794()
+		{
+			var carouselView = new CarouselView();
+
+            BindingContext = this;
+
+            // This is gross, but the idea is the page contains the data and passes a refernece to the view.
+            // Data is loaded from the page (eg via web request, loaded from file)
+            _data = new ObservableCollection<string>();
+
+            _myCollectionView = new MyCollectionView(_data);
+
+            // In my code I was replacing the Footer already defined in the xaml.
+            // This didn't seem to contribute to the issue.
+            //_myCollectionView.Footer = new BoxView();
+
+            // Add collection view to a CarouselView. This was the only way I could replicate the issue.
+            // In my actual app I have 3 different user feeds, and user can change between them.
+            carouselView.ItemsSource = new List<View>()
+            {
+                _myCollectionView,
+            };
+
+            // This makes more sense when there is 3 differnet things to select.
+            carouselView.ItemTemplate = new MyDataTemplateSelector()
+            {
+                MyCollectionViewDataTemplate = new DataTemplate(() => _myCollectionView),
+            };
+
+            // I was trying to set _myCollectionView as root Content but it doesn't appear to
+            // cause the problem. Its related to the CarouselView
+            //Content = _myCollectionView;
+
+
+            // Add data
+            var rand = new Random();
+            _data.Add(rand.Next().ToString());
+            _data.Add(rand.Next().ToString());
+            _data.Add(rand.Next().ToString());
+
+
+
+            // Does not have the issue if the data is loaded with a delay.
+            /*
+            Task.Run(async () =>
+            {
+                await Task.Delay(1000);
+
+                var rand = new Random();
+                _data.Add(rand.Next().ToString());
+                _data.Add(rand.Next().ToString());
+                _data.Add(rand.Next().ToString());
+            });
+            */
+
+            Content = carouselView;
+		}
+
+		protected override void Init()
+		{
+			
+		}
+	}
+
+	public class MyDataTemplateSelector : DataTemplateSelector
+	{
+		public DataTemplate MyCollectionViewDataTemplate { get; set; }
+
+		protected override DataTemplate OnSelectTemplate(object item, BindableObject container)
+		{
+			if (item is MyCollectionView)
+			{
+				return MyCollectionViewDataTemplate;
+			}
+
+			return null;
+		}
+	}
+}
+

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1861,6 +1861,11 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14805.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue11954.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13918.xaml.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13794.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Controls\MyCollectionView.xaml.cs">
+      <DependentUpon>MyCollectionView.xaml</DependentUpon>
+      <SubType>Code</SubType>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2405,6 +2410,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13918.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Controls\MyCollectionView.xaml">
+      <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
   </ItemGroup>
@@ -3013,7 +3022,7 @@
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue14801.xaml">
       <SubType>Designer</SubType>
-      <Generator>MSBuild:Compile</Generator>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue8804.xaml">
       <SubType>Designer</SubType>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -17,7 +17,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public TItemsView ItemsView { get; }
 		protected ItemsViewLayout ItemsViewLayout { get; set; }
 		bool _initialized;
-		bool _isEmpty;
+		bool _isEmpty = true;
 		bool _emptyViewDisplayed;
 		bool _disposed;
 


### PR DESCRIPTION
### Description of Change ###

TBD, want to verify with the author first through resulting NuGets on this build

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #13794

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
