### PR TITLE
Bump MonoAndroid target to 13.0

### DIFF
--- a/.nuspec/Xamarin.Forms.AppLinks.nuspec
+++ b/.nuspec/Xamarin.Forms.AppLinks.nuspec
@@ -14,14 +14,14 @@
     <description>Add support for deep linking and indexing app content using Xamarin.Forms on the Android Platform</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <group targetFramework="MonoAndroid10.0">
-        <dependency id="Xamarin.Firebase.AppIndexing" version="119.1.0"/>        
-        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="2.2.0.4"/>
-        <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.7"/>
+      <group targetFramework="MonoAndroid13.0">
+        <dependency id="Xamarin.Firebase.AppIndexing" version="120.0.0.11"/>        
+        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="2.5.1.2"/>
+        <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="1.0.0.16"/>
       </group>
     </dependencies>
     <references>
-      <group targetFramework="MonoAndroid10.0">
+      <group targetFramework="MonoAndroid13.0">
         <reference file="Xamarin.Forms.Platform.Android.AppLinks.dll" />
       </group>
     </references>
@@ -29,7 +29,7 @@
   <files>
     <!--Icon-->
     <file src="..\Assets\xamarin_128x128.png" target="Assets\" />
-    <file src="..\Xamarin.Forms.Platform.Android.AppLinks\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.Android.AppLinks.dll" target="lib\MonoAndroid10.0" />
+    <file src="..\Xamarin.Forms.Platform.Android.AppLinks\bin\$Configuration$\MonoAndroid13.0\Xamarin.Forms.Platform.Android.AppLinks.dll" target="lib\MonoAndroid13.0" />
 
     <!--Licenses-->
     <file src="..\THIRD-PARTY-NOTICES.txt" target="Licenses\" />

--- a/.nuspec/Xamarin.Forms.DualScreen.nuspec
+++ b/.nuspec/Xamarin.Forms.DualScreen.nuspec
@@ -17,7 +17,7 @@
       <group>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
-      <group targetFramework="MonoAndroid10.0">
+      <group targetFramework="MonoAndroid13.0">
         <dependency id="Xamarin.DuoSdk" version="0.0.3.4" />
       </group>
     </dependencies>
@@ -36,9 +36,9 @@
     <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\netstandard2.0\Xamarin.Forms.DualScreen.*mdb" target="lib\netstandard2.0" />
     
     <!--Android 10.0-->
-    <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\monoandroid10.0\Xamarin.Forms.DualScreen.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\monoandroid10.0\Xamarin.Forms.DualScreen.*pdb" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\monoandroid10.0\Xamarin.Forms.DualScreen.*mdb" target="lib\MonoAndroid10.0" />
+    <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\monoandroid13.0\Xamarin.Forms.DualScreen.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\monoandroid13.0\Xamarin.Forms.DualScreen.*pdb" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\monoandroid13.0\Xamarin.Forms.DualScreen.*mdb" target="lib\MonoAndroid13.0" />
     
     <!--UAP-->
     <file src="..\Xamarin.Forms.DualScreen\bin\$Configuration$\uap10.0.16299\Xamarin.Forms.DualScreen.dll" target="lib\uap10.0.16299" />

--- a/.nuspec/Xamarin.Forms.Maps.nuspec
+++ b/.nuspec/Xamarin.Forms.Maps.nuspec
@@ -17,7 +17,7 @@
       <group>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
-      <group targetFramework="MonoAndroid10.0">
+      <group targetFramework="MonoAndroid13.0">
         <dependency id="Xamarin.GooglePlayServices.Maps" version="117.0.0"/>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
@@ -35,9 +35,9 @@
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\netstandard2.0" />
     <file src="..\build\docs\Xamarin.Forms.Maps.xml" target="lib\netstandard2.0" />
 
-    <file src="..\Xamarin.Forms.Maps.Android\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Maps.Android.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\build\docs\Xamarin.Forms.Maps.xml" target="lib\MonoAndroid10.0" />
+    <file src="..\Xamarin.Forms.Maps.Android\bin\$Configuration$\MonoAndroid13.0\Xamarin.Forms.Maps.Android.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\build\docs\Xamarin.Forms.Maps.xml" target="lib\MonoAndroid13.0" />
 
     <file src="..\Xamarin.Forms.Maps.iOS\bin\iPhoneSimulator\$Configuration$\Xamarin.Forms.Maps.iOS.dll" target="lib\Xamarin.iOS10" />
     <file src="..\Xamarin.Forms.Maps\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Maps.dll" target="lib\Xamarin.iOS10" />

--- a/.nuspec/Xamarin.Forms.Visual.Material.nuspec
+++ b/.nuspec/Xamarin.Forms.Visual.Material.nuspec
@@ -17,11 +17,11 @@
       <group>
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
-      <group targetFramework="MonoAndroid10">
+      <group targetFramework="MonoAndroid13">
         <dependency id="Xamarin.Forms" version="$version$"/>
       </group>
 
-      <group targetFramework="MonoAndroid10.0">
+      <group targetFramework="MonoAndroid13.0">
         <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.1]" />
         <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.5)" />
       </group>
@@ -41,16 +41,16 @@
     <file src="_._" target="lib\netstandard1.0\_._" />
 
     <!--Android 10-->
-    <file src="_._" target="lib\MonoAndroid10\_._" />
-    <file src="Xamarin.Forms.Visual.Material.targets" target="build\MonoAndroid10\Xamarin.Forms.Visual.Material.targets" />
+    <file src="_._" target="lib\MonoAndroid13\_._" />
+    <file src="Xamarin.Forms.Visual.Material.targets" target="build\MonoAndroid13\Xamarin.Forms.Visual.Material.targets" />
 
     <!--Android 10 buildTransitive-->
-    <file src="Xamarin.Forms.Visual.Material.targets" target="buildTransitive\MonoAndroid10\Xamarin.Forms.Visual.Material.targets" />
+    <file src="Xamarin.Forms.Visual.Material.targets" target="buildTransitive\MonoAndroid13\Xamarin.Forms.Visual.Material.targets" />
       
     <!--Android 10.0-->
-    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid10.0\Xamarin.Forms.Material.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid10.0\Xamarin.Forms.Material.*pdb" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid10.0\Xamarin.Forms.Material.*mdb" target="lib\MonoAndroid10.0" />
+    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid13.0\Xamarin.Forms.Material.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid13.0\Xamarin.Forms.Material.*pdb" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Material.Android\bin\$Configuration$\monoandroid13.0\Xamarin.Forms.Material.*mdb" target="lib\MonoAndroid13.0" />
 
     <!--iOS-->
     <file src="..\Xamarin.Forms.Material.iOS\bin\$Configuration$\Xamarin.Forms.Material.dll" target="lib\Xamarin.iOS10" />

--- a/.nuspec/Xamarin.Forms.Visual.Material.nuspec
+++ b/.nuspec/Xamarin.Forms.Visual.Material.nuspec
@@ -22,8 +22,8 @@
       </group>
 
       <group targetFramework="MonoAndroid13.0">
-        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.1]" />
-        <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.5)" />
+        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.7)" />
+        <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.9)" />
       </group>
       <group targetFramework="Xamarin.iOS10">
         <dependency id="Xamarin.iOS.MaterialComponents" version="92.0.0"/>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -15,18 +15,18 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework="MonoAndroid13.0">
-        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.1]" />
-        <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.5)" />
+        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.2]" />
+        <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.9)" />
         <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="[1.0.0.8,1.1)" />
-        <dependency id="Xamarin.AndroidX.Browser" version="[1.3.0.6,1.4)" />
+        <dependency id="Xamarin.AndroidX.Browser" version="[1.3.0.6,1.6)" />
 
         <!-- Because of a misspelled reference these all need to be explicitly included so the fixed version 
           is transitively loaded  https://github.com/xamarin/AndroidX/issues/283#issuecomment-788103573 -->
-        <dependency id="Xamarin.AndroidX.Core" version="[1.6.0.1,1.9.0.1]" />
+        <dependency id="Xamarin.AndroidX.Core" version="[1.6.0.1,2.0)" />
         <dependency id="Xamarin.AndroidX.CustomView" version="[1.1.0.7,1.2)" />
-        <dependency id="Xamarin.AndroidX.Preference" version="[1.1.1.9,1.2)" />
-        <dependency id="Xamarin.AndroidX.RecyclerView" version="[1.2.1.1,1.3)" />
-        <dependency id="Xamarin.AndroidX.Navigation.UI" version="[2.3.5.1,2.4)" />
+        <dependency id="Xamarin.AndroidX.Preference" version="[1.1.1.9,1.3)" />
+        <dependency id="Xamarin.AndroidX.RecyclerView" version="[1.2.1.1,1.4)" />
+        <dependency id="Xamarin.AndroidX.Navigation.UI" version="[2.3.5.1,2.6)" />
       </group>
       <group targetFramework="uap10.0.14393">
         <dependency id="NETStandard.Library" version="2.0.1"/>

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -14,7 +14,7 @@
     <description>Build native UIs for iOS, Android, UWP, macOS, Tizen and many more from a single, shared C# codebase</description>
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
-      <group targetFramework="MonoAndroid10.0">
+      <group targetFramework="MonoAndroid13.0">
         <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.1]" />
         <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.5)" />
         <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="[1.0.0.8,1.1)" />
@@ -60,7 +60,7 @@
         <reference file="Xamarin.Forms.Xaml.dll" />
         <reference file="Xamarin.Forms.Platform.iOS.dll" />
       </group>
-      <group targetFramework="MonoAndroid10.0">
+      <group targetFramework="MonoAndroid13.0">
         <reference file="Xamarin.Forms.Core.dll" />
         <reference file="Xamarin.Forms.Platform.dll" />
         <reference file="Xamarin.Forms.Xaml.dll" />
@@ -174,8 +174,8 @@
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\netstandard2.0\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\netstandard1.0\Design" />
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\netstandard1.0\Design" />
-    <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid10.0\Design" />
-    <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid10.0\Design" />
+    <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\MonoAndroid13.0\Design" />
+    <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\MonoAndroid13.0\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\Xamarin.iOS10\Design" />
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\Xamarin.iOS10\Design" />
     <file src="..\Xamarin.Forms.Core.Design\bin\$Configuration$\Xamarin.Forms.Core.Design.dll" target="lib\uap10.0.14393\Design" />
@@ -188,23 +188,23 @@
     <file src="..\Xamarin.Forms.Xaml.Design\bin\$Configuration$\Xamarin.Forms.Xaml.Design.dll" target="lib\tizen40\Design" />
 
     <!--Android 10-->
-    <file src="proguard.cfg" target="build\MonoAndroid10\proguard.cfg" />
-    <file src="proguard.cfg" target="buildTransitive\MonoAndroid10\proguard.cfg" />
+    <file src="proguard.cfg" target="build\MonoAndroid13\proguard.cfg" />
+    <file src="proguard.cfg" target="buildTransitive\MonoAndroid13\proguard.cfg" />
     
     <!--Android 10-->
-    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.*pdb" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid10.0" />
-    <file src="..\build\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid10.0" />
-    <file src="..\build\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid10.0" />
-    <file src="..\build\docs\**\Xamarin.Forms.Core.xml" target="lib\MonoAndroid10.0" />
-    <file src="..\build\docs\**\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid10.0" />
-    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid10.0" />
-    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid10.0\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid10.0" />
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid13.0\Xamarin.Forms.Platform.Android.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid13.0\Xamarin.Forms.Platform.Android.*pdb" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Platform.Android.FormsViewGroup\bin\$Configuration$\FormsViewGroup.*pdb" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Core\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Core.*pdb" target="lib\MonoAndroid13.0" />
+    <file src="..\build\docs\Xamarin.Forms.Core.xml" target="lib\MonoAndroid13.0" />
+    <file src="..\build\docs\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid13.0" />
+    <file src="..\build\docs\**\Xamarin.Forms.Core.xml" target="lib\MonoAndroid13.0" />
+    <file src="..\build\docs\**\Xamarin.Forms.Xaml.xml" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.dll" target="lib\MonoAndroid13.0" />
+    <file src="..\Xamarin.Forms.Xaml\bin\$Configuration$\netstandard2.0\Xamarin.Forms.Xaml.*pdb" target="lib\MonoAndroid13.0" />
+    <file src="..\Stubs\Xamarin.Forms.Platform.Android\bin\$Configuration$\MonoAndroid13.0\Xamarin.Forms.Platform.dll" target="lib\MonoAndroid13.0" />
 
     <!--iPhone Unified-->
     <file src="..\Xamarin.Forms.Platform.iOS\bin\$Configuration$\Xamarin.Forms.Platform.iOS.dll" target="lib\Xamarin.iOS10" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -15,7 +15,7 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework="MonoAndroid13.0">
-        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.7)" />
+        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.2]" />
         <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.9)" />
         <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="[1.0.0.8,1.1)" />
         <dependency id="Xamarin.AndroidX.Browser" version="[1.3.0.6,1.6)" />

--- a/.nuspec/Xamarin.Forms.nuspec
+++ b/.nuspec/Xamarin.Forms.nuspec
@@ -15,10 +15,11 @@
     <copyright>© Microsoft Corporation. All rights reserved.</copyright>
     <dependencies>
       <group targetFramework="MonoAndroid13.0">
-        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.5.1.2]" />
+        <dependency id="Xamarin.AndroidX.Lifecycle.LiveData" version="[2.3.1.1,2.7)" />
         <dependency id="Xamarin.Google.Android.Material" version="[1.4.0.2,1.9)" />
         <dependency id="Xamarin.AndroidX.Legacy.Support.V4" version="[1.0.0.8,1.1)" />
         <dependency id="Xamarin.AndroidX.Browser" version="[1.3.0.6,1.6)" />
+        <dependency id="Xamarin.AndroidX.AppCompat" version="[1.6.0,1.7)" />
 
         <!-- Because of a misspelled reference these all need to be explicitly included so the fixed version 
           is transitively loaded  https://github.com/xamarin/AndroidX/issues/283#issuecomment-788103573 -->

--- a/.nuspec/Xamarin.Forms.targets
+++ b/.nuspec/Xamarin.Forms.targets
@@ -159,7 +159,7 @@
   
  <!-- 
     Platform Specific Targets.
-    We can't use a framework specific targets file because it breaks shared projects i.e.  /build/MonoAndroid10/Xamarin.Forms.targets
+    We can't use a framework specific targets file because it breaks shared projects i.e.  /build/MonoAndroid13/Xamarin.Forms.targets
   -->
 
   <!-- MonoAndroid targets. -->
@@ -176,7 +176,7 @@
   
   <Target Name="IncludeProguardForAndroid" Condition="'$(XFDisableDefaultProguardConfiguration)' != 'True'">
     <ItemGroup>
-      <ProguardConfiguration Include="$(MSBuildThisFileDirectory)MonoAndroid10\proguard.cfg" />
+      <ProguardConfiguration Include="$(MSBuildThisFileDirectory)MonoAndroid13\proguard.cfg" />
     </ItemGroup>
   </Target>
 

--- a/DualScreen/DualScreen.Android/DualScreen.Android.csproj
+++ b/DualScreen/DualScreen.Android/DualScreen.Android.csproj
@@ -115,9 +115,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />    
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />    
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\values\colors.xml" />

--- a/DualScreen/DualScreen.Android/DualScreen.Android.csproj
+++ b/DualScreen/DualScreen.Android/DualScreen.Android.csproj
@@ -116,7 +116,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />    
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>

--- a/DualScreen/DualScreen.Android/DualScreen.Android.csproj
+++ b/DualScreen/DualScreen.Android/DualScreen.Android.csproj
@@ -116,7 +116,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />    
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>

--- a/DualScreen/DualScreen.Android/DualScreen.Android.csproj
+++ b/DualScreen/DualScreen.Android/DualScreen.Android.csproj
@@ -17,7 +17,7 @@
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
     <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
     <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
-    <TargetFrameworkVersion>v11.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidEnableSGenConcurrent>true</AndroidEnableSGenConcurrent>
     <AndroidUseAapt2>true</AndroidUseAapt2>
     <AndroidHttpClientHandlerType>Xamarin.Android.Net.AndroidClientHandler</AndroidHttpClientHandlerType>

--- a/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
+++ b/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
+    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.6" />
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
   </ItemGroup>
 </Project>

--- a/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
+++ b/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
@@ -1,9 +1,9 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.6" />
-    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>
 </Project>

--- a/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
+++ b/EmbeddingTestBeds/Embedding.Droid/Directory.Build.targets
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>

--- a/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
+++ b/EmbeddingTestBeds/Embedding.Droid/Embedding.Droid.csproj
@@ -16,10 +16,10 @@
     <AndroidApplication>True</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v10.0</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v13.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0.99'">Properties\AndroidManifest30.xml</AndroidManifest>
-    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v10.0'">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v13.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
   </PropertyGroup>

--- a/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest.xml
+++ b/EmbeddingTestBeds/Embedding.Droid/Properties/AndroidManifest.xml
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" package="Embedding.Droid.Embedding.Droid" android:versionCode="1" android:versionName="1.0">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="29" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="33" />
 	<application android:label="Embedding.Droid"></application>
 </manifest>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -34,7 +34,7 @@
 
   <!-- This is used by the libraries -->
   <PropertyGroup Condition="'$(AndroidTargetFrameworks)' == ''">
-    <AndroidTargetFrameworks>MonoAndroid10.0;</AndroidTargetFrameworks>
+    <AndroidTargetFrameworks>MonoAndroid13.0;</AndroidTargetFrameworks>
   </PropertyGroup>
 
   <!-- Auto install any missing Android SDKs -->

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -41,6 +41,6 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
-    <AndroidSdkBuildToolsVersion>33.0.2</AndroidSdkBuildToolsVersion>
+    <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -41,5 +41,6 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
+    <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -41,7 +41,5 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
-    <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -43,6 +43,5 @@
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
     <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
-    <AndroidTargetFrameworkVersion>v13.0</AndroidTargetFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -42,5 +42,6 @@
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
     <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -41,6 +41,5 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
-    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -41,5 +41,6 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
+    <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -41,6 +41,6 @@
   <PropertyGroup Condition="'$(CI)' == 'true'">
     <AndroidRestoreOnBuild Condition="'$(AndroidRestoreOnBuild)' == ''">False</AndroidRestoreOnBuild>
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
-    <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
+    <AndroidSdkBuildToolsVersion>33.0.2</AndroidSdkBuildToolsVersion>
   </PropertyGroup>
 </Project>

--- a/Environment.Build.props
+++ b/Environment.Build.props
@@ -43,5 +43,6 @@
     <AcceptAndroidSDKLicenses Condition="'$(AcceptAndroidSDKLicenses)' == ''">False</AcceptAndroidSDKLicenses>
     <AndroidSdkBuildToolsVersion>32.0.0</AndroidSdkBuildToolsVersion>
     <AndroidUseLatestPlatformSdk>true</AndroidUseLatestPlatformSdk>
+    <AndroidTargetFrameworkVersion>v13.0</AndroidTargetFrameworkVersion>
   </PropertyGroup>
 </Project>

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\..\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android.csproj">
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid13.0'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.9" />

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -22,7 +22,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.9" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -22,7 +22,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.9" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />

--- a/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
+++ b/Stubs/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android (Forwarders).csproj
@@ -21,10 +21,10 @@
     <ProjectReference Include="..\..\Xamarin.Forms.Platform.Android\Xamarin.Forms.Platform.Android.csproj">
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid13.0'">
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.9" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
@@ -1,10 +1,10 @@
 <Project>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.8" />    
-    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.6" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />    
+    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>
   <Import Project="Nuget.Build.targets" />
   <Import Project="..\Nuget.targets" Condition="'$(FromSource)' == 'false'" />

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />    
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Directory.Build.targets
@@ -2,7 +2,7 @@
   <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />    
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
@@ -7,7 +7,7 @@
     <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     </ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
@@ -1,14 +1,14 @@
 <Project>
     <ItemGroup>
         <PackageReference Include="Xamarin.Build.Download">
-            <Version>0.10.0</Version>
+            <Version>0.11.4</Version>
         </PackageReference>
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.8" />    
-    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.3.0.6" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />
+    <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     </ItemGroup>
 </Project>

--- a/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
+++ b/Xamarin.Forms.ControlGallery.Android/Nuget.Build.targets
@@ -7,7 +7,7 @@
     <ItemGroup>
     <PackageReference Include="Xamarin.AndroidX.Palette" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Browser" Version="1.5.0" />
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     </ItemGroup>

--- a/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest.xml
+++ b/Xamarin.Forms.ControlGallery.Android/Properties/AndroidManifest.xml
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="AndroidControlGallery.AndroidControlGallery" android:installLocation="auto">
-	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="30" />
+	<uses-sdk android:minSdkVersion="19" android:targetSdkVersion="33" />
 	<uses-permission android:name="android.permission.INTERNET" />
 	<uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 	<uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -19,6 +19,7 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v13.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
+    <TargetFrameworks>$(AndroidTargetFrameworks)</TargetFrameworks>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v13.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -17,9 +17,9 @@
     <AndroidApplication>true</AndroidApplication>
     <AndroidResgenFile>Resources\Resource.Designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v11.0</AndroidTargetFrameworkVersion>
+    <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v13.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
-    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v11.0'">Properties\AndroidManifest.xml</AndroidManifest>
+    <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v13.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <NuGetPackageImportStamp>
@@ -349,12 +349,12 @@
     </PackageReference>
     <PackageReference Include="Xam.Plugin.DeviceInfo">
       <Version>3.0.2</Version>
-    </PackageReference>  
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.6.0.1" />
-    <PackageReference Include="Xamarin.AndroidX.CustomView" Version="1.1.0.7" />
-    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.1.1.9" />
-    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.1" />
+    </PackageReference>
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
+    <PackageReference Include="Xamarin.AndroidX.Core" Version="1.9.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.CustomView" Version="1.1.0.15" />
+    <PackageReference Include="Xamarin.AndroidX.Preference" Version="1.2.0.4" />
+    <PackageReference Include="Xamarin.AndroidX.RecyclerView" Version="1.2.1.9" />
   </ItemGroup>
   <ItemGroup>
     <AndroidAsset Include="Assets\fonts\ionicons.ttf">
@@ -402,7 +402,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties TriggeredFromHotReload="False" XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" />
+      <UserProperties XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" TriggeredFromHotReload="False" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -19,7 +19,6 @@
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v13.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>$(AndroidTargetFrameworkVersion)</TargetFrameworkVersion>
-    <TargetFrameworks>$(AndroidTargetFrameworks)</TargetFrameworks>
     <AndroidManifest Condition="$(AndroidTargetFrameworkVersion) == 'v13.0'">Properties\AndroidManifest.xml</AndroidManifest>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>

--- a/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
+++ b/Xamarin.Forms.ControlGallery.Android/Xamarin.Forms.ControlGallery.Android.csproj
@@ -402,7 +402,7 @@
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <ProjectExtensions>
     <VisualStudio>
-      <UserProperties XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" TriggeredFromHotReload="False" />
+      <UserProperties TriggeredFromHotReload="False" XamarinHotReloadUnhandledDeviceExceptionXamarinFormsControlGalleryAndroidHideInfoBar="True" />
     </VisualStudio>
   </ProjectExtensions>
 </Project>

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -54,7 +54,7 @@
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid13.0'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -55,7 +55,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -55,7 +55,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>

--- a/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
+++ b/Xamarin.Forms.DualScreen/Xamarin.Forms.DualScreen.csproj
@@ -54,9 +54,9 @@
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid13.0'">
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -20,7 +20,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="118.1.0.1" />

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -20,7 +20,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="118.1.0.1" />

--- a/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
+++ b/Xamarin.Forms.Maps.Android/Xamarin.Forms.Maps.Android.csproj
@@ -20,9 +20,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
-    <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="117.0.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
+    <PackageReference Include="Xamarin.GooglePlayServices.Maps" Version="118.1.0.1" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -15,8 +15,8 @@
     <AndroidResource Include="Resources\**\*" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) " >
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidResource Include="Resources\**\*" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) " >
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
+++ b/Xamarin.Forms.Material.Android/Xamarin.Forms.Material.Android.csproj
@@ -15,7 +15,7 @@
     <AndroidResource Include="Resources\**\*" />
   </ItemGroup>
   <ItemGroup Condition=" $(TargetFramework.StartsWith('MonoAndroid')) " >
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
   </ItemGroup>
   <ItemGroup>

--- a/Xamarin.Forms.Platform.Android.AppLinks/AndroidAppLinks.cs
+++ b/Xamarin.Forms.Platform.Android.AppLinks/AndroidAppLinks.cs
@@ -73,8 +73,8 @@ namespace Xamarin.Forms.Platform.Android.AppLinks
 			 * https://firebase.google.com/docs/app-indexing/android/personal-content#update-the-index for
 			 * adding content to the index 
             */
-			FirebaseAppIndex.Instance.Update(indexable);
-			GMSTask gmsTask = FirebaseUserActions.Instance
+			FirebaseAppIndex.GetInstance(Context).Update(indexable);
+			GMSTask gmsTask = FirebaseUserActions.GetInstance(Context)
 												 .Start(indexAction)
 												 .AddOnSuccessListener(Context.GetActivity(),
 																	   new AndroidActionSuccessListener(appLink as AppLinkEntry, indexAction))
@@ -84,7 +84,7 @@ namespace Xamarin.Forms.Platform.Android.AppLinks
 
 		void RemoveFromIndexItemAsync(string identifier)
 		{
-			FirebaseAppIndex.Instance.Remove(identifier);
+			FirebaseAppIndex.GetInstance(Context).Remove(identifier);
 		}
 
 		IIndexable GetIndexable(IAppLinkEntry appLink, string url)
@@ -122,11 +122,11 @@ namespace Xamarin.Forms.Platform.Android.AppLinks
 						{
 							if (appLink.IsLinkActive)
 							{
-								FirebaseUserActions.Instance.Start(indexAction);
+								FirebaseUserActions.GetInstance(Context).Start(indexAction);
 							}
 							else
 							{
-								FirebaseUserActions.Instance.End(indexAction);
+								FirebaseUserActions.GetInstance(Context).End(indexAction);
 							}
 						}
 					};

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -25,7 +25,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -25,7 +25,7 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -19,13 +19,13 @@
     <AndroidResource Include="Resources\values\Strings.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.Firebase.AppIndexing" Version="119.1.0" />
+    <PackageReference Include="Xamarin.Firebase.AppIndexing" Version="120.0.0.11" />
     <ProjectReference Include="..\Xamarin.Forms.Core\Xamarin.Forms.Core.csproj">
       <Name>Xamarin.Forms.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid10.0'">
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid13.0'">
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>
 </Project>

--- a/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
+++ b/Xamarin.Forms.Platform.Android.AppLinks/Xamarin.Forms.Platform.Android.AppLinks.csproj
@@ -24,7 +24,7 @@
       <Name>Xamarin.Forms.Core</Name>
     </ProjectReference>
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'MonoAndroid13.0'">
+  <ItemGroup Condition="$(TargetFramework.StartsWith('MonoAndroid'))">
     <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
   </ItemGroup>

--- a/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
+++ b/Xamarin.Forms.Platform.Android.FormsViewGroup/Xamarin.Forms.Platform.Android.FormsViewGroup.csproj
@@ -16,7 +16,7 @@
     <RootNamespace>FormsViewGroup</RootNamespace>
     <AssemblyName>FormsViewGroup</AssemblyName>
     <FileAlignment>512</FileAlignment>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -16,9 +16,7 @@
     <Deterministic>True</Deterministic>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v13.0</AndroidTargetFrameworkVersion>
     <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
-    <TargetFrameworks>$(AndroidTargetFrameworks)</TargetFrameworks>
     <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -103,9 +101,6 @@
     <AndroidResource Include="Resources\layout\LayoutTest.axml" />
     <AndroidResource Include="Resources\drawable\DrawableTest.png" />
   </ItemGroup>
-  <ItemGroup>
-    <Folder Include="Resources\drawable\" />
-    <Folder Include="Resources\layout\" />
-  </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\Android\Xamarin.Android.CSharp.targets" />
 </Project>

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -16,6 +16,7 @@
     <Deterministic>True</Deterministic>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <TargetFrameworks>$(AndroidTargetFrameworks)</TargetFrameworks>
     <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -17,7 +17,6 @@
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
     <TargetFrameworks>$(AndroidTargetFrameworks)</TargetFrameworks>
-    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -16,6 +16,8 @@
     <Deterministic>True</Deterministic>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
+    <AndroidTargetFrameworkVersion Condition="'$(AndroidTargetFrameworkVersion)' == ''">v13.0</AndroidTargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <TargetFrameworks>$(AndroidTargetFrameworks)</TargetFrameworks>
     <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>

--- a/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
+++ b/Xamarin.Forms.Platform.Android.UnitTests/Xamarin.Forms.Platform.Android.UnitTests.csproj
@@ -16,7 +16,7 @@
     <Deterministic>True</Deterministic>
     <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
     <GenerateSerializationAssemblies>Off</GenerateSerializationAssemblies>
-    <TargetFrameworkVersion>v10.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v13.0</TargetFrameworkVersion>
     <AndroidUseAapt2>true</AndroidUseAapt2>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
+++ b/Xamarin.Forms.Platform.Android/AppCompat/FormsAppCompatActivity.cs
@@ -69,11 +69,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		public event EventHandler ConfigurationChanged;
 
+#pragma warning disable CS0672 // Member overrides obsolete member
 		public override void OnBackPressed()
+#pragma warning restore CS0672 // Member overrides obsolete member
 		{
 			if (BackPressed != null && BackPressed(this, EventArgs.Empty))
 				return;
+#pragma warning disable CS0618 // Type or member is obsolete
 			base.OnBackPressed();
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -190,13 +190,7 @@ namespace Xamarin.Forms.Platform.Android
 				MenuItem action = ActionModeContext.ContextActions[i];
 
 #pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
-#pragma warning disable CS0618 // Type or member is obsolete
 				IMenuItem item = menu.Add(global::Android.Views.Menu.None, i, global::Android.Views.Menu.None, action.Text);
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
-#pragma warning restore CS0618 // Type or member is obsolete
 #pragma warning restore CS0618 // Type or member is obsolete
 
 				_ = _context.ApplyDrawableAsync(action, MenuItem.IconImageSourceProperty, iconDrawable =>

--- a/Xamarin.Forms.Platform.Android/CellAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/CellAdapter.cs
@@ -189,7 +189,15 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				MenuItem action = ActionModeContext.ContextActions[i];
 
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
+#pragma warning disable CS0618 // Type or member is obsolete
 				IMenuItem item = menu.Add(global::Android.Views.Menu.None, i, global::Android.Views.Menu.None, action.Text);
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
+#pragma warning restore CS0618 // Type or member is obsolete
 
 				_ = _context.ApplyDrawableAsync(action, MenuItem.IconImageSourceProperty, iconDrawable =>
 				{

--- a/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
+++ b/Xamarin.Forms.Platform.Android/FormsApplicationActivity.cs
@@ -40,11 +40,15 @@ namespace Xamarin.Forms.Platform.Android
 
 		public static event BackButtonPressedEventHandler BackPressed;
 
+#pragma warning disable CS0672 // Member overrides obsolete member
 		public override void OnBackPressed()
+#pragma warning restore CS0672 // Member overrides obsolete member
 		{
 			if (BackPressed != null && BackPressed(this, EventArgs.Empty))
 				return;
+#pragma warning disable CS0618 // Type or member is obsolete
 			base.OnBackPressed();
+#pragma warning restore CS0618 // Type or member is obsolete
 		}
 
 		public override void OnConfigurationChanged(Configuration newConfig)

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
@@ -365,7 +365,7 @@ namespace Xamarin.Forms.Platform.Android
 			}
 		}
 
-		class ClipDrawableWrapper : ASupportDrawable.DrawableWrapper
+		class ClipDrawableWrapper : ASupportDrawable.DrawableWrapperCompat
 		{
 			public ClipDrawableWrapper(Drawable dr) : base(dr)
 			{

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" Version="2.3.5.1" />

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -43,7 +43,7 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.6.1" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
     <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
     <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" Version="2.3.5.1" />

--- a/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
+++ b/Xamarin.Forms.Platform.Android/Xamarin.Forms.Platform.Android.csproj
@@ -43,9 +43,9 @@
     <Reference Include="System.Net.Http" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.3.1.1" />
-    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.4.0.2" />
-    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.8" />
+    <PackageReference Include="Xamarin.AndroidX.Lifecycle.LiveData" Version="2.5.1.2" />
+    <PackageReference Include="Xamarin.Google.Android.Material" Version="1.8.0" />
+    <PackageReference Include="Xamarin.AndroidX.Legacy.Support.V4" Version="1.0.0.16" />
     <PackageReference Include="Xamarin.AndroidX.Navigation.UI" Version="2.3.5.1" />
   </ItemGroup>
   <ItemGroup>

--- a/build.cake
+++ b/build.cake
@@ -252,7 +252,7 @@ Task("provision-iossdk")
 
 Task("provision-androidsdk")
     .Description("Install Xamarin.Android SDK")
-    .Does(async () =>
+    .Does(async (ctx) =>
     {
         Information ("ANDROID_HOME: {0}", ANDROID_HOME);
 
@@ -297,6 +297,10 @@ Task("provision-androidsdk")
             {
                 Information("AndroidSdkManagerInstall: {0}", exc);
             }
+        }
+
+        if (IsRunningOnWindows() && isHostedAgent && isCIBuild) {
+            SetEnvironmentVariable("JAVA_HOME", EnvironmentVariable("JAVA_HOME_11_X64", "JAVA_HOME_8_X64"), ctx)
         }
 
         if (!IsRunningOnWindows ()) {

--- a/build.cake
+++ b/build.cake
@@ -88,7 +88,7 @@ MSBuildArguments = $"{MSBuildArgumentsENV} {MSBuildArgumentsARGS}";
     
 Information("MSBuildArguments: {0}", MSBuildArguments);
 
-string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,build-tools;30.0.2");
+string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,build-tools;30.0.2,platforms;android-33,build-tools;33.0.2");
 
 Information("ANDROID_API_SDKS: {0}", androidSdks);
 string[] androidSdkManagerInstalls = androidSdks.Split(',');

--- a/build.cake
+++ b/build.cake
@@ -299,17 +299,13 @@ Task("provision-androidsdk")
             }
         }
 
-        if (!IsRunningOnWindows ()) {
-            if(!String.IsNullOrWhiteSpace(androidSDK))
-            {
-                await Boots (androidSDK);
-            }
-            else
-                await Boots (Product.XamarinAndroid, releaseChannel);
-        }
-        else if(!String.IsNullOrWhiteSpace(androidSDK))
+        if(!String.IsNullOrWhiteSpace(androidSDK))
         {
             await Boots (androidSDK);
+        }
+        else
+        {
+            await Boots (Product.XamarinAndroid, releaseChannel);
         }
     });
 

--- a/build.cake
+++ b/build.cake
@@ -88,7 +88,7 @@ MSBuildArguments = $"{MSBuildArgumentsENV} {MSBuildArgumentsARGS}";
     
 Information("MSBuildArguments: {0}", MSBuildArguments);
 
-string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,platforms;android-33,build-tools;33.0.0");
+string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,build-tools;30.0.2,platforms;android-33,build-tools;33.0.2");
 
 Information("ANDROID_API_SDKS: {0}", androidSdks);
 string[] androidSdkManagerInstalls = androidSdks.Split(',');

--- a/build.cake
+++ b/build.cake
@@ -88,7 +88,7 @@ MSBuildArguments = $"{MSBuildArgumentsENV} {MSBuildArgumentsARGS}";
     
 Information("MSBuildArguments: {0}", MSBuildArguments);
 
-string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,build-tools;30.0.2,platforms;android-33,build-tools;33.0.2");
+string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,build-tools;30.0.2,platforms;android-32,build-tools;32.0.0,platforms;android-33,build-tools;33.0.2");
 
 Information("ANDROID_API_SDKS: {0}", androidSdks);
 string[] androidSdkManagerInstalls = androidSdks.Split(',');

--- a/build.cake
+++ b/build.cake
@@ -299,10 +299,6 @@ Task("provision-androidsdk")
             }
         }
 
-        if (IsRunningOnWindows() && isHostedAgent && isCIBuild) {
-            SetEnvironmentVariable("JAVA_HOME", EnvironmentVariable("JAVA_HOME_11_X64", "JAVA_HOME_8_X64"), ctx);
-        }
-
         if (!IsRunningOnWindows ()) {
             if(!String.IsNullOrWhiteSpace(androidSDK))
             {

--- a/build.cake
+++ b/build.cake
@@ -88,7 +88,7 @@ MSBuildArguments = $"{MSBuildArgumentsENV} {MSBuildArgumentsARGS}";
     
 Information("MSBuildArguments: {0}", MSBuildArguments);
 
-string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,build-tools;30.0.2,platforms;android-33,build-tools;33.0.2");
+string androidSdks = EnvironmentVariable("ANDROID_API_SDKS", "platform-tools,platforms;android-26,platforms;android-27,platforms;android-28,platforms;android-29,build-tools;29.0.3,platforms;android-30,platforms;android-33,build-tools;33.0.0");
 
 Information("ANDROID_API_SDKS: {0}", androidSdks);
 string[] androidSdkManagerInstalls = androidSdks.Split(',');

--- a/build.cake
+++ b/build.cake
@@ -22,7 +22,7 @@ PowerShell:
 #addin "nuget:?package=Cake.Android.Adb&version=3.2.0"
 #addin "nuget:?package=Cake.Git&version=0.21.0"
 #addin "nuget:?package=Cake.Android.SdkManager&version=3.0.2"
-#addin "nuget:?package=Cake.Boots&version=1.0.2.437"
+#addin "nuget:?package=Cake.Boots&version=1.1.0.36"
 #addin "nuget:?package=Cake.AppleSimulator&version=0.2.0"
 #addin "nuget:?package=Cake.FileHelpers&version=3.2.1"
 

--- a/build.cake
+++ b/build.cake
@@ -300,7 +300,7 @@ Task("provision-androidsdk")
         }
 
         if (IsRunningOnWindows() && isHostedAgent && isCIBuild) {
-            SetEnvironmentVariable("JAVA_HOME", EnvironmentVariable("JAVA_HOME_11_X64", "JAVA_HOME_8_X64"), ctx)
+            SetEnvironmentVariable("JAVA_HOME", EnvironmentVariable("JAVA_HOME_11_X64", "JAVA_HOME_8_X64"), ctx);
         }
 
         if (!IsRunningOnWindows ()) {

--- a/build.cake
+++ b/build.cake
@@ -798,14 +798,14 @@ Task("Build")
     }
 });
 
-Task("Android100")
-    .Description("Builds Monodroid10.0 targets")
+Task("Android130")
+    .Description("Builds Monodroid13.0 targets")
     .Does(() =>
     {
         MSBuild("Xamarin.Forms.sln",
                 GetMSBuildSettings()
                     .WithRestore()
-                    .WithProperty("AndroidTargetFrameworks", "MonoAndroid10.0"));
+                    .WithProperty("AndroidTargetFrameworks", "MonoAndroid13.0"));
     });
 
 Task("VSMAC")

--- a/build/provisioning/provisioning.csx
+++ b/build/provisioning/provisioning.csx
@@ -104,6 +104,7 @@ if(String.IsNullOrWhiteSpace(ANDROID_API_SDKS))
 		.ApiLevel((AndroidApiLevel)28)
 		.ApiLevel((AndroidApiLevel)29)
 		.ApiLevel((AndroidApiLevel)30)
+		.ApiLevel((AndroidApiLevel)33)
 		.SdkManagerPackage ("build-tools;29.0.3");
 }
 else{

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -19,11 +19,6 @@ steps:
       version: $(DOTNET_VERSION)
       packageType: 'sdk'
 
-  - task: Boots@1
-    displayName: Install Xamarin.Android
-    inputs:
-      uri: https://aka.ms/xamarin-android-commercial-d16-2-windows
-
   - script: build.cmd -Target provision
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -23,6 +23,11 @@ steps:
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')
 
+  # Setup JDK Paths
+  - bash: |
+      echo "##vso[task.setvariable variable=JI_JAVA_HOME]$(JAVA_HOME_11_X64)"
+    displayName: 'Setup JDK Paths'
+
   - task: xamops.azdevex.provisionator-task.provisionator@2
     displayName: 'Provisionator'
     condition: eq(variables['provisioning'], 'true')

--- a/build/steps/build-windows.yml
+++ b/build/steps/build-windows.yml
@@ -19,6 +19,11 @@ steps:
       version: $(DOTNET_VERSION)
       packageType: 'sdk'
 
+  - task: Boots@1
+    displayName: Install Xamarin.Android
+    inputs:
+      uri: https://aka.ms/xamarin-android-commercial-d16-2-windows
+
   - script: build.cmd -Target provision
     displayName: 'Cake Provision'
     condition: eq(variables['provisioningCake'], 'true')


### PR DESCRIPTION
This builds Xamarin.Forms with the MonoAndroid 13.0 target. With this we can now use the latest Android(X) packages again and should be more prepared for future Android versions and targets.

However, this change is pretty significant as also a lot of the dependencies got a good bump in their version numbers. Please test your code carefully!

Fixes #15668
Fixes #15678
Fixes #15677
Fixes #15714

Also see https://github.com/xamarin/Essentials/pull/2087