### PR TITLE
`ItemsViewController` null checks

### DIFF
--- a/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
+++ b/Xamarin.Forms.Platform.iOS/CollectionView/ItemsViewController.cs
@@ -114,7 +114,7 @@ namespace Xamarin.Forms.Platform.iOS
 			if (_isEmpty)
 			{
 				UnbindCells();
-				_measurementCells.Clear();
+				_measurementCells?.Clear();
 				ItemsViewLayout?.ClearCellSizeCache();
 			}
 
@@ -231,7 +231,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public virtual void UpdateItemsSource()
 		{
-			_measurementCells.Clear();
+			_measurementCells?.Clear();
 			ItemsViewLayout?.ClearCellSizeCache();
 			ItemsSource?.Dispose();
 			ItemsSource = CreateItemsViewSource();
@@ -275,7 +275,7 @@ namespace Xamarin.Forms.Platform.iOS
 			var bindingContext = ItemsSource[indexPath];
 
 			// If we've already created a cell for this index path (for measurement), re-use the content
-			if (_measurementCells.TryGetValue(bindingContext, out TemplatedCell measurementCell))
+			if (_measurementCells != null && _measurementCells.TryGetValue(bindingContext, out TemplatedCell measurementCell))
 			{
 				_measurementCells.Remove(bindingContext);
 				measurementCell.ContentSizeChanged -= CellContentSizeChanged;
@@ -620,7 +620,8 @@ namespace Xamarin.Forms.Platform.iOS
 			UpdateTemplatedCell(templatedCell, indexPath);
 
 			// Keep this cell around, we can transfer the contents to the actual cell when the UICollectionView creates it
-			_measurementCells[ItemsSource[indexPath]] = templatedCell;
+			if (_measurementCells != null)
+				_measurementCells[ItemsSource[indexPath]] = templatedCell;
 
 			return templatedCell;
 		}


### PR DESCRIPTION
### Description of Change ###

In the `ItemsViewController` multiple methods (i.e. `UICollectionViewController.GetCell()` which calls `ItemsViewController.UpdateTemplatedCell()` and `UICollectionViewController.GetItemsCount()` and `UICollectionViewController.NumberOfSections()` which both call `ItemsViewController.CheckForEmptySource()`) can be called by iOS after `ItemsViewController.Dispose()` has been called and `_measurementCells` has been set to `null`. There are already null checks for `_measurementCells` in certain places, but not all. This should cover the rest of the cases where it can be null.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15637 

### API Changes ###
 
 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###

I was able to reproduce the crash in the attached sample from #15637. I then created a local nuget package from the 5.0.0 branch and confirmed the cause. After making these changes I created another nuget package, updated the repro sample and confirmed the crash no longer happened.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
