### PR TITLE
Account for RTL on Android Tablet

### DIFF
--- a/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageContainer.cs
@@ -274,7 +274,17 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				//to keep some behavior we have on iPad where you can toggle and it won't do anything 
 				bool isDefaultNoToggle = _parent.FlyoutLayoutBehavior == FlyoutLayoutBehavior.Default;
-				xPos = isFlyoutPage ? 0 : (_parent.IsPresented || isDefaultNoToggle ? DefaultWidthFlyout : 0);
+
+				if (_parent.FlowDirection == FlowDirection.RightToLeft)
+				{
+					double rightDp2 = Context.FromPixels(right);
+					xPos = isFlyoutPage ? rightDp2 - DefaultWidthFlyout : (_parent.IsPresented || isDefaultNoToggle ? 0 : rightDp2 - DefaultWidthFlyout);
+				}
+				else
+				{
+					xPos = isFlyoutPage ? 0 : (_parent.IsPresented || isDefaultNoToggle ? DefaultWidthFlyout : 0);
+				}
+
 				width = isFlyoutPage ? DefaultWidthFlyout : _parent.IsPresented || isDefaultNoToggle ? width - DefaultWidthFlyout : width;
 			}
 			else

--- a/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageContainer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageContainer.cs
@@ -291,8 +291,15 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				//if we are showing the normal popover master doesn't have padding
 				supressPadding = isFlyoutPage;
+
+				if (_parent.FlowDirection == FlowDirection.RightToLeft && isFlyoutPage)
+				{
+					xPos = width - DefaultWidthFlyout;
+				}
+
 				//popover make the master smaller
 				width = isFlyoutPage && (Device.Info.CurrentOrientation.IsLandscape() || Device.Idiom == TargetIdiom.Tablet) ? DefaultWidthFlyout : width;
+
 			}
 
 			double padding = supressPadding ? 0 : Context.FromPixels(TopPadding);

--- a/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageRenderer.cs
@@ -308,7 +308,12 @@ namespace Xamarin.Forms.Platform.Android
 			base.OnLayout(changed, l, t, r, b);
 			//hack to make the split layout handle touches the full width
 			if (FlyoutPageController.ShouldShowSplitMode && _flyoutLayout != null)
-				_flyoutLayout.Right = r;
+			{
+				if (Element.FlowDirection == FlowDirection.RightToLeft)
+					_flyoutLayout.Left = l;
+				else
+					_flyoutLayout.Right = r;
+			}
 		}
 
 		async void DeviceInfoPropertyChanged(object sender, PropertyChangedEventArgs e)

--- a/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FlyoutPageRenderer.cs
@@ -348,6 +348,9 @@ namespace Xamarin.Forms.Platform.Android
 
 				if (Device.Idiom == TargetIdiom.Tablet && _flyoutLayout != null)
 				{
+					// This is required to add/remove the drawer button
+					// This basically runs the same code that runs when 
+					// a device changes between landscape/portrait
 					_detailLayout.GetFirstChildOfType<NavigationPageRenderer>()?.ResetToolbar();
 				}
 			}
@@ -400,6 +403,8 @@ namespace Xamarin.Forms.Platform.Android
 			else if (e.PropertyName == VisualElement.FlowDirectionProperty.PropertyName)
 			{
 				UpdateFlowDirection();
+
+				// This will move the drawer layout button to the proper side of the toolbar
 				_detailLayout.GetFirstChildOfType<NavigationPageRenderer>()?.UpdateToolbar();
 			}
 			else if (e.Is(FlyoutPage.FlyoutLayoutBehaviorProperty))

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -983,6 +983,10 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 					toggle.DrawerIndicatorEnabled = _flyoutPage.ShouldShowToolbarButton();
 					toggle.SyncState();
 
+					// When pivoting between split mode and flyout mode
+					// The DrawerArrowDrawable Progress will get out of sync and show a back button
+					// this forces it back to a hamburger
+
 					if (toggle.DrawerArrowDrawable != null)
 						toggle.DrawerArrowDrawable.Progress = 0;
 				}

--- a/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/NavigationPageRenderer.cs
@@ -736,7 +736,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			});
 		}
 
-		void ResetToolbar()
+		internal void ResetToolbar()
 		{
 			AToolbar oldToolbar = _toolbar;
 
@@ -933,7 +933,7 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 			ToolbarExtensions.UpdateMenuItemIcon(context, menuItem, toolBarItem, null);
 		}
 
-		void UpdateToolbar()
+		internal void UpdateToolbar()
 		{
 			if (_disposed)
 				return;
@@ -982,6 +982,9 @@ namespace Xamarin.Forms.Platform.Android.AppCompat
 				{
 					toggle.DrawerIndicatorEnabled = _flyoutPage.ShouldShowToolbarButton();
 					toggle.SyncState();
+
+					if (toggle.DrawerArrowDrawable != null)
+						toggle.DrawerArrowDrawable.Progress = 0;
 				}
 			}
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ViewGroupExtensions.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ViewGroupExtensions.cs
@@ -23,5 +23,27 @@ namespace Xamarin.Forms.Platform.Android
 				}
 			}
 		}
+
+		public static T GetFirstChildOfType<T>(this AViewGroup viewGroup) where T : AView
+		{
+			for (var i = 0; i < viewGroup.ChildCount; i++)
+			{
+				AView child = viewGroup.GetChildAt(i);
+
+				if (child is T typedChild)
+					return typedChild;
+
+				if (child is AViewGroup vg)
+				{
+					var descendant = vg.GetFirstChildOfType<T>();
+					if (descendant != null)
+					{
+						return descendant;
+					}
+				}
+			}
+
+			return null;
+		}
 	}
 }

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -61,6 +61,9 @@ steps:
     inputs:
       provProfileSecureFile: 'Xamarin Forms iOS Provisioning.mobileprovision'
 
+  - bash: rm -rf ~/.config/NuGet/NuGet.Config
+    displayName: 'Workaround to make build work'       
+
   - task: Bash@3
     displayName: 'Build Control Gallery IPA'
     inputs:


### PR DESCRIPTION
### Description of Change ###

The original RTL PR didn't test on an Android tablet so AFAICT this has never really worked on an Android Tablet. 

The split mode on Android is a bit of a hack of the drawer layout. It forces the flyout to be visible and then we calculate the layout bounds ourselves. 

Side note :-) This all works fine in MAUI because on MAUI when using split mode the flyout and details are just moved to a linear layout. This means the platform is able to apply RTL without us having to do anything magical. 

### Issues Resolved ### 
- fixes #15359

### PICTURES

![image](https://user-images.githubusercontent.com/5375137/174167175-84640090-7379-4c36-ab16-5a57a447054e.png)

