### PR TITLE
Prevent ArgumentOutOfRangeException

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -237,7 +237,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal object ElementAt(int index)
 		{
-			if (_itemsSource is IList list)
+			if (_itemsSource is IList list && list.Count > index)
 				return list[index];
 
 			int count = 0;


### PR DESCRIPTION
Accessing ObservableCollection which was changed may result in an ArgumentOutOfRangeException. The exception will crash the Application because the CollectionViewRenderer cannot handle that condition in its internal drawing.

The bug is actually caused by a race condition when ItemSource is edited (cleared) while the Renderer still paints the native control and is difficult to reproduce in a simple example.

### Description of Change ###

Check length of list before blindly accessing its indexer. This prevents an ArgumentOutOfRangeException when the ObservableCollection is changing while the CollectionViewRenderer is recalculating.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15567

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None (no crash)

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###

Hard to test as this only happens when a race condition happens between Thread changing ObservableCollection data and Renderer.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
