### PR TITLE
Add gallery pages for some carouselview bugs

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/CarouselViewGallery.cs
@@ -51,6 +51,8 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 							new CarouselXamlGallery(false, 3), Navigation),
 						GalleryBuilder.NavButton("CarouselView Set CurrentItem Loop", () =>
 							new CarouselXamlGallery(true, 3), Navigation),
+						GalleryBuilder.NavButton("CarouselView Replace Source", () =>
+							new ReplaceSourceGallery(), Navigation)
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml
@@ -4,14 +4,24 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.ReplaceSourceGallery">
     <StackLayout>
-        <CarouselView Loop="False" ItemsSource="{Binding Images}" HeightRequest="200" x:Name="Carousel">
+        <CarouselView Loop="False" ItemsSource="{Binding Images}" HeightRequest="200" x:Name="ImageCarousel">
             <CarouselView.ItemTemplate>
                 <DataTemplate>
                     <Image Source="{Binding .}" />
                 </DataTemplate>
             </CarouselView.ItemTemplate>
         </CarouselView>
-        <Label Text="{Binding Position, Source={x:Reference Carousel}}"/>
+        <Label Text="{Binding Position, Source={x:Reference ImageCarousel}}"/>
+
+        <CarouselView Loop="False" ItemsSource="{Binding Colors}" HeightRequest="200" x:Name="ColorCarousel">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <BoxView Color="{Binding .}" />
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+        <Label Text="{Binding Position, Source={x:Reference ColorCarousel}}"/>
+
         <Button Text="Update BindingContext" Clicked="BindingContextButton_Clicked" />
         <Button Text="Update ItemsSource" Clicked="ItemsSourceButton_Clicked" />
     </StackLayout>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml
@@ -1,0 +1,18 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries.ReplaceSourceGallery">
+    <StackLayout>
+        <CarouselView Loop="False" ItemsSource="{Binding Images}" HeightRequest="200" x:Name="Carousel">
+            <CarouselView.ItemTemplate>
+                <DataTemplate>
+                    <Image Source="{Binding .}" />
+                </DataTemplate>
+            </CarouselView.ItemTemplate>
+        </CarouselView>
+        <Label Text="{Binding Position, Source={x:Reference Carousel}}"/>
+        <Button Text="Update BindingContext" Clicked="BindingContextButton_Clicked" />
+        <Button Text="Update ItemsSource" Clicked="ItemsSourceButton_Clicked" />
+    </StackLayout>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselViewGalleries
+{
+	public partial class ReplaceSourceGallery : ContentPage
+	{
+		public ReplaceSourceGallery()
+        {
+            InitializeComponent();
+            BindingContext = new ViewModel();
+        }
+
+        public void BindingContextButton_Clicked(object sender, EventArgs eventArgs)
+        {
+            BindingContext = new ViewModel();
+        }
+
+        public void ItemsSourceButton_Clicked(object sender, EventArgs eventArgs)
+        {
+            ((ViewModel)BindingContext).Images = new[]
+            {
+                "cover1.jpg",
+                "oasis.jpg",
+                "photo.jpg",
+                "Vegetables.jpg",
+                "Fruits.jpg",
+                "FlowerBuds.jpg",
+                "Legumes.jpg"
+            };
+        }
+
+        public class ViewModel
+        {
+            public IList<string> Images { get; set; } = new []
+            {
+                "cover1.jpg",
+                "oasis.jpg",
+                "photo.jpg",
+                "Vegetables.jpg",
+                "Fruits.jpg",
+                "FlowerBuds.jpg",
+                "Legumes.jpg"
+            };
+        }
+    }
+}

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CarouselViewGalleries/ReplaceSourceGallery.xaml.cs
@@ -18,30 +18,29 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.CarouselVi
 
         public void ItemsSourceButton_Clicked(object sender, EventArgs eventArgs)
         {
-            ((ViewModel)BindingContext).Images = new[]
-            {
-                "cover1.jpg",
-                "oasis.jpg",
-                "photo.jpg",
-                "Vegetables.jpg",
-                "Fruits.jpg",
-                "FlowerBuds.jpg",
-                "Legumes.jpg"
-            };
+            ((ViewModel)BindingContext).Images = CreateImages();
         }
+
+        private static IList<string> CreateImages() => new[]
+        {
+            "cover1.jpg",
+            "oasis.jpg",
+            "photo.jpg",
+            "Vegetables.jpg",
+            "Fruits.jpg",
+            "FlowerBuds.jpg",
+            "Legumes.jpg"
+        };
+
+        private static IList<Color> CreateColors() => new[]
+        {
+            Color.Red, Color.Blue, Color.Green
+        };
 
         public class ViewModel
         {
-            public IList<string> Images { get; set; } = new []
-            {
-                "cover1.jpg",
-                "oasis.jpg",
-                "photo.jpg",
-                "Vegetables.jpg",
-                "Fruits.jpg",
-                "FlowerBuds.jpg",
-                "Legumes.jpg"
-            };
+            public IList<string> Images { get; set; } = CreateImages();
+            public IList<Color> Colors { get; set; } = CreateColors();
         }
     }
 }

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/CollectionViewGallery.cs
@@ -37,6 +37,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries
 						GalleryBuilder.NavButton("Alternate Layout Galleries", () => new AlternateLayoutGallery(), Navigation),
 						GalleryBuilder.NavButton("Header/Footer Galleries", () => new HeaderFooterGallery(), Navigation),
 						GalleryBuilder.NavButton("Nested CollectionViews", () => new NestedGalleries.NestedCollectionViewGallery(), Navigation),
+						GalleryBuilder.NavButton("CarouselView in CollectionView", () => new NestedGalleries.CarouselInCollectionViewGallery(), Navigation),
 					}
 				}
 			};

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/CarouselInCollectionViewGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/CarouselInCollectionViewGallery.xaml
@@ -1,0 +1,25 @@
+﻿<?xml version="1.0" encoding="UTF-8" ?>
+<ContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    x:Class="Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.NestedGalleries.CarouselInCollectionViewGallery">
+    <CollectionView ItemsSource="{Binding Items}">
+        <CollectionView.ItemsLayout>
+            <GridItemsLayout Span="2" Orientation="Vertical" />
+        </CollectionView.ItemsLayout>
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <StackLayout>
+                    <CarouselView Loop="False" ItemsSource="{Binding Images}" HeightRequest="200" x:Name="Carousel">
+                        <CarouselView.ItemTemplate>
+                            <DataTemplate>
+                                <Image Source="{Binding .}" />
+                            </DataTemplate>
+                        </CarouselView.ItemTemplate>
+                    </CarouselView>
+                    <Label Text="{Binding Position, Source={x:Reference Carousel}}"/>
+                </StackLayout>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/CarouselInCollectionViewGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/CollectionViewGalleries/NestedGalleries/CarouselInCollectionViewGallery.xaml.cs
@@ -1,0 +1,38 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+
+namespace Xamarin.Forms.Controls.GalleryPages.CollectionViewGalleries.NestedGalleries
+{
+	public partial class CarouselInCollectionViewGallery : ContentPage
+	{
+		public CarouselInCollectionViewGallery()
+		{
+			InitializeComponent();
+			BindingContext = new ViewModel();
+		}
+
+        public class ViewModel
+        {
+            public List<Item> Items { get; }
+
+            public ViewModel()
+            {
+                Items = Enumerable.Range(0, 30).Select(x => new Item()).ToList();
+            }
+        }
+
+        public class Item
+        {
+            public IList<string> Images { get; set; } = new[]
+            {
+                "cover1.jpg",
+                "oasis.jpg",
+                "photo.jpg",
+                "Vegetables.jpg",
+                "Fruits.jpg",
+                "FlowerBuds.jpg",
+                "Legumes.jpg"
+            };
+        }
+    }
+}


### PR DESCRIPTION

### Description of Change ###

* Adds gallery page for changing the itemssource of a `CarouselView` for #15231 (CarsouelView Gallery -> CarsouselView Replace Source)
* Adds gallery page for `CarouselView` in `CollectionView` for #15082` (CollectionView Gallery -> CarouselView in CollectionView) 

Now I have these test cases, I'm going to have a look at fixing, but I figured the test cases were still useful on their own.

Incidentally, the existing CarouselView code galleries show weird behavior on Android if you update the number of items.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
