### PR TITLE
Fix 15368 Editor's TextChanged event is fired on Unfocus even when no text changed

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15368.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15368.cs
@@ -1,0 +1,49 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.Github5000)]
+	[Category(UITestCategories.Editor)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15368, "[iOS] Editor's TextChanged event is fired on Unfocus even when no text changed", PlatformAffected.iOS)]
+	public class Issue15368 : TestContentPage
+	{
+		Label _label = new Label { Text = "Focus the Editor, then click the Label to unfocus the Editor. If this text changes, this test has failed." };
+
+		protected override void Init()
+		{
+			var editor = new Editor { AutomationId = "editor" };
+			editor.TextChanged += Editor_TextChanged;
+
+			var layout = new StackLayout { Children = { _label, editor, new Label { Text = "Click me", AutomationId = "click" } } };
+
+			Content = layout;
+		}
+
+		void Editor_TextChanged(object sender, TextChangedEventArgs e)
+		{
+			_label.Text = "FAIL";
+		}
+
+#if UITEST
+		[Test]
+		public void Issue15368Test()
+		{
+			RunningApp.WaitForElement("editor");
+			RunningApp.Tap("editor");
+			RunningApp.WaitForElement("click");
+			RunningApp.Tap("click");
+			RunningApp.WaitForNoElement("FAIL");
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -54,6 +54,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue14801.xaml.cs">
       <DependentUpon>Issue14801.xaml</DependentUpon>
     </Compile>
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15368.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8606.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue15066.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">

--- a/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EditorRenderer.cs
@@ -277,8 +277,15 @@ namespace Xamarin.Forms.Platform.iOS
 
 		void OnEnded(object sender, EventArgs eventArgs)
 		{
-			if (TextView.Text != Element.Text)
-				ElementController.SetValueFromRenderer(Editor.TextProperty, TextView.Text);
+			// Typing aid changes don't always raise EditingChanged event
+			// Normalizing nulls to string.Empty allows us to ensure that a change from null to "" doesn't result in a change event.
+			// While technically this is a difference it serves no functional good.
+			
+			var textViewText = TextView.Text ?? string.Empty;
+			var editorText = Element.Text ?? string.Empty;
+			
+			if (textViewText != editorText)
+				ElementController.SetValueFromRenderer(Editor.TextProperty, textViewText);			
 
 			Element.SetValue(VisualElement.IsFocusedPropertyKey, false);
 			ElementController.SendCompleted();


### PR DESCRIPTION
### Description of Change ###

Update OnEnded method

### Issues Resolved ### 

- fixes https://github.com/xamarin/Xamarin.Forms/issues/15368

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Testing Procedure ###

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
