### PR TITLE
handle SurfaceContentsLost, fake ImageSource.

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8293.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue8293.cs
@@ -1,0 +1,62 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.Generic;
+using System;
+using System.Threading;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 8293, "[Bug] Font Icon Disappears when Minimizing Window in UWP", PlatformAffected.UWP)]
+	public class Issue8293 : TestContentPage
+	{
+		protected override void Init()
+		{
+			var stackLayout = new StackLayout
+			{
+				AutomationId = "Issue8293Label"
+			};
+
+			var iconColor = Color.White;
+			var fontImageSource = new FontImageSource { Size = 60, Color = Color.White, FontFamily = GetFontFamily("materialdesignicons-webfont.ttf", "Material Design Icons"), Glyph = GetGlyph("f625") };
+
+			List<Func<FontImageSource, View>> affectedViewsCreators = new List<Func<FontImageSource, View>>
+			{
+				(fontImageSource) => new Button { ImageSource = fontImageSource},
+				(fontImageSource) => new ImageButton { Source = fontImageSource},
+				(fontImageSource) => new Image { Source = fontImageSource},
+			};
+
+			foreach (var affectedViewCreator in affectedViewsCreators)
+			{
+				var affectedView = affectedViewCreator(fontImageSource);
+				stackLayout.Children.Add(affectedView);
+			}
+
+			Content = stackLayout;
+
+		}
+
+		private string GetFontFamily(string fileName, string fontName)
+		{
+			return $"Assets/Fonts/{fileName}#{fontName}";
+		}
+
+		private static string GetGlyph(string codePoint)
+		{
+			int p = int.Parse(codePoint, System.Globalization.NumberStyles.HexNumber);
+			return char.ConvertFromUtf32(p);
+		}
+	}
+
+
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -53,6 +53,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14801.xaml.cs">
       <DependentUpon>Issue14801.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue8293.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8606.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue15066.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">

--- a/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ButtonRenderer.cs
@@ -235,6 +235,10 @@ namespace Xamarin.Forms.Platform.UWP
 					image.Source = recreateImageSource.CreateImageSource();
 				};
 			}
+			else
+			{
+				surfaceContentsLostAction = null;
+			}
 
 			// BitmapImage is a special case that has an event when the image is loaded
 			// when this happens, we want to resize the button

--- a/Xamarin.Forms.Platform.UAP/Extensions/ImageExtensions.cs
+++ b/Xamarin.Forms.Platform.UAP/Extensions/ImageExtensions.cs
@@ -22,7 +22,13 @@ namespace Xamarin.Forms.Platform.UWP
 			{
 				return Size.Zero;
 			}
-			else if (source is BitmapSource bitmap)
+
+			if(source is IRecreateImageSource recreateImageSource)
+			{
+				source = recreateImageSource.InitialSource;
+			}
+
+			if (source is BitmapSource bitmap)
 			{
 				return new Size
 				{
@@ -38,6 +44,7 @@ namespace Xamarin.Forms.Platform.UWP
 					Height = canvas.Size.Height
 				};
 			}
+			
 
 			throw new InvalidCastException($"\"{source.GetType().FullName}\" is not supported.");
 		}

--- a/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
+++ b/Xamarin.Forms.Platform.UAP/FontImageSourceHandler.cs
@@ -1,9 +1,6 @@
 ﻿using System;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.Graphics.Canvas;
-using Microsoft.Graphics.Canvas.Text;
-using Microsoft.Graphics.Canvas.UI.Xaml;
 using Windows.UI.Xaml.Controls;
 using WFontIconSource = Microsoft.UI.Xaml.Controls.FontIconSource;
 
@@ -11,42 +8,17 @@ namespace Xamarin.Forms.Platform.UWP
 {
 	public sealed class FontImageSourceHandler : IImageSourceHandler, IIconElementHandler
 	{
-		float _minimumDpi = 300;
-
 		public Task<Windows.UI.Xaml.Media.ImageSource> LoadImageAsync(ImageSource imagesource,
 			CancellationToken cancelationToken = default(CancellationToken))
 		{
 			if (!(imagesource is FontImageSource fontsource))
 				return null;
 
-			var device = CanvasDevice.GetSharedDevice();
-			var dpi = Math.Max(_minimumDpi, Windows.Graphics.Display.DisplayInformation.GetForCurrentView().LogicalDpi);
-
-			var textFormat = new CanvasTextFormat
-			{
-				FontFamily = GetFontSource(fontsource),
-				FontSize = (float)fontsource.Size,
-				HorizontalAlignment = CanvasHorizontalAlignment.Left,
-				VerticalAlignment = CanvasVerticalAlignment.Center,
-				Options = CanvasDrawTextOptions.Default
-			};
-
-			using (var layout = new CanvasTextLayout(device, fontsource.Glyph, textFormat, (float)fontsource.Size, (float)fontsource.Size))
-			{
-				var canvasWidth = (float)layout.LayoutBounds.Width + 2;
-				var canvasHeight = (float)layout.LayoutBounds.Height + 2;
-
-				var imageSource = new CanvasImageSource(device, canvasWidth, canvasHeight, dpi);
-				using (var ds = imageSource.CreateDrawingSession(Windows.UI.Colors.Transparent))
-				{
-					var iconcolor = (fontsource.Color != Color.Default ? fontsource.Color : Color.White).ToWindowsColor();
-
-					// offset by 1 as we added a 1 inset
-					ds.DrawTextLayout(layout, 1f, 1f, iconcolor);
-				}
-
-				return Task.FromResult((Windows.UI.Xaml.Media.ImageSource)imageSource);
-			}
+			
+			var fontFamily = GetFontSource(fontsource);
+			var fontSize = (float)fontsource.Size;
+			var iconcolor = (fontsource.Color != Color.Default ? fontsource.Color : Color.White).ToWindowsColor();
+			return Task.FromResult((Windows.UI.Xaml.Media.ImageSource)new ImageSourceProviderImageSource(fontFamily, fontSize, fontsource.Glyph, iconcolor));
 		}
 
 		public Task<Microsoft.UI.Xaml.Controls.IconSource> LoadIconSourceAsync(ImageSource imagesource, CancellationToken cancellationToken = default(CancellationToken))

--- a/Xamarin.Forms.Platform.UAP/IRecreateImageSource.cs
+++ b/Xamarin.Forms.Platform.UAP/IRecreateImageSource.cs
@@ -1,0 +1,8 @@
+﻿namespace Xamarin.Forms.Platform.UWP
+{
+	public interface IRecreateImageSource
+	{
+		Windows.UI.Xaml.Media.ImageSource InitialSource { get; }
+		Windows.UI.Xaml.Media.ImageSource CreateImageSource();
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -18,10 +18,19 @@ namespace Xamarin.Forms.Platform.UWP
 		bool _disposed;
 		WImage _image;
 		FormsButton _formsButton;
+		Action surfaceContentsLostAction;
 
 		public ImageButtonRenderer() : base()
 		{
 			ImageElementManager.Init(this);
+		}
+
+		protected override void SurfaceContentsLost()
+		{
+			if (surfaceContentsLostAction != null)
+			{
+				surfaceContentsLostAction();
+			}
 		}
 
 		protected override void Dispose(bool disposing)
@@ -273,6 +282,15 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void IImageVisualElementRenderer.SetImage(Windows.UI.Xaml.Media.ImageSource image)
 		{
+			if (image is IRecreateImageSource recreateImageSource)
+			{
+				image = recreateImageSource.InitialSource;
+				surfaceContentsLostAction = () =>
+				{
+					_image.Source = recreateImageSource.CreateImageSource();
+				};
+			}
+			
 			_image.Source = image;
 		}
 

--- a/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageButtonRenderer.cs
@@ -290,6 +290,10 @@ namespace Xamarin.Forms.Platform.UWP
 					_image.Source = recreateImageSource.CreateImageSource();
 				};
 			}
+			else
+			{
+				surfaceContentsLostAction = null;
+			}
 			
 			_image.Source = image;
 		}

--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -143,13 +143,17 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void IImageVisualElementRenderer.SetImage(Windows.UI.Xaml.Media.ImageSource image)
 		{
-			if(image is IRecreateImageSource recreateImageSource)
+			if (image is IRecreateImageSource recreateImageSource)
 			{
 				image = recreateImageSource.InitialSource;
 				surfaceContentsLostAction = () =>
 				{
 					Control.Source = recreateImageSource.CreateImageSource();
 				};
+			}
+			else
+			{
+				surfaceContentsLostAction = null;
 			}
 			Control.Source = image;
 		}

--- a/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageRenderer.cs
@@ -10,11 +10,20 @@ namespace Xamarin.Forms.Platform.UWP
 	{
 		bool _measured;
 		bool _disposed;
+		Action surfaceContentsLostAction;
 
 		public ImageRenderer() : base()
 		{
 			ImageElementManager.Init(this);
 			Windows.UI.Xaml.Application.Current.Resuming += OnResumingAsync;
+		}
+
+		protected override void SurfaceContentsLost()
+		{
+			if (surfaceContentsLostAction != null)
+			{
+				surfaceContentsLostAction();
+			}
 		}
 
 		bool IImageVisualElementRenderer.IsDisposed => _disposed;
@@ -134,6 +143,14 @@ namespace Xamarin.Forms.Platform.UWP
 
 		void IImageVisualElementRenderer.SetImage(Windows.UI.Xaml.Media.ImageSource image)
 		{
+			if(image is IRecreateImageSource recreateImageSource)
+			{
+				image = recreateImageSource.InitialSource;
+				surfaceContentsLostAction = () =>
+				{
+					Control.Source = recreateImageSource.CreateImageSource();
+				};
+			}
 			Control.Source = image;
 		}
 

--- a/Xamarin.Forms.Platform.UAP/ImageSourceProviderImageSource.cs
+++ b/Xamarin.Forms.Platform.UAP/ImageSourceProviderImageSource.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using Microsoft.Graphics.Canvas;
+using Microsoft.Graphics.Canvas.Text;
+using Microsoft.Graphics.Canvas.UI.Xaml;
+
+namespace Xamarin.Forms.Platform.UWP
+{
+	public class ImageSourceProviderImageSource : Windows.UI.Xaml.Media.Imaging.SurfaceImageSource, IRecreateImageSource
+	{
+		private const float _minimumDpi = 300;
+		private readonly string fontFamily;
+		private readonly float fontSize;
+		private readonly string glyph;
+		private readonly Windows.UI.Color iconColor;
+
+		public Windows.UI.Xaml.Media.ImageSource InitialSource { get; private set; }
+
+		public ImageSourceProviderImageSource(string fontFamily, float fontSize,string glyph, Windows.UI.Color iconColor) :base(0,0)
+		{
+			this.fontFamily = fontFamily;
+			this.fontSize = fontSize;
+			this.glyph = glyph;
+			this.iconColor = iconColor;
+			InitialSource = CreateImageSource();
+		}
+
+		public Windows.UI.Xaml.Media.ImageSource CreateImageSource()
+		{
+			var device = CanvasDevice.GetSharedDevice();
+			var dpi = Math.Max(_minimumDpi, Windows.Graphics.Display.DisplayInformation.GetForCurrentView().LogicalDpi);
+
+			var textFormat = new CanvasTextFormat
+			{
+				FontFamily = fontFamily,
+				FontSize = fontSize,
+				HorizontalAlignment = CanvasHorizontalAlignment.Left,
+				VerticalAlignment = CanvasVerticalAlignment.Center,
+				Options = CanvasDrawTextOptions.Default
+			};
+
+			using (var layout = new CanvasTextLayout(device, glyph, textFormat, (float)fontSize, (float)fontSize))
+			{
+				var canvasWidth = (float)layout.LayoutBounds.Width + 2;
+				var canvasHeight = (float)layout.LayoutBounds.Height + 2;
+
+				var imageSource = new CanvasImageSource(device, canvasWidth, canvasHeight, dpi);
+				using (var ds = imageSource.CreateDrawingSession(Windows.UI.Colors.Transparent))
+				{
+					// offset by 1 as we added a 1 inset
+					ds.DrawTextLayout(layout, 1f, 1f, iconColor);
+				}
+				return imageSource;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/VisualElementRenderer.cs
@@ -32,6 +32,29 @@ namespace Xamarin.Forms.Platform.UWP
 
 		Canvas _backgroundLayer;
 
+		public VisualElementRenderer()
+		{
+			this.Loaded += VisualElementRenderer_Loaded;
+			this.Unloaded += VisualElementRenderer_Unloaded;
+		}
+
+		private void VisualElementRenderer_Unloaded(object sender, RoutedEventArgs e)
+		{
+			CompositionTarget.SurfaceContentsLost -= CompositionTarget_SurfaceContentsLost;
+		}
+
+		private void VisualElementRenderer_Loaded(object sender, RoutedEventArgs e)
+		{
+			CompositionTarget.SurfaceContentsLost += CompositionTarget_SurfaceContentsLost;
+		}
+
+		private void CompositionTarget_SurfaceContentsLost(object sender, object e)
+		{
+			SurfaceContentsLost();
+		}
+
+		protected virtual void SurfaceContentsLost() { }
+
 		public TNativeElement Control { get; private set; }
 
 		public TElement Element { get; private set; }


### PR DESCRIPTION

### Description of Change ###

React to the CompositionTarget.SurfaceContentsLost event ( that is the cause of the issue ) in the base renderer calling a new protected method to notify derivations that may need to update their image sources.
ImageRenderer, ImageButtonRenderer and ButtonRenderer all update image sources that require this functionality.
Image sources requiring this functionality implement a new interface IRecreateImageSource.
This is hacky as an ImageSource should be usable directly but it is the CanvasImageSource that necessitates this behaviour.



The best solution is an SvgImageSource instead of CanvasImageSource.
See https://github.com/xamarin/Xamarin.Forms/pull/15070#issuecomment-1017772128

See https://microsoft.github.io/Win2D/WinUI3/html/M_Microsoft_Graphics_Canvas_UI_Xaml_CanvasImageSource_Recreate.htm and https://github.com/microsoft/Win2D-Samples/blob/c4106b22ac385719c3424021c9a58ca3ba8a9d07/ExampleGallery/ImageSourceUpdateRegion.xaml.cs for further details on SurfaceContentLost.

@jfversluis Can we work together to get this fixed as it severely limits Xamarin Forms as a cross platform framework.

Other solutions proposed.
https://github.com/xamarin/Xamarin.Forms/pull/15070 and https://github.com/xamarin/Xamarin.Forms/pull/15083.


### Issues Resolved ### 

 fixes #8293 fixes #14323.

### API Changes ###

As described above - UWP only.


### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
Can see images with source CanvasImageSource after minimize.

### Before/After Screenshots ### 


Not applicable

### Testing Procedure ###
Added issue class.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
