### PR TITLE
Replace Shell sans-serif-medium magic string on Android

### DIFF
--- a/Xamarin.Forms.Core/Shell/BaseShellItem.cs
+++ b/Xamarin.Forms.Core/Shell/BaseShellItem.cs
@@ -453,7 +453,6 @@ namespace Xamarin.Forms
 				{
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontSizeProperty, Value = 14 });
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.TextColorProperty, Value = Color.Black.MultiplyAlpha(0.87) });
-					defaultLabelClass.Setters.Add(new Setter { Property = Label.FontFamilyProperty, Value = "sans-serif-medium" });
 					defaultLabelClass.Setters.Add(new Setter { Property = Label.MarginProperty, Value = new Thickness(20, 0, 0, 0) });
 				}
 				else if (Device.RuntimePlatform == Device.iOS)

--- a/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/BottomNavigationViewUtils.cs
@@ -173,7 +173,7 @@ namespace Xamarin.Forms.Platform.Android
 
 					using (var text = new TextView(context))
 					{
-						text.SetTypeface(Typeface.Create("sans-serif-medium", TypefaceStyle.Normal), TypefaceStyle.Normal);
+						text.SetTypeface(Typeface.SansSerif, TypefaceStyle.Normal);
 						text.SetTextColor(AColor.Black);
 						text.Text = shellContent.title;
 						lp = new LinearLayout.LayoutParams(0, LP.WrapContent)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellItemRenderer.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.Specialized;
 using System.ComponentModel;
 using Android.Content;
+using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
 using Android.Views;
@@ -216,7 +217,7 @@ namespace Xamarin.Forms.Platform.Android
 
 					using (var text = new TextView(Context))
 					{
-						text.Typeface = "sans-serif-medium".ToTypeFace();
+						text.Typeface = Typeface.SansSerif;
 						text.SetTextColor(AColor.Black);
 						text.Text = shellContent.Title;
 						lp = new LinearLayout.LayoutParams(0, LP.WrapContent)


### PR DESCRIPTION
### Description of Change ###

In 3 places which had to do with Shell and/or TabbedPage we had a reference to sans-serif-medium as a string. This was causing exceptions, from what I can tell, on all Android devices and throwing underwater exceptions that the font could not be loaded.

I've changed these references to the TypeFace.SansSerif which is built-in and assume that it resolves to the same. From a visual test I don't see any differences.

Thinking about it, there will probably be no differences, since the font couldn't be loaded earlier, it would not have shown as it was intended in the first place.

Unfortunately, I couldn't really find any definitive source on if this was removed on Android at some point or what the cause is that we are seeing this now.

### Issues Resolved ### 

- fixes #13601

### API Changes ###
 
 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

Should be none! If there are any changes in fonts especially in the area of tab titles or flyout menu items, let me know!

### Before/After Screenshots ### 

Not applicable
