### PR TITLE
[iOS] Change how ItemsViewController.CheckEmptySource checks for item size

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15287.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15287.xaml
@@ -1,0 +1,30 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<ContentPage  
+    xmlns="http://xamarin.com/schemas/2014/forms" 
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml" 
+    x:Class="Xamarin.Forms.Controls.Issues.Issue15287"
+    Title="Issue 15287">
+    <CollectionView ItemsSource="{Binding Items}" x:Name="MainCollection">
+        <CollectionView.ItemsLayout>
+            <GridItemsLayout Span="2" Orientation="Vertical" />
+        </CollectionView.ItemsLayout>
+        <CollectionView.ItemTemplate>
+            <DataTemplate>
+                <Grid>
+                    <Grid.RowDefinitions>
+                        <RowDefinition Height="200" />
+                        <RowDefinition Height="40" />
+                    </Grid.RowDefinitions>
+                    <CarouselView Loop="False" ItemsSource="{Binding Images}" x:Name="Carousel">
+                        <CarouselView.ItemTemplate>
+                            <DataTemplate>
+                                <Image Source="{Binding .}" Aspect="AspectFill"/>
+                            </DataTemplate>
+                        </CarouselView.ItemTemplate>
+                    </CarouselView>
+                    <Label Text="{Binding Position, Source={x:Reference Carousel}}" Grid.Row="1"/>
+                </Grid>
+            </DataTemplate>
+        </CollectionView.ItemTemplate>
+    </CollectionView>
+</ContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15287.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15287.xaml.cs
@@ -1,0 +1,50 @@
+﻿using System.Collections.Generic;
+using System.Linq;
+using Xamarin.Forms;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Shapes;
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15287, "[Bug] [iOS] Changing CollectionView.ItemSizingStrategy that contains a CarouselView causes the CarouselView to size its cells incorrectly.", PlatformAffected.iOS)]
+	public partial class Issue15287 : ContentPage
+	{
+        public Issue15287()
+        {
+            InitializeComponent();
+            BindingContext = new ViewModel();
+        }
+
+        protected override void OnAppearing()
+        {
+            base.OnAppearing();
+            MainCollection.ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem;
+        }
+
+        public class ViewModel
+        {
+            public List<Item> Items { get; private set; }
+
+            public ViewModel()
+            {
+                Items = Enumerable.Range(0, 30).Select(x => new Item()).ToList();
+            }
+        }
+
+        public class Item
+        {
+            public IList<string> Images { get; } = new[]
+            {
+                "cover1.jpg",
+                "oasis.jpg",
+                "photo.jpg",
+                "Vegetables.jpg",
+                "Fruits.jpg",
+                "FlowerBuds.jpg",
+                "Legumes.jpg"
+            };
+        }
+    }
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15287.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15287.xaml.cs
@@ -13,14 +13,18 @@ namespace Xamarin.Forms.Controls.Issues
 	{
         public Issue15287()
         {
+#if APP
             InitializeComponent();
+#endif
             BindingContext = new ViewModel();
         }
 
         protected override void OnAppearing()
         {
             base.OnAppearing();
+#if APP
             MainCollection.ItemSizingStrategy = ItemSizingStrategy.MeasureFirstItem;
+#endif
         }
 
         public class ViewModel

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1867,6 +1867,9 @@
       <DependentUpon>MyCollectionView.xaml</DependentUpon>
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15287.xaml.cs">
+      <DependentUpon>Issue15287.xaml</DependentUpon>
+    </Compile>
   </ItemGroup>
   <ItemGroup>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Bugzilla22229.xaml">
@@ -2414,6 +2417,10 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Controls\MyCollectionView.xaml">
+      <SubType>Designer</SubType>
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue15287.xaml">
       <SubType>Designer</SubType>
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -128,7 +128,7 @@ namespace Xamarin.Forms.Platform.iOS
 				// If we're going from empty to having stuff, it's possible that we've never actually measured
 				// a prototype cell and our itemSize or estimatedItemSize are wrong/unset
 				// So trigger a constraint update; if we need a measurement, that will make it happen
-				ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);
+				ConstrainToItemsView();
 			}
 		}
 


### PR DESCRIPTION
### Description of Change ###

This commit https://github.com/xamarin/Xamarin.Forms/blob/aeec18668f72a34ee7990b822956eb845cae99d3/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs#L20 caused the iOS `CarouselView` native items to have the wrong size under some specific circumstances.

Stepping through , there was an incorrect call to `ItemsViewLayout.ConstrainTo(CollectionView.Bounds.Size);`. This changes it to use `ConstrainToItemsView()` instead (which uses the `ItemsView` size if it has been calculated and `CollectionView.Bounds.Size` otherwise, which seems to match the existing comment).

### Issues Resolved ### 

- fixes #15287 

### API Changes ###

 None

### Platforms Affected ### 

 iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

<img src="https://user-images.githubusercontent.com/475450/161984112-9b2abaf4-1ad2-4fcd-9e05-125a331e3a1f.png" width="300" />
<img src="https://user-images.githubusercontent.com/475450/161984124-0b937d3c-cc6a-4226-8362-ba7ffc8766e9.png" width="300" />

Not applicable

### Testing Procedure ###
 
Issue 15287 has been added to the app. Scroll up and down the collection view and see that none of the items are incorrectly sized.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
