### PR TITLE
UWP Dispatcher should use the internal core dispatcher for state

### DIFF
--- a/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
+++ b/Xamarin.Forms.Controls.Issues/Xamarin.Forms.Controls.Issues.Shared/Issue2482.cs
@@ -80,13 +80,13 @@ namespace Xamarin.Forms.Controls.Issues
 			var threadpoolButton = new Button { Text = "Update Instructions from Thread Pool" };
 			layout.Children.Add(threadpoolButton);
 
-			this.Dispatcher.BeginInvokeOnMainThread(() => { instructions.Text = "updated from thread pool 1"; });
+			this.Dispatcher.BeginInvokeOnMainThread(() => { instructions.Text = "updated from thread pool 1 IsInvokeRequired=" + this.Dispatcher.IsInvokeRequired; });
 
 			threadpoolButton.Clicked += (o, a) =>
 			{
 				Task.Run(() =>
 				{
-					this.Dispatcher.BeginInvokeOnMainThread(() => { instructions.Text = "updated from thread pool 2"; });
+					this.Dispatcher.BeginInvokeOnMainThread(() => { instructions.Text = "updated from thread pool 2 IsInvokeRequired=" + this.Dispatcher.IsInvokeRequired; });
 				});
 			};
 

--- a/Xamarin.Forms.Platform.UAP/Dispatcher.cs
+++ b/Xamarin.Forms.Platform.UAP/Dispatcher.cs
@@ -25,6 +25,6 @@ namespace Xamarin.Forms.Platform.UWP
 			_coreDispatcher = coreDispatcher;
 		}
 
-		bool IDispatcher.IsInvokeRequired => Device.IsInvokeRequired;
+		bool IDispatcher.IsInvokeRequired => !_coreDispatcher.HasThreadAccess;
 	}
 }

--- a/Xamarin.Forms.Platform.UAP/DispatcherProvider.cs
+++ b/Xamarin.Forms.Platform.UAP/DispatcherProvider.cs
@@ -27,6 +27,11 @@ namespace Xamarin.Forms.Platform.UWP
 						s_current = new Dispatcher(renderer.ContainerElement.Dispatcher);
 						return s_current;
 					}
+					else
+					{
+						s_current = new Dispatcher();
+						return s_current;
+					}
 				}
 
 				return null;


### PR DESCRIPTION
### Description of Change ###

This PR makes sure the UWP dispatcher is using the internal core dispatcher for thread access checks instead of the global device dispatcher which does not support multiple windows.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15652
- related to #11880

### API Changes ###

 None

### Platforms Affected ### 

- UWP

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

None

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

Not applicable

### Testing Procedure ###
<!-- Please list the steps that should be taken to properly test these changes on each relevant platform. If you were unable to test these changes yourself on any or all platforms, please let us know. Also, if you are able to attach a video of your test run, you will be our personal hero. -->

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
