### PR TITLE
Software Bill of Materials (SBOM) manifest generation

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -271,7 +271,7 @@ stages:
       dependsOn: nuget_signing
       displayName: 'Software Bill of Materials'
       jobs:
-      - template: compliance/sbom/job.v1.yml@xamarin-templates
+      - template: compliance/sbom/job.v1.yml@xamarin-templates        # Software Bill of Materials (SBOM): https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator
         parameters:
           artifactNames: ['nuget']
           artifactMap: ['nuget/signed']

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,6 +11,8 @@ variables:
   value: true
 - name: DOTNET_VERSION
   value: 5.0.102
+- name: signingCondition
+  value: and(succeeded(), ne(variables['signVmImage'], ''), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
 
 resources:
   repositories:
@@ -260,8 +262,19 @@ stages:
             signedArtifactName: nuget
             signedArtifactPath: signed
             displayName: Sign Phase
-            condition: and(succeeded(), ne(variables['signVmImage'], ''), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+            condition: ${{ variables.signingCondition }}
             preSignSteps:
               - task: NuGetToolInstaller@1
                 inputs:
                   versionSpec: $(NUGET_VERSION)
+    - stage: sbom
+      dependsOn: nuget_signing
+      displayName: 'Software Bill of Materials'
+      jobs:
+      - template: compliance/sbom/job.v1.yml@xamarin-templates
+        parameters:
+          artifactNames: ['nuget']
+          artifactMap: ['nuget/signed']
+          packageName: 'Xamarin Forms'
+          packageFilter: '*.nupkg'
+          condition: ${{ variables.signingCondition }}


### PR DESCRIPTION
### Description of Change ###

Per Executive Order (EO) produce a Software Bill of Materials (SBOM) capturing the produced nuget files from a dedicated job
https://eng.ms/docs/cloud-ai-platform/devdiv/one-engineering-system-1es/1es-docs/secure-supply-chain/ado-sbom-generator

As a result of this change you will find an artifact named `sbom` attached to each build.  Within that artifact is a `manifest.json` file under a `_manifest` directory capturing all of the packages that constitute the `Software Bill of Materials` 

The `sbom` job captures the nuget package files (*.nupkg) published (uploaded) by the build. The sbom is only produced for signed builds.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
