### PR TITLE
Binding convert looks at right culture setting

### DIFF
--- a/Xamarin.Forms.Core.UnitTests/BindingExpressionTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingExpressionTests.cs
@@ -123,7 +123,7 @@ namespace Xamarin.Forms.Core.UnitTests
 		[TestCaseSource(nameof(TryConvertWithNumbersAndCulturesCases))]
 		public void TryConvertWithNumbersAndCultures(object inputString, CultureInfo culture, object expected)
 		{
-			CultureInfo.CurrentUICulture = culture;
+			CultureInfo.CurrentCulture = culture;
 			BindingExpression.TryConvert(ref inputString, Entry.TextProperty, expected.GetType(), false);
 
 			Assert.AreEqual(expected, inputString);

--- a/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/BindingUnitTests.cs
@@ -2000,7 +2000,7 @@ namespace Xamarin.Forms.Core.UnitTests
 #if !WINDOWS_PHONE
 		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
 		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
-		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
+		public void ConvertIsCultureAware(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 

--- a/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
+++ b/Xamarin.Forms.Core.UnitTests/TypedBindingUnitTests.cs
@@ -1272,7 +1272,7 @@ namespace Xamarin.Forms.Core.UnitTests
 #if !WINDOWS_PHONE
 		[TestCase("en-US", "0.5", 0.5, 0.9, "0.9")]
 		[TestCase("pt-PT", "0,5", 0.5, 0.9, "0,9")]
-		public void ConvertIsCultureInvariant(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
+		public void ConvertIsCultureAware(string culture, string sliderSetStringValue, double sliderExpectedDoubleValue, double sliderSetDoubleValue, string sliderExpectedStringValue)
 		{
 			System.Threading.Thread.CurrentThread.CurrentCulture = System.Threading.Thread.CurrentThread.CurrentUICulture = new CultureInfo(culture);
 

--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -462,7 +462,7 @@ namespace Xamarin.Forms
 				var stringValue = value as string ?? string.Empty;
 				// see: https://bugzilla.xamarin.com/show_bug.cgi?id=32871
 				// do not canonicalize "*.[.]"; "1." should not update bound BindableProperty
-				if (stringValue.EndsWith(CultureInfo.CurrentUICulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
+				if (stringValue.EndsWith(CultureInfo.CurrentCulture.NumberFormat.NumberDecimalSeparator, StringComparison.Ordinal) && DecimalTypes.Contains(convertTo))
 				{
 					value = original;
 					return false;
@@ -475,7 +475,7 @@ namespace Xamarin.Forms
 					return false;
 				}
 
-				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentUICulture);
+				value = Convert.ChangeType(value, convertTo, CultureInfo.CurrentCulture);
 
 				return true;
 			}


### PR DESCRIPTION
### Description of Change ###

I ported #11815 to [.NET MAUI](https://github.com/dotnet/maui/pull/5005), but in the review it was revealed that `CurrentCulture` is actually the right setting to look at here. So fixing that back to Forms as well and making the test names a bit more clear.