### PR TITLE
Android CarouselViewRenderer should call base UpdateItemsSource and UpdateAdapter

### DIFF
--- a/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/CollectionView/CarouselViewRenderer.cs
@@ -119,11 +119,8 @@ namespace Xamarin.Forms.Platform.Android
 
 		protected override void UpdateAdapter()
 		{
-			// By default the CollectionViewAdapter creates the items at whatever size the template calls for
-			// But for the Carousel, we want it to create the items to fit the width/height of the viewport
-			// So we give it an alternate delegate for creating the views
-
 			var oldItemViewAdapter = ItemsViewAdapter;
+
 			UnsubscribeCollectionItemsSourceChanged(oldItemViewAdapter);
 			if (oldItemViewAdapter != null)
 			{
@@ -131,25 +128,28 @@ namespace Xamarin.Forms.Platform.Android
 				Carousel.SetValueFromRenderer(FormsCarouselView.CurrentItemProperty, null);
 			}
 
-			ItemsViewAdapter = new CarouselViewAdapter<ItemsView, IItemsViewSource>(Carousel,
-				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
-
 			_gotoPosition = -1;
 
-			SwapAdapter(ItemsViewAdapter, false);
+			base.UpdateAdapter();
 
 			UpdateInitialPosition();
 
 			if (ItemsViewAdapter?.ItemsSource is ObservableItemsSource observableItemsSource)
 				observableItemsSource.CollectionItemsSourceChanged += CollectionItemsSourceChanged;
-
-			oldItemViewAdapter?.Dispose();
 		}
 
-		protected override void UpdateItemsSource()
+        protected override ItemsViewAdapter<ItemsView, IItemsViewSource> CreateAdapter()
 		{
-			UpdateAdapter();
-			UpdateEmptyView();
+			// By default the CollectionViewAdapter creates the items at whatever size the template calls for
+			// But for the Carousel, we want it to create the items to fit the width/height of the viewport
+			// So we give it an alternate delegate for creating the views
+			return new CarouselViewAdapter<ItemsView, IItemsViewSource>(Carousel,
+				(view, context) => new SizedItemContentView(Context, GetItemWidth, GetItemHeight));
+		}
+
+        protected override void UpdateItemsSource()
+		{
+			base.UpdateItemsSource();
 			_carouselViewLoopManager.SetItemsSource(ItemsViewAdapter.ItemsSource);
 		}
 


### PR DESCRIPTION
### Description of Change ###

Android CarouselViewRenderer should call base UpdateItemsSource and UpdateAdapter to reset scroll listener and observers

### Issues Resolved ### 

- fixes #15265 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
