### PR TITLE
[iOS 16] Fix wrong size TitleView issue on iOS 16

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15542.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15542.cs
@@ -1,0 +1,77 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15542, "[Bug] Shell.TitleView does not render on iOS 16",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.TitleView)]
+#endif
+	public class Issue15542 : TestShell
+	{
+		protected override void Init()
+		{
+			AddTopTab(createContentPage("title 1"), "page 1");
+			AddTopTab(createContentPage("title 2"), "page 2");
+			AddTopTab(createContentPage("title 3"), "page 3");
+
+			static ContentPage createContentPage(string titleView)
+			{
+				Label safeArea = new Label();
+				ContentPage page = new ContentPage()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "If the TitleView is not visible the test has failed.",
+								AutomationId = "Instructions"
+							},
+							safeArea
+						}
+					}
+				};
+
+				if (!string.IsNullOrWhiteSpace(titleView))
+				{
+					SetTitleView(page,
+						new Grid()
+						{
+							BackgroundColor = Color.Red,
+							AutomationId = "TitleViewId",
+							Children = { new Label() { Text = titleView, VerticalTextAlignment = TextAlignment.End } }
+						});
+				}
+
+				return page;
+			}
+		}
+
+
+#if UITEST
+
+		[Test]
+		public void TitleViewHeightDoesntOverflow()
+		{
+			var titleView = RunningApp.WaitForElement("TitleViewId")[0].Rect;
+			var topTab = RunningApp.WaitForElement("page 1")[0].Rect;
+
+			var titleViewBottom = titleView.Y + titleView.Height;
+			var topTabTop = topTab.Y;
+
+			Assert.GreaterOrEqual(topTabTop, titleViewBottom, "Title View is incorrectly positioned in iOS 16");
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -55,6 +55,7 @@
       <DependentUpon>Issue14801.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue15368.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15542.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8606.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue15066.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">

--- a/Xamarin.Forms.Platform.iOS/Forms.cs
+++ b/Xamarin.Forms.Platform.iOS/Forms.cs
@@ -42,6 +42,7 @@ namespace Xamarin.Forms
 		static bool? s_isiOS14OrNewer;
 		static bool? s_isiOS15OrNewer;
 		static bool? s_isiOS154OrNewer;
+		static bool? s_isiOS16OrNewer;
 		static bool? s_respondsTosetNeedsUpdateOfHomeIndicatorAutoHidden;
 
 		internal static bool IsiOS9OrNewer
@@ -125,6 +126,15 @@ namespace Xamarin.Forms
 			}
 		}
 
+		internal static bool IsiOS16OrNewer
+		{
+			get
+			{
+				if (!s_isiOS16OrNewer.HasValue)
+					s_isiOS16OrNewer = UIDevice.CurrentDevice.CheckSystemVersion(16, 0);
+				return s_isiOS16OrNewer.Value;
+			}
+		}
 
 		internal static bool RespondsToSetNeedsUpdateOfHomeIndicatorAutoHidden
 		{

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				SearchHandler = Shell.GetSearchHandler(Page);
 			}
-			else if (e.PropertyName == Shell.TitleViewProperty.PropertyName)
+			else if (e.PropertyName == Shell.TitleViewProperty.PropertyName || e.PropertyName == VisualElement.HeightProperty.PropertyName || e.PropertyName == VisualElement.WidthProperty.PropertyName)
 			{
 				UpdateTitleView();
 			}


### PR DESCRIPTION
### Description of Change ###

Fix wrong size TitleView issue on iOS 16.

![image](https://user-images.githubusercontent.com/6755973/201710301-2df501fa-4ad3-433c-9511-718b415ad0e9.png)

### Issues Resolved ### 

- fixes #15542 

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch the Xamarin.Forms Core Gallery App and navigate to the issue 15542. If the Red TitleView is rendering, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
