### PR TITLE
fixed NotSupportedException in Xamarin.Forms.Platform.Android.Platform.DefaultRenderer

### DIFF
--- a/Xamarin.Forms.Platform.Android/Platform.cs
+++ b/Xamarin.Forms.Platform.Android/Platform.cs
@@ -10,6 +10,7 @@ using Android.Content.Res;
 using Android.Graphics;
 using Android.Graphics.Drawables;
 using Android.OS;
+using Android.Runtime;
 using Android.Util;
 using Android.Views;
 using Android.Widget;
@@ -1253,6 +1254,11 @@ namespace Xamarin.Forms.Platform.Android
 			public DefaultRenderer(Context context) : base(context)
 			{
 				ChildrenDrawingOrderEnabled = true;
+			}
+
+			public DefaultRenderer(IntPtr handle, JniHandleOwnership transfer)
+				: base(handle, transfer)
+			{
 			}
 
 			internal void NotifyFakeHandling()

--- a/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/VisualElementRenderer.cs
@@ -37,6 +37,11 @@ namespace Xamarin.Forms.Platform.Android
 			_gestureManager = new GestureManager(this);
 		}
 
+		protected VisualElementRenderer(IntPtr handle, JniHandleOwnership transfer)
+			: base(handle, transfer)
+		{
+		}
+
 		public override bool OnTouchEvent(MotionEvent e)
 		{
 			return _gestureManager.OnTouchEvent(e) || base.OnTouchEvent(e);


### PR DESCRIPTION
### Description of Change ###

Added definition for (IntPtr, JniHandleOwnership) to Android DefaultRenderer. Delegates to its base call in Android.Views.ViewGroup.

### Issues Resolved ### 

- fixes #15729

### API Changes ###

Added:
 - Constructor Xamarin.Forms.Platform.Android.DefaultRenderer(IntPtr handle, JniHandleOwnership transfer)

Changed:
 - none
 
 Removed:
 - none
 
### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###

None

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
