### PR TITLE
Add suppressions for Xam.iOS obsoletes

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/ColorExtensions.cs
@@ -13,6 +13,10 @@ using UIColor = AppKit.NSColor;
 namespace Xamarin.Forms.Platform.MacOS
 #endif
 {
+	// Ignore obsolete Xamarin.iOS colors for now
+	// until this Xamarin.iOS version has been adopted more widely
+	// This is just a change in Xamarin.iOS not UIKit
+#pragma warning disable CS0618 // Type or member is obsolete
 	public static class ColorExtensions
 	{
 #if __MOBILE__
@@ -221,6 +225,8 @@ namespace Xamarin.Forms.Platform.MacOS
 				return Color.LightGray.ToNSColor();
 			}
 		}
+#pragma warning restore CS0618 // Type or member is obsolete
+
 #endif
 
 		public static CGColor ToCGColor(this Color color)

--- a/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/LabelExtensions.cs
@@ -113,7 +113,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			var glyphRange = new NSRange();
 
 #if __MOBILE__
+#pragma warning disable CS0618 // Type or member is obsolete
 			layoutManager.CharacterRangeForGlyphRange(characterRange, ref glyphRange);
+#pragma warning restore CS0618 // Type or member is obsolete
 #else
 #pragma warning disable CS0618 // Type or member is obsolete
 			layoutManager.CharacterRangeForGlyphRange(characterRange, out glyphRange);

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -363,6 +363,10 @@ namespace Xamarin.Forms
 				// If iOS 13+ check all dynamic colors too
 				switch (name)
 				{
+					// Ignore obsolete Xamarin.iOS colors for now
+					// until this Xamarin.iOS version has been adopted more widely
+					// This is just a change in Xamarin.iOS not UIKit
+#pragma warning disable CS0618 // Type or member is obsolete
 					case NamedPlatformColor.Label:
 						resultColor = UIColor.LabelColor;
 						break;
@@ -432,6 +436,7 @@ namespace Xamarin.Forms
 					case NamedPlatformColor.TertiaryLabel:
 						resultColor = UIColor.TertiaryLabelColor;
 						break;
+#pragma warning restore CS0618 // Type or member is obsolete
 					default:
 						resultColor = UIColor.FromName(name);
 						break;


### PR DESCRIPTION
Fixes the build for now, we should remove the actual obsoletes probably at some point