### PR TITLE
Comparing Enum to Object crashes ItemComparer

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemComparer.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemComparer.cs
@@ -13,6 +13,8 @@ namespace Xamarin.Forms.Platform.iOS
 
             if (valueA == null && valueB != null || valueA != null && valueB == null)
                 result = false;
+			else if(valueA is Enum && !(valueB is Enum))
+				result = false;
             else if (selfValueComparer != null && selfValueComparer.CompareTo(valueB) != 0)
                 result = false;
             else if (!object.Equals(valueA, valueB))


### PR DESCRIPTION
### Description of Change ###

When an different types are used via Bindings on a Collectionview the ItemComparer can crash the application.

### Issues Resolved ### 

When valueA passed to ItemComparer is and Enum and valueB is an object, the Enum.CompareTo will throw an exception.

Sample:
```
var a=FooEnum.One;
var b = new CrazyObject();
	
ItemComparer.AreEquals(a,b);
// -> ArgumentException: Object must be the same type as the enum. The type passed in was 'CrazyObject'; the enum type was 'FooEnum'.
```

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS
- 
### Behavioral/Visual Changes ###

None (no Exception in Renderer, thus no crash)

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
See Code sample above, code can be unittested.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
