### PR TITLE
Remove interfering keyboard focus logic

### DIFF
--- a/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/PlatformRenderer.cs
@@ -10,9 +10,6 @@ namespace Xamarin.Forms.Platform.Android
 	internal class PlatformRenderer : ViewGroup
 	{
 		readonly IPlatformLayout _canvas;
-		Point _downPosition;
-
-		DateTime _downTime;
 
 		public PlatformRenderer(Context context, IPlatformLayout canvas) : base(context)
 		{
@@ -22,53 +19,6 @@ namespace Xamarin.Forms.Platform.Android
 				Focusable = true;
 				FocusableInTouchMode = true;
 			}
-		}
-
-		public override bool DispatchTouchEvent(MotionEvent e)
-		{
-			if (e.Action == MotionEventActions.Down)
-			{
-				_downTime = DateTime.UtcNow;
-				_downPosition = new Point(e.RawX, e.RawY);
-			}
-
-			if (e.Action != MotionEventActions.Up)
-				return base.DispatchTouchEvent(e);
-
-			global::Android.Views.View currentView = Context.GetActivity().CurrentFocus;
-			bool result = base.DispatchTouchEvent(e);
-
-			do
-			{
-				if (!(currentView is EditText))
-					break;
-
-				global::Android.Views.View newCurrentView = Context.GetActivity().CurrentFocus;
-
-				if (currentView != newCurrentView)
-					break;
-
-				double distance = _downPosition.Distance(new Point(e.RawX, e.RawY));
-
-				if (distance > Context.ToPixels(20) || DateTime.UtcNow - _downTime > TimeSpan.FromMilliseconds(200))
-					break;
-
-				var location = new int[2];
-				currentView.GetLocationOnScreen(location);
-
-				float x = e.RawX + currentView.Left - location[0];
-				float y = e.RawY + currentView.Top - location[1];
-
-				var rect = new Rectangle(currentView.Left, currentView.Top, currentView.Width, currentView.Height);
-
-				if (rect.Contains(x, y))
-					break;
-
-				Context.HideKeyboard(currentView);
-				Context.GetActivity().Window.DecorView.ClearFocus();
-			} while (false);
-
-			return result;
 		}
 
 		protected override void OnLayout(bool changed, int l, int t, int r, int b)

--- a/Xamarin.Forms.Platform.Android/Renderers/IShellSearchView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/IShellSearchView.cs
@@ -12,7 +12,5 @@ namespace Xamarin.Forms.Platform.Android
 		void LoadView();
 
 		event EventHandler SearchConfirmed;
-
-		bool ShowKeyboardOnAttached { get; set; }
 	}
 }

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchBarRenderer.cs
@@ -46,7 +46,6 @@ namespace Xamarin.Forms.Platform.Android
 		bool SearchView.IOnQueryTextListener.OnQueryTextSubmit(string query)
 		{
 			((ISearchBarController)Element).OnSearchButtonPressed();
-			ClearFocus(Control);
 			return true;
 		}
 
@@ -225,7 +224,6 @@ namespace Xamarin.Forms.Platform.Android
 			SearchView control = Control;
 			if (!model.IsEnabled)
 			{
-				ClearFocus(control);
 				// removes cursor in SearchView
 				control.SetInputType(InputTypes.Null);
 			}

--- a/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/SearchHandlerAppearanceTracker.cs
@@ -32,7 +32,6 @@ namespace Xamarin.Forms.Platform.Android
 			_searchHandler = searchView.SearchHandler;
 			_control = searchView.View;
 			_searchHandler.PropertyChanged += SearchHandlerPropertyChanged;
-			_searchHandler.FocusChangeRequested += SearchHandlerFocusChangeRequested;
 			_editText = (_control as ViewGroup).GetChildrenOfType<EditText>().FirstOrDefault();
 			_textColorSwitcher = new TextColorSwitcher(_editText.TextColors, false);
 			_hintColorSwitcher = new TextColorSwitcher(_editText.HintTextColors, false);
@@ -41,22 +40,6 @@ namespace Xamarin.Forms.Platform.Android
 			UpdateHorizontalTextAlignment();
 			UpdateVerticalTextAlignment();
 			UpdateInputType();
-		}
-
-		protected virtual void SearchHandlerFocusChangeRequested(object sender, VisualElement.FocusRequestArgs e)
-		{
-			e.Result = true;
-
-			if (e.Focus)
-			{
-				_control?.RequestFocus();
-				_control?.PostShowKeyboard();
-			}
-			else
-			{
-				_control.ClearFocus();
-				_control.HideKeyboard();
-			}
 		}
 
 		protected virtual void SearchHandlerPropertyChanged(object sender, System.ComponentModel.PropertyChangedEventArgs e)
@@ -235,7 +218,6 @@ namespace Xamarin.Forms.Platform.Android
 			{
 				if (_searchHandler != null)
 				{
-					_searchHandler.FocusChangeRequested -= SearchHandlerFocusChangeRequested;
 					_searchHandler.PropertyChanged -= SearchHandlerPropertyChanged;
 				}
 				_searchHandler = null;

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellFlyoutRecyclerAdapter.cs
@@ -105,13 +105,11 @@ namespace Xamarin.Forms.Platform.Android
 			elementHolder.Element = item.Element;
 		}
 
-		class LinearLayoutWithFocus : LinearLayout, ITabStop, IVisualElementRenderer
+		class ShellLinearLayout : LinearLayout, IVisualElementRenderer
 		{
-			public LinearLayoutWithFocus(global::Android.Content.Context context) : base(context)
+			public ShellLinearLayout(global::Android.Content.Context context) : base(context)
 			{
 			}
-
-			AView ITabStop.TabStop => this;
 
 			#region IVisualElementRenderer
 
@@ -180,7 +178,7 @@ namespace Xamarin.Forms.Platform.Android
 
 			var content = (View)template.CreateContent();
 
-			var linearLayout = new LinearLayoutWithFocus(parent.Context)
+			var linearLayout = new ShellLinearLayout(parent.Context)
 			{
 				Orientation = Orientation.Vertical,
 				LayoutParameters = new RecyclerView.LayoutParams(LP.MatchParent, LP.WrapContent),

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellSearchView.cs
@@ -28,8 +28,6 @@ namespace Xamarin.Forms.Platform.Android
 
 		public SearchHandler SearchHandler { get; set; }
 
-		public bool ShowKeyboardOnAttached { get; set; }
-
 		AView IShellSearchView.View
 		{
 			get
@@ -113,8 +111,6 @@ namespace Xamarin.Forms.Platform.Android
 			// Fire Completed and dismiss keyboard for hardware / physical keyboards
 			if (actionId == ImeAction.Done || (actionId == ImeAction.ImeNull && e.KeyCode == Keycode.Enter && e.Action == KeyEventActions.Up))
 			{
-				_textBlock.ClearFocus();
-				v.HideKeyboard();
 				SearchConfirmed?.Invoke(this, EventArgs.Empty);
 				Controller.QueryConfirmed();
 			}
@@ -248,9 +244,6 @@ namespace Xamarin.Forms.Platform.Android
 		{
 			base.OnAttachedToWindow();
 
-			if (!ShowKeyboardOnAttached)
-				return;
-
 			Alpha = 0;
 			Animate().Alpha(1).SetDuration(200).SetListener(null);
 
@@ -259,9 +252,6 @@ namespace Xamarin.Forms.Platform.Android
 
 			if (_disposed)
 				return;
-
-			_textBlock.RequestFocus();
-			Context.ShowKeyboard(_textBlock);
 		}
 
 		protected virtual void OnClearButtonClicked(object sender, EventArgs e)
@@ -343,7 +333,6 @@ namespace Xamarin.Forms.Platform.Android
 			var item = Controller.ListProxy[index];
 
 			_textBlock.Text = "";
-			_textBlock.HideKeyboard();
 			SearchConfirmed?.Invoke(this, EventArgs.Empty);
 			Controller.ItemSelected(item);
 		}

--- a/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
+++ b/Xamarin.Forms.Platform.Android/Renderers/ShellToolbarTracker.cs
@@ -595,13 +595,11 @@ namespace Xamarin.Forms.Platform.Android
 					if (_searchView.View.Parent != null)
 						_searchView.View.RemoveFromParent();
 
-					_searchView.ShowKeyboardOnAttached = true;
 					item.SetActionView(_searchView.View);
 					item.Dispose();
 				}
 				else if (SearchHandler.SearchBoxVisibility == SearchBoxVisibility.Expanded)
 				{
-					_searchView.ShowKeyboardOnAttached = false;
 					if (_searchView.View.Parent != _toolbar)
 						_toolbar.AddView(_searchView.View);
 				}


### PR DESCRIPTION
### Description of Change ###

This is a backport of https://github.com/dotnet/maui/commit/a3d8d2034377fb169a13ff7e196a482ccfbd4686 which fixed https://github.com/dotnet/maui/issues/5916 in MAUI two years ago. The responding code already existed in Xamarin.Forms before, but the fix was only done in MAUI.

Essentially it removes the code which hid the soft keyboard when you touch anywhere outside an `Editor` or `Entry`.

### Issues Resolved ### 
<!-- Please use the format "fixes #xxxx" for each issue this PR addresses -->

- fixes #15870 

### API Changes ###

 None

### Platforms Affected ### 

- Android

### Behavioral/Visual Changes ###
<!-- Describe any changes that may change how a user's app behaves or appears when upgrading to this version of the codebase. -->

When an `Entry` is focused, tapping any other element does not close the soft keyboard.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
