### PR TITLE
Fixing issue #15314

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/LabelRenderer.cs
@@ -263,6 +263,9 @@ namespace Xamarin.Forms.Platform.MacOS
 			if (!(Control.AttributedStringValue?.Length > 0))
 				return;
 #endif
+			// If FormattedText is changed after the initial render, it will be removed on either line 285 or line 290.
+			if(IsTextFormatted && _formatted.Spans?.Any(span => span.TextDecoration > TextDecorations.None))
+				return;
 
 			var textDecorations = Element.TextDecorations;
 #if __MOBILE__


### PR DESCRIPTION

### Description of Change ###

Before updating textdecorations in LabelRenderer, it is necessary to check if it is using FormattedText and if any of its spans are styled with TextDecorations. If this is the case, the process should return to avoid removing the existing styling.

### Issues Resolved ### 
- fixes #15314

### API Changes ###
 None

### Platforms Affected ### 
- iOS


### Behavioral/Visual Changes ###
TextDecorations will now show when updating FormattedText after initial render.

### Before/After Screenshots ### 
Not applicable

### Testing Procedure ###
Create a label with text and a button that setting the FormattedText in the codebehind.

### PR Checklist ###


- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
