### PR TITLE
Null-check VerticalCell measure to prevent NRE

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/VerticalCell.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/VerticalCell.cs
@@ -16,10 +16,10 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public override CGSize Measure()
 		{
-			var measure = VisualElementRenderer.Element.Measure(ConstrainedDimension,
+			var measure = VisualElementRenderer?.Element?.Measure(ConstrainedDimension,
 				double.PositiveInfinity, MeasureFlags.IncludeMargins);
 
-			return new CGSize(ConstrainedDimension, measure.Request.Height);
+			return new CGSize(ConstrainedDimension, measure?.Request.Height ?? Frame.Height);
 		}
 
 		protected override bool AttributesConsistentWithConstrainedDimension(UICollectionViewLayoutAttributes attributes)


### PR DESCRIPTION
### Description of Change ###

Add guarding null checks to prevent an NRE when the device is rotated. Only thing I'm not 100% sure about is the value I provide in case `measure` actually turns out to be null

### Issues Resolved ### 

- fixes #15232

### API Changes ###
 
 None

### Platforms Affected ###

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
