### PR TITLE
Revert "Disable installing "missing" Android SDKs for CI"

### DIFF
--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -39,7 +39,7 @@
 
   <!-- Auto install any missing Android SDKs -->
   <PropertyGroup Condition="'$(CI)' == 'true'">
-    <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
-    <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
+    <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">True</AndroidRestoreOnBuild>
+    <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">True</AcceptAndroidSDKLicenses>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Reverts xamarin/Xamarin.Forms#15336

Putting this here as a reminder we might want to revert this. Not sure if we really need to though.