### PR TITLE
Use AUTH_TOKEN_GITHUB_COM when invoking Provisionator

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -13,6 +13,7 @@ variables:
   value: 5.0.102
 - name: signingCondition
   value: and(succeeded(), ne(variables['signVmImage'], ''), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+- group: Xamarin-Secrets
 
 resources:
   repositories:

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -67,6 +67,8 @@ jobs:
         inputs:
           provisioning_script: ${{ parameters.provisionatorPath }}
           provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
+        env:
+          AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
       - script: '/bin/bash -c "sudo $AGENT_HOMEDIRECTORY/scripts/select-xamarin-sdk.sh ${{ parameters.monoVersion }}"'
         displayName: 'Select MONO ${{ parameters.monoVersion }}'

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -7,6 +7,8 @@ steps:
     condition: ne(variables['REQUIRED_XCODE'], '')
     inputs:
       provisioning_script: 'build/provisioning/xcode.csx'
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provisionator'
@@ -14,6 +16,8 @@ steps:
     inputs:
       provisioning_script: $(provisionator.osxPath)
       provisioning_extra_args: $(provisionator.extraArguments) --v
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
   - script: |
       echo "##vso[task.prependpath]/Library/Frameworks/Mono.framework/Versions/Current/Commands/"

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -22,6 +22,8 @@ steps:
     inputs:
       provisioning_script: ${{ parameters.provisionatorPath }}
       provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
   
   - task: xamops.azdevex.provisionator-task.provisionator@1
     displayName: 'Provisioning VS'
@@ -29,6 +31,8 @@ steps:
     inputs:
       provisioning_script: ${{ parameters.provisionatorVSPath }}
       provisioning_extra_args: ${{ parameters.provisionator.extraArguments }}
+    env:
+      AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
   - script: build.cmd -Target cg-uwp-build-tests -ScriptArgs '--BUILD_CONFIGURATION="$(BuildConfiguration)"','--MSBUILD="$(msbuild)"'
     condition: eq(variables['BuildConfiguration'], 'Release')

--- a/eng/xf-release.yml
+++ b/eng/xf-release.yml
@@ -13,6 +13,7 @@ variables:
   value: 5.0.102
 - name: signingCondition
   value: and(succeeded(), or(eq(variables['Sign'], 'true'), or(eq(variables['Build.SourceBranch'], 'refs/heads/main'), startsWith(variables['Build.SourceBranch'],'refs/tags/'))))
+- group: Xamarin-Secrets
 
 resources:
   repositories:


### PR DESCRIPTION

### Description of Change ###

Invokes Provisionator with AUTH_TOKEN_GITHUB_AUTH set to support bootstrapping/downloading through dl.internalx.com

### Issues Resolved ### 


### API Changes ###
None

### Platforms Affected ### 
None

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
In CI

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
