### PR TITLE
[iOS] Fix warnings on obsolete api

### DIFF
--- a/Xamarin.Forms.Platform.iOS.UnitTests/TransformationTests.cs
+++ b/Xamarin.Forms.Platform.iOS.UnitTests/TransformationTests.cs
@@ -28,6 +28,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 		[Description("View transformation should match renderer transformation")]
 		public async Task TransformationConsistent(View view)
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			var expected = new CATransform3D
 			{
 				m11 = -1.4984f,
@@ -39,6 +40,7 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 				m42 = 30f,
 				m44 = 1f,
 			};
+
 			var actual = await GetRendererProperty(view, r => r.NativeView.Layer.Transform, requiresLayout: true);
 			AssertTransform3DEqual(actual, expected, 0.0001);
 		}
@@ -62,5 +64,6 @@ namespace Xamarin.Forms.Platform.iOS.UnitTests
 			Assert.That((double)actual.m43, Is.EqualTo((double)expected.m43).Within(delta));
 			Assert.That((double)actual.m44, Is.EqualTo((double)expected.m44).Within(delta));
 		}
+#pragma warning restore CS0618 // Type or member is obsolete
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -501,11 +501,11 @@ namespace Xamarin.Forms.Platform.iOS
 
 			if (isRtl)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				if (_emptyUIView.Transform.xx == -1)
 				{
 					return;
 				}
-
 				FlipEmptyView();
 			}
 			else
@@ -515,6 +515,7 @@ namespace Xamarin.Forms.Platform.iOS
 					FlipEmptyView();
 				}
 			}
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void FlipEmptyView()

--- a/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/VisualElementTracker.cs
@@ -319,7 +319,9 @@ namespace Xamarin.Forms.Platform.MacOS
 
 				// not just an optimization, iOS will not "pixel align" a view which has m34 set
 				if (Math.Abs(rotationY % 180) > epsilon || Math.Abs(rotationX % 180) > epsilon)
+#pragma warning disable CS0618 // Type or member is obsolete
 					transform.m34 = 1.0f / -400f;
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				if (Math.Abs(rotationX % 360) > epsilon)
 					transform = transform.Rotate(rotationX * (float)Math.PI / 180.0f, 1.0f, 0.0f, 0.0f);


### PR DESCRIPTION
### Description of Change ###

Fix using new Xamarin.IOS apis

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- Core/XAML (all platforms)
- iOS
- Android
- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
