### PR TITLE
GTK: Call Pixbuf ctor on MainThread for LoadImageAsync functions

### DIFF
--- a/Xamarin.Forms.Platform.GTK/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.GTK/Renderers/ImageRenderer.cs
@@ -171,7 +171,7 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 	public sealed class FileImageSourceHandler : IImageSourceHandler
 	{
-		public Task<Pixbuf> LoadImageAsync(
+		public async Task<Pixbuf> LoadImageAsync(
 			ImageSource imagesource,
 			CancellationToken cancelationToken = default(CancellationToken),
 			float scale = 1f)
@@ -188,12 +188,15 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 					if (File.Exists(imagePath))
 					{
-						image = new Pixbuf(imagePath);
+						await Device.InvokeOnMainThreadAsync(() =>
+						{
+							image = new Pixbuf(imagePath);
+						});
 					}
 				}
 			}
 
-			return Task.FromResult(image);
+			return image;
 		}
 	}
 
@@ -210,7 +213,12 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				.GetStreamAsync(cancelationToken).ConfigureAwait(false))
 			{
 				if (streamImage != null)
-					image = new Pixbuf(streamImage);
+				{	
+					await Device.InvokeOnMainThreadAsync(() =>
+					{
+						image = new Pixbuf(streamImage);
+					});
+				}
 			}
 
 			return image;
@@ -238,7 +246,10 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 					return null;
 				}
 
-				image = new Pixbuf(streamImage);
+				await Device.InvokeOnMainThreadAsync(() =>
+				{
+					image = new Pixbuf(streamImage);
+				});
 			}
 
 			return image;
@@ -248,13 +259,13 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 
 	public sealed class FontImageSourceHandler : IImageSourceHandler
 	{
-		public Task<Pixbuf> LoadImageAsync(ImageSource imageSource,
+		public async Task<Pixbuf> LoadImageAsync(ImageSource imageSource,
 			CancellationToken cancellationToken = new CancellationToken(), float scale = 1)
 		{
 			if (!(imageSource is FontImageSource fontImageSource))
 				return null;
 
-			Pixbuf pixbuf;
+			Pixbuf pixbuf = null;
 			using (var bmp = new Bitmap((int)fontImageSource.Size, (int)fontImageSource.Size))
 			{
 				using (var g = Graphics.FromImage(bmp))
@@ -270,11 +281,15 @@ namespace Xamarin.Forms.Platform.GTK.Renderers
 				using (var stream = new MemoryStream())
 				{
 					bmp.Save(stream, ImageFormat.Jpeg);
-					pixbuf = new Pixbuf(stream.ToArray());
+					await Device.InvokeOnMainThreadAsync(() =>
+					{
+						pixbuf = new Pixbuf(stream.ToArray());
+					});
+					
 				}
 			}
 
-			return Task.FromResult(pixbuf);
+			return pixbuf;
 		}
 
 		static FontFamily GetFontFamily(FontImageSource fontImageSource)


### PR DESCRIPTION
This fix avoids threading problems caused by calling Pixbuf ctor from outside of the MainThread.

<!-- WAIT! 

After July 15, 2020, feature related pull requests cannot be guaranteed to merge by Xamarin.Forms 5.0. They will be labeled "maui" for transition to dotnet/maui. See the [transition to .NET MAUI](https://github.com/xamarin/Xamarin.Forms/wiki/Feature-Roadmap#transition-to-net-maui) for more information.

Before you submit this PR, make sure you're building on and targeting the right branch!
     - If this is an enhancement or contains API changes or breaking changes, target main.
     - If the issue you're working on has a milestone, target the corresponding branch.
     - If this is a bug fix, target the branch of the latest stable version (unless the bug is only in a prerelease or main, of course!).
     See [Contributing](https://github.com/xamarin/Xamarin.Forms/blob/main/.github/CONTRIBUTING.md) for more tips!

     PLEASE DELETE THE ALL THESE COMMENTS BEFORE SUBMITTING! THANKS!!!
 -->
### Description of Change ###

This fix avoids threading problems caused by calling Pixbuf ctor from outside of the MainThread by invoking it on the MainThread using Device.InvokeOnMainThreadAsync function.

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced this issue, if possible. -->

### API Changes ###
<!-- List all API changes here (or just put None), example:

Added:
 - bool FakeControl.MakeShiny { get; set; } //Bindable Property
 - void FakeControl.Clear ();

Changed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 Removed:
 - object FakeControl.MakeShiny => FakeControl FakeControl.MakeShiny
 
 -->
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->

- GTK

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [x] Targets the correct branch
- [x] Tests are passing (or failures are unrelated)
