### PR TITLE
Fix crash creating native image of size 0,0

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
@@ -105,7 +105,7 @@ namespace Xamarin.Forms.Platform.iOS
 
 		public static UIImage GetBackgroundImage(this UIView control, Brush brush)
 		{
-			if (control == null || brush == null || brush.IsEmpty)
+			if (control == null || brush == null || brush.IsEmpty || control.Bounds == CGRect.Empty)
 				return null;
 
 			var backgroundLayer = control.GetBackgroundLayer(brush);


### PR DESCRIPTION
Fixes bug appeared on iOS 17 crash creating native image of zero size when linear gradient is set for button at app startup

 
### Description of Change ###

<!-- Describe your changes here. If you're fixing a regression, please also include a link to the commit that first introduced added check for zero size

### Issues Resolved ### 
 
 
 None

### Platforms Affected ### 
<!-- Please list all platforms affected by these changes -->


- iOS


### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

No crash

### Before/After Screenshots ### 
<!-- If possible, take a screenshot of your test case before these changes were made and another screenshot after the changes were made to show possible visual changes. -->

 on iOS 17 crash creating native image of zero size when linear gradient is set for button at app startup

 
