### PR TITLE
Fix gtk shapes rendering nav glitch

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/NavigationPageRenderer.cs
@@ -359,6 +359,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 			{
 				var oldPageRenderer = Platform.GetRenderer(oldPage);
 				oldPageRenderer.Container.Sensitive = true;
+				oldPageRenderer.Container.ShowAll();
 			}
 
 			(page as IPageController)?.SendDisappearing();


### PR DESCRIPTION

### Description of Change ###

Queue a redraw properly when coming back from navigation-bar event.

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/15170

### API Changes ###

 None

### Platforms Affected ### 

- Gtk

### Testing Procedure ###
See the testcase in https://github.com/xamarin/Xamarin.Forms/issues/15170

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
