### PR TITLE
[UWP] Fix shell tab font icon set with Embedded Font

### DIFF
--- a/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.UAP/Shell/ShellItemRenderer.cs
@@ -161,7 +161,7 @@ namespace Xamarin.Forms.Platform.UWP
 							var icon = new FontIcon()
 							{
 								Glyph = fontImageSource.Glyph,
-								FontFamily = new FontFamily(fontImageSource.FontFamily),
+								FontFamily = fontImageSource.FontFamily.ToFontFamily(),
 								FontSize = fontImageSource.Size,
 							};
 


### PR DESCRIPTION
### Description of Change ###
Fixes the tab bar icon set with embedded font on UWP

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->
fixes #13688
fixes #14959 

### Platforms Affected ### 
- UWP

### Behavioral/Visual Changes ###
Icon is correctly displayed
