### PR TITLE
gracefully handle null values in BindingExpression.TryConvert

### DIFF
--- a/Xamarin.Forms.Core/BindingExpression.cs
+++ b/Xamarin.Forms.Core/BindingExpression.cs
@@ -442,6 +442,10 @@ namespace Xamarin.Forms
 
 		internal static bool TryConvert(ref object value, BindableProperty targetProperty, Type convertTo, bool toTarget)
 		{
+			if (targetProperty == null)
+				return false;
+			if (convertTo == null)
+				return false;
 			if (value == null)
 				return !convertTo.GetTypeInfo().IsValueType || Nullable.GetUnderlyingType(convertTo) != null;
 			try


### PR DESCRIPTION
### Description of Change ###

Added null handling to BindingExpression.TryConvert to mitigate an `NullReferenceException` which thereafter leads to app crash in production.

### Issues Resolved ### 

- fixes #15381

### API Changes ###

None

### Platforms Affected ### 

- Core/XAML (all platforms)

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
