### PR TITLE
fix: #13429

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13429.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue13429.cs
@@ -1,0 +1,209 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System;
+using System.Diagnostics;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.CollectionView)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(
+		IssueTracker.Github,
+		13429,
+		"[Bug] Xamarin.Forms 5.0.0.x ObservableCollection.Add performance decrease on iOS",
+		PlatformAffected.iOS)]
+	public class Issue13429 : TestContentPage
+	{
+		ObservableCollection<Item> _items;
+		Label _statusLabel, _timeoutLabel;
+		int _itemIndex;
+		const int INITIAL_SIZE = 1000;
+		const int DELTA_SIZE = INITIAL_SIZE / 5;
+		const string ADDITION_COMPLETED = "addition completed";
+		const string REMOVAL_COMPLETED = "removal completed";
+		const string REPLACEMENT_COMPLETED = "replacement completed";
+		const string ADD = "Add";
+		const string REMOVE = "Remove";
+		const string REPLACE = "Replace";
+		const string TIMEOUT_ID = nameof(_timeoutLabel);
+
+		public Issue13429()
+		{
+		}
+			
+		protected override void Init()
+		{
+			Button addButton, removeButton, replaceButton;
+			CollectionView collectionView;	
+			Title = "Bug 13429";
+			_items = new ObservableCollection<Item>();
+			var grid = new Grid()
+			{
+				ColumnDefinitions = new ColumnDefinitionCollection
+				{
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = GridLength.Star },
+					new ColumnDefinition { Width = GridLength.Star },
+				},
+				RowDefinitions = new RowDefinitionCollection
+				{
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Auto },
+					new RowDefinition { Height = GridLength.Star },
+				},
+				Children =
+				{
+					(addButton = new Button { Text = ADD }),
+					(removeButton = new Button { Text = REMOVE }),
+					(replaceButton = new Button { Text = REPLACE }),
+					(_statusLabel = new Label { Text = "Waiting" }),
+					(_timeoutLabel = new Label { Text = "", AutomationId = TIMEOUT_ID }),
+					(collectionView = new CollectionView
+					{
+						ItemTemplate = new DataTemplate(() =>
+						{
+							Label name, description;
+							var sl = new StackLayout
+							{
+								Children =
+								{
+									(name = new Label()),
+									(description = new Label())
+								}
+							};
+							name.SetBinding(Label.TextProperty, new Binding(nameof(Item.Name)));
+							description.SetBinding(Label.TextProperty, new Binding(nameof(Item.Description)));
+							return sl;
+						}),
+						ItemsSource = _items,
+					})
+				}
+			};
+
+			Grid.SetColumn(addButton, 0);
+			Grid.SetColumn(removeButton, 1);
+			Grid.SetColumn(replaceButton, 2);
+
+			Grid.SetRow(_statusLabel, 1);
+			Grid.SetColumnSpan(_statusLabel, 3);
+
+			Grid.SetRow(_timeoutLabel, 2);
+			Grid.SetColumnSpan(_timeoutLabel, 3);
+
+			Grid.SetRow(collectionView, 3);
+			Grid.SetColumnSpan(collectionView, 3);
+
+			grid.Children.Add(addButton);
+			grid.Children.Add(removeButton);
+			grid.Children.Add(replaceButton);
+			grid.Children.Add(collectionView);
+
+			addButton.Clicked += (o, e) => AddItems();
+			removeButton.Clicked += (o, e) => RemoveItems();
+			replaceButton.Clicked += (o, e) => ReplaceItems();
+
+			for (int i = 0; i < INITIAL_SIZE; i++)
+				_items.Add(NewItem());
+			Content = grid;
+		}
+
+		Item NewItem()
+		{
+			var result = new Item($"item #{_itemIndex}", $"description of #{_itemIndex} {Guid.NewGuid()}");
+			_itemIndex++;
+			return result;
+		}
+
+		void AddItems(int count = DELTA_SIZE)
+		{
+			IsBusy = true;
+			_statusLabel.Text = "adding items";
+			var sw = new Stopwatch();
+			sw.Start();
+			for (int i = 0; i < count; i++)
+				_items.Add(NewItem());
+			_timeoutLabel.Text = sw.ElapsedMilliseconds.ToString();
+			_statusLabel.Text = ADDITION_COMPLETED;
+			IsBusy = false;
+		}
+
+		void RemoveItems(int count = DELTA_SIZE)
+		{
+			IsBusy = true;
+			_statusLabel.Text = "removing items";
+			var sw = new Stopwatch();
+			sw.Start();
+			if (_items.Count < count)
+				count = _items.Count;
+			while (count-- > 0)
+				_items.RemoveAt(_items.Count - 1);
+			_timeoutLabel.Text = sw.ElapsedMilliseconds.ToString();
+			_statusLabel.Text = REMOVAL_COMPLETED;
+			IsBusy = false;
+		}
+
+		void ReplaceItems(int count = DELTA_SIZE)
+		{
+			IsBusy = true;
+			_statusLabel.Text = "replacing items";
+			var sw = new Stopwatch();
+			sw.Start();
+			for (int i = _items.Count - count; i < _items.Count; i++)
+				_items[i] = NewItem();
+			_timeoutLabel.Text = sw.ElapsedMilliseconds.ToString();
+			_statusLabel.Text = REPLACEMENT_COMPLETED;
+			IsBusy = false;
+		}
+
+		public class Item
+		{
+			public string Name { get; }
+			public string Description { get; }
+
+			public Item(string name, string description)
+			{
+				Name = name;
+				Description = description;
+			}
+		}
+
+#if UITEST
+		const long EXPECTED_TIMEOUT = 2000;
+
+		[Test]
+		public void CollectionViewItemAddtionPerformanceCheck()
+		{
+			RunningApp.Tap(ADD);
+			RunningApp.WaitForElement(q => q.Marked(ADDITION_COMPLETED));
+			var actualTimeout = long.Parse(RunningApp.WaitForElement(q => q.Marked(TIMEOUT_ID))[0].Text);
+			Assert.Less(actualTimeout, EXPECTED_TIMEOUT);
+		}
+		[Test]
+		public void CollectionViewItemRemovalPerformanceCheck()
+		{
+			RunningApp.Tap(REMOVE);
+			RunningApp.WaitForElement(q => q.Marked(REMOVAL_COMPLETED));
+			var actualTimeout = long.Parse(RunningApp.WaitForElement(q => q.Marked(TIMEOUT_ID))[0].Text);
+			Assert.Less(actualTimeout, EXPECTED_TIMEOUT);
+		}
+		[Test]
+		public void CollectionViewItemReplacementPerformanceCheck()
+		{
+			RunningApp.Tap(REPLACE);
+			RunningApp.WaitForElement(q => q.Marked(REPLACEMENT_COMPLETED));
+			var actualTimeout = long.Parse(RunningApp.WaitForElement(q => q.Marked(TIMEOUT_ID))[0].Text);
+			Assert.Less(actualTimeout, EXPECTED_TIMEOUT);
+		}
+#endif
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -23,6 +23,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue11214.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13109.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13268.cs" />
+    <Compile Include="$(MSBuildThisFileDirectory)Issue13429.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Issue13437.xaml.cs">
       <DependentUpon>Issue13437.xaml</DependentUpon>
     </Compile>

--- a/Xamarin.Forms.Platform.iOS/CollectionView/EmptySource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/EmptySource.cs
@@ -14,6 +14,7 @@ namespace Xamarin.Forms.Platform.iOS
 		public int LoopCount => 0;
 
 		public object this[NSIndexPath indexPath] => throw new IndexOutOfRangeException("IItemsViewSource is empty");
+		public object this[NSIndexPathRef indexPath] => throw new IndexOutOfRangeException("IItemsViewSource is empty");
 
 		public int ItemCountInGroup(nint group) => 0;
 

--- a/Xamarin.Forms.Platform.iOS/CollectionView/IItemsViewSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/IItemsViewSource.cs
@@ -8,6 +8,7 @@ namespace Xamarin.Forms.Platform.iOS
 		int ItemCountInGroup(nint group);
 		int GroupCount { get; }
 		object this[Foundation.NSIndexPath indexPath] { get; }
+		object this[NSIndexPathRef indexPath] { get; }
 		object Group(Foundation.NSIndexPath indexPath);
 		Foundation.NSIndexPath GetIndexForItem(object item);
 	}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathHelpers.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/IndexPathHelpers.cs
@@ -47,5 +47,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 			return true;
 		}
+
+		public static bool IsIndexPathValid(this IItemsViewSource source, NSIndexPathRef indexPath)
+		{
+			if (indexPath.Section >= source.GroupCount)
+			{
+				return false;
+			}
+
+			if (indexPath.Item >= source.ItemCountInGroup(indexPath.Section))
+			{
+				return false;
+			}
+
+			return true;
+		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -625,7 +625,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return templatedCell;
 		}
 
-		internal CGSize GetSizeForItem(NSIndexPath indexPath) 
+		internal CGSize GetSizeForItem(NSIndexPathRef indexPath) 
 		{
 			if (ItemsViewLayout.EstimatedItemSize.IsEmpty)
 			{

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewDelegator.cs
@@ -6,7 +6,18 @@ using UIKit;
 
 namespace Xamarin.Forms.Platform.iOS
 {
-	public class ItemsViewDelegator<TItemsView, TViewController> : UICollectionViewDelegateFlowLayout
+	public abstract class ItemsViewDelegator : UICollectionViewDelegateFlowLayout
+	{
+		[Export("collectionView:layout:sizeForItemAtIndexPath:")]
+		public CGSize GetSizeForItem(IntPtr collectionView, IntPtr layout, IntPtr indexPath)
+		{
+			return GetSizeForItem(collectionView, layout, new NSIndexPathRef(indexPath));
+		}
+
+		public abstract CGSize GetSizeForItem(IntPtr collectionView, IntPtr layout, NSIndexPathRef indexPath);
+	}
+
+	public class ItemsViewDelegator<TItemsView, TViewController> : ItemsViewDelegator
 		where TItemsView : ItemsView
 		where TViewController : ItemsViewController<TItemsView>
 	{
@@ -191,7 +202,7 @@ namespace Xamarin.Forms.Platform.iOS
 			return index;
 		}
 
-		public override CGSize GetSizeForItem(UICollectionView collectionView, UICollectionViewLayout layout, NSIndexPath indexPath)
+		public override CGSize GetSizeForItem(IntPtr collectionView, IntPtr layout, NSIndexPathRef indexPath)
 		{
 			return ViewController.GetSizeForItem(indexPath);
 		}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ListSource.cs
@@ -42,6 +42,19 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		public object this[NSIndexPathRef indexPath]
+		{
+			get
+			{
+				if (indexPath.Section > 0)
+				{
+					throw new ArgumentOutOfRangeException(nameof(indexPath));
+				}
+
+				return this[(int)indexPath.Item];
+			}
+		}
+
 		public int GroupCount => 1;
 
 		public int ItemCount => Count;

--- a/Xamarin.Forms.Platform.iOS/CollectionView/NSIndexPathRef.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/NSIndexPathRef.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using System.ComponentModel;
+using Foundation;
+using ObjCRuntime;
+
+namespace Xamarin.Forms.Platform.iOS
+{
+	/// <summary>
+	/// Custom wrapper for <see cref="NSIndexPath"/>. Required to speed up
+	/// <see cref="ItemsViewDelegator.GetSizeForItem(IntPtr, IntPtr, NSIndexPathRef)"/>
+	/// More info <see href="https://github.com/xamarin/xamarin-macios/issues/4923#issuecomment-435827504"/>.
+	/// Must be a ref struct to seize a reference at stack.
+	/// </summary>
+	[EditorBrowsable(EditorBrowsableState.Never)]
+	public ref struct NSIndexPathRef
+	{
+		readonly IntPtr _reference;
+
+		internal NSIndexPathRef(IntPtr reference) => _reference = reference;
+
+		public nint Length => Messaging.nint_objc_msgSend(_reference, Selector.GetHandle("length"));
+		public nint Row => Messaging.nint_objc_msgSend(_reference, Selector.GetHandle("row"));
+		public nint Item => Messaging.nint_objc_msgSend(_reference, Selector.GetHandle("item"));
+		public nint Section => Messaging.nint_objc_msgSend(_reference, Selector.GetHandle("section"));
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableGroupedSource.cs
@@ -37,6 +37,14 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		public object this[NSIndexPathRef indexPath]
+		{
+			get
+			{
+				return GetGroupItemAt((int)indexPath.Section, (int)indexPath.Item);
+			}
+		}
+
 		public int GroupCount => _groupSource.Count;
 
 		public int ItemCount

--- a/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ObservableItemsSource.cs
@@ -97,6 +97,19 @@ namespace Xamarin.Forms.Platform.iOS
 			}
 		}
 
+		public object this[NSIndexPathRef indexPath]
+		{
+			get
+			{
+				if (indexPath.Section != _section)
+				{
+					throw new ArgumentOutOfRangeException(nameof(indexPath));
+				}
+
+				return this[(int)indexPath.Item];
+			}
+		}
+
 		void CollectionChanged(object sender, NotifyCollectionChangedEventArgs args)
 		{
 			if (Device.IsInvokeRequired)

--- a/Xamarin.Forms.Platform.iOS/ObjCRuntime/Messaging.cs
+++ b/Xamarin.Forms.Platform.iOS/ObjCRuntime/Messaging.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Runtime.InteropServices;
+
+namespace ObjCRuntime
+{
+	static class Messaging
+	{
+		[DllImport(Constants.ObjectiveCLibrary, EntryPoint = "objc_msgSend")]
+		public static extern nint nint_objc_msgSend(IntPtr receiver, IntPtr selector);
+	}
+}

--- a/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
+++ b/Xamarin.Forms.Platform.iOS/Xamarin.Forms.Platform.iOS.csproj
@@ -135,6 +135,7 @@
     <Compile Include="CollectionView\HorizontalDefaultCell.cs" />
     <Compile Include="CollectionView\ItemsViewController.cs" />
     <Compile Include="CollectionView\LayoutAttributesChangedEventArgs.cs" />
+    <Compile Include="CollectionView\NSIndexPathRef.cs" />
     <Compile Include="CollectionView\ObservableGroupedSource.cs" />
     <Compile Include="CollectionView\ScrollToPositionExtensions.cs" />
     <Compile Include="CollectionView\SelectableItemsViewController.cs" />
@@ -175,6 +176,7 @@
     <Compile Include="IOSDeviceInfo.cs" />
     <Compile Include="LinkerSafeAttribute.cs" />
     <Compile Include="ModalWrapper.cs" />
+    <Compile Include="ObjCRuntime\Messaging.cs" />
     <Compile Include="Renderers\FormsCAKeyFrameAnimation.cs" />
     <Compile Include="Renderers\FormsCheckBox.cs" />
     <Compile Include="Renderers\FormsUIImageView.cs" />


### PR DESCRIPTION
### Description of Change ###
Because Xamarin.iOS uses a reflection to provide arguments in callbacks [as decribed here](https://github.com/xamarin/xamarin-macios/issues/4923#issuecomment-435827504). This PR provides a custom NSIndexPath wrapper to avoid reflection calling in ItemsViewDelegator.GetSizeForItem. Performance boost is 12x on Simulator or 17x on iPhone.

### Issues Resolved ### 

- fixes #13429 

### API Changes ###
Added:
 - public object IItemsViewSource.this[NSIndexPathRef indexPath] { get; }
 - internal object EmptySource.this[NSIndexPathRef indexPath] { get; }
 - internal object ListSource.this[NSIndexPathRef indexPath] { get; }
 - internal object ObservableGroupedSource.this[NSIndexPathRef indexPath] { get; }
 - internal object ObservableItemsSource.this[NSIndexPathRef indexPath] { get; }
 - public ref struct NSIndexPathRef
 - public CGSize ItemsViewDelegator.GetSizeForItem(IntPtr collectionView, IntPtr layout, IntPtr indexPath)
 - public CGSize ItemsViewDelegator.GetSizeForItem(IntPtr collectionView, IntPtr layout, NSIndexPathRef indexPath)
 - internal bool IndexPathHelpers.IsIndexPathValid(this IItemsViewSource source, NSIndexPathRef indexPath)

Changed:
 - internal CGSize ItemsViewController.GetSizeForItem(NSIndexPath indexPath) => internal CGSize ItemsViewController.GetSizeForItem(NSIndexPathRef indexPath)

### Platforms Affected ### 
- iOS

### Behavioral/Visual Changes ###
None

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Test page for control gallery Issue13429 is provided, UITest included. You may able to run this test from VS. Because this is performance issue you may want to place some different timing depending on your hardware. Current timings is applicable for iPhone 11 and mac mini 2018 i5/16GB. See EXPECTED_TIMEOUT constant at Issue13429 test page. If you want to run this test through control gallery, then launch test, then tap "Add", "Remove" or "Replace" button. Test will show you how much time is taken by operation in milliseconds.

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
