### PR TITLE
[iOS] Remove deprecated BeginImageContextWithOptions

### DIFF
--- a/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
+++ b/Xamarin.Forms.Platform.iOS/Extensions/BrushExtensions.cs
@@ -113,16 +113,13 @@ namespace Xamarin.Forms.Platform.iOS
 			if (backgroundLayer == null)
 				return null;
 
-			UIGraphics.BeginImageContextWithOptions(backgroundLayer.Bounds.Size, false, UIScreen.MainScreen.Scale);
+			var renderer = new UIGraphicsImageRenderer(backgroundLayer.Bounds.Size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale,
+			});
 
-			if (UIGraphics.GetCurrentContext() == null)
-				return null;
-
-			backgroundLayer.RenderInContext(UIGraphics.GetCurrentContext());
-			UIImage gradientImage = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext(); 
-
-			return gradientImage;
+			return renderer.CreateImage((context) => backgroundLayer.RenderInContext(context.CGContext));
 		}
 
 		public static void InsertBackgroundLayer(this UIView view, CALayer backgroundLayer, int index = -1)

--- a/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/EntryRenderer.cs
@@ -597,26 +597,20 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var size = image.Size;
 
-			UIGraphics.BeginImageContextWithOptions(size, false, UIScreen.MainScreen.Scale);
+			var renderer = new UIGraphicsImageRenderer(size, new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = UIScreen.MainScreen.Scale,
+			});
 
-			if (UIGraphics.GetCurrentContext() == null)
-				return null;
+			return renderer.CreateImage((context) =>
+			{
+				image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
+				color.ColorWithAlpha(1.0f).SetFill();
 
-			var context = UIGraphics.GetCurrentContext();
-
-			image.Draw(CGPoint.Empty, CGBlendMode.Normal, 1.0f);
-			context?.SetFillColor(color.CGColor);
-			context?.SetBlendMode(CGBlendMode.SourceIn);
-			context?.SetAlpha(1.0f);
-
-			var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
-			context?.FillRect(rect);
-
-			var tintedImage = UIGraphics.GetImageFromCurrentImageContext();
-
-			UIGraphics.EndImageContext();
-
-			return tintedImage;
+				var rect = new CGRect(CGPoint.Empty.X, CGPoint.Empty.Y, image.Size.Width, image.Size.Height);
+				context?.FillRect(rect, CGBlendMode.SourceIn);
+			});
 		}
 	}
 }

--- a/Xamarin.Forms.Platform.iOS/Renderers/FormsCheckBox.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/FormsCheckBox.cs
@@ -171,60 +171,57 @@ namespace Xamarin.Forms.Platform.iOS
 
 		internal virtual UIImage CreateCheckBox(UIImage check)
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(_defaultSize, _defaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
-
-			var checkedColor = CheckBoxTintUIColor;
-			checkedColor.SetFill();
-			checkedColor.SetStroke();
-
-			var vPadding = _lineWidth / 2;
-			var hPadding = _lineWidth / 2;
-			var diameter = _defaultSize - _lineWidth;
-
-			var backgroundRect = new CGRect(hPadding, vPadding, diameter, diameter);
-			var boxPath = CreateBoxPath(backgroundRect);
-			boxPath.LineWidth = _lineWidth;
-			boxPath.Stroke();
-
-			if (check != null)
+			var renderer = new UIGraphicsImageRenderer(new CGSize(_defaultSize, _defaultSize), new UIGraphicsImageRendererFormat()
 			{
-				boxPath.Fill();
-				check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
-			}
+				Opaque = false,
+				Scale = 0,
+			});
 
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			return renderer.CreateImage((context) =>
+			{
+				var checkedColor = CheckBoxTintUIColor;
+				checkedColor.SetFill();
+				checkedColor.SetStroke();
 
-			return img;
+				var vPadding = _lineWidth / 2;
+				var hPadding = _lineWidth / 2;
+				var diameter = _defaultSize - _lineWidth;
+
+				var backgroundRect = new CGRect(hPadding, vPadding, diameter, diameter);
+				var boxPath = CreateBoxPath(backgroundRect);
+				boxPath.LineWidth = _lineWidth;
+				boxPath.Stroke();
+
+				if (check != null)
+				{
+					boxPath.Fill();
+					check.Draw(new CGPoint(0, 0), CGBlendMode.DestinationOut, 1);
+				}
+			});
 		}
-
 
 		internal UIImage CreateCheckMark()
 		{
-			UIGraphics.BeginImageContextWithOptions(new CGSize(_defaultSize, _defaultSize), false, 0);
-			var context = UIGraphics.GetCurrentContext();
-			context.SaveState();
+			var renderer = new UIGraphicsImageRenderer(new CGSize(_defaultSize, _defaultSize), new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 0,
+			});
 
-			var vPadding = _lineWidth / 2;
-			var hPadding = _lineWidth / 2;
-			var diameter = _defaultSize - _lineWidth;
+			return renderer.CreateImage((context) =>
+			{
+				var vPadding = _lineWidth / 2;
+				var hPadding = _lineWidth / 2;
+				var diameter = _defaultSize - _lineWidth;
 
-			var checkPath = CreateCheckPath();
+				var checkPath = CreateCheckPath();
 
-			context.TranslateCTM(hPadding + (nfloat)(0.05 * diameter), vPadding + (nfloat)(0.1 * diameter));
-			context.ScaleCTM(diameter, diameter);
-			DrawCheckMark(checkPath);
-			UIColor.White.SetStroke();
-			checkPath.Stroke();
-
-			context.RestoreState();
-			var img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
-
-			return img;
+				context.CGContext.TranslateCTM(hPadding + (nfloat)(0.05 * diameter), vPadding + (nfloat)(0.1 * diameter));
+				context.CGContext.ScaleCTM(diameter, diameter);
+				DrawCheckMark(checkPath);
+				UIColor.White.SetStroke();
+				checkPath.Stroke();
+			});
 		}
 
 		protected override void Dispose(bool disposing)

--- a/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ImageRenderer.cs
@@ -8,6 +8,8 @@ using UIKit;
 using Xamarin.Forms.Internals;
 using RectangleF = CoreGraphics.CGRect;
 using PreserveAttribute = Foundation.PreserveAttribute;
+using CoreGraphics;
+using System.Drawing;
 
 namespace Xamarin.Forms.Platform.iOS
 {
@@ -279,17 +281,23 @@ namespace Xamarin.Forms.Platform.iOS
 				var iconcolor = fontsource.Color.IsDefault ? _defaultColor : fontsource.Color;
 				var attString = new NSAttributedString(fontsource.Glyph, font: font, foregroundColor: iconcolor.ToUIColor());
 				var imagesize = ((NSString)fontsource.Glyph).GetSizeUsingAttributes(attString.GetUIKitAttributes(0, out _));
-				
-				UIGraphics.BeginImageContextWithOptions(imagesize, false, 0f);
-				var ctx = new NSStringDrawingContext();
-				var boundingRect = attString.GetBoundingRect(imagesize, (NSStringDrawingOptions)0, ctx);
-				attString.DrawString(new RectangleF(
-					imagesize.Width / 2 - boundingRect.Size.Width / 2,
-					imagesize.Height / 2 - boundingRect.Size.Height / 2,
-					imagesize.Width,
-					imagesize.Height));
-				image = UIGraphics.GetImageFromCurrentImageContext();
-				UIGraphics.EndImageContext();
+
+				var renderer = new UIGraphicsImageRenderer(imagesize, new UIGraphicsImageRendererFormat()
+				{
+					Opaque = false,
+					Scale = 0,
+				});
+
+				image = renderer.CreateImage((context) =>
+				{
+					var ctx = new NSStringDrawingContext();
+					var boundingRect = attString.GetBoundingRect(imagesize, (NSStringDrawingOptions)0, ctx);
+					attString.DrawString(new RectangleF(
+						imagesize.Width / 2 - boundingRect.Size.Width / 2,
+						imagesize.Height / 2 - boundingRect.Size.Height / 2,
+						imagesize.Width,
+						imagesize.Height));
+				});
 
 				if (image != null && iconcolor != _defaultColor)
 					image = image.ImageWithRenderingMode(UIImageRenderingMode.AlwaysOriginal);

--- a/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/ShellPageRendererTracker.cs
@@ -325,25 +325,30 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var rect = new CGRect(0, 0, 23f, 23f);
 
-			UIGraphics.BeginImageContextWithOptions(rect.Size, false, 0);
-			var ctx = UIGraphics.GetCurrentContext();
-			ctx.SaveState();
-			ctx.SetStrokeColor(UIColor.Blue.CGColor);
-
-			float size = 3f;
-			float start = 4f;
-			ctx.SetLineWidth(size);
-
-			for (int i = 0; i < 3; i++)
+			var renderer = new UIGraphicsImageRenderer(rect.Size, new UIGraphicsImageRendererFormat()
 			{
-				ctx.MoveTo(1f, start + i * (size * 2));
-				ctx.AddLineToPoint(22f, start + i * (size * 2));
-				ctx.StrokePath();
-			}
+				Opaque = false,
+				Scale = 0,
+			});
 
-			ctx.RestoreState();
-			img = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
+			img = renderer.CreateImage((context) =>
+			{
+				context.CGContext.SaveState();
+				UIColor.Blue.SetStroke();
+
+				float size = 3f;
+				float start = 4f;
+				context.CGContext.SetLineWidth(size);
+
+				for (int i = 0; i < 3; i++)
+				{
+					context.CGContext.MoveTo(1f, start + i * (size * 2));
+					context.CGContext.AddLineToPoint(22f, start + i * (size * 2));
+					context.CGContext.StrokePath();
+				}
+
+				context.CGContext.RestoreState();
+			});
 
 			_nSCache.SetObjectforKey(img, (NSString)hamburgerKey);
 			return img;

--- a/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
+++ b/Xamarin.Forms.Platform.iOS/Renderers/SwipeViewRenderer.cs
@@ -750,12 +750,17 @@ namespace Xamarin.Forms.Platform.iOS
 
 			var width = maxResizeFactor * sourceSize.Width;
 			var height = maxResizeFactor * sourceSize.Height;
-			UIGraphics.BeginImageContextWithOptions(new CGSize((nfloat)width, (nfloat)height), false, 0);
-			sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
-			var resultImage = UIGraphics.GetImageFromCurrentImageContext();
-			UIGraphics.EndImageContext();
 
-			return resultImage;
+			var renderer = new UIGraphicsImageRenderer(new CGSize((nfloat)width, (nfloat)height), new UIGraphicsImageRendererFormat()
+			{
+				Opaque = false,
+				Scale = 0,
+			});
+
+			return renderer.CreateImage((context) =>
+			{
+				sourceImage.Draw(new CGRect(0, 0, (nfloat)width, (nfloat)height));
+			});
 		}
 
 		void HandleTouchInteractions(GestureStatus status, CGPoint point)


### PR DESCRIPTION
This change removes the deprecated `UIGraphics.BeginImageContextWithOptions` and substitutes it with the now recommended `UIGraphicsImageRenderer` in a. couple of places. This also prevents crashes that are now happening on iOS 17/Xcode 15.

The `UIGraphicsImageRenderer` is already supported since iOS 10 and up so it should not give us any issues on older versions.

Fixes #15827

Closes #15828