### PR TITLE
Fix 15329 NavigationBarSeparator is visible after changing BarBackgroundColor when SetHideNavigationBarSeparator(true)

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs
@@ -451,7 +451,8 @@ namespace Xamarin.Forms.Platform.iOS
 			else if (e.PropertyName == NavigationPage.BarBackgroundColorProperty.PropertyName ||
 				e.PropertyName == NavigationPage.BarBackgroundProperty.PropertyName)
 			{
-				UpdateBarBackground();
+				UpdateBarBackground();		
+				UpdateHideNavigationBarSeparator();
 			}
 			else if (e.PropertyName == NavigationPage.BarTextColorProperty.PropertyName
 				  || e.PropertyName == StatusBarTextColorModeProperty.PropertyName)


### PR DESCRIPTION
### Description of Change ###

Add method UpdateHideNavigationBarSeparator after UpdateBarBackground on HandlePropertyChanged (Xamarin.Forms.Platform.iOS/Renderers/NavigationRenderer.cs)

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/15329

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

NavigationBarSeparator is Hidden when the BarBackgroundColor is changed

### Before/After Screenshots ### 

Before:
![Capture3](https://user-images.githubusercontent.com/33731962/164746209-2a3d3b62-5eff-4d27-90fb-ddd79b739a5f.PNG)
After:
![Capture1](https://user-images.githubusercontent.com/33731962/164746106-9f0a18f3-7b73-4c3e-aa34-f1fbc193f848.PNG)

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
