### PR TITLE
Disable installing "missing" Android SDKs for CI

### DIFF
--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -39,7 +39,7 @@
 
   <!-- Auto install any missing Android SDKs -->
   <PropertyGroup Condition="'$(CI)' == 'true'">
-    <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">True</AndroidRestoreOnBuild>
-    <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">True</AcceptAndroidSDKLicenses>
+    <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
+    <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Disable installing "missing" Android SDKs for now to work around https://github.com/xamarin/android-sdk-installer/pull/614