### PR TITLE
Fix IndexOutOfBoundsException: setSpan crash in Editor on Android

### DIFF
--- a/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/EditorRenderer.cs
@@ -265,6 +265,9 @@ namespace Xamarin.Forms.Platform.Android
 
 		void UpdateText()
 		{
+			if (EditText == null || Element == null)
+				return;
+
 			string newText = Element.UpdateFormsText(Element.Text, Element.TextTransform);
 
 			if (EditText.Text == newText)
@@ -272,7 +275,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			newText = TrimToMaxLength(newText);
 			EditText.Text = newText;
-			EditText.SetSelection(newText.Length);
+			EditText.SetSelection(EditText.Text.Length);
 		}
 
 		abstract protected void UpdateTextColor();


### PR DESCRIPTION
### Description of Change ###

Ports a fix for a very similar issue with `Entry` also to `Editor` to overcome this bug.

### Issues Resolved ### 

- fixes #15465

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
