### PR TITLE
Fix Editor.Placeholder to show again on Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
+++ b/Xamarin.Forms.Platform.Android/FastRenderers/AutomationPropertiesProvider.cs
@@ -205,7 +205,7 @@ namespace Xamarin.Forms.Platform.Android.FastRenderers
 
 			// TODO: add EntryAccessibilityDelegate to Entry
 			// Let the specified Placeholder take precedence, but don't set the ContentDescription (won't work anyway)
-			if ((Element as Entry)?.Placeholder != null)
+			if ((Element as Entry)?.Placeholder != null || (Element as Editor)?.Placeholder != null)
 			{
 				return true;
 			}


### PR DESCRIPTION
### Description of Change ###

Seems like some check was forgotten in regard to accessibility and the Editor which caused the placeholder not to show up anymore on Android.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15435

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
