### PR TITLE
Fix radio button initial checked state when using int, object, boolean and string

### DIFF
--- a/Xamarin.Forms.Controls/GalleryPages/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml
+++ b/Xamarin.Forms.Controls/GalleryPages/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml
@@ -3,20 +3,60 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+             xmlns:radiobuttongalleries="clr-namespace:Xamarin.Forms.Controls.GalleryPages.RadioButtonGalleries"
              mc:Ignorable="d"
+             x:DataType="radiobuttongalleries:RadioButtonGroupBindingModel"
              x:Class="Xamarin.Forms.Controls.GalleryPages.RadioButtonGalleries.RadioButtonGroupBindingGallery">
+    <ContentPage.Resources>
+        <ResourceDictionary>
+                 <Style TargetType="RadioButton">
+                    <Setter Property="BorderWidth" Value="0" />
+                    <Setter Property="Margin" Value="0" />
+                </Style>
+                <Style TargetType="Frame">
+                    <Setter Property="Padding" Value="0" />
+                    <Setter Property="IsClippedToBounds" Value="True" />
+                </Style>
+                <ControlTemplate x:Key="RadioTemplate">
+                    <Frame HasShadow="False" BorderColor="Transparent" CornerRadius="0" HeightRequest="40" MinimumWidthRequest="100" HorizontalOptions="Fill" VerticalOptions="Start" Padding="0">
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroupList>
+                                <VisualStateGroup x:Name="CheckedStates">
+                                    <VisualState x:Name="Normal">
+                                        <VisualState.Setters>
+                                            <Setter Property="BackgroundColor" Value="Red"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Checked">
+                                        <VisualState.Setters>
+                                            <Setter Property="BackgroundColor" Value="Green"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                    <VisualState x:Name="Unchecked">
+                                        <VisualState.Setters>
+                                            <Setter Property="BackgroundColor" Value="Blue"/>
+                                        </VisualState.Setters>
+                                    </VisualState>
+                                </VisualStateGroup>
+                            </VisualStateGroupList>
+                        </VisualStateManager.VisualStateGroups>
+                        <Grid Margin="0" WidthRequest="100">
+                            <ContentPresenter></ContentPresenter>
+                        </Grid>
+                    </Frame>
+                </ControlTemplate>
+        </ResourceDictionary>
+    </ContentPage.Resources>
     <ContentPage.Content>
-        <StackLayout>
-            
+        <ScrollView>
+            <StackLayout>
             <Grid RadioButtonGroup.GroupName="{Binding GroupName}" 
                          RadioButtonGroup.SelectedValue="{Binding Selection}">
 
                 <Grid.RowDefinitions>
                     <RowDefinition></RowDefinition>
                     <RowDefinition Height="50"></RowDefinition>
-                    <RowDefinition></RowDefinition>
-                    <RowDefinition></RowDefinition>
-                    <RowDefinition></RowDefinition>
+                    <RowDefinition Height="200"></RowDefinition>
                 </Grid.RowDefinitions>
 
                 <Grid.ColumnDefinitions>
@@ -28,14 +68,202 @@
 
                 <Label Text="{Binding GroupName, StringFormat='The GroupName is {0}'}" Grid.Row="1" />
                 <Label Text="{Binding Selection, StringFormat='The Selection is {0}'}" Grid.Row="1" Grid.Column="1" />
+                <Frame Grid.Row="2">
+                    <StackLayout>
+                        
+                <RadioButton Content="Option A" Value="A"></RadioButton>
+                <RadioButton Content="Option B" Value="B"></RadioButton>
+                <RadioButton Content="Option C" Value="C"></RadioButton>
+                <RadioButton Content="Option D" Value="D"></RadioButton>
 
-                <RadioButton Content="Option A" Value="A" Grid.Row="2"></RadioButton>
-                <RadioButton Content="Option B" Value="B" Grid.Row="2" Grid.Column="1"></RadioButton>
-                <RadioButton Content="Option C" Value="C" Grid.Row="3"></RadioButton>
-                <RadioButton Content="Option D" Value="D" Grid.Row="3" Grid.Column="1"></RadioButton>
-
-                <Button Margin="5" Grid.ColumnSpan="2" Grid.Row="4" Text="Set selection in view model to 'B'" Clicked="Button_Clicked"></Button>
+                    </StackLayout>
+                </Frame>
             </Grid>
-        </StackLayout>
+
+
+            <Grid RadioButtonGroup.GroupName="MySecondGroup" 
+                         RadioButtonGroup.SelectedValue="{Binding Selection2}">
+
+                <Grid.RowDefinitions>
+                    <RowDefinition></RowDefinition>
+                    <RowDefinition Height="50"></RowDefinition>
+                    <RowDefinition Height="200"></RowDefinition>
+                    <RowDefinition></RowDefinition>
+                </Grid.RowDefinitions>
+
+                <Grid.ColumnDefinitions>
+                    <ColumnDefinition></ColumnDefinition>
+                    <ColumnDefinition></ColumnDefinition>
+                </Grid.ColumnDefinitions>
+
+                <Label Grid.ColumnSpan="2" Text="The RadioButtons in this Grid has Selection2 bound to a ViewModel."></Label>
+
+                <Frame Grid.Row="2">
+                    <StackLayout>
+                        
+                        <RadioButton Content="Option A" Value="A"></RadioButton>
+                        <RadioButton Content="Option B" Value="B"></RadioButton>
+                        <RadioButton Content="Option C" Value="C"></RadioButton>
+                        <RadioButton Content="Option D" Value="D"></RadioButton>
+
+                    </StackLayout>
+                </Frame>
+            </Grid>
+
+
+           <StackLayout Orientation="Vertical" >
+                        
+                            <Frame BorderColor="LightGray" CornerRadius="15" BackgroundColor="Transparent" >
+
+                                <StackLayout Orientation="Horizontal"
+                                             Spacing="0" BackgroundColor="Transparent" Padding="0" Margin="0"
+                                             RadioButtonGroup.GroupName="MyLanguage"
+                                             RadioButtonGroup.SelectedValue="{Binding SelectionInt}">
+
+                                    <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                                 Value="1"
+                                                  CornerRadius="15">
+                                        <RadioButton.Content>
+                                            <StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
+                                                <Label Text="1"/>
+                                            </StackLayout>
+                                        </RadioButton.Content>
+                                    </RadioButton>
+                        
+                                    <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                                 Value="2"
+                                                 CornerRadius="15">
+                                        <RadioButton.Content>
+                                            <StackLayout HorizontalOptions="CenterAndExpand" VerticalOptions="Center">
+                                                <Label Text="2"/>
+                                            </StackLayout>
+                                        </RadioButton.Content>
+                                    </RadioButton>
+
+                                    <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                                 Value="3"
+                                                 CornerRadius="15">
+                                        <RadioButton.Content>
+                                            <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                                <Label Text="3"/>
+                                            </StackLayout>
+                                        </RadioButton.Content>
+                                    </RadioButton>
+
+                                    <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                                 Value="4"
+                                                 CornerRadius="15">
+                                        <RadioButton.Content>
+                                            <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                                <Label Text="4"/>
+                                            </StackLayout>
+                                        </RadioButton.Content>
+                                    </RadioButton>
+                                </StackLayout>
+                                </Frame>
+                    </StackLayout>
+
+
+                
+
+                    <Frame BorderColor="LightGray" CornerRadius="15" BackgroundColor="Transparent" >
+
+                        <StackLayout Orientation="Horizontal"
+                                        Spacing="0" BackgroundColor="Transparent" Padding="0" Margin="0"
+                                        RadioButtonGroup.GroupName="MyBool"
+                                        RadioButtonGroup.SelectedValue="{Binding SelectionBool}">
+
+                            <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                            Value="true" WidthRequest="175"
+                                            CornerRadius="15">
+                                <RadioButton.Content>
+                                    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="True"/>
+                                    </StackLayout>
+                                </RadioButton.Content>
+                            </RadioButton>
+                        
+                            <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                            Value="false" WidthRequest="175"
+                                            CornerRadius="15">
+                                <RadioButton.Content>
+                                    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="False"/>
+                                    </StackLayout>
+                                </RadioButton.Content>
+                            </RadioButton>
+
+                        </StackLayout>
+                    </Frame>
+
+                    <Frame BorderColor="LightGray" CornerRadius="15" BackgroundColor="Transparent" >
+
+                        <StackLayout Orientation="Horizontal"
+                                        Spacing="0" BackgroundColor="Transparent" Padding="0" Margin="0"
+                                        RadioButtonGroup.GroupName="MyObject"
+                                        RadioButtonGroup.SelectedValue="{Binding SelectionObject}">
+
+                            <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                            Value="True" WidthRequest="175"
+                                            CornerRadius="15">
+                                <RadioButton.Content>
+                                    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="True"/>
+                                    </StackLayout>
+                                </RadioButton.Content>
+                            </RadioButton>
+                        
+                            <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                            Value="False" WidthRequest="175"
+                                            CornerRadius="15">
+                                <RadioButton.Content>
+                                    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="False"/>
+                                    </StackLayout>
+                                </RadioButton.Content>
+                            </RadioButton>
+
+                        </StackLayout>
+                    </Frame>
+
+
+                    <Frame BorderColor="LightGray" CornerRadius="15" BackgroundColor="Transparent" >
+
+                        <StackLayout Orientation="Horizontal"
+                                        Spacing="0" BackgroundColor="Transparent" Padding="0" Margin="0"
+                                        RadioButtonGroup.GroupName="MyEnum"
+                                        RadioButtonGroup.SelectedValue="{Binding SelectionEnum}">
+
+                            <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                            Value="Red" WidthRequest="175"
+                                            CornerRadius="15">
+                                <RadioButton.Content>
+                                    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="Red pill"/>
+                                    </StackLayout>
+                                </RadioButton.Content>
+                            </RadioButton>
+                        
+                            <RadioButton ControlTemplate="{StaticResource RadioTemplate}"
+                                            Value="Blue" WidthRequest="175"
+                                            CornerRadius="15">
+                                <RadioButton.Content>
+                                    <StackLayout HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="Blue pill"/>
+                                    </StackLayout>
+                                </RadioButton.Content>
+                            </RadioButton>
+
+                        </StackLayout>
+                    </Frame>
+
+
+                <!-- -scrollview layout -->
+                </StackLayout>
+
+        </ScrollView>
+
+
+
     </ContentPage.Content>
 </ContentPage>

--- a/Xamarin.Forms.Controls/GalleryPages/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml.cs
+++ b/Xamarin.Forms.Controls/GalleryPages/RadioButtonGalleries/RadioButtonGroupBindingGallery.xaml.cs
@@ -18,13 +18,20 @@ namespace Xamarin.Forms.Controls.GalleryPages.RadioButtonGalleries
 		private void Button_Clicked(object sender, System.EventArgs e)
 		{
 			_viewModel.Selection = "B";
+			_viewModel.Selection2 = "D";
+			_viewModel.SelectionBool = !_viewModel.SelectionBool;
 		}
 	}
 
 	public class RadioButtonGroupBindingModel : INotifyPropertyChanged
 	{
 		private string _groupName;
-		private object _selection;
+		private string _selection = "A";
+		private string _selection2 = "C";
+		private int _selectionInt = 1;
+		private bool _selectionBool = false;
+		private object _selectionObject = "False";
+		private Pill _selectionEnum = Pill.Blue;
 
 		public event PropertyChangedEventHandler PropertyChanged;
 
@@ -43,7 +50,7 @@ namespace Xamarin.Forms.Controls.GalleryPages.RadioButtonGalleries
 			}
 		}
 
-		public object Selection
+		public string Selection
 		{
 			get => _selection;
 			set
@@ -52,5 +59,65 @@ namespace Xamarin.Forms.Controls.GalleryPages.RadioButtonGalleries
 				OnPropertyChanged(nameof(Selection));
 			}
 		}
+
+
+		public string Selection2
+		{
+			get => _selection2;
+			set
+			{
+				_selection2 = value;
+				OnPropertyChanged(nameof(Selection2));
+			}
+		}
+
+
+		public int SelectionInt
+		{
+			get => _selectionInt;
+			set
+			{
+				_selectionInt = value;
+				OnPropertyChanged(nameof(_selectionInt));
+			}
+		}
+
+
+		public bool SelectionBool
+		{
+			get => _selectionBool;
+			set
+			{
+				_selectionBool = value;
+				OnPropertyChanged(nameof(_selectionBool));
+			}
+		}
+
+		public object SelectionObject
+		{
+			get => _selectionObject;
+			set
+			{
+				_selectionObject = value;
+				OnPropertyChanged(nameof(_selectionObject));
+			}
+		}
+
+		public Pill SelectionEnum
+		{
+			get => _selectionEnum;
+			set
+			{
+				_selectionEnum = value;
+				OnPropertyChanged(nameof(_selectionEnum));
+			}
+		}
+
+	}
+
+	public enum Pill
+	{
+		Red,
+		Blue
 	}
 }

--- a/Xamarin.Forms.Core/RadioButton.cs
+++ b/Xamarin.Forms.Core/RadioButton.cs
@@ -419,12 +419,39 @@ namespace Xamarin.Forms
 
 		void HandleRadioButtonGroupValueChanged(Layout<View> layout, RadioButtonGroupValueChanged args)
 		{
-			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || Value != args.Value || !MatchesScope(args))
+			if (IsChecked || string.IsNullOrEmpty(GroupName) || GroupName != args.GroupName || !MatchesScope(args))
 			{
 				return;
 			}
 
-			IsChecked = true;
+			// 2022-04-06 jtorvald: the old check failed because it compare value and type
+			// in most cases working with XAML this is probably not what we want
+			// issue: 
+			// if both value and args value are null, we consider it good.
+			if (Value == null && args.Value == null)
+			{
+				IsChecked = true;
+				return;
+			}
+			else if (args.Value is bool && bool.TryParse(Value.ToString(), out bool boolRes))
+			{
+				// if it is a boolean value, compare as bool
+				if ((bool)args.Value == boolRes)
+				{
+					IsChecked = true;
+					return;
+				}
+			}
+
+			// 2022-04-06 jtorvald: other values we can probably safely compare as string (int, string, enum)
+			// maybe we need other checks for decimals values types?
+			if (Value != null && Value.ToString().Equals(args.Value.ToString()))
+			{
+				IsChecked = true;
+				return;
+			}
+
+			IsChecked = false;
 		}
 
 		static void BindToTemplatedParent(BindableObject bindableObject, params BindableProperty[] properties)


### PR DESCRIPTION
This PR fixes [issue #13752](https://github.com/xamarin/Xamarin.Forms/issues/13752) where a lot of people experience issues with the initial state of the radio button and bound values in the selection group.

It's such as waste to have such a multi purpose control that is hard to work with. I really love the content control template with the RadioButton to make different input types.

Personally I also had some weird issue with strings in a workaround that I created that I didn't manage to reproduce in the ControlGallery. Hopefully the change in value comparison also helps me to remove the workaround and have my code working as well. If not, I will dig deeper into it.

That being said: I think this change will make the RadioButton more usable for a lot of people. There are not API changes.

### Description of Change ###
I only improved the selection in HandleRadioButtonGroupValueChanged to do a ToString() or boolean comparison on the values, which is probably what people expect.

### Issues Resolved ### 

- fixes #13752
- might also fix #14549

### API Changes ###
None

### Platforms Affected ### 
- Core/XAML (all platforms)

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Before:
![radiobutton-old-value-selection](https://user-images.githubusercontent.com/1808131/162060622-ecb22427-1ba0-44d8-93fa-a7326de1a2ed.png)

After:
![radiobutton-improved-value-selection](https://user-images.githubusercontent.com/1808131/162060639-ab70ed28-0134-4284-8841-78a589db0406.png)

### Testing Procedure ###
In the control gallery go to RadioButton Gallery -> RadioButton Group (Attached Property, Binding)
In old situation see, a lot of options are not pre-selected even thought they have a value in the binding property. After the fix you will see all the Buttons checked with their correct value.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
