### PR TITLE
Fixed issue #15874 - NRE when iOS app is running on MacOS and "More" item is clicked in ListView context menu

### DIFF
--- a/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
+++ b/Xamarin.Forms.Platform.iOS/ContextActionCell.cs
@@ -358,15 +358,18 @@ namespace Xamarin.Forms.Platform.iOS
 				if (controller == null)
 					throw new InvalidOperationException("No UIViewController found to present.");
 
-				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone)
+				if (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Phone || (UIDevice.CurrentDevice.UserInterfaceIdiom == UIUserInterfaceIdiom.Pad && actionSheet.PopoverPresentationController == null))
 				{
 					var cancel = UIAlertAction.Create(StringResources.Cancel, UIAlertActionStyle.Cancel, null);
 					actionSheet.AddAction(cancel);
 				}
 				else
 				{
-					actionSheet.PopoverPresentationController.SourceView = _tableView;
-					actionSheet.PopoverPresentationController.SourceRect = sourceRect;
+					if (actionSheet.PopoverPresentationController != null)
+					{
+						actionSheet.PopoverPresentationController.SourceView = _tableView;
+						actionSheet.PopoverPresentationController.SourceRect = sourceRect;
+					}
 				}
 
 				controller.PresentViewController(actionSheet, true, null);

--- a/Xamarin.Forms.Platform.iOS/Platform.cs
+++ b/Xamarin.Forms.Platform.iOS/Platform.cs
@@ -472,7 +472,11 @@ namespace Xamarin.Forms.Platform.iOS
 			{
 				UIDevice.CurrentDevice.BeginGeneratingDeviceOrientationNotifications();
 				var observer = NSNotificationCenter.DefaultCenter.AddObserver(UIDevice.OrientationDidChangeNotification,
-					n => { alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds; });
+					n =>
+					{
+						if (alert.PopoverPresentationController != null)
+							alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
+					});
 
 				arguments.Result.Task.ContinueWith(t =>
 				{
@@ -480,9 +484,12 @@ namespace Xamarin.Forms.Platform.iOS
 					UIDevice.CurrentDevice.EndGeneratingDeviceOrientationNotifications();
 				}, TaskScheduler.FromCurrentSynchronizationContext());
 
-				alert.PopoverPresentationController.SourceView = window.RootViewController.View;
-				alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
-				alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
+				if (alert.PopoverPresentationController != null)
+				{
+					alert.PopoverPresentationController.SourceView = window.RootViewController.View;
+					alert.PopoverPresentationController.SourceRect = window.RootViewController.View.Bounds;
+					alert.PopoverPresentationController.PermittedArrowDirections = 0; // No arrow
+				}
 			}
 
 			if(!Forms.IsiOS9OrNewer)


### PR DESCRIPTION
### Description of Change ###

Fixed an NRE when iOS app runs in MacOS

### Issues Resolved ### 

- fixes #15874

### API Changes ###

None

### Platforms Affected ### 

- iOS

### Behavioral/Visual Changes ###

None

### Before/After Screenshots ###

TBD

### Testing Procedure ###
Launch an iOS app with ListView and its context menu on MacOS, click on "More" item in the context menu.
Previously the app crashed, now you should see correct popup with "Cancel" button.

### PR Checklist ###
<!-- To be completed by reviewers -->

- [ ] Targets the correct branch
- [ ] Tests are passing (or failures are unrelated)
