### PR TITLE
[Android] fix item indices and item count in a ListView – second try

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15305.xaml
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15305.xaml
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<controls:TestContentPage
+    xmlns="http://xamarin.com/schemas/2014/forms"
+    xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+    xmlns:controls="clr-namespace:Xamarin.Forms.Controls"
+    xmlns:issues="clr-namespace:Xamarin.Forms.Controls.Issues"
+    x:Class="Xamarin.Forms.Controls.Issues.Issue15305"
+    x:DataType="issues:ViewModelIssue15305">
+    <StackLayout>
+        <Label HorizontalTextAlignment="Center"
+               Padding="3.0"
+               Text="Activate TalkBack. Tap on the first or second item in the ListView on this page.&#x0a;If the screen reader reads out &quot;two of four in list, four items&quot; for the first item (or &quot;three of four in list, four items&quot; for the second item),&#x0a;the test has failed." />
+        <ListView ItemsSource="{Binding Path=Items}">
+            <ListView.ItemTemplate>
+                <DataTemplate x:DataType="x:String">
+                    <ViewCell>
+                        <Label Text="{Binding Path=.}" />
+                    </ViewCell>
+                </DataTemplate>
+            </ListView.ItemTemplate>
+        </ListView>
+    </StackLayout>
+</controls:TestContentPage>

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15305.xaml.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15305.xaml.cs
@@ -1,0 +1,47 @@
+﻿using System.Collections.ObjectModel;
+using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using Xamarin.Forms.Xaml;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+#if APP
+	[XamlCompilation(XamlCompilationOptions.Compile)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15305, "[Android] TalkBack always considers ListView's header and footer for indexing/counting", PlatformAffected.Android)]
+	public partial class Issue15305 : TestContentPage
+	{
+		public Issue15305()
+		{
+#if APP
+			InitializeComponent();
+#endif
+		}
+
+		protected override void Init()
+		{
+			BindingContext = new ViewModelIssue15305();
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue15305
+	{
+		public ViewModelIssue15305()
+		{
+			Items = new ObservableCollection<string>() { "first item", "second item", };
+		}
+
+		public ObservableCollection<string> Items { get; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1864,6 +1864,9 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11954.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13918.xaml.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13794.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15305.xaml.cs">
+      <DependentUpon>Issue15305.xaml</DependentUpon>
+    </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Controls\MyCollectionView.xaml.cs">
       <DependentUpon>MyCollectionView.xaml</DependentUpon>
       <SubType>Code</SubType>
@@ -2417,6 +2420,9 @@
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue13918.xaml">
+      <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
+    </EmbeddedResource>
+    <EmbeddedResource Include="$(MSBuildThisFileDirectory)Issue15305.xaml">
       <Generator>MSBuild:UpdateDesignTimeXaml</Generator>
     </EmbeddedResource>
     <EmbeddedResource Include="$(MSBuildThisFileDirectory)Controls\MyCollectionView.xaml">

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -132,13 +132,12 @@ namespace Xamarin.Forms.Platform.Android
 
 		public void OnItemClick(AdapterView parent, AView view, int position, long id)
 		{
+			var listView = parent as AListView;
+			if (listView != null)
+				position -= listView.HeaderViewsCount;
+
 			if (_actionMode != null || _supportActionMode != null)
-			{
-				var listView = parent as AListView;
-				if (listView != null)
-					position -= listView.HeaderViewsCount;
 				HandleContextMode(view, position);
-			}
 			else
 				HandleItemClick(parent, view, position, id);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -481,9 +481,6 @@ namespace Xamarin.Forms.Platform.Android
 				cell = (Cell)(cellOwner as INativeElementView)?.Element;
 			}
 
-			// All our ListView's have called AddHeaderView. This effectively becomes index 0, so our index 0 is index 1 to the listView.
-			position--;
-
 			if (position < 0 || position >= Count)
 				return;
 

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -365,7 +365,14 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			if (footer == null)
+			{
+				if (_footerView.ChildCount == 0)
+				{
+					AListView nativeListView = Control;
+					nativeListView.RemoveFooterView(_adapter.FooterView);
+				}
 				return;
+			}
 
 			if (_footerRenderer != null)
 				_footerRenderer.SetElement(footer);
@@ -397,7 +404,14 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			if (header == null)
+			{
+				if (_headerView.ChildCount == 0)
+				{
+					AListView nativeListView = Control;
+					nativeListView.RemoveHeaderView(_adapter.HeaderView);
+				}
 				return;
+			}
 
 			if (_headerRenderer != null)
 				_headerRenderer.SetElement(header);

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewRenderer.cs
@@ -308,7 +308,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 
 			//Android offsets position of cells when using header
-			int realPositionWithHeader = scrollPosition + 1;
+			int realPositionWithHeader = scrollPosition + _headerView?.ChildCount ?? 0;
 
 			if (e.Position == ScrollToPosition.MakeVisible)
 			{


### PR DESCRIPTION
### Description of Change ###

- fix the wrong item indices and the wrong total count of items in a ListView on Android
- for this the header and footer are removed when they are empty
- partially taken from #10151
- the first try #15306 led to a bug when using the ScrollTo method and this PR was reverted #15473
- in this PR the ScrollTo method was also adapted to fix this bug

### Issues Resolved ### 

- fixes #4090
- fixes #15305

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

The TalkBack screen reader now has the correct item indices and item count for the elements in a ListView.

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

- Android: description can be seen in Issue15305.cs

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
