### PR TITLE
Issue 15647: Fix selecting of an item in an Android ListView

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15647.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue15647.cs
@@ -1,0 +1,90 @@
+﻿using Xamarin.Forms.CustomAttributes;
+using Xamarin.Forms.Internals;
+using System.Collections.ObjectModel;
+using System;
+
+#if UITEST
+using Xamarin.Forms.Core.UITests;
+using Xamarin.UITest;
+using NUnit.Framework;
+#endif
+
+namespace Xamarin.Forms.Controls.Issues
+{
+#if UITEST
+	[Category(UITestCategories.ManualReview)]
+#endif
+	[Preserve(AllMembers = true)]
+	[Issue(IssueTracker.Github, 15647, "[Bug] Android ListView SelectedItem highlighting", PlatformAffected.Android)]
+	public class Issue15647 : TestContentPage
+	{
+		protected override void Init()
+		{
+			ViewModelIssue15647 viewModelIssue15647 = new ViewModelIssue15647();
+
+			Label testInstructionsLabel = new Label()
+			{
+				HorizontalTextAlignment = TextAlignment.Center,
+				Padding = new Thickness(3.0),
+				Text = "Click on the buttons to select the first or second item of the ListView." + Environment.NewLine +
+					"The correct item has to be marked as selected so that this test is successful.",
+			};
+
+			DataTemplate itemDataTemplate = new DataTemplate(() =>
+			{
+				Label itemLabel = new Label();
+				itemLabel.SetBinding(Label.TextProperty, ".");
+				return new ViewCell()
+				{
+					View = itemLabel,
+				};
+			});
+			ListView itemsListView = new ListView()
+			{
+				// Header = "Header",
+				ItemTemplate = itemDataTemplate,
+			};
+			itemsListView.SetBinding(ListView.ItemsSourceProperty, nameof(ViewModelIssue15647.Items));
+
+			Button selectFirstItemButton = new Button()
+			{
+				Text = "Select first item",
+			};
+			selectFirstItemButton.Clicked += (_, __) =>
+			{
+				Console.WriteLine(itemsListView.SelectedItem);
+				itemsListView.SelectedItem = viewModelIssue15647.Items[0];
+				Console.WriteLine(itemsListView.SelectedItem);
+			};
+
+			Button selectSecondItemButton = new Button()
+			{
+				Text = "Select second item",
+			};
+			selectSecondItemButton.Clicked += (_, __) =>
+			{
+				Console.WriteLine(itemsListView.SelectedItem);
+				itemsListView.SelectedItem = viewModelIssue15647.Items[1];
+				Console.WriteLine(itemsListView.SelectedItem);
+			};
+
+			Content = new StackLayout()
+			{
+				Children = { testInstructionsLabel, selectFirstItemButton, selectSecondItemButton, itemsListView },
+			};
+
+			BindingContext = viewModelIssue15647;
+		}
+	}
+
+	[Preserve(AllMembers = true)]
+	public class ViewModelIssue15647
+	{
+		public ViewModelIssue15647()
+		{
+			Items = new ObservableCollection<string>() { "first item", "second item" };
+		}
+
+		public ObservableCollection<string> Items { get; }
+	}
+}

--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Xamarin.Forms.Controls.Issues.Shared.projitems
@@ -1870,6 +1870,7 @@
     <Compile Include="$(MSBuildThisFileDirectory)Issue15305.xaml.cs">
       <DependentUpon>Issue15305.xaml</DependentUpon>
     </Compile>
+	<Compile Include="$(MSBuildThisFileDirectory)Issue15647.cs" />
     <Compile Include="$(MSBuildThisFileDirectory)Controls\MyCollectionView.xaml.cs">
       <DependentUpon>MyCollectionView.xaml</DependentUpon>
       <SubType>Code</SubType>

--- a/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ListViewAdapter.cs
@@ -672,7 +672,7 @@ namespace Xamarin.Forms.Platform.Android
 			int position = TemplatedItemsView.TemplatedItems.GetGlobalIndexOfItem(item);
 			AView view = null;
 			if (position != -1)
-				view = _realListView.GetChildAt(position + 1 - _realListView.FirstVisiblePosition);
+				view = _realListView.GetChildAt(position + _realListView.HeaderViewsCount - _realListView.FirstVisiblePosition);
 
 			Select(position, view);
 		}


### PR DESCRIPTION
### Description of Change ###

- fix selecting the correct item in an Android ListView when the selected item of the ListView is set in code via the `ListView.SelectedItem` setter
- this bug was introduced by myself with this fix: #15477 which was unfortunately incomplete

### Issues Resolved ###

- fixes #15647

### API Changes ###
 
 None

### Platforms Affected ###

- Android

### Behavioral/Visual Changes ###

Android: The correct item of a ListView is marked as selected when the SelectedItem of a ListView is set programmatically.

### Before/After Screenshots ###

Not applicable

### Testing Procedure ###

- Android: description can be seen in Issue15647.cs

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
