### PR TITLE
Fix text color usage for different visual states when using a button with character spacing

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ButtonLayoutManager.cs
@@ -144,6 +144,7 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (e.PropertyName == Button.ImageSourceProperty.PropertyName)
 				_ = UpdateImageAsync();
 			else if (e.PropertyName == Button.TextProperty.PropertyName ||
+					 e.PropertyName == Button.TextColorProperty.PropertyName ||
 					 e.PropertyName == Button.TextTransformProperty.PropertyName ||
 					 e.PropertyName == Button.CharacterSpacingProperty.PropertyName)
 				UpdateText();


### PR DESCRIPTION
This PR fixes an issue where title color of a button on iOS won't update when switching between different visual states and using character spacing.

### Description of Change ###

I only added a call to `UpdateText()` on ButtonLayoutRenderer when TextColor property changed.

### API Changes ###
None

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
Title color of button gets updated when visual state changed,

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Use a button with character spacing and add different text colors for different visual states. Switching between these visual states will change the text color.

### PR Checklist ###
- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
