### PR TITLE
removed a broken direct link to net47 dev pack

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -104,7 +104,6 @@ string[] netFrameworkSdksLocalInstall = new string[]
     "https://go.microsoft.com/fwlink/?linkid=2099470", //NET461 SDK
     "https://go.microsoft.com/fwlink/?linkid=874338", //NET472 SDK
     "https://go.microsoft.com/fwlink/?linkid=2099465", //NET47
-    "https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe", //net47 targeting pack
     "https://go.microsoft.com/fwlink/?linkid=2088517", //NET48 SDK
 };
 


### PR DESCRIPTION
Hello! 
Running the `\build.ps1 -Target provision` on the recent branch, I've noticed that the script cannot pass through all the steps:
```
Installing: https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe
An error occurred when executing task 'provision-netsdk-local'.
Error: One or more errors occurred. (One or more errors occurred. (Response status code does not indicate success: 404 (Not Found).))
        Response status code does not indicate success: 404 (Not Found).
```

That happened due to line 107 in the file `build.cake`:
```
string[] netFrameworkSdksLocalInstall = new string[]
{
    "https://go.microsoft.com/fwlink/?linkid=2099470", //NET461 SDK
    "https://go.microsoft.com/fwlink/?linkid=874338", //NET472 SDK
    106: "https://go.microsoft.com/fwlink/?linkid=2099465", //NET47
    107: "https://download.microsoft.com/download/A/1/D/A1D07600-6915-4CB8-A931-9A980EF47BB7/NDP47-DevPack-KB3186612-ENU.exe", //net47 targeting pack
    "https://go.microsoft.com/fwlink/?linkid=2088517", //NET48 SDK
};
```
I've tried to solve this issue and found that the link `https://go.microsoft.com/fwlink/?linkid=2099465` is pointing to the same (at least now) file name: `ndp47-devpack-kb3186612-enu.exe`, so I simply removed line 107 as needless. The link can be found from the https://support.microsoft.com/en-us/topic/the-net-framework-4-7-developer-pack-and-language-packs-80ad488a-bed3-3468-c9bd-4563a6f54636 

I double-checked execution of the fixed provision command on a freshly installed win11+vs2019, the result is OK:
![vmware_05_02_2022__21_10_07__6bf6ffdf-2f86-45b2-abec-c0b6030284f0](https://user-images.githubusercontent.com/3184414/152655523-fadb6136-1ca6-4fbf-9fcd-f67a108bf0b3.jpg)


Could you verify and accept my PR?  