### PR TITLE
[Material] Fixed Renderer's LayoutSubviews may cause NRE.

### DIFF
--- a/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialButtonRenderer.cs
@@ -115,7 +115,7 @@ namespace Xamarin.Forms.Material.iOS
 
 		protected virtual void ApplyThemeIfNeeded()
 		{
-			var bgBrush = Element.Background;
+			var bgBrush = Element?.Background;
 
 			if (Brush.IsNullOrEmpty(bgBrush))
 				return;

--- a/Xamarin.Forms.Material.iOS/MaterialFrameRenderer.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialFrameRenderer.cs
@@ -133,7 +133,7 @@ namespace Xamarin.Forms.Material.iOS
 
 		protected virtual void ApplyThemeIfNeeded()
 		{
-			var bgBrush = Element.Background;
+			var bgBrush = Element?.Background;
 
 			if (Brush.IsNullOrEmpty(bgBrush))
 				return;

--- a/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
+++ b/Xamarin.Forms.Material.iOS/MaterialTextManager.cs
@@ -89,7 +89,7 @@ namespace Xamarin.Forms.Material.iOS
 
 		public static void ApplyThemeIfNeeded(IMaterialTextField textField, IMaterialEntryRenderer element)
 		{
-			var bgBrush = element.Background;
+			var bgBrush = element?.Background;
 
 			if (Brush.IsNullOrEmpty(bgBrush))
 				return;


### PR DESCRIPTION
### Description of Change ###

[Material] Fixed Renderer's LayoutSubviews may cause NullReferenceException on iOS.

```
var bgBrush = Element.Background;
```
to
```
var bgBrush = Element?.Background;
```

### Issues Resolved ### 

- fixes #15669

### API Changes ###

 None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ### 

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
