### PR TITLE
Blank WebViews on iOS - Determine if WebView has been terminated

### DIFF
--- a/Xamarin.Forms.Core/WebNavigationResult.cs
+++ b/Xamarin.Forms.Core/WebNavigationResult.cs
@@ -5,6 +5,7 @@ namespace Xamarin.Forms
 		Success = 1,
 		Cancel = 2,
 		Timeout = 3,
-		Failure = 4
+		Failure = 4,
+		Terminated = 5
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/WkWebViewRenderer.cs
@@ -714,6 +714,16 @@ namespace Xamarin.Forms.Platform.iOS
 				_renderer.UpdateCanGoBackForward();
 			}
 
+			public override void ContentProcessDidTerminate(WKWebView webView)
+			{
+				var url = GetCurrentUrl();
+				WebView.SendNavigated(
+					new WebNavigatedEventArgs(_lastEvent, new UrlWebViewSource { Url = url }, url, WebNavigationResult.Terminated)
+				);
+
+				_renderer.UpdateCanGoBackForward();
+			}
+
 			public override void DidFinishNavigation(WKWebView webView, WKNavigation navigation)
 			{
 				if (webView.IsLoading)


### PR DESCRIPTION
### Description of Change ###

From time to time WebViews on iOS will show as blank because iOS terminates them. This is a common issue, it impacts all frameworks and native apps:

https://blog.embrace.io/bug-of-the-month-blank-webviews/
https://github.com/flutter/flutter/issues/61795
https://nevermeant.dev/handling-blank-wkwebviews/#my-solutions

TLDR;
A nice video explaining this issue: https://youtu.be/r3wDBjr5LKk

The solution is to allow the app to react to:
https://developer.apple.com/documentation/webkit/wknavigationdelegate/1455639-webviewwebcontentprocessdidtermi?language=objc


### Issues Resolved ### 

React to blank WebViews after iOS has terminated them, this can happen if you leave an app with a WebView and return after some time.

### API Changes ###

```
	public enum WebNavigationResult
	{
		Success = 1,
		Cancel = 2,
		Timeout = 3,
		Failure = 4,
		Terminated = 5
	}
```

A new terminated status was added to a navigation event.  There is no dedicated error handler, but this does seem to work nicely with the navigation event.  It will trigger a navigation event of terminated, allowing the app to reload the WebView - including the URL that was previously loaded.

Added:
`Terminated = 5`


### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Registering  `Navigating` event handler and checking for a terminated status followed by an alert is the best method to verify this.  

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
