### PR TITLE
Fix crash iOS Label measure for RTL languages

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -153,7 +153,9 @@ namespace Xamarin.Forms.Platform.Android
 					_currentTabbedPage.PropertyChanged -= CurrentTabbedPageOnPropertyChanged;
 
 					if (value == null)
+#pragma warning disable CS0618 // Type or member is obsolete
 						ActionBar.RemoveAllTabs();
+#pragma warning restore CS0618 // Type or member is obsolete
 				}
 
 				_currentTabbedPage = value;
@@ -646,15 +648,21 @@ namespace Xamarin.Forms.Platform.Android
 
 			TabbedPage currentTabs = CurrentTabbedPage;
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			var atab = actionBar.NewTab();
+#pragma warning restore CS0618 // Type or member is obsolete
 
+#pragma warning disable CS0618 // Type or member is obsolete
 			atab.SetText(new Java.Lang.String(page.Title));
+#pragma warning restore CS0618 // Type or member is obsolete
 			atab.TabSelected += (sender, e) =>
 			{
 				if (!_ignoreAndroidSelection)
 					currentTabs.CurrentPage = page;
 			};
+#pragma warning disable CS0618 // Type or member is obsolete
 			actionBar.AddTab(atab, index);
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			page.PropertyChanged += PagePropertyChanged;
 			return atab;
@@ -737,7 +745,11 @@ namespace Xamarin.Forms.Platform.Android
 				Page page = CurrentTabbedPage.CurrentPage;
 				int index = TabbedPage.GetIndex(page);
 				if (index >= 0 && index < CurrentTabbedPage.Children.Count)
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 					ActionBar.GetTabAt(index).Select();
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 
 			_ignoreAndroidSelection = false;
@@ -766,7 +778,9 @@ namespace Xamarin.Forms.Platform.Android
 			Page page = _currentTabbedPage.CurrentPage;
 			if (page == null)
 			{
+#pragma warning disable CS0618 // Type or member is obsolete
 				ActionBar.SelectTab(null);
+#pragma warning restore CS0618 // Type or member is obsolete
 				return;
 			}
 
@@ -776,7 +790,11 @@ namespace Xamarin.Forms.Platform.Android
 				return;
 			}
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 			ActionBar.SelectTab(ActionBar.GetTabAt(index));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		Drawable GetActionBarBackgroundDrawable()
@@ -874,8 +892,12 @@ namespace Xamarin.Forms.Platform.Android
 					return;
 
 				var page = sender as Page;
+#pragma warning disable CS0618 // Type or member is obsolete
 				var atab = actionBar.GetTabAt(currentTabs.Children.IndexOf(page));
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				atab.SetText(new Java.Lang.String(page.Title));
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
 
@@ -940,12 +962,16 @@ namespace Xamarin.Forms.Platform.Android
 		void RemoveTab(Page page, int index)
 		{
 			page.PropertyChanged -= PagePropertyChanged;
+#pragma warning disable CS0618 // Type or member is obsolete
 			ActionBar?.RemoveTabAt(index);
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		void Reset()
 		{
+#pragma warning disable CS0618 // Type or member is obsolete
 			ActionBar.RemoveAllTabs();
+#pragma warning restore CS0618 // Type or member is obsolete
 
 			if (CurrentTabbedPage == null)
 				return;
@@ -955,7 +981,9 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				var realTab = AddTab(tab, i++);
 				if (tab == CurrentTabbedPage.CurrentPage)
+#pragma warning disable CS0618 // Type or member is obsolete
 					realTab.Select();
+#pragma warning restore CS0618 // Type or member is obsolete
 			}
 		}
 

--- a/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/UIViewExtensions.cs
@@ -88,8 +88,18 @@ namespace Xamarin.Forms.Platform.MacOS
 			else
 				s = self.FittingSize;
 #endif
-			var request = new Size(s.Width == float.PositiveInfinity ? double.PositiveInfinity : s.Width,
-				s.Height == float.PositiveInfinity ? double.PositiveInfinity : s.Height);
+
+			var width = s.Width;
+			var height = s.Height;
+
+			if (nfloat.IsNaN(width))
+				width = float.PositiveInfinity;
+
+			if (nfloat.IsNaN(height))
+				height = float.PositiveInfinity;
+
+			var request = new Size(width == float.PositiveInfinity ? double.PositiveInfinity : width,
+				height == float.PositiveInfinity ? double.PositiveInfinity : height);
 			var minimum = new Size(minimumWidth < 0 ? request.Width : minimumWidth,
 				minimumHeight < 0 ? request.Height : minimumHeight);
 			return new SizeRequest(request, minimum);

--- a/build/steps/build-android.yml
+++ b/build/steps/build-android.yml
@@ -61,7 +61,7 @@ jobs:
           echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)"
         displayName: 'Setup JDK Paths'
 
-      - task: xamops.azdevex.provisionator-task.provisionator@1
+      - task: xamops.azdevex.provisionator-task.provisionator@2
         displayName: 'Provisionator'
         condition: eq(variables['provisioning'], 'true')
         inputs:

--- a/build/steps/build-osx.yml
+++ b/build/steps/build-osx.yml
@@ -2,7 +2,7 @@ steps:
   - checkout: self
     clean: true
 
-  - task: xamops.azdevex.provisionator-task.provisionator@1
+  - task: xamops.azdevex.provisionator-task.provisionator@2
     displayName: 'Provision Xcode'
     condition: ne(variables['REQUIRED_XCODE'], '')
     inputs:
@@ -10,7 +10,7 @@ steps:
     env:
       AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
 
-  - task: xamops.azdevex.provisionator-task.provisionator@1
+  - task: xamops.azdevex.provisionator-task.provisionator@2
     displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')
     inputs:

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -16,7 +16,7 @@ steps:
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')
 
-  - task: xamops.azdevex.provisionator-task.provisionator@1
+  - task: xamops.azdevex.provisionator-task.provisionator@2
     displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')
     inputs:
@@ -25,7 +25,7 @@ steps:
     env:
       AUTH_TOKEN_GITHUB_COM: $(github--pat--vs-mobiletools-engineering-service2)
   
-  - task: xamops.azdevex.provisionator-task.provisionator@1
+  - task: xamops.azdevex.provisionator-task.provisionator@2
     displayName: 'Provisioning VS'
     condition: eq(variables['provisioningVS'], 'true')
     inputs:


### PR DESCRIPTION
### Description of Change ###

As of iOS 16 (or probably more likely; Xcode 14) a `NaN` value would occur when measuring this label size. To account for that, detect `NaN` values and set it to an unknown value so it will recalculate.

### Issues Resolved ### 

- fixes #15535
- fixes #15579

### API Changes ###
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
