### PR TITLE
[iOS] Fix issue using ToolbarItems with TitleView on iOS 16

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15565.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15565.cs
@@ -1,0 +1,103 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+
+#if UITEST
+using NUnit.Framework;
+using Xamarin.Forms.Core.UITests;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15565, "[Bug] Shell TitleView and ToolBarItems rendering strange display on iOS 16",
+		PlatformAffected.iOS)]
+#if UITEST
+	[NUnit.Framework.Category(UITestCategories.Shell)]
+	[NUnit.Framework.Category(UITestCategories.TitleView)]
+#endif
+	public class Issue15565 : TestShell
+	{
+		protected override void Init()
+		{
+			AddTopTab(createContentPage("title 1"), "page 1");
+			AddTopTab(createContentPage("title 2"), "page 2");
+			AddTopTab(createContentPage("title 3"), "page 3");
+
+			static ContentPage createContentPage(string titleView)
+			{
+				Label safeArea = new Label();
+				ContentPage page = new ContentPage()
+				{
+					Content = new StackLayout()
+					{
+						Children =
+						{
+							new Label()
+							{
+								Text = "If the TitleView is not visible at the same time as the ToolbarItems, the test has failed.",
+								AutomationId = "Instructions"
+							},
+							safeArea
+						}
+					}
+				};
+
+				page.ToolbarItems.Add(new ToolbarItem() { Text = "Item 1" });
+				page.ToolbarItems.Add(new ToolbarItem() { Text = "Item 2" });
+
+				if (!string.IsNullOrWhiteSpace(titleView))
+				{
+					SetTitleView(page,
+						new Grid()
+						{
+							BackgroundColor = Color.Red,
+							AutomationId = "TitleViewId",
+							Children = { new Label() { Text = titleView, VerticalTextAlignment = TextAlignment.End } }
+						});
+				}
+
+				return page;
+			}
+		}
+
+
+#if UITEST
+
+		[Test]
+		public void TitleViewHeightIsNotZero()
+		{
+			var titleView = RunningApp.WaitForElement("TitleViewId")[0].Rect;
+			var topTab = RunningApp.WaitForElement("page 1")[0].Rect;
+
+			var titleViewBottom = titleView.Y + titleView.Height;
+			var topTabTop = topTab.Y;
+
+			Assert.GreaterOrEqual(topTabTop, titleViewBottom, "Title View is incorrectly positioned in iOS 16");
+		}
+
+		[Test]
+		public void ToolbarItemsWithTitleViewAreRendering()
+		{
+			RunningApp.WaitForElement("Item 1");
+			RunningApp.WaitForElement("Item 3");
+		}
+
+		[Test]
+		public void NoDuplicateTitleViews()
+		{
+			var titleView = RunningApp.WaitForElement("TitleViewId");
+
+			Assert.AreEqual(1, titleView.Length);
+
+			RunningApp.Tap("page 1");
+			RunningApp.Tap("page 2");
+			RunningApp.Tap("page 3");
+
+			titleView = RunningApp.WaitForElement("TitleViewId");
+
+			Assert.AreEqual(1, titleView.Length);
+		}
+#endif
+
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -55,6 +55,7 @@
       <DependentUpon>Issue14801.xaml</DependentUpon>
     </Compile>
     <Compile Include="$(MSBuildThisFileDirectory)Issue15368.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue15565.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8606.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue15066.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue8804.xaml.cs">

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				SearchHandler = Shell.GetSearchHandler(Page);
 			}
-			else if (e.PropertyName == Shell.TitleViewProperty.PropertyName)
+			else if (e.PropertyName == Shell.TitleViewProperty.PropertyName || e.PropertyName == VisualElement.HeightProperty.PropertyName || e.PropertyName == VisualElement.WidthProperty.PropertyName)
 			{
 				UpdateTitleView();
 			}


### PR DESCRIPTION
### Description of Change ###

Fix issue using ToolbarItems with TitleView on iOS 16.

![image](https://user-images.githubusercontent.com/6755973/201894224-a5927082-9873-4a29-a559-7fa85be9bd96.png)

NOTE: The fix is the same applied in https://github.com/xamarin/Xamarin.Forms/pull/15600 This PR include specific UI Tests to validate the TitleView usage with ToolbarItems on iOS 16.

### Issues Resolved ### 

- fixes #15565

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
Launch the Xamarin.Forms Core Gallery App and navigate to the issue 15565. If the Red TitleView is rendering with the ToolbarItems, the test has passed.

### PR Checklist ###

- [x] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
