### PR TITLE
Added InvokeOnMainThreadAsync to consolidate GoToAsync calls

### DIFF
--- a/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
+++ b/Xamarin.Forms.Core/Shell/ShellNavigationManager.cs
@@ -163,7 +163,11 @@ namespace Xamarin.Forms
 			}
 			else
 			{
-				await _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+				// TODO get rid of this hack and fix so if there's a stack the current page doesn't display
+				await Device.InvokeOnMainThreadAsync(() =>
+				{
+					return _shell.CurrentItem.CurrentItem.GoToAsync(navigationRequest, queryData, animate, isRelativePopping);
+				});
 			}
 
 			(_shell as IShellController).UpdateCurrentState(source);


### PR DESCRIPTION
### Description of Change ###

Two of three GoToAsync calls were already wrapped by InvokeOnMainThreadAsync. We had a navigation issue because the third GoToAsync call in ShellNavigationManager is not surrounded by InvokeOnMainThreadAsync. 
I do realise that this is a temporary fix and there should be a better fix. Nevertheless this consolidation is better than keeping it broken.

### Issues Resolved ###  

Fixes a navigation call that won't be executed otherwise. 
We had this issue in the OnResume method. A specific scenario could be that the user has moved the app into the background while being at an important process step. The app could be terminated while it's in the background. To let the user proceed from where he has left off, we added a "ReentryService" that allows the user to jump to an important point where he left off. The ReentryService basically loads some stuff from SecureStorage (asynchronously) and invoked GoToAsync at its end.

I think we also had this issue when we used PushNotification, but I cannot remember the full scenario.

### Platforms Affected ### 

- Core/XAML (all platforms)

### Testing Procedure ###
I'm not sure how to test this case properly. I hope one of you reviewers knows how to test it.
