### PR TITLE
Introduce Android AppCompat renderers for Entry, Editor and Label

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -135,13 +135,18 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				RegisterHandler(typeof(Button), typeof(AppCompat.ButtonRenderer), typeof(ButtonRenderer));
 				RegisterHandler(typeof(Frame), typeof(AppCompat.FrameRenderer), typeof(FrameRenderer));
+				RegisterHandler(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
+				RegisterHandler(typeof(Entry), typeof(EntryRenderer), typeof(EntryRenderer));
+				RegisterHandler(typeof(Editor), typeof(EditorRenderer), typeof(EditorRenderer));
 			}
 			else
 			{
 				RegisterHandler(typeof(Button), typeof(FastRenderers.ButtonRenderer), typeof(ButtonRenderer));
-				RegisterHandler(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
+				RegisterHandler(typeof(Label), typeof(FastRenderers.LabelAppCompatRenderer), typeof(LabelRenderer));
 				RegisterHandler(typeof(Image), typeof(FastRenderers.ImageRenderer), typeof(ImageRenderer));
 				RegisterHandler(typeof(Frame), typeof(FastRenderers.FrameRenderer), typeof(FrameRenderer));
+				RegisterHandler(typeof(Entry), typeof(EntryAppCompatRenderer), typeof(EntryRenderer));
+				RegisterHandler(typeof(Editor), typeof(EditorAppCompatRenderer), typeof(EditorRenderer));
 			}
 
 			Registrar.Registered.Register(typeof(RadioButton), typeof(RadioButtonRenderer));

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -131,22 +131,36 @@ namespace Xamarin.Forms.Platform.Android
 			RegisterHandler(typeof(MasterDetailPage), typeof(MasterDetailPageRenderer), typeof(MasterDetailRenderer));
 #pragma warning restore CS0618 // Type or member is obsolete
 
-			if (Forms.Flags.Contains(Flags.UseLegacyRenderers))
+			var useLegacyRenderers = Forms.Flags.Contains(Flags.UseLegacyRenderers);
+			var disableAppCompatRenderers = Forms.Flags.Contains(Flags.DisableAppCompatRenderer);
+
+			if (useLegacyRenderers)
 			{
 				RegisterHandler(typeof(Button), typeof(AppCompat.ButtonRenderer), typeof(ButtonRenderer));
 				RegisterHandler(typeof(Frame), typeof(AppCompat.FrameRenderer), typeof(FrameRenderer));
-				RegisterHandler(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
-				RegisterHandler(typeof(Entry), typeof(EntryRenderer), typeof(EntryRenderer));
-				RegisterHandler(typeof(Editor), typeof(EditorRenderer), typeof(EditorRenderer));
 			}
 			else
 			{
 				RegisterHandler(typeof(Button), typeof(FastRenderers.ButtonRenderer), typeof(ButtonRenderer));
-				RegisterHandler(typeof(Label), typeof(FastRenderers.LabelAppCompatRenderer), typeof(LabelRenderer));
 				RegisterHandler(typeof(Image), typeof(FastRenderers.ImageRenderer), typeof(ImageRenderer));
 				RegisterHandler(typeof(Frame), typeof(FastRenderers.FrameRenderer), typeof(FrameRenderer));
+
+			}
+
+			if (disableAppCompatRenderers)
+			{
+				RegisterHandler(typeof(Entry), typeof(EntryRenderer), typeof(EntryRenderer));
+				RegisterHandler(typeof(Editor), typeof(EditorRenderer), typeof(EditorRenderer));
+
+				if (!useLegacyRenderers)
+					RegisterHandler(typeof(Label), typeof(FastRenderers.LabelRenderer), typeof(LabelRenderer));
+			}
+			else
+			{
 				RegisterHandler(typeof(Entry), typeof(EntryAppCompatRenderer), typeof(EntryRenderer));
 				RegisterHandler(typeof(Editor), typeof(EditorAppCompatRenderer), typeof(EditorRenderer));
+				RegisterHandler(typeof(Label), typeof(FastRenderers.LabelAppCompatRenderer), typeof(LabelRenderer));
+
 			}
 
 			Registrar.Registered.Register(typeof(RadioButton), typeof(RadioButtonRenderer));

--- a/Xamarin.Forms.Platform.Android/FastRenderers/LabelAppCompatRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/LabelAppCompatRenderer.cs
@@ -1,0 +1,465 @@
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Content.Res;
+using Android.Graphics;
+using Android.Text;
+using Android.Util;
+using Android.Views;
+using AndroidX.Core.View;
+using AView = Android.Views.View;
+
+namespace Xamarin.Forms.Platform.Android.FastRenderers
+{
+	public class LabelAppCompatRenderer : FormsAppCompatTextView, IVisualElementRenderer, IViewRenderer, ITabStop
+	{
+		int? _defaultLabelFor;
+		bool _disposed;
+		Label _element;
+		// Do not dispose _labelTextColorDefault
+		readonly ColorStateList _labelTextColorDefault;
+		int _lastConstraintHeight;
+		int _lastConstraintWidth;
+		SizeRequest? _lastSizeRequest;
+		float _lastTextSize = -1f;
+		Typeface _lastTypeface;
+		Color _lastUpdateColor = Color.Default;
+		float _lineSpacingExtraDefault = -1.0f;
+		float _lineSpacingMultiplierDefault = -1.0f;
+		VisualElementTracker _visualElementTracker;
+		VisualElementRenderer _visualElementRenderer;
+		readonly MotionEventHelper _motionEventHelper = new MotionEventHelper();
+		SpannableString _spannableString;
+		bool _hasLayoutOccurred;
+		bool _wasFormatted;
+
+		public LabelAppCompatRenderer(Context context) : base(context)
+		{
+			_labelTextColorDefault = TextColors;
+			_visualElementRenderer = new VisualElementRenderer(this);
+			BackgroundManager.Init(this);
+		}
+
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use LabelRenderer(Context) instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public LabelAppCompatRenderer() : base(Forms.Context)
+		{
+			_labelTextColorDefault = TextColors;
+			_visualElementRenderer = new VisualElementRenderer(this);
+			BackgroundManager.Init(this);
+		}
+
+		public event EventHandler<VisualElementChangedEventArgs> ElementChanged;
+		public event EventHandler<PropertyChangedEventArgs> ElementPropertyChanged;
+
+		VisualElement IVisualElementRenderer.Element => Element;
+
+		VisualElementTracker IVisualElementRenderer.Tracker => _visualElementTracker;
+
+		AView IVisualElementRenderer.View => this;
+
+		AView ITabStop.TabStop => this;
+
+		ViewGroup IVisualElementRenderer.ViewGroup => null;
+
+		protected Label Element
+		{
+			get { return _element; }
+			set
+			{
+				if (_element == value)
+					return;
+
+				Label oldElement = _element;
+				_element = value;
+
+				OnElementChanged(new ElementChangedEventArgs<Label>(oldElement, _element));
+
+				_element?.SendViewInitialized(this);
+			}
+		}
+		protected global::Android.Widget.TextView Control => this;
+
+		SizeRequest IVisualElementRenderer.GetDesiredSize(int widthConstraint, int heightConstraint)
+		{
+			if (_disposed)
+			{
+				return new SizeRequest();
+			}
+
+			if (_lastSizeRequest.HasValue)
+			{
+				// if we are measuring the same thing, no need to waste the time
+				bool canRecycleLast = widthConstraint == _lastConstraintWidth && heightConstraint == _lastConstraintHeight;
+
+				if (!canRecycleLast)
+				{
+					// if the last time we measured the returned size was all around smaller than the passed constraint
+					// and the constraint is bigger than the last size request, we can assume the newly measured size request
+					// will not change either.
+					int lastConstraintWidthSize = MeasureSpecFactory.GetSize(_lastConstraintWidth);
+					int lastConstraintHeightSize = MeasureSpecFactory.GetSize(_lastConstraintHeight);
+
+					int currentConstraintWidthSize = MeasureSpecFactory.GetSize(widthConstraint);
+					int currentConstraintHeightSize = MeasureSpecFactory.GetSize(heightConstraint);
+
+					bool lastWasSmallerThanConstraints = _lastSizeRequest.Value.Request.Width < lastConstraintWidthSize && _lastSizeRequest.Value.Request.Height < lastConstraintHeightSize;
+
+					bool currentConstraintsBiggerThanLastRequest = currentConstraintWidthSize >= _lastSizeRequest.Value.Request.Width && currentConstraintHeightSize >= _lastSizeRequest.Value.Request.Height;
+
+					canRecycleLast = lastWasSmallerThanConstraints && currentConstraintsBiggerThanLastRequest;
+				}
+
+				if (canRecycleLast)
+					return _lastSizeRequest.Value;
+			}
+
+			//We need to clear the Hint or else it will interfere with the sizing of the Label
+			var hint = Control.Hint;
+			bool setHint = Control.LayoutParameters != null;
+			if (!string.IsNullOrEmpty(hint) && setHint)
+				Control.Hint = string.Empty;
+
+			var hc = MeasureSpec.GetSize(heightConstraint);
+
+			Measure(widthConstraint, heightConstraint);
+			var result = new SizeRequest(new Size(MeasuredWidth, MeasuredHeight), new Size());
+
+			//Set Hint back after sizing
+			if (setHint)
+				Control.Hint = hint;
+
+			result.Minimum = new Size(Math.Min(Context.ToPixels(10), result.Request.Width), result.Request.Height);
+
+			// if the measure of the view has changed then trigger a request for layout
+			// if the measure hasn't changed then force a layout of the label
+			var measureIsChanged = !_lastSizeRequest.HasValue ||
+				_lastSizeRequest.HasValue && (_lastSizeRequest.Value.Request.Height != MeasuredHeight || _lastSizeRequest.Value.Request.Width != MeasuredWidth);
+			if (measureIsChanged)
+				this.MaybeRequestLayout();
+			else
+				ForceLayout();
+
+			_lastConstraintWidth = widthConstraint;
+			_lastConstraintHeight = heightConstraint;
+			_lastSizeRequest = result;
+
+			return result;
+		}
+
+		public override void Draw(Canvas canvas)
+		{
+			canvas.ClipShape(Context, Element);
+
+			base.Draw(canvas);
+		}
+
+		protected override void OnLayout(bool changed, int left, int top, int right, int bottom)
+		{
+			base.OnLayout(changed, left, top, right, bottom);
+			this.RecalculateSpanPositions(Element, _spannableString, new SizeRequest(new Size(right - left, bottom - top)));
+			_hasLayoutOccurred = true;
+		}
+
+		void IVisualElementRenderer.SetElement(VisualElement element)
+		{
+			var label = element as Label;
+			if (label == null)
+				throw new ArgumentException("Element must be of type Label");
+
+			Element = label;
+			_motionEventHelper.UpdateElement(element);
+		}
+
+		void IVisualElementRenderer.SetLabelFor(int? id)
+		{
+			if (_defaultLabelFor == null)
+				_defaultLabelFor = ViewCompat.GetLabelFor(this);
+
+			ViewCompat.SetLabelFor(this, (int)(id ?? _defaultLabelFor));
+		}
+
+		void IVisualElementRenderer.UpdateLayout()
+		{
+			VisualElementTracker tracker = _visualElementTracker;
+			tracker?.UpdateLayout();
+		}
+
+		void IViewRenderer.MeasureExactly()
+		{
+			ViewRenderer.MeasureExactly(this, Element, Context);
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (_disposed)
+				return;
+
+			_disposed = true;
+
+			if (disposing)
+			{
+				if (Element != null)
+				{
+					Element.PropertyChanged -= OnElementPropertyChanged;
+				}
+
+				BackgroundManager.Dispose(this);
+				if (_visualElementTracker != null)
+				{
+					_visualElementTracker.Dispose();
+					_visualElementTracker = null;
+				}
+
+				if (_visualElementRenderer != null)
+				{
+					_visualElementRenderer.Dispose();
+					_visualElementRenderer = null;
+				}
+
+				_spannableString?.Dispose();
+
+				if (Element != null)
+				{
+					if (Platform.GetRenderer(Element) == this)
+						Element.ClearValue(Platform.RendererProperty);
+				}
+			}
+
+			base.Dispose(disposing);
+		}
+
+		public override bool OnTouchEvent(MotionEvent e)
+		{
+			if (_visualElementRenderer.OnTouchEvent(e) || base.OnTouchEvent(e))
+			{
+				return true;
+			}
+
+			return _motionEventHelper.HandleMotionEvent(Parent, e);
+		}
+
+		protected virtual void OnElementChanged(ElementChangedEventArgs<Label> e)
+		{
+			ElementChanged?.Invoke(this, new VisualElementChangedEventArgs(e.OldElement, e.NewElement));
+
+			if (e.OldElement != null)
+			{
+				e.OldElement.PropertyChanged -= OnElementPropertyChanged;
+				this.MaybeRequestLayout();
+			}
+
+			if (e.NewElement != null)
+			{
+				this.EnsureId();
+
+				if (_visualElementTracker == null)
+				{
+					_visualElementTracker = new VisualElementTracker(this);
+				}
+
+				e.NewElement.PropertyChanged += OnElementPropertyChanged;
+
+				UpdateText();
+				UpdateLineHeight();
+				UpdateCharacterSpacing();
+				UpdateTextDecorations();
+				if (e.OldElement?.LineBreakMode != e.NewElement.LineBreakMode)
+					UpdateLineBreakMode();
+				if (e.OldElement?.HorizontalTextAlignment != e.NewElement.HorizontalTextAlignment || e.OldElement?.VerticalTextAlignment != e.NewElement.VerticalTextAlignment)
+					UpdateGravity();
+				if (e.OldElement?.MaxLines != e.NewElement.MaxLines)
+					UpdateMaxLines();
+
+				UpdatePadding();
+
+				ElevationHelper.SetElevation(this, e.NewElement);
+			}
+		}
+
+		protected virtual void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			if (this.IsDisposed())
+			{
+				return;
+			}
+
+			ElementPropertyChanged?.Invoke(this, e);
+
+			if (Control?.LayoutParameters == null && _hasLayoutOccurred)
+				return;
+
+			if (e.PropertyName == Label.HorizontalTextAlignmentProperty.PropertyName || e.PropertyName == Label.VerticalTextAlignmentProperty.PropertyName)
+				UpdateGravity();
+			else if (e.PropertyName == Label.TextColorProperty.PropertyName ||
+				e.PropertyName == Label.TextTypeProperty.PropertyName)
+				UpdateText();
+			else if (e.PropertyName == Label.FontProperty.PropertyName)
+				UpdateText();
+			else if (e.PropertyName == Label.LineBreakModeProperty.PropertyName)
+				UpdateLineBreakMode();
+			else if (e.PropertyName == Label.CharacterSpacingProperty.PropertyName)
+				UpdateCharacterSpacing();
+			else if (e.PropertyName == Label.TextDecorationsProperty.PropertyName)
+				UpdateTextDecorations();
+			else if (e.IsOneOf(Label.TextProperty, Label.FormattedTextProperty, Label.TextTransformProperty))
+				UpdateText();
+			else if (e.PropertyName == Label.LineHeightProperty.PropertyName)
+				UpdateLineHeight();
+			else if (e.PropertyName == Label.MaxLinesProperty.PropertyName)
+				UpdateMaxLines();
+			else if (e.PropertyName == Label.PaddingProperty.PropertyName)
+				UpdatePadding();
+		}
+
+		void UpdateColor()
+		{
+			Color c = Element.TextColor;
+			if (c == _lastUpdateColor)
+				return;
+			_lastUpdateColor = c;
+
+			if (c.IsDefault)
+				SetTextColor(_labelTextColorDefault);
+			else
+				SetTextColor(c.ToAndroid());
+		}
+
+		void UpdateFont()
+		{
+#pragma warning disable 618 // We will need to update this when .Font goes away
+			Font f = Element.Font;
+#pragma warning restore 618
+
+			Typeface newTypeface = f.ToTypeface();
+			if (newTypeface != _lastTypeface)
+			{
+				Typeface = newTypeface;
+				_lastTypeface = newTypeface;
+			}
+
+			float newTextSize = f.ToScaledPixel();
+			if (newTextSize != _lastTextSize)
+			{
+				SetTextSize(ComplexUnitType.Sp, newTextSize);
+				_lastTextSize = newTextSize;
+			}
+		}
+
+		void UpdateTextDecorations()
+		{
+			if (!Element.IsSet(Label.TextDecorationsProperty))
+				return;
+
+			var textDecorations = Element.TextDecorations;
+
+			if ((textDecorations & TextDecorations.Strikethrough) == 0)
+				PaintFlags &= ~PaintFlags.StrikeThruText;
+			else
+				PaintFlags |= PaintFlags.StrikeThruText;
+
+			if ((textDecorations & TextDecorations.Underline) == 0)
+				PaintFlags &= ~PaintFlags.UnderlineText;
+			else
+				PaintFlags |= PaintFlags.UnderlineText;
+		}
+
+		void UpdateGravity()
+		{
+			Label label = Element;
+
+			Gravity = label.HorizontalTextAlignment.ToHorizontalGravityFlags() | label.VerticalTextAlignment.ToVerticalGravityFlags();
+
+			_lastSizeRequest = null;
+		}
+
+		void UpdateCharacterSpacing()
+		{
+			if (Forms.IsLollipopOrNewer)
+			{
+				LetterSpacing = Element.CharacterSpacing.ToEm();
+			}
+		}
+
+		void UpdateLineBreakMode()
+		{
+			this.SetLineBreakMode(Element);
+			_lastSizeRequest = null;
+		}
+
+		void UpdateMaxLines()
+		{
+			this.SetMaxLines(Element);
+			_lastSizeRequest = null;
+		}
+
+		void UpdateText()
+		{
+			if (Element.FormattedText != null)
+			{
+				FormattedString formattedText = Element.FormattedText ?? Element.Text;
+#pragma warning disable 618 // We will need to update this when .Font goes away
+				TextFormatted = _spannableString = formattedText.ToAttributed(Element.Font, Element.TextColor, this);
+#pragma warning restore 618
+				_wasFormatted = true;
+			}
+			else
+			{
+				if (_wasFormatted)
+				{
+					SetTextColor(_labelTextColorDefault);
+					_lastUpdateColor = Color.Default;
+				}
+
+				switch (Element.TextType)
+				{
+					case TextType.Html:
+						if (Forms.IsNougatOrNewer)
+							Control.SetText(Html.FromHtml(Element.Text ?? string.Empty, FromHtmlOptions.ModeCompact), BufferType.Spannable);
+						else
+#pragma warning disable CS0618 // Type or member is obsolete
+							Control.SetText(Html.FromHtml(Element.Text ?? string.Empty), BufferType.Spannable);
+#pragma warning restore CS0618 // Type or member is obsolete
+						break;
+
+					default:
+						Text = Element.UpdateFormsText(Element.Text, Element.TextTransform);
+						break;
+				}
+
+				UpdateColor();
+				UpdateFont();
+
+				_wasFormatted = false;
+			}
+
+			_lastSizeRequest = null;
+		}
+
+		void UpdateLineHeight()
+		{
+			if (_lineSpacingExtraDefault < 0)
+				_lineSpacingExtraDefault = LineSpacingExtra;
+			if (_lineSpacingMultiplierDefault < 0)
+				_lineSpacingMultiplierDefault = LineSpacingMultiplier;
+
+			if (Element.LineHeight == -1)
+				SetLineSpacing(_lineSpacingExtraDefault, _lineSpacingMultiplierDefault);
+			else if (Element.LineHeight >= 0)
+				SetLineSpacing(0, (float)Element.LineHeight);
+
+			_lastSizeRequest = null;
+		}
+
+		void UpdatePadding()
+		{
+			SetPadding(
+				(int)Context.ToPixels(Element.Padding.Left),
+				(int)Context.ToPixels(Element.Padding.Top),
+				(int)Context.ToPixels(Element.Padding.Right),
+				(int)Context.ToPixels(Element.Padding.Bottom));
+
+			_lastSizeRequest = null;
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Flags.cs
+++ b/Xamarin.Forms.Platform.Android/Flags.cs
@@ -6,6 +6,8 @@ namespace Xamarin.Forms
 	{
 		internal const string UseLegacyRenderers = "UseLegacyRenderers";
 
+		internal const string DisableAppCompatRenderer = "DisableAppCompatRenderers";
+
 		internal const string AccessibilityExperimental = "Accessibility_Experimental";
 
 		public static bool IsFlagSet(string flagName)

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorAppCompatRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorAppCompatRenderer.cs
@@ -1,0 +1,59 @@
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Views.InputMethods;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public class EditorAppCompatRenderer : EditorRendererBase<FormsAppCompatEditText>
+	{
+		TextColorSwitcher _hintColorSwitcher;
+		TextColorSwitcher _textColorSwitcher;
+
+		public EditorAppCompatRenderer(Context context) : base(context)
+		{
+		}
+
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use EditorRenderer(Context) instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public EditorAppCompatRenderer()
+		{
+			AutoPackage = false;
+		}
+
+		protected override FormsAppCompatEditText CreateNativeControl()
+		{
+			return new FormsAppCompatEditText(Context)
+			{
+				ImeOptions = ImeAction.Done
+			};
+		}
+
+		protected override EditText EditText => Control;
+
+		protected override void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher = _hintColorSwitcher ?? new TextColorSwitcher(EditText.HintTextColors, Element.UseLegacyColorManagement());
+			_hintColorSwitcher.UpdateTextColor(EditText, Element.PlaceholderColor, EditText.SetHintTextColor);
+		}
+
+		protected override void UpdateTextColor()
+		{
+			_textColorSwitcher = _textColorSwitcher ?? new TextColorSwitcher(EditText.TextColors, Element.UseLegacyColorManagement());
+			_textColorSwitcher.UpdateTextColor(EditText, Element.TextColor);
+		}
+
+		protected override void OnAttachedToWindow()
+		{
+			base.OnAttachedToWindow();
+
+			if (EditText.IsAlive() && EditText.Enabled)
+			{
+				// https://issuetracker.google.com/issues/37095917
+				EditText.Enabled = false;
+				EditText.Enabled = true;
+			}
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -2,8 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.ComponentModel;
 using Android.Content;
-using Android.Content.Res;
-using Android.OS;
 using Android.Text;
 using Android.Text.Method;
 using Android.Util;

--- a/Xamarin.Forms.Platform.Android/Renderers/EntryAppCompatRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EntryAppCompatRenderer.cs
@@ -1,0 +1,55 @@
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public class EntryAppCompatRenderer : EntryRendererBase<FormsAppCompatEditText>
+	{
+		TextColorSwitcher _hintColorSwitcher;
+		TextColorSwitcher _textColorSwitcher;
+
+		public EntryAppCompatRenderer(Context context) : base(context)
+		{
+		}
+
+		[Obsolete("This constructor is obsolete as of version 2.5. Please use EntryRenderer(Context) instead.")]
+		[EditorBrowsable(EditorBrowsableState.Never)]
+		public EntryAppCompatRenderer()
+		{
+			AutoPackage = false;
+		}
+
+		protected override FormsAppCompatEditText CreateNativeControl()
+		{
+			return new FormsAppCompatEditText(Context);
+		}
+
+		protected override EditText EditText => Control;
+
+		protected override void UpdateIsReadOnly()
+		{
+			base.UpdateIsReadOnly();
+			bool isReadOnly = !Element.IsReadOnly;
+			EditText.SetCursorVisible(isReadOnly);
+		}
+
+		protected override void UpdatePlaceholderColor()
+		{
+			_hintColorSwitcher = _hintColorSwitcher ?? new TextColorSwitcher(EditText.HintTextColors, Element.UseLegacyColorManagement());
+			_hintColorSwitcher.UpdateTextColor(EditText, Element.PlaceholderColor, EditText.SetHintTextColor);
+		}
+
+		protected override void UpdateColor()
+		{
+			UpdateTextColor(Element.TextColor);
+		}
+
+		protected override void UpdateTextColor(Color color)
+		{
+			_textColorSwitcher = _textColorSwitcher ?? new TextColorSwitcher(EditText.TextColors, Element.UseLegacyColorManagement());
+			_textColorSwitcher.UpdateTextColor(EditText, color);
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsAppCompatEditText.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsAppCompatEditText.cs
@@ -1,0 +1,94 @@
+using System;
+using System.ComponentModel;
+using Android.Content;
+using Android.Views;
+using AndroidX.AppCompat.Widget;
+using AndroidX.Core.Graphics.Drawable;
+using ARect = Android.Graphics.Rect;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public class FormsAppCompatEditText : FormsAppCompatEditTextBase, IFormsEditText
+	{
+		public FormsAppCompatEditText(Context context) : base(context)
+		{
+		}
+
+
+		public override bool OnKeyPreIme(Keycode keyCode, KeyEvent e)
+		{
+			if (keyCode != Keycode.Back || e.Action != KeyEventActions.Down)
+			{
+				return base.OnKeyPreIme(keyCode, e);
+			}
+
+			this.HideKeyboard();
+
+			_onKeyboardBackPressed?.Invoke(this, EventArgs.Empty);
+			return true;
+		}
+
+		protected override void OnSelectionChanged(int selStart, int selEnd)
+		{
+			base.OnSelectionChanged(selStart, selEnd);
+			_selectionChanged?.Invoke(this, new SelectionChangedEventArgs(selStart, selEnd));
+		}
+
+		event EventHandler _onKeyboardBackPressed;
+		event EventHandler IFormsEditText.OnKeyboardBackPressed
+		{
+			add => _onKeyboardBackPressed += value;
+			remove => _onKeyboardBackPressed -= value;
+		}
+
+		event EventHandler<SelectionChangedEventArgs> _selectionChanged;
+		event EventHandler<SelectionChangedEventArgs> IFormsEditText.SelectionChanged
+		{
+			add => _selectionChanged += value;
+			remove => _selectionChanged -= value;
+		}
+	}
+
+	public class FormsAppCompatEditTextBase : AppCompatEditText, IDescendantFocusToggler
+	{
+		DescendantFocusToggler _descendantFocusToggler;
+
+		public FormsAppCompatEditTextBase(Context context) : base(context)
+		{
+			DrawableCompat.Wrap(Background);
+		}
+
+		bool IDescendantFocusToggler.RequestFocus(global::Android.Views.View control, Func<bool> baseRequestFocus)
+		{
+			_descendantFocusToggler = _descendantFocusToggler ?? new DescendantFocusToggler();
+
+			return _descendantFocusToggler.RequestFocus(control, baseRequestFocus);
+		}
+
+
+		public override bool RequestFocus(FocusSearchDirection direction, ARect previouslyFocusedRect)
+		{
+			return (this as IDescendantFocusToggler).RequestFocus(this, () => base.RequestFocus(direction, previouslyFocusedRect));
+		}
+
+
+	}
+
+	[Obsolete("EntryEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.FormsEditText instead.")]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class EntryAppCompatEditText : FormsAppCompatEditText
+	{
+		public EntryAppCompatEditText(Context context) : base(context)
+		{
+		}
+	}
+
+	[Obsolete("EditorEditText is obsolete as of version 2.4.0. Please use Xamarin.Forms.Platform.Android.FormsEditText instead.")]
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public class EditorAppCompatEditText : FormsAppCompatEditText
+	{
+		public EditorAppCompatEditText(Context context) : base(context)
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsAppCompatTextView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsAppCompatTextView.cs
@@ -1,0 +1,35 @@
+using System;
+using Android.Content;
+using Android.Runtime;
+using Android.Util;
+using AndroidX.AppCompat.Widget;
+
+namespace Xamarin.Forms.Platform.Android
+{
+	public class FormsAppCompatTextView : AppCompatTextView
+	{
+		public FormsAppCompatTextView(Context context) : base(context)
+		{
+		}
+
+		[Obsolete]
+		public FormsAppCompatTextView(Context context, IAttributeSet attrs) : base(context, attrs)
+		{
+		}
+
+		[Obsolete]
+		public FormsAppCompatTextView(Context context, IAttributeSet attrs, int defStyle) : base(context, attrs, defStyle)
+		{
+		}
+
+		[Obsolete]
+		protected FormsAppCompatTextView(IntPtr javaReference, JniHandleOwnership transfer) : base(javaReference, transfer)
+		{
+		}
+
+		[Obsolete]
+		public void SkipNextInvalidate()
+		{
+		}
+	}
+}

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsTextView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsTextView.cs
@@ -3,10 +3,11 @@ using Android.Content;
 using Android.Runtime;
 using Android.Util;
 using Android.Widget;
+using AndroidX.AppCompat.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class FormsTextView : TextView
+	public class FormsTextView : AppCompatTextView
 	{
 		public FormsTextView(Context context) : base(context)
 		{

--- a/Xamarin.Forms.Platform.Android/Renderers/FormsTextView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/FormsTextView.cs
@@ -3,11 +3,10 @@ using Android.Content;
 using Android.Runtime;
 using Android.Util;
 using Android.Widget;
-using AndroidX.AppCompat.Widget;
 
 namespace Xamarin.Forms.Platform.Android
 {
-	public class FormsTextView : AppCompatTextView
+	public class FormsTextView : TextView
 	{
 		public FormsTextView(Context context) : base(context)
 		{


### PR DESCRIPTION
### Description of Change ###

Adds 3 copies of renderers for `Entry`, `Editor` and `Label` which now inherit from the AppCompat version of the Android counterpart as opposed to the non-AppCompat version that it is currently.

To ensure a safety switch these are copies of the existing renderers, the new renderers are the default, but with a flag you can revert back to the old renderers and behavior.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15245

### API Changes ###
Added:

* `public class EntryAppCompatRenderer : EntryRendererBase<FormsAppCompatEditText>`
* `public class EditorAppCompatRenderer : EditorRendererBase<FormsAppCompatEditText>`
* `public class LabelAppCompatRenderer : FormsAppCompatTextView`
* `public class FormsAppCompatTextView : AppCompatTextView`
* `public class FormsAppCompatEditText : FormsAppCompatEditTextBase`
* `public class FormsAppCompatEditTextBase : AppCompatEditText`
* `public class FormsAppCompatEditText : FormsAppCompatEditTextBase`
* `public class FormsAppCompatEditTextBase : AppCompatEditText`

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
Hopefully none, but this should maximize backwards and forwards compatibility on Android for `Entry`, `Editor` and `Label`.

The new AppCompat renderers are the default as we expect no issues, but in case we do find issues, there is a flag to revert to the old behavior.

To do this, in your `MainActivity.cs` on Android call `Forms.SetFlags("DisableAppCompatRenderers");` _before_ the `Forms.Init()` call.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Add the resulting NuGet from this PR to your app and see if it behaves as before

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
