### PR TITLE
Adds a null-guard in `SwipeItemView` to prevent NRE

### DIFF
--- a/Xamarin.Forms.Core/SwipeItemView.cs
+++ b/Xamarin.Forms.Core/SwipeItemView.cs
@@ -64,7 +64,7 @@ namespace Xamarin.Forms
 
 		void OnCommandCanExecuteChanged(object sender, EventArgs eventArgs)
 		{
-			IsEnabled = Command.CanExecute(CommandParameter);
+			IsEnabled = Command?.CanExecute(CommandParameter) ?? true;
 		}
 	}
 }


### PR DESCRIPTION
Same fix as #15636 made for `MenuItem` replicated for `SwipeItemView`.